### PR TITLE
feat: implement dual-ingestion ChatGPT migration flow

### DIFF
--- a/backend/rag/chatgpt_migration.py
+++ b/backend/rag/chatgpt_migration.py
@@ -1,0 +1,372 @@
+"""
+ChatGPT Migration Module - Dual Ingestion
+==========================================
+
+Provides reusable functions for parsing ChatGPT conversation exports and
+ingesting them into both Neo4j (graph) and Chroma (vector store).
+
+This module is used by:
+- The CLI import script (scripts/chatgpt_import/import_chatgpt.py)
+- The HTTP endpoint for drag-and-drop ChatGPT import (guardian/routes/rag_upload.py)
+"""
+
+import json
+import logging
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def parse_chatgpt_export(raw_bytes: bytes) -> Iterable[Dict[str, Any]]:
+    """
+    Parse a ChatGPT-style export (OpenAI conversations JSON) into normalized conversations.
+
+    Args:
+        raw_bytes: Raw bytes of a ChatGPT export JSON file
+
+    Returns:
+        Iterable of normalized conversations with structure:
+        [
+          {
+            "thread_id": str,
+            "title": str | None,
+            "messages": [
+              {
+                "id": str,
+                "parent_id": str | None,
+                "role": str,
+                "content": str,
+                "timestamp": float | None,
+              }, ...
+            ]
+          }, ...
+        ]
+
+    Raises:
+        ValueError: If the export cannot be parsed or is invalid
+    """
+    try:
+        data = json.loads(raw_bytes.decode("utf-8"))
+    except Exception as e:
+        raise ValueError(f"Failed to parse ChatGPT export JSON: {e}")
+
+    # Handle both array format and single conversation format
+    if isinstance(data, dict):
+        conversations = [data]
+    elif isinstance(data, list):
+        conversations = data
+    else:
+        raise ValueError("ChatGPT export must be a JSON object or array")
+
+    normalized = []
+
+    for convo in conversations:
+        # Extract thread info
+        thread_id = convo.get("id") or convo.get("conversation_id")
+        if not thread_id:
+            # Generate a fallback ID if none exists
+            thread_id = f"thread_{hash(str(convo))}"
+
+        title = convo.get("title", "Untitled Thread")
+        create_time = convo.get("create_time")
+        update_time = convo.get("update_time")
+
+        # Parse messages from the mapping structure
+        mapping = convo.get("mapping", {})
+        messages = []
+
+        for node_id, node in mapping.items():
+            msg = node.get("message")
+            if not msg:
+                continue
+
+            # Extract message content
+            message_id = msg.get("id", node_id)
+            content_obj = msg.get("content", {})
+
+            # Handle different content formats
+            if isinstance(content_obj, dict):
+                parts = content_obj.get("parts", [])
+            elif isinstance(content_obj, list):
+                parts = content_obj
+            else:
+                parts = [str(content_obj)] if content_obj else []
+
+            # Join all parts into single content string
+            content = "\n".join(str(part) for part in parts if part)
+
+            # Skip empty messages
+            if not content.strip():
+                continue
+
+            # Extract metadata
+            author = msg.get("author", {})
+            role = author.get("role", "unknown") if isinstance(author, dict) else str(author)
+            author_name = author.get("name", role) if isinstance(author, dict) else role
+
+            # Extract parent relationship
+            parent_id = node.get("parent")
+            # Resolve parent to actual message ID if it exists in mapping
+            if parent_id and parent_id in mapping:
+                parent_msg = mapping[parent_id].get("message")
+                if parent_msg:
+                    parent_id = parent_msg.get("id", parent_id)
+                else:
+                    parent_id = None
+            else:
+                parent_id = None
+
+            # Normalize timestamp
+            timestamp = msg.get("create_time")
+
+            messages.append({
+                "id": message_id,
+                "parent_id": parent_id,
+                "role": role,
+                "author_name": author_name,
+                "content": content,
+                "timestamp": timestamp,
+            })
+
+        normalized.append({
+            "thread_id": thread_id,
+            "title": title,
+            "create_time": create_time,
+            "update_time": update_time,
+            "messages": messages,
+        })
+
+    return normalized
+
+
+def _normalize_timestamp(ts: Any) -> str:
+    """
+    Normalize various timestamp formats to ISO format.
+
+    Args:
+        ts: Timestamp (unix timestamp, ISO string, or None)
+
+    Returns:
+        ISO formatted timestamp string
+    """
+    if ts is None:
+        return datetime.utcnow().isoformat()
+
+    try:
+        # Try parsing as unix timestamp
+        if isinstance(ts, (int, float)):
+            return datetime.utcfromtimestamp(ts).isoformat()
+        # Try parsing as ISO string
+        elif isinstance(ts, str):
+            return datetime.fromisoformat(ts.replace('Z', '+00:00')).isoformat()
+        else:
+            return datetime.utcnow().isoformat()
+    except Exception:
+        return datetime.utcnow().isoformat()
+
+
+def ingest_chatgpt_export(
+    raw_bytes: bytes,
+    user_id: Optional[str] = None,
+) -> Dict[str, int]:
+    """
+    Ingest a ChatGPT export into both Neo4j (graph) and Chroma (vector store).
+
+    This function:
+    1. Parses the export via parse_chatgpt_export()
+    2. Writes threads/messages into Neo4j with proper relationships
+    3. Embeds messages into Chroma via the existing embedder abstraction
+
+    Args:
+        raw_bytes: Raw bytes of the ChatGPT export JSON file
+        user_id: Optional user ID to associate with the imported data
+
+    Returns:
+        Statistics dictionary:
+        {
+            "threads_imported": int,
+            "messages_imported": int,
+        }
+
+    Raises:
+        ValueError: If the export cannot be parsed
+        RuntimeError: If Neo4j or Chroma operations fail
+    """
+    # Parse the export
+    logger.info("Parsing ChatGPT export...")
+    conversations = list(parse_chatgpt_export(raw_bytes))
+    logger.info(f"Parsed {len(conversations)} conversation(s)")
+
+    stats = {
+        "threads_imported": 0,
+        "messages_imported": 0,
+    }
+
+    # Phase 1: Import to Neo4j
+    logger.info("Starting Neo4j import...")
+    try:
+        from guardian.db.neo import get_session
+
+        with get_session() as session:
+            for convo in conversations:
+                thread_id = convo["thread_id"]
+                title = convo["title"]
+                create_time = _normalize_timestamp(convo.get("create_time"))
+                update_time = _normalize_timestamp(convo.get("update_time"))
+
+                # Create thread node
+                session.run(
+                    """
+                    MERGE (t:Thread {id: $id})
+                    SET t.title = $title,
+                        t.created_at = $created_at,
+                        t.updated_at = $updated_at
+                    """,
+                    {
+                        "id": thread_id,
+                        "title": title,
+                        "created_at": create_time,
+                        "updated_at": update_time,
+                    },
+                )
+                stats["threads_imported"] += 1
+
+                # Create messages and relationships
+                for msg in convo["messages"]:
+                    message_id = msg["id"]
+                    role = msg["role"]
+                    content = msg["content"]
+                    author_name = msg.get("author_name", role)
+                    created = _normalize_timestamp(msg.get("timestamp"))
+
+                    # Create message node
+                    session.run(
+                        """
+                        MERGE (m:Message {id: $mid})
+                        SET m.role = $role,
+                            m.content = $content,
+                            m.created_at = $created,
+                            m.author_name = $author_name
+                        """,
+                        {
+                            "mid": message_id,
+                            "role": role,
+                            "content": content,
+                            "created": created,
+                            "author_name": author_name,
+                        },
+                    )
+                    stats["messages_imported"] += 1
+
+                    # Link message to thread
+                    session.run(
+                        """
+                        MATCH (t:Thread {id: $tid}), (m:Message {id: $mid})
+                        MERGE (t)-[:CONTAINS]->(m)
+                        """,
+                        {"tid": thread_id, "mid": message_id},
+                    )
+
+                    # Create author node and relationship
+                    if author_name:
+                        session.run(
+                            """
+                            MERGE (a:Author {name: $name, role: $role})
+                            WITH a
+                            MATCH (m:Message {id: $mid})
+                            MERGE (a)-[:AUTHORED]->(m)
+                            """,
+                            {"name": author_name, "role": role, "mid": message_id},
+                        )
+
+                    # Create parent-child relationships
+                    parent_id = msg.get("parent_id")
+                    if parent_id:
+                        session.run(
+                            """
+                            MATCH (p:Message {id: $parent}), (c:Message {id: $child})
+                            MERGE (p)-[:REPLIED_WITH]->(c)
+                            """,
+                            {"parent": parent_id, "child": message_id},
+                        )
+
+        logger.info(f"Neo4j import complete: {stats['threads_imported']} threads, {stats['messages_imported']} messages")
+
+    except Exception as e:
+        logger.error(f"Neo4j import failed: {e}")
+        raise RuntimeError(f"Failed to import to Neo4j: {e}")
+
+    # Phase 2: Import to Chroma
+    logger.info("Starting Chroma import...")
+    try:
+        from guardian.runtime.embed.embedder import CodexifyEmbedder
+        import os
+
+        # Collect all messages for embedding
+        all_messages = []
+        for convo in conversations:
+            thread_id = convo["thread_id"]
+            for msg in convo["messages"]:
+                message_id = msg["id"]
+                content = msg["content"]
+                role = msg["role"]
+                timestamp = msg.get("timestamp")
+
+                all_messages.append({
+                    "id": f"chatgpt::{message_id}",
+                    "content": content,
+                    "metadata": {
+                        "thread_id": thread_id,
+                        "message_id": message_id,
+                        "role": role,
+                        "timestamp": _normalize_timestamp(timestamp),
+                        "source": "chatgpt_export",
+                        "user_id": user_id or "unknown",
+                    },
+                })
+
+        if all_messages:
+            # Use OpenAI embeddings if available, otherwise fall back to local
+            use_openai = bool(os.getenv("OPENAI_API_KEY"))
+            chroma_path = os.getenv("CHROMA_PATH") or os.getenv("CODEXIFY_CHROMA_PATH", "./.chroma")
+
+            embedder = CodexifyEmbedder(
+                use_openai=use_openai,
+                store="chroma",
+                chroma_path=chroma_path,
+                collection="chat_history",
+            )
+
+            # Embed and index
+            docs = [msg["content"] for msg in all_messages]
+            metadatas = [msg["metadata"] for msg in all_messages]
+            ids_prefix = "chatgpt"
+
+            # The CodexifyEmbedder.embed_and_index method uses auto-generated IDs,
+            # but we want to use our custom IDs. So we'll use the lower-level API:
+            vectors = embedder.embed_texts(docs)
+
+            # Store directly in Chroma with our custom IDs
+            import chromadb
+            client = chromadb.PersistentClient(path=chroma_path)
+            collection = client.get_or_create_collection(name="chat_history")
+
+            # Use our custom IDs
+            custom_ids = [msg["id"] for msg in all_messages]
+            collection.upsert(
+                ids=custom_ids,
+                embeddings=vectors,
+                documents=docs,
+                metadatas=metadatas,
+            )
+
+            logger.info(f"Chroma import complete: {len(all_messages)} messages embedded")
+        else:
+            logger.warning("No messages to embed")
+
+    except Exception as e:
+        logger.warning(f"Chroma import failed (graph data was saved): {e}")
+        # Don't raise - graph import already succeeded
+
+    return stats

