### PR TITLE
Refactor Guardian API into modular route files

### DIFF
--- a/guardian/routes/admin.py
+++ b/guardian/routes/admin.py
@@ -1,0 +1,166 @@
+"""
+Admin Routes
+~~~~~~~~~~~~
+
+Diagnostic and administrative endpoints including health checks,
+session token management, and configuration debugging.
+"""
+
+import logging
+import os
+import secrets
+from typing import Optional
+from fastapi import APIRouter, Depends, Header, HTTPException, Response
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+# Import shared context
+try:
+    from guardian.guardian_api import (
+        chatlog_db,
+        require_api_key,
+        API_KEY,
+        PG_DSN,
+        SQLITE_PATH,
+        DB_BACKEND,
+        GUARDIAN_PROVIDER,
+        allowed_origins,
+        get_groq_chat,
+    )
+    from guardian.core.auth import issue_session_token, verify_session_token
+except ImportError as e:
+    logger.warning(f"[admin] Import warning: {e}")
+    chatlog_db = None
+    require_api_key = lambda x: x
+    issue_session_token = None
+    API_KEY = None
+    PG_DSN = None
+    SQLITE_PATH = None
+    DB_BACKEND = "unknown"
+    GUARDIAN_PROVIDER = "unknown"
+    allowed_origins = []
+    get_groq_chat = lambda: None
+
+
+class SessionRequest(BaseModel):
+    ttl_seconds: int | None = None
+
+
+router = APIRouter(tags=["Admin"])
+
+
+# =========================
+# Health & Ping Endpoints
+# =========================
+
+@router.get("/ping", summary="Health check endpoint")
+def ping():
+    """Simple health check endpoint to verify that the Guardian API is awake."""
+    logger.debug("Ping request received")
+    return {"status": "Guardian awake!"}
+
+
+@router.get("/healthz", summary="DB health and table existence")
+def healthz():
+    """
+    Returns DB target and existence of projects/chat_threads for quick diagnostics.
+    """
+    db_target = PG_DSN if DB_BACKEND == "postgres" else SQLITE_PATH
+    projects_exists = False
+    threads_exists = False
+    try:
+        projects_exists = chatlog_db.table_exists("projects")
+        threads_exists = chatlog_db.table_exists("chat_threads")
+    except Exception as e:
+        logger.warning("/healthz check failed: %s", e)
+    return {
+        "db_target": db_target,
+        "backend": DB_BACKEND,
+        "projects_table_exists": projects_exists,
+        "chat_threads_table_exists": threads_exists,
+    }
+
+
+# =========================
+# Session Token Management
+# =========================
+
+@router.post("/auth/session", tags=["Auth"], summary="Exchange API key for a short-lived session token")
+def create_session(body: SessionRequest, x_api_key: Optional[str] = Header(default=None, alias="X-API-Key")):
+    """
+    Exchange API key for a short-lived JWT session token.
+
+    Args:
+        body: Request with optional TTL override
+        x_api_key: API key from X-API-Key header
+
+    Returns:
+        Session token and expiration timestamp
+    """
+    expected = os.getenv("GUARDIAN_API_KEY") or ""
+    if not (x_api_key and secrets.compare_digest(x_api_key, expected)):
+        raise HTTPException(status_code=401, detail="API key required to mint session")
+    token, exp = issue_session_token(subject="web", ttl_seconds=body.ttl_seconds or 24 * 3600)
+    return {"token": token, "expires": exp}
+
+
+@router.post("/auth/session/cookie", tags=["Auth"], summary="Mint a session token and set it as an HttpOnly cookie")
+def create_session_cookie(
+    response: Response,
+    body: SessionRequest,
+    x_api_key: Optional[str] = Header(default=None, alias="X-API-Key"),
+):
+    """
+    Exchange API key for a session token and set it as an HttpOnly cookie.
+
+    Args:
+        response: FastAPI response object for cookie setting
+        body: Request with optional TTL override
+        x_api_key: API key from X-API-Key header
+
+    Returns:
+        Success status and expiration timestamp
+    """
+    expected = os.getenv("GUARDIAN_API_KEY") or ""
+    if not (x_api_key and secrets.compare_digest(x_api_key, expected)):
+        raise HTTPException(status_code=401, detail="API key required to mint session")
+    token, exp = issue_session_token(subject="web", ttl_seconds=body.ttl_seconds or 24 * 3600)
+    max_age = (body.ttl_seconds or 24 * 3600)
+    # NOTE: set secure=True when serving over HTTPS
+    response.set_cookie("gc_session", token, max_age=max_age, httponly=True, samesite="Lax", secure=False)
+    return {"ok": True, "expires": exp}
+
+
+# =========================
+# Diagnostic Endpoints
+# =========================
+
+@router.get("/authz/debug", tags=["Diag"], summary="Echo masked API key received in header")
+def authz_debug(api_key: str = Depends(require_api_key)):
+    """Return the masked API key received via X-API-Key, masked for safety."""
+    key = api_key or ""
+    masked = (key[:4] + "…" + key[-4:]) if len(key) > 8 else key
+    return {"received_api_key": masked}
+
+
+@router.get("/debug/config", tags=["Diag"], summary="Return masked config for debugging (development only)")
+def debug_config(api_key: str = Depends(require_api_key)):
+    """
+    Return a small, masked snapshot of runtime config useful for local debugging.
+    This endpoint requires a valid X-API-Key header and is intended for dev use only.
+    """
+    env = os.getenv("GUARDIAN_ENV", "development")
+    masked_key = (
+        (API_KEY[:4] + "…" + API_KEY[-4:]) if API_KEY and len(API_KEY) > 8 else API_KEY
+    )
+    db_target = PG_DSN if DB_BACKEND == "postgres" else SQLITE_PATH
+    return {
+        "env": env,
+        "db_target": db_target,
+        "db_backend": DB_BACKEND,
+        "provider": GUARDIAN_PROVIDER,
+        "allowed_origins": allowed_origins,
+        "masked_api_key": masked_key,
+        "groq_available": bool(get_groq_chat()),
+    }

--- a/guardian/routes/chat.py
+++ b/guardian/routes/chat.py
@@ -1,0 +1,660 @@
+"""
+Chat Routes
+~~~~~~~~~~~
+
+Chat thread and message management endpoints.
+Includes thread creation, messaging, completion, branching, and lineage tracking.
+"""
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field, ValidationError, ConfigDict
+
+logger = logging.getLogger(__name__)
+
+# Import shared context
+try:
+    from guardian.guardian_api import (
+        chatlog_db,
+        require_api_key,
+        _groq_complete,
+        event_bus,
+        _vector_store,
+        _memory_store,
+        _sensors,
+        DEFAULT_MODEL,
+    )
+    from guardian.context.broker import ContextBroker
+except ImportError as e:
+    logger.warning(f"[chat] Import warning: {e}")
+    chatlog_db = None
+    require_api_key = lambda x: x
+    _groq_complete = None
+    event_bus = None
+    ContextBroker = None
+    _vector_store = None
+    _memory_store = None
+    _sensors = None
+    DEFAULT_MODEL = None
+
+# Optional Neo4j imports for graph sync
+try:
+    from db.neo import UserNode, MessageNode, ThreadNode
+    NEO4J_SYNC_AVAILABLE = True
+except Exception:
+    NEO4J_SYNC_AVAILABLE = False
+
+
+# Pydantic models for thread operations
+class ThreadDTO(BaseModel):
+    id: int
+    user_id: str
+    title: str
+    summary: str = ""
+    project_id: Optional[int] = None
+    parent_id: Optional[int] = None
+    archived_at: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ThreadUpdate(BaseModel):
+    title: Optional[str] = None
+    summary: Optional[str] = None
+    project_id: Optional[int] = None
+    archived: Optional[bool] = None
+
+
+class ThreadBranchRequest(BaseModel):
+    title: Optional[str] = None
+    summary: Optional[str] = None
+    project_id: Optional[int] = None
+
+
+class ThreadCreateRequest(BaseModel):
+    parent_thread_id: int = None
+    session_id: str = None
+    summary: str = ""
+    user_id: str = "default"
+    project_id: str = None
+
+
+# Helper functions
+def _normalize_thread_title(raw: Optional[str]) -> Optional[str]:
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    return text or "New Chat"
+
+
+def _normalize_thread_summary(raw: Optional[str]) -> Optional[str]:
+    if raw is None:
+        return None
+    return str(raw).strip()
+
+
+def _apply_thread_update(thread_id: int, update: ThreadUpdate) -> Dict[str, Any]:
+    """Apply updates to a thread and emit appropriate events."""
+    payload = update.dict(exclude_unset=True)
+    if not payload:
+        raise HTTPException(status_code=400, detail="No valid fields to update")
+
+    updated_field_keys = [key for key in ("title", "summary", "project_id") if key in payload]
+    existing = chatlog_db.get_chat_thread(thread_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Thread not found")
+
+    title_value = _normalize_thread_title(payload.get("title")) if "title" in payload else None
+    summary_value = _normalize_thread_summary(payload.get("summary")) if "summary" in payload else None
+    project_present = "project_id" in payload
+    project_value = payload.get("project_id") if project_present else None
+    archived_present = "archived" in payload
+    archived_requested = payload.get("archived") if archived_present else None
+
+    has_field_updates = any(
+        field is not None for field in (
+            title_value if "title" in payload else None,
+            summary_value if "summary" in payload else None,
+            project_value if project_present else None,
+        )
+    ) or project_present and payload.get("project_id") is None
+
+    if not has_field_updates and not archived_present:
+        raise HTTPException(status_code=400, detail="No valid fields to update")
+
+    if has_field_updates:
+        updated = chatlog_db.update_thread(
+            thread_id,
+            title=title_value if "title" in payload else None,
+            summary=(summary_value if "summary" in payload else None),
+            project_id=project_value if project_present else None,
+        )
+        if not updated:
+            raise HTTPException(status_code=404, detail="Thread not found")
+
+    refreshed = chatlog_db.get_chat_thread(thread_id)
+    if not refreshed:
+        raise HTTPException(status_code=404, detail="Thread not found")
+
+    if has_field_updates:
+        chatlog_db.write_audit_log(
+            "update",
+            "chat_thread",
+            str(thread_id),
+            user_id=refreshed.get("user_id", "default"),
+        )
+        event_bus.emit_event(
+            "thread.updated",
+            {
+                "thread": refreshed,
+                "changes": {key: payload.get(key) for key in updated_field_keys},
+            },
+        )
+        logger.info(
+            "[threads] updated thread_id=%s fields=%s",
+            thread_id,
+            updated_field_keys or list(payload.keys()),
+        )
+
+    if archived_requested is True:
+        # Archive if not already archived
+        if not refreshed.get("archived_at"):
+            archived = chatlog_db.archive_thread(thread_id)
+            if archived:
+                refreshed = archived
+                event_bus.emit_event("thread.archived", {"thread": archived})
+                logger.info("[threads] archived thread_id=%s", thread_id)
+                chatlog_db.write_audit_log(
+                    "archive",
+                    "chat_thread",
+                    str(thread_id),
+                    user_id=archived.get("user_id", "default"),
+                )
+        else:
+            logger.debug("Thread %s already archived", thread_id)
+    elif archived_requested is False:
+        # Unarchive if currently archived
+        if refreshed.get("archived_at"):
+            unarchived = chatlog_db.unarchive_thread(thread_id)
+            if unarchived:
+                refreshed = unarchived
+                event_bus.emit_event("thread.unarchived", {"thread": unarchived})
+                logger.info("[threads] unarchived thread_id=%s", thread_id)
+                chatlog_db.write_audit_log(
+                    "unarchive",
+                    "chat_thread",
+                    str(thread_id),
+                    user_id=unarchived.get("user_id", "default"),
+                )
+        else:
+            logger.debug("Thread %s already unarchived", thread_id)
+
+    return refreshed
+
+
+router = APIRouter(prefix="/chat", tags=["Chat"])
+
+
+# =========================
+# Chat Threads API
+# =========================
+
+@router.post("/threads")
+def chat_create_thread(body: dict = Body(...)):
+    """Create a chat thread and return identifier metadata."""
+    try:
+        payload = body or {}
+        raw_title = payload.get("title")
+        title = (
+            str(raw_title).strip() if raw_title is not None else "New Chat"
+        ) or "New Chat"
+        raw_user = payload.get("user_id")
+        user_id = str(raw_user) if raw_user not in (None, "") else "default"
+        raw_summary = payload.get("summary")
+        summary = str(raw_summary).strip() if raw_summary is not None else ""
+        project_id = payload.get("project_id")
+        normalized_project: Optional[int] = None
+        if project_id is not None:
+            try:
+                normalized_project = int(project_id)
+            except (TypeError, ValueError):
+                normalized_project = None
+        if normalized_project is None:
+            # default to Loose Threads (id=1)
+            normalized_project = 1
+
+        # Idempotency guard: check for recent empty thread from same user
+        recent_thread = chatlog_db.get_recent_thread(user_id)
+        if recent_thread:
+            # If recent thread exists and has no messages, reuse it
+            recent_id = recent_thread.get("id")
+            if recent_id and chatlog_db.count_messages(recent_id) == 0:
+                logger.info(
+                    "Reusing recent empty thread %s for user %s", recent_id, user_id
+                )
+                return {"ok": True, "id": recent_id, "thread": recent_thread}
+
+        record = chatlog_db.create_chat_thread(
+            user_id=user_id,
+            title=title,
+            summary=summary,
+            project_id=normalized_project,
+        )
+        chatlog_db.write_audit_log(
+            "create", "chat_thread", str(record["id"]), user_id=user_id
+        )
+        return {"ok": True, "id": record["id"], "thread": record}
+    except Exception as exc:
+        logger.exception("Failed to create chat thread: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to create chat thread")
+
+
+@router.get("/threads")
+def chat_list_threads():
+    """Return the list of persisted chat threads."""
+    try:
+        threads = chatlog_db.list_chat_threads()
+        return {"ok": True, "threads": threads}
+    except Exception as exc:
+        logger.exception("Failed to list chat threads: %s", exc)
+        return {"ok": True, "threads": []}
+
+
+# =========================
+# Chat Messages API
+# =========================
+
+@router.post("/{thread_id}/messages")
+def chat_post_message(thread_id: int, body: Dict[str, str] = Body(...)):
+    """Post a new message to a chat thread."""
+    role = body.get("role")
+    content = body.get("content", "").strip()
+    if not role or not content:
+        return JSONResponse(
+            status_code=400, content={"ok": False, "error": "role and content required"}
+        )
+    owner = body.get("user_id") or "default"
+    try:
+        chatlog_db.ensure_chat_thread(
+            thread_id=thread_id,
+            user_id=str(owner),
+            title="New Chat",
+            summary="",
+            project_id=1,  # always assign to Loose Threads by default
+        )
+    except Exception as exc:
+        logger.exception("Failed to ensure chat thread %s exists: %s", thread_id, exc)
+        raise HTTPException(status_code=500, detail="Failed to persist chat message")
+    mid = chatlog_db.create_message(thread_id, role, content)
+    chatlog_db.write_audit_log("create", "chat_message", str(mid), user_id=str(owner))
+
+    # Emit event for real-time updates
+    event_bus.emit_event(
+        "message.created",
+        {
+            "thread_id": thread_id,
+            "message_id": mid,
+            "role": role,
+            "content": content,
+        },
+    )
+
+    # --- Neo4j sync ---
+    if NEO4J_SYNC_AVAILABLE:
+        try:
+            import uuid
+            # Use string IDs for Neo4j
+            message_id = str(mid)
+            thread_id_str = str(thread_id)
+            user_id_str = str(owner)
+            message_text = content
+
+            neo_user = UserNode.nodes.get_or_none(user_id=user_id_str)
+            if not neo_user:
+                neo_user = UserNode(user_id=user_id_str, name=user_id_str).save()
+
+            neo_thread = ThreadNode.nodes.get_or_none(thread_id=thread_id_str)
+            if not neo_thread:
+                neo_thread = ThreadNode(thread_id=thread_id_str).save()
+
+            neo_msg = MessageNode(
+                message_id=message_id,
+                content=message_text,
+                created_at=datetime.utcnow()
+            ).save()
+
+            neo_msg.user.connect(neo_user)
+            neo_msg.thread.connect(neo_thread)
+
+        except Exception as e:
+            logger.warning(f"[Neo4j Sync Error] {e}")
+
+    return {
+        "ok": True,
+        "message": {
+            "id": mid,
+            "thread_id": thread_id,
+            "role": role,
+            "content": content,
+        },
+    }
+
+
+@router.get("/{thread_id}/messages")
+def chat_list_messages(thread_id: int, limit: int = 50, offset: int = 0):
+    """List messages for a chat thread."""
+    items = chatlog_db.list_messages(thread_id, limit=limit, offset=offset)
+    total = chatlog_db.count_messages(thread_id)
+    return {"ok": True, "total": total, "messages": items}
+
+
+@router.post("/{thread_id}/complete")
+async def chat_complete(thread_id: int, body: Dict[str, Any] = Body(default_factory=dict)):
+    """
+    Generate an assistant reply for the given thread using the configured provider
+    and persist it as a new message (role='assistant'). Emits message.created.
+    Optional body:
+      - model: override model name
+      - max_context: how many recent messages to include (default 50)
+    """
+    try:
+        limit = int(body.get("max_context") or 50)
+        items = chatlog_db.list_messages(thread_id, limit=limit, offset=0)
+
+        # Shape OpenAI-style messages; drop empty or literal "null" content
+        context: List[Dict[str, str]] = []
+        for m in items:
+            role = str(m.get("role") or "").strip()
+            content = m.get("content")
+            if isinstance(content, str) and content.strip() and content.strip().lower() != "null":
+                context.append({"role": role, "content": content})
+
+        if not context:
+            raise HTTPException(status_code=400, detail="Thread has no usable context")
+
+        # Build ContextBroker bundle using latest user message as query
+        latest_message = ""
+        for m in reversed(items):
+            if str(m.get("role") or "").strip() == "user":
+                lm = str(m.get("content") or "").strip()
+                if lm:
+                    latest_message = lm
+                    break
+
+        depth = str(body.get("depth") or "normal").strip().lower()
+        bundle: Optional[Dict[str, Any]] = None
+        try:
+            broker = ContextBroker(chatlog_db, _vector_store, _memory_store, _sensors)
+            bundle = await broker.assemble(thread_id, query=latest_message, depth=depth)
+        except Exception as e:
+            logger.warning("[context] broker assemble failed (depth=%s): %s", depth, e)
+            bundle = None
+
+        model = body.get("model") or DEFAULT_MODEL
+        assistant_text = _groq_complete(context, model=model, context=bundle)
+
+        mid = chatlog_db.create_message(thread_id, "assistant", assistant_text)
+        try:
+            chatlog_db.write_audit_log("create", "chat_message", str(mid), user_id="bot")
+        except Exception:
+            pass
+
+        try:
+            event_bus.emit_event("message.created", {"thread_id": thread_id, "message_id": mid, "role": "assistant"})
+        except Exception:
+            logger.debug("[live] emit message.created failed", exc_info=True)
+
+        return {"ok": True, "message": {"id": mid, "thread_id": thread_id, "role": "assistant", "content": assistant_text}}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("complete failed: %s", exc)
+        raise HTTPException(status_code=500, detail="completion_failed")
+
+
+@router.delete("/{thread_id}/messages/{message_id}")
+def chat_delete_message(thread_id: int, message_id: int):
+    """Delete a message from a chat thread."""
+    chatlog_db.delete_message(thread_id, message_id)
+    chatlog_db.write_audit_log(
+        "delete", "chat_message", str(message_id), user_id="default"
+    )
+    return {"ok": True}
+
+
+# =========================
+# Thread Management
+# =========================
+
+@router.post("/{thread_id}/branch", response_model=ThreadDTO)
+def branch_thread(
+    thread_id: int,
+    body: Optional[ThreadBranchRequest] = Body(default=None),
+    api_key: str = Depends(require_api_key),
+):
+    """Create a branch (child thread) from an existing thread."""
+    payload = body or ThreadBranchRequest()
+    parent = chatlog_db.get_chat_thread(thread_id)
+    if not parent:
+        raise HTTPException(status_code=404, detail="Thread not found")
+
+    title = _normalize_thread_title(payload.title)
+    if title is None:
+        base_title = parent.get("title") or "New Chat"
+        title = f"{base_title} (branch)"
+
+    summary = _normalize_thread_summary(payload.summary)
+    if summary is None:
+        summary = parent.get("summary") or ""
+
+    project_id: Optional[int]
+    if payload.project_id is not None:
+        project_id = payload.project_id
+    else:
+        project_id = parent.get("project_id")
+        try:
+            project_id = int(project_id) if project_id is not None else None
+        except (TypeError, ValueError):
+            project_id = None
+
+    child = chatlog_db.create_chat_thread(
+        user_id=parent.get("user_id", "default"),
+        title=title,
+        summary=summary,
+        project_id=project_id,
+        parent_id=parent["id"],
+    )
+
+    chatlog_db.write_audit_log(
+        "create",
+        "chat_thread",
+        str(child["id"]),
+        user_id=child.get("user_id", "default"),
+    )
+
+    event_bus.emit_event(
+        "thread.branch",
+        {
+            "parent": {
+                "id": parent.get("id"),
+                "title": parent.get("title"),
+                "archived_at": parent.get("archived_at"),
+                "project_id": parent.get("project_id"),
+            },
+            "child": child,
+        },
+    )
+
+    return child
+
+
+@router.patch("/{thread_id}", response_model=ThreadDTO)
+def update_thread(thread_id: int, payload: ThreadUpdate, api_key: str = Depends(require_api_key)):
+    """Update thread metadata (title, summary, project, archive status)."""
+    updated = _apply_thread_update(thread_id, payload)
+    return updated
+
+
+@router.patch("/threads/{thread_id}")
+def patch_thread(thread_id: int, body: Dict[str, object] = Body(...)):
+    """Alternative PATCH endpoint for thread updates (less strict validation)."""
+    try:
+        update = ThreadUpdate(**(body or {}))
+        refreshed = _apply_thread_update(thread_id, update)
+        return {"ok": True, "thread": refreshed}
+    except ValidationError as err:
+        logger.warning("Invalid payload for thread update: %s", err)
+        return JSONResponse(
+            status_code=400,
+            content={"ok": False, "error": "Invalid payload"},
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to update chat thread %s: %s", thread_id, exc)
+        return JSONResponse(
+            status_code=500, content={"ok": False, "error": "Failed to update thread"}
+        )
+
+
+@router.delete("/{thread_id}")
+def delete_thread(thread_id: int, force: bool = Query(False)):
+    """Hard delete a thread regardless of archived state."""
+    deleted = chatlog_db.delete_thread(thread_id, force=force)
+    if not deleted:
+        raise HTTPException(
+            status_code=404,
+            detail="Thread not found or not deletable (archive first or set force=true)"
+        )
+    try:
+        event_bus.emit_event("thread.deleted", {"thread_id": thread_id})
+    except Exception:
+        pass
+    logger.info("[threads] deleted thread_id=%s", thread_id)
+    return {"ok": True}
+
+
+# =========================
+# Health endpoint
+# =========================
+
+@router.get("/health/chat", tags=["Health"])
+def health_chat():
+    """Get health status of chat subsystem."""
+    try:
+        threads = chatlog_db.count_chat_threads()
+        messages = chatlog_db.count_all_messages()
+    except Exception as _e:
+        logger.warning("[health/chat] check failed: %s", _e)
+        threads = 0
+        messages = 0
+    return {"ok": True, "threads": threads, "messages": messages}
+
+
+# =========================
+# Thread Lineage Endpoints
+# =========================
+
+threads_router = APIRouter(prefix="/threads", tags=["Threads"])
+
+
+@threads_router.get("")
+def list_threads(
+    user_id: str = Query(None, description="Filter by user_id"),
+    project_id: str = Query(None, description="Filter by project_id"),
+    api_key: str = Depends(require_api_key),
+):
+    """List all threads. Optionally filter by user or project."""
+    try:
+        items = chatlog_db.list_threads(user_id=user_id, project_id=project_id)
+        return {"threads": items}
+    except Exception as exc:
+        if (
+            "no such table" in str(exc).lower()
+            or getattr(exc, "pgcode", None) == "42P01"
+        ):
+            return {"threads": []}
+        logger.exception("Thread listing failed")
+        raise HTTPException(status_code=500, detail="Thread listing failed")
+
+
+@threads_router.post("")
+def create_thread_alias(
+    req: ThreadCreateRequest, api_key: str = Depends(require_api_key)
+):
+    """Create a new thread (alias endpoint)."""
+    thread_id = chatlog_db.create_thread(
+        parent_thread_id=req.parent_thread_id,
+        session_id=req.session_id,
+        summary=req.summary,
+        user_id=req.user_id,
+        project_id=req.project_id,
+    )
+    return {"thread_id": thread_id}
+
+
+# Single thread endpoints
+thread_router = APIRouter(prefix="/thread", tags=["Threads"])
+
+
+@thread_router.get("/{thread_id}")
+def get_thread(thread_id: int, api_key: str = Depends(require_api_key)):
+    """Get details for a specific thread by thread_id."""
+    row = chatlog_db.get_thread(thread_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="Thread not found")
+    return {
+        "thread_id": row[0],
+        "parent_thread_id": row[1],
+        "session_id": row[2],
+        "summary": row[3],
+        "created_at": row[4],
+        "user_id": row[5],
+        "project_id": row[6],
+    }
+
+
+@thread_router.get("/{thread_id}/children")
+def get_child_threads(thread_id: int, api_key: str = Depends(require_api_key)):
+    """List all child threads for a parent thread."""
+    rows = chatlog_db.get_child_threads(thread_id)
+    results = [
+        {
+            "thread_id": row.get("id"),
+            "user_id": row.get("user_id"),
+            "title": row.get("title"),
+            "summary": row.get("summary"),
+            "project_id": row.get("project_id"),
+            "parent_id": row.get("parent_id"),
+            "archived_at": row.get("archived_at"),
+            "created_at": row.get("created_at"),
+            "updated_at": row.get("updated_at"),
+        }
+        for row in rows
+    ]
+    return {"children": results}
+
+
+@thread_router.get("/{thread_id}/summary")
+def get_thread_summary(thread_id: int, api_key: str = Depends(require_api_key)):
+    """Get the summary for a thread."""
+    summary = chatlog_db.get_thread_summary(thread_id)
+    return {"thread_id": thread_id, "summary": summary}
+
+
+@thread_router.post("")
+def create_thread(req: ThreadCreateRequest, api_key: str = Depends(require_api_key)):
+    """Create a new thread with optional parent, summary, session, user, and project."""
+    thread_id = chatlog_db.create_thread(
+        parent_thread_id=req.parent_thread_id,
+        session_id=req.session_id,
+        summary=req.summary,
+        user_id=req.user_id,
+        project_id=req.project_id,
+    )
+    return {"thread_id": thread_id}

--- a/guardian/routes/connectors.py
+++ b/guardian/routes/connectors.py
@@ -1,0 +1,530 @@
+"""
+Connectors Routes
+~~~~~~~~~~~~~~~~~
+
+Management of external service connectors (GitHub, Google Drive, etc.)
+and background sync worker.
+"""
+
+import asyncio
+import datetime
+import json
+import logging
+import os
+import psycopg2
+import psycopg2.extras
+from typing import Any, Callable, Dict, List, Optional
+from fastapi import APIRouter, Body, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# Import shared context from guardian_api
+try:
+    from guardian.core import event_bus
+    from guardian.core.chat_db import ChatDB
+    from guardian.guardian_api import chatlog_db, require_api_key, PG_DSN
+    from guardian.connectors.github import sync_repo
+except ImportError as e:
+    logger.warning(f"[connectors] Import warning: {e}")
+    chatlog_db = None
+    require_api_key = lambda x: x
+    PG_DSN = None
+
+
+# Helper: recursively convert datetimes/times to ISO strings for JSON/DB
+def _jsonify(obj: Any) -> Any:
+    """Recursively convert datetimes and times into ISO strings so JSON/DB can accept them.
+    Leaves other types untouched.
+    """
+    from datetime import datetime, date, time
+    if isinstance(obj, (datetime, date, time)):
+        return obj.isoformat()
+    if isinstance(obj, dict):
+        return {k: _jsonify(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_jsonify(v) for v in obj]
+    return obj
+
+
+def _connector_status_from_env(connector_id: str) -> str:
+    """Heuristic: mark as connected if an env token that looks relevant exists.
+    Examples: GITHUB_TOKEN, GOOGLE_DRIVE_TOKEN, NOTION_TOKEN, SLACK_BOT_TOKEN, etc.
+    """
+    cid = connector_id.upper()
+    candidates = [
+        f"{cid}_TOKEN",
+        f"{cid}_API_KEY",
+        f"{cid}_KEY",
+        f"{cid}_ACCESS_TOKEN",
+    ]
+    for k in candidates:
+        if os.getenv(k):
+            return "connected"
+    return "disconnected"
+
+
+def _display_name(connector_id: str) -> str:
+    return connector_id.replace("_", " ").title()
+
+
+def _read_sync_interval(default: str = "300") -> int:
+    raw = os.getenv("CONNECTOR_SYNC_INTERVAL")
+    if raw is None:
+        raw = os.getenv("GUARDIAN_CONNECTOR_SYNC_INTERVAL", default)
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        value = int(default)
+    return max(30, value)
+
+
+CONNECTOR_REGISTRY: Dict[str, Dict[str, Any]] = {
+    "github": {
+        "id": "github",
+        "name": "GitHub",
+        "capabilities": {
+            "supportsOAuth": False,
+            "supportsApiKey": True,
+            "supportsLocal": False,
+        },
+        "requiredFields": [
+            {"key": "owner", "label": "Owner", "type": "string"},
+            {"key": "repo", "label": "Repository", "type": "string"},
+        ],
+        "scopes": ["repo", "read:org"],
+        "options": [],
+    }
+}
+
+ENABLE_CONNECTOR_WORKER = os.getenv("ENABLE_CONNECTOR_WORKER", "0").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+CONNECTOR_SYNC_INTERVAL = _read_sync_interval()
+
+_CONNECTOR_WORKER_STOP: Optional[asyncio.Event] = None
+_CONNECTOR_WORKER_TASK: Optional[asyncio.Task] = None
+
+
+class ConnectorCreate(BaseModel):
+    name: str
+    type: str
+    settings: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ConnectorUpdate(BaseModel):
+    settings: Optional[Dict[str, Any]] = None
+
+
+class ConnectorConfigFields(BaseModel):
+    fields: Dict[str, Any]
+
+
+def _required_settings_for_type(type_: str) -> List[str]:
+    if type_ == "github":
+        return ["owner", "repo"]
+    return []
+
+
+def _serialize_connector_config(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    settings = cfg.get("settings") or {}
+    meta = CONNECTOR_REGISTRY.get(cfg.get("type", ""), {})
+    last_run = cfg.get("last_run")
+    status = "disconnected"
+    last_sync_at = None
+    error_message = None
+    if last_run:
+        status_map = {
+            "succeeded": "connected",
+            "running": "running",
+            "failed": "error",
+        }
+        status = status_map.get(last_run.get("status"), "error")
+        last_sync_at = last_run.get("finished_at") or last_run.get("started_at")
+        error_message = last_run.get("error")
+    return {
+        "id": cfg.get("name"),
+        "configId": cfg.get("id"),
+        "name": cfg.get("name"),
+        "type": cfg.get("type"),
+        "settings": settings,
+        "status": status,
+        "lastRun": last_run,
+        "lastSyncAt": last_sync_at,
+        "errorMessage": error_message,
+        "auth": None,
+        "syncInterval": settings.get("syncInterval", "manual"),
+        "scopes": meta.get("scopes", []),
+        "options": meta.get("options", []),
+        "capabilities": meta.get("capabilities"),
+        "requiredFields": meta.get("requiredFields"),
+        "needsAdminSecret": False,
+    }
+
+
+def _get_connector_by_name(name: str) -> Dict[str, Any]:
+    cfg = chatlog_db.get_connector_config(name)
+    if not cfg:
+        raise HTTPException(status_code=404, detail={"error": "Connector not found"})
+    last_run = chatlog_db.get_last_connector_run(cfg["id"])
+    cfg["last_run"] = last_run
+    return cfg
+
+
+def _validate_connector_settings(type_: str, settings: Dict[str, Any]) -> None:
+    required = _required_settings_for_type(type_)
+    missing = [key for key in required if not settings.get(key)]
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": f"Missing required settings: {', '.join(missing)}"},
+        )
+
+
+def _emit_connector_event(config: Dict[str, Any], run: Dict[str, Any]) -> None:
+    payload = {
+        "connector": config.get("name"),
+        "connector_id": config.get("id"),
+        "type": config.get("type"),
+        "run_id": run.get("id"),
+        "status": run.get("status"),
+        "started_at": run.get("started_at"),
+        "finished_at": run.get("finished_at"),
+        "document_count": run.get("document_count"),
+        "error": run.get("error"),
+    }
+    # Ensure datetimes (or other non-JSON types) are serialized safely before storing
+    event_bus.emit_event("connector.sync", _jsonify(payload))
+
+
+async def _schedule_github_sync(config: Dict[str, Any]) -> None:
+    if config.get("type") != "github":
+        logger.info("[connectors] sync skipped for unsupported type %s", config.get("type"))
+        return
+    loop = asyncio.get_running_loop()
+    loop.create_task(_run_github_sync(config))
+
+
+async def _run_github_sync(config: Dict[str, Any]) -> None:
+    settings = config.get("settings") or {}
+    # Explicitly cast settings to Dict[str, Any]
+    if not isinstance(settings, dict):
+        settings = dict(settings)
+    owner = str(settings.get("owner") or "")
+    repo = str(settings.get("repo") or "")
+    if not owner or not repo:
+        logger.error("[connectors] missing owner/repo for %s", str(config.get("name")))
+        return
+    token = os.getenv("GITHUB_TOKEN")
+    loop = asyncio.get_running_loop()
+    started_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    run = await _run_db(
+        chatlog_db.create_connector_run,
+        config["id"],
+        status="running",
+        started_at=started_at,
+    )
+    run["document_count"] = 0
+    _emit_connector_event(config, run)
+    try:
+        # Explicitly typecast owner/repo to str for run_in_executor
+        docs = await loop.run_in_executor(None, sync_repo, owner, repo, token)
+        await _run_db(chatlog_db.upsert_raw_documents, config["id"], docs)
+        logger.info(
+            "[connectors] github sync stored %d docs for %s/%s",
+            len(docs),
+            str(owner),
+            str(repo),
+        )
+        finished = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        run = await _run_db(
+            chatlog_db.complete_connector_run,
+            run["id"],
+            status="succeeded",
+            finished_at=finished,
+            error=None,
+        )
+        run["document_count"] = len(docs)
+        _emit_connector_event(config, run)
+    except Exception as exc:  # pragma: no cover - network failure logging
+        logger.exception(
+            "[connectors] github sync failed for %s/%s: %s", str(owner), str(repo), exc
+        )
+        finished = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        run = await _run_db(
+            chatlog_db.complete_connector_run,
+            run["id"],
+            status="failed",
+            finished_at=finished,
+            error=str(exc),
+        )
+        run["document_count"] = 0
+        _emit_connector_event(config, run)
+
+
+def _ingest_github_for_config(connector_name: str) -> dict:
+    """Transform raw_documents for the given connector into memory_entries.
+    Dedups on (silo,key) so re-running is safe. Emits a durable outbox event.
+    """
+    dsn = os.environ.get("DATABASE_URL") or PG_DSN
+    if not dsn:
+        raise HTTPException(status_code=500, detail="DATABASE_URL not configured")
+
+    conn = psycopg2.connect(dsn)
+    conn.autocommit = False
+    cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+    # Keep any single query from hanging forever
+    try:
+        cur.execute("SET LOCAL statement_timeout = 15000")  # 15s
+    except Exception:
+        pass
+    logger.info("[ingest] begin github ingest name=%s", connector_name)
+
+    # Resolve the connector and its owner/repo
+    cur.execute(
+        """
+        SELECT id, config->>'owner' AS owner, config->>'repo' AS repo
+          FROM connector_configs
+         WHERE name = %s
+        """,
+        (connector_name,),
+    )
+    cfg = cur.fetchone()
+    if not cfg:
+        conn.rollback()
+        conn.close()
+        raise HTTPException(status_code=404, detail="Connector not found")
+
+    # Fetch raw docs for the connector
+    cur.execute(
+        """
+        SELECT id, external_id, payload::text AS payload
+          FROM raw_documents
+         WHERE config_id = %s
+         ORDER BY id
+        """,
+        (cfg["id"],),
+    )
+    rows = cur.fetchall()
+
+    inserted = 0
+    for r in rows:
+        try:
+            payload = json.loads(r["payload"]) if isinstance(r["payload"], str) else (r["payload"] or {})
+        except Exception:
+            # Skip malformed rows but continue ingesting others
+            continue
+        # Heuristic type classification
+        typ = "issue"
+        if isinstance(payload, dict):
+            if payload.get("pull_request") is not None:
+                typ = "pr"
+            elif payload.get("sha"):
+                typ = "commit"
+
+        key = f"gh:{cfg['owner']}/{cfg['repo']}:{typ}:{r['external_id']}"
+        doc = {
+            "type": typ,
+            "repo": f"{cfg['owner']}/{cfg['repo']}",
+            "external_id": r["external_id"],
+            "title": (payload or {}).get("title"),
+            "body": (payload or {}).get("body"),
+            "url": (payload or {}).get("html_url"),
+            "state": (payload or {}).get("state"),
+            "number": (payload or {}).get("number"),
+            "author": ((payload or {}).get("user") or {}).get("login"),
+            "labels": [lbl.get("name") for lbl in (payload or {}).get("labels", []) if isinstance(lbl, dict)],
+            "created_at": (payload or {}).get("created_at"),
+            "updated_at": (payload or {}).get("updated_at"),
+        }
+
+        cur.execute(
+            """
+            INSERT INTO memory_entries (silo, key, payload)
+            SELECT %s, %s, %s::json
+            WHERE NOT EXISTS (
+              SELECT 1 FROM memory_entries WHERE silo=%s AND key=%s
+            )
+            """,
+            ("github", key, json.dumps(doc), "github", key),
+        )
+        inserted += cur.rowcount
+
+    # Telemetry counts
+    cur.execute("SELECT COUNT(*) AS n FROM raw_documents WHERE config_id=%s", (cfg["id"],))
+    raw_total = int(cur.fetchone()["n"])
+    cur.execute("SELECT COUNT(*) AS n FROM memory_entries WHERE silo='github'")
+    mem_total = int(cur.fetchone()["n"])
+
+    conn.commit()
+    conn.close()
+
+    # Durable event for SSE (emit after commit so readers can see the rows)
+    event_bus.emit_event(
+        "memory.ingest",
+        {"source": "github", "connector": connector_name, "inserted": inserted}
+    )
+    logger.info(
+        "[ingest] completed github ingest name=%s inserted=%s raw_total=%s mem_total=%s",
+        connector_name, inserted, raw_total, mem_total
+    )
+    return {"inserted": inserted, "raw_total": raw_total, "mem_total": mem_total}
+
+
+async def _connector_worker(stop_event: asyncio.Event) -> None:
+    logger.info(
+        "[connectors] worker started interval=%ss (enabled=%s)",
+        CONNECTOR_SYNC_INTERVAL,
+        ENABLE_CONNECTOR_WORKER,
+    )
+    try:
+        while not stop_event.is_set():
+            configs = await _run_db(chatlog_db.list_connector_configs, "github")
+            if not configs:
+                try:
+                    await asyncio.wait_for(stop_event.wait(), timeout=CONNECTOR_SYNC_INTERVAL)
+                except asyncio.TimeoutError:
+                    continue
+                else:
+                    break
+            for cfg in configs:
+                if stop_event.is_set():
+                    break
+                await _run_github_sync(cfg)
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=CONNECTOR_SYNC_INTERVAL)
+            except asyncio.TimeoutError:
+                continue
+    except asyncio.CancelledError:  # pragma: no cover
+        logger.debug("[connectors] worker cancelled")
+        raise
+    finally:
+        logger.info("[connectors] worker stopped")
+
+
+async def _run_db(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, lambda: func(*args, **kwargs))
+
+
+router = APIRouter(prefix="/api/connectors", tags=["Connectors"])
+
+
+@router.get("")
+def list_connectors():
+    """List all connector configurations with their last run status."""
+    configs = chatlog_db.list_connector_configs_with_last_run()
+    return [_serialize_connector_config(cfg) for cfg in configs]
+
+
+@router.post("")
+def create_connector(cfg: ConnectorCreate):
+    """Create a new connector configuration."""
+    cfg_type = cfg.type.lower()
+    if cfg_type not in CONNECTOR_REGISTRY:
+        raise HTTPException(status_code=400, detail={"error": "Unsupported connector type"})
+    if chatlog_db.get_connector_config(cfg.name):
+        raise HTTPException(status_code=400, detail={"error": "Connector name already exists"})
+    _validate_connector_settings(cfg_type, cfg.settings)
+    stored = chatlog_db.create_connector_config(cfg.name, cfg_type, cfg.settings)
+    stored["last_run"] = None
+    return _serialize_connector_config(stored)
+
+
+@router.get("/{connector_name}")
+def get_connector(connector_name: str):
+    """Get a specific connector configuration by name."""
+    cfg = _get_connector_by_name(connector_name)
+    return _serialize_connector_config(cfg)
+
+
+@router.patch("/{connector_name}")
+def patch_connector(connector_name: str, update: ConnectorUpdate):
+    """Update a connector's settings."""
+    cfg = _get_connector_by_name(connector_name)
+    if update.settings is not None:
+        merged = {**(cfg.get("settings") or {}), **update.settings}
+        _validate_connector_settings(cfg["type"], merged)
+        cfg = chatlog_db.update_connector_config(connector_name, config=merged)
+        cfg["last_run"] = chatlog_db.get_last_connector_run(cfg["id"])
+    return _serialize_connector_config(cfg)
+
+
+@router.post("/{connector_name}/config")
+def update_connector_fields(connector_name: str, payload: ConnectorConfigFields):
+    """Update specific configuration fields for a connector."""
+    cfg = _get_connector_by_name(connector_name)
+    merged = {**(cfg.get("settings") or {}), **payload.fields}
+    _validate_connector_settings(cfg["type"], merged)
+    cfg = chatlog_db.update_connector_config(connector_name, config=merged)
+    cfg["last_run"] = chatlog_db.get_last_connector_run(cfg["id"])
+    return _serialize_connector_config(cfg)
+
+
+@router.post("/{connector_name}/test")
+def connector_test(connector_name: str) -> Dict[str, str]:
+    """Test a connector connection (offline mode returns stub response)."""
+    _get_connector_by_name(connector_name)
+    return {"ok": "True", "message": "Connection not validated in offline mode"}
+
+
+@router.post("/{connector_name}/sync")
+async def connector_sync(connector_name: str):
+    """Trigger a manual sync for the specified connector."""
+    cfg = _get_connector_by_name(connector_name)
+    await _schedule_github_sync(cfg)
+    return {"ok": True}
+
+
+@router.post("/{connector_name}/authorize")
+def connector_authorize_not_supported(connector_name: str):
+    """OAuth authorization endpoint (not supported for current connectors)."""
+    raise HTTPException(
+        status_code=400,
+        detail={"error": "OAuth authorization is not supported for this connector"},
+    )
+
+
+@router.get("/{connector_name}/status")
+def connector_status(connector_name: str) -> Dict[str, Any]:
+    """Get the current status of a connector including its latest run."""
+    cfg = _get_connector_by_name(connector_name)
+    serialized = _serialize_connector_config(cfg)
+    return {
+        "ok": True,
+        "connector": serialized,
+        "status": serialized.get("status"),
+        "latest_run": serialized.get("lastRun"),
+    }
+
+
+@router.post("/{name}/ingest")
+def api_ingest_connector(name: str, api_key: str = Depends(require_api_key)):
+    """One-shot transform of GitHub raw_documents -> memory_entries for this connector.
+    Returns insert count and totals; also emits a `memory.ingest` SSE event via the durable outbox.
+    """
+    try:
+        logger.info("[ingest] API request received for connector=%s", name)
+        result = _ingest_github_for_config(name)
+        logger.info("[ingest] API ingest done for connector=%s -> %s", name, result)
+        return {"ok": True, **result}
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# Health endpoint
+@router.get("/health", tags=["Health"])
+def connectors_health() -> Dict[str, object]:
+    """Get health status of all connectors."""
+    connectors = chatlog_db.list_connector_configs_with_last_run()
+    total = len(connectors)
+    healthy = 0
+    for cfg in connectors:
+        run = cfg.get("last_run")
+        if run and run.get("status") == "succeeded":
+            healthy += 1
+    return {"ok": "True", "count": total, "connected": healthy}

--- a/guardian/routes/graph.py
+++ b/guardian/routes/graph.py
@@ -1,0 +1,83 @@
+"""
+Graph Routes
+~~~~~~~~~~~~
+
+Neo4j graph visualization and health check endpoints.
+"""
+
+import os
+import logging
+from typing import Dict, Any
+from fastapi import APIRouter, HTTPException, Depends
+from neo4j import GraphDatabase
+
+logger = logging.getLogger(__name__)
+
+# Optional Neo4j driver session provider
+try:
+    from db.neo import get_session as get_neo_session
+    NEO4J_AVAILABLE = True
+except Exception as e:
+    logging.warning(f"[Codexify ⚠️] Neo4j driver not available: {e}")
+    get_neo_session = None
+    NEO4J_AVAILABLE = False
+
+router = APIRouter(tags=["Graph"])
+
+
+@router.get('/graph', summary='Return graph data from Neo4j')
+def get_graph(scope: str = 'codexify'):
+    """
+    Fetch graph data from Neo4j and return nodes and links.
+
+    Args:
+        scope: Scope for the graph query (default: 'codexify')
+
+    Returns:
+        Dictionary containing nodes and links arrays
+    """
+    uri = os.getenv('NEO4J_URI', 'bolt://neo4j:7687')
+    user = os.getenv('NEO4J_USER', 'neo4j')
+    password = os.getenv('NEO4J_PASSWORD', 'test')
+
+    try:
+        driver = GraphDatabase.driver(uri, auth=(user, password))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f'Failed to connect to Neo4j: {e}')
+
+    nodes, links = [], []
+    try:
+        with driver.session() as session:
+            result = session.run('MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 250')
+            for record in result:
+                a, r, b = record['a'], record['r'], record['b']
+                nodes.extend([
+                    {"id": a.element_id, "label": a.get('name', list(a.labels)[0] if a.labels else 'Node'), "type": list(a.labels)[0] if a.labels else 'node'},
+                    {"id": b.element_id, "label": b.get('name', list(b.labels)[0] if b.labels else 'Node'), "type": list(b.labels)[0] if b.labels else 'node'}
+                ])
+                links.append({"source": a.element_id, "target": b.element_id, "label": r.type})
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f'Graph query failed: {e}')
+    finally:
+        driver.close()
+
+    unique_nodes = list({n['id']: n for n in nodes}.values())
+    return {"nodes": unique_nodes, "links": links}
+
+
+@router.get("/health/neo4j", tags=["Health"])
+async def neo4j_health(session=Depends(get_neo_session) if NEO4J_AVAILABLE and get_neo_session else None):
+    """
+    Check Neo4j database health.
+
+    Returns:
+        Health status dictionary
+    """
+    if not NEO4J_AVAILABLE or not get_neo_session:
+        raise HTTPException(status_code=503, detail="Neo4j driver not available")
+
+    try:
+        await session.run("RETURN 1 AS ok")
+        return {"ok": True}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/guardian/routes/memory.py
+++ b/guardian/routes/memory.py
@@ -1,21 +1,440 @@
-from fastapi import APIRouter, Request
+"""
+Memory Routes
+~~~~~~~~~~~~~
+
+Memory management endpoints for ephemeral, midterm, and longterm storage.
+Includes memory pruning, search, and history retrieval.
+"""
+
+import logging
+import os
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+from fastapi import APIRouter, Body, Depends, Query, HTTPException
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-router = APIRouter()
+logger = logging.getLogger(__name__)
+
+# Import shared context
+try:
+    from guardian.guardian_api import chatlog_db, require_api_key
+except ImportError:
+    chatlog_db = None
+    require_api_key = lambda x: x
+
+# Memory retention configuration
+MEMORY_RETENTION_DAYS = int(os.getenv("MEMORY_RETENTION_DAYS", "90"))
+EPHEMERAL_MEMORY: List[Dict[str, Any]] = []
+
+# Prune expired midterm memories at startup
+try:
+    # Use timezone-aware UTC timestamps to avoid deprecation warnings
+    cutoff = (datetime.now(datetime.UTC) - timedelta(days=MEMORY_RETENTION_DAYS)).isoformat()
+    pruned = chatlog_db.prune_midterm(cutoff)
+    if pruned:
+        logger.info("[memory] pruned %d expired midterm entries", pruned)
+except Exception as _e:
+    logger.debug("[memory] prune skipped: %s", _e)
 
 
-class MemoryInput(BaseModel):
-    input: str
-    thread_id: str | None = None
-    mode: str | None = "default"
+def _silo_valid(s: str) -> bool:
+    return s in ("ephemeral", "midterm", "longterm")
 
 
-@router.post("/memory")
-async def memory_handler(data: MemoryInput, request: Request):
-    # Placeholder for now — you can wire this up to your actual logic later
+router = APIRouter(prefix="/api/memory", tags=["Memory"])
+
+
+@router.get("/{silo}")
+def memory_list(silo: str, limit: int = 50, offset: int = 0):
+    """
+    List memory entries from the specified silo.
+
+    Args:
+        silo: Memory silo (ephemeral, midterm, longterm)
+        limit: Maximum number of entries to return
+        offset: Starting offset for pagination
+
+    Returns:
+        Memory entries and total count
+    """
+    if not _silo_valid(silo):
+        return JSONResponse(
+            status_code=400, content={"ok": False, "error": "invalid silo"}
+        )
+    if silo == "ephemeral":
+        items = EPHEMERAL_MEMORY[offset : offset + limit]
+        return {"ok": True, "count": len(EPHEMERAL_MEMORY), "entries": items}
+    items = chatlog_db.list_memories(silo, limit=limit, offset=offset)
+    count = chatlog_db.count_memories(silo)
+    return {"ok": True, "count": count, "entries": items}
+
+
+@router.post("/{silo}")
+def memory_create(silo: str, body: Dict[str, object] = Body(...)):
+    """
+    Create a new memory entry in the specified silo.
+
+    Args:
+        silo: Memory silo (ephemeral, midterm, longterm)
+        body: Memory entry data with content, tags, and pinned flag
+
+    Returns:
+        Created entry ID or full entry for ephemeral
+    """
+    if not _silo_valid(silo):
+        return JSONResponse(
+            status_code=400, content={"ok": False, "error": "invalid silo"}
+        )
+    content = str(body.get("content", "")).strip()
+    tags = ",".join(body.get("tags", []) or [])
+    pinned = bool(body.get("pinned", False))
+    if not content:
+        return JSONResponse(
+            status_code=400, content={"ok": False, "error": "content required"}
+        )
+    if silo == "ephemeral":
+        entry = {
+            "id": len(EPHEMERAL_MEMORY) + 1,
+            "user_id": "default",
+            "silo": "ephemeral",
+            "content": content,
+            "tags": tags,
+            "pinned": pinned,
+            "created_at": datetime.utcnow().isoformat(),
+            "updated_at": datetime.utcnow().isoformat(),
+        }
+        EPHEMERAL_MEMORY.append(entry)
+        return {"ok": True, "entry": entry}
+    eid = chatlog_db.add_memory("default", silo, content, tags=tags, pinned=pinned)
+    chatlog_db.write_audit_log("create", "memory_entry", str(eid), user_id="default")
+    return {"ok": True, "id": eid}
+
+
+@router.patch("/{silo}/{entry_id}")
+def memory_update(silo: str, entry_id: int, body: Dict[str, object] = Body(...)):
+    """
+    Update an existing memory entry.
+
+    Args:
+        silo: Memory silo
+        entry_id: Entry ID to update
+        body: Updated fields (content, tags, pinned)
+
+    Returns:
+        Success status
+    """
+    if not _silo_valid(silo):
+        return JSONResponse(
+            status_code=400, content={"ok": False, "error": "invalid silo"}
+        )
+    if silo == "ephemeral":
+        for e in EPHEMERAL_MEMORY:
+            if e.get("id") == entry_id:
+                if "content" in body:
+                    e["content"] = str(body["content"])
+                if "tags" in body:
+                    e["tags"] = ",".join(body.get("tags", []) or [])
+                if "pinned" in body:
+                    e["pinned"] = bool(body["pinned"])
+                e["updated_at"] = datetime.utcnow().isoformat()
+                return {"ok": True}
+        return JSONResponse(
+            status_code=404, content={"ok": False, "error": "not found"}
+        )
+    chatlog_db.update_memory(
+        entry_id,
+        content=body.get("content"),
+        tags=(
+            ",".join(body.get("tags", []) or [])
+            if body.get("tags") is not None
+            else None
+        ),
+        pinned=body.get("pinned") if body.get("pinned") is not None else None,
+    )
+    chatlog_db.write_audit_log(
+        "update", "memory_entry", str(entry_id), user_id="default"
+    )
+    return {"ok": True}
+
+
+@router.delete("/{silo}/{entry_id}")
+def memory_delete(silo: str, entry_id: int):
+    """
+    Delete a memory entry.
+
+    Args:
+        silo: Memory silo
+        entry_id: Entry ID to delete
+
+    Returns:
+        Success status
+    """
+    if not _silo_valid(silo):
+        return JSONResponse(
+            status_code=400, content={"ok": False, "error": "invalid silo"}
+        )
+    if silo == "ephemeral":
+        idx = next(
+            (i for i, e in enumerate(EPHEMERAL_MEMORY) if e.get("id") == entry_id), -1
+        )
+        if idx >= 0:
+            EPHEMERAL_MEMORY.pop(idx)
+            return {"ok": True}
+        return JSONResponse(
+            status_code=404, content={"ok": False, "error": "not found"}
+        )
+    chatlog_db.delete_memory(entry_id)
+    chatlog_db.write_audit_log(
+        "delete", "memory_entry", str(entry_id), user_id="default"
+    )
+    return {"ok": True}
+
+
+# Additional memory endpoints
+
+@router.get("/health/memory", tags=["Health"])
+def health_memory():
+    """Get health status of all memory silos."""
     return {
-        "message": "Memory endpoint received.",
-        "input": data.input,
-        "thread_id": data.thread_id,
-        "mode": data.mode,
+        "ok": True,
+        "silos": {
+            "ephemeral": len(EPHEMERAL_MEMORY),
+            "midterm": chatlog_db.count_memories("midterm"),
+            "longterm": chatlog_db.count_memories("longterm"),
+        },
     }
+
+
+# GitHub-specific memory search
+github_router = APIRouter(prefix="/api/github", tags=["Memory", "GitHub"])
+
+
+@github_router.get("/search", summary="Search GitHub memory (github silo)")
+def github_memory_search(
+    query: str = Query(
+        ...,
+        description="Search query string (full‑text over GitHub issues/PRs)",
+    ),
+    repo: Optional[str] = Query(
+        None,
+        description="Optional owner/repo filter (e.g. Resonant-Jones/guardian-backend)",
+    ),
+    limit: int = Query(
+        20, ge=1, le=100, description="Maximum number of results to return"
+    ),
+    api_key: str = Depends(require_api_key),
+):
+    """
+    Search the GitHub documents that were ingested into the `memory_entries`
+    table (silo='github'). Supports an optional `repo` filter.
+    """
+    try:
+        rows = chatlog_db.search_github_memory(query, repo=repo, limit=limit)
+        results = []
+        for r in rows:
+            payload = r.get("payload") or {}
+            results.append(
+                {
+                    "id": r["id"],
+                    "key": r["key"],
+                    "repo": payload.get("repo"),
+                    "type": payload.get("type"),
+                    "title": payload.get("title"),
+                    "url": payload.get("url"),
+                    "state": payload.get("state"),
+                    "created_at": payload.get("created_at"),
+                }
+            )
+        return {"ok": True, "count": len(results), "results": results}
+    except Exception as exc:
+        logger.error("GitHub memory search failed: %s", exc)
+        raise HTTPException(
+            status_code=500, detail="GitHub memory search failed"
+        )
+
+
+# General search and history endpoints
+search_router = APIRouter(tags=["Memory"])
+
+
+@search_router.get("/search", summary="Search memory entries")
+def search(
+    query: str = Query(..., description="Search query string"),
+    limit: int = Query(10, ge=1, le=100),
+    api_key: str = Depends(require_api_key),
+):
+    """
+    Search the Guardian memory entries matching the query string.
+
+    Args:
+        query: The search query
+        limit: Maximum number of results to return
+
+    Returns:
+        List of matching memory entries
+    """
+    try:
+        rows = chatlog_db.search_memory(query, limit)
+        results = [
+            {
+                "timestamp": r["timestamp"],
+                "command": r["command"],
+                "tag": r["tag"],
+                "agent": r["agent"],
+            }
+            for r in rows
+        ]
+        logger.info(
+            f"Search performed with query: {query}, results found: {len(results)}"
+        )
+    except Exception as e:
+        logger.error(f"Search failed: {e}")
+        raise HTTPException(status_code=500, detail="Search operation failed")
+    return results
+
+
+@search_router.get("/history", summary="Retrieve history entries with optional filters")
+def history(
+    limit: int = Query(
+        10, ge=1, le=100, description="Maximum number of entries to return"
+    ),
+    tag: Optional[str] = Query(None, description="Filter by tag"),
+    agent: Optional[str] = Query(None, description="Filter by agent"),
+    start_date: Optional[str] = Query(
+        None, description="Filter entries from this date (inclusive), format YYYY-MM-DD"
+    ),
+    end_date: Optional[str] = Query(
+        None,
+        description="Filter entries up to this date (inclusive), format YYYY-MM-DD",
+    ),
+    api_key: str = Depends(require_api_key),
+):
+    """
+    Retrieve history entries from Guardian memory with optional filtering by tag, agent, and date range.
+
+    Args:
+        limit: Maximum number of entries to return
+        tag: Filter entries by tag
+        agent: Filter entries by agent
+        start_date: Filter entries from this date (inclusive)
+        end_date: Filter entries up to this date (inclusive)
+
+    Returns:
+        List of filtered history entries
+    """
+    # Validate date formats
+    start_dt = None
+    end_dt = None
+    try:
+        if start_date:
+            start_dt = datetime.strptime(start_date, "%Y-%m-%d")
+        if end_date:
+            end_dt = datetime.strptime(end_date, "%Y-%m-%d")
+    except ValueError as ve:
+        logger.error(f"Invalid date format in history filters: {ve}")
+        raise HTTPException(
+            status_code=400, detail="Invalid date format. Use YYYY-MM-DD."
+        )
+
+    try:
+        rows = chatlog_db.history_entries(limit=limit, tag=tag, agent=agent)
+        filtered_rows = []
+        for r in rows:
+            entry_dt = datetime.fromisoformat(r["timestamp"])
+            if start_dt and entry_dt < start_dt:
+                continue
+            if end_dt and entry_dt > end_dt:
+                continue
+            filtered_rows.append(r)
+        results = [
+            {
+                "timestamp": r["timestamp"],
+                "command": r["command"],
+                "tag": r["tag"],
+                "agent": r["agent"],
+            }
+            for r in filtered_rows
+        ]
+        logger.info(
+            f"History retrieved with filters - tag: {tag}, agent: {agent}, start_date: {start_date}, end_date: {end_date}, entries returned: {len(results)}"
+        )
+    except Exception as e:
+        logger.error(f"Failed to retrieve history entries: {e}")
+        raise HTTPException(
+            status_code=500, detail="Failed to retrieve history entries"
+        )
+    return results
+
+
+# Log and summarize endpoints (for memory event storage)
+
+
+class LogEntry(BaseModel):
+    command: str
+    tag: Optional[str] = None
+    agent: Optional[str] = "system"
+
+
+class SummaryEntry(BaseModel):
+    parent_id: int
+    summary: str
+    tag: Optional[str] = None
+    agent: Optional[str] = "system"
+
+
+log_router = APIRouter(tags=["Memory"])
+
+
+@log_router.post("/log", summary="Log a command entry")
+def log_entry(entry: LogEntry, api_key: str = Depends(require_api_key)):
+    """
+    Log a command entry into the Guardian memory database.
+
+    Args:
+        entry: The log entry data
+
+    Returns:
+        Confirmation message with timestamp
+    """
+    timestamp = datetime.now().isoformat()
+    try:
+        chatlog_db.insert_memory_event(
+            content=entry.command,
+            tag=entry.tag,
+            agent=entry.agent or "system",
+            type_="log",
+            parent_id=None,
+        )
+        logger.info(f"Log entry stored: {entry.command}")
+    except Exception as e:
+        logger.error(f"Failed to store log entry: {e}")
+        raise HTTPException(status_code=500, detail="Failed to store log entry")
+    return {"result": "Log stored!", "timestamp": timestamp}
+
+
+@log_router.post("/summarize", summary="Store a summary entry")
+def summarize_entry(entry: SummaryEntry, api_key: str = Depends(require_api_key)):
+    """
+    Store a summary related to a parent entry in the Guardian memory database.
+
+    Args:
+        entry: The summary entry data
+
+    Returns:
+        Confirmation message with timestamp
+    """
+    timestamp = datetime.now().isoformat()
+    try:
+        chatlog_db.insert_memory_event(
+            content=entry.summary,
+            tag=entry.tag,
+            agent=entry.agent or "system",
+            type_="summary",
+            parent_id=entry.parent_id,
+        )
+        logger.info(f"Summary entry stored for parent_id {entry.parent_id}")
+    except Exception as e:
+        logger.error(f"Failed to store summary entry: {e}")
+        raise HTTPException(status_code=500, detail="Failed to store summary entry")
+    return {"result": "Summary stored!", "timestamp": timestamp}

--- a/guardian/routes/meta.py
+++ b/guardian/routes/meta.py
@@ -1,0 +1,39 @@
+"""
+Meta / Self-Check Routes
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Self-diagnostic endpoints for quick runtime status checks.
+"""
+
+import json
+import logging
+from pathlib import Path
+from fastapi import APIRouter
+
+# Import self-check function
+try:
+    from guardian.self_check import epistemic_self_check
+except ImportError:
+    def epistemic_self_check(*args, **kwargs):
+        return {"error": "epistemic_self_check not available"}
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/meta", tags=["Meta"])
+
+
+@router.get("/selfcheck")
+async def meta_selfcheck():
+    result = epistemic_self_check(
+        intent="runtime_status",
+        available_functions=["base_operation", "query_processing"],
+        context={"system": "guardian_api"},
+    )
+    try:
+        log_dir = Path(__file__).resolve().parent.parent / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        with (log_dir / "selfcheck.jsonl").open("a", encoding="utf-8") as f:
+            f.write(json.dumps(result) + "\n")
+    except Exception as _e:
+        logger.debug("[meta] failed to write selfcheck log: %s", _e)
+    return result

--- a/guardian/routes/projects.py
+++ b/guardian/routes/projects.py
@@ -1,0 +1,102 @@
+"""
+Projects Routes
+~~~~~~~~~~~~~~~
+
+Project creation and management endpoints.
+Includes default "Loose Threads" project initialization.
+"""
+
+import logging
+from typing import Dict, Optional
+from fastapi import APIRouter, Body, Depends
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+# Import shared context
+try:
+    from guardian.guardian_api import chatlog_db, require_api_key
+except ImportError:
+    chatlog_db = None
+    require_api_key = lambda x: x
+
+
+# Helper: ensure "Loose Threads" project exists at startup
+def _ensure_loose_threads_project():
+    """
+    Ensure the default 'Loose Threads' project exists for unassigned threads.
+    This function is called at startup to create the project if it doesn't exist.
+    """
+    try:
+        chatlog_db.ensure_project(
+            "Loose Threads", "Default bucket for unassigned threads"
+        )
+        logger.info("[projects] Ensured Loose Threads project exists")
+    except Exception as e:
+        logger.warning("[projects] Failed to ensure Loose Threads project: %s", e)
+
+
+# Initialize Loose Threads project on module import
+_ensure_loose_threads_project()
+
+
+class ProjectCreate(BaseModel):
+    name: str
+    description: Optional[str] = ""
+
+
+router = APIRouter(prefix="/projects", tags=["Projects"])
+
+
+@router.patch("/{project_id}")
+def patch_project(project_id: int, body: Dict[str, object] = Body(...)):
+    """
+    Update an existing project's name or description.
+
+    Args:
+        project_id: Project ID to update
+        body: Updated fields (name, description)
+
+    Returns:
+        Success status
+    """
+    name = body.get("name")
+    description = body.get("description")
+    try:
+        chatlog_db.update_project(
+            project_id,
+            name=name if name is not None else None,
+            description=description if description is not None else None,
+        )
+        return {"ok": True}
+    except Exception as e:
+        return JSONResponse(status_code=400, content={"ok": False, "error": str(e)})
+
+
+@router.delete("/{project_id}")
+def delete_project_and_eject(project_id: int):
+    """
+    Delete a project and eject all threads back to the default project.
+
+    Args:
+        project_id: Project ID to delete
+
+    Returns:
+        Success status
+    """
+    # Eject threads from this project first
+    try:
+        chatlog_db.eject_threads_from_project(project_id)
+    except Exception as e:
+        logger.warning("eject threads failed: %s", e)
+    # Delete project row
+    try:
+        deleted = chatlog_db.delete_project(project_id)
+        if not deleted:
+            return JSONResponse(
+                status_code=404, content={"ok": False, "error": "Project not found"}
+            )
+        return {"ok": True}
+    except Exception as e:
+        return JSONResponse(status_code=400, content={"ok": False, "error": str(e)})

--- a/guardian/routes/rag_upload.py
+++ b/guardian/routes/rag_upload.py
@@ -1,0 +1,51 @@
+"""
+RAG Upload Routes
+~~~~~~~~~~~~~~~~~
+
+Upload and embed chat history for RAG (Retrieval-Augmented Generation).
+"""
+
+import logging
+from fastapi import APIRouter, File, UploadFile
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+# RAG modules import
+try:
+    from backend.rag.enhanced_rag import EnhancedRAG
+    from backend.rag.embedder import Embedder
+    from backend.rag.parser import parse_chat_history
+    RAG_AVAILABLE = True
+except Exception as e:
+    logging.warning(f"[RAG] Failed to import RAG modules: {e}")
+    RAG_AVAILABLE = False
+
+router = APIRouter(tags=["RAG"])
+
+
+@router.post("/upload-chat")
+async def upload_chat(file: UploadFile = File(...)):
+    """
+    Upload a chat history file and embed it for RAG.
+
+    Args:
+        file: Chat history file to upload
+
+    Returns:
+        Number of embedded documents or error message
+    """
+    if not RAG_AVAILABLE:
+        return JSONResponse(
+            {"error": "RAG modules not available"},
+            status_code=503
+        )
+
+    content = await file.read()
+    try:
+        text_blocks = parse_chat_history(content.decode("utf-8"))
+        embedder = Embedder()
+        results = embedder.embed_documents(text_blocks)
+        return JSONResponse({"embedded": len(results)})
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)

--- a/guardian/routes/tools.py
+++ b/guardian/routes/tools.py
@@ -1,0 +1,64 @@
+"""
+Tools Routes
+~~~~~~~~~~~~
+
+Minimal tools execution dispatcher and job status endpoints.
+"""
+
+import logging
+from typing import Any, Dict
+from uuid import uuid4
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# In-memory job registry (ok for dev; replace with persistent store for prod)
+JOBS: Dict[str, Dict[str, Any]] = {}
+
+
+class ToolRequest(BaseModel):
+    name: str
+    args: dict = Field(default_factory=dict)
+
+
+class ToolResponse(BaseModel):
+    job_id: str
+
+
+class JobStatus(BaseModel):
+    job_id: str
+    status: str
+    result: dict = Field(default_factory=dict)
+
+
+# Import API key dependency
+try:
+    from guardian.guardian_api import require_api_key
+except ImportError:
+    # Fallback for standalone usage
+    def require_api_key(api_key: str = None):
+        return api_key
+
+
+router = APIRouter(prefix="/tools", tags=["Tools"])
+
+
+@router.post("/execute", response_model=ToolResponse)
+def tools_execute(body: ToolRequest, api_key: str = Depends(require_api_key)):
+    """
+    Minimal tools dispatcher. For now, just echoes args and marks job done.
+    Replace with real tool routing/execution as needed.
+
+    Args:
+        body: Tool execution request with name and arguments
+
+    Returns:
+        Job ID for tracking execution
+    """
+    jid = str(uuid4())
+    # Example: no-op tool that returns provided args
+    result = {"ok": True, "tool": body.name, "args": body.args}
+    JOBS[jid] = {"status": "done", "result": result}
+    logger.info("Tools.execute: %s job_id=%s", body.name, jid)
+    return {"job_id": jid}


### PR DESCRIPTION
Split monolithic guardian_api.py into 9 feature-focused route modules:

- meta.py: Self-check diagnostics (/meta/selfcheck)
- graph.py: Neo4j graph endpoints (/graph, /health/neo4j)
- rag_upload.py: RAG chat upload (/upload-chat)
- tools.py: Tool execution dispatcher (/tools/execute)
- connectors.py: External service connectors (/api/connectors/*)
- memory.py: Memory management (ephemeral/midterm/longterm)
- projects.py: Project management (/projects/*)
- chat.py: Chat threads and messages (/chat/*, /threads/*, /thread/*)
- admin.py: Admin and diagnostics (/ping, /healthz, /auth/session)

All 50 routes preserved with 1:1 functionality parity. Original guardian_api.py remains unchanged for testing.

Total: 70.3 KB across 9 modules, 50 routes, 46 helper functions, 14 models

## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:

