### PR TITLE
fix(routes): Preserve /health/chat endpoint by moving to unprefixed router

### DIFF
--- a/guardian/guardian_api.py
+++ b/guardian/guardian_api.py
@@ -138,7 +138,7 @@ from transformers import (
 
 # Internal
 from guardian.config import get_settings
-from guardian.routes import agent, memory, research, threads, documents, share, federation
+from guardian.routes import agent, memory, research, threads, documents, share, federation, health
 from guardian.realtime import collaboration
 from guardian.core.auth import issue_session_token, verify_session_token, require_auth
 from guardian.context.broker import ContextBroker
@@ -627,6 +627,7 @@ def get_graph(scope: str = 'codexify'):
     return {"nodes": unique_nodes, "links": links}
 
 # Include routers for modular endpoints
+app.include_router(health.router)
 app.include_router(threads.router, prefix="/threads")
 app.include_router(research.router, prefix="/research")
 app.include_router(memory.router, prefix="/memory")
@@ -1812,7 +1813,7 @@ def memory_delete(silo: str, entry_id: int):
 
 
 # =========================
-# Health endpoints for chat/memory
+# Health endpoints for memory
 # =========================
 
 
@@ -1826,18 +1827,6 @@ def health_memory():
             "longterm": chatlog_db.count_memories("longterm"),
         },
     }
-
-
-@app.get("/health/chat")
-def health_chat():
-    try:
-        threads = chatlog_db.count_chat_threads()
-        messages = chatlog_db.count_all_messages()
-    except Exception as _e:
-        logger.warning("[health/chat] check failed: %s", _e)
-        threads = 0
-        messages = 0
-    return {"ok": True, "threads": threads, "messages": messages, "backend": DB_BACKEND}
 
 
 # =========================

--- a/guardian/routes/chat.py
+++ b/guardian/routes/chat.py
@@ -540,23 +540,6 @@ def delete_thread(thread_id: int, force: bool = Query(False)):
 
 
 # =========================
-# Health endpoint
-# =========================
-
-@router.get("/health/chat", tags=["Health"])
-def health_chat():
-    """Get health status of chat subsystem."""
-    try:
-        threads = chatlog_db.count_chat_threads()
-        messages = chatlog_db.count_all_messages()
-    except Exception as _e:
-        logger.warning("[health/chat] check failed: %s", _e)
-        threads = 0
-        messages = 0
-    return {"ok": True, "threads": threads, "messages": messages}
-
-
-# =========================
 # Thread Lineage Endpoints
 # =========================
 

--- a/guardian/routes/health.py
+++ b/guardian/routes/health.py
@@ -1,0 +1,43 @@
+"""
+Health Routes
+~~~~~~~~~~~~~
+
+Health check endpoints for monitoring subsystem status.
+Mounted without a prefix to preserve public paths like /health/chat.
+"""
+
+import logging
+from fastapi import APIRouter
+
+logger = logging.getLogger(__name__)
+
+# Import shared context
+try:
+    from guardian.guardian_api import chatlog_db, DB_BACKEND
+except ImportError as e:
+    logger.warning(f"[health] Import warning: {e}")
+    chatlog_db = None
+    DB_BACKEND = "unknown"
+
+
+# Create unprefixed router to preserve /health/chat path
+router = APIRouter(tags=["Health"])
+
+
+@router.get("/health")
+def health():
+    """Base health check endpoint for system-level monitoring."""
+    return {"status": "ok"}
+
+
+@router.get("/health/chat")
+def health_chat():
+    """Get health status of chat subsystem."""
+    try:
+        threads = chatlog_db.count_chat_threads()
+        messages = chatlog_db.count_all_messages()
+    except Exception as _e:
+        logger.warning("[health/chat] check failed: %s", _e)
+        threads = 0
+        messages = 0
+    return {"ok": True, "threads": threads, "messages": messages, "backend": DB_BACKEND}

--- a/guardian/routes/health.py
+++ b/guardian/routes/health.py
@@ -11,15 +11,6 @@ from fastapi import APIRouter
 
 logger = logging.getLogger(__name__)
 
-# Import shared context
-try:
-    from guardian.guardian_api import chatlog_db, DB_BACKEND
-except ImportError as e:
-    logger.warning(f"[health] Import warning: {e}")
-    chatlog_db = None
-    DB_BACKEND = "unknown"
-
-
 # Create unprefixed router to preserve /health/chat path
 router = APIRouter(tags=["Health"])
 
@@ -33,6 +24,11 @@ def health():
 @router.get("/health/chat")
 def health_chat():
     """Get health status of chat subsystem."""
+    # Lazy import to avoid circular dependency - guardian_api imports this module,
+    # so we can't import from it at module level. By the time this handler runs,
+    # guardian_api is fully loaded and these symbols are available.
+    from guardian.guardian_api import chatlog_db, DB_BACKEND
+
     try:
         threads = chatlog_db.count_chat_threads()
         messages = chatlog_db.count_all_messages()


### PR DESCRIPTION
- Created guardian/routes/health.py with unprefixed APIRouter
- Moved health_chat() handler from chat.py to health.py to prevent path conflicts
- Added base /health endpoint for system-level health checks
- Removed duplicate health_chat() from guardian_api.py
- Updated guardian_api.py to include health router without prefix

This ensures /health/chat remains accessible at the correct path for readiness
probes and load balancer health checks, preventing the route from becoming
/chat/health/chat when chat routes are mounted under /chat prefix.