--- a/guardian/routes/rag_upload.py
+++ b/guardian/routes/rag_upload.py
@@ -3,10 +3,12 @@ RAG Upload Routes
 ~~~~~~~~~~~~~~~~~
 
 Upload and embed chat history for RAG (Retrieval-Augmented Generation).
+Includes specialized ChatGPT export migration endpoint.
 """
 
 import logging
-from fastapi import APIRouter, File, UploadFile
+from typing import Optional
+from fastapi import APIRouter, File, UploadFile, Header
 from fastapi.responses import JSONResponse
 
 logger = logging.getLogger(__name__)
@@ -20,6 +22,14 @@ try:
 except Exception as e:
     logging.warning(f"[RAG] Failed to import RAG modules: {e}")
     RAG_AVAILABLE = False
+
+# ChatGPT migration module import
+try:
+    from backend.rag.chatgpt_migration import ingest_chatgpt_export
+    CHATGPT_MIGRATION_AVAILABLE = True
+except Exception as e:
+    logging.warning(f"[RAG] Failed to import ChatGPT migration module: {e}")
+    CHATGPT_MIGRATION_AVAILABLE = False
 
 router = APIRouter(tags=["RAG"])
 
@@ -49,3 +59,117 @@ async def upload_chat(file: UploadFile = File(...)):
         return JSONResponse({"embedded": len(results)})
     except Exception as e:
         return JSONResponse({"error": str(e)}, status_code=500)
+
+
+@router.post("/upload-chatgpt-export")
+async def upload_chatgpt_export(
+    file: UploadFile = File(...),
+    x_user_id: Optional[str] = Header(None, alias="X-User-Id"),
+):
+    """
+    Migrate a ChatGPT-style JSON export (OpenAI conversations export)
+    into BOTH Neo4j (graph) and Chroma (vector store).
+
+    This endpoint enables a drag-and-drop "Import from ChatGPT" UI experience,
+    ingesting conversations into the full Codexify knowledge graph and vector store.
+
+    Args:
+        file: ChatGPT export JSON file
+        x_user_id: Optional user ID from request header
+
+    Returns:
+        JSON response with import statistics:
+        {
+          "status": "ok",
+          "threads_imported": N,
+          "messages_imported": M
+        }
+
+    Raises:
+        503: If ChatGPT migration module is not available
+        400: If file is invalid or cannot be parsed
+        500: If import operation fails
+    """
+    if not CHATGPT_MIGRATION_AVAILABLE:
+        logger.error("ChatGPT migration module not available")
+        return JSONResponse(
+            {
+                "status": "error",
+                "error": "ChatGPT migration module not available",
+                "details": "The backend.rag.chatgpt_migration module could not be loaded"
+            },
+            status_code=503
+        )
+
+    # Validate content type
+    content_type = file.content_type or ""
+    valid_types = ["application/json", "text/json", "application/octet-stream"]
+    if not any(ct in content_type.lower() for ct in valid_types):
+        # Allow files with no content type if they have .json extension
+        if not (file.filename and file.filename.endswith(".json")):
+            logger.warning(f"Invalid content type for ChatGPT export: {content_type}")
+            return JSONResponse(
+                {
+                    "status": "error",
+                    "error": "Invalid file type",
+                    "details": "Please upload a JSON file exported from ChatGPT/OpenAI"
+                },
+                status_code=400
+            )
+
+    # Read file bytes
+    try:
+        raw_bytes = await file.read()
+        logger.info(f"Received ChatGPT export upload: {len(raw_bytes)} bytes, user_id={x_user_id}")
+    except Exception as e:
+        logger.error(f"Failed to read uploaded file: {e}")
+        return JSONResponse(
+            {
+                "status": "error",
+                "error": "Failed to read file",
+                "details": str(e)
+            },
+            status_code=400
+        )
+
+    # Perform dual-ingestion
+    try:
+        stats = ingest_chatgpt_export(raw_bytes, user_id=x_user_id)
+
+        logger.info(
+            f"ChatGPT export import successful: "
+            f"{stats['threads_imported']} threads, "
+            f"{stats['messages_imported']} messages"
+        )
+
+        return JSONResponse(
+            {
+                "status": "ok",
+                "threads_imported": stats["threads_imported"],
+                "messages_imported": stats["messages_imported"],
+            }
+        )
+
+    except ValueError as e:
+        # Parsing errors
+        logger.error(f"Failed to parse ChatGPT export: {e}")
+        return JSONResponse(
+            {
+                "status": "error",
+                "error": "Invalid ChatGPT export format",
+                "details": str(e)
+            },
+            status_code=400
+        )
+
+    except Exception as e:
+        # Other errors (Neo4j connection, Chroma, etc.)
+        logger.error(f"ChatGPT export import failed: {e}", exc_info=True)
+        return JSONResponse(
+            {
+                "status": "error",
+                "error": "Import operation failed",
+                "details": str(e)
+            },
+            status_code=500
+        )

--- a/scripts/chatgpt_import/import_chatgpt.py
+++ b/scripts/chatgpt_import/import_chatgpt.py
@@ -18,63 +18,14 @@ Usage:
     python scripts/chatgpt_import/import_chatgpt.py
 """
 
-import json
 import os
 import sys
 import time
-from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
 
 from dotenv import load_dotenv
 
 # Third-party imports with graceful fallback
-try:
-    from neo4j import GraphDatabase
-except ImportError:
-    print("❌ Error: neo4j package not found. Please install with: pip install neo4j")
-    sys.exit(1)
-
-try:
-    from openai import OpenAI
-except ImportError:
-    print("❌ Error: openai package not found. Please install with: pip install openai")
-    sys.exit(1)
-
-try:
-    import chromadb
-except ImportError:
-    print("❌ Error: chromadb package not found. Please install with: pip install chromadb")
-    sys.exit(1)
-
-try:
-    from tqdm import tqdm
-except ImportError:
-    # Fallback to simple progress indicator if tqdm not available
-    class tqdm:
-        """Minimal tqdm replacement for when package isn't installed."""
-        def __init__(self, iterable, desc="", **kwargs):
-            self.iterable = iterable
-            self.desc = desc
-            self.total = len(iterable) if hasattr(iterable, '__len__') else None
-            self.n = 0
-
-        def __iter__(self):
-            print(f"{self.desc}...", flush=True)
-            for item in self.iterable:
-                self.n += 1
-                if self.total:
-                    if self.n % max(1, self.total // 10) == 0:
-                        print(f"  Progress: {self.n}/{self.total}", flush=True)
-                yield item
-            print(f"  ✓ {self.desc} complete", flush=True)
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *args):
-            pass
-
 try:
     from colorama import Fore, Style, init as colorama_init
     colorama_init(autoreset=True)
@@ -89,22 +40,24 @@ except ImportError:
     HAS_COLOR = False
 
 
+# Add project root to path to import backend modules
+project_root = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+# Import the dual-ingestion module
+try:
+    from backend.rag.chatgpt_migration import ingest_chatgpt_export
+except ImportError as e:
+    print(f"❌ Error: Could not import migration module: {e}")
+    print("   Make sure you're running from the project root.")
+    sys.exit(1)
+
+
 # Load environment variables
 load_dotenv()
 
 # Configuration
-NEO4J_URL = os.getenv("NEO4J_URL", "bolt://localhost:7687")
-NEO4J_USER = os.getenv("NEO4J_USER", "neo4j")
-NEO4J_PASS = os.getenv("NEO4J_PASS", "password")
-
-CHROMA_PATH = os.getenv("CHROMA_PATH", "./chroma")
 CHATGPT_FILE = os.getenv("CHATGPT_EXPORT_FILE", "./chatgpt_conversation.json")
-
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-BATCH_SIZE = int(os.getenv("EMBED_BATCH_SIZE", "20"))
-
-# Logging configuration
-SKIP_LOG_FILE = Path("logs/migration_skipped.json")
 
 
 def print_colored(message: str, color: str = ""):
@@ -113,316 +66,6 @@ def print_colored(message: str, color: str = ""):
         print(f"{color}{message}{Style.RESET_ALL}")
     else:
         print(message)
-
-
-def normalize_timestamp(ts: Any) -> str:
-    """
-    Normalize various timestamp formats to ISO format.
-
-    Args:
-        ts: Timestamp (unix timestamp, ISO string, or None)
-
-    Returns:
-        ISO formatted timestamp string
-    """
-    if ts is None:
-        return datetime.utcnow().isoformat()
-
-    try:
-        # Try parsing as unix timestamp
-        if isinstance(ts, (int, float)):
-            return datetime.utcfromtimestamp(ts).isoformat()
-        # Try parsing as ISO string
-        elif isinstance(ts, str):
-            return datetime.fromisoformat(ts.replace('Z', '+00:00')).isoformat()
-        else:
-            return datetime.utcnow().isoformat()
-    except Exception:
-        return datetime.utcnow().isoformat()
-
-
-def batch(iterable: List[Any], size: int = 20) -> List[List[Any]]:
-    """
-    Split an iterable into batches of specified size.
-
-    Args:
-        iterable: List to batch
-        size: Batch size
-
-    Yields:
-        Batches of items
-    """
-    for i in range(0, len(iterable), size):
-        yield iterable[i : i + size]
-
-
-def load_chatgpt_export(file_path: str) -> List[Dict[str, Any]]:
-    """
-    Load and validate ChatGPT export JSON file.
-
-    Args:
-        file_path: Path to ChatGPT export file
-
-    Returns:
-        List of conversation dictionaries
-
-    Raises:
-        FileNotFoundError: If file doesn't exist
-        json.JSONDecodeError: If file is not valid JSON
-    """
-    path = Path(file_path)
-    if not path.exists():
-        raise FileNotFoundError(
-            f"ChatGPT export file not found: {file_path}\n"
-            f"Please export your ChatGPT conversations and place them at: {path.absolute()}"
-        )
-
-    with open(path, 'r', encoding='utf-8') as f:
-        data = json.load(f)
-
-    # Handle both array format and single conversation format
-    if isinstance(data, dict):
-        data = [data]
-
-    return data
-
-
-def import_to_neo4j(driver, conversations: List[Dict[str, Any]]) -> Tuple[int, int, int]:
-    """
-    Import conversations to Neo4j graph database.
-
-    Args:
-        driver: Neo4j driver instance
-        conversations: List of conversation dictionaries
-
-    Returns:
-        Tuple of (threads_count, messages_count, relationships_count)
-    """
-    threads_count = 0
-    messages_count = 0
-    relationships_count = 0
-
-    with driver.session() as session:
-        for convo in tqdm(conversations, desc=f"{Fore.CYAN}📊 Importing to Neo4j"):
-            # Extract thread info
-            thread_id = convo.get("id") or convo.get("conversation_id") or f"thread_{hash(str(convo))}"
-            title = convo.get("title", "Untitled Thread")
-            create_time = normalize_timestamp(convo.get("create_time"))
-            update_time = normalize_timestamp(convo.get("update_time"))
-
-            # Create thread node
-            session.run(
-                """
-                MERGE (t:Thread {id: $id})
-                SET t.title = $title,
-                    t.created_at = $created_at,
-                    t.updated_at = $updated_at
-                """,
-                {
-                    "id": thread_id,
-                    "title": title,
-                    "created_at": create_time,
-                    "updated_at": update_time,
-                },
-            )
-            threads_count += 1
-
-            # Extract and process messages
-            mapping = convo.get("mapping", {})
-
-            for node_id, node in mapping.items():
-                msg = node.get("message")
-                if not msg:
-                    continue
-
-                # Extract message content
-                message_id = msg.get("id", node_id)
-                content_obj = msg.get("content", {})
-
-                # Handle different content formats
-                if isinstance(content_obj, dict):
-                    parts = content_obj.get("parts", [])
-                elif isinstance(content_obj, list):
-                    parts = content_obj
-                else:
-                    parts = [str(content_obj)] if content_obj else []
-
-                # Join all parts into single content string
-                content = "\n".join(str(part) for part in parts if part)
-
-                # Skip empty messages
-                if not content.strip():
-                    continue
-
-                # Extract metadata
-                author = msg.get("author", {})
-                role = author.get("role", "unknown") if isinstance(author, dict) else str(author)
-                author_name = author.get("name", role) if isinstance(author, dict) else role
-                created = normalize_timestamp(msg.get("create_time"))
-
-                # Create message node
-                session.run(
-                    """
-                    MERGE (m:Message {id: $mid})
-                    SET m.role = $role,
-                        m.content = $content,
-                        m.created_at = $created,
-                        m.author_name = $author_name
-                    """,
-                    {
-                        "mid": message_id,
-                        "role": role,
-                        "content": content,
-                        "created": created,
-                        "author_name": author_name,
-                    },
-                )
-                messages_count += 1
-
-                # Link message to thread
-                session.run(
-                    """
-                    MATCH (t:Thread {id: $tid}), (m:Message {id: $mid})
-                    MERGE (t)-[:CONTAINS]->(m)
-                    """,
-                    {"tid": thread_id, "mid": message_id},
-                )
-                relationships_count += 1
-
-                # Create author node and relationship
-                if author_name:
-                    session.run(
-                        """
-                        MERGE (a:Author {name: $name, role: $role})
-                        WITH a
-                        MATCH (m:Message {id: $mid})
-                        MERGE (a)-[:AUTHORED]->(m)
-                        """,
-                        {"name": author_name, "role": role, "mid": message_id},
-                    )
-                    relationships_count += 1
-
-                # Create parent-child relationships
-                parent_id = node.get("parent")
-                if parent_id and parent_id in mapping:
-                    parent_msg = mapping[parent_id].get("message")
-                    if parent_msg:
-                        parent_msg_id = parent_msg.get("id", parent_id)
-                        session.run(
-                            """
-                            MATCH (p:Message {id: $parent}), (c:Message {id: $child})
-                            MERGE (p)-[:REPLIED_WITH]->(c)
-                            """,
-                            {"parent": parent_msg_id, "child": message_id},
-                        )
-                        relationships_count += 1
-
-    return threads_count, messages_count, relationships_count
-
-
-def import_embeddings_to_chroma(
-    client,
-    collection,
-    conversations: List[Dict[str, Any]],
-    batch_size: int = 20
-) -> Tuple[int, int]:
-    """
-    Generate embeddings and import to Chroma vector database.
-
-    Args:
-        client: OpenAI client instance
-        collection: Chroma collection
-        conversations: List of conversation dictionaries
-        batch_size: Number of texts to embed per batch
-
-    Returns:
-        Tuple of (successful_count, failed_count)
-    """
-    # Extract all message texts with IDs
-    all_texts: List[Tuple[str, str]] = []
-    skipped_messages: List[Dict[str, Any]] = []
-
-    for convo in conversations:
-        mapping = convo.get("mapping", {})
-        for node_id, node in mapping.items():
-            msg = node.get("message")
-            if not msg:
-                continue
-
-            message_id = msg.get("id", node_id)
-            content_obj = msg.get("content", {})
-
-            # Handle different content formats
-            if isinstance(content_obj, dict):
-                parts = content_obj.get("parts", [])
-            elif isinstance(content_obj, list):
-                parts = content_obj
-            else:
-                parts = [str(content_obj)] if content_obj else []
-
-            content = "\n".join(str(part) for part in parts if part)
-
-            if content.strip():
-                all_texts.append((message_id, content))
-
-    if not all_texts:
-        print_colored("⚠️  No messages found to embed", Fore.YELLOW)
-        return 0, 0
-
-    print_colored(f"💫 Reawakening your Companion... Embedding {len(all_texts)} messages", Fore.MAGENTA)
-
-    successful_count = 0
-    failed_count = 0
-
-    # Process in batches
-    batches = list(batch(all_texts, batch_size))
-
-    for chunk in tqdm(batches, desc=f"{Fore.GREEN}🧠 Generating embeddings"):
-        ids, texts = zip(*chunk)
-
-        try:
-            # Generate embeddings using OpenAI
-            response = client.embeddings.create(
-                model="text-embedding-3-small",
-                input=list(texts)
-            )
-
-            # Extract embedding vectors
-            vectors = [embedding.embedding for embedding in response.data]
-
-            # Add to Chroma collection
-            collection.add(
-                ids=list(ids),
-                embeddings=vectors,
-                documents=list(texts),
-                metadatas=[{"source": "chatgpt_import"} for _ in ids]
-            )
-
-            successful_count += len(ids)
-
-        except Exception as e:
-            print_colored(f"⚠️  Batch failed: {e}", Fore.YELLOW)
-            print_colored(f"   Skipping {len(ids)} messages in this batch", Fore.YELLOW)
-
-            # Log skipped messages
-            for msg_id, text in zip(ids, texts):
-                skipped_messages.append({
-                    "id": msg_id,
-                    "content_preview": text[:100] + "..." if len(text) > 100 else text,
-                    "error": str(e),
-                    "timestamp": datetime.utcnow().isoformat()
-                })
-
-            failed_count += len(ids)
-
-    # Save skipped messages log if any
-    if skipped_messages:
-        SKIP_LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
-        with open(SKIP_LOG_FILE, 'w', encoding='utf-8') as f:
-            json.dump(skipped_messages, f, indent=2)
-        print_colored(f"📝 Logged {len(skipped_messages)} skipped messages to {SKIP_LOG_FILE}", Fore.YELLOW)
-
-    return successful_count, failed_count
 
 
 def import_chatgpt():
@@ -440,77 +83,44 @@ def import_chatgpt():
     # Validate configuration
     print_colored("🔍 Validating configuration...", Fore.CYAN)
 
-    if not Path(CHATGPT_FILE).exists():
+    chatgpt_path = Path(CHATGPT_FILE)
+    if not chatgpt_path.exists():
         print_colored(f"❌ ChatGPT export file not found: {CHATGPT_FILE}", Fore.RED)
         print_colored(f"   Please set CHATGPT_EXPORT_FILE in .env or place file at default location", Fore.RED)
         sys.exit(1)
 
-    if not OPENAI_API_KEY:
-        print_colored("⚠️  OPENAI_API_KEY not set - embeddings will fail", Fore.YELLOW)
-        print_colored("   Graph import will continue, but no embeddings will be created", Fore.YELLOW)
+    # Check for OpenAI API key
+    if not os.getenv("OPENAI_API_KEY"):
+        print_colored("⚠️  OPENAI_API_KEY not set - will use local embeddings if available", Fore.YELLOW)
+        print_colored("   Set OPENAI_API_KEY for better embedding quality", Fore.YELLOW)
 
-    # Load conversations
+    # Load the file
     print_colored(f"📂 Loading ChatGPT export from: {CHATGPT_FILE}", Fore.CYAN)
     try:
-        conversations = load_chatgpt_export(CHATGPT_FILE)
-        print_colored(f"✅ Loaded {len(conversations)} conversation thread(s)", Fore.GREEN)
+        with open(chatgpt_path, 'rb') as f:
+            raw_bytes = f.read()
+        print_colored(f"✅ Loaded file ({len(raw_bytes)} bytes)", Fore.GREEN)
     except Exception as e:
         print_colored(f"❌ Failed to load export file: {e}", Fore.RED)
         sys.exit(1)
 
-    # Phase 1: Import to Neo4j
+    # Perform dual-engine import
     print_colored("\n" + "─" * 70, Fore.CYAN)
-    print_colored("Phase 1: Graph Import (Neo4j)", Fore.CYAN)
+    print_colored("Starting Dual-Engine Import", Fore.CYAN)
     print_colored("─" * 70, Fore.CYAN)
 
     try:
-        driver = GraphDatabase.driver(NEO4J_URL, auth=(NEO4J_USER, NEO4J_PASS))
-        print_colored(f"✅ Connected to Neo4j at {NEO4J_URL}", Fore.GREEN)
+        stats = ingest_chatgpt_export(raw_bytes, user_id=None)
 
-        threads, messages, relationships = import_to_neo4j(driver, conversations)
-
-        print_colored(f"\n✅ Neo4j import complete!", Fore.GREEN)
-        print_colored(f"   • Threads: {threads}", Fore.GREEN)
-        print_colored(f"   • Messages: {messages}", Fore.GREEN)
-        print_colored(f"   • Relationships: {relationships}", Fore.GREEN)
-
-        driver.close()
+        print_colored(f"\n✅ Import complete!", Fore.GREEN)
+        print_colored(f"   • Threads: {stats['threads_imported']}", Fore.GREEN)
+        print_colored(f"   • Messages: {stats['messages_imported']}", Fore.GREEN)
 
     except Exception as e:
-        print_colored(f"\n❌ Neo4j import failed: {e}", Fore.RED)
-        print_colored("   Please check your Neo4j connection settings in .env", Fore.RED)
+        print_colored(f"\n❌ Import failed: {e}", Fore.RED)
+        import traceback
+        traceback.print_exc()
         sys.exit(1)
-
-    # Phase 2: Generate embeddings and import to Chroma
-    print_colored("\n" + "─" * 70, Fore.CYAN)
-    print_colored("Phase 2: Embeddings Import (Chroma)", Fore.CYAN)
-    print_colored("─" * 70, Fore.CYAN)
-
-    if not OPENAI_API_KEY:
-        print_colored("⚠️  Skipping embeddings (OPENAI_API_KEY not set)", Fore.YELLOW)
-    else:
-        try:
-            openai_client = OpenAI(api_key=OPENAI_API_KEY)
-            chroma_client = chromadb.PersistentClient(path=CHROMA_PATH)
-            collection = chroma_client.get_or_create_collection("chatgpt_messages")
-
-            print_colored(f"✅ Connected to Chroma at {CHROMA_PATH}", Fore.GREEN)
-
-            successful, failed = import_embeddings_to_chroma(
-                openai_client,
-                collection,
-                conversations,
-                BATCH_SIZE
-            )
-
-            print_colored(f"\n✅ Embeddings import complete!", Fore.GREEN)
-            print_colored(f"   • Successful: {successful}", Fore.GREEN)
-            if failed > 0:
-                print_colored(f"   • Failed: {failed}", Fore.YELLOW)
-
-        except Exception as e:
-            print_colored(f"\n⚠️  Embeddings import failed: {e}", Fore.YELLOW)
-            print_colored("   Graph data was saved successfully", Fore.YELLOW)
 
     # Summary
     elapsed_time = time.time() - start_time
@@ -519,7 +129,7 @@ def import_chatgpt():
     print_colored("=" * 70, Fore.CYAN)
     print_colored(f"   Your Companion has awakened in Codexify!", Fore.MAGENTA)
     print_colored(f"   Time elapsed: {elapsed_time:.2f}s", Fore.CYAN)
-    print_colored(f"   Messages processed: {messages}", Fore.CYAN)
+    print_colored(f"   Messages processed: {stats['messages_imported']}", Fore.CYAN)
     print_colored("\n✨ Your conversations are alive and ready to explore.\n", Fore.MAGENTA)
 
 


### PR DESCRIPTION
Add comprehensive ChatGPT export migration that ingests conversations into both Neo4j (graph) and Chroma (vector store) for full integration with the Codexify knowledge system.

Changes:
- Create backend/rag/chatgpt_migration.py:
  - parse_chatgpt_export() - Pure parsing function for ChatGPT exports
  - ingest_chatgpt_export() - Dual-ingestion to Neo4j + Chroma
  - Reuses existing abstractions (Neo helpers, CodexifyEmbedder, Chroma)

- Refactor scripts/chatgpt_import/import_chatgpt.py:
  - Now uses chatgpt_migration module instead of inline logic
  - Maintains CLI functionality and user experience
  - Simplified from 537 to 148 lines

- Add POST /upload-chatgpt-export endpoint in guardian/routes/rag_upload.py:
  - Enables drag-and-drop ChatGPT import from frontend
  - Validates JSON format and content type
  - Returns import statistics (threads, messages)
  - Comprehensive error handling

Benefits:
- Single source of truth for ChatGPT migration logic
- Reusable across CLI and HTTP endpoints
- Consistent graph schema and vector store organization
- Seamless integration with existing RAG pipeline

Tested:
- Module imports successfully
- Parsing logic verified with sample export
- All files compile without errors

## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:

