### PR TITLE
Add Guardian agent runtime onboarding guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,7 @@ hf_cache/
 .cache/transformers/
 **/.cache/transformers/
 daniel-manickam/boxbeyond-kutiraai/
+
+# Local artifacts
+output/
+tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ hf_cache/
 **/.cache/torch/
 .cache/transformers/
 **/.cache/transformers/
+daniel-manickam/boxbeyond-kutiraai/

--- a/docs/Plans/Guardian-delegationPLAN.md
+++ b/docs/Plans/Guardian-delegationPLAN.md
@@ -1,0 +1,93 @@
+# Patch Plan Update: Deterministic CI-Gated Multi-Agent Loop v1
+
+## Summary
+This extends Guardian orchestration with deterministic retries, confidence scoring, durable escalation telemetry, strict commit boundaries, and SSE event streaming.
+Locked semantic: `Task = each mutating step` and each successful task produces exactly two commits:
+- Commit A: mutation commit (after tests pass)
+- Commit B: validation boundary commit (allow-empty preferred)
+
+## Phase 0: Preconditions and Repo Safety
+1. Treat this as a dedicated patch sequence because unrelated workspace changes may exist.
+2. Enforce worker invariant: no commits unless tests pass for the current mutating step.
+3. Persist every attempt and outcome, including failures and escalations.
+
+## Phase 1: Durable Postgres Domain (Expanded)
+1. Durable entities:
+- `agent_deployments`
+- `agent_runs`
+- `agent_run_steps`
+- `agent_run_attempts`
+- `agent_run_artifacts`
+- `agent_confidence_reports`
+- `agent_escalations`
+- `agent_events`
+- `agent_reflections`
+2. Migration chains from Alembic head `a7c9d1e2f3b4`.
+
+## Phase 2: Config and Runtime Flags
+1. Add deterministic retry and commit policy flags:
+- `AGENT_MAX_ATTEMPTS=5`
+- `AGENT_MIN_ATTEMPTS_BEFORE_ABORT=2`
+- `AGENT_NO_PROGRESS_WINDOW=2`
+- `AGENT_MAX_SAME_SIGNATURE_REPEATS=2`
+- `AGENT_REGRESSION_LIMIT=2`
+- `AGENT_AUTO_ROLLBACK_ON_FAIL=true`
+- `AGENT_VALIDATOR_MODEL_ENABLED=false`
+- `AGENT_REQUIRE_TWO_COMMITS=true`
+- `AGENT_VALIDATION_COMMIT_ALLOW_EMPTY=true`
+
+## Phase 3: Confidence Engine (Step + Task)
+1. Guardian confidence is canonical. Model self-confidence is telemetry only.
+2. Step confidence formula:
+`C_step = 0.35*C_tests + 0.20*C_schema + 0.20*C_spec_alignment + 0.15*C_diff_risk + 0.10*C_model_stability`
+3. Task confidence formula:
+`C_task = 0.40*mean(C_step) + 0.25*min(C_step) + 0.15*C_convergence + 0.10*C_risk + 0.10*(1-escalation_penalty)`
+4. Thresholds:
+- Step: `>=0.85 continue`, `0.70-0.85 warn`, `0.55-0.70 soft escalate`, `<0.55 hard escalate`
+- Task: `>=0.85 autonomous approve`, `0.70-0.85 optional audit`, `0.55-0.70 audit required`, `<0.55 block merge/human required`
+
+## Phase 4: Adaptive Retry Engine
+1. Attempt metrics:
+- `fail_count`
+- `fail_signature`
+- `diff_added`, `diff_deleted`
+- `error_category`
+2. Progress definition: `fail_count` reduced OR error category improved.
+3. Early escalation triggers after min attempts:
+- no-progress window reached
+- repeated signature exceeds threshold
+- regression exceeds best-so-far + regression limit
+- spec alignment violation (immediate)
+
+## Phase 5: Worker Determinism + Commit Doctrine
+1. No intermediate retry attempts create commits.
+2. Failed runs produce zero commits.
+3. Successful mutating step produces exactly two commits; both hashes are persisted in artifacts.
+4. Commit B defaults to allow-empty boundary commit.
+
+## Phase 6: Worktree Naming, Rollback, Preservation
+1. Deterministic worktree id derived from `deployment_id:run_id:step_index`.
+2. Auto rollback default ON for failed runs.
+3. Escalated runs preserve worktree/branch for review.
+4. Worktree creation applies only to mutating steps.
+
+## Phase 7: Agent Events + SSE Integration
+1. Emit durable typed events:
+- `created`, `started`, `attempt_failed`, `attempt_progress`, `step_succeeded`
+- `escalated`, `canceled`, `failed`, `succeeded`
+2. Publish to Redis task stream with `task_id = run_id`.
+3. Keep `/api/tasks/{task_id}/events` compatibility unchanged.
+
+## Phase 8: Adapter Contract + Validator Scaffold
+1. Strict JSON `AgentRunEnvelope` is required for delegated adapters.
+2. v1 adapters:
+- Codex
+- ClaudeCode
+3. Optional validator pre-step (feature-flagged) can generate/improve tests before done, but passing tests remains required.
+
+## Acceptance Mapping
+1. Failing test run never produces commits.
+2. Successful mutating task produces exactly two commits and both hashes are stored.
+3. Attempts are persisted and queryable.
+4. Escalations persist and stream.
+5. Confidence is computed per-step and per-task and drives escalation behavior.

--- a/docs/architecture/providers.md
+++ b/docs/architecture/providers.md
@@ -11,18 +11,33 @@ Set:
 
 - `LLM_PROVIDER=minimax`
 - `MINIMAX_API_KEY=<your_minimax_api_key>`
-- `MINIMAX_API_BASE=<openai_compatible_base_url>`
+- `MINIMAX_API_BASE=<minimax_base_url>`
+- `ALLOW_CLOUD_PROVIDERS=true`
+- `CODEXIFY_LOCAL_ONLY_MODE=false`
+- `CODEXIFY_EGRESS_ALLOWLIST=...` including `minimax`
 
 Optional:
 
+- `MINIMAX_API_FLAVOR=<openai|anthropic>` (default: `openai`)
+- `MINIMAX_ANTHROPIC_VERSION=<anthropic_api_version>` (used when flavor is `anthropic`)
 - `MINIMAX_MODEL=<default_model_id>`
 - `MINIMAX_TIMEOUT_SECONDS=<request_timeout_seconds>`
+
+Base URL examples:
+
+- OpenAI flavor (`MINIMAX_API_FLAVOR=openai`): `https://api.minimax.io/v1`
+- Anthropic flavor (`MINIMAX_API_FLAVOR=anthropic`): `https://api.minimax.io/anthropic`
 
 When `LLM_PROVIDER=minimax`, backend config validation fails fast with a clear
 message if `MINIMAX_API_KEY` or `MINIMAX_API_BASE` is missing.
 
 ### Routing behavior
 
+- Runtime chat routing uses MiniMax only when explicitly selected.
+- `MINIMAX_API_FLAVOR=openai` calls `.../chat/completions`.
+- `MINIMAX_API_FLAVOR=anthropic` calls `.../v1/messages` (Anthropic-compatible).
+- Explicit request selection (`provider`/`model`) takes precedence over profile
+  overrides in the chat worker.
 - Provider registry loads MiniMax only when both `MINIMAX_API_KEY` and
   `MINIMAX_API_BASE` are present.
 - Catalog entry is deterministic and includes one default model:

--- a/docs/guardian/agent-orchestration.md
+++ b/docs/guardian/agent-orchestration.md
@@ -1,0 +1,493 @@
+# Agent Orchestration & Run Events (SSE) — Codexify
+
+**Last verified (observed runtime):** 2026-02-18  
+**Audience:** Codexify contributors/operators running the Docker stack locally.
+
+This document explains **how agent orchestration works end-to-end**, how to **configure** it, and how to **debug** the common migration + event-stream failure modes you just hit.
+
+> Current scope note: the API **creates plans, deployments, and runs**, and emits **run state/events**. A “real” delegated execution loop (worker consuming a run and performing mutating steps) may be **scaffolded but not fully wired** depending on your branch/config.
+
+---
+
+## Architecture at a glance
+
+### Entities
+
+- **Plan**: a proposed spec derived from a prompt (and optionally user-proposed steps).
+- **Deployment**: a persisted “runnable” spec bound to a `flow_id` and `thread_id`, with a `trust_state`.
+- **Run**: an execution instance of a deployment (tracks status, runtime target, timestamps).
+- **Run Events**: append-only events associated with a run, streamed over SSE and (typically) persisted for replay.
+
+### Request flow
+
+1. Client creates a **plan** (`/api/agents/plans`).
+2. Client creates a **deployment** (`/api/agents/deployments`).
+3. Client starts a **run** (`/api/agents/deployments/{deployment_id}/runs`).
+4. Client streams **run events** (`/api/agents/runs/{run_id}/events`).
+5. Client can **cancel** a run (`/api/agents/runs/{run_id}/cancel`).
+6. Client can list runs for a chat thread (`/api/chat/{thread_id}/agent-runs`).
+
+---
+
+## Database + migrations
+
+Agent orchestration requires the latest DB schema. The authoritative schema version for this feature is the Alembic revision:
+
+- **`9f3d2b1a7c4e`** — `add_agent_orchestration_tables`
+
+### Verify the migration is applied
+
+```bash
+docker compose exec db sh -lc 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "select version_num from alembic_version;"'
+```
+
+Expected:
+
+- `version_num` should be `9f3d2b1a7c4e` (or a newer head, if you’ve added more migrations).
+
+### Canonical migration path (recommended)
+
+Use the repo’s migrator container. This avoids local env drift and ensures `DATABASE_URL` is present inside the container.
+
+```bash
+docker compose up -d db
+docker compose run --rm migrator
+```
+
+### If you see “Can't locate revision identified by …”
+
+Example failure:
+
+- `Can't locate revision identified by '384dde1f793c'`
+
+This means **your DB is stamped with a revision your current code checkout does not contain** (branch mismatch or a pruned migration).
+
+Fix options:
+
+1) **Nuke local DB volume** (dev only) and rerun migrator:
+
+```bash
+docker compose down -v
+docker compose up -d db
+docker compose run --rm migrator
+```
+
+2) Or check out the code revision that includes that Alembic revision (not recommended unless you must preserve data).
+
+### Why local `alembic upgrade head` failed for you
+
+You saw:
+
+- `RuntimeError: sqlalchemy.url not configured. Set DATABASE_URL environment variable or update alembic.ini`
+
+Local Alembic requires `DATABASE_URL` in your shell:
+
+```bash
+export DATABASE_URL="postgresql://codexify:<password>@localhost:5433/Codexify"
+alembic -c backend/alembic.ini upgrade head
+```
+
+…but the **migrator container** is still the preferred path.
+
+---
+
+## Services + runtime configuration
+
+### Docker Compose services you care about
+
+- `db` — Postgres (mapped to host `5433`)
+- `redis` — queue/event infra (if used by your run/event bus)
+- `backend` — API server (host `8888`)
+- `worker-*` — background workers (chat/embedding/etc)
+- `frontend` — Vite (host `5173`)
+- `migrator` — runs Alembic migrations + seed
+
+### Required environment variables (backend)
+
+| Variable | Purpose | Where |
+|---|---|---|
+| `GUARDIAN_API_KEY` | API auth key for `X-API-Key` header | compose / env |
+| `DATABASE_URL` | Postgres DSN | compose |
+| `CORS_ALLOWED_ORIGINS` (or equivalent) | allow frontend origin | compose/config |
+
+Your backend logs confirmed:
+
+- it loads `GUARDIAN_API_KEY=...`
+- it uses PostgreSQL via `DATABASE_URL`
+- it allows origin `http://localhost:5173`
+
+---
+
+## API contract
+
+### Authentication
+
+All endpoints below require:
+
+- Header: `X-API-Key: <your dev key>`
+
+Example:
+
+```bash
+export API_KEY="your-key"
+export BASE="http://localhost:8888"
+```
+
+---
+
+## 1) Create plan
+
+**POST** `/api/agents/plans`
+
+```bash
+curl -s -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{"prompt":"test plan","thread_id":77,"proposed_steps":[]}' \
+  "$BASE/api/agents/plans"
+```
+
+Example response (observed):
+
+```json
+{
+  "ok": true,
+  "plan_id": "plan_...",
+  "spec_hash": "...",
+  "spec": { "prompt": "test plan", "thread_id": 77, "steps": [] }
+}
+```
+
+---
+
+## 2) Create deployment
+
+**POST** `/api/agents/deployments`
+
+```bash
+curl -s -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{"flow_id":"flow-test","thread_id":77,"spec":{"steps":[]},"trust_state":"supervised"}' \
+  "$BASE/api/agents/deployments"
+```
+
+Example response (observed):
+
+```json
+{
+  "ok": true,
+  "deployment": {
+    "deployment_id": "dep_...",
+    "flow_id": "flow-test",
+    "thread_id": 77,
+    "spec_json": {"steps":[]},
+    "trust_state": "supervised",
+    "status": "active"
+  }
+}
+```
+
+---
+
+## 3) Start run
+
+**POST** `/api/agents/deployments/{deployment_id}/runs`
+
+```bash
+curl -s -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{"runtime_target":"container","supervised":true}' \
+  "$BASE/api/agents/deployments/dep_a193ce01ccd247e5/runs"
+```
+
+Example response (observed):
+
+```json
+{
+  "ok": true,
+  "run": {
+    "run_id": "run_...",
+    "deployment_id": "dep_...",
+    "thread_id": 77,
+    "status": "running",
+    "runtime_target": "container",
+    "rollback_mode": "auto",
+    "created_at": "2026-02-18T19:53:57.627359+00:00",
+    "started_at": "2026-02-18T19:53:57.627359+00:00"
+  }
+}
+```
+
+**Important:** do not literally use `<deployment_id>` in the URL. If you do, you’ll get:
+
+```json
+{"detail":"deployment_not_found", ...}
+```
+
+---
+
+## 4) List runs for a chat thread
+
+**GET** `/api/chat/{thread_id}/agent-runs`
+
+```bash
+curl -s -H "X-API-Key: $API_KEY" "$BASE/api/chat/77/agent-runs"
+```
+
+Observed response (after starting one run):
+
+```json
+{"ok":true,"thread_id":77,"runs":[{"run_id":"run_...","status":"running", ...}]}
+```
+
+---
+
+## 5) Stream run events (SSE)
+
+**GET** `/api/agents/runs/{run_id}/events`
+
+This returns **Server-Sent Events** with fields:
+
+- `id:` monotonically increasing identifier (often timestamp-based)
+- `event:` event type name
+- `data:` JSON payload
+- `: ping` keepalive comment lines
+
+Example:
+
+```bash
+curl -N -H "X-API-Key: $API_KEY" \
+  "$BASE/api/agents/runs/run_338c4bdd9ca94f3c/events"
+```
+
+Observed output:
+
+```text
+retry: 3000
+
+id: 1771444437629-0
+event: created
+data: {"deployment_id": "dep_...", "run_id": "run_..."}
+
+id: 1771444437629-1
+event: started
+data: {"deployment_id": "dep_...", "run_id": "run_..."}
+
+: ping
+: ping
+...
+```
+
+### Are these events “live”?
+
+Yes, you’re connected to the live backend process. However, what you see on connect can be a mix of:
+
+- **Replay**: historical run events persisted earlier (sent immediately on connect)
+- **Tail**: new events appended while the stream is open
+- **Keepalive**: `: ping` lines to prevent idle timeouts
+
+With the current scaffolding, it’s expected to see only `created` and `started` unless the worker/runner emits additional step/log events.
+
+---
+
+## 6) Cancel a run
+
+**POST** `/api/agents/runs/{run_id}/cancel`
+
+```bash
+curl -s -X POST -H "X-API-Key: $API_KEY" \
+  "$BASE/api/agents/runs/run_338c4bdd9ca94f3c/cancel"
+```
+
+Expected behavior:
+
+- Run status transitions away from `running`
+- An event may be appended/emitted (depending on implementation)
+
+If you have the SSE stream open in another terminal, you should see the cancel-related event if it’s wired.
+
+---
+
+## Event semantics (current observed set)
+
+From your live run stream, the backend currently emits at least:
+
+- `created`
+- `started`
+
+Additional events you typically want in a full orchestration loop (may or may not already exist in your code):
+
+- `step_started`
+- `step_progress`
+- `step_completed`
+- `log`
+- `terminal_output`
+- `cancel_requested`
+- `canceled`
+- `completed`
+- `failed`
+
+> Recommendation: Treat the **event names as contract** once you publish this feature. If you change them, version the API or provide compatibility mapping.
+
+---
+
+## Trust + supervision model
+
+You’re passing:
+
+- `trust_state: "supervised"` on deployments
+- `supervised: true` on run-start
+
+Interpretation (intended contract):
+
+- **supervised** implies the worker/runner should respect commit boundaries, require approvals for mutating actions, and/or emit audit artifacts.
+
+Even if execution isn’t fully wired yet, this is where you hang:
+- approval gates
+- command allowlists
+- “commit boundary” enforcement
+- rollback / worktree isolation
+
+---
+
+## Troubleshooting
+
+### A) Backend warns: “Expected database tables missing … Apply latest Alembic migrations.”
+
+Example:
+
+- `Expected database tables missing: ['project_document_links']`
+
+This means the backend’s startup schema check expects tables that are absent in the DB it is actually connected to.
+
+**Checklist**
+
+1) Confirm DB revision:
+
+```bash
+docker compose exec db sh -lc 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "select version_num from alembic_version;"'
+```
+
+2) Confirm backend is pointing to the same DB:
+
+- Check `DATABASE_URL` in backend logs (should reference `db:5432/Codexify` in compose)
+- Ensure you didn’t also have a local Postgres running and point backend at `localhost`
+
+3) If you recently swapped branches or migrations:
+- `docker compose down -v`
+- rerun migrator
+
+---
+
+### B) `deployment_not_found`
+
+Cause: you hit:
+
+- `/deployments/<deployment_id>/runs` literally
+
+Fix: substitute the real deployment id returned from create deployment.
+
+---
+
+### C) `psql: executable file not found` inside backend container
+
+The backend image likely doesn’t ship `psql`. Query via the `db` service container instead:
+
+```bash
+docker compose exec db sh -lc 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "\dt"'
+```
+
+---
+
+### D) Port conflicts (e.g., `5173` already in use)
+
+Error:
+
+- `bind: address already in use`
+
+Fix:
+
+- stop whatever owns that port, or
+- remap the compose port for frontend, or
+- run Vite on a different port.
+
+---
+
+## Recommended “operator” workflow
+
+### Fresh bring-up (safe dev default)
+
+```bash
+docker compose down -v
+docker compose up -d db
+docker compose run --rm migrator
+docker compose up -d redis backend
+```
+
+Then (optional):
+
+```bash
+docker compose up -d frontend
+```
+
+### Smoke test the full orchestration surface
+
+```bash
+export API_KEY="..."
+export BASE="http://localhost:8888"
+
+# plan
+curl -s -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{"prompt":"test plan","thread_id":77,"proposed_steps":[]}' \
+  "$BASE/api/agents/plans"
+
+# deployment
+DEP=$(curl -s -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{"flow_id":"flow-test","thread_id":77,"spec":{"steps":[]},"trust_state":"supervised"}' \
+  "$BASE/api/agents/deployments" | python -c 'import sys,json; print(json.load(sys.stdin)["deployment"]["deployment_id"])')
+
+# run
+RUN=$(curl -s -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d '{"runtime_target":"container","supervised":true}' \
+  "$BASE/api/agents/deployments/$DEP/runs" | python -c 'import sys,json; print(json.load(sys.stdin)["run"]["run_id"])')
+
+# stream
+curl -N -H "X-API-Key: $API_KEY" "$BASE/api/agents/runs/$RUN/events"
+```
+
+---
+
+## Where to extend next (wiring “real execution”)
+
+To make runs do more than `created/started`, the system needs:
+
+1. A worker that **consumes runs** (from DB queue or Redis stream)
+2. A runner that creates:
+   - an isolated worktree / sandbox
+   - deterministic state files / audit artifacts
+3. Event emission for step lifecycle + logs
+
+If you already have deterministic primitives in `guardian/workers/agent_worker.py`, the next doc to add is:
+
+- **Execution Wiring:** “How a run transitions from `running` to `completed/failed/canceled`”  
+- **Artifacts:** “Where audit receipts live and how they map to run IDs”  
+- **Security model:** “What supervised mode blocks and how approvals are recorded”
+
+---
+
+## Appendix: Quick DB introspection commands
+
+Count tables:
+
+```bash
+docker compose exec db sh -lc 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "select count(*) as tables from information_schema.tables where table_schema='\''public'\'';"'
+```
+
+List orchestration tables (guessing naming; adjust if needed):
+
+```bash
+docker compose exec db sh -lc 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "\dt *agent* \dt *deployment* \dt *run*";'
+```
+
+---
+
+## Change log
+
+- 2026-02-18: Initial doc written from live local run + migration recovery session.  
+  Observed SSE events: `created`, `started`. Alembic head verified: `9f3d2b1a7c4e`.

--- a/docs/guardian/agent-runtime-onboarding.md
+++ b/docs/guardian/agent-runtime-onboarding.md
@@ -1,0 +1,422 @@
+# Guardian Agent Runtime & Delegation Loop: Onboarding
+
+## Who This Is For
+
+This guide serves two audiences:
+
+- Product and operations users running delegated work from Guardian chat.
+- Developers extending adapters, retry policy, confidence policy, persistence, and orchestration routes.
+
+Use this document to onboard new people quickly without reading the full design plan first.
+
+## User Perspective (Start Here)
+
+Guardian is the main interface. A user asks for work in chat, and Guardian can run delegated loops through configured agents under supervision.
+
+In practical terms, a delegated run is:
+
+- A supervised execution loop with retries, confidence scoring, and escalation.
+- Deterministic on commit boundaries for mutating work.
+- Test-gated for mutation steps.
+
+Core behavior to understand:
+
+- Mutating work must pass tests before commit actions are allowed.
+- Successful mutating step semantics are strict:
+  - Commit A: mutation commit (code changes).
+  - Commit B: validation boundary commit (allow-empty by default).
+- Escalation preserves the worktree for human review instead of auto-cleaning it.
+
+If something looks stuck or risky, Guardian escalates and keeps durable records (attempts, events, and escalation context).
+
+## First Session Quickstart (Docker-First)
+
+### Prerequisites
+
+- Docker Desktop or equivalent Docker engine
+- Valid API key (`GUARDIAN_API_KEY`) configured server-side
+- Backend reachable from your shell (default: `http://localhost:8888`)
+
+Set local shell variables (example placeholders only):
+
+```bash
+export BASE_URL="http://localhost:8888"
+export API_KEY="<your-guardian-api-key>"
+```
+
+### 1) Bring up required services
+
+```bash
+docker compose up -d db redis backend worker-chat
+```
+
+Expected result:
+
+- Containers are running for DB, Redis, backend, and worker-chat.
+
+### 2) Apply migrations
+
+```bash
+docker compose exec backend alembic -c /app/backend/alembic.ini upgrade head
+```
+
+Expected result:
+
+- Alembic reports database at latest revision (including orchestration tables).
+
+### 3) Create a plan
+
+```bash
+curl -sS -X POST \
+  -H "X-API-Key: ${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Create a small delegated onboarding run",
+    "thread_id": 77,
+    "proposed_steps": []
+  }' \
+  "${BASE_URL}/api/agents/plans"
+```
+
+Expected result:
+
+- JSON payload with `ok: true`, a `plan_id`, and a `spec_hash`.
+
+### 4) Create a deployment
+
+```bash
+curl -sS -X POST \
+  -H "X-API-Key: ${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "flow_id": "flow-onboarding",
+    "thread_id": 77,
+    "spec": {"steps": []},
+    "trust_state": "supervised"
+  }' \
+  "${BASE_URL}/api/agents/deployments"
+```
+
+Expected result:
+
+- JSON payload with `deployment.deployment_id`.
+
+### 5) Start a run
+
+```bash
+DEPLOYMENT_ID="<paste-deployment-id>"
+
+curl -sS -X POST \
+  -H "X-API-Key: ${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "runtime_target": "container",
+    "supervised": true
+  }' \
+  "${BASE_URL}/api/agents/deployments/${DEPLOYMENT_ID}/runs"
+```
+
+Expected result:
+
+- JSON payload with `run.run_id` and initial run status.
+- Lifecycle events begin with `created` and `started`.
+
+### 6) Stream run events (SSE)
+
+```bash
+RUN_ID="<paste-run-id>"
+
+curl -N \
+  -H "X-API-Key: ${API_KEY}" \
+  "${BASE_URL}/api/agents/runs/${RUN_ID}/events"
+```
+
+Expected result:
+
+- SSE frames with `event:` and `data:` lines.
+- You should see lifecycle event names over time.
+
+### 7) Cancel a run
+
+```bash
+curl -sS -X POST \
+  -H "X-API-Key: ${API_KEY}" \
+  "${BASE_URL}/api/agents/runs/${RUN_ID}/cancel"
+```
+
+Expected result:
+
+- JSON payload confirming canceled state.
+- `canceled` event appears in event stream.
+
+### 8) List runs for a chat thread
+
+```bash
+curl -sS \
+  -H "X-API-Key: ${API_KEY}" \
+  "${BASE_URL}/api/chat/77/agent-runs"
+```
+
+Expected result:
+
+- JSON payload listing runs associated with `thread_id=77`.
+
+### Canonical API Interfaces (Current Runtime)
+
+Treat the following interfaces as canonical for runtime operations:
+
+- `POST /api/agents/plans`
+- `POST /api/agents/deployments`
+- `POST /api/agents/deployments/{deployment_id}/runs`
+- `POST /api/agents/runs/{run_id}/cancel`
+- `GET /api/agents/runs/{run_id}`
+- `GET /api/agents/runs/{run_id}/events`
+- `GET /api/chat/{thread_id}/agent-runs`
+
+Compatibility stream note:
+
+- Existing consumers of `/api/tasks/{task_id}/events` remain valid where `task_id == run_id`.
+
+Adapter contract reference:
+
+- Delegated adapters must return strict `AgentRunEnvelope` payloads.
+
+## Daily Operator Workflow
+
+Use this loop for normal operations:
+
+1. Define intent in chat.
+2. Launch run from deployment.
+3. Observe SSE lifecycle during execution.
+4. Inspect run status and artifacts.
+5. Continue on success, or triage escalation/failure.
+
+Event names you should expect:
+
+- `created`
+- `started`
+- `attempt_failed`
+- `attempt_progress`
+- `step_succeeded`
+- `escalated`
+- `canceled`
+- `failed`
+- `succeeded`
+
+Primary inspection points:
+
+- `GET /api/agents/runs/{run_id}` for run status.
+- `GET /api/agents/runs/{run_id}/events` for live stream.
+- Compatibility consumers may continue reading `/api/tasks/{task_id}/events` where `task_id == run_id`.
+
+## Safety and Trust Gates (Practical)
+
+Operational safety model:
+
+- Supervised is default.
+- Unsupervised start requires explicit unlock at deployment trust state.
+- No commit actions before tests pass for mutating steps.
+- Retry behavior is adaptive and escalates early when a run is stuck.
+
+Confidence outcomes are practical control signals.
+
+Step confidence bands:
+
+- `>= 0.85`: continue
+- `0.70 - 0.85`: warn
+- `0.55 - 0.70`: soft escalate
+- `< 0.55`: hard escalate
+
+Task confidence bands:
+
+- `>= 0.85`: autonomous approve
+- `0.70 - 0.85`: optional audit
+- `0.55 - 0.70`: audit required
+- `< 0.55`: block merge, human required
+
+Security reminders:
+
+- Keep provider and Guardian secrets server-side only.
+- Do not expose backend API keys to frontend in production.
+- Do not commit secret values to `.env` files tracked in git.
+
+## Failure Modes and What To Do
+
+### 1) Tests never pass
+
+- Symptom: repeated `attempt_failed`, terminal `failed`.
+- Likely cause: mutation did not satisfy test suite or introduced regressions.
+- Immediate recovery action: inspect the last failing attempt details and rerun with narrowed scope.
+- Where to inspect:
+  - `GET /api/agents/runs/{run_id}`
+  - SSE stream for attempt lifecycle
+  - run artifacts and attempt telemetry in orchestration records
+
+### 2) Repeated same failure signature
+
+- Symptom: attempts repeat with effectively same failure signature, then escalation.
+- Likely cause: loop is not making progress and is cycling the same fix.
+- Immediate recovery action: human intervention to change strategy, constraints, or input spec.
+- Where to inspect:
+  - `/api/agents/runs/{run_id}`
+  - event stream for escalation reason
+  - attempt telemetry (`fail_signature`, `error_category`)
+
+### 3) Regression in fail count
+
+- Symptom: failing test count increases versus best-so-far attempt.
+- Likely cause: an attempted fix widened breakage.
+- Immediate recovery action: stop autonomous continuation, review diff risk and step intent.
+- Where to inspect:
+  - run status endpoint
+  - attempt metrics and event timeline
+  - step-level confidence reports
+
+### 4) Spec alignment violation
+
+- Symptom: immediate escalation without normal retry continuation.
+- Likely cause: output violated step contract or intent requirements.
+- Immediate recovery action: revise task specification and rerun under supervision.
+- Where to inspect:
+  - run endpoint (escalated status)
+  - event stream for `reason_code`
+  - stored escalation payload
+
+### 5) SSE shows escalation but run appears idle
+
+- Symptom: escalated event is emitted, no further progress events.
+- Likely cause: expected behavior after escalation pause.
+- Immediate recovery action: inspect preserved worktree and decide manual continue/cancel.
+- Where to inspect:
+  - `GET /api/agents/runs/{run_id}`
+  - `GET /api/agents/runs/{run_id}/events`
+  - durable artifacts and escalation records
+
+## Dev Notes (Contributor Appendix)
+
+### Architecture map
+
+Key implementation areas:
+
+- Adapters:
+  - `guardian/agents/adapters/base.py`
+  - `guardian/agents/adapters/codex.py`
+  - `guardian/agents/adapters/claudecode.py`
+- Worker:
+  - `guardian/workers/agent_worker.py`
+- Store/persistence service:
+  - `guardian/agents/store.py`
+- Events publisher:
+  - `guardian/agents/events.py`
+- Routes:
+  - `guardian/routes/agent_orchestration.py`
+  - mounted in `guardian/guardian_api.py`
+- Configuration flags:
+  - `guardian/core/config.py`
+- DB models and migration:
+  - `guardian/db/models.py`
+  - `guardian/db/migrations/versions/9f3d2b1a7c4e_add_agent_orchestration_tables.py`
+
+### Durable orchestration tables
+
+- `agent_deployments`
+- `agent_runs`
+- `agent_run_steps`
+- `agent_run_attempts`
+- `agent_run_artifacts`
+- `agent_confidence_reports`
+- `agent_escalations`
+- `agent_events`
+- `agent_reflections`
+
+### Deterministic invariants
+
+- No intermediate retry attempt can create commits.
+- Successful mutating step creates exactly two commits:
+  - mutation commit
+  - validation boundary commit
+- Failed run produces zero commits for the failed step path.
+- Escalations persist durably and are emitted on stream.
+- Failed runs can auto-clean worktrees; escalated runs preserve worktree for review.
+
+### Confidence formulas and policy constants
+
+Step confidence:
+
+```text
+C_step =
+  0.35*C_tests +
+  0.20*C_schema +
+  0.20*C_spec_alignment +
+  0.15*C_diff_risk +
+  0.10*C_model_stability
+```
+
+Task confidence:
+
+```text
+C_task =
+  0.40*mean(C_step) +
+  0.25*min(C_step) +
+  0.15*C_convergence +
+  0.10*C_risk +
+  0.10*(1-escalation_penalty)
+```
+
+Retry policy defaults (configurable):
+
+- `AGENT_MAX_ATTEMPTS=5`
+- `AGENT_MIN_ATTEMPTS_BEFORE_ABORT=2`
+- `AGENT_NO_PROGRESS_WINDOW=2`
+- `AGENT_MAX_SAME_SIGNATURE_REPEATS=2`
+- `AGENT_REGRESSION_LIMIT=2`
+- `AGENT_AUTO_ROLLBACK_ON_FAIL=true`
+- `AGENT_VALIDATOR_MODEL_ENABLED=false`
+- `AGENT_REQUIRE_TWO_COMMITS=true`
+- `AGENT_VALIDATION_COMMIT_ALLOW_EMPTY=true`
+
+### Extension guidance
+
+Add a new delegated adapter:
+
+1. Implement adapter contract in terms of strict `AgentRunEnvelope` output.
+2. Register adapter in `guardian/agents/adapters/__init__.py`.
+3. Add tests for envelope shape and failure mapping.
+
+Tune policy behavior:
+
+- Add or adjust policy flags in `guardian/core/config.py`.
+- Keep deterministic behavior and update tests accordingly.
+
+Add event types:
+
+1. Add event emission site in worker or route layer.
+2. Persist via `AgentEventPublisher.emit`.
+3. Ensure stream compatibility for `/api/agents/runs/{run_id}/events` and `/api/tasks/{task_id}/events`.
+4. Add route and worker tests.
+
+### Test strategy references
+
+- Confidence engine tests:
+  - `guardian/tests/agents/test_confidence_engine.py`
+- Adaptive retry tests:
+  - `guardian/tests/agents/test_adaptive_retry.py`
+- Commit boundary tests:
+  - `guardian/tests/workers/test_agent_worker_commit_boundaries.py`
+- Event persistence and SSE tests:
+  - `guardian/tests/routes/test_agent_orchestration_events.py`
+
+For deeper rationale and phased design context, see:
+
+- `docs/Plans/Guardian-delegationPLAN.md`
+
+## Glossary
+
+- **deployment**: Durable record of a delegated specification and trust state.
+- **run**: One execution instance created from a deployment.
+- **step**: A unit of work within a run.
+- **attempt**: A single retry iteration for a step.
+- **escalation**: Durable pause/alert state when policy blocks continuation.
+- **confidence report**: Guardian-derived step or task confidence record used for decisions.
+- **validation boundary commit**: Commit B after mutation success, used as deterministic validation boundary.
+- **worktree preservation**: Retaining escalated run workspace for human review instead of deleting it.

--- a/docs/ui/UI-DESIGN-MAP.md
+++ b/docs/ui/UI-DESIGN-MAP.md
@@ -1,0 +1,184 @@
+# Codexify UI Design Map
+
+Purpose: Provide a deterministic, implementation-accurate map of all major frontend UI components so automated agents (Claude, Codex, etc.) can extract structure, behavior, and design semantics without parsing the entire src/ tree blindly.
+
+Last updated: 2026-02-18
+
+---
+
+## 1. Frontend Entry Points
+
+Source anchors:
+- `frontend/src/main.tsx`
+- `frontend/src/App.tsx`
+- `frontend/src/components/persona/layout/AppShell.tsx`
+
+### 1.1 App Root
+
+- Bootstraps React app.
+- Provides global providers (PersonaProvider, routing, API client).
+- Establishes the UI shell boundary.
+
+### 1.2 AppShell
+
+Primary structural container.
+
+Responsibilities:
+- Layout scaffolding (panels, gutters, slabs)
+- View switching (threads, documents, settings)
+- Global UI chrome
+
+Design invariants:
+- All major panels must use `GlassSlab.tsx` tokens.
+- 8px gutter spacing between slab edges.
+- Layered glass aesthetic is canonical.
+
+---
+
+## 2. Core Layout Components
+
+Source anchors:
+- `frontend/src/components/persona/layout/`
+- `frontend/src/components/ui/GlassSlab.tsx`
+
+> Note: A deprecated copy exists at `frontend/src/components/deprecated/GlassSlab.tsx` — do not reference it.
+
+### 2.1 GlassSlab
+
+Purpose:
+- Canonical card/panel container.
+- Encodes visual token system (bezel, blur, layering).
+
+Agents must:
+- Copy visual tokens directly from implementation.
+- Not reinterpret border, blur, or spacing rules.
+
+### 2.2 Panel Structure
+
+All panels follow:
+
+```
+GlassSlab
+├─ Header
+├─ Content
+└─ Footer (optional)
+```
+
+Spacing:
+- 8px minimum slab-to-slab spacing.
+- No edge collision between slabs.
+
+---
+
+## 3. Conversation UI Stack
+
+Source anchors:
+- `frontend/src/components/persona/ThreadPromptBox.tsx`
+- `frontend/src/components/chat/ChatBubble.tsx`
+- `frontend/src/components/chat/Composer.tsx`
+
+> Note: `MessageList.tsx` and `MessageItem.tsx` are not yet implemented. The chat rendering layer is currently handled by `ChatBubble.tsx` and `Composer.tsx` in `components/chat/`.
+
+### 3.1 ThreadPromptBox
+
+Responsibilities:
+- User input capture
+- Persona-aware invocation
+- Completion trigger
+
+Calls:
+- `generateWithMemory`
+- `/api/chat/{thread_id}/complete`
+
+### 3.2 ChatBubble
+
+Responsibilities:
+- Render ordered chat messages.
+- Preserve role distinctions (user/assistant/system).
+
+### 3.3 Composer
+
+Responsibilities:
+- Role-based styling
+- Content rendering (markdown, attachments)
+
+---
+
+## 4. Persona System UI
+
+Source anchors:
+- `frontend/src/components/persona/PersonaProvider.tsx`
+- `frontend/src/components/persona/TagSelector.tsx`
+
+> Note: `PersonaPanel.tsx` and `MemoryFragments.tsx` are not yet implemented.
+
+### 4.1 PersonaProvider
+
+Global state container:
+- Active persona
+- Memory tags
+- Debug mode
+
+Single source of truth.
+
+### 4.2 TagSelector
+
+UI control for:
+- Persona selection
+- Persona preview (tone/avatar)
+
+### 4.3 MemoryFragments (Debug Surface) — _not yet implemented_
+
+Planned: Visible only in debug mode. Displays injected memory fragments.
+
+---
+
+## 5. Document Workspace UI
+
+Source anchors:
+- `frontend/src/components/documents/DocumentsView.tsx`
+- `frontend/src/components/documents/DocumentTile.tsx`
+- `guardian/routes/documents.py` (behavior reference)
+
+Responsibilities:
+- Autosave document rendering
+- LLM-generated document display
+- Thread linkage visualization
+
+Relation types:
+- autosave
+- attached
+- reference
+
+---
+
+## 6. Global Design Constraints
+
+Derived from:
+- UI Rendering Protocol
+- Structural Layout Specification
+- System Overview
+
+Invariants:
+
+- All major UI panels use GlassSlab (`components/ui/GlassSlab.tsx`).
+- Gutter spacing is consistent (8px edge-to-edge).
+- No implicit layout nesting without explicit slab boundary.
+- Persona context is global, not component-local.
+- Chat completion is async; UI must respect task state.
+
+---
+
+## 7. What This Document Is For
+
+This file is the canonical extraction entrypoint.
+
+Agents should:
+- Read this file first.
+- Traverse only referenced anchors.
+- Generate structured UI documentation.
+- Never attempt to infer layout from raw src without this map.
+
+---
+
+End of Document

--- a/guardian/agents/adapters/__init__.py
+++ b/guardian/agents/adapters/__init__.py
@@ -1,0 +1,25 @@
+"""Delegated CLI adapter registry."""
+
+from .base import (
+    AgentAdapter,
+    AgentExecutionRequest,
+    AgentRunEnvelope,
+    AgentRunStatus,
+)
+from .claudecode import ClaudeCodeAdapter
+from .codex import CodexAdapter
+
+ADAPTERS = {
+    "codex": CodexAdapter(),
+    "claudecode": ClaudeCodeAdapter(),
+}
+
+__all__ = [
+    "ADAPTERS",
+    "AgentAdapter",
+    "AgentExecutionRequest",
+    "AgentRunEnvelope",
+    "AgentRunStatus",
+    "ClaudeCodeAdapter",
+    "CodexAdapter",
+]

--- a/guardian/agents/adapters/base.py
+++ b/guardian/agents/adapters/base.py
@@ -1,0 +1,44 @@
+"""Typed adapter contract for delegated CLI agents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AgentRunStatus(str):
+    OK = "ok"
+    ERROR = "error"
+
+
+class AgentRunEnvelope(BaseModel):
+    """Strict adapter output envelope for orchestration."""
+
+    status: str = Field(min_length=1)
+    summary: str = Field(min_length=1)
+    artifacts: list[dict[str, Any]] = Field(default_factory=list)
+    next_actions: list[str] = Field(default_factory=list)
+    errors: list[str] = Field(default_factory=list)
+    metrics: dict[str, Any] = Field(default_factory=dict)
+    spec_alignment_ok: bool = True
+    schema_valid: bool = True
+    model_self_confidence: float | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+@dataclass(frozen=True)
+class AgentExecutionRequest:
+    prompt: str
+    cwd: str | None = None
+    timeout_seconds: int = 120
+    metadata: dict[str, Any] | None = None
+
+
+class AgentAdapter(Protocol):
+    name: str
+
+    def execute(self, request: AgentExecutionRequest) -> AgentRunEnvelope:
+        """Execute one delegated step and return a strict run envelope."""

--- a/guardian/agents/adapters/claudecode.py
+++ b/guardian/agents/adapters/claudecode.py
@@ -1,0 +1,59 @@
+"""ClaudeCode CLI delegated adapter."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+
+from .base import AgentExecutionRequest, AgentRunEnvelope
+
+
+def _command_from_env() -> list[str]:
+    raw = os.getenv("CLAUDECODE_ADAPTER_COMMAND", "claude --print").strip()
+    return shlex.split(raw) if raw else ["claude", "--print"]
+
+
+class ClaudeCodeAdapter:
+    name = "claudecode"
+
+    def execute(self, request: AgentExecutionRequest) -> AgentRunEnvelope:
+        cmd = [*_command_from_env(), request.prompt]
+        proc = subprocess.run(
+            cmd,
+            cwd=request.cwd or None,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=request.timeout_seconds,
+        )
+        stdout = (proc.stdout or "").strip()
+        stderr = (proc.stderr or "").strip()
+
+        if proc.returncode != 0:
+            return AgentRunEnvelope(
+                status="error",
+                summary="ClaudeCode adapter execution failed",
+                artifacts=[],
+                next_actions=[],
+                errors=[stderr or f"exit={proc.returncode}"],
+                metrics={"returncode": proc.returncode},
+                spec_alignment_ok=True,
+                schema_valid=False,
+            )
+
+        try:
+            payload = json.loads(stdout)
+            return AgentRunEnvelope.model_validate(payload)
+        except Exception:
+            return AgentRunEnvelope(
+                status="error",
+                summary="ClaudeCode adapter returned non-JSON output",
+                artifacts=[],
+                next_actions=[],
+                errors=["invalid_json_envelope"],
+                metrics={"stdout_preview": stdout[:240]},
+                spec_alignment_ok=True,
+                schema_valid=False,
+            )

--- a/guardian/agents/adapters/codex.py
+++ b/guardian/agents/adapters/codex.py
@@ -1,0 +1,59 @@
+"""Codex CLI delegated adapter."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+
+from .base import AgentExecutionRequest, AgentRunEnvelope
+
+
+def _command_from_env() -> list[str]:
+    raw = os.getenv("CODEX_ADAPTER_COMMAND", "codex exec").strip()
+    return shlex.split(raw) if raw else ["codex", "exec"]
+
+
+class CodexAdapter:
+    name = "codex"
+
+    def execute(self, request: AgentExecutionRequest) -> AgentRunEnvelope:
+        cmd = [*_command_from_env(), request.prompt]
+        proc = subprocess.run(
+            cmd,
+            cwd=request.cwd or None,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=request.timeout_seconds,
+        )
+        stdout = (proc.stdout or "").strip()
+        stderr = (proc.stderr or "").strip()
+
+        if proc.returncode != 0:
+            return AgentRunEnvelope(
+                status="error",
+                summary="Codex adapter execution failed",
+                artifacts=[],
+                next_actions=[],
+                errors=[stderr or f"exit={proc.returncode}"],
+                metrics={"returncode": proc.returncode},
+                spec_alignment_ok=True,
+                schema_valid=False,
+            )
+
+        try:
+            payload = json.loads(stdout)
+            return AgentRunEnvelope.model_validate(payload)
+        except Exception:
+            return AgentRunEnvelope(
+                status="error",
+                summary="Codex adapter returned non-JSON output",
+                artifacts=[],
+                next_actions=[],
+                errors=["invalid_json_envelope"],
+                metrics={"stdout_preview": stdout[:240]},
+                spec_alignment_ok=True,
+                schema_valid=False,
+            )

--- a/guardian/agents/confidence.py
+++ b/guardian/agents/confidence.py
@@ -1,0 +1,132 @@
+"""Deterministic confidence scoring for delegated agent runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import mean
+
+
+def _clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:
+    return max(low, min(high, float(value)))
+
+
+@dataclass(frozen=True)
+class StepConfidenceResult:
+    score: float
+    decision: str
+    factors: dict[str, float]
+
+
+@dataclass(frozen=True)
+class TaskConfidenceResult:
+    score: float
+    decision: str
+    factors: dict[str, float]
+
+
+def classify_step_confidence(score: float) -> str:
+    value = _clamp(score)
+    if value >= 0.85:
+        return "continue"
+    if value >= 0.70:
+        return "warn"
+    if value >= 0.55:
+        return "soft_escalate"
+    return "hard_escalate"
+
+
+def classify_task_confidence(score: float) -> str:
+    value = _clamp(score)
+    if value >= 0.85:
+        return "autonomous_approve"
+    if value >= 0.70:
+        return "optional_audit"
+    if value >= 0.55:
+        return "audit_required"
+    return "block_merge_human_required"
+
+
+def compute_step_confidence(
+    *,
+    c_diff_risk: float,
+    c_model_stability: float,
+    c_tests: float = 1.0,
+    c_schema: float = 1.0,
+    c_spec_alignment: float = 1.0,
+) -> StepConfidenceResult:
+    factors = {
+        "c_tests": _clamp(c_tests),
+        "c_schema": _clamp(c_schema),
+        "c_spec_alignment": _clamp(c_spec_alignment),
+        "c_diff_risk": _clamp(c_diff_risk),
+        "c_model_stability": _clamp(c_model_stability),
+    }
+    score = _clamp(
+        (0.35 * factors["c_tests"])
+        + (0.20 * factors["c_schema"])
+        + (0.20 * factors["c_spec_alignment"])
+        + (0.15 * factors["c_diff_risk"])
+        + (0.10 * factors["c_model_stability"])
+    )
+    decision = classify_step_confidence(score)
+    return StepConfidenceResult(score=score, decision=decision, factors=factors)
+
+
+def _compute_convergence(step_scores: list[float]) -> float:
+    if not step_scores:
+        return 0.0
+    if len(step_scores) == 1:
+        return _clamp(step_scores[0])
+    deltas = []
+    for prev, cur in zip(step_scores[:-1], step_scores[1:]):
+        deltas.append(abs(cur - prev))
+    drift = mean(deltas) if deltas else 0.0
+    return _clamp(1.0 - drift)
+
+
+def compute_task_confidence(
+    *,
+    step_scores: list[float],
+    c_risk: float,
+    escalation_penalty: float,
+    c_convergence: float | None = None,
+) -> TaskConfidenceResult:
+    if not step_scores:
+        raise ValueError("step_scores must contain at least one value")
+
+    normalized_steps = [_clamp(score) for score in step_scores]
+    mean_step = _clamp(mean(normalized_steps))
+    min_step = _clamp(min(normalized_steps))
+    convergence = (
+        _compute_convergence(normalized_steps)
+        if c_convergence is None
+        else _clamp(c_convergence)
+    )
+    risk = _clamp(c_risk)
+    penalty = _clamp(escalation_penalty)
+    score = _clamp(
+        (0.40 * mean_step)
+        + (0.25 * min_step)
+        + (0.15 * convergence)
+        + (0.10 * risk)
+        + (0.10 * (1.0 - penalty))
+    )
+    decision = classify_task_confidence(score)
+    factors = {
+        "mean_step": mean_step,
+        "min_step": min_step,
+        "c_convergence": convergence,
+        "c_risk": risk,
+        "escalation_penalty": penalty,
+    }
+    return TaskConfidenceResult(score=score, decision=decision, factors=factors)
+
+
+__all__ = [
+    "StepConfidenceResult",
+    "TaskConfidenceResult",
+    "classify_step_confidence",
+    "classify_task_confidence",
+    "compute_step_confidence",
+    "compute_task_confidence",
+]

--- a/guardian/agents/events.py
+++ b/guardian/agents/events.py
@@ -1,0 +1,82 @@
+"""Agent event publisher with durable DB persistence + SSE stream fanout."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from guardian.db.models import AgentEvent, AgentRun
+from guardian.queue import task_events
+
+logger = logging.getLogger(__name__)
+
+
+class AgentEventPublisher:
+    """Persist agent events and publish them on existing task event streams."""
+
+    def __init__(self, db: Any | None = None) -> None:
+        self._db = db
+        self._mem_events: list[dict[str, Any]] = []
+
+    def configure_db(self, db: Any | None) -> None:
+        self._db = db
+
+    def emit(
+        self,
+        *,
+        run_id: str,
+        event_type: str,
+        payload: dict[str, Any] | None = None,
+        run_step_id: int | None = None,
+        attempt_id: int | None = None,
+    ) -> None:
+        safe_payload = dict(payload or {})
+        self._mem_events.append(
+            {
+                "run_id": run_id,
+                "event_type": event_type,
+                "payload": safe_payload,
+            }
+        )
+
+        # Stream fanout for existing `/api/tasks/{task_id}/events` compatibility.
+        try:
+            task_events.publish(run_id, event_type, safe_payload)
+        except Exception as exc:
+            logger.warning("[agent-events] stream publish failed: %s", exc)
+
+        db = self._db
+        if db is None or not hasattr(db, "get_session"):
+            return
+
+        try:
+            with db.get_session() as session:
+                run_row = (
+                    session.query(AgentRun).filter_by(run_id=run_id).first()
+                )
+                if run_row is None:
+                    return
+                row = AgentEvent(
+                    run_id=run_row.id,
+                    run_step_id=run_step_id,
+                    attempt_id=attempt_id,
+                    event_type=event_type,
+                    payload_json=safe_payload,
+                )
+                session.add(row)
+                session.commit()
+        except Exception as exc:
+            logger.warning("[agent-events] durable write failed: %s", exc)
+
+    def list_events(self, run_id: str | None = None) -> list[dict[str, Any]]:
+        if run_id is None:
+            return list(self._mem_events)
+        return [
+            event for event in self._mem_events if event.get("run_id") == run_id
+        ]
+
+
+publisher = AgentEventPublisher()
+
+
+__all__ = ["AgentEventPublisher", "publisher"]

--- a/guardian/agents/retry_policy.py
+++ b/guardian/agents/retry_policy.py
@@ -1,0 +1,179 @@
+"""Adaptive retry policy for delegated agent mutating steps."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+
+def _stable_text_lines(lines: list[str] | None) -> list[str]:
+    out: list[str] = []
+    for raw in lines or []:
+        clean = " ".join(str(raw).strip().split())
+        if clean:
+            out.append(clean)
+    return out
+
+
+def build_fail_signature(
+    failing_tests: list[str] | None,
+    stderr_lines: list[str] | None,
+) -> str:
+    tests = sorted(set(_stable_text_lines(failing_tests)))
+    stderr = _stable_text_lines(stderr_lines)[:20]
+    payload = "\n".join([*tests, "---", *stderr])
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return digest[:24]
+
+
+def _error_rank(value: str | None) -> int:
+    ranks = {
+        "spec_alignment_violation": 0,
+        "schema_invalid": 1,
+        "tests_failed": 2,
+        "unknown": 3,
+    }
+    key = str(value or "unknown").strip().lower()
+    return ranks.get(key, ranks["unknown"])
+
+
+@dataclass(frozen=True)
+class AttemptMetrics:
+    fail_count: int
+    fail_signature: str
+    diff_added: int
+    diff_deleted: int
+    error_category: str
+    progress_made: bool = False
+
+
+@dataclass(frozen=True)
+class RetryConfig:
+    max_attempts: int = 5
+    min_attempts_before_abort: int = 2
+    no_progress_window: int = 2
+    max_same_signature_repeats: int = 2
+    regression_limit: int = 2
+
+
+@dataclass(frozen=True)
+class RetryDecision:
+    should_retry: bool
+    escalate: bool
+    reason: str
+
+
+def _count_same_signature_suffix(
+    history: list[AttemptMetrics], current_signature: str
+) -> int:
+    count = 0
+    for item in reversed(history):
+        if item.fail_signature != current_signature:
+            break
+        count += 1
+    return count
+
+
+def _no_progress_suffix(history: list[AttemptMetrics]) -> int:
+    count = 0
+    for item in reversed(history):
+        if item.progress_made:
+            break
+        count += 1
+    return count
+
+
+def _is_progress(
+    current: AttemptMetrics,
+    previous: AttemptMetrics | None,
+    best_fail_count: int | None,
+) -> bool:
+    if previous is not None:
+        if current.fail_count < previous.fail_count:
+            return True
+        if _error_rank(current.error_category) < _error_rank(
+            previous.error_category
+        ):
+            return True
+    if best_fail_count is not None and current.fail_count < best_fail_count:
+        return True
+    return False
+
+
+def evaluate_retry_decision(
+    *,
+    attempt_index: int,
+    current: AttemptMetrics,
+    history: list[AttemptMetrics],
+    config: RetryConfig,
+    spec_alignment_violation: bool = False,
+) -> RetryDecision:
+    if spec_alignment_violation:
+        return RetryDecision(
+            should_retry=False,
+            escalate=True,
+            reason="spec_alignment_violation",
+        )
+
+    best_fail_count = min(
+        (item.fail_count for item in history),
+        default=None,
+    )
+    previous = history[-1] if history else None
+    progress = _is_progress(current, previous, best_fail_count)
+    current_with_progress = AttemptMetrics(
+        fail_count=current.fail_count,
+        fail_signature=current.fail_signature,
+        diff_added=current.diff_added,
+        diff_deleted=current.diff_deleted,
+        error_category=current.error_category,
+        progress_made=progress,
+    )
+    extended = [*history, current_with_progress]
+    min_reached = attempt_index >= config.min_attempts_before_abort
+
+    if min_reached:
+        no_progress = _no_progress_suffix(extended)
+        if no_progress >= config.no_progress_window:
+            return RetryDecision(
+                should_retry=False,
+                escalate=True,
+                reason="no_progress_window",
+            )
+
+        same_sig = _count_same_signature_suffix(
+            extended, current.fail_signature
+        )
+        if same_sig > config.max_same_signature_repeats:
+            return RetryDecision(
+                should_retry=False,
+                escalate=True,
+                reason="same_signature_repeat",
+            )
+
+        if best_fail_count is not None and (
+            current.fail_count > best_fail_count + config.regression_limit
+        ):
+            return RetryDecision(
+                should_retry=False,
+                escalate=True,
+                reason="regression_limit",
+            )
+
+    if attempt_index >= config.max_attempts:
+        return RetryDecision(
+            should_retry=False,
+            escalate=False,
+            reason="max_attempts_exhausted",
+        )
+
+    return RetryDecision(should_retry=True, escalate=False, reason="retry")
+
+
+__all__ = [
+    "AttemptMetrics",
+    "RetryConfig",
+    "RetryDecision",
+    "build_fail_signature",
+    "evaluate_retry_decision",
+]

--- a/guardian/agents/store.py
+++ b/guardian/agents/store.py
@@ -1,0 +1,814 @@
+"""Persistence helpers for agent orchestration entities."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from guardian.db.models import (
+    AgentConfidenceReport,
+    AgentDeployment,
+    AgentEscalation,
+    AgentEvent,
+    AgentRun,
+    AgentRunArtifact,
+    AgentRunAttempt,
+    AgentRunStep,
+)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _new_external_id(prefix: str) -> str:
+    return f"{prefix}_{uuid4().hex[:16]}"
+
+
+def deterministic_worktree_id(
+    *, deployment_id: str, run_id: str, step_index: int
+) -> str:
+    seed = f"{deployment_id}:{run_id}:{step_index}".encode()
+    digest = hashlib.sha256(seed).hexdigest()
+    return digest[:24]
+
+
+@dataclass
+class AgentStore:
+    """Durable store with SQLAlchemy-backed persistence and in-memory fallback."""
+
+    db: Any | None = None
+
+    def __post_init__(self) -> None:
+        self._mem_deployments: dict[str, dict[str, Any]] = {}
+        self._mem_runs: dict[str, dict[str, Any]] = {}
+        self._mem_steps: dict[tuple[str, int], dict[str, Any]] = {}
+        self._mem_attempts: list[dict[str, Any]] = []
+        self._mem_artifacts: list[dict[str, Any]] = []
+        self._mem_confidence: list[dict[str, Any]] = []
+        self._mem_escalations: list[dict[str, Any]] = []
+
+    def configure_db(self, db: Any | None) -> None:
+        self.db = db
+
+    def _has_db(self) -> bool:
+        return bool(self.db is not None and hasattr(self.db, "get_session"))
+
+    def create_deployment(
+        self,
+        *,
+        flow_id: str,
+        thread_id: int | None,
+        spec_json: dict[str, Any],
+        spec_hash: str,
+        trust_state: str = "supervised",
+    ) -> dict[str, Any]:
+        deployment_id = _new_external_id("dep")
+        now = _utc_now()
+        if self._has_db():
+            with self.db.get_session() as session:
+                row = AgentDeployment(
+                    deployment_id=deployment_id,
+                    flow_id=flow_id,
+                    thread_id=thread_id,
+                    spec_json=spec_json or {},
+                    spec_hash=spec_hash,
+                    trust_state=trust_state,
+                    unlocked_for_unsupervised=(trust_state == "unlocked"),
+                    status="active",
+                    created_at=now,
+                    updated_at=now,
+                )
+                session.add(row)
+                session.commit()
+                return {
+                    "deployment_id": row.deployment_id,
+                    "flow_id": row.flow_id,
+                    "thread_id": row.thread_id,
+                    "trust_state": row.trust_state,
+                    "status": row.status,
+                    "spec_hash": row.spec_hash,
+                }
+
+        data = {
+            "deployment_id": deployment_id,
+            "flow_id": flow_id,
+            "thread_id": thread_id,
+            "spec_json": dict(spec_json or {}),
+            "spec_hash": spec_hash,
+            "trust_state": trust_state,
+            "status": "active",
+            "created_at": now.isoformat(),
+            "updated_at": now.isoformat(),
+        }
+        self._mem_deployments[deployment_id] = data
+        return data
+
+    def get_deployment(self, deployment_id: str) -> dict[str, Any] | None:
+        if self._has_db():
+            with self.db.get_session() as session:
+                row = (
+                    session.query(AgentDeployment)
+                    .filter_by(deployment_id=deployment_id)
+                    .first()
+                )
+                if row is None:
+                    return None
+                return {
+                    "deployment_id": row.deployment_id,
+                    "flow_id": row.flow_id,
+                    "thread_id": row.thread_id,
+                    "trust_state": row.trust_state,
+                    "status": row.status,
+                    "spec_hash": row.spec_hash,
+                }
+        return self._mem_deployments.get(deployment_id)
+
+    def create_run(
+        self,
+        *,
+        deployment_id: str,
+        thread_id: int | None,
+        runtime_target: str = "container",
+        rollback_mode: str = "auto",
+        status: str = "running",
+        worktree_id: str | None = None,
+        worktree_path: str | None = None,
+    ) -> dict[str, Any]:
+        run_id = _new_external_id("run")
+        now = _utc_now()
+        if self._has_db():
+            with self.db.get_session() as session:
+                dep_row = (
+                    session.query(AgentDeployment)
+                    .filter_by(deployment_id=deployment_id)
+                    .first()
+                )
+                if dep_row is None:
+                    raise ValueError(f"Unknown deployment_id '{deployment_id}'")
+                row = AgentRun(
+                    run_id=run_id,
+                    deployment_id=dep_row.id,
+                    thread_id=thread_id,
+                    status=status,
+                    runtime_target=runtime_target,
+                    rollback_mode=rollback_mode,
+                    worktree_id=worktree_id,
+                    worktree_path=worktree_path,
+                    started_at=now if status == "running" else None,
+                    created_at=now,
+                )
+                session.add(row)
+                session.commit()
+                return {
+                    "run_id": row.run_id,
+                    "deployment_id": deployment_id,
+                    "thread_id": row.thread_id,
+                    "status": row.status,
+                    "runtime_target": row.runtime_target,
+                    "worktree_id": row.worktree_id,
+                    "worktree_path": row.worktree_path,
+                }
+
+        data = {
+            "run_id": run_id,
+            "deployment_id": deployment_id,
+            "thread_id": thread_id,
+            "status": status,
+            "runtime_target": runtime_target,
+            "rollback_mode": rollback_mode,
+            "worktree_id": worktree_id,
+            "worktree_path": worktree_path,
+            "created_at": now.isoformat(),
+            "started_at": now.isoformat() if status == "running" else None,
+        }
+        self._mem_runs[run_id] = data
+        return data
+
+    def get_run(self, run_id: str) -> dict[str, Any] | None:
+        if self._has_db():
+            with self.db.get_session() as session:
+                row = session.query(AgentRun).filter_by(run_id=run_id).first()
+                if row is None:
+                    return None
+                dep = (
+                    session.query(AgentDeployment)
+                    .filter_by(id=row.deployment_id)
+                    .first()
+                )
+                return {
+                    "run_id": row.run_id,
+                    "deployment_id": dep.deployment_id if dep else None,
+                    "thread_id": row.thread_id,
+                    "status": row.status,
+                    "runtime_target": row.runtime_target,
+                    "rollback_applied": bool(row.rollback_applied),
+                    "rollback_reason": row.rollback_reason,
+                    "worktree_id": row.worktree_id,
+                    "worktree_path": row.worktree_path,
+                }
+        return self._mem_runs.get(run_id)
+
+    def list_runs_for_thread(self, thread_id: int) -> list[dict[str, Any]]:
+        if self._has_db():
+            with self.db.get_session() as session:
+                rows = (
+                    session.query(AgentRun)
+                    .filter_by(thread_id=thread_id)
+                    .order_by(AgentRun.created_at.desc())
+                    .all()
+                )
+                return [
+                    {
+                        "run_id": row.run_id,
+                        "thread_id": row.thread_id,
+                        "status": row.status,
+                        "runtime_target": row.runtime_target,
+                        "worktree_id": row.worktree_id,
+                        "worktree_path": row.worktree_path,
+                    }
+                    for row in rows
+                ]
+        items = [
+            value
+            for value in self._mem_runs.values()
+            if value.get("thread_id") == thread_id
+        ]
+        return sorted(
+            items,
+            key=lambda item: str(item.get("created_at") or ""),
+            reverse=True,
+        )
+
+    def update_run_status(
+        self,
+        *,
+        run_id: str,
+        status: str,
+        error: str | None = None,
+        rollback_applied: bool | None = None,
+        rollback_reason: str | None = None,
+    ) -> None:
+        now = _utc_now()
+        if self._has_db():
+            with self.db.get_session() as session:
+                row = session.query(AgentRun).filter_by(run_id=run_id).first()
+                if row is None:
+                    return
+                row.status = status
+                if error is not None:
+                    row.error = error
+                if rollback_applied is not None:
+                    row.rollback_applied = rollback_applied
+                if rollback_reason is not None:
+                    row.rollback_reason = rollback_reason
+                if status in {"failed", "succeeded", "canceled", "escalated"}:
+                    row.ended_at = now
+                session.commit()
+                return
+
+        item = self._mem_runs.get(run_id)
+        if item is None:
+            return
+        item["status"] = status
+        if error is not None:
+            item["error"] = error
+        if rollback_applied is not None:
+            item["rollback_applied"] = rollback_applied
+        if rollback_reason is not None:
+            item["rollback_reason"] = rollback_reason
+        if status in {"failed", "succeeded", "canceled", "escalated"}:
+            item["ended_at"] = now.isoformat()
+
+    def create_step(
+        self,
+        *,
+        run_id: str,
+        step_index: int,
+        step_id: str,
+        primitive: str,
+        is_mutating: bool,
+    ) -> dict[str, Any]:
+        now = _utc_now()
+        if self._has_db():
+            with self.db.get_session() as session:
+                run_row = (
+                    session.query(AgentRun).filter_by(run_id=run_id).first()
+                )
+                if run_row is None:
+                    raise ValueError(f"Unknown run_id '{run_id}'")
+                row = AgentRunStep(
+                    run_id=run_row.id,
+                    step_index=step_index,
+                    step_id=step_id,
+                    primitive=primitive,
+                    is_mutating=is_mutating,
+                    status="running",
+                    started_at=now,
+                )
+                session.add(row)
+                session.commit()
+                return {
+                    "run_id": run_id,
+                    "step_index": row.step_index,
+                    "step_id": row.step_id,
+                    "status": row.status,
+                }
+
+        data = {
+            "run_id": run_id,
+            "step_index": step_index,
+            "step_id": step_id,
+            "primitive": primitive,
+            "is_mutating": is_mutating,
+            "status": "running",
+            "started_at": now.isoformat(),
+        }
+        self._mem_steps[(run_id, step_index)] = data
+        return data
+
+    def update_step_status(
+        self,
+        *,
+        run_id: str,
+        step_index: int,
+        status: str,
+        schema_valid: bool | None = None,
+        spec_alignment_ok: bool | None = None,
+        tests_passed: bool | None = None,
+    ) -> None:
+        now = _utc_now()
+        if self._has_db():
+            with self.db.get_session() as session:
+                run_row = (
+                    session.query(AgentRun).filter_by(run_id=run_id).first()
+                )
+                if run_row is None:
+                    return
+                row = (
+                    session.query(AgentRunStep)
+                    .filter_by(run_id=run_row.id, step_index=step_index)
+                    .first()
+                )
+                if row is None:
+                    return
+                row.status = status
+                if schema_valid is not None:
+                    row.schema_valid = schema_valid
+                if spec_alignment_ok is not None:
+                    row.spec_alignment_ok = spec_alignment_ok
+                if tests_passed is not None:
+                    row.tests_passed = tests_passed
+                if status in {"succeeded", "failed", "escalated", "canceled"}:
+                    row.ended_at = now
+                session.commit()
+                return
+
+        item = self._mem_steps.get((run_id, step_index))
+        if item is None:
+            return
+        item["status"] = status
+        if schema_valid is not None:
+            item["schema_valid"] = schema_valid
+        if spec_alignment_ok is not None:
+            item["spec_alignment_ok"] = spec_alignment_ok
+        if tests_passed is not None:
+            item["tests_passed"] = tests_passed
+        if status in {"succeeded", "failed", "escalated", "canceled"}:
+            item["ended_at"] = now.isoformat()
+
+    def add_attempt(
+        self,
+        *,
+        run_id: str,
+        step_index: int,
+        attempt_index: int,
+        status: str,
+        fail_count: int,
+        fail_signature: str,
+        diff_added: int,
+        diff_deleted: int,
+        error_category: str,
+        progress_made: bool,
+        stderr_excerpt: str | None = None,
+    ) -> dict[str, Any]:
+        if self._has_db():
+            with self.db.get_session() as session:
+                run_row = (
+                    session.query(AgentRun).filter_by(run_id=run_id).first()
+                )
+                if run_row is None:
+                    raise ValueError(f"Unknown run_id '{run_id}'")
+                step_row = (
+                    session.query(AgentRunStep)
+                    .filter_by(run_id=run_row.id, step_index=step_index)
+                    .first()
+                )
+                if step_row is None:
+                    raise ValueError(
+                        f"Unknown step run_id='{run_id}' step_index={step_index}"
+                    )
+                row = AgentRunAttempt(
+                    run_step_id=step_row.id,
+                    attempt_index=attempt_index,
+                    status=status,
+                    fail_count=fail_count,
+                    fail_signature=fail_signature,
+                    diff_added=diff_added,
+                    diff_deleted=diff_deleted,
+                    error_category=error_category,
+                    progress_made=progress_made,
+                    stderr_excerpt=stderr_excerpt,
+                    ended_at=_utc_now(),
+                )
+                session.add(row)
+                session.commit()
+                return {
+                    "run_id": run_id,
+                    "step_index": step_index,
+                    "attempt_index": attempt_index,
+                    "status": status,
+                    "id": row.id,
+                }
+
+        item = {
+            "run_id": run_id,
+            "step_index": step_index,
+            "attempt_index": attempt_index,
+            "status": status,
+            "fail_count": fail_count,
+            "fail_signature": fail_signature,
+            "diff_added": diff_added,
+            "diff_deleted": diff_deleted,
+            "error_category": error_category,
+            "progress_made": progress_made,
+            "stderr_excerpt": stderr_excerpt,
+        }
+        self._mem_attempts.append(item)
+        return item
+
+    def add_artifact(
+        self,
+        *,
+        run_id: str,
+        step_index: int | None,
+        artifact_type: str,
+        content_json: dict[str, Any],
+    ) -> None:
+        if self._has_db():
+            with self.db.get_session() as session:
+                run_row = (
+                    session.query(AgentRun).filter_by(run_id=run_id).first()
+                )
+                if run_row is None:
+                    return
+                step_row = None
+                if step_index is not None:
+                    step_row = (
+                        session.query(AgentRunStep)
+                        .filter_by(run_id=run_row.id, step_index=step_index)
+                        .first()
+                    )
+                row = AgentRunArtifact(
+                    run_id=run_row.id,
+                    run_step_id=step_row.id if step_row else None,
+                    artifact_type=artifact_type,
+                    content_json=dict(content_json or {}),
+                )
+                session.add(row)
+                session.commit()
+                return
+        self._mem_artifacts.append(
+            {
+                "run_id": run_id,
+                "step_index": step_index,
+                "artifact_type": artifact_type,
+                "content_json": dict(content_json or {}),
+            }
+        )
+
+    def add_confidence_report(
+        self,
+        *,
+        run_id: str,
+        step_index: int | None,
+        scope: str,
+        confidence: float,
+        decision: str,
+        factors: dict[str, Any],
+        model_self_confidence: float | None = None,
+    ) -> None:
+        if self._has_db():
+            with self.db.get_session() as session:
+                run_row = (
+                    session.query(AgentRun).filter_by(run_id=run_id).first()
+                )
+                if run_row is None:
+                    return
+                step_row = None
+                if step_index is not None:
+                    step_row = (
+                        session.query(AgentRunStep)
+                        .filter_by(run_id=run_row.id, step_index=step_index)
+                        .first()
+                    )
+                row = AgentConfidenceReport(
+                    run_id=run_row.id,
+                    run_step_id=step_row.id if step_row else None,
+                    step_index=step_index,
+                    scope=scope,
+                    confidence=confidence,
+                    decision=decision,
+                    factors_json=dict(factors or {}),
+                    model_self_confidence=model_self_confidence,
+                )
+                session.add(row)
+                session.commit()
+                return
+        self._mem_confidence.append(
+            {
+                "run_id": run_id,
+                "step_index": step_index,
+                "scope": scope,
+                "confidence": confidence,
+                "decision": decision,
+                "factors": dict(factors or {}),
+                "model_self_confidence": model_self_confidence,
+            }
+        )
+
+    def add_escalation(
+        self,
+        *,
+        run_id: str,
+        step_index: int | None,
+        severity: str,
+        reason_code: str,
+        reason: str,
+        preserved_worktree: bool,
+        payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        if self._has_db():
+            with self.db.get_session() as session:
+                run_row = (
+                    session.query(AgentRun).filter_by(run_id=run_id).first()
+                )
+                if run_row is None:
+                    raise ValueError(f"Unknown run_id '{run_id}'")
+                step_row = None
+                if step_index is not None:
+                    step_row = (
+                        session.query(AgentRunStep)
+                        .filter_by(run_id=run_row.id, step_index=step_index)
+                        .first()
+                    )
+                row = AgentEscalation(
+                    run_id=run_row.id,
+                    run_step_id=step_row.id if step_row else None,
+                    step_index=step_index,
+                    severity=severity,
+                    reason_code=reason_code,
+                    reason=reason,
+                    status="open",
+                    preserved_worktree=preserved_worktree,
+                    payload_json=dict(payload or {}),
+                )
+                session.add(row)
+                session.commit()
+                return {
+                    "id": row.id,
+                    "run_id": run_id,
+                    "step_index": step_index,
+                    "severity": severity,
+                    "reason_code": reason_code,
+                    "reason": reason,
+                    "status": row.status,
+                    "preserved_worktree": bool(row.preserved_worktree),
+                }
+        entry = {
+            "id": len(self._mem_escalations) + 1,
+            "run_id": run_id,
+            "step_index": step_index,
+            "severity": severity,
+            "reason_code": reason_code,
+            "reason": reason,
+            "status": "open",
+            "preserved_worktree": preserved_worktree,
+            "payload": dict(payload or {}),
+        }
+        self._mem_escalations.append(entry)
+        return entry
+
+    def list_attempts(
+        self,
+        *,
+        run_id: str,
+        step_index: int | None = None,
+    ) -> list[dict[str, Any]]:
+        if self._has_db():
+            with self.db.get_session() as session:
+                run_row = (
+                    session.query(AgentRun).filter_by(run_id=run_id).first()
+                )
+                if run_row is None:
+                    return []
+                query = (
+                    session.query(AgentRunAttempt)
+                    .join(
+                        AgentRunStep,
+                        AgentRunAttempt.run_step_id == AgentRunStep.id,
+                    )
+                    .filter(AgentRunStep.run_id == run_row.id)
+                )
+                if step_index is not None:
+                    query = query.filter(AgentRunStep.step_index == step_index)
+                rows = query.order_by(
+                    AgentRunStep.step_index.asc(),
+                    AgentRunAttempt.attempt_index.asc(),
+                ).all()
+                return [
+                    {
+                        "step_index": row_step.step_index,
+                        "attempt_index": row_attempt.attempt_index,
+                        "status": row_attempt.status,
+                        "fail_count": row_attempt.fail_count,
+                        "fail_signature": row_attempt.fail_signature,
+                        "diff_added": row_attempt.diff_added,
+                        "diff_deleted": row_attempt.diff_deleted,
+                        "error_category": row_attempt.error_category,
+                        "progress_made": bool(row_attempt.progress_made),
+                    }
+                    for (row_attempt, row_step) in (
+                        (
+                            attempt,
+                            session.query(AgentRunStep)
+                            .filter_by(id=attempt.run_step_id)
+                            .first(),
+                        )
+                        for attempt in rows
+                    )
+                    if row_step is not None
+                ]
+
+        rows = [item for item in self._mem_attempts if item["run_id"] == run_id]
+        if step_index is not None:
+            rows = [row for row in rows if row["step_index"] == step_index]
+        return sorted(rows, key=lambda row: int(row.get("attempt_index") or 0))
+
+    def list_artifacts(
+        self,
+        *,
+        run_id: str,
+        step_index: int | None = None,
+        artifact_type: str | None = None,
+    ) -> list[dict[str, Any]]:
+        if self._has_db():
+            with self.db.get_session() as session:
+                run_row = (
+                    session.query(AgentRun).filter_by(run_id=run_id).first()
+                )
+                if run_row is None:
+                    return []
+                query = session.query(AgentRunArtifact).filter_by(
+                    run_id=run_row.id
+                )
+                if artifact_type is not None:
+                    query = query.filter_by(artifact_type=artifact_type)
+                rows = query.order_by(AgentRunArtifact.created_at.asc()).all()
+                out: list[dict[str, Any]] = []
+                for row in rows:
+                    resolved_step_index = None
+                    if row.run_step_id is not None:
+                        step_row = (
+                            session.query(AgentRunStep)
+                            .filter_by(id=row.run_step_id)
+                            .first()
+                        )
+                        resolved_step_index = (
+                            step_row.step_index if step_row else None
+                        )
+                    if (
+                        step_index is not None
+                        and resolved_step_index != step_index
+                    ):
+                        continue
+                    out.append(
+                        {
+                            "step_index": resolved_step_index,
+                            "artifact_type": row.artifact_type,
+                            "content_json": dict(row.content_json or {}),
+                        }
+                    )
+                return out
+
+        rows = [
+            item for item in self._mem_artifacts if item["run_id"] == run_id
+        ]
+        if step_index is not None:
+            rows = [row for row in rows if row["step_index"] == step_index]
+        if artifact_type is not None:
+            rows = [
+                row for row in rows if row["artifact_type"] == artifact_type
+            ]
+        return rows
+
+    def list_confidence_reports(
+        self,
+        *,
+        run_id: str,
+        scope: str | None = None,
+    ) -> list[dict[str, Any]]:
+        if self._has_db():
+            with self.db.get_session() as session:
+                run_row = (
+                    session.query(AgentRun).filter_by(run_id=run_id).first()
+                )
+                if run_row is None:
+                    return []
+                query = session.query(AgentConfidenceReport).filter_by(
+                    run_id=run_row.id
+                )
+                if scope is not None:
+                    query = query.filter_by(scope=scope)
+                rows = query.order_by(
+                    AgentConfidenceReport.created_at.asc()
+                ).all()
+                return [
+                    {
+                        "step_index": row.step_index,
+                        "scope": row.scope,
+                        "confidence": row.confidence,
+                        "decision": row.decision,
+                        "factors": dict(row.factors_json or {}),
+                        "model_self_confidence": row.model_self_confidence,
+                    }
+                    for row in rows
+                ]
+
+        rows = [
+            item for item in self._mem_confidence if item["run_id"] == run_id
+        ]
+        if scope is not None:
+            rows = [row for row in rows if row["scope"] == scope]
+        return rows
+
+    def list_escalations(self, *, run_id: str) -> list[dict[str, Any]]:
+        if self._has_db():
+            with self.db.get_session() as session:
+                run_row = (
+                    session.query(AgentRun).filter_by(run_id=run_id).first()
+                )
+                if run_row is None:
+                    return []
+                rows = (
+                    session.query(AgentEscalation)
+                    .filter_by(run_id=run_row.id)
+                    .order_by(AgentEscalation.created_at.asc())
+                    .all()
+                )
+                return [
+                    {
+                        "step_index": row.step_index,
+                        "severity": row.severity,
+                        "reason_code": row.reason_code,
+                        "reason": row.reason,
+                        "status": row.status,
+                        "preserved_worktree": bool(row.preserved_worktree),
+                    }
+                    for row in rows
+                ]
+        return [
+            row for row in self._mem_escalations if row.get("run_id") == run_id
+        ]
+
+    def list_events(self, *, run_id: str) -> list[dict[str, Any]]:
+        if self._has_db():
+            with self.db.get_session() as session:
+                run_row = (
+                    session.query(AgentRun).filter_by(run_id=run_id).first()
+                )
+                if run_row is None:
+                    return []
+                rows = (
+                    session.query(AgentEvent)
+                    .filter_by(run_id=run_row.id)
+                    .order_by(AgentEvent.created_at.asc())
+                    .all()
+                )
+                return [
+                    {
+                        "event_type": row.event_type,
+                        "payload": dict(row.payload_json or {}),
+                    }
+                    for row in rows
+                ]
+        return []
+
+
+store = AgentStore()
+
+
+__all__ = ["AgentStore", "deterministic_worktree_id", "store"]

--- a/guardian/core/ai_router.py
+++ b/guardian/core/ai_router.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Optional
 
 import requests
 from fastapi import HTTPException
@@ -73,6 +73,8 @@ def _default_model_for_provider(provider: str, settings: Settings) -> str:
         return settings.LLM_MODEL or settings.DEFAULT_GROQ_MODEL
     if provider == "openai":
         return settings.DEFAULT_OPENAI_MODEL
+    if provider == "minimax":
+        return (settings.MINIMAX_MODEL or "").strip()
     return ""
 
 
@@ -115,6 +117,8 @@ def chat_with_ai(
             _normalize_openai_model(target_model, settings),
             settings=settings,
         )
+    if provider_name == "minimax":
+        return call_minimax(messages, target_model, settings=settings)
 
     logger.warning("Unsupported LLM provider: %s", provider_name)
     raise HTTPException(
@@ -327,3 +331,197 @@ def call_openai(messages, model: str, *, settings: Optional[Settings] = None):
     except Exception as e:
         logger.exception("OpenAI backend error")
         raise HTTPException(status_code=502, detail=str(e))
+
+
+def _sanitize_provider_error(message: str, *, secret: str | None = None) -> str:
+    detail = (message or "").strip()
+    if secret:
+        detail = detail.replace(secret, "<redacted>")
+    return detail or "request failed"
+
+
+def _extract_provider_error_message(
+    response: requests.Response,
+    *,
+    secret: str | None = None,
+) -> str:
+    text = ""
+    try:
+        payload = response.json()
+        if isinstance(payload, dict):
+            error = payload.get("error")
+            if isinstance(error, dict):
+                text = str(error.get("message") or "").strip()
+            elif isinstance(error, str):
+                text = error.strip()
+            if not text:
+                text = str(payload.get("message") or "").strip()
+    except Exception:
+        text = ""
+
+    if not text:
+        text = (response.text or "").strip() or f"HTTP {response.status_code}"
+    return _sanitize_provider_error(text, secret=secret)
+
+
+def _normalize_messages_for_anthropic(
+    messages: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], str | None]:
+    system_parts: list[str] = []
+    normalized: list[dict[str, Any]] = []
+
+    for raw in messages:
+        if not isinstance(raw, dict):
+            continue
+        role = str(raw.get("role") or "user").strip().lower() or "user"
+        text = str(raw.get("content") or "").strip()
+        if not text:
+            continue
+        if role == "system":
+            system_parts.append(text)
+            continue
+        if role not in {"user", "assistant"}:
+            role = "user"
+        normalized.append(
+            {"role": role, "content": [{"type": "text", "text": text}]}
+        )
+
+    if not normalized:
+        normalized = [
+            {"role": "user", "content": [{"type": "text", "text": ""}]}
+        ]
+
+    system_text = "\n\n".join(part for part in system_parts if part).strip()
+    return normalized, (system_text or None)
+
+
+def _extract_anthropic_text(payload: dict[str, Any]) -> str:
+    content = payload.get("content")
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if str(block.get("type") or "").strip() != "text":
+            continue
+        text = str(block.get("text") or "").strip()
+        if text:
+            parts.append(text)
+    return "".join(parts)
+
+
+def call_minimax(messages, model: str, *, settings: Optional[Settings] = None):
+    """Call MiniMax via OpenAI- or Anthropic-compatible endpoints."""
+    settings = _resolve_settings(settings)
+
+    try:
+        assert_egress_allowed("minimax", settings=settings)
+    except EgressDeniedError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+
+    api_key = (settings.MINIMAX_API_KEY or "").strip()
+    if not api_key:
+        raise HTTPException(
+            status_code=400,
+            detail="MINIMAX_API_KEY is not configured",
+        )
+
+    base_url = (settings.MINIMAX_API_BASE or "").strip().rstrip("/")
+    if not base_url:
+        raise HTTPException(
+            status_code=400,
+            detail="MINIMAX_API_BASE is not configured",
+        )
+
+    api_flavor = str(getattr(settings, "MINIMAX_API_FLAVOR", "openai") or "")
+    api_flavor = api_flavor.strip().lower() or "openai"
+    if api_flavor not in {"openai", "anthropic"}:
+        raise HTTPException(
+            status_code=400,
+            detail="MINIMAX_API_FLAVOR must be one of: openai, anthropic",
+        )
+
+    if api_flavor == "anthropic":
+        anthropic_messages, system_prompt = _normalize_messages_for_anthropic(
+            messages
+        )
+        payload: Dict[str, Any] = {
+            "model": model,
+            "messages": anthropic_messages,
+            "temperature": 0.7,
+            "max_tokens": int(
+                getattr(settings, "MINIMAX_ANTHROPIC_MAX_TOKENS", 1024)
+            ),
+        }
+        if system_prompt:
+            payload["system"] = system_prompt
+        headers = {
+            "x-api-key": api_key,
+            "anthropic-version": str(
+                getattr(settings, "MINIMAX_ANTHROPIC_VERSION", "2023-06-01")
+                or "2023-06-01"
+            ),
+            "Content-Type": "application/json",
+        }
+        if base_url.endswith("/v1"):
+            url = f"{base_url}/messages"
+        else:
+            url = f"{base_url}/v1/messages"
+    else:
+        payload = {
+            "model": model,
+            "messages": messages,
+            "temperature": 0.7,
+        }
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        url = f"{base_url}/chat/completions"
+
+    timeout = float(
+        getattr(
+            settings,
+            "MINIMAX_TIMEOUT_SECONDS",
+            getattr(settings, "LLM_REQUEST_TIMEOUT_SECONDS", 60),
+        )
+    )
+
+    try:
+        response = requests.post(
+            url,
+            json=payload,
+            headers=headers,
+            timeout=timeout,
+        )
+    except req_exc.RequestException as exc:
+        logger.exception("MiniMax backend request error")
+        detail = _sanitize_provider_error(str(exc), secret=api_key)
+        raise HTTPException(
+            status_code=502,
+            detail=f"MiniMax request failed: {detail}",
+        ) from exc
+
+    if not (200 <= response.status_code < 300):
+        detail = _extract_provider_error_message(response, secret=api_key)
+        raise HTTPException(
+            status_code=502,
+            detail=f"MiniMax request failed ({response.status_code}): {detail}",
+        )
+
+    try:
+        data = response.json()
+        if api_flavor == "anthropic":
+            text = _extract_anthropic_text(data)
+            if text:
+                return text
+            raise KeyError("content")
+        return data["choices"][0]["message"]["content"]
+    except Exception as exc:
+        logger.exception("MiniMax backend response parse error")
+        detail = _sanitize_provider_error(str(exc), secret=api_key)
+        raise HTTPException(
+            status_code=502,
+            detail=f"MiniMax response parse failed: {detail}",
+        ) from exc

--- a/guardian/core/config.py
+++ b/guardian/core/config.py
@@ -130,6 +130,19 @@ class Settings(BaseSettings):
         default=None,
         description="Base URL for MiniMax's OpenAI-compatible API endpoint.",
     )
+    MINIMAX_API_FLAVOR: str = Field(
+        default="openai",
+        description=(
+            "MiniMax API surface to use: 'openai' for /chat/completions or "
+            "'anthropic' for /v1/messages."
+        ),
+    )
+    MINIMAX_ANTHROPIC_VERSION: str = Field(
+        default="2023-06-01",
+        description=(
+            "Anthropic API version header used when MINIMAX_API_FLAVOR=anthropic."
+        ),
+    )
     MINIMAX_MODEL: str | None = Field(
         default=None,
         description="Optional default chat model for MiniMax.",
@@ -608,6 +621,14 @@ def validate_llm_config(
             raise LLMConfigError(
                 "LLM_PROVIDER is 'minimax' but required environment variable(s) are missing: "
                 f"{missing_text}. Set {missing_text} in your backend environment."
+            )
+        api_flavor = str(
+            getattr(settings, "MINIMAX_API_FLAVOR", "openai") or ""
+        )
+        api_flavor = api_flavor.strip().lower() or "openai"
+        if api_flavor not in {"openai", "anthropic"}:
+            raise LLMConfigError(
+                "MINIMAX_API_FLAVOR must be one of: openai, anthropic."
             )
         return
 

--- a/guardian/core/config.py
+++ b/guardian/core/config.py
@@ -156,6 +156,58 @@ class Settings(BaseSettings):
     AGENT_TIMEOUT_SECONDS: int = Field(
         default=30, description="Timeout in seconds for agent execution."
     )
+    AGENT_MAX_ATTEMPTS: int = Field(
+        default=5,
+        description="Maximum retry attempts for mutating delegated steps.",
+    )
+    AGENT_MIN_ATTEMPTS_BEFORE_ABORT: int = Field(
+        default=2,
+        description=(
+            "Minimum attempts before early-abort retry heuristics may escalate."
+        ),
+    )
+    AGENT_NO_PROGRESS_WINDOW: int = Field(
+        default=2,
+        description=(
+            "Consecutive no-progress attempts required before early escalation."
+        ),
+    )
+    AGENT_MAX_SAME_SIGNATURE_REPEATS: int = Field(
+        default=2,
+        description=(
+            "Maximum repeated identical failure signatures before escalation."
+        ),
+    )
+    AGENT_REGRESSION_LIMIT: int = Field(
+        default=2,
+        description=(
+            "Maximum allowed regression in failing tests versus best-so-far attempt."
+        ),
+    )
+    AGENT_AUTO_ROLLBACK_ON_FAIL: bool = Field(
+        default=True,
+        description=(
+            "When true, failed runs auto-clean their worktree/branch unless escalated."
+        ),
+    )
+    AGENT_VALIDATOR_MODEL_ENABLED: bool = Field(
+        default=False,
+        description=(
+            "Enable optional validator pre-step for writing/improving tests."
+        ),
+    )
+    AGENT_REQUIRE_TWO_COMMITS: bool = Field(
+        default=True,
+        description=(
+            "Require exactly two commits for each successful mutating step."
+        ),
+    )
+    AGENT_VALIDATION_COMMIT_ALLOW_EMPTY: bool = Field(
+        default=True,
+        description=(
+            "Allow empty validation-boundary commit to avoid repository metadata churn."
+        ),
+    )
     PROVIDER_MAX_RETRIES: int = Field(
         default=3,
         description="Max retry attempts for provider requests (applies to local/openai/groq).",

--- a/guardian/db/migrations/versions/9f3d2b1a7c4e_add_agent_orchestration_tables.py
+++ b/guardian/db/migrations/versions/9f3d2b1a7c4e_add_agent_orchestration_tables.py
@@ -1,0 +1,588 @@
+"""add agent orchestration tables
+
+Revision ID: 9f3d2b1a7c4e
+Revises: a7c9d1e2f3b4
+Create Date: 2026-02-18 15:10:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "9f3d2b1a7c4e"
+down_revision: Union[str, Sequence[str], None] = "a7c9d1e2f3b4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "agent_deployments",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("deployment_id", sa.String(length=64), nullable=False),
+        sa.Column("flow_id", sa.String(length=128), nullable=False),
+        sa.Column("thread_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "spec_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column("spec_hash", sa.String(length=64), nullable=False),
+        sa.Column(
+            "trust_state",
+            sa.String(length=32),
+            server_default="supervised",
+            nullable=False,
+        ),
+        sa.Column(
+            "unlocked_for_unsupervised",
+            sa.Boolean(),
+            server_default="false",
+            nullable=False,
+        ),
+        sa.Column("unlocked_by", sa.String(length=255), nullable=True),
+        sa.Column("unlocked_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(length=32),
+            server_default="active",
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "trust_state IN ('supervised', 'unlocked')",
+            name="agent_deployments_trust_state_check",
+        ),
+        sa.CheckConstraint(
+            "status IN ('active', 'canceled', 'archived')",
+            name="agent_deployments_status_check",
+        ),
+        sa.ForeignKeyConstraint(
+            ["thread_id"], ["chat_threads.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("deployment_id"),
+    )
+    op.create_index(
+        "ix_agent_deployments_thread_id",
+        "agent_deployments",
+        ["thread_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_agent_deployments_spec_hash",
+        "agent_deployments",
+        ["spec_hash"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_agent_deployments_status",
+        "agent_deployments",
+        ["status"],
+        unique=False,
+    )
+
+    op.create_table(
+        "agent_runs",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("run_id", sa.String(length=64), nullable=False),
+        sa.Column("deployment_id", sa.BigInteger(), nullable=False),
+        sa.Column("thread_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(length=32),
+            server_default="queued",
+            nullable=False,
+        ),
+        sa.Column(
+            "runtime_target",
+            sa.String(length=32),
+            server_default="container",
+            nullable=False,
+        ),
+        sa.Column(
+            "rollback_mode",
+            sa.String(length=32),
+            server_default="auto",
+            nullable=False,
+        ),
+        sa.Column(
+            "rollback_applied",
+            sa.Boolean(),
+            server_default="false",
+            nullable=False,
+        ),
+        sa.Column("rollback_reason", sa.Text(), nullable=True),
+        sa.Column("worktree_id", sa.String(length=128), nullable=True),
+        sa.Column("worktree_path", sa.Text(), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("started_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("ended_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "status IN ('queued', 'running', 'escalated', 'canceled', 'failed', 'succeeded')",
+            name="agent_runs_status_check",
+        ),
+        sa.CheckConstraint(
+            "runtime_target IN ('host', 'container')",
+            name="agent_runs_runtime_target_check",
+        ),
+        sa.CheckConstraint(
+            "rollback_mode IN ('auto', 'manual')",
+            name="agent_runs_rollback_mode_check",
+        ),
+        sa.ForeignKeyConstraint(
+            ["deployment_id"], ["agent_deployments.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["thread_id"], ["chat_threads.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("run_id"),
+    )
+    op.create_index(
+        "ix_agent_runs_deployment_id",
+        "agent_runs",
+        ["deployment_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_agent_runs_thread_id", "agent_runs", ["thread_id"], unique=False
+    )
+    op.create_index(
+        "ix_agent_runs_status", "agent_runs", ["status"], unique=False
+    )
+
+    op.create_table(
+        "agent_run_steps",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("run_id", sa.BigInteger(), nullable=False),
+        sa.Column("step_index", sa.Integer(), nullable=False),
+        sa.Column("step_id", sa.String(length=128), nullable=False),
+        sa.Column("primitive", sa.String(length=64), nullable=False),
+        sa.Column(
+            "is_mutating",
+            sa.Boolean(),
+            server_default="false",
+            nullable=False,
+        ),
+        sa.Column(
+            "status",
+            sa.String(length=32),
+            server_default="pending",
+            nullable=False,
+        ),
+        sa.Column("schema_valid", sa.Boolean(), nullable=True),
+        sa.Column("spec_alignment_ok", sa.Boolean(), nullable=True),
+        sa.Column("tests_passed", sa.Boolean(), nullable=True),
+        sa.Column(
+            "metadata",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column("started_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("ended_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "status IN ('pending', 'running', 'succeeded', 'failed', 'escalated', 'canceled')",
+            name="agent_run_steps_status_check",
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_id"], ["agent_runs.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "run_id", "step_index", name="uq_agent_run_steps_run_step_index"
+        ),
+    )
+    op.create_index(
+        "ix_agent_run_steps_run_id", "agent_run_steps", ["run_id"], unique=False
+    )
+    op.create_index(
+        "ix_agent_run_steps_status", "agent_run_steps", ["status"], unique=False
+    )
+
+    op.create_table(
+        "agent_run_attempts",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("run_step_id", sa.BigInteger(), nullable=False),
+        sa.Column("attempt_index", sa.Integer(), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(length=32),
+            server_default="running",
+            nullable=False,
+        ),
+        sa.Column("fail_count", sa.Integer(), nullable=True),
+        sa.Column("fail_signature", sa.String(length=128), nullable=True),
+        sa.Column(
+            "diff_added", sa.Integer(), server_default="0", nullable=False
+        ),
+        sa.Column(
+            "diff_deleted", sa.Integer(), server_default="0", nullable=False
+        ),
+        sa.Column("error_category", sa.String(length=64), nullable=True),
+        sa.Column(
+            "progress_made",
+            sa.Boolean(),
+            server_default="false",
+            nullable=False,
+        ),
+        sa.Column("stderr_excerpt", sa.Text(), nullable=True),
+        sa.Column(
+            "metadata",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column("started_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("ended_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "status IN ('running', 'failed', 'succeeded', 'escalated')",
+            name="agent_run_attempts_status_check",
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_step_id"], ["agent_run_steps.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "run_step_id",
+            "attempt_index",
+            name="uq_agent_run_attempts_step_attempt_index",
+        ),
+    )
+    op.create_index(
+        "ix_agent_run_attempts_step_id",
+        "agent_run_attempts",
+        ["run_step_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_agent_run_attempts_signature",
+        "agent_run_attempts",
+        ["fail_signature"],
+        unique=False,
+    )
+
+    op.create_table(
+        "agent_run_artifacts",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("run_id", sa.BigInteger(), nullable=False),
+        sa.Column("run_step_id", sa.BigInteger(), nullable=True),
+        sa.Column("attempt_id", sa.BigInteger(), nullable=True),
+        sa.Column("artifact_type", sa.String(length=64), nullable=False),
+        sa.Column("uri", sa.Text(), nullable=True),
+        sa.Column(
+            "content_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_id"], ["agent_runs.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_step_id"], ["agent_run_steps.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["attempt_id"], ["agent_run_attempts.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_agent_run_artifacts_run_id",
+        "agent_run_artifacts",
+        ["run_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_agent_run_artifacts_type",
+        "agent_run_artifacts",
+        ["artifact_type"],
+        unique=False,
+    )
+
+    op.create_table(
+        "agent_confidence_reports",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("run_id", sa.BigInteger(), nullable=False),
+        sa.Column("run_step_id", sa.BigInteger(), nullable=True),
+        sa.Column("step_index", sa.Integer(), nullable=True),
+        sa.Column("scope", sa.String(length=16), nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=False),
+        sa.Column("decision", sa.String(length=64), nullable=False),
+        sa.Column(
+            "factors",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column("model_self_confidence", sa.Float(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "scope IN ('step', 'task')",
+            name="agent_confidence_reports_scope_check",
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_id"], ["agent_runs.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_step_id"], ["agent_run_steps.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_agent_confidence_reports_run_id",
+        "agent_confidence_reports",
+        ["run_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_agent_confidence_reports_scope_step",
+        "agent_confidence_reports",
+        ["scope", "step_index"],
+        unique=False,
+    )
+
+    op.create_table(
+        "agent_escalations",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("run_id", sa.BigInteger(), nullable=False),
+        sa.Column("run_step_id", sa.BigInteger(), nullable=True),
+        sa.Column("step_index", sa.Integer(), nullable=True),
+        sa.Column("severity", sa.String(length=16), nullable=False),
+        sa.Column("reason_code", sa.String(length=64), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(length=32),
+            server_default="open",
+            nullable=False,
+        ),
+        sa.Column(
+            "preserved_worktree",
+            sa.Boolean(),
+            server_default="false",
+            nullable=False,
+        ),
+        sa.Column(
+            "payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("resolved_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "severity IN ('soft', 'hard')",
+            name="agent_escalations_severity_check",
+        ),
+        sa.CheckConstraint(
+            "status IN ('open', 'acknowledged', 'resolved', 'canceled')",
+            name="agent_escalations_status_check",
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_id"], ["agent_runs.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_step_id"], ["agent_run_steps.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_agent_escalations_run_id",
+        "agent_escalations",
+        ["run_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_agent_escalations_status",
+        "agent_escalations",
+        ["status"],
+        unique=False,
+    )
+
+    op.create_table(
+        "agent_events",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("run_id", sa.BigInteger(), nullable=False),
+        sa.Column("run_step_id", sa.BigInteger(), nullable=True),
+        sa.Column("attempt_id", sa.BigInteger(), nullable=True),
+        sa.Column("event_type", sa.String(length=64), nullable=False),
+        sa.Column(
+            "payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_id"], ["agent_runs.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_step_id"], ["agent_run_steps.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["attempt_id"], ["agent_run_attempts.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_agent_events_run_id", "agent_events", ["run_id"], unique=False
+    )
+    op.create_index(
+        "ix_agent_events_type", "agent_events", ["event_type"], unique=False
+    )
+
+    op.create_table(
+        "agent_reflections",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("run_id", sa.BigInteger(), nullable=False),
+        sa.Column("run_step_id", sa.BigInteger(), nullable=True),
+        sa.Column("reflection_kind", sa.String(length=32), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("derived_from", sa.String(length=64), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "reflection_kind IN ('step_note', 'session_summary')",
+            name="agent_reflections_kind_check",
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_id"], ["agent_runs.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_step_id"], ["agent_run_steps.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_agent_reflections_run_id",
+        "agent_reflections",
+        ["run_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_agent_reflections_run_id", table_name="agent_reflections")
+    op.drop_table("agent_reflections")
+
+    op.drop_index("ix_agent_events_type", table_name="agent_events")
+    op.drop_index("ix_agent_events_run_id", table_name="agent_events")
+    op.drop_table("agent_events")
+
+    op.drop_index("ix_agent_escalations_status", table_name="agent_escalations")
+    op.drop_index("ix_agent_escalations_run_id", table_name="agent_escalations")
+    op.drop_table("agent_escalations")
+
+    op.drop_index(
+        "ix_agent_confidence_reports_scope_step",
+        table_name="agent_confidence_reports",
+    )
+    op.drop_index(
+        "ix_agent_confidence_reports_run_id",
+        table_name="agent_confidence_reports",
+    )
+    op.drop_table("agent_confidence_reports")
+
+    op.drop_index(
+        "ix_agent_run_artifacts_type", table_name="agent_run_artifacts"
+    )
+    op.drop_index(
+        "ix_agent_run_artifacts_run_id", table_name="agent_run_artifacts"
+    )
+    op.drop_table("agent_run_artifacts")
+
+    op.drop_index(
+        "ix_agent_run_attempts_signature",
+        table_name="agent_run_attempts",
+    )
+    op.drop_index(
+        "ix_agent_run_attempts_step_id", table_name="agent_run_attempts"
+    )
+    op.drop_table("agent_run_attempts")
+
+    op.drop_index("ix_agent_run_steps_status", table_name="agent_run_steps")
+    op.drop_index("ix_agent_run_steps_run_id", table_name="agent_run_steps")
+    op.drop_table("agent_run_steps")
+
+    op.drop_index("ix_agent_runs_status", table_name="agent_runs")
+    op.drop_index("ix_agent_runs_thread_id", table_name="agent_runs")
+    op.drop_index("ix_agent_runs_deployment_id", table_name="agent_runs")
+    op.drop_table("agent_runs")
+
+    op.drop_index("ix_agent_deployments_status", table_name="agent_deployments")
+    op.drop_index(
+        "ix_agent_deployments_spec_hash", table_name="agent_deployments"
+    )
+    op.drop_index(
+        "ix_agent_deployments_thread_id", table_name="agent_deployments"
+    )
+    op.drop_table("agent_deployments")

--- a/guardian/db/models.py
+++ b/guardian/db/models.py
@@ -1274,6 +1274,414 @@ class SystemDocLink(Base):
 
 
 # =========================
+# Agent Orchestration
+# =========================
+
+
+class AgentDeployment(Base):
+    """Immutable deployment definition for delegated agent flows."""
+
+    __tablename__ = "agent_deployments"
+
+    id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, autoincrement=True
+    )
+    deployment_id: Mapped[str] = mapped_column(
+        String(64), nullable=False, unique=True
+    )
+    flow_id: Mapped[str] = mapped_column(String(128), nullable=False)
+    thread_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("chat_threads.id", ondelete="SET NULL")
+    )
+    spec_json: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default="{}"
+    )
+    spec_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    trust_state: Mapped[str] = mapped_column(
+        String(32), nullable=False, server_default="supervised"
+    )
+    unlocked_for_unsupervised: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false"
+    )
+    unlocked_by: Mapped[str | None] = mapped_column(String(255))
+    unlocked_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True)
+    )
+    status: Mapped[str] = mapped_column(
+        String(32), nullable=False, server_default="active"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "trust_state IN ('supervised', 'unlocked')",
+            name="agent_deployments_trust_state_check",
+        ),
+        CheckConstraint(
+            "status IN ('active', 'canceled', 'archived')",
+            name="agent_deployments_status_check",
+        ),
+    )
+    __mapper_args__ = {"eager_defaults": True}
+
+
+class AgentRun(Base):
+    """Durable run state for a deployed delegated agent execution."""
+
+    __tablename__ = "agent_runs"
+
+    id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, autoincrement=True
+    )
+    run_id: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    deployment_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("agent_deployments.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    thread_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("chat_threads.id", ondelete="SET NULL")
+    )
+    status: Mapped[str] = mapped_column(
+        String(32), nullable=False, server_default="queued"
+    )
+    runtime_target: Mapped[str] = mapped_column(
+        String(32), nullable=False, server_default="container"
+    )
+    rollback_mode: Mapped[str] = mapped_column(
+        String(32), nullable=False, server_default="auto"
+    )
+    rollback_applied: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false"
+    )
+    rollback_reason: Mapped[str | None] = mapped_column(Text)
+    worktree_id: Mapped[str | None] = mapped_column(String(128))
+    worktree_path: Mapped[str | None] = mapped_column(Text)
+    error: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    started_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True)
+    )
+    ended_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('queued', 'running', 'escalated', 'canceled', 'failed', 'succeeded')",
+            name="agent_runs_status_check",
+        ),
+        CheckConstraint(
+            "runtime_target IN ('host', 'container')",
+            name="agent_runs_runtime_target_check",
+        ),
+        CheckConstraint(
+            "rollback_mode IN ('auto', 'manual')",
+            name="agent_runs_rollback_mode_check",
+        ),
+    )
+    __mapper_args__ = {"eager_defaults": True}
+
+
+class AgentRunStep(Base):
+    """Step-level lifecycle records for a delegated run."""
+
+    __tablename__ = "agent_run_steps"
+
+    id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, autoincrement=True
+    )
+    run_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("agent_runs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    step_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    step_id: Mapped[str] = mapped_column(String(128), nullable=False)
+    primitive: Mapped[str] = mapped_column(String(64), nullable=False)
+    is_mutating: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false"
+    )
+    status: Mapped[str] = mapped_column(
+        String(32), nullable=False, server_default="pending"
+    )
+    schema_valid: Mapped[bool | None] = mapped_column(Boolean)
+    spec_alignment_ok: Mapped[bool | None] = mapped_column(Boolean)
+    tests_passed: Mapped[bool | None] = mapped_column(Boolean)
+    metadata_json: Mapped[dict] = mapped_column(
+        "metadata", JSONB, nullable=False, server_default="{}"
+    )
+    started_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True)
+    )
+    ended_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "run_id",
+            "step_index",
+            name="uq_agent_run_steps_run_step_index",
+        ),
+        CheckConstraint(
+            "status IN ('pending', 'running', 'succeeded', 'failed', 'escalated', 'canceled')",
+            name="agent_run_steps_status_check",
+        ),
+    )
+    __mapper_args__ = {"eager_defaults": True}
+
+
+class AgentRunAttempt(Base):
+    """Attempt-level diagnostics for deterministic adaptive retry."""
+
+    __tablename__ = "agent_run_attempts"
+
+    id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, autoincrement=True
+    )
+    run_step_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("agent_run_steps.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    attempt_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(32), nullable=False, server_default="running"
+    )
+    fail_count: Mapped[int | None] = mapped_column(Integer)
+    fail_signature: Mapped[str | None] = mapped_column(String(128))
+    diff_added: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0"
+    )
+    diff_deleted: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0"
+    )
+    error_category: Mapped[str | None] = mapped_column(String(64))
+    progress_made: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false"
+    )
+    stderr_excerpt: Mapped[str | None] = mapped_column(Text)
+    metadata_json: Mapped[dict] = mapped_column(
+        "metadata", JSONB, nullable=False, server_default="{}"
+    )
+    started_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True)
+    )
+    ended_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "run_step_id",
+            "attempt_index",
+            name="uq_agent_run_attempts_step_attempt_index",
+        ),
+        CheckConstraint(
+            "status IN ('running', 'failed', 'succeeded', 'escalated')",
+            name="agent_run_attempts_status_check",
+        ),
+    )
+    __mapper_args__ = {"eager_defaults": True}
+
+
+class AgentRunArtifact(Base):
+    """Artifacts and receipts emitted by delegated runs and steps."""
+
+    __tablename__ = "agent_run_artifacts"
+
+    id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, autoincrement=True
+    )
+    run_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("agent_runs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    run_step_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("agent_run_steps.id", ondelete="CASCADE")
+    )
+    attempt_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("agent_run_attempts.id", ondelete="SET NULL")
+    )
+    artifact_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    uri: Mapped[str | None] = mapped_column(Text)
+    content_json: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default="{}"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __mapper_args__ = {"eager_defaults": True}
+
+
+class AgentConfidenceReport(Base):
+    """Guardian-derived confidence reports for step and task decisions."""
+
+    __tablename__ = "agent_confidence_reports"
+
+    id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, autoincrement=True
+    )
+    run_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("agent_runs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    run_step_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("agent_run_steps.id", ondelete="CASCADE")
+    )
+    step_index: Mapped[int | None] = mapped_column(Integer)
+    scope: Mapped[str] = mapped_column(String(16), nullable=False)
+    confidence: Mapped[float] = mapped_column(Float, nullable=False)
+    decision: Mapped[str] = mapped_column(String(64), nullable=False)
+    factors_json: Mapped[dict] = mapped_column(
+        "factors", JSONB, nullable=False, server_default="{}"
+    )
+    model_self_confidence: Mapped[float | None] = mapped_column(Float)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "scope IN ('step', 'task')",
+            name="agent_confidence_reports_scope_check",
+        ),
+    )
+    __mapper_args__ = {"eager_defaults": True}
+
+
+class AgentEscalation(Base):
+    """Durable escalation records for paused or blocked delegated runs."""
+
+    __tablename__ = "agent_escalations"
+
+    id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, autoincrement=True
+    )
+    run_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("agent_runs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    run_step_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("agent_run_steps.id", ondelete="CASCADE")
+    )
+    step_index: Mapped[int | None] = mapped_column(Integer)
+    severity: Mapped[str] = mapped_column(String(16), nullable=False)
+    reason_code: Mapped[str] = mapped_column(String(64), nullable=False)
+    reason: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(32), nullable=False, server_default="open"
+    )
+    preserved_worktree: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false"
+    )
+    payload_json: Mapped[dict] = mapped_column(
+        "payload", JSONB, nullable=False, server_default="{}"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+    resolved_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True)
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "severity IN ('soft', 'hard')",
+            name="agent_escalations_severity_check",
+        ),
+        CheckConstraint(
+            "status IN ('open', 'acknowledged', 'resolved', 'canceled')",
+            name="agent_escalations_status_check",
+        ),
+    )
+    __mapper_args__ = {"eager_defaults": True}
+
+
+class AgentEvent(Base):
+    """Append-only event graph stream for delegated run lifecycle events."""
+
+    __tablename__ = "agent_events"
+
+    id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, autoincrement=True
+    )
+    run_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("agent_runs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    run_step_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("agent_run_steps.id", ondelete="CASCADE")
+    )
+    attempt_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("agent_run_attempts.id", ondelete="SET NULL")
+    )
+    event_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    payload_json: Mapped[dict] = mapped_column(
+        "payload", JSONB, nullable=False, server_default="{}"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __mapper_args__ = {"eager_defaults": True}
+
+
+class AgentReflection(Base):
+    """Derived reflection notes for steps and runs (non-canonical)."""
+
+    __tablename__ = "agent_reflections"
+
+    id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, autoincrement=True
+    )
+    run_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("agent_runs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    run_step_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("agent_run_steps.id", ondelete="CASCADE")
+    )
+    reflection_kind: Mapped[str] = mapped_column(String(32), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    derived_from: Mapped[str | None] = mapped_column(String(64))
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "reflection_kind IN ('step_note', 'session_summary')",
+            name="agent_reflections_kind_check",
+        ),
+    )
+    __mapper_args__ = {"eager_defaults": True}
+
+
+# =========================
 # Indexes
 # =========================
 
@@ -1409,6 +1817,29 @@ Index("ix_tts_outputs_project", TTSOutput.project_id)
 Index("ix_tts_outputs_thread", TTSOutput.thread_id)
 Index("ix_tts_outputs_provider", TTSOutput.provider)
 Index("ix_tts_outputs_created", TTSOutput.created_at.desc())
+Index("ix_agent_deployments_thread_id", AgentDeployment.thread_id)
+Index("ix_agent_deployments_spec_hash", AgentDeployment.spec_hash)
+Index("ix_agent_deployments_status", AgentDeployment.status)
+Index("ix_agent_runs_deployment_id", AgentRun.deployment_id)
+Index("ix_agent_runs_thread_id", AgentRun.thread_id)
+Index("ix_agent_runs_status", AgentRun.status)
+Index("ix_agent_run_steps_run_id", AgentRunStep.run_id)
+Index("ix_agent_run_steps_status", AgentRunStep.status)
+Index("ix_agent_run_attempts_step_id", AgentRunAttempt.run_step_id)
+Index("ix_agent_run_attempts_signature", AgentRunAttempt.fail_signature)
+Index("ix_agent_run_artifacts_run_id", AgentRunArtifact.run_id)
+Index("ix_agent_run_artifacts_type", AgentRunArtifact.artifact_type)
+Index("ix_agent_confidence_reports_run_id", AgentConfidenceReport.run_id)
+Index(
+    "ix_agent_confidence_reports_scope_step",
+    AgentConfidenceReport.scope,
+    AgentConfidenceReport.step_index,
+)
+Index("ix_agent_escalations_run_id", AgentEscalation.run_id)
+Index("ix_agent_escalations_status", AgentEscalation.status)
+Index("ix_agent_events_run_id", AgentEvent.run_id)
+Index("ix_agent_events_type", AgentEvent.event_type)
+Index("ix_agent_reflections_run_id", AgentReflection.run_id)
 
 
 class SharedLink(Base):

--- a/guardian/guardian_api.py
+++ b/guardian/guardian_api.py
@@ -144,7 +144,7 @@ OUTBOX_TENANT_ID = normalize_outbox_tenant_id(
 from guardian.realtime import collaboration
 
 # Import all routers (after DB init so dependencies.chatlog_db is ready)
-from guardian.routes import admin, agent, backfill
+from guardian.routes import admin, agent, agent_orchestration, backfill
 from guardian.routes import cron as cron_routes
 from guardian.routes import (
     devtools,
@@ -239,8 +239,9 @@ async def app_lifespan(app: FastAPI):
         documents.configure_db(guardian_db)
         share.configure_db(guardian_db)
         websocket_routes.configure_db(guardian_db)
+        agent_orchestration.configure_db(guardian_db)
         logger.info(
-            "[startup] GuardianDB configured for cron/documents/share/websocket routes"
+            "[startup] GuardianDB configured for cron/documents/share/websocket/agent_orchestration routes"
         )
 
     # Configure durable outbox storage
@@ -518,6 +519,8 @@ app.include_router(devtools.router)
 app.include_router(websocket_routes.router)
 app.include_router(cron_routes.router)
 app.include_router(ui_session.router)
+app.include_router(agent_orchestration.router)
+app.include_router(agent_orchestration.chat_router)
 
 logger.info("[routers] All routers included")
 

--- a/guardian/providers/minimax_adapter.py
+++ b/guardian/providers/minimax_adapter.py
@@ -1,13 +1,11 @@
-"""
-MiniMax chat adapter using an OpenAI-compatible API surface.
-"""
+"""MiniMax chat adapter supporting OpenAI- and Anthropic-compatible surfaces."""
 
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
 
 import json
 import os
-from typing import Any, Iterator, Optional
+from typing import Any, Iterator
 
 import requests
 
@@ -69,6 +67,45 @@ def _normalize_messages(
     return [{"role": "user", "content": prompt}]
 
 
+def _normalize_anthropic_messages(
+    prompt: str, kw: dict[str, Any]
+) -> tuple[list[dict[str, Any]], str | None]:
+    raw_messages = kw.pop("messages", None)
+    system_parts: list[str] = []
+    normalized: list[dict[str, Any]] = []
+
+    if isinstance(raw_messages, list):
+        for raw in raw_messages:
+            if not isinstance(raw, dict):
+                continue
+            role = str(raw.get("role") or "user").strip().lower() or "user"
+            text = _coerce_text(raw.get("content")).strip()
+            if not text:
+                continue
+            if role == "system":
+                system_parts.append(text)
+                continue
+            if role not in {"user", "assistant"}:
+                role = "user"
+            normalized.append(
+                {
+                    "role": role,
+                    "content": [{"type": "text", "text": text}],
+                }
+            )
+
+    if not normalized:
+        normalized = [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": prompt}],
+            }
+        ]
+
+    system_text = "\n\n".join(part for part in system_parts if part).strip()
+    return normalized, (system_text or None)
+
+
 def _extract_text_from_payload(payload: Any) -> str:
     choices = _get_value(payload, "choices")
     if not isinstance(choices, list) or not choices:
@@ -88,6 +125,37 @@ def _extract_text_from_payload(payload: Any) -> str:
     return _coerce_text(_get_value(choice, "text"))
 
 
+def _extract_text_from_anthropic_payload(payload: Any) -> str:
+    content = _get_value(payload, "content")
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if str(block.get("type") or "").strip() != "text":
+            continue
+        text = _coerce_text(block.get("text")).strip()
+        if text:
+            parts.append(text)
+    return "".join(parts)
+
+
+def _extract_text_from_anthropic_stream_event(payload: Any) -> str:
+    event_type = str(_get_value(payload, "type") or "").strip()
+    if event_type == "content_block_delta":
+        delta = _get_value(payload, "delta")
+        text = _coerce_text(_get_value(delta, "text"))
+        if text:
+            return text
+    if event_type == "content_block_start":
+        block = _get_value(payload, "content_block")
+        text = _coerce_text(_get_value(block, "text"))
+        if text:
+            return text
+    return _extract_text_from_anthropic_payload(payload)
+
+
 class MiniMaxProviderError(RuntimeError):
     def __init__(self, message: str, *, status_code: int = 502):
         super().__init__(message)
@@ -103,6 +171,8 @@ class MiniMaxAdapter(ChatProvider):
         base_url: str | None = None,
         default_model: str | None = None,
         timeout: float = 60.0,
+        api_flavor: str | None = None,
+        anthropic_version: str | None = None,
     ):
         try:
             assert_egress_allowed("minimax")
@@ -119,6 +189,19 @@ class MiniMaxAdapter(ChatProvider):
             default_model or os.getenv("MINIMAX_MODEL") or ""
         ).strip()
         self.timeout = float(os.getenv("MINIMAX_TIMEOUT_SECONDS", timeout))
+        self.api_flavor = (
+            (api_flavor or os.getenv("MINIMAX_API_FLAVOR") or "openai")
+            .strip()
+            .lower()
+        )
+        self.anthropic_version = (
+            anthropic_version
+            or os.getenv("MINIMAX_ANTHROPIC_VERSION")
+            or "2023-06-01"
+        ).strip()
+        self.anthropic_max_tokens = int(
+            os.getenv("MINIMAX_ANTHROPIC_MAX_TOKENS", "1024")
+        )
 
         missing: list[str] = []
         if not self.api_key:
@@ -132,11 +215,14 @@ class MiniMaxAdapter(ChatProvider):
                 + "."
             )
 
-        self.client = (
-            OpenAI(api_key=self.api_key, base_url=self.base_url)
-            if OpenAI is not None
-            else None
-        )
+        if self.api_flavor not in {"openai", "anthropic"}:
+            raise RuntimeError(
+                "MINIMAX_API_FLAVOR must be either 'openai' or 'anthropic'."
+            )
+
+        self.client = None
+        if self.api_flavor == "openai" and OpenAI is not None:
+            self.client = OpenAI(api_key=self.api_key, base_url=self.base_url)
 
     def _safe_error(self, detail: str, *, status_code: int = 502) -> Exception:
         message = (detail or "").replace(self.api_key, "<redacted>").strip()
@@ -147,6 +233,19 @@ class MiniMaxAdapter(ChatProvider):
             status_code=status_code,
         )
 
+    def _extract_error_detail(self, response: requests.Response) -> str:
+        detail = response.text
+        try:
+            body = response.json()
+            detail = (
+                _coerce_text(_get_value(_get_value(body, "error"), "message"))
+                or _coerce_text(_get_value(body, "message"))
+                or detail
+            )
+        except Exception:
+            pass
+        return detail
+
     def _resolve_model(self, model: str | None) -> str:
         resolved = (model or self.default_model).strip()
         if not resolved:
@@ -156,16 +255,31 @@ class MiniMaxAdapter(ChatProvider):
             )
         return resolved
 
-    def _http_url(self) -> str:
+    def _openai_http_url(self) -> str:
         return f"{self.base_url}/chat/completions"
 
-    def _http_headers(self) -> dict[str, str]:
+    def _anthropic_http_url(self) -> str:
+        if self.base_url.endswith("/v1"):
+            return f"{self.base_url}/messages"
+        return f"{self.base_url}/v1/messages"
+
+    def _openai_headers(self) -> dict[str, str]:
         return {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
         }
 
+    def _anthropic_headers(self) -> dict[str, str]:
+        return {
+            "x-api-key": self.api_key,
+            "anthropic-version": self.anthropic_version,
+            "Content-Type": "application/json",
+        }
+
     def generate(self, prompt: str, model: str | None = None, **kw) -> str:
+        if self.api_flavor == "anthropic":
+            return self._generate_anthropic(prompt, model=model, **kw)
+
         resolved_model = self._resolve_model(model)
         messages = _normalize_messages(prompt, kw)
         if self.client is not None:
@@ -189,26 +303,52 @@ class MiniMaxAdapter(ChatProvider):
 
         try:
             response = requests.post(
-                self._http_url(),
+                self._openai_http_url(),
                 json=payload,
-                headers=self._http_headers(),
+                headers=self._openai_headers(),
                 timeout=request_timeout,
             )
             if not (200 <= response.status_code < 300):
-                detail = response.text
-                try:
-                    body = response.json()
-                    detail = (
-                        _coerce_text(
-                            _get_value(_get_value(body, "error"), "message")
-                        )
-                        or _coerce_text(_get_value(body, "message"))
-                        or detail
-                    )
-                except Exception:
-                    pass
-                raise self._safe_error(detail, status_code=response.status_code)
+                raise self._safe_error(
+                    self._extract_error_detail(response),
+                    status_code=response.status_code,
+                )
             return _extract_text_from_payload(response.json())
+        except MiniMaxProviderError:
+            raise
+        except Exception as exc:
+            raise self._safe_error(str(exc)) from exc
+
+    def _generate_anthropic(
+        self, prompt: str, model: str | None = None, **kw
+    ) -> str:
+        resolved_model = self._resolve_model(model)
+        messages, system_prompt = _normalize_anthropic_messages(prompt, kw)
+        request_timeout = float(kw.pop("timeout", self.timeout))
+        max_tokens = int(kw.pop("max_tokens", self.anthropic_max_tokens))
+
+        payload: dict[str, Any] = {
+            "model": resolved_model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+        }
+        if system_prompt:
+            payload["system"] = system_prompt
+        payload.update(kw)
+
+        try:
+            response = requests.post(
+                self._anthropic_http_url(),
+                json=payload,
+                headers=self._anthropic_headers(),
+                timeout=request_timeout,
+            )
+            if not (200 <= response.status_code < 300):
+                raise self._safe_error(
+                    self._extract_error_detail(response),
+                    status_code=response.status_code,
+                )
+            return _extract_text_from_anthropic_payload(response.json())
         except MiniMaxProviderError:
             raise
         except Exception as exc:
@@ -217,6 +357,10 @@ class MiniMaxAdapter(ChatProvider):
     def stream(
         self, prompt: str, model: str | None = None, **kw
     ) -> Iterator[str]:
+        if self.api_flavor == "anthropic":
+            yield from self._stream_anthropic(prompt, model=model, **kw)
+            return
+
         resolved_model = self._resolve_model(model)
         messages = _normalize_messages(prompt, kw)
         if self.client is not None:
@@ -246,15 +390,16 @@ class MiniMaxAdapter(ChatProvider):
 
         try:
             with requests.post(
-                self._http_url(),
+                self._openai_http_url(),
                 json=payload,
-                headers=self._http_headers(),
+                headers=self._openai_headers(),
                 stream=True,
                 timeout=request_timeout,
             ) as response:
                 if not (200 <= response.status_code < 300):
                     raise self._safe_error(
-                        response.text, status_code=response.status_code
+                        self._extract_error_detail(response),
+                        status_code=response.status_code,
                     )
                 for raw_line in response.iter_lines(decode_unicode=True):
                     if not raw_line:
@@ -269,6 +414,64 @@ class MiniMaxAdapter(ChatProvider):
                     except json.JSONDecodeError:
                         continue
                     text = _extract_text_from_payload(payload)
+                    if text:
+                        yield text
+        except MiniMaxProviderError:
+            raise
+        except Exception as exc:
+            raise self._safe_error(str(exc)) from exc
+
+    def _stream_anthropic(
+        self, prompt: str, model: str | None = None, **kw
+    ) -> Iterator[str]:
+        resolved_model = self._resolve_model(model)
+        messages, system_prompt = _normalize_anthropic_messages(prompt, kw)
+        request_timeout = float(kw.pop("timeout", self.timeout))
+        max_tokens = int(kw.pop("max_tokens", self.anthropic_max_tokens))
+
+        payload: dict[str, Any] = {
+            "model": resolved_model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "stream": True,
+        }
+        if system_prompt:
+            payload["system"] = system_prompt
+        payload.update(kw)
+
+        try:
+            with requests.post(
+                self._anthropic_http_url(),
+                json=payload,
+                headers=self._anthropic_headers(),
+                stream=True,
+                timeout=request_timeout,
+            ) as response:
+                if not (200 <= response.status_code < 300):
+                    raise self._safe_error(
+                        self._extract_error_detail(response),
+                        status_code=response.status_code,
+                    )
+
+                for raw_line in response.iter_lines(decode_unicode=True):
+                    if not raw_line:
+                        continue
+                    line = raw_line.strip()
+                    if line.startswith("event:"):
+                        continue
+                    if line.startswith("data:"):
+                        line = line[5:].strip()
+                    if not line or line == "[DONE]":
+                        continue
+
+                    try:
+                        event_payload = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    text = _extract_text_from_anthropic_stream_event(
+                        event_payload
+                    )
                     if text:
                         yield text
         except MiniMaxProviderError:

--- a/guardian/routes/agent_orchestration.py
+++ b/guardian/routes/agent_orchestration.py
@@ -1,0 +1,220 @@
+"""Agent orchestration routes for delegated multi-agent runs."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from typing import Any, AsyncGenerator
+
+from fastapi import (
+    APIRouter,
+    Body,
+    Depends,
+    Header,
+    HTTPException,
+    Query,
+    Request,
+)
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, ConfigDict, Field
+
+from guardian.agents.events import AgentEventPublisher, publisher
+from guardian.agents.store import AgentStore, store
+from guardian.core.dependencies import require_api_key
+from guardian.queue import task_events
+
+router = APIRouter(
+    prefix="/api/agents",
+    tags=["Agent Orchestration"],
+    dependencies=[Depends(require_api_key)],
+)
+chat_router = APIRouter(
+    tags=["Agent Orchestration"],
+    dependencies=[Depends(require_api_key)],
+)
+
+_store: AgentStore = store
+_event_publisher: AgentEventPublisher = publisher
+
+
+def configure_db(db: Any | None) -> None:
+    _store.configure_db(db)
+    _event_publisher.configure_db(db)
+
+
+def _stable_hash(payload: dict[str, Any]) -> str:
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+class AgentPlanRequest(BaseModel):
+    prompt: str = Field(min_length=1)
+    thread_id: int | None = None
+    proposed_steps: list[dict[str, Any]] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class AgentDeploymentRequest(BaseModel):
+    flow_id: str = Field(min_length=1)
+    thread_id: int | None = None
+    spec: dict[str, Any] = Field(default_factory=dict)
+    spec_hash: str | None = None
+    trust_state: str = "supervised"
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class AgentRunStartRequest(BaseModel):
+    runtime_target: str = "container"
+    supervised: bool = True
+
+    model_config = ConfigDict(extra="forbid")
+
+
+@router.post("/plans")
+async def create_plan(body: AgentPlanRequest) -> dict[str, Any]:
+    spec = {
+        "prompt": body.prompt,
+        "thread_id": body.thread_id,
+        "steps": body.proposed_steps,
+    }
+    plan_hash = _stable_hash(spec)
+    return {
+        "ok": True,
+        "plan_id": f"plan_{plan_hash[:16]}",
+        "spec_hash": plan_hash,
+        "spec": spec,
+    }
+
+
+@router.post("/deployments")
+async def create_deployment(body: AgentDeploymentRequest) -> dict[str, Any]:
+    spec = dict(body.spec or {})
+    spec_hash = body.spec_hash or _stable_hash(spec)
+    deployment = _store.create_deployment(
+        flow_id=body.flow_id,
+        thread_id=body.thread_id,
+        spec_json=spec,
+        spec_hash=spec_hash,
+        trust_state=body.trust_state,
+    )
+    return {"ok": True, "deployment": deployment}
+
+
+@router.post("/deployments/{deployment_id}/runs")
+async def start_run(
+    deployment_id: str,
+    body: AgentRunStartRequest = Body(default_factory=AgentRunStartRequest),
+) -> dict[str, Any]:
+    deployment = _store.get_deployment(deployment_id)
+    if deployment is None:
+        raise HTTPException(status_code=404, detail="deployment_not_found")
+    if not body.supervised and deployment.get("trust_state") != "unlocked":
+        raise HTTPException(
+            status_code=403,
+            detail="unsupervised_run_requires_unlocked_deployment",
+        )
+
+    run = _store.create_run(
+        deployment_id=deployment_id,
+        thread_id=deployment.get("thread_id"),
+        runtime_target=body.runtime_target,
+        rollback_mode="auto",
+        status="running",
+    )
+    _event_publisher.emit(
+        run_id=run["run_id"],
+        event_type="created",
+        payload={"deployment_id": deployment_id, "run_id": run["run_id"]},
+    )
+    _event_publisher.emit(
+        run_id=run["run_id"],
+        event_type="started",
+        payload={"deployment_id": deployment_id, "run_id": run["run_id"]},
+    )
+    return {"ok": True, "run": run}
+
+
+@router.post("/runs/{run_id}/cancel")
+async def cancel_run(run_id: str) -> dict[str, Any]:
+    run = _store.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="run_not_found")
+    _store.update_run_status(run_id=run_id, status="canceled")
+    _event_publisher.emit(
+        run_id=run_id,
+        event_type="canceled",
+        payload={"run_id": run_id},
+    )
+    return {"ok": True, "run_id": run_id, "status": "canceled"}
+
+
+@router.get("/runs/{run_id}")
+async def get_run(run_id: str) -> dict[str, Any]:
+    run = _store.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="run_not_found")
+    return {"ok": True, "run": run}
+
+
+@router.get("/runs/{run_id}/events")
+async def stream_run_events(
+    request: Request,
+    run_id: str,
+    last_id_query: str = Query("0-0", alias="last_id"),
+    last_event_id_header: str | None = Header(None, alias="Last-Event-ID"),
+) -> StreamingResponse:
+    async def event_stream() -> AsyncGenerator[str, None]:
+        last_id = str(last_event_id_header or last_id_query or "0-0")
+        if "-" not in last_id:
+            last_id = "0-0"
+        yield "retry: 3000\n\n"
+
+        heartbeat_elapsed = 0.0
+        heartbeat_interval = 15.0
+        block_ms = 15000
+
+        while True:
+            if await request.is_disconnected():
+                break
+            try:
+                events = await asyncio.to_thread(
+                    task_events.read_events,
+                    run_id,
+                    last_id,
+                    block_ms=block_ms,
+                    count=100,
+                )
+            except Exception:
+                await asyncio.sleep(1)
+                continue
+
+            if events:
+                for event_id, event in events:
+                    data_str = json.dumps(event.get("data") or {}, default=str)
+                    yield f"id: {event_id}\n"
+                    yield f"event: {event.get('type') or 'task.event'}\n"
+                    yield f"data: {data_str}\n\n"
+                    last_id = event_id
+                heartbeat_elapsed = 0.0
+            else:
+                heartbeat_elapsed += block_ms / 1000.0
+                if heartbeat_elapsed >= heartbeat_interval:
+                    yield ": ping\n\n"
+                    heartbeat_elapsed = 0.0
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+
+@router.get("/chat/{thread_id}/agent-runs")
+async def list_thread_runs(thread_id: int) -> dict[str, Any]:
+    runs = _store.list_runs_for_thread(thread_id)
+    return {"ok": True, "thread_id": thread_id, "runs": runs}
+
+
+@chat_router.get("/api/chat/{thread_id}/agent-runs")
+async def list_thread_runs_via_chat(thread_id: int) -> dict[str, Any]:
+    runs = _store.list_runs_for_thread(thread_id)
+    return {"ok": True, "thread_id": thread_id, "runs": runs}

--- a/guardian/routes/agent_orchestration.py
+++ b/guardian/routes/agent_orchestration.py
@@ -37,6 +37,8 @@ chat_router = APIRouter(
 _store: AgentStore = store
 _event_publisher: AgentEventPublisher = publisher
 
+ALLOWED_RUNTIME_TARGETS = {"container", "terminal"}
+
 
 def configure_db(db: Any | None) -> None:
     _store.configure_db(db)
@@ -108,6 +110,10 @@ async def start_run(
     deployment_id: str,
     body: AgentRunStartRequest = Body(default_factory=AgentRunStartRequest),
 ) -> dict[str, Any]:
+    runtime_target = (body.runtime_target or "container").strip()
+    if runtime_target not in ALLOWED_RUNTIME_TARGETS:
+        raise HTTPException(status_code=400, detail="invalid_runtime_target")
+
     deployment = _store.get_deployment(deployment_id)
     if deployment is None:
         raise HTTPException(status_code=404, detail="deployment_not_found")
@@ -120,19 +126,27 @@ async def start_run(
     run = _store.create_run(
         deployment_id=deployment_id,
         thread_id=deployment.get("thread_id"),
-        runtime_target=body.runtime_target,
+        runtime_target=runtime_target,
         rollback_mode="auto",
         status="running",
     )
     _event_publisher.emit(
         run_id=run["run_id"],
         event_type="created",
-        payload={"deployment_id": deployment_id, "run_id": run["run_id"]},
+        payload={
+            "deployment_id": deployment_id,
+            "run_id": run["run_id"],
+            "runtime_target": runtime_target,
+        },
     )
     _event_publisher.emit(
         run_id=run["run_id"],
         event_type="started",
-        payload={"deployment_id": deployment_id, "run_id": run["run_id"]},
+        payload={
+            "deployment_id": deployment_id,
+            "run_id": run["run_id"],
+            "runtime_target": runtime_target,
+        },
     )
     return {"ok": True, "run": run}
 

--- a/guardian/tests/agents/test_adaptive_retry.py
+++ b/guardian/tests/agents/test_adaptive_retry.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from guardian.agents.retry_policy import (
+    AttemptMetrics,
+    RetryConfig,
+    evaluate_retry_decision,
+)
+
+DEFAULT_CFG = RetryConfig(
+    max_attempts=5,
+    min_attempts_before_abort=2,
+    no_progress_window=2,
+    max_same_signature_repeats=2,
+    regression_limit=2,
+)
+
+
+def test_retry_escalates_on_no_progress_window() -> None:
+    history = [
+        AttemptMetrics(
+            fail_count=3,
+            fail_signature="sig-a",
+            diff_added=10,
+            diff_deleted=2,
+            error_category="tests_failed",
+            progress_made=False,
+        )
+    ]
+    current = AttemptMetrics(
+        fail_count=3,
+        fail_signature="sig-b",
+        diff_added=1,
+        diff_deleted=0,
+        error_category="tests_failed",
+    )
+
+    decision = evaluate_retry_decision(
+        attempt_index=2,
+        current=current,
+        history=history,
+        config=DEFAULT_CFG,
+    )
+
+    assert decision.escalate is True
+    assert decision.should_retry is False
+    assert decision.reason == "no_progress_window"
+
+
+def test_retry_escalates_on_same_signature_repeats() -> None:
+    history = [
+        AttemptMetrics(
+            fail_count=4,
+            fail_signature="same",
+            diff_added=1,
+            diff_deleted=0,
+            error_category="tests_failed",
+            progress_made=True,
+        ),
+        AttemptMetrics(
+            fail_count=4,
+            fail_signature="same",
+            diff_added=1,
+            diff_deleted=0,
+            error_category="tests_failed",
+            progress_made=True,
+        ),
+    ]
+    current = AttemptMetrics(
+        fail_count=4,
+        fail_signature="same",
+        diff_added=1,
+        diff_deleted=0,
+        error_category="tests_failed",
+    )
+
+    decision = evaluate_retry_decision(
+        attempt_index=3,
+        current=current,
+        history=history,
+        config=DEFAULT_CFG,
+    )
+
+    assert decision.escalate is True
+    assert decision.should_retry is False
+    assert decision.reason == "same_signature_repeat"
+
+
+def test_retry_escalates_on_regression_limit() -> None:
+    history = [
+        AttemptMetrics(
+            fail_count=1,
+            fail_signature="sig-best",
+            diff_added=2,
+            diff_deleted=1,
+            error_category="tests_failed",
+            progress_made=True,
+        ),
+        AttemptMetrics(
+            fail_count=2,
+            fail_signature="sig-next",
+            diff_added=2,
+            diff_deleted=1,
+            error_category="tests_failed",
+            progress_made=True,
+        ),
+    ]
+    current = AttemptMetrics(
+        fail_count=4,
+        fail_signature="sig-regressed",
+        diff_added=20,
+        diff_deleted=5,
+        error_category="tests_failed",
+    )
+
+    decision = evaluate_retry_decision(
+        attempt_index=3,
+        current=current,
+        history=history,
+        config=DEFAULT_CFG,
+    )
+
+    assert decision.escalate is True
+    assert decision.should_retry is False
+    assert decision.reason == "regression_limit"

--- a/guardian/tests/agents/test_confidence_engine.py
+++ b/guardian/tests/agents/test_confidence_engine.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pytest
+
+from guardian.agents.confidence import (
+    classify_step_confidence,
+    classify_task_confidence,
+    compute_step_confidence,
+    compute_task_confidence,
+)
+
+
+def test_step_confidence_formula_and_continue_band() -> None:
+    result = compute_step_confidence(
+        c_tests=1.0,
+        c_schema=1.0,
+        c_spec_alignment=1.0,
+        c_diff_risk=0.8,
+        c_model_stability=0.9,
+    )
+
+    # 0.35 + 0.20 + 0.20 + 0.15*0.8 + 0.10*0.9 = 0.96
+    assert result.score == pytest.approx(0.96, rel=1e-6)
+    assert result.decision == "continue"
+
+
+def test_step_confidence_band_mapping() -> None:
+    assert classify_step_confidence(0.90) == "continue"
+    assert classify_step_confidence(0.80) == "warn"
+    assert classify_step_confidence(0.60) == "soft_escalate"
+    assert classify_step_confidence(0.20) == "hard_escalate"
+
+
+def test_task_confidence_rollup_and_optional_audit_band() -> None:
+    result = compute_task_confidence(
+        step_scores=[0.90, 0.80],
+        c_risk=0.70,
+        escalation_penalty=0.20,
+    )
+
+    # mean=0.85, min=0.80, convergence=(1-0.10)=0.90
+    expected = (
+        (0.40 * 0.85)
+        + (0.25 * 0.80)
+        + (0.15 * 0.90)
+        + (0.10 * 0.70)
+        + (0.10 * 0.80)
+    )
+    assert result.score == pytest.approx(expected, rel=1e-6)
+    assert result.decision == "optional_audit"
+
+
+def test_task_confidence_threshold_mapping() -> None:
+    assert classify_task_confidence(0.90) == "autonomous_approve"
+    assert classify_task_confidence(0.75) == "optional_audit"
+    assert classify_task_confidence(0.60) == "audit_required"
+    assert classify_task_confidence(0.30) == "block_merge_human_required"

--- a/guardian/tests/core/test_ai_router.py
+++ b/guardian/tests/core/test_ai_router.py
@@ -9,6 +9,7 @@ class _FakeResponse:
     def __init__(self, payload):
         self._payload = payload
         self.status_code = 200
+        self.text = ""
 
     def raise_for_status(self):
         return None
@@ -22,9 +23,13 @@ def _fake_settings(provider: str) -> Settings:
         LLM_PROVIDER=provider,
         ALLOW_CLOUD_PROVIDERS=True,
         CODEXIFY_LOCAL_ONLY_MODE=False,
-        CODEXIFY_EGRESS_ALLOWLIST="openai,groq",
+        CODEXIFY_EGRESS_ALLOWLIST="openai,groq,minimax",
         GROQ_API_KEY="groq-key",
         OPENAI_API_KEY="openai-key",
+        MINIMAX_API_KEY="minimax-key",
+        MINIMAX_API_BASE="https://api.minimax.local/v1",
+        MINIMAX_API_FLAVOR="openai",
+        MINIMAX_MODEL="minimax-chat",
         LLM_MODEL="moonshotai-kimi-k2-instruct-9050",
         DEFAULT_GROQ_MODEL="moonshotai-kimi-k2-instruct-9050",
         DEFAULT_OPENAI_MODEL="gpt-4o",
@@ -65,6 +70,66 @@ def test_chat_with_ai_openai_default(monkeypatch):
     assert "api.openai.com/v1/chat/completions" in calls["url"]
     assert calls["json"]["model"] == "gpt-4o"
     assert reply == "ok"
+
+
+def test_chat_with_ai_minimax_default(monkeypatch):
+    calls = {}
+
+    def fake_post(url, json, headers, timeout):
+        calls["url"] = url
+        calls["json"] = json
+        calls["headers"] = headers
+        calls["timeout"] = timeout
+        return _FakeResponse({"choices": [{"message": {"content": "ok"}}]})
+
+    monkeypatch.setattr("guardian.core.ai_router.requests.post", fake_post)
+
+    settings = _fake_settings("minimax")
+    reply = chat_with_ai([{"role": "user", "content": "hi"}], settings=settings)
+
+    assert "api.minimax.local/v1/chat/completions" in calls["url"]
+    assert calls["json"]["model"] == "minimax-chat"
+    assert calls["headers"]["Authorization"] == "Bearer minimax-key"
+    assert calls["timeout"] == 60.0
+    assert reply == "ok"
+
+
+def test_chat_with_ai_minimax_anthropic_surface(monkeypatch):
+    calls = {}
+
+    def fake_post(url, json, headers, timeout):
+        calls["url"] = url
+        calls["json"] = json
+        calls["headers"] = headers
+        calls["timeout"] = timeout
+        return _FakeResponse({"content": [{"type": "text", "text": "ok-a"}]})
+
+    monkeypatch.setattr("guardian.core.ai_router.requests.post", fake_post)
+
+    settings = _fake_settings("minimax")
+    settings.MINIMAX_API_FLAVOR = "anthropic"
+    settings.MINIMAX_API_BASE = "https://api.minimax.local/anthropic"
+    settings.MINIMAX_MODEL = "MiniMax-M2.5"
+    settings.MINIMAX_ANTHROPIC_VERSION = "2023-06-01"
+
+    reply = chat_with_ai(
+        [
+            {"role": "system", "content": "Be precise."},
+            {"role": "user", "content": "hi"},
+        ],
+        settings=settings,
+    )
+
+    assert "api.minimax.local/anthropic/v1/messages" in calls["url"]
+    assert calls["json"]["model"] == "MiniMax-M2.5"
+    assert calls["json"]["system"] == "Be precise."
+    assert calls["json"]["messages"] == [
+        {"role": "user", "content": [{"type": "text", "text": "hi"}]}
+    ]
+    assert calls["headers"]["x-api-key"] == "minimax-key"
+    assert calls["headers"]["anthropic-version"] == "2023-06-01"
+    assert calls["timeout"] == 60.0
+    assert reply == "ok-a"
 
 
 def test_chat_with_ai_groq_override_not_openai(monkeypatch):

--- a/guardian/tests/routes/test_agent_orchestration_events.py
+++ b/guardian/tests/routes/test_agent_orchestration_events.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Literal
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from guardian.agents.events import AgentEventPublisher
+from guardian.agents.store import AgentStore
+from guardian.db.models import AgentEvent, AgentRun
+from guardian.routes import agent_orchestration
+from guardian.workers.agent_worker import (
+    AttemptEvaluation,
+    process_mutating_step,
+)
+
+
+class _SessionContext:
+    def __init__(self, session: _FakeSession) -> None:
+        self._session = session
+
+    def __enter__(self) -> _FakeSession:
+        return self._session
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Literal[False]:
+        return False
+
+
+class _FakeRunRow:
+    def __init__(self, run_id: str, db_id: int) -> None:
+        self.run_id = run_id
+        self.id = db_id
+
+
+class _FakeQuery:
+    def __init__(self, model: Any, session: _FakeSession) -> None:
+        self._model = model
+        self._session = session
+        self._filter: dict[str, Any] = {}
+
+    def filter_by(self, **kwargs: Any) -> _FakeQuery:
+        self._filter = dict(kwargs)
+        return self
+
+    def first(self) -> Any | None:
+        if self._model is AgentRun:
+            run_id = self._filter.get("run_id")
+            return self._session.run_rows.get(run_id)
+        return None
+
+
+class _FakeSession:
+    def __init__(
+        self, run_rows: dict[str, _FakeRunRow], added: list[Any]
+    ) -> None:
+        self.run_rows = run_rows
+        self.added = added
+
+    def query(self, model: Any) -> _FakeQuery:
+        return _FakeQuery(model, self)
+
+    def add(self, obj: Any) -> None:
+        self.added.append(obj)
+
+    def commit(self) -> None:
+        return
+
+
+class _FakeDB:
+    def __init__(self) -> None:
+        self.added: list[Any] = []
+        self.run_rows: dict[str, _FakeRunRow] = {
+            "run-123": _FakeRunRow(run_id="run-123", db_id=101)
+        }
+
+    def get_session(self) -> _SessionContext:
+        return _SessionContext(_FakeSession(self.run_rows, self.added))
+
+
+def _build_client() -> TestClient:
+    app = FastAPI()
+    app.include_router(agent_orchestration.router)
+    app.include_router(agent_orchestration.chat_router)
+    return TestClient(app)
+
+
+def test_escalation_persists_and_streams_event(monkeypatch) -> None:
+    published: list[tuple[str, str, dict[str, Any]]] = []
+
+    def fake_publish(
+        task_id: str,
+        event_type: str,
+        data: dict[str, Any] | None = None,
+    ) -> str:
+        published.append((task_id, event_type, dict(data or {})))
+        return "1-0"
+
+    monkeypatch.setattr(
+        "guardian.agents.events.task_events.publish", fake_publish
+    )
+
+    telemetry_store = AgentStore()
+    event_publisher = AgentEventPublisher()
+    deployment = telemetry_store.create_deployment(
+        flow_id="flow-1",
+        thread_id=7,
+        spec_json={"steps": []},
+        spec_hash="spec-hash",
+    )
+    run = telemetry_store.create_run(
+        deployment_id=str(deployment["deployment_id"]),
+        thread_id=7,
+        status="running",
+    )
+
+    def executor(_attempt_index: int) -> AttemptEvaluation:
+        return AttemptEvaluation(
+            schema_valid=True,
+            tests_passed=True,
+            spec_alignment_ok=False,
+            fail_count=0,
+            fail_signature="spec-mismatch",
+            diff_added=0,
+            diff_deleted=0,
+            error_category="spec_alignment_violation",
+        )
+
+    result = process_mutating_step(
+        deployment_id=str(deployment["deployment_id"]),
+        run_id=str(run["run_id"]),
+        step_index=1,
+        step_id="step-1",
+        primitive="mutate",
+        worktree_path="/tmp/worktree",
+        attempt_executor=executor,
+        telemetry_store=telemetry_store,
+        event_publisher=event_publisher,
+    )
+
+    assert result.status == "escalated"
+    escalations = telemetry_store.list_escalations(run_id=str(run["run_id"]))
+    assert len(escalations) == 1
+    assert escalations[0]["reason_code"] == "spec_alignment_violation"
+    assert any(event_type == "escalated" for _, event_type, _ in published)
+
+
+def test_agent_event_publisher_persists_agent_event_rows(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "guardian.agents.events.task_events.publish",
+        lambda *_args, **_kwargs: "1-0",
+    )
+    fake_db = _FakeDB()
+    event_publisher = AgentEventPublisher(db=fake_db)
+
+    event_publisher.emit(
+        run_id="run-123",
+        event_type="succeeded",
+        payload={"step_index": 3},
+    )
+
+    assert len(fake_db.added) == 1
+    row = fake_db.added[0]
+    assert isinstance(row, AgentEvent)
+    assert row.run_id == 101
+    assert row.event_type == "succeeded"
+    assert row.payload_json == {"step_index": 3}
+
+
+class _FakeRequest:
+    def __init__(self, disconnect_after: int = 2) -> None:
+        self._checks = 0
+        self._disconnect_after = disconnect_after
+
+    async def is_disconnected(self) -> bool:
+        self._checks += 1
+        return self._checks > self._disconnect_after
+
+
+@pytest.mark.asyncio
+async def test_agent_run_events_sse_streams_terminal_events(
+    monkeypatch,
+) -> None:
+    batches: list[list[tuple[str, dict[str, Any]]]] = [
+        [
+            ("1-1", {"type": "escalated", "data": {"reason": "x"}}),
+            ("1-2", {"type": "failed", "data": {"reason": "y"}}),
+            ("1-3", {"type": "succeeded", "data": {"reason": "z"}}),
+        ],
+        [],
+    ]
+
+    def fake_read_events(
+        _task_id: str,
+        _last_id: str,
+        *,
+        block_ms: int = 15000,
+        count: int = 100,
+    ) -> list[tuple[str, dict[str, Any]]]:
+        _ = block_ms, count
+        if batches:
+            return batches.pop(0)
+        return []
+
+    monkeypatch.setattr(
+        agent_orchestration.task_events,
+        "read_events",
+        fake_read_events,
+    )
+
+    response = await agent_orchestration.stream_run_events(
+        request=_FakeRequest(disconnect_after=2),
+        run_id="run-evt",
+        last_id_query="0-0",
+        last_event_id_header=None,
+    )
+    observed: list[str] = []
+    buffer = ""
+
+    async for chunk in response.body_iterator:
+        text = (
+            chunk.decode()
+            if isinstance(chunk, (bytes, bytearray))
+            else str(chunk)
+        )
+        buffer += text
+        while "\n\n" in buffer:
+            frame, buffer = buffer.split("\n\n", 1)
+            if (
+                not frame.strip()
+                or frame.startswith("retry:")
+                or frame.startswith(": ping")
+            ):
+                continue
+            lines = frame.splitlines()
+            event_line = next(
+                (line for line in lines if line.startswith("event:")),
+                None,
+            )
+            data_line = next(
+                (line for line in lines if line.startswith("data:")),
+                None,
+            )
+            if event_line is None or data_line is None:
+                continue
+            observed.append(event_line.split(":", 1)[1].strip())
+            _ = json.loads(data_line.split(":", 1)[1].strip() or "{}")
+
+    assert "escalated" in observed
+    assert "failed" in observed
+    assert "succeeded" in observed
+
+
+def test_chat_thread_agent_runs_endpoint(monkeypatch) -> None:
+    monkeypatch.setenv("GUARDIAN_API_KEY", "test-key")
+
+    local_store = AgentStore()
+    local_publisher = AgentEventPublisher()
+    monkeypatch.setattr(agent_orchestration, "_store", local_store)
+    monkeypatch.setattr(
+        agent_orchestration, "_event_publisher", local_publisher
+    )
+
+    deployment = local_store.create_deployment(
+        flow_id="flow-thread",
+        thread_id=77,
+        spec_json={},
+        spec_hash="spec-thread",
+    )
+    run = local_store.create_run(
+        deployment_id=str(deployment["deployment_id"]),
+        thread_id=77,
+        status="running",
+    )
+
+    client = _build_client()
+    response = client.get(
+        "/api/chat/77/agent-runs",
+        headers={"X-API-Key": "test-key"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    run_ids = [item["run_id"] for item in payload["runs"]]
+    assert str(run["run_id"]) in run_ids

--- a/guardian/tests/routes/test_agent_orchestration_events.py
+++ b/guardian/tests/routes/test_agent_orchestration_events.py
@@ -284,3 +284,115 @@ def test_chat_thread_agent_runs_endpoint(monkeypatch) -> None:
     payload = response.json()
     run_ids = [item["run_id"] for item in payload["runs"]]
     assert str(run["run_id"]) in run_ids
+
+
+def test_start_run_terminal_runtime_target_is_persisted_and_emitted(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("GUARDIAN_API_KEY", "test-key")
+
+    published: list[tuple[str, str, dict[str, Any]]] = []
+
+    def fake_publish(
+        task_id: str,
+        event_type: str,
+        data: dict[str, Any] | None = None,
+    ) -> str:
+        published.append((task_id, event_type, dict(data or {})))
+        return "1-0"
+
+    monkeypatch.setattr(
+        "guardian.agents.events.task_events.publish",
+        fake_publish,
+    )
+
+    local_store = AgentStore()
+    local_publisher = AgentEventPublisher()
+    monkeypatch.setattr(agent_orchestration, "_store", local_store)
+    monkeypatch.setattr(
+        agent_orchestration, "_event_publisher", local_publisher
+    )
+
+    client = _build_client()
+    deploy_response = client.post(
+        "/api/agents/deployments",
+        json={"flow_id": "flow-terminal", "thread_id": 91, "spec": {}},
+        headers={"X-API-Key": "test-key"},
+    )
+    assert deploy_response.status_code == 200
+    deployment_id = deploy_response.json()["deployment"]["deployment_id"]
+
+    run_response = client.post(
+        f"/api/agents/deployments/{deployment_id}/runs",
+        json={"runtime_target": "terminal", "supervised": True},
+        headers={"X-API-Key": "test-key"},
+    )
+    assert run_response.status_code == 200
+    payload = run_response.json()
+    assert payload["ok"] is True
+    assert payload["run"]["runtime_target"] == "terminal"
+
+    run_id = payload["run"]["run_id"]
+    stored_run = local_store.get_run(run_id)
+    assert stored_run is not None
+    assert stored_run["runtime_target"] == "terminal"
+
+    run_events = [
+        (event_type, data)
+        for task_id, event_type, data in published
+        if task_id == run_id and event_type in {"created", "started"}
+    ]
+    assert len(run_events) == 2
+    expected = {
+        "deployment_id": deployment_id,
+        "run_id": run_id,
+        "runtime_target": "terminal",
+    }
+    assert dict(run_events)["created"] == expected
+    assert dict(run_events)["started"] == expected
+
+
+def test_start_run_rejects_invalid_runtime_target(monkeypatch) -> None:
+    monkeypatch.setenv("GUARDIAN_API_KEY", "test-key")
+
+    published: list[tuple[str, str, dict[str, Any]]] = []
+
+    def fake_publish(
+        task_id: str,
+        event_type: str,
+        data: dict[str, Any] | None = None,
+    ) -> str:
+        published.append((task_id, event_type, dict(data or {})))
+        return "1-0"
+
+    monkeypatch.setattr(
+        "guardian.agents.events.task_events.publish",
+        fake_publish,
+    )
+
+    local_store = AgentStore()
+    local_publisher = AgentEventPublisher()
+    monkeypatch.setattr(agent_orchestration, "_store", local_store)
+    monkeypatch.setattr(
+        agent_orchestration, "_event_publisher", local_publisher
+    )
+
+    client = _build_client()
+    deploy_response = client.post(
+        "/api/agents/deployments",
+        json={"flow_id": "flow-invalid-target", "thread_id": 92, "spec": {}},
+        headers={"X-API-Key": "test-key"},
+    )
+    assert deploy_response.status_code == 200
+    deployment_id = deploy_response.json()["deployment"]["deployment_id"]
+
+    run_response = client.post(
+        f"/api/agents/deployments/{deployment_id}/runs",
+        json={"runtime_target": "host"},
+        headers={"X-API-Key": "test-key"},
+    )
+
+    assert run_response.status_code == 400
+    assert run_response.json() == {"detail": "invalid_runtime_target"}
+    assert local_store.list_runs_for_thread(92) == []
+    assert published == []

--- a/guardian/tests/test_minimax_provider.py
+++ b/guardian/tests/test_minimax_provider.py
@@ -59,6 +59,21 @@ def test_validate_llm_config_minimax_missing_required_env(monkeypatch):
     assert "MINIMAX_API_BASE" in message
 
 
+def test_validate_llm_config_minimax_invalid_api_flavor():
+    settings = Settings(
+        LLM_PROVIDER="minimax",
+        ALLOW_CLOUD_PROVIDERS=True,
+        MINIMAX_API_KEY="minimax-key",
+        MINIMAX_API_BASE="https://api.minimax.local/v1",
+        MINIMAX_API_FLAVOR="invalid",
+    )
+
+    with pytest.raises(LLMConfigError) as exc:
+        validate_llm_config(settings)
+
+    assert "MINIMAX_API_FLAVOR" in str(exc.value)
+
+
 def test_minimax_adapter_uses_openai_compatible_client(monkeypatch):
     _allow_minimax_egress(monkeypatch)
 
@@ -144,4 +159,115 @@ def test_minimax_adapter_uses_openai_compatible_client(monkeypatch):
     assert calls[1]["model"] == "minimax-override"
     assert calls[1]["messages"] == [
         {"role": "user", "content": "stream this"},
+    ]
+
+
+def test_minimax_adapter_supports_anthropic_compatible_http(monkeypatch):
+    _allow_minimax_egress(monkeypatch)
+    monkeypatch.setattr("guardian.providers.minimax_adapter.OpenAI", None)
+
+    calls: list[dict[str, object]] = []
+
+    class _DummyResponse:
+        def __init__(
+            self,
+            *,
+            payload: dict | None = None,
+            lines: list[str] | None = None,
+            status_code: int = 200,
+        ):
+            self._payload = payload or {}
+            self._lines = lines or []
+            self.status_code = status_code
+            self.text = ""
+
+        def json(self):
+            return self._payload
+
+        def iter_lines(self, decode_unicode=True):
+            _ = decode_unicode
+            yield from self._lines
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_post(url, json, headers, timeout, stream=False):
+        calls.append(
+            {
+                "url": url,
+                "json": json,
+                "headers": headers,
+                "timeout": timeout,
+                "stream": stream,
+            }
+        )
+        if stream:
+            return _DummyResponse(
+                lines=[
+                    "event: message_start",
+                    'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"hello"}}',
+                    'data: {"type":"content_block_delta","delta":{"text":" world"}}',
+                    'data: {"type":"message_stop"}',
+                ]
+            )
+        return _DummyResponse(
+            payload={"content": [{"type": "text", "text": "generated reply"}]}
+        )
+
+    monkeypatch.setattr(
+        "guardian.providers.minimax_adapter.requests.post", fake_post
+    )
+
+    adapter = MiniMaxAdapter(
+        api_key="minimax-secret",
+        base_url="https://api.minimax.local/anthropic",
+        default_model="MiniMax-M2.5",
+        timeout=45,
+        api_flavor="anthropic",
+        anthropic_version="2023-06-01",
+    )
+    reply = adapter.generate(
+        "ignored prompt",
+        messages=[
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": "Say hi"},
+        ],
+        temperature=0.2,
+        max_tokens=111,
+    )
+    chunks = list(
+        adapter.stream(
+            "ignored prompt",
+            model="MiniMax-M2.5",
+            messages=[{"role": "user", "content": "stream this"}],
+        )
+    )
+
+    assert reply == "generated reply"
+    assert "".join(chunks) == "hello world"
+    assert len(calls) == 2
+
+    assert calls[0]["url"] == "https://api.minimax.local/anthropic/v1/messages"
+    assert calls[0]["headers"]["x-api-key"] == "minimax-secret"
+    assert calls[0]["headers"]["anthropic-version"] == "2023-06-01"
+    assert calls[0]["json"]["model"] == "MiniMax-M2.5"
+    assert calls[0]["json"]["system"] == "You are concise."
+    assert calls[0]["json"]["messages"] == [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "Say hi"}],
+        }
+    ]
+    assert calls[0]["json"]["max_tokens"] == 111
+    assert calls[0]["stream"] is False
+
+    assert calls[1]["stream"] is True
+    assert calls[1]["json"]["messages"] == [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "stream this"}],
+        }
     ]

--- a/guardian/tests/workers/test_agent_worker_commit_boundaries.py
+++ b/guardian/tests/workers/test_agent_worker_commit_boundaries.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+from guardian.agents.events import AgentEventPublisher
+from guardian.agents.store import AgentStore
+from guardian.workers.agent_worker import (
+    AttemptEvaluation,
+    process_mutating_step,
+)
+
+
+@dataclass
+class _FakeCommitBackend:
+    calls: list[tuple[str, bool | None]]
+
+    def commit_mutation(self, *, worktree_path: str, message: str) -> str:
+        _ = worktree_path, message
+        self.calls.append(("mutation", None))
+        return "commit-a-hash"
+
+    def commit_validation_boundary(
+        self, *, worktree_path: str, message: str, allow_empty: bool
+    ) -> str:
+        _ = worktree_path, message
+        self.calls.append(("validation", allow_empty))
+        return "commit-b-hash"
+
+
+def _settings(**overrides: object) -> SimpleNamespace:
+    values: dict[str, object] = {
+        "AGENT_MAX_ATTEMPTS": 5,
+        "AGENT_MIN_ATTEMPTS_BEFORE_ABORT": 2,
+        "AGENT_NO_PROGRESS_WINDOW": 2,
+        "AGENT_MAX_SAME_SIGNATURE_REPEATS": 2,
+        "AGENT_REGRESSION_LIMIT": 2,
+        "AGENT_VALIDATOR_MODEL_ENABLED": False,
+        "AGENT_VALIDATION_COMMIT_ALLOW_EMPTY": True,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _seed_run(telemetry_store: AgentStore) -> str:
+    deployment = telemetry_store.create_deployment(
+        flow_id="flow-1",
+        thread_id=42,
+        spec_json={"steps": []},
+        spec_hash="spec-hash-1",
+    )
+    run = telemetry_store.create_run(
+        deployment_id=str(deployment["deployment_id"]),
+        thread_id=42,
+        status="running",
+    )
+    return str(run["run_id"])
+
+
+def test_failing_attempts_create_no_commits() -> None:
+    telemetry_store = AgentStore()
+    event_publisher = AgentEventPublisher()
+    run_id = _seed_run(telemetry_store)
+    commit_backend = _FakeCommitBackend(calls=[])
+
+    def executor(_attempt_index: int) -> AttemptEvaluation:
+        return AttemptEvaluation(
+            schema_valid=True,
+            tests_passed=False,
+            spec_alignment_ok=True,
+            fail_count=3,
+            fail_signature="sig-fail",
+            diff_added=4,
+            diff_deleted=1,
+            error_category="tests_failed",
+        )
+
+    result = process_mutating_step(
+        deployment_id="dep-1",
+        run_id=run_id,
+        step_index=1,
+        step_id="step-fail",
+        primitive="mutate",
+        worktree_path="/tmp/worktree",
+        attempt_executor=executor,
+        telemetry_store=telemetry_store,
+        event_publisher=event_publisher,
+        settings=_settings(
+            AGENT_MAX_ATTEMPTS=3,
+            AGENT_MIN_ATTEMPTS_BEFORE_ABORT=99,
+        ),
+        commit_backend=commit_backend,
+    )
+
+    assert result.status == "failed"
+    assert result.commit_a_hash is None
+    assert result.commit_b_hash is None
+    assert commit_backend.calls == []
+
+    attempts = telemetry_store.list_attempts(run_id=run_id, step_index=1)
+    assert len(attempts) == 3
+    artifacts = telemetry_store.list_artifacts(run_id=run_id, step_index=1)
+    assert artifacts == []
+
+
+def test_successful_mutating_task_creates_exactly_two_commits_and_persists_hashes() -> (
+    None
+):
+    telemetry_store = AgentStore()
+    event_publisher = AgentEventPublisher()
+    run_id = _seed_run(telemetry_store)
+    commit_backend = _FakeCommitBackend(calls=[])
+
+    def executor(_attempt_index: int) -> AttemptEvaluation:
+        return AttemptEvaluation(
+            schema_valid=True,
+            tests_passed=True,
+            spec_alignment_ok=True,
+            fail_count=0,
+            fail_signature="sig-ok",
+            diff_added=2,
+            diff_deleted=1,
+            error_category="tests_failed",
+            diff_risk=0.95,
+            model_stability=0.90,
+            model_self_confidence=0.66,
+        )
+
+    result = process_mutating_step(
+        deployment_id="dep-1",
+        run_id=run_id,
+        step_index=2,
+        step_id="step-success",
+        primitive="mutate",
+        worktree_path="/tmp/worktree",
+        attempt_executor=executor,
+        telemetry_store=telemetry_store,
+        event_publisher=event_publisher,
+        settings=_settings(),
+        commit_backend=commit_backend,
+    )
+
+    assert result.status == "succeeded"
+    assert result.commit_a_hash == "commit-a-hash"
+    assert result.commit_b_hash == "commit-b-hash"
+    assert commit_backend.calls == [
+        ("mutation", None),
+        ("validation", True),
+    ]
+
+    artifacts = telemetry_store.list_artifacts(run_id=run_id, step_index=2)
+    by_type = {item["artifact_type"]: item for item in artifacts}
+    assert by_type["commit_a_hash"]["content_json"]["hash"] == "commit-a-hash"
+    assert by_type["commit_b_hash"]["content_json"]["hash"] == "commit-b-hash"
+
+    confidence_reports = telemetry_store.list_confidence_reports(run_id=run_id)
+    scopes = [item["scope"] for item in confidence_reports]
+    assert "step" in scopes
+    assert "task" in scopes
+
+
+def test_retry_then_success_still_commits_only_once_per_boundary() -> None:
+    telemetry_store = AgentStore()
+    event_publisher = AgentEventPublisher()
+    run_id = _seed_run(telemetry_store)
+    commit_backend = _FakeCommitBackend(calls=[])
+    state = {"attempt": 0}
+
+    def executor(attempt_index: int) -> AttemptEvaluation:
+        state["attempt"] = attempt_index
+        if attempt_index == 1:
+            return AttemptEvaluation(
+                schema_valid=True,
+                tests_passed=False,
+                spec_alignment_ok=True,
+                fail_count=3,
+                fail_signature="sig-fail-1",
+                diff_added=6,
+                diff_deleted=0,
+                error_category="tests_failed",
+            )
+        return AttemptEvaluation(
+            schema_valid=True,
+            tests_passed=True,
+            spec_alignment_ok=True,
+            fail_count=1,
+            fail_signature="sig-pass",
+            diff_added=1,
+            diff_deleted=1,
+            error_category="tests_failed",
+            diff_risk=0.90,
+            model_stability=0.90,
+        )
+
+    result = process_mutating_step(
+        deployment_id="dep-1",
+        run_id=run_id,
+        step_index=3,
+        step_id="step-retry-success",
+        primitive="mutate",
+        worktree_path="/tmp/worktree",
+        attempt_executor=executor,
+        telemetry_store=telemetry_store,
+        event_publisher=event_publisher,
+        settings=_settings(),
+        commit_backend=commit_backend,
+    )
+
+    assert result.status == "succeeded"
+    assert result.attempts == 2
+    assert state["attempt"] == 2
+    assert commit_backend.calls == [
+        ("mutation", None),
+        ("validation", True),
+    ]
+    attempts = telemetry_store.list_attempts(run_id=run_id, step_index=3)
+    assert len(attempts) == 2

--- a/guardian/workers/agent_worker.py
+++ b/guardian/workers/agent_worker.py
@@ -1,0 +1,560 @@
+"""Deterministic delegated-agent worker primitives."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable, Protocol
+
+from guardian.agents.confidence import (
+    compute_step_confidence,
+    compute_task_confidence,
+)
+from guardian.agents.events import AgentEventPublisher, publisher
+from guardian.agents.retry_policy import (
+    AttemptMetrics,
+    RetryConfig,
+    evaluate_retry_decision,
+)
+from guardian.agents.store import AgentStore, deterministic_worktree_id, store
+from guardian.core.config import Settings, get_settings
+from guardian.core.orchestrator.workspace_manager import WorkspaceManager
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AttemptEvaluation:
+    schema_valid: bool
+    tests_passed: bool
+    spec_alignment_ok: bool
+    fail_count: int
+    fail_signature: str
+    diff_added: int
+    diff_deleted: int
+    error_category: str
+    diff_risk: float = 1.0
+    model_stability: float = 1.0
+    model_self_confidence: float | None = None
+    stderr_excerpt: str | None = None
+
+
+@dataclass(frozen=True)
+class StepExecutionResult:
+    status: str
+    attempts: int
+    commit_a_hash: str | None = None
+    commit_b_hash: str | None = None
+    escalation_reason: str | None = None
+    preserved_worktree: bool = False
+
+
+class CommitBackend(Protocol):
+    def commit_mutation(self, *, worktree_path: str, message: str) -> str:
+        ...
+
+    def commit_validation_boundary(
+        self, *, worktree_path: str, message: str, allow_empty: bool
+    ) -> str:
+        ...
+
+
+def _run_git(
+    args: list[str],
+    *,
+    cwd: str,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=check,
+    )
+
+
+class GitCommitBackend:
+    """Git-backed commit boundary helper."""
+
+    def __init__(
+        self,
+        run_cmd: Callable[..., subprocess.CompletedProcess[str]] = _run_git,
+    ) -> None:
+        self._run_cmd = run_cmd
+
+    def _head_hash(self, *, worktree_path: str) -> str:
+        proc = self._run_cmd(
+            ["git", "rev-parse", "HEAD"],
+            cwd=worktree_path,
+            check=True,
+        )
+        return (proc.stdout or "").strip()
+
+    def commit_mutation(self, *, worktree_path: str, message: str) -> str:
+        self._run_cmd(["git", "add", "-A"], cwd=worktree_path, check=True)
+        self._run_cmd(
+            ["git", "commit", "-m", message],
+            cwd=worktree_path,
+            check=True,
+        )
+        return self._head_hash(worktree_path=worktree_path)
+
+    def commit_validation_boundary(
+        self, *, worktree_path: str, message: str, allow_empty: bool
+    ) -> str:
+        args = ["git", "commit", "-m", message]
+        if allow_empty:
+            args.insert(2, "--allow-empty")
+        self._run_cmd(args, cwd=worktree_path, check=True)
+        return self._head_hash(worktree_path=worktree_path)
+
+
+def _progress_made(
+    *,
+    current: AttemptEvaluation,
+    history: list[AttemptMetrics],
+) -> bool:
+    if not history:
+        return False
+    prev = history[-1]
+    if current.fail_count < prev.fail_count:
+        return True
+    rank = {
+        "spec_alignment_violation": 0,
+        "schema_invalid": 1,
+        "tests_failed": 2,
+        "unknown": 3,
+    }
+    prev_rank = rank.get(prev.error_category, 3)
+    cur_rank = rank.get(current.error_category, 3)
+    return cur_rank < prev_rank
+
+
+def _settings_retry_config(settings: Settings) -> RetryConfig:
+    return RetryConfig(
+        max_attempts=int(settings.AGENT_MAX_ATTEMPTS),
+        min_attempts_before_abort=int(settings.AGENT_MIN_ATTEMPTS_BEFORE_ABORT),
+        no_progress_window=int(settings.AGENT_NO_PROGRESS_WINDOW),
+        max_same_signature_repeats=int(
+            settings.AGENT_MAX_SAME_SIGNATURE_REPEATS
+        ),
+        regression_limit=int(settings.AGENT_REGRESSION_LIMIT),
+    )
+
+
+def _emit(
+    event_publisher: AgentEventPublisher,
+    *,
+    run_id: str,
+    event_type: str,
+    payload: dict[str, Any],
+) -> None:
+    event_publisher.emit(
+        run_id=run_id,
+        event_type=event_type,
+        payload=payload,
+    )
+
+
+def _persist_escalation(
+    *,
+    telemetry_store: AgentStore,
+    event_publisher: AgentEventPublisher,
+    run_id: str,
+    step_index: int,
+    reason_code: str,
+    reason: str,
+    severity: str,
+    preserved_worktree: bool,
+) -> None:
+    telemetry_store.add_escalation(
+        run_id=run_id,
+        step_index=step_index,
+        severity=severity,
+        reason_code=reason_code,
+        reason=reason,
+        preserved_worktree=preserved_worktree,
+        payload={"reason_code": reason_code, "step_index": step_index},
+    )
+    _emit(
+        event_publisher,
+        run_id=run_id,
+        event_type="escalated",
+        payload={
+            "step_index": step_index,
+            "reason_code": reason_code,
+            "reason": reason,
+            "severity": severity,
+            "preserved_worktree": preserved_worktree,
+        },
+    )
+
+
+def process_mutating_step(
+    *,
+    deployment_id: str,
+    run_id: str,
+    step_index: int,
+    step_id: str,
+    primitive: str,
+    worktree_path: str,
+    attempt_executor: Callable[[int], AttemptEvaluation],
+    telemetry_store: AgentStore | None = None,
+    event_publisher: AgentEventPublisher | None = None,
+    settings: Settings | None = None,
+    commit_backend: CommitBackend | None = None,
+    validator_hook: Callable[[int], None] | None = None,
+) -> StepExecutionResult:
+    """Execute one mutating step with adaptive retries and strict commit doctrine."""
+    resolved_store = telemetry_store or store
+    resolved_events = event_publisher or publisher
+    resolved_settings = settings or get_settings()
+    resolved_commits = commit_backend or GitCommitBackend()
+    retry_cfg = _settings_retry_config(resolved_settings)
+
+    resolved_store.create_step(
+        run_id=run_id,
+        step_index=step_index,
+        step_id=step_id,
+        primitive=primitive,
+        is_mutating=True,
+    )
+    _emit(
+        resolved_events,
+        run_id=run_id,
+        event_type="started",
+        payload={"step_index": step_index, "step_id": step_id},
+    )
+
+    history: list[AttemptMetrics] = []
+
+    for attempt_index in range(1, retry_cfg.max_attempts + 1):
+        if resolved_settings.AGENT_VALIDATOR_MODEL_ENABLED and validator_hook:
+            validator_hook(attempt_index)
+
+        attempt = attempt_executor(attempt_index)
+        progress = _progress_made(current=attempt, history=history)
+        attempt_status = (
+            "succeeded"
+            if (
+                attempt.schema_valid
+                and attempt.tests_passed
+                and attempt.spec_alignment_ok
+            )
+            else "failed"
+        )
+
+        if not attempt.spec_alignment_ok:
+            attempt_status = "escalated"
+
+        resolved_store.add_attempt(
+            run_id=run_id,
+            step_index=step_index,
+            attempt_index=attempt_index,
+            status=attempt_status,
+            fail_count=attempt.fail_count,
+            fail_signature=attempt.fail_signature,
+            diff_added=attempt.diff_added,
+            diff_deleted=attempt.diff_deleted,
+            error_category=attempt.error_category,
+            progress_made=progress,
+            stderr_excerpt=attempt.stderr_excerpt,
+        )
+
+        if not attempt.spec_alignment_ok:
+            resolved_store.update_step_status(
+                run_id=run_id,
+                step_index=step_index,
+                status="escalated",
+                schema_valid=attempt.schema_valid,
+                spec_alignment_ok=False,
+                tests_passed=attempt.tests_passed,
+            )
+            resolved_store.update_run_status(run_id=run_id, status="escalated")
+            _persist_escalation(
+                telemetry_store=resolved_store,
+                event_publisher=resolved_events,
+                run_id=run_id,
+                step_index=step_index,
+                reason_code="spec_alignment_violation",
+                reason="Spec alignment violation detected",
+                severity="hard",
+                preserved_worktree=True,
+            )
+            return StepExecutionResult(
+                status="escalated",
+                attempts=attempt_index,
+                escalation_reason="spec_alignment_violation",
+                preserved_worktree=True,
+            )
+
+        if attempt.schema_valid and attempt.tests_passed:
+            step_conf = compute_step_confidence(
+                c_diff_risk=attempt.diff_risk,
+                c_model_stability=attempt.model_stability,
+                c_tests=1.0,
+                c_schema=1.0,
+                c_spec_alignment=1.0,
+            )
+            resolved_store.add_confidence_report(
+                run_id=run_id,
+                step_index=step_index,
+                scope="step",
+                confidence=step_conf.score,
+                decision=step_conf.decision,
+                factors=step_conf.factors,
+                model_self_confidence=attempt.model_self_confidence,
+            )
+
+            if step_conf.decision in {"soft_escalate", "hard_escalate"}:
+                severity = (
+                    "soft" if step_conf.decision == "soft_escalate" else "hard"
+                )
+                resolved_store.update_step_status(
+                    run_id=run_id,
+                    step_index=step_index,
+                    status="escalated",
+                    schema_valid=True,
+                    spec_alignment_ok=True,
+                    tests_passed=True,
+                )
+                resolved_store.update_run_status(
+                    run_id=run_id, status="escalated"
+                )
+                _persist_escalation(
+                    telemetry_store=resolved_store,
+                    event_publisher=resolved_events,
+                    run_id=run_id,
+                    step_index=step_index,
+                    reason_code=step_conf.decision,
+                    reason=("Confidence gate blocked autonomous continuation"),
+                    severity=severity,
+                    preserved_worktree=True,
+                )
+                return StepExecutionResult(
+                    status="escalated",
+                    attempts=attempt_index,
+                    escalation_reason=step_conf.decision,
+                    preserved_worktree=True,
+                )
+
+            task_conf = compute_task_confidence(
+                step_scores=[step_conf.score],
+                c_risk=attempt.diff_risk,
+                escalation_penalty=0.0,
+            )
+            resolved_store.add_confidence_report(
+                run_id=run_id,
+                step_index=None,
+                scope="task",
+                confidence=task_conf.score,
+                decision=task_conf.decision,
+                factors=task_conf.factors,
+                model_self_confidence=attempt.model_self_confidence,
+            )
+
+            # Commit doctrine: only after passing tests/schema/spec.
+            commit_a = resolved_commits.commit_mutation(
+                worktree_path=worktree_path,
+                message=f"TASK-{step_id}: mutation",
+            )
+            commit_b = resolved_commits.commit_validation_boundary(
+                worktree_path=worktree_path,
+                message=f"TASK-{step_id}: validation-boundary",
+                allow_empty=bool(
+                    resolved_settings.AGENT_VALIDATION_COMMIT_ALLOW_EMPTY
+                ),
+            )
+            resolved_store.add_artifact(
+                run_id=run_id,
+                step_index=step_index,
+                artifact_type="commit_a_hash",
+                content_json={"hash": commit_a},
+            )
+            resolved_store.add_artifact(
+                run_id=run_id,
+                step_index=step_index,
+                artifact_type="commit_b_hash",
+                content_json={"hash": commit_b},
+            )
+            resolved_store.update_step_status(
+                run_id=run_id,
+                step_index=step_index,
+                status="succeeded",
+                schema_valid=True,
+                spec_alignment_ok=True,
+                tests_passed=True,
+            )
+            resolved_store.update_run_status(run_id=run_id, status="succeeded")
+            _emit(
+                resolved_events,
+                run_id=run_id,
+                event_type="step_succeeded",
+                payload={
+                    "step_index": step_index,
+                    "commit_a_hash": commit_a,
+                    "commit_b_hash": commit_b,
+                },
+            )
+            _emit(
+                resolved_events,
+                run_id=run_id,
+                event_type="succeeded",
+                payload={
+                    "step_index": step_index,
+                    "commit_a_hash": commit_a,
+                    "commit_b_hash": commit_b,
+                },
+            )
+            return StepExecutionResult(
+                status="succeeded",
+                attempts=attempt_index,
+                commit_a_hash=commit_a,
+                commit_b_hash=commit_b,
+                preserved_worktree=False,
+            )
+
+        _emit(
+            resolved_events,
+            run_id=run_id,
+            event_type="attempt_failed",
+            payload={
+                "step_index": step_index,
+                "attempt_index": attempt_index,
+                "fail_count": attempt.fail_count,
+                "fail_signature": attempt.fail_signature,
+                "error_category": attempt.error_category,
+            },
+        )
+
+        current_metrics = AttemptMetrics(
+            fail_count=attempt.fail_count,
+            fail_signature=attempt.fail_signature,
+            diff_added=attempt.diff_added,
+            diff_deleted=attempt.diff_deleted,
+            error_category=attempt.error_category,
+            progress_made=progress,
+        )
+        decision = evaluate_retry_decision(
+            attempt_index=attempt_index,
+            current=current_metrics,
+            history=history,
+            config=retry_cfg,
+            spec_alignment_violation=False,
+        )
+        history.append(current_metrics)
+
+        if decision.escalate:
+            resolved_store.update_step_status(
+                run_id=run_id,
+                step_index=step_index,
+                status="escalated",
+                schema_valid=attempt.schema_valid,
+                spec_alignment_ok=True,
+                tests_passed=attempt.tests_passed,
+            )
+            resolved_store.update_run_status(run_id=run_id, status="escalated")
+            _persist_escalation(
+                telemetry_store=resolved_store,
+                event_publisher=resolved_events,
+                run_id=run_id,
+                step_index=step_index,
+                reason_code=decision.reason,
+                reason="Adaptive retry policy escalated step",
+                severity="soft",
+                preserved_worktree=True,
+            )
+            return StepExecutionResult(
+                status="escalated",
+                attempts=attempt_index,
+                escalation_reason=decision.reason,
+                preserved_worktree=True,
+            )
+
+        if not decision.should_retry:
+            break
+
+        _emit(
+            resolved_events,
+            run_id=run_id,
+            event_type="attempt_progress",
+            payload={
+                "step_index": step_index,
+                "attempt_index": attempt_index,
+                "decision": decision.reason,
+            },
+        )
+
+    resolved_store.update_step_status(
+        run_id=run_id,
+        step_index=step_index,
+        status="failed",
+        schema_valid=False,
+        spec_alignment_ok=True,
+        tests_passed=False,
+    )
+    resolved_store.update_run_status(run_id=run_id, status="failed")
+    _emit(
+        resolved_events,
+        run_id=run_id,
+        event_type="failed",
+        payload={"step_index": step_index, "reason": "max_attempts_exhausted"},
+    )
+    return StepExecutionResult(
+        status="failed",
+        attempts=retry_cfg.max_attempts,
+        escalation_reason="max_attempts_exhausted",
+        preserved_worktree=False,
+    )
+
+
+def apply_worktree_cleanup_policy(
+    *,
+    workspace_manager: WorkspaceManager,
+    task_worktree_id: str,
+    result: StepExecutionResult,
+    settings: Settings | None = None,
+) -> None:
+    resolved = settings or get_settings()
+    should_cleanup = bool(resolved.AGENT_AUTO_ROLLBACK_ON_FAIL)
+    if result.status == "failed" and should_cleanup:
+        workspace_manager.cleanup_worktree(task_worktree_id)
+        return
+    # Escalated runs intentionally preserve worktree for manual review.
+
+
+def create_mutating_worktree(
+    *,
+    workspace_manager: WorkspaceManager,
+    deployment_id: str,
+    run_id: str,
+    step_index: int,
+    base_branch: str,
+    campaign_id: str,
+) -> tuple[str, str]:
+    task_worktree_id = deterministic_worktree_id(
+        deployment_id=deployment_id,
+        run_id=run_id,
+        step_index=step_index,
+    )
+    path = workspace_manager.create_worktree(
+        task_id=task_worktree_id,
+        base_branch=base_branch,
+        campaign_id=campaign_id,
+        force=True,
+    )
+    return task_worktree_id, str(Path(path).resolve())
+
+
+__all__ = [
+    "AttemptEvaluation",
+    "CommitBackend",
+    "GitCommitBackend",
+    "StepExecutionResult",
+    "apply_worktree_cleanup_policy",
+    "create_mutating_worktree",
+    "process_mutating_step",
+]


### PR DESCRIPTION
## Summary
- add a Docker-first onboarding guide that introduces the Guardian Agent Runtime and Delegation Loop from the user perspective before diving into developer notes
- document operator workflows, safety gates, failure runbook items, public APIs, event names, invariants, and extensibility hints in `docs/guardian/agent-runtime-onboarding.md`
- ensure the guide references the delegation plan where appropriate and keeps dev notes clearly separated at the bottom

## Testing
- Not run (not requested)