### PR TITLE
TASK-2026-02-15-projects-api-canonical: make /api/projects canonical;…

### DIFF
--- a/frontend/src/components/sidebar/SidebarRoot.tsx
+++ b/frontend/src/components/sidebar/SidebarRoot.tsx
@@ -209,7 +209,7 @@ export default function SidebarRoot({
           created = await onCreateProject(data);
         } else {
           const icon = data.icon?.trim() || "📁";
-          const resp = await api.post("/projects", { name, icon, description: "" });
+          const resp = await api.post("/api/projects", { name, icon, description: "" });
           const payload = resp?.data ?? {};
           const createdId = payload?.id ?? payload?.project_id;
           if (createdId) {

--- a/frontend/src/components/sidebar/__tests__/CreateProjectModal.test.tsx
+++ b/frontend/src/components/sidebar/__tests__/CreateProjectModal.test.tsx
@@ -100,7 +100,7 @@ describe("CreateProjectModal", () => {
     fireEvent.click(screen.getByRole("button", { name: /create project/i }));
 
     await waitFor(() => {
-      expect(mockApi.post).toHaveBeenCalledWith("/projects", {
+      expect(mockApi.post).toHaveBeenCalledWith("/api/projects", {
         name: "Delta",
         icon: "📁",
         description: "",

--- a/frontend/src/components/sidebar/useProjectsCache.ts
+++ b/frontend/src/components/sidebar/useProjectsCache.ts
@@ -123,7 +123,7 @@ export function useProjectsCache({
 
   const refreshProjectsFromServer = useCallback(async () => {
     try {
-      const res = await api.get("/projects");
+      const res = await api.get("/api/projects");
       const list = normalizeProjectsResponse(res);
       if (Array.isArray(list) && list.length) {
         setProjectList((prev) => {

--- a/frontend/src/dcw-services/gc.ts
+++ b/frontend/src/dcw-services/gc.ts
@@ -34,10 +34,10 @@ export const Threads = {
   del: (id: number | string) => req(`/threads/${id}`, { method: 'DELETE' })
 };
 export const Projects = {
-  list: () => req('/projects'),
+  list: () => req('/api/projects'),
   create: (body: { name: string; description?: string }) =>
-    req('/projects', { method: 'POST', body: JSON.stringify(body) }),
-  del: (id: number | string) => req(`/projects/${id}`, { method: 'DELETE' })
+    req('/api/projects', { method: 'POST', body: JSON.stringify(body) }),
+  del: (id: number | string) => req(`/api/projects/${id}`, { method: 'DELETE' })
 };
 export const Notes = {
   log:(b:any)=>req('/log',{method:'POST',body:JSON.stringify(b)}),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -19,7 +19,10 @@ function isDevRuntime(): boolean {
 
 function resolveDevApiKey(): string {
   if (!isDevRuntime()) return "";
-  return readRuntimeEnv("VITE_GUARDIAN_DEV_API_KEY").trim();
+  const explicitDevKey = readRuntimeEnv("VITE_GUARDIAN_DEV_API_KEY").trim();
+  if (explicitDevKey) return explicitDevKey;
+  // Backward-compat: existing local setups may still use VITE_GUARDIAN_API_KEY.
+  return readRuntimeEnv("VITE_GUARDIAN_API_KEY").trim();
 }
 
 function toHeaderRecord(headers?: HeadersInit): Record<string, string> {
@@ -78,6 +81,10 @@ export function getAuthToken(): string | null {
     loadedAuthToken = true;
   }
   return cachedAuthToken;
+}
+
+export function getDevApiKey(): string {
+  return resolveDevApiKey();
 }
 
 export function setAuthToken(token: string | null): void {

--- a/guardian/guardian_api.py
+++ b/guardian/guardian_api.py
@@ -155,6 +155,7 @@ from guardian.routes.imprint import system_docs_router, system_prompt_router
 from guardian.routes.media import router as media_router
 from guardian.routes.memory import EPHEMERAL_MEMORY  # re-export for tests
 from guardian.routes.personal_facts import router as personal_facts_router
+from guardian.routes.projects import api_router as api_projects_router
 from guardian.routes.projects import ensure_loose_threads_project
 from guardian.routes.projects import router as projects_router
 from guardian.routes.tools import router as tools_router
@@ -475,6 +476,7 @@ app.include_router(embeddings.router)
 # Core feature routers
 app.include_router(threads.router)
 app.include_router(projects_router)
+app.include_router(api_projects_router)
 app.include_router(memory.router)
 app.include_router(personal_facts_router)
 app.include_router(agent.router, prefix="/agent")

--- a/guardian/routes/projects.py
+++ b/guardian/routes/projects.py
@@ -68,6 +68,33 @@ def list_projects():
     return projects
 
 
+@router.post("")
+@api_router.post("")
+def create_project(body: ProjectCreate):
+    """
+    Create a new project.
+
+    Args:
+        body: Project name and optional description
+
+    Returns:
+        Created project dict with id, name, description
+    """
+    try:
+        project_id = chatlog_db.create_project(
+            body.name, body.description or ""
+        )
+        return {
+            "id": project_id,
+            "name": body.name,
+            "description": body.description or "",
+        }
+    except Exception as e:
+        return JSONResponse(
+            status_code=400, content={"ok": False, "error": str(e)}
+        )
+
+
 @router.patch("/{project_id}")
 @api_router.patch("/{project_id}")
 def patch_project(project_id: int, body: Dict[str, object] = Body(...)):

--- a/guardian/tests/test_threads_projects.py
+++ b/guardian/tests/test_threads_projects.py
@@ -79,10 +79,10 @@ def test_project_patch_and_delete_ejects_threads():
     pid = _create_project_row()
     tid = _create_thread_row(project_id=pid)
     # Rename project
-    r = client.patch(f"/projects/{pid}", json={"name": "Renamed"})
+    r = client.patch(f"/api/projects/{pid}", json={"name": "Renamed"})
     assert r.status_code == 200 and r.json().get("ok")
     # Delete project -> thread survives, project_id becomes NULL
-    r = client.delete(f"/projects/{pid}")
+    r = client.delete(f"/api/projects/{pid}")
     assert r.status_code == 200 and r.json().get("ok")
     with sqlite3.connect(settings.GUARDIAN_DB_PATH) as conn:
         c = conn.cursor()

--- a/tests/routes/test_projects_routes.py
+++ b/tests/routes/test_projects_routes.py
@@ -14,7 +14,7 @@ class TestProjectsPatch:
         """Test successful project name update returns 200."""
         payload = {"name": "Updated Project Name"}
 
-        response = test_client.patch("/projects/1", json=payload)
+        response = test_client.patch("/api/projects/1", json=payload)
 
         assert response.status_code == 200
         data = response.json()
@@ -27,7 +27,7 @@ class TestProjectsPatch:
         """Test successful project description update returns 200."""
         payload = {"description": "Updated project description"}
 
-        response = test_client.patch("/projects/1", json=payload)
+        response = test_client.patch("/api/projects/1", json=payload)
 
         assert response.status_code == 200
         data = response.json()
@@ -40,7 +40,7 @@ class TestProjectsPatch:
         """Test updating both name and description simultaneously."""
         payload = {"name": "New Name", "description": "New description"}
 
-        response = test_client.patch("/projects/1", json=payload)
+        response = test_client.patch("/api/projects/1", json=payload)
 
         assert response.status_code == 200
         data = response.json()
@@ -53,7 +53,7 @@ class TestProjectsPatch:
         """Test patching project with empty payload still succeeds."""
         payload = {}
 
-        response = test_client.patch("/projects/1", json=payload)
+        response = test_client.patch("/api/projects/1", json=payload)
 
         assert response.status_code == 200
         # Should call update_project with None values
@@ -68,7 +68,7 @@ class TestProjectsPatch:
         )
 
         payload = {"name": "New Name"}
-        response = test_client.patch("/projects/1", json=payload)
+        response = test_client.patch("/api/projects/1", json=payload)
 
         assert response.status_code == 400
         data = response.json()
@@ -78,7 +78,9 @@ class TestProjectsPatch:
     def test_patch_project_invalid_id(self, test_client, mock_db):
         """Test patching project with invalid ID type."""
         # FastAPI should handle path parameter validation
-        response = test_client.patch("/projects/invalid", json={"name": "Test"})
+        response = test_client.patch(
+            "/api/projects/invalid", json={"name": "Test"}
+        )
 
         # FastAPI returns 422 for validation errors
         assert response.status_code == 422
@@ -87,7 +89,7 @@ class TestProjectsPatch:
         """Test patching project with null name."""
         payload = {"name": None}
 
-        response = test_client.patch("/projects/1", json=payload)
+        response = test_client.patch("/api/projects/1", json=payload)
 
         assert response.status_code == 200
         mock_db.update_project.assert_called_once_with(
@@ -98,7 +100,7 @@ class TestProjectsPatch:
         """Test patching project with empty string name."""
         payload = {"name": ""}
 
-        response = test_client.patch("/projects/1", json=payload)
+        response = test_client.patch("/api/projects/1", json=payload)
 
         assert response.status_code == 200
         # Empty string should be passed as-is
@@ -112,7 +114,7 @@ class TestProjectsDelete:
 
     def test_delete_project_success(self, test_client, mock_db):
         """Test successful project deletion returns 200."""
-        response = test_client.delete("/projects/1")
+        response = test_client.delete("/api/projects/1")
 
         assert response.status_code == 200
         data = response.json()
@@ -125,7 +127,7 @@ class TestProjectsDelete:
         """Test deleting non-existent project returns 404."""
         mock_db.delete_project.return_value = False
 
-        response = test_client.delete("/projects/999")
+        response = test_client.delete("/api/projects/999")
 
         assert response.status_code == 404
         data = response.json()
@@ -134,7 +136,7 @@ class TestProjectsDelete:
 
     def test_delete_project_ejects_threads_first(self, test_client, mock_db):
         """Test project deletion ejects threads before deleting."""
-        response = test_client.delete("/projects/1")
+        response = test_client.delete("/api/projects/1")
 
         assert response.status_code == 200
         # Verify eject was called before delete
@@ -160,7 +162,7 @@ class TestProjectsDelete:
             "Eject failed"
         )
 
-        response = test_client.delete("/projects/1")
+        response = test_client.delete("/api/projects/1")
 
         # Should still attempt to delete project
         assert response.status_code == 200
@@ -170,7 +172,7 @@ class TestProjectsDelete:
         """Test project deletion handles database errors."""
         mock_db.delete_project.side_effect = Exception("Foreign key constraint")
 
-        response = test_client.delete("/projects/1")
+        response = test_client.delete("/api/projects/1")
 
         assert response.status_code == 400
         data = response.json()
@@ -179,7 +181,7 @@ class TestProjectsDelete:
 
     def test_delete_project_invalid_id(self, test_client, mock_db):
         """Test deleting project with invalid ID type."""
-        response = test_client.delete("/projects/invalid")
+        response = test_client.delete("/api/projects/invalid")
 
         # FastAPI returns 422 for path parameter validation errors
         assert response.status_code == 422
@@ -187,7 +189,7 @@ class TestProjectsDelete:
     def test_delete_default_project(self, test_client, mock_db):
         """Test deleting default project (Loose Threads, id=1)."""
         # This should work technically, but might have special handling
-        response = test_client.delete("/projects/1")
+        response = test_client.delete("/api/projects/1")
 
         # If it succeeds, verify behavior
         if response.status_code == 200:
@@ -204,12 +206,12 @@ class TestProjectsIntegration:
         """Test updating then deleting a project in sequence."""
         # First, patch the project
         patch_response = test_client.patch(
-            "/projects/2", json={"name": "To Be Deleted"}
+            "/api/projects/2", json={"name": "To Be Deleted"}
         )
         assert patch_response.status_code == 200
 
         # Then delete it
-        delete_response = test_client.delete("/projects/2")
+        delete_response = test_client.delete("/api/projects/2")
         assert delete_response.status_code == 200
 
         # Verify both operations were called
@@ -221,7 +223,7 @@ class TestProjectsIntegration:
         # Patch multiple projects
         for project_id in [1, 2, 3]:
             response = test_client.patch(
-                f"/projects/{project_id}",
+                f"/api/projects/{project_id}",
                 json={"name": f"Project {project_id}"},
             )
             assert response.status_code == 200


### PR DESCRIPTION
… keep /projects compat

## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
