### PR TITLE
Fix provider picker endpoints and payloads

### DIFF
--- a/frontend/src/components/ProviderSelect.tsx
+++ b/frontend/src/components/ProviderSelect.tsx
@@ -9,7 +9,8 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { usePreferredProvider } from "@/hooks/usePreferredProvider";
-import api from "@/lib/api";
+import api, { buildLlmCatalogPath } from "@/lib/api";
+import { setPreferredProviderSelection } from "@/lib/providerPref";
 
 type ProviderSelectProps = {
   value?: string;
@@ -59,8 +60,9 @@ export function ProviderSelect({
   const loadCatalog = useCallback(async () => {
     setLoading(true);
     setLoadError(null);
+    const catalogPath = buildLlmCatalogPath();
     try {
-      const response = await api.get<{ providers?: CatalogProvider[] }>("/llm/catalog");
+      const response = await api.get<{ providers?: CatalogProvider[] }>(catalogPath);
       const rawProviders = Array.isArray(response?.data?.providers)
         ? response.data.providers
         : [];
@@ -107,9 +109,10 @@ export function ProviderSelect({
           ? previous
           : null
       );
-    } catch {
+    } catch (error) {
       setProviders([]);
-      setLoadError("Provider catalog unavailable.");
+      setLoadError("Provider catalog unavailable");
+      console.warn(`[providers] failed to load catalog from ${catalogPath}`, error);
     } finally {
       setLoading(false);
     }
@@ -165,30 +168,59 @@ export function ProviderSelect({
 
   const applySelection = useCallback(
     (modelId: string, providerId?: string | null) => {
+      const normalizedModel = String(modelId || "").trim() || "default";
+      const normalizedProvider = providerId ? String(providerId).trim() : null;
       if (onChange) {
-        if (providerId) {
-          setProvider(providerId);
-        } else if (modelId === "default") {
+        if (normalizedProvider) {
+          setProvider(normalizedProvider);
+          setPreferredProviderSelection({
+            provider: normalizedProvider,
+            model: normalizedModel === "default" ? null : normalizedModel,
+          });
+        } else if (normalizedModel === "default") {
           setProvider(null);
+          setPreferredProviderSelection(null);
+        } else {
+          const providerFromModel = providers.find((entry) =>
+            entry.models.some((model) => model.id === normalizedModel)
+          );
+          const providerValue = providerFromModel?.id || null;
+          if (providerValue) setProvider(providerValue);
+          setPreferredProviderSelection({
+            provider: providerValue,
+            model: normalizedModel,
+          });
         }
-        onChange(modelId);
+        onChange(normalizedModel);
         return;
       }
 
-      if (modelId === "default") {
+      if (normalizedModel === "default") {
         setProvider(null);
+        setPreferredProviderSelection(null);
         return;
       }
 
-      if (providerId) {
-        setProvider(providerId);
+      if (normalizedProvider) {
+        setProvider(normalizedProvider);
+        setPreferredProviderSelection({
+          provider: normalizedProvider,
+          model: normalizedModel,
+        });
         return;
       }
 
       const providerFromModel = providers.find((entry) =>
-        entry.models.some((model) => model.id === modelId)
+        entry.models.some((model) => model.id === normalizedModel)
       );
-      setProvider(providerFromModel?.id || modelId);
+      const providerValue = providerFromModel?.id || null;
+      if (providerValue) {
+        setProvider(providerValue);
+      }
+      setPreferredProviderSelection({
+        provider: providerValue,
+        model: normalizedModel,
+      });
     },
     [onChange, providers, setProvider]
   );

--- a/frontend/src/components/__tests__/ProviderSelect.catalog.test.tsx
+++ b/frontend/src/components/__tests__/ProviderSelect.catalog.test.tsx
@@ -10,6 +10,7 @@ vi.mock("@/lib/api", () => ({
   default: {
     get: vi.fn(),
   },
+  buildLlmCatalogPath: () => "/llm/catalog",
 }));
 
 vi.mock("@/hooks/usePreferredProvider", () => ({
@@ -169,5 +170,15 @@ describe("ProviderSelect catalog routing", () => {
     await waitFor(() => {
       expect(screen.queryByRole("button", { name: "Groq" })).not.toBeInTheDocument();
     });
+  });
+
+  it("shows a visible error when the provider catalog request fails", async () => {
+    (api.get as any).mockRejectedValueOnce(new Error("network down"));
+
+    render(<ProviderSelect value="default" onChange={vi.fn()} openSignal={1} />);
+
+    expect(
+      await screen.findByText("Provider catalog unavailable")
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/persona/layout/AppShell.tsx
+++ b/frontend/src/components/persona/layout/AppShell.tsx
@@ -18,7 +18,7 @@
  *   - Do NOT rename the existing CSS vars — their current names are the future token keys.
  *   - Migration should be trivial if naming consistency is preserved.
  */
-import api from "@/lib/api";
+import api, { buildThreadDocumentsPath } from "@/lib/api";
 import React, { PropsWithChildren, useCallback, useEffect, useMemo, useState } from "react";
 
 // Global font injection for Apple system font
@@ -616,7 +616,7 @@ export default function AppShell({}: PropsWithChildren) {
     }
     (async () => {
       try {
-        const res = await api.get(`/threads/${activeRouteThreadId}/documents`);
+        const res = await api.get(buildThreadDocumentsPath(activeRouteThreadId));
         const docs = unwrapDocumentArray(res?.data);
         if (cancelled) return;
         const normalized = dedupeDocItems(

--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -12,7 +12,8 @@ import { Thread } from "@/types/ui";
 import { Composer } from "./components";
 import ChatView from "@/features/chat/ChatView";
 import useChat from "@/features/chat/useChat";
-import api from "@/lib/api";
+import api, { buildChatCompletePath } from "@/lib/api";
+import { buildChatCompletionPayload } from "@/lib/chatClient";
 import { useLiveEvents } from "@/hooks/useLiveEvents";
 import FrameCard from "@/components/surface/FrameCard";
 import { setTrace } from "@/state/contextTrace";
@@ -442,27 +443,9 @@ export function GuardianChat({
   );
   // Helper: ask backend to complete the thread and then refresh
   const completeThread = async (tid: number) => {
-    const selected = String(activeModelId || "").trim();
-    const hasSelection = selected.length > 0 && selected !== "default";
-    const knownProviders = new Set([
-      "local",
-      "openai",
-      "anthropic",
-      "gemini",
-      "groq",
-    ]);
-    const providerSelection = hasSelection && knownProviders.has(selected)
-      ? selected
-      : undefined;
-    const modelSelection = hasSelection && !knownProviders.has(selected)
-      ? selected
-      : undefined;
+    const payload = buildChatCompletionPayload(depth, activeModelId || "default");
     try {
-      const response = await api.post(`/chat/${tid}/complete`, {
-        depth_mode: depth,
-        provider: providerSelection,
-        model: modelSelection,
-      });
+      const response = await api.post(buildChatCompletePath(tid), payload);
       console.log(`[guardian] Completing with depth=${depth}`);
 
       // Capture task_id for completion state tracking

--- a/frontend/src/hooks/usePreferredProvider.ts
+++ b/frontend/src/hooks/usePreferredProvider.ts
@@ -11,7 +11,10 @@ export function usePreferredProvider() {
   // Cross-tab updates
   useEffect(() => {
     const onStorage = (e: StorageEvent) => {
-      if (e.key === "guardian.provider.v1") {
+      if (
+        e.key === "guardian.provider.v1"
+        || e.key === "guardian.provider_model.v1"
+      ) {
         setProviderState(getPreferredProvider());
       }
     };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -172,6 +172,22 @@ function resolveTimeoutMs(): number {
 
 const DEFAULT_TIMEOUT_MS = resolveTimeoutMs();
 
+function normalizePathSegment(value: string | number): string {
+  return encodeURIComponent(String(value).trim());
+}
+
+export function buildThreadDocumentsPath(threadId: string | number): string {
+  return `/documents/threads/${normalizePathSegment(threadId)}/documents`;
+}
+
+export function buildLlmCatalogPath(): string {
+  return "/llm/catalog";
+}
+
+export function buildChatCompletePath(threadId: string | number): string {
+  return `/chat/${normalizePathSegment(threadId)}/complete`;
+}
+
 /**
  * Central Axios instance for the frontend.
  * Reads `VITE_API_BASE_URL` at build time; defaults to "/api".

--- a/frontend/src/lib/chatClient.ts
+++ b/frontend/src/lib/chatClient.ts
@@ -1,0 +1,59 @@
+import {
+  getPreferredProviderSelection,
+  type ProviderModelSelection,
+} from "@/lib/providerPref";
+
+const KNOWN_PROVIDER_IDS = new Set([
+  "local",
+  "openai",
+  "anthropic",
+  "gemini",
+  "groq",
+]);
+
+function normalizeValue(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+type ProviderModelPayload = {
+  provider?: string;
+  model?: string;
+};
+
+function resolveProviderModelPayload(
+  activeModelId: string,
+  persistedSelection: ProviderModelSelection | null
+): ProviderModelPayload {
+  const persistedProvider = normalizeValue(persistedSelection?.provider);
+  const persistedModel = normalizeValue(persistedSelection?.model);
+  if (persistedProvider || persistedModel) {
+    return {
+      ...(persistedProvider ? { provider: persistedProvider } : {}),
+      ...(persistedModel ? { model: persistedModel } : {}),
+    };
+  }
+
+  const selected = normalizeValue(activeModelId);
+  if (!selected || selected === "default") return {};
+  if (KNOWN_PROVIDER_IDS.has(selected)) {
+    return { provider: selected };
+  }
+  return { model: selected };
+}
+
+export function buildChatCompletionPayload(
+  depthMode: string,
+  activeModelId: string,
+  preferredSelection?: ProviderModelSelection | null
+): { depth_mode: string; provider?: string; model?: string } {
+  const persistedSelection =
+    preferredSelection !== undefined
+      ? preferredSelection
+      : getPreferredProviderSelection();
+  return {
+    depth_mode: depthMode,
+    ...resolveProviderModelPayload(activeModelId, persistedSelection),
+  };
+}

--- a/frontend/src/lib/providerPref.ts
+++ b/frontend/src/lib/providerPref.ts
@@ -1,15 +1,33 @@
-// Local persistence for the selected provider.
-const KEY = "guardian.provider.v1";
+// Local persistence for selected provider/model routing.
+const PROVIDER_KEY = "guardian.provider.v1";
+const PROVIDER_MODEL_KEY = "guardian.provider_model.v1";
 
 export type ProviderName = string | null;
+export type ProviderModelSelection = {
+  provider: ProviderName;
+  model: string | null;
+};
+
+function normalizeString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function emitProviderChanged(): void {
+  try {
+    window.dispatchEvent(new CustomEvent("guardian:providerChanged"));
+  } catch {}
+}
 
 export function getPreferredProvider(): ProviderName {
   if (typeof window === "undefined") return null;
   try {
-    const raw = localStorage.getItem(KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw);
-    return typeof parsed === "string" ? parsed : null;
+    const raw = localStorage.getItem(PROVIDER_KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    const provider = normalizeString(parsed);
+    if (provider) return provider;
+    return getPreferredProviderSelection()?.provider ?? null;
   } catch {
     return null;
   }
@@ -18,10 +36,80 @@ export function getPreferredProvider(): ProviderName {
 export function setPreferredProvider(p: ProviderName): void {
   if (typeof window === "undefined") return;
   try {
-    if (p === null) localStorage.removeItem(KEY);
-    else localStorage.setItem(KEY, JSON.stringify(p));
-    // Broadcast same-tab updates for instant sync across components
-    try { window.dispatchEvent(new CustomEvent("guardian:providerChanged")); } catch {}
+    const normalizedProvider = normalizeString(p);
+    if (normalizedProvider === null) {
+      localStorage.removeItem(PROVIDER_KEY);
+      localStorage.removeItem(PROVIDER_MODEL_KEY);
+      emitProviderChanged();
+      return;
+    }
+
+    localStorage.setItem(PROVIDER_KEY, JSON.stringify(normalizedProvider));
+    const current = getPreferredProviderSelection();
+    const nextSelection: ProviderModelSelection = {
+      provider: normalizedProvider,
+      model: current?.provider === normalizedProvider ? current.model : null,
+    };
+    localStorage.setItem(PROVIDER_MODEL_KEY, JSON.stringify(nextSelection));
+    emitProviderChanged();
+  } catch {
+    /* ignore */
+  }
+}
+
+export function getPreferredProviderSelection(): ProviderModelSelection | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(PROVIDER_MODEL_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return null;
+    const provider = normalizeString((parsed as { provider?: unknown }).provider);
+    const model = normalizeString((parsed as { model?: unknown }).model);
+    if (!provider && !model) return null;
+    return {
+      provider: provider ?? null,
+      model: model ?? null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function setPreferredProviderSelection(
+  selection: ProviderModelSelection | null
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (!selection) {
+      localStorage.removeItem(PROVIDER_KEY);
+      localStorage.removeItem(PROVIDER_MODEL_KEY);
+      emitProviderChanged();
+      return;
+    }
+
+    const provider = normalizeString(selection.provider);
+    const model = normalizeString(selection.model);
+    if (!provider && !model) {
+      localStorage.removeItem(PROVIDER_KEY);
+      localStorage.removeItem(PROVIDER_MODEL_KEY);
+      emitProviderChanged();
+      return;
+    }
+
+    if (provider) {
+      localStorage.setItem(PROVIDER_KEY, JSON.stringify(provider));
+    } else {
+      localStorage.removeItem(PROVIDER_KEY);
+    }
+    localStorage.setItem(
+      PROVIDER_MODEL_KEY,
+      JSON.stringify({
+        provider: provider ?? null,
+        model: model ?? null,
+      })
+    );
+    emitProviderChanged();
   } catch {
     /* ignore */
   }

--- a/frontend/src/test/api-paths.test.ts
+++ b/frontend/src/test/api-paths.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { buildThreadDocumentsPath } from "@/lib/api";
+
+describe("API path builders", () => {
+  it("builds thread documents path under /documents/threads/:id/documents", () => {
+    expect(buildThreadDocumentsPath("123")).toBe(
+      "/documents/threads/123/documents"
+    );
+  });
+});

--- a/frontend/src/test/chatClient.completePayload.test.ts
+++ b/frontend/src/test/chatClient.completePayload.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { buildChatCompletionPayload } from "@/lib/chatClient";
+import {
+  setPreferredProviderSelection,
+  setPreferredProvider,
+} from "@/lib/providerPref";
+
+describe("buildChatCompletionPayload", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("includes provider and model from persisted preference", () => {
+    setPreferredProviderSelection({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+    });
+
+    expect(buildChatCompletionPayload("deep", "default")).toEqual({
+      depth_mode: "deep",
+      provider: "openai",
+      model: "gpt-4.1-mini",
+    });
+  });
+
+  it("falls back to active model id when no persisted provider-model preference exists", () => {
+    setPreferredProvider(null);
+
+    expect(buildChatCompletionPayload("normal", "llama3.1:8b")).toEqual({
+      depth_mode: "normal",
+      model: "llama3.1:8b",
+    });
+  });
+});

--- a/frontend/src/tests/thread_documents_rehydration.spec.tsx
+++ b/frontend/src/tests/thread_documents_rehydration.spec.tsx
@@ -65,7 +65,7 @@ describe("Thread document rehydration", () => {
           data: { documents: [] },
         } as AxiosResponse);
       }
-      if (url === "/threads/101/documents") {
+      if (url === "/documents/threads/101/documents") {
         return Promise.resolve({
           data: {
             ok: true,
@@ -81,7 +81,7 @@ describe("Thread document rehydration", () => {
           },
         } as AxiosResponse);
       }
-      if (url === "/threads/202/documents") {
+      if (url === "/documents/threads/202/documents") {
         return Promise.resolve({
           data: {
             ok: true,
@@ -106,7 +106,9 @@ describe("Thread document rehydration", () => {
 
     await waitFor(() => {
       expect(
-        getSpy.mock.calls.some(([path]) => path === "/threads/101/documents")
+        getSpy.mock.calls.some(
+          ([path]) => path === "/documents/threads/101/documents"
+        )
       ).toBe(true);
     });
 
@@ -119,7 +121,9 @@ describe("Thread document rehydration", () => {
 
     await waitFor(() => {
       expect(
-        getSpy.mock.calls.some(([path]) => path === "/threads/202/documents")
+        getSpy.mock.calls.some(
+          ([path]) => path === "/documents/threads/202/documents"
+        )
       ).toBe(true);
     });
 

--- a/guardian/agents/adapters/claudecode.py
+++ b/guardian/agents/adapters/claudecode.py
@@ -20,14 +20,26 @@ class ClaudeCodeAdapter:
 
     def execute(self, request: AgentExecutionRequest) -> AgentRunEnvelope:
         cmd = [*_command_from_env(), request.prompt]
-        proc = subprocess.run(
-            cmd,
-            cwd=request.cwd or None,
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=request.timeout_seconds,
-        )
+        try:
+            proc = subprocess.run(
+                cmd,
+                cwd=request.cwd or None,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=request.timeout_seconds,
+            )
+        except subprocess.TimeoutExpired:
+            return AgentRunEnvelope(
+                status="error",
+                summary="ClaudeCode adapter execution timed out",
+                artifacts=[],
+                next_actions=[],
+                errors=["timeout_expired"],
+                metrics={"timeout_seconds": request.timeout_seconds},
+                spec_alignment_ok=True,
+                schema_valid=False,
+            )
         stdout = (proc.stdout or "").strip()
         stderr = (proc.stderr or "").strip()
 

--- a/guardian/agents/adapters/codex.py
+++ b/guardian/agents/adapters/codex.py
@@ -20,14 +20,26 @@ class CodexAdapter:
 
     def execute(self, request: AgentExecutionRequest) -> AgentRunEnvelope:
         cmd = [*_command_from_env(), request.prompt]
-        proc = subprocess.run(
-            cmd,
-            cwd=request.cwd or None,
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=request.timeout_seconds,
-        )
+        try:
+            proc = subprocess.run(
+                cmd,
+                cwd=request.cwd or None,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=request.timeout_seconds,
+            )
+        except subprocess.TimeoutExpired:
+            return AgentRunEnvelope(
+                status="error",
+                summary="Codex adapter execution timed out",
+                artifacts=[],
+                next_actions=[],
+                errors=["timeout_expired"],
+                metrics={"timeout_seconds": request.timeout_seconds},
+                spec_alignment_ok=True,
+                schema_valid=False,
+            )
         stdout = (proc.stdout or "").strip()
         stderr = (proc.stderr or "").strip()
 

--- a/guardian/db/migrations/versions/9f3d2b1a7c4e_add_agent_orchestration_tables.py
+++ b/guardian/db/migrations/versions/9f3d2b1a7c4e_add_agent_orchestration_tables.py
@@ -146,7 +146,7 @@ def upgrade() -> None:
             name="agent_runs_status_check",
         ),
         sa.CheckConstraint(
-            "runtime_target IN ('host', 'container')",
+            "runtime_target IN ('container', 'terminal')",
             name="agent_runs_runtime_target_check",
         ),
         sa.CheckConstraint(

--- a/guardian/db/models.py
+++ b/guardian/db/models.py
@@ -1380,7 +1380,7 @@ class AgentRun(Base):
             name="agent_runs_status_check",
         ),
         CheckConstraint(
-            "runtime_target IN ('host', 'container')",
+            "runtime_target IN ('container', 'terminal')",
             name="agent_runs_runtime_target_check",
         ),
         CheckConstraint(

--- a/guardian/tests/agents/test_cli_adapter_timeouts.py
+++ b/guardian/tests/agents/test_cli_adapter_timeouts.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from guardian.agents.adapters.base import AgentExecutionRequest
+from guardian.agents.adapters.claudecode import ClaudeCodeAdapter
+from guardian.agents.adapters.codex import CodexAdapter
+
+
+@pytest.mark.parametrize(
+    ("adapter", "patch_target", "summary"),
+    [
+        (
+            CodexAdapter(),
+            "guardian.agents.adapters.codex.subprocess.run",
+            "Codex adapter execution timed out",
+        ),
+        (
+            ClaudeCodeAdapter(),
+            "guardian.agents.adapters.claudecode.subprocess.run",
+            "ClaudeCode adapter execution timed out",
+        ),
+    ],
+)
+def test_cli_adapter_timeout_returns_error_envelope(
+    adapter: Any,
+    patch_target: str,
+    summary: str,
+) -> None:
+    request = AgentExecutionRequest(
+        prompt="return envelope", timeout_seconds=17
+    )
+
+    with patch(
+        patch_target,
+        side_effect=subprocess.TimeoutExpired(cmd=["agent-cli"], timeout=17),
+    ):
+        envelope = adapter.execute(request)
+
+    assert envelope.status == "error"
+    assert envelope.summary == summary
+    assert envelope.errors == ["timeout_expired"]
+    assert envelope.metrics["timeout_seconds"] == 17
+    assert envelope.spec_alignment_ok is True
+    assert envelope.schema_valid is False

--- a/guardian/tests/routes/test_agent_orchestration_events.py
+++ b/guardian/tests/routes/test_agent_orchestration_events.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any, Literal
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from sqlalchemy import CheckConstraint
 
 from guardian.agents.events import AgentEventPublisher
 from guardian.agents.store import AgentStore
@@ -396,3 +398,33 @@ def test_start_run_rejects_invalid_runtime_target(monkeypatch) -> None:
     assert run_response.json() == {"detail": "invalid_runtime_target"}
     assert local_store.list_runs_for_thread(92) == []
     assert published == []
+
+
+def test_runtime_target_route_allowlist_matches_agent_run_constraint() -> None:
+    route_targets = set(agent_orchestration.ALLOWED_RUNTIME_TARGETS)
+    runtime_check = next(
+        constraint
+        for constraint in AgentRun.__table__.constraints
+        if isinstance(constraint, CheckConstraint)
+        and constraint.name == "agent_runs_runtime_target_check"
+    )
+    sql = str(runtime_check.sqltext)
+    values = {
+        token.strip().strip("'")
+        for token in sql.partition("(")[2].rstrip(")").split(",")
+    }
+    assert route_targets == values
+
+
+def test_agent_run_migration_runtime_target_constraint_includes_terminal() -> (
+    None
+):
+    migration_path = (
+        Path(__file__).resolve().parents[2]
+        / "db"
+        / "migrations"
+        / "versions"
+        / "9f3d2b1a7c4e_add_agent_orchestration_tables.py"
+    )
+    text = migration_path.read_text(encoding="utf-8")
+    assert "runtime_target IN ('container', 'terminal')" in text

--- a/guardian/tests/workers/test_agent_worker_commit_boundaries.py
+++ b/guardian/tests/workers/test_agent_worker_commit_boundaries.py
@@ -152,6 +152,9 @@ def test_successful_mutating_task_creates_exactly_two_commits_and_persists_hashe
     by_type = {item["artifact_type"]: item for item in artifacts}
     assert by_type["commit_a_hash"]["content_json"]["hash"] == "commit-a-hash"
     assert by_type["commit_b_hash"]["content_json"]["hash"] == "commit-b-hash"
+    run_state = telemetry_store.get_run(run_id)
+    assert run_state is not None
+    assert run_state["status"] == "running"
 
     confidence_reports = telemetry_store.list_confidence_reports(run_id=run_id)
     scopes = [item["scope"] for item in confidence_reports]

--- a/guardian/workers/agent_worker.py
+++ b/guardian/workers/agent_worker.py
@@ -388,7 +388,6 @@ def process_mutating_step(
                 spec_alignment_ok=True,
                 tests_passed=True,
             )
-            resolved_store.update_run_status(run_id=run_id, status="succeeded")
             _emit(
                 resolved_events,
                 run_id=run_id,


### PR DESCRIPTION
Summary
- align thread documents and catalog calls with `/api/documents/threads/:id/documents` and `/api/llm/catalog`, add path builders/tests, and surface catalog loading errors
- persist provider/model selection via `providerPref`, build completion payloads that include them, and wire the chat completion POST through the new utility
- Git commit hash: not available (not committed)

Testing
- Not run (not requested)