### PR TITLE
Add Guardian agent onboarding doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,8 @@ hf_cache/
 **/.cache/torch/
 .cache/transformers/
 **/.cache/transformers/
+
+# Local artifacts
+boxbeyond-kutiraai/
+output/
+tmp/


### PR DESCRIPTION
## Summary

Add local artifact directories to `.gitignore` to prevent accidental commits of runtime outputs and experimental folders.

This change ensures build artifacts, temporary files, and local-only project directories are excluded from version control.

---

## Changes

### Updated
- `.gitignore`

### Added Ignore Rules
- `boxbeyond-kutiraai/`
- `output/`
- `tmp/`

### Context

These directories are generated during local runs, experiments, or artifact production and should not be tracked in Git. Ignoring them:

- Prevents noisy diffs
- Reduces risk of committing local-only artifacts
- Keeps the repository clean and deterministic
- Maintains separation between source and runtime outputs

---

## Validation

-