### PR TITLE
Fix prometheus_client dependency and memory router imports

### DIFF
--- a/guardian/guardian_api.py
+++ b/guardian/guardian_api.py
@@ -508,6 +508,9 @@ from guardian.core import metrics
 metrics.set_db_backend(DB_BACKEND)
 logger.info("[metrics] Prometheus metrics initialized (db_backend=%s)", DB_BACKEND)
 
+# Bind memory route dependencies (after chatlog_db and require_api_key are initialized)
+memory.bind_dependencies(chatlog_db_instance=chatlog_db, require_api_key_func=require_api_key)
+
 # Initialize shared ContextBroker dependencies (vector store + sensors)
 _vector_store = VectorStore()
 _sensors = Sensors(chatlog_db)

--- a/guardian/routes/memory.py
+++ b/guardian/routes/memory.py
@@ -16,12 +16,26 @@ from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
-# Import shared context
-try:
-    from guardian.guardian_api import chatlog_db, require_api_key
-except ImportError:
-    chatlog_db = None
-    require_api_key = lambda x: x
+# Import shared context (initialized as None, bound later via bind_dependencies)
+chatlog_db = None
+require_api_key = lambda x: x
+
+
+def bind_dependencies(*, chatlog_db_instance, require_api_key_func):
+    """
+    Bind runtime dependencies for memory routes.
+
+    This function should be called after guardian_api initializes its globals
+    to ensure memory routes have access to the database and auth function.
+
+    Args:
+        chatlog_db_instance: Initialized ChatDB instance
+        require_api_key_func: API key validation dependency function
+    """
+    global chatlog_db, require_api_key
+    chatlog_db = chatlog_db_instance
+    require_api_key = require_api_key_func
+    logger.info("[memory] dependencies bound successfully")
 
 
 # User context dependency for extracting user ID from request headers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "typer>=0.12.3",
     "slowapi>=0.1.8",
     "fastapi-security-headers>=1.3.0",
+    "prometheus-client>=0.20.0",
 ]
 requires-python = ">=3.10"
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -10,6 +10,7 @@ python-dotenv
 pydantic-settings
 structlog
 redis
+prometheus-client>=0.20.0
 
 # Core Utils
 requests


### PR DESCRIPTION
…ation

1. Dependencies:
   - Added prometheus-client>=0.20.0 to pyproject.toml
   - Added prometheus-client>=0.20.0 to requirements/base.in
   - Fixes ModuleNotFoundError when importing guardian.core.metrics

2. Memory Router Import Order Fix:
   - Added bind_dependencies() function to guardian/routes/memory.py
   - Memory router now properly binds chatlog_db and require_api_key after initialization
   - Called bind_dependencies() in guardian_api.py after globals are initialized
   - Prevents AttributeError and ensures proper API key validation

This ensures that:
- Prometheus metrics endpoint (/metrics) works without import errors
- Memory routes (/api/memory/*) have proper access to chatlog_db
- API key authentication works correctly on memory endpoints

## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:

