### PR TITLE
Codex/reformat chat header nav

### DIFF
--- a/docs/Future-Features/PLAN.md
+++ b/docs/Future-Features/PLAN.md
@@ -1,0 +1,212 @@
+# Codexify Studio v1 Plan (Paid Add-On, Local-First, Reaper-Canonical)
+
+## Summary
+Codexify Studio v1 will be a separate paid add-on product surface, backed by a new Node/TypeScript harness that sits between Codexify backend and Reaper.  
+Codexify remains the intent/planning/identity brain; Reaper remains the source of truth for DAW state; Studio harness executes deterministic actions and streams status/events back.  
+The MVP focuses on flow essentials: session bootstrap, Strudel MIDI generation with optional audio print, sample/preset retrieval, macro-bank plugin control with 5 curated plugin maps, and stem export profiles.
+
+## 1. Scope and Product Boundaries
+1. In scope: Text + MIDI hardware interaction, project/session setup, Strudel pattern operations, plugin/macro control, exports, full action ledger, persona-aware permissions, add-on licensing.
+2. In scope: Codexify project-level binding to Reaper project, multiple threads per project, active-thread execution context with shared project DAW state.
+3. Out of scope for v1: Full DAW clone parity, voice execution path, multi-persona concurrent command execution, external billing integration, cross-platform parity beyond macOS-first.
+4. Principle: No hardcoded values; all paths, ports, plugin lists, compatibility versions, and feature toggles come from config.
+
+## 2. Target Architecture
+1. `Codexify Backend` (existing core + new Studio module): Intent parsing, persona/permission enforcement, command validation, orchestration, IDDB persistence.
+2. `Studio Harness` (new Node/TS service): Reaper bridge, Strudel engine runtime, asset indexing/search adapters, command execution engine, ack/state/error events.
+3. `Reaper Add-On Bundle` (ReaPack package): ReaScripts + OSC config templates + MIDI mapping helpers for deterministic control and state extraction.
+4. `Codexify Studio UI` (separate add-on frontend package): Studio workspace focused on immediacy, nested controls, chat/controller-first workflow.
+5. `Data Stores`: Postgres for operational records, Chroma/FAISS for semantic asset/action recall, Redis for async events/tasks when needed, Neo4j optional graph enrichment where enabled.
+
+## 3. Public APIs / Interfaces / Types
+
+### 3.1 Backend REST Endpoints (new)
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/api/studio/commands` | Submit a parsed/validated Studio command against active thread context |
+| GET | `/api/studio/projects/{project_id}/state` | Retrieve latest mirrored Reaper project snapshot + session context |
+| POST | `/api/studio/projects/{project_id}/activate-thread` | Set active execution thread for project-scoped DAW actions |
+| POST | `/api/studio/assets/index` | Start/restart indexing for configured sample/preset paths |
+| GET | `/api/studio/assets/search` | NLP/semantic retrieval over indexed assets |
+| POST | `/api/studio/macros/learn/start` | Begin MIDI learn capture flow |
+| POST | `/api/studio/macros/learn/commit` | Persist macro binding for plugin parameter/action |
+| POST | `/api/studio/exports` | Start export job with profile and target format bundle |
+| GET | `/api/studio/exports/{export_id}` | Poll export state + artifact manifest |
+| GET | `/api/studio/compatibility` | Return Reaper/Strudel compatibility checks and status |
+| POST | `/api/studio/license/activate` | Activate local perpetual add-on license token |
+| GET | `/api/studio/license/status` | Verify local entitlement status and integrity |
+
+### 3.2 Backend ↔ Harness WebSocket Topics (new)
+| Direction | Topic | Payload |
+|---|---|---|
+| Backend -> Harness | `studio.command.execute` | `StudioCommandEnvelope` |
+| Harness -> Backend | `studio.command.ack` | accepted/rejected with reason |
+| Harness -> Backend | `studio.command.result` | success/failure + outputs/artifacts |
+| Harness -> Backend | `studio.state.snapshot` | normalized Reaper project/session snapshot |
+| Harness -> Backend | `studio.asset.index.progress` | indexing progress and errors |
+| Harness -> Backend | `studio.export.progress` | export lifecycle events |
+| Both | `studio.health` | heartbeat + capability status |
+
+### 3.3 New Canonical Types
+```ts
+type StudioActionFamily =
+  | "session"
+  | "routing"
+  | "plugin_control"
+  | "asset_search"
+  | "render"
+  | "file_io"
+  | "destructive_ops";
+
+type StudioCommand = {
+  command_id: string;
+  project_id: number;
+  thread_id: number;
+  persona_id: number | null;
+  action_family: StudioActionFamily;
+  action: string;
+  params: Record<string, unknown>;
+  requires_confirmation: boolean;
+  correlation_id: string;
+};
+
+type StudioStateSnapshot = {
+  project_uid: string;
+  project_name: string;
+  bpm: number | null;
+  key_signature: string | null;
+  time_signature: string | null;
+  tracks: Array<{ track_id: string; name: string; type: "audio" | "midi" | "bus" }>;
+  fx_summary: Array<{ track_id: string; plugin: string; enabled: boolean }>;
+  updated_at: string;
+};
+
+type StudioActionLedgerEntry = {
+  id: string;
+  project_id: number;
+  thread_id: number;
+  persona_id: number | null;
+  provider: string | null;
+  action_family: StudioActionFamily;
+  action: string;
+  intent_text: string;
+  params_json: Record<string, unknown>;
+  result_json: Record<string, unknown>;
+  status: "accepted" | "completed" | "failed" | "cancelled";
+  latency_ms: number | null;
+  created_at: string;
+};
+```
+
+## 4. Data Model Additions (Postgres)
+1. `studio_project_bindings`: binds Codexify project to Reaper project identity and harness connection metadata.
+2. `studio_active_thread`: tracks active execution thread per project; supports many threads per project with one active executor context.
+3. `studio_action_ledger`: full audit trail for all Studio commands, outcomes, persona/provider attribution, and artifact references.
+4. `studio_plugin_maps`: user-selected curated plugin maps and semantic parameter aliases.
+5. `studio_macro_bindings`: MIDI learn bindings (CC/channel/plugin/action/scale/curve).
+6. `studio_asset_index_jobs`: indexing lifecycle and diagnostics.
+7. `studio_assets`: normalized sample/preset metadata records with tags, source path hash, and availability flags.
+8. `studio_exports`: export job records, profile, outputs, manifest path/hash.
+9. `studio_license_tokens`: local entitlement token fingerprints and activation metadata (perpetual local mode).
+
+## 5. Permission and Persona Model
+1. Execution model: Single active persona for command execution; explicit persona switch required.
+2. Scope model: Action-family permissions (`session`, `routing`, `plugin_control`, `asset_search`, `render`, `file_io`, `destructive_ops`).
+3. Enforcement point: Backend pre-execution gate; harness never executes unscoped commands.
+4. Destructive confirmation policy: Required for delete/overwrite/render-replace/mass-routing-reset/export-overwrite actions only.
+5. Memory policy: Log everything; every action written with persona/project/thread tags and embedded for recall.
+6. Thread model: Active thread executes commands; project state is shared; rationale and logs remain thread-scoped.
+
+## 6. Command Pipeline
+1. User input arrives in Studio UI/chat/controller event.
+2. Codexify intent parser generates structured `StudioCommand`.
+3. If parser uncertainty or provider unavailable: deterministic DSL fallback parser runs.
+4. If required params missing: ask minimal clarification; else proceed.
+5. Persona/tool-scope + destructive confirmation checks run.
+6. Backend emits `studio.command.execute` to harness.
+7. Harness executes via ReaScript/OSC/MIDI chain and returns result/snapshot.
+8. Backend writes ledger, emits outbox events, updates thread/project context summaries.
+
+## 7. Reaper + Strudel Integration Design
+1. Primary control path: ReaScript command execution with OSC telemetry and MIDI fallback.
+2. Strudel default mode: MIDI generation to configured virtual MIDI bus; optional on-demand audio print into Reaper.
+3. Audio print flow: Arm print track, set bar window, record aligned region, annotate artifact in ledger.
+4. Plugin control strategy: Macro bank first, direct params when stable, fallback to MIDI CC learn where direct mapping is fragile.
+5. Curated mappings: User-selectable top 5 plugins in Studio settings, map templates generated/edited per plugin version.
+6. Compatibility: Pinned matrix file for supported Reaper + Strudel versions; startup compatibility check endpoint blocks unsafe execution.
+
+## 8. Add-On Packaging and Licensing
+1. Studio UI ships as separate add-on package, not merged into free Codexify UI runtime.
+2. Entitlement model: Local perpetual license token after activation; backend integrity checks are advisory, not hard requirement for offline usage.
+3. Activation flow: one-time activation endpoint returns signed token; token stored locally with integrity fingerprint.
+4. Failure policy: if backend unavailable post-activation, Studio remains fully functional offline.
+
+## 9. Implementation Milestones
+
+1. **Milestone A: Studio Contracts + Skeleton**
+- Deliverables: New Studio API surface, WS topic schemas, config loader, compatibility endpoint, empty harness with health events.
+- Exit criteria: End-to-end command echo path works with correlation IDs and ledger writes.
+
+2. **Milestone B: Reaper Bridge Core**
+- Deliverables: ReaPack bundle scaffolding, command executor subset (`create_track`, `set_tempo`, `route_bus`, `insert_fx`, `arm_record`), state snapshot extraction.
+- Exit criteria: Deterministic project bootstrap from command payloads with round-trip state verification.
+
+3. **Milestone C: Strudel Engine Path**
+- Deliverables: Strudel runtime in harness, MIDI emission bridge, optional audio print command, bar-aligned recording flow.
+- Exit criteria: Prompt -> Strudel pattern -> MIDI in Reaper -> optional printed audio clip with ledger artifact record.
+
+4. **Milestone D: Asset Retrieval + Maps**
+- Deliverables: User-configured path indexing, NLP/semantic asset search, macro learn capture/commit, curated plugin map management.
+- Exit criteria: “Find X sample/preset” and “map macro Y” commands work reliably on configured libraries/plugins.
+
+5. **Milestone E: Export + Packaging**
+- Deliverables: export profiles (`WAV24`, `MP3 ref`, `Stem pack`), manifest generation, separate Studio add-on UI package, license activation/status flow.
+- Exit criteria: One-click exports produce all artifacts and complete manifest; add-on entitlement enforced in UI/backend.
+
+6. **Milestone F: Persona + IDDB Deepening**
+- Deliverables: action-family permission policies, active-thread project execution gates, session rehydration payload builder with depth-aware detail expansion.
+- Exit criteria: Thread resume reliably restores context without token bloat and honors persona scopes.
+
+## 10. Testing and Acceptance
+
+### 10.1 Automated Tests
+1. Unit tests: command schema validation, DSL fallback parser, permission gate logic, destructive confirmation rules, compatibility matrix checks.
+2. Integration tests: backend↔harness WS contracts, ledger persistence, outbox event emission, active-thread project binding behavior.
+3. Integration tests: macro learn persistence, curated map resolution, asset indexing/search ranking basics.
+4. API tests: Studio endpoints auth and error envelopes.
+5. Contract tests: ReaScript adapter interface with mock Reaper executor.
+6. Licensing tests: activation, token tamper detection, offline perpetual behavior.
+
+### 10.2 Manual / System Tests (macOS-first)
+1. Empty project bootstrap under 60 seconds from first command to audible output.
+2. Multi-thread same-project behavior: active thread executes; non-active threads remain non-executing but fully conversational.
+3. Strudel MIDI generation and optional audio print for fixed bar ranges.
+4. Plugin mapping fallback: when direct param unavailable, macro/CC path still controls target.
+5. Export profile validation: full mix WAV24, MP3 reference, stems with manifest.
+6. Failure drills: harness offline, Reaper closed, incompatible version, missing asset paths, permission-denied persona.
+
+### 10.3 Acceptance Criteria
+1. `Time-to-first-sound <= 60s` on supported setup.
+2. `>= 90%` of top command catalog executes without manual cleanup in test corpus.
+3. `100%` of destructive ops require confirmation.
+4. `100%` of Studio actions create ledger entries with persona/project/thread attribution.
+5. Session rehydration includes project summary + depth-aware detail expansion with no unbounded prompt growth.
+
+## 11. Assumptions and Defaults Locked
+1. Product name remains `Codexify Studio`; harness internal name can be `Studio Harness`.
+2. v1 target platform is macOS first.
+3. Reaper-side install uses ReaPack bundle.
+4. Harness runtime is Node/TypeScript.
+5. Interaction priority is Text + MIDI hardware; voice is deferred adapter work.
+6. Reaper is canonical for DAW/timeline state.
+7. Strudel default is MIDI with optional audio print.
+8. Intent parsing lives in Codexify backend; harness executes deterministic actions.
+9. Backend↔harness uses WebSocket topic protocol.
+10. Full action ledger persistence is mandatory.
+11. Studio ships as separate paid add-on package.
+12. Entitlement model is perpetual local license after activation.
+13. Curated plugin maps are user-selectable initial 5.
+14. Asset indexing is user-configured paths only.
+15. Compatibility policy is pinned Reaper/Strudel matrix.
+16. Mapping model is Codexify Project ↔ Reaper Project with many threads; active thread executes commands and project state is shared.
+17. Design requirement: modular configuration only, no hardcoded operational values.

--- a/guardian/command_bus/__init__.py
+++ b/guardian/command_bus/__init__.py
@@ -1,0 +1,1 @@
+"""Unified command bus package."""

--- a/guardian/command_bus/contracts.py
+++ b/guardian/command_bus/contracts.py
@@ -1,0 +1,103 @@
+"""Contracts and protocol constants for the command bus."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+MANIFEST_VERSION = "1.0"
+INVOKE_VERSION = "1.0"
+EVENT_PROTOCOL_VERSION = "1.0"
+MAX_PAYLOAD_BYTES = 262_144
+
+EVENT_TYPES_SUPPORTED = [
+    "run.created",
+    "run.started",
+    "run.completed",
+    "run.failed",
+    "run.blocked",
+]
+
+APPROVAL_MODES_SUPPORTED = ["none", "blocked_phase1"]
+
+
+class ActorSpec(BaseModel):
+    """Caller identity attached to each invoke request."""
+
+    kind: Literal["human", "agent", "system"]
+    id: str = Field(min_length=1, max_length=255)
+    session_id: str | None = Field(default=None, max_length=255)
+    delegated_by: str | None = Field(default=None, max_length=255)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class InvokeArguments(BaseModel):
+    """Transport-agnostic command arguments."""
+
+    path_params: dict[str, Any] = Field(default_factory=dict)
+    query: dict[str, Any] = Field(default_factory=dict)
+    headers: dict[str, Any] = Field(default_factory=dict)
+    body: dict[str, Any] | list[Any] | str | int | float | bool | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class InvokeRequest(BaseModel):
+    """Command invocation payload."""
+
+    invoke_version: str = Field(min_length=1, max_length=32)
+    command_id: str = Field(min_length=1, max_length=512)
+    actor: ActorSpec
+    arguments: InvokeArguments = Field(default_factory=InvokeArguments)
+    idempotency_key: str | None = Field(default=None, max_length=255)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class CommandSpec(BaseModel):
+    """Raw command manifest entry."""
+
+    command_id: str
+    aliases: list[str] = Field(default_factory=list)
+    layer: Literal["raw"] = "raw"
+    method: str
+    path_template: str
+    operation_id: str | None = None
+    risk: Literal["read_only", "mutating"]
+    effect: Literal["read", "write"]
+    idempotency: Literal["safe", "unsafe"]
+    approval_mode: Literal["none", "blocked_phase1"]
+    input_schema: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class CapabilitiesSpec(BaseModel):
+    """Server capabilities for version negotiation."""
+
+    invoke_versions_supported: list[str] = Field(
+        default_factory=lambda: [INVOKE_VERSION]
+    )
+    event_protocol_version: str = EVENT_PROTOCOL_VERSION
+    event_types_supported: list[str] = Field(
+        default_factory=lambda: list(EVENT_TYPES_SUPPORTED)
+    )
+    approval_modes_supported: list[str] = Field(
+        default_factory=lambda: list(APPROVAL_MODES_SUPPORTED)
+    )
+    max_payload_bytes: int = MAX_PAYLOAD_BYTES
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ManifestResponse(BaseModel):
+    """Manifest response payload."""
+
+    manifest_version: str = MANIFEST_VERSION
+    generated_at: str
+    capabilities: CapabilitiesSpec
+    commands: list[CommandSpec]
+
+    model_config = ConfigDict(extra="forbid")

--- a/guardian/command_bus/invoke.py
+++ b/guardian/command_bus/invoke.py
@@ -1,0 +1,201 @@
+"""Invoke orchestrator for command bus execution."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+
+from guardian.command_bus.contracts import (
+    INVOKE_VERSION,
+    MAX_PAYLOAD_BYTES,
+    InvokeRequest,
+)
+from guardian.command_bus.loopback_http_adapter import (
+    execute_loopback_request,
+    is_recursion_blocked,
+    render_path,
+)
+from guardian.command_bus.manifest import build_command_index
+from guardian.command_bus.redaction_policy import (
+    canonical_json,
+    compute_args_hash,
+    redact_arguments,
+)
+from guardian.command_bus.store import CommandBusStore
+
+
+def validate_invoke_version(version: str) -> None:
+    if version != INVOKE_VERSION:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "unsupported_invoke_version",
+                "requested": version,
+                "supported_invoke_versions": [INVOKE_VERSION],
+            },
+        )
+
+
+def validate_actor_claim(
+    *, actor_id: str, delegated_by: str | None, auth_subject: str
+) -> None:
+    if actor_id == auth_subject:
+        return
+    if delegated_by and delegated_by == auth_subject:
+        return
+    raise HTTPException(
+        status_code=403,
+        detail={
+            "error": "actor_claim_not_permitted",
+            "auth_subject": auth_subject,
+        },
+    )
+
+
+async def execute_invoke(
+    *,
+    payload: InvokeRequest,
+    auth_subject: str,
+    inbound_headers: dict[str, str],
+    store: CommandBusStore,
+    app: Any,
+) -> dict[str, Any]:
+    validate_invoke_version(payload.invoke_version)
+    validate_actor_claim(
+        actor_id=payload.actor.id,
+        delegated_by=payload.actor.delegated_by,
+        auth_subject=auth_subject,
+    )
+
+    args_dict = payload.arguments.model_dump(mode="json", exclude_none=False)
+    encoded_size = len(canonical_json(args_dict).encode("utf-8"))
+    if encoded_size > MAX_PAYLOAD_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail={
+                "error": "payload_too_large",
+                "max_payload_bytes": MAX_PAYLOAD_BYTES,
+            },
+        )
+
+    index, manifest = build_command_index(app)
+    command = index.get(payload.command_id)
+    if command is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error": "command_not_found",
+                "command_id": payload.command_id,
+            },
+        )
+
+    args_hash = compute_args_hash(args_dict)
+    args_redacted = redact_arguments(command.command_id, args_dict)
+    run = store.create_run(
+        command_id=command.command_id,
+        status="queued",
+        actor_kind=payload.actor.kind,
+        actor_id=payload.actor.id,
+        actor_session_id=payload.actor.session_id,
+        delegated_by=payload.actor.delegated_by,
+        auth_subject=auth_subject,
+        invoke_version=payload.invoke_version,
+        args_hash=args_hash,
+        args_redacted=args_redacted,
+    )
+    run_id = run["run_id"]
+    store.append_event(
+        run_id=run_id,
+        event_type="run.created",
+        payload={"command_id": command.command_id, "status": "queued"},
+    )
+
+    should_execute = command.effect == "read" and command.method in {
+        "GET",
+        "HEAD",
+    }
+    blocked_reason: str | None = None
+
+    # Explicit recursion guard, including future alias paths.
+    try:
+        rendered = render_path(
+            command.path_template, args_dict.get("path_params") or {}
+        )
+    except Exception as exc:
+        blocked_reason = f"invalid_path_params: {exc}"
+    else:
+        if is_recursion_blocked(rendered):
+            blocked_reason = "recursion_guard_blocked"
+
+    if not should_execute and blocked_reason is None:
+        blocked_reason = "phase1_write_blocked"
+
+    if blocked_reason is not None:
+        store.update_run(
+            run_id=run_id, status="blocked", error_text=blocked_reason
+        )
+        store.append_event(
+            run_id=run_id,
+            event_type="run.blocked",
+            payload={"reason": blocked_reason},
+        )
+        return {
+            "run_id": run_id,
+            "status": "blocked",
+            "invoke_version": payload.invoke_version,
+            "manifest_version": manifest.manifest_version,
+            "events_url": f"/api/guardian/commands/runs/{run_id}/events?after_seq=0",
+            "error": blocked_reason,
+        }
+
+    store.update_run(run_id=run_id, status="running")
+    store.append_event(
+        run_id=run_id,
+        event_type="run.started",
+        payload={"command_id": command.command_id, "status": "running"},
+    )
+
+    try:
+        execution_result = await execute_loopback_request(
+            method=command.method,
+            path_template=command.path_template,
+            path_params=args_dict.get("path_params") or {},
+            query=args_dict.get("query") or {},
+            headers=args_dict.get("headers") or {},
+            body=args_dict.get("body"),
+            inbound_headers=inbound_headers,
+        )
+    except Exception as exc:
+        error_text = str(exc)
+        store.update_run(run_id=run_id, status="failed", error_text=error_text)
+        store.append_event(
+            run_id=run_id,
+            event_type="run.failed",
+            payload={"error": error_text},
+        )
+        return {
+            "run_id": run_id,
+            "status": "failed",
+            "invoke_version": payload.invoke_version,
+            "manifest_version": manifest.manifest_version,
+            "events_url": f"/api/guardian/commands/runs/{run_id}/events?after_seq=0",
+            "error": error_text,
+        }
+
+    store.update_run(
+        run_id=run_id, status="completed", result_json=execution_result
+    )
+    store.append_event(
+        run_id=run_id,
+        event_type="run.completed",
+        payload={"status_code": execution_result.get("status_code")},
+    )
+    return {
+        "run_id": run_id,
+        "status": "completed",
+        "invoke_version": payload.invoke_version,
+        "manifest_version": manifest.manifest_version,
+        "events_url": f"/api/guardian/commands/runs/{run_id}/events?after_seq=0",
+        "inline_result": execution_result,
+    }

--- a/guardian/command_bus/loopback_http_adapter.py
+++ b/guardian/command_bus/loopback_http_adapter.py
@@ -1,0 +1,111 @@
+"""Loopback HTTP adapter for raw command execution."""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any
+from urllib.parse import quote, urlparse
+
+import httpx
+
+_PATH_TOKEN_RE = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
+_FORWARDED_AUTH_HEADERS = ("authorization", "x-api-key", "x-user-id", "cookie")
+
+RECURSION_BLOCKED_PREFIXES = (
+    "/api/guardian/commands/",
+    "/tools/",
+    "/api/tools/",
+)
+
+
+def resolve_loopback_base() -> str:
+    """Resolve deterministic loopback base URL for command execution."""
+    raw = (os.getenv("GUARDIAN_COMMAND_BUS_LOOPBACK_BASE") or "").strip()
+    if not raw:
+        raise RuntimeError(
+            "GUARDIAN_COMMAND_BUS_LOOPBACK_BASE is required for command bus loopback execution"
+        )
+    parsed = urlparse(raw)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise RuntimeError(
+            "GUARDIAN_COMMAND_BUS_LOOPBACK_BASE must be a valid absolute http(s) URL"
+        )
+    return raw.rstrip("/")
+
+
+def render_path(path_template: str, path_params: dict[str, Any]) -> str:
+    """Render OpenAPI path template from path params."""
+    params = {str(k): v for k, v in (path_params or {}).items()}
+
+    def _replace(match: re.Match[str]) -> str:
+        name = match.group(1)
+        if name not in params:
+            raise ValueError(f"missing required path param '{name}'")
+        return quote(str(params[name]), safe="")
+
+    return _PATH_TOKEN_RE.sub(_replace, path_template)
+
+
+def is_recursion_blocked(path: str) -> bool:
+    normalized = "/" + str(path or "").lstrip("/")
+    for prefix in RECURSION_BLOCKED_PREFIXES:
+        if normalized.startswith(prefix):
+            return True
+    return False
+
+
+async def execute_loopback_request(
+    *,
+    method: str,
+    path_template: str,
+    path_params: dict[str, Any],
+    query: dict[str, Any],
+    headers: dict[str, Any],
+    body: Any,
+    inbound_headers: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Execute raw command over loopback HTTP."""
+    path = render_path(path_template, path_params)
+    if is_recursion_blocked(path):
+        raise RuntimeError("recursion_guard_blocked")
+
+    base_url = resolve_loopback_base()
+    url = f"{base_url}{path}"
+    outbound_headers: dict[str, str] = {}
+
+    for key, value in (inbound_headers or {}).items():
+        if key.lower() in _FORWARDED_AUTH_HEADERS:
+            outbound_headers[key] = value
+
+    for key, value in (headers or {}).items():
+        outbound_headers[str(key)] = str(value)
+
+    kwargs: dict[str, Any] = {
+        "method": method.upper(),
+        "url": url,
+        "params": query or None,
+        "headers": outbound_headers or None,
+        "timeout": 30.0,
+    }
+    if body is not None and method.upper() not in {"GET", "HEAD"}:
+        kwargs["json"] = body
+
+    async with httpx.AsyncClient(follow_redirects=True) as client:
+        response = await client.request(**kwargs)
+
+    content_type = (response.headers.get("content-type") or "").lower()
+    parsed_body: Any
+    if "application/json" in content_type:
+        try:
+            parsed_body = response.json()
+        except Exception:
+            parsed_body = {"raw": response.text}
+    else:
+        parsed_body = response.text
+
+    return {
+        "status_code": int(response.status_code),
+        "headers": dict(response.headers),
+        "body": parsed_body,
+    }

--- a/guardian/command_bus/manifest.py
+++ b/guardian/command_bus/manifest.py
@@ -1,0 +1,221 @@
+"""OpenAPI-backed raw command manifest generation."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import FastAPI
+
+from guardian.command_bus.contracts import (
+    CapabilitiesSpec,
+    CommandSpec,
+    ManifestResponse,
+)
+
+_HTTP_METHODS = {"get", "head", "post", "put", "patch", "delete", "options"}
+
+
+def build_manifest(app: FastAPI) -> ManifestResponse:
+    schema = app.openapi()
+    components = schema.get("components", {})
+    paths = schema.get("paths", {})
+
+    operation_id_counts: dict[str, int] = {}
+    for path_item in paths.values():
+        if not isinstance(path_item, dict):
+            continue
+        for method, operation in path_item.items():
+            if method.lower() not in _HTTP_METHODS:
+                continue
+            if not isinstance(operation, dict):
+                continue
+            operation_id = operation.get("operationId")
+            if isinstance(operation_id, str) and operation_id:
+                operation_id_counts[operation_id] = (
+                    operation_id_counts.get(operation_id, 0) + 1
+                )
+
+    commands: list[CommandSpec] = []
+    for path_template, path_item in sorted(paths.items()):
+        if not isinstance(path_item, dict):
+            continue
+        for method in sorted(path_item.keys()):
+            if method.lower() not in _HTTP_METHODS:
+                continue
+            operation = path_item.get(method) or {}
+            if not isinstance(operation, dict):
+                continue
+            commands.append(
+                _build_command_spec(
+                    operation=operation,
+                    method=method.upper(),
+                    path_template=path_template,
+                    operation_id_counts=operation_id_counts,
+                    components=components,
+                )
+            )
+
+    generated_at = datetime.now(tz=timezone.utc).isoformat()
+    return ManifestResponse(
+        generated_at=generated_at,
+        capabilities=CapabilitiesSpec(),
+        commands=commands,
+    )
+
+
+def build_command_index(
+    app: FastAPI,
+) -> tuple[dict[str, CommandSpec], ManifestResponse]:
+    manifest = build_manifest(app)
+    index: dict[str, CommandSpec] = {}
+    for command in manifest.commands:
+        index[command.command_id] = command
+        for alias in command.aliases:
+            index.setdefault(alias, command)
+    return index, manifest
+
+
+def _build_command_spec(
+    *,
+    operation: dict[str, Any],
+    method: str,
+    path_template: str,
+    operation_id_counts: dict[str, int],
+    components: dict[str, Any],
+) -> CommandSpec:
+    operation_id = operation.get("operationId")
+    unique_operation_id = (
+        isinstance(operation_id, str)
+        and operation_id_counts.get(operation_id, 0) == 1
+    )
+
+    route_fallback_id = f"route::{method}::{path_template}"
+    if unique_operation_id:
+        command_id = f"op::{operation_id}"
+        aliases = [route_fallback_id]
+    else:
+        command_id = route_fallback_id
+        aliases = []
+
+    effect = "read" if method in {"GET", "HEAD"} else "write"
+    risk = "read_only" if effect == "read" else "mutating"
+    idempotency = "safe" if effect == "read" else "unsafe"
+    approval_mode = "none" if effect == "read" else "blocked_phase1"
+
+    input_schema = _build_input_schema(
+        operation=operation, components=components
+    )
+    return CommandSpec(
+        command_id=command_id,
+        aliases=aliases,
+        layer="raw",
+        method=method,
+        path_template=path_template,
+        operation_id=operation_id if isinstance(operation_id, str) else None,
+        risk=risk,
+        effect=effect,
+        idempotency=idempotency,
+        approval_mode=approval_mode,
+        input_schema=input_schema,
+    )
+
+
+def _build_input_schema(
+    *,
+    operation: dict[str, Any],
+    components: dict[str, Any],
+) -> dict[str, Any]:
+    path_params = _parameter_schema(operation, "path", components)
+    query = _parameter_schema(operation, "query", components)
+    headers = _parameter_schema(operation, "header", components)
+    body = _request_body_schema(operation, components)
+    return {
+        "path_params": path_params,
+        "query": query,
+        "headers": headers,
+        "body": body,
+    }
+
+
+def _parameter_schema(
+    operation: dict[str, Any], location: str, components: dict[str, Any]
+) -> dict[str, Any]:
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for param in operation.get("parameters", []) or []:
+        if not isinstance(param, dict):
+            continue
+        if param.get("in") != location:
+            continue
+        name = param.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        schema = _resolve_schema(param.get("schema") or {}, components)
+        properties[name] = schema
+        if param.get("required") is True:
+            required.append(name)
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": sorted(required),
+    }
+
+
+def _request_body_schema(
+    operation: dict[str, Any], components: dict[str, Any]
+) -> dict[str, Any]:
+    request_body = operation.get("requestBody")
+    if not isinstance(request_body, dict):
+        return {}
+    content = request_body.get("content") or {}
+    if not isinstance(content, dict) or not content:
+        return {}
+    media_type = (
+        "application/json"
+        if "application/json" in content
+        else next(iter(content.keys()))
+    )
+    media_obj = content.get(media_type) or {}
+    if not isinstance(media_obj, dict):
+        return {}
+    schema = _resolve_schema(media_obj.get("schema") or {}, components)
+    if request_body.get("required") is True and isinstance(schema, dict):
+        schema = dict(schema)
+        schema.setdefault("required", [])
+    return schema
+
+
+def _resolve_schema(schema: Any, components: dict[str, Any]) -> Any:
+    if not isinstance(schema, dict):
+        return schema
+
+    ref = schema.get("$ref")
+    if isinstance(ref, str) and ref.startswith("#/components/schemas/"):
+        ref_name = ref.split("/")[-1]
+        target = (components.get("schemas") or {}).get(ref_name)
+        if isinstance(target, dict):
+            return _resolve_schema(target, components)
+        return schema
+
+    resolved = dict(schema)
+    if "properties" in resolved and isinstance(resolved["properties"], dict):
+        resolved["properties"] = {
+            key: _resolve_schema(value, components)
+            for key, value in resolved["properties"].items()
+        }
+    if "items" in resolved:
+        resolved["items"] = _resolve_schema(resolved["items"], components)
+    if "allOf" in resolved and isinstance(resolved["allOf"], list):
+        resolved["allOf"] = [
+            _resolve_schema(v, components) for v in resolved["allOf"]
+        ]
+    if "oneOf" in resolved and isinstance(resolved["oneOf"], list):
+        resolved["oneOf"] = [
+            _resolve_schema(v, components) for v in resolved["oneOf"]
+        ]
+    if "anyOf" in resolved and isinstance(resolved["anyOf"], list):
+        resolved["anyOf"] = [
+            _resolve_schema(v, components) for v in resolved["anyOf"]
+        ]
+    return resolved

--- a/guardian/command_bus/redaction_policy.py
+++ b/guardian/command_bus/redaction_policy.py
@@ -1,0 +1,121 @@
+"""Deterministic argument redaction and hashing for command runs."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+REDACTED = "[REDACTED]"
+
+_SENSITIVE_KEY_PARTS = {
+    "authorization",
+    "cookie",
+    "token",
+    "secret",
+    "password",
+    "api_key",
+    "apikey",
+    "x-api-key",
+}
+
+# Optional per-command explicit path rules.
+# Path segments are rooted at InvokeArguments keys: path_params/query/headers/body.
+COMMAND_REDACTION_RULES: dict[str, list[tuple[str, ...]]] = {
+    "*": [
+        ("headers", "authorization"),
+        ("headers", "cookie"),
+        ("headers", "x-api-key"),
+        ("query", "api_key"),
+        ("query", "token"),
+    ]
+}
+
+
+def canonical_json(value: Any) -> str:
+    """Serialize deterministic JSON for hashing."""
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    )
+
+
+def compute_args_hash(arguments: dict[str, Any]) -> str:
+    """Compute stable sha256 hash for the original invocation arguments."""
+    raw = canonical_json(arguments).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def redact_arguments(
+    command_id: str, arguments: dict[str, Any]
+) -> dict[str, Any]:
+    """Apply deterministic redaction to arguments."""
+    payload = copy.deepcopy(arguments)
+    _redact_recursive(payload)
+    _apply_explicit_paths(payload, COMMAND_REDACTION_RULES.get("*", []))
+    _apply_explicit_paths(payload, COMMAND_REDACTION_RULES.get(command_id, []))
+    return payload
+
+
+def _looks_sensitive_key(key: str) -> bool:
+    normalized = key.strip().lower().replace("-", "_")
+    if not normalized:
+        return False
+    if normalized in _SENSITIVE_KEY_PARTS:
+        return True
+    return any(part in normalized for part in _SENSITIVE_KEY_PARTS)
+
+
+def _redact_recursive(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        for key in list(value.keys()):
+            key_text = str(key)
+            if _looks_sensitive_key(key_text):
+                value[key] = REDACTED
+                continue
+            value[key] = _redact_recursive(value[key])
+        return value
+    if isinstance(value, list):
+        for idx in range(len(value)):
+            value[idx] = _redact_recursive(value[idx])
+        return value
+    return value
+
+
+def _apply_explicit_paths(
+    payload: dict[str, Any], path_rules: Sequence[tuple[str, ...]]
+) -> None:
+    for path in path_rules:
+        if not path:
+            continue
+        _set_path_redacted(payload, path)
+
+
+def _set_path_redacted(root: Any, path: Sequence[str]) -> None:
+    current = root
+    for segment in path[:-1]:
+        if not isinstance(current, Mapping):
+            return
+        match = _find_mapping_key(current, segment)
+        if match is None:
+            return
+        current = current.get(match)
+    if not isinstance(current, Mapping):
+        return
+    target = _find_mapping_key(current, path[-1])
+    if target is None:
+        return
+    current[target] = REDACTED
+
+
+def _find_mapping_key(mapping: Mapping[Any, Any], target: str) -> Any | None:
+    target_norm = str(target).strip().lower()
+    for key in mapping.keys():
+        if str(key).strip().lower() == target_norm:
+            return key
+    return None

--- a/guardian/command_bus/store.py
+++ b/guardian/command_bus/store.py
@@ -1,0 +1,256 @@
+"""Persistence helpers for command bus runs and events."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from sqlalchemy import func
+
+from guardian.db.models import CommandRun, CommandRunEvent
+
+TERMINAL_STATUSES = {"completed", "failed", "blocked"}
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class CommandBusStore:
+    """Store command runs/events in DB with in-memory fallback for tests."""
+
+    def __init__(self, db: Any | None = None) -> None:
+        self._db = db
+        self._mem_runs: dict[str, dict[str, Any]] = {}
+        self._mem_events: dict[str, list[dict[str, Any]]] = {}
+
+    def configure_db(self, db: Any | None) -> None:
+        self._db = db
+
+    def _has_db(self) -> bool:
+        return bool(self._db is not None and hasattr(self._db, "get_session"))
+
+    def create_run(
+        self,
+        *,
+        command_id: str,
+        status: str,
+        actor_kind: str,
+        actor_id: str,
+        actor_session_id: str | None,
+        delegated_by: str | None,
+        auth_subject: str,
+        invoke_version: str,
+        args_hash: str,
+        args_redacted: dict[str, Any],
+    ) -> dict[str, Any]:
+        run_id = f"run_{uuid4().hex[:16]}"
+        now = _utc_now()
+
+        if self._has_db():
+            with self._db.get_session() as session:
+                row = CommandRun(
+                    run_id=run_id,
+                    command_id=command_id,
+                    status=status,
+                    actor_kind=actor_kind,
+                    actor_id=actor_id,
+                    actor_session_id=actor_session_id,
+                    delegated_by=delegated_by,
+                    auth_subject=auth_subject,
+                    invoke_version=invoke_version,
+                    args_hash=args_hash,
+                    args_redacted=args_redacted,
+                    created_at=now,
+                )
+                session.add(row)
+                session.commit()
+
+            return {
+                "run_id": run_id,
+                "command_id": command_id,
+                "status": status,
+                "args_hash": args_hash,
+                "args_redacted": args_redacted,
+            }
+
+        run = {
+            "run_id": run_id,
+            "command_id": command_id,
+            "status": status,
+            "actor_kind": actor_kind,
+            "actor_id": actor_id,
+            "actor_session_id": actor_session_id,
+            "delegated_by": delegated_by,
+            "auth_subject": auth_subject,
+            "invoke_version": invoke_version,
+            "args_hash": args_hash,
+            "args_redacted": args_redacted,
+            "result_json": None,
+            "error_text": None,
+            "created_at": now.isoformat(),
+            "started_at": None,
+            "ended_at": None,
+        }
+        self._mem_runs[run_id] = run
+        self._mem_events.setdefault(run_id, [])
+        return dict(run)
+
+    def get_run(self, run_id: str) -> dict[str, Any] | None:
+        if self._has_db():
+            with self._db.get_session() as session:
+                row = session.query(CommandRun).filter_by(run_id=run_id).first()
+                if row is None:
+                    return None
+                return {
+                    "run_id": row.run_id,
+                    "command_id": row.command_id,
+                    "status": row.status,
+                    "actor_kind": row.actor_kind,
+                    "actor_id": row.actor_id,
+                    "actor_session_id": row.actor_session_id,
+                    "delegated_by": row.delegated_by,
+                    "auth_subject": row.auth_subject,
+                    "invoke_version": row.invoke_version,
+                    "args_hash": row.args_hash,
+                    "args_redacted": row.args_redacted or {},
+                    "result_json": row.result_json,
+                    "error_text": row.error_text,
+                    "created_at": row.created_at.isoformat()
+                    if row.created_at
+                    else None,
+                    "started_at": row.started_at.isoformat()
+                    if row.started_at
+                    else None,
+                    "ended_at": row.ended_at.isoformat()
+                    if row.ended_at
+                    else None,
+                }
+        run = self._mem_runs.get(run_id)
+        return dict(run) if run is not None else None
+
+    def append_event(
+        self, *, run_id: str, event_type: str, payload: dict[str, Any]
+    ) -> int:
+        now = _utc_now()
+        if self._has_db():
+            with self._db.get_session() as session:
+                run_row = (
+                    session.query(CommandRun)
+                    .filter_by(run_id=run_id)
+                    .with_for_update()
+                    .first()
+                )
+                if run_row is None:
+                    raise ValueError(f"run_id not found: {run_id}")
+                max_seq = (
+                    session.query(
+                        func.coalesce(func.max(CommandRunEvent.sequence), 0)
+                    )
+                    .filter(CommandRunEvent.run_id == run_id)
+                    .scalar()
+                )
+                next_seq = int(max_seq or 0) + 1
+                row = CommandRunEvent(
+                    run_id=run_id,
+                    sequence=next_seq,
+                    event_type=event_type,
+                    payload_json=payload or {},
+                    created_at=now,
+                )
+                session.add(row)
+                session.commit()
+                return next_seq
+
+        events = self._mem_events.setdefault(run_id, [])
+        next_seq = len(events) + 1
+        events.append(
+            {
+                "run_id": run_id,
+                "sequence": next_seq,
+                "event_type": event_type,
+                "payload_json": dict(payload or {}),
+                "created_at": now.isoformat(),
+            }
+        )
+        return next_seq
+
+    def list_events_after(
+        self, *, run_id: str, after_seq: int, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        if self._has_db():
+            with self._db.get_session() as session:
+                rows = (
+                    session.query(CommandRunEvent)
+                    .filter(
+                        CommandRunEvent.run_id == run_id,
+                        CommandRunEvent.sequence > max(after_seq, 0),
+                    )
+                    .order_by(CommandRunEvent.sequence.asc())
+                    .limit(limit)
+                    .all()
+                )
+                return [
+                    {
+                        "run_id": row.run_id,
+                        "sequence": row.sequence,
+                        "event_type": row.event_type,
+                        "payload_json": row.payload_json or {},
+                        "created_at": row.created_at.isoformat()
+                        if row.created_at
+                        else None,
+                    }
+                    for row in rows
+                ]
+
+        rows = [
+            event
+            for event in self._mem_events.get(run_id, [])
+            if int(event.get("sequence") or 0) > max(after_seq, 0)
+        ]
+        rows.sort(key=lambda item: int(item.get("sequence") or 0))
+        return [dict(item) for item in rows[:limit]]
+
+    def update_run(
+        self,
+        *,
+        run_id: str,
+        status: str,
+        result_json: dict[str, Any] | None = None,
+        error_text: str | None = None,
+    ) -> None:
+        now = _utc_now()
+        if self._has_db():
+            with self._db.get_session() as session:
+                row = session.query(CommandRun).filter_by(run_id=run_id).first()
+                if row is None:
+                    raise ValueError(f"run_id not found: {run_id}")
+                row.status = status
+                if row.started_at is None and status in {"running"}:
+                    row.started_at = now
+                if status in TERMINAL_STATUSES:
+                    row.ended_at = now
+                    if row.started_at is None:
+                        row.started_at = now
+                if result_json is not None:
+                    row.result_json = result_json
+                if error_text is not None:
+                    row.error_text = error_text
+                session.commit()
+                return
+
+        run = self._mem_runs.get(run_id)
+        if run is None:
+            raise ValueError(f"run_id not found: {run_id}")
+        run["status"] = status
+        if run.get("started_at") is None and status in {"running"}:
+            run["started_at"] = now.isoformat()
+        if status in TERMINAL_STATUSES:
+            if run.get("started_at") is None:
+                run["started_at"] = now.isoformat()
+            run["ended_at"] = now.isoformat()
+        if result_json is not None:
+            run["result_json"] = result_json
+        if error_text is not None:
+            run["error_text"] = error_text

--- a/guardian/db/migrations/versions/e0f1a2b3c4d5_add_command_bus_phase1_tables.py
+++ b/guardian/db/migrations/versions/e0f1a2b3c4d5_add_command_bus_phase1_tables.py
@@ -1,0 +1,144 @@
+"""add command bus phase1 tables
+
+Revision ID: e0f1a2b3c4d5
+Revises: d1a6b9f2c4e7
+Create Date: 2026-02-23
+
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "e0f1a2b3c4d5"
+down_revision: str | Sequence[str] | None = "d1a6b9f2c4e7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "command_runs",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("run_id", sa.String(length=64), nullable=False),
+        sa.Column("command_id", sa.String(length=512), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(length=32),
+            nullable=False,
+            server_default="queued",
+        ),
+        sa.Column("actor_kind", sa.String(length=32), nullable=False),
+        sa.Column("actor_id", sa.String(length=255), nullable=False),
+        sa.Column("actor_session_id", sa.String(length=255), nullable=True),
+        sa.Column("delegated_by", sa.String(length=255), nullable=True),
+        sa.Column("auth_subject", sa.String(length=255), nullable=False),
+        sa.Column("invoke_version", sa.String(length=32), nullable=False),
+        sa.Column("args_hash", sa.String(length=64), nullable=False),
+        sa.Column(
+            "args_redacted",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "result_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column("error_text", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("started_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("ended_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "status IN ('queued', 'running', 'completed', 'failed', 'blocked')",
+            name="command_runs_status_check",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("run_id"),
+    )
+    op.create_index(
+        "ix_command_runs_command_id",
+        "command_runs",
+        ["command_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_command_runs_status", "command_runs", ["status"], unique=False
+    )
+    op.create_index(
+        "ix_command_runs_created_at",
+        "command_runs",
+        ["created_at"],
+        unique=False,
+    )
+
+    op.create_table(
+        "command_run_events",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("run_id", sa.String(length=64), nullable=False),
+        sa.Column("sequence", sa.Integer(), nullable=False),
+        sa.Column("event_type", sa.String(length=64), nullable=False),
+        sa.Column(
+            "payload_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_id"],
+            ["command_runs.run_id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "run_id",
+            "sequence",
+            name="uq_command_run_events_run_sequence",
+        ),
+    )
+    op.create_index(
+        "ix_command_run_events_run_id",
+        "command_run_events",
+        ["run_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_command_run_events_created_at",
+        "command_run_events",
+        ["created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(
+        "ix_command_run_events_created_at", table_name="command_run_events"
+    )
+    op.drop_index(
+        "ix_command_run_events_run_id", table_name="command_run_events"
+    )
+    op.drop_table("command_run_events")
+
+    op.drop_index("ix_command_runs_created_at", table_name="command_runs")
+    op.drop_index("ix_command_runs_status", table_name="command_runs")
+    op.drop_index("ix_command_runs_command_id", table_name="command_runs")
+    op.drop_table("command_runs")

--- a/guardian/db/models.py
+++ b/guardian/db/models.py
@@ -2169,6 +2169,85 @@ class CronRun(Base):
     __mapper_args__ = {"eager_defaults": True}
 
 
+class CommandRun(Base):
+    """Durable command invocation run records."""
+
+    __tablename__ = "command_runs"
+
+    id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, autoincrement=True
+    )
+    run_id: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    command_id: Mapped[str] = mapped_column(String(512), nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(32), nullable=False, server_default="queued"
+    )
+    actor_kind: Mapped[str] = mapped_column(String(32), nullable=False)
+    actor_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    actor_session_id: Mapped[str | None] = mapped_column(String(255))
+    delegated_by: Mapped[str | None] = mapped_column(String(255))
+    auth_subject: Mapped[str] = mapped_column(String(255), nullable=False)
+    invoke_version: Mapped[str] = mapped_column(String(32), nullable=False)
+    args_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    args_redacted: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default="{}"
+    )
+    result_json: Mapped[dict | None] = mapped_column(JSONB)
+    error_text: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    started_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True)
+    )
+    ended_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('queued', 'running', 'completed', 'failed', 'blocked')",
+            name="command_runs_status_check",
+        ),
+        Index("ix_command_runs_command_id", "command_id"),
+        Index("ix_command_runs_status", "status"),
+        Index("ix_command_runs_created_at", "created_at"),
+    )
+    __mapper_args__ = {"eager_defaults": True}
+
+
+class CommandRunEvent(Base):
+    """Ordered append-only event records for command run streaming."""
+
+    __tablename__ = "command_run_events"
+
+    id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, autoincrement=True
+    )
+    run_id: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey("command_runs.run_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    sequence: Mapped[int] = mapped_column(Integer, nullable=False)
+    event_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    payload_json: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default="{}"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "run_id",
+            "sequence",
+            name="uq_command_run_events_run_sequence",
+        ),
+        Index("ix_command_run_events_run_id", "run_id"),
+        Index("ix_command_run_events_created_at", "created_at"),
+    )
+    __mapper_args__ = {"eager_defaults": True}
+
+
 class ChannelConfig(Base):
     """Per-user channel adapter configuration blobs."""
 

--- a/guardian/guardian_api.py
+++ b/guardian/guardian_api.py
@@ -145,6 +145,7 @@ from guardian.realtime import collaboration
 
 # Import all routers (after DB init so dependencies.chatlog_db is ready)
 from guardian.routes import admin, agent, agent_orchestration, backfill
+from guardian.routes import command_bus as command_bus_routes
 from guardian.routes import cron as cron_routes
 from guardian.routes import (
     devtools,
@@ -241,8 +242,9 @@ async def app_lifespan(app: FastAPI):
         share.configure_db(guardian_db)
         websocket_routes.configure_db(guardian_db)
         agent_orchestration.configure_db(guardian_db)
+        command_bus_routes.configure_db(guardian_db)
         logger.info(
-            "[startup] GuardianDB configured for cron/documents/share/websocket/agent_orchestration routes"
+            "[startup] GuardianDB configured for cron/documents/share/websocket/agent_orchestration/command_bus routes"
         )
         collaboration.configure_db(guardian_db)
         logger.info(
@@ -538,6 +540,7 @@ app.include_router(cron_routes.router)
 app.include_router(ui_session.router)
 app.include_router(agent_orchestration.router)
 app.include_router(agent_orchestration.chat_router)
+app.include_router(command_bus_routes.router)
 
 logger.info("[routers] All routers included")
 

--- a/guardian/routes/command_bus.py
+++ b/guardian/routes/command_bus.py
@@ -1,0 +1,107 @@
+"""Unified command bus routes (Phase 1)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, AsyncGenerator
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import StreamingResponse
+
+from guardian.command_bus.contracts import InvokeRequest
+from guardian.command_bus.invoke import execute_invoke
+from guardian.command_bus.manifest import build_manifest
+from guardian.command_bus.store import CommandBusStore
+from guardian.core.dependencies import get_current_user, require_api_key
+
+router = APIRouter(
+    prefix="/api/guardian/commands",
+    tags=["Command Bus"],
+    dependencies=[Depends(require_api_key)],
+)
+
+_db: Any | None = None
+_store = CommandBusStore()
+
+
+def configure_db(db: Any | None) -> None:
+    """Configure DB handle for command bus persistence."""
+    global _db, _store
+    _db = db
+    _store = CommandBusStore(db=db)
+
+
+@router.get("/manifest")
+async def get_manifest(request: Request) -> dict[str, Any]:
+    manifest = build_manifest(request.app)
+    return manifest.model_dump(mode="json")
+
+
+@router.post("/invoke")
+async def invoke_command(
+    payload: InvokeRequest,
+    request: Request,
+    auth_subject: str = Depends(get_current_user),
+) -> dict[str, Any]:
+    inbound_headers = {
+        key: value
+        for key, value in request.headers.items()
+        if key.lower() in {"authorization", "x-api-key", "x-user-id", "cookie"}
+    }
+    return await execute_invoke(
+        payload=payload,
+        auth_subject=auth_subject,
+        inbound_headers=inbound_headers,
+        store=_store,
+        app=request.app,
+    )
+
+
+@router.get("/runs/{run_id}/events")
+async def stream_run_events(
+    run_id: str,
+    request: Request,
+    after_seq: int = Query(default=0, ge=0),
+) -> StreamingResponse:
+    run = _store.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="run_not_found")
+
+    async def event_stream() -> AsyncGenerator[str, None]:
+        current_seq = int(after_seq or 0)
+        yield "retry: 3000\n\n"
+
+        heartbeat_elapsed = 0.0
+        heartbeat_interval = 15.0
+        poll_interval = 0.5
+
+        while True:
+            if await request.is_disconnected():
+                break
+
+            events = _store.list_events_after(
+                run_id=run_id,
+                after_seq=current_seq,
+                limit=200,
+            )
+            if events:
+                for event in events:
+                    seq = int(event.get("sequence") or 0)
+                    event_type = str(event.get("event_type") or "run.event")
+                    payload = event.get("payload_json") or {}
+                    payload_str = json.dumps(payload, default=str)
+                    yield f"id: {seq}\n"
+                    yield f"event: {event_type}\n"
+                    yield f"data: {payload_str}\n\n"
+                    current_seq = max(current_seq, seq)
+                heartbeat_elapsed = 0.0
+            else:
+                heartbeat_elapsed += poll_interval
+                if heartbeat_elapsed >= heartbeat_interval:
+                    yield ": ping\n\n"
+                    heartbeat_elapsed = 0.0
+
+            await asyncio.sleep(poll_interval)
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")

--- a/tests/routes/test_command_bus_phase1_events.py
+++ b/tests/routes/test_command_bus_phase1_events.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from guardian.routes import command_bus
+
+
+def _build_client(monkeypatch) -> TestClient:
+    monkeypatch.setenv("GUARDIAN_API_KEY", "test-key")
+    monkeypatch.setenv("DEBUG", "1")
+    command_bus.configure_db(None)
+
+    app = FastAPI()
+
+    @app.post("/write", operation_id="write_item")
+    def write(payload: dict[str, Any]) -> dict[str, Any]:
+        return {"ok": True, "payload": payload}
+
+    app.include_router(command_bus.router)
+    return TestClient(app)
+
+
+def _invoke_blocked_run(client: TestClient) -> str:
+    manifest = client.get(
+        "/api/guardian/commands/manifest",
+        headers={"X-API-Key": "test-key", "X-User-Id": "operator"},
+    ).json()
+    command_id = None
+    for command in manifest["commands"]:
+        if command["method"] == "POST" and command["path_template"] == "/write":
+            command_id = command["command_id"]
+            break
+    assert command_id is not None
+
+    response = client.post(
+        "/api/guardian/commands/invoke",
+        headers={"X-API-Key": "test-key", "X-User-Id": "operator"},
+        json={
+            "invoke_version": "1.0",
+            "command_id": command_id,
+            "actor": {"kind": "human", "id": "operator"},
+            "arguments": {"body": {"x": 1}},
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "blocked"
+    return payload["run_id"]
+
+
+class _FakeRequest:
+    def __init__(self, disconnect_after: int = 2) -> None:
+        self._checks = 0
+        self._disconnect_after = disconnect_after
+
+    async def is_disconnected(self) -> bool:
+        self._checks += 1
+        return self._checks > self._disconnect_after
+
+
+async def _collect_events(
+    run_id: str,
+    after_seq: int,
+    expected_count: int,
+) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    response = await command_bus.stream_run_events(
+        run_id=run_id,
+        request=_FakeRequest(disconnect_after=2),
+        after_seq=after_seq,
+    )
+    buffer = ""
+    async for chunk in response.body_iterator:
+        text = (
+            chunk.decode()
+            if isinstance(chunk, (bytes, bytearray))
+            else str(chunk)
+        )
+        buffer += text
+        while "\n\n" in buffer:
+            frame, buffer = buffer.split("\n\n", 1)
+            if (
+                not frame.strip()
+                or frame.startswith("retry:")
+                or frame.startswith(": ping")
+            ):
+                continue
+            lines = frame.splitlines()
+            id_line = next(
+                (line for line in lines if line.startswith("id:")), None
+            )
+            event_line = next(
+                (line for line in lines if line.startswith("event:")), None
+            )
+            data_line = next(
+                (line for line in lines if line.startswith("data:")), None
+            )
+            if not (id_line and event_line and data_line):
+                continue
+            payload = json.loads(data_line.split(":", 1)[1].strip() or "{}")
+            events.append(
+                {
+                    "id": int(id_line.split(":", 1)[1].strip()),
+                    "event": event_line.split(":", 1)[1].strip(),
+                    "data": payload,
+                }
+            )
+            if len(events) >= expected_count:
+                return events
+    return events
+
+
+@pytest.mark.asyncio
+async def test_events_stream_order_and_resume(monkeypatch) -> None:
+    client = _build_client(monkeypatch)
+    run_id = _invoke_blocked_run(client)
+
+    all_events = await _collect_events(
+        run_id=run_id, after_seq=0, expected_count=2
+    )
+    assert [event["id"] for event in all_events] == [1, 2]
+    assert [event["event"] for event in all_events] == [
+        "run.created",
+        "run.blocked",
+    ]
+
+    resumed_events = await _collect_events(
+        run_id=run_id, after_seq=1, expected_count=1
+    )
+    assert [event["id"] for event in resumed_events] == [2]
+    assert [event["event"] for event in resumed_events] == ["run.blocked"]

--- a/tests/routes/test_command_bus_phase1_invoke.py
+++ b/tests/routes/test_command_bus_phase1_invoke.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from guardian.routes import command_bus
+
+
+def _build_client(monkeypatch) -> TestClient:
+    monkeypatch.setenv("GUARDIAN_API_KEY", "test-key")
+    monkeypatch.setenv("DEBUG", "1")
+    command_bus.configure_db(None)
+
+    app = FastAPI()
+
+    @app.get("/health", operation_id="health_check")
+    def health() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.post("/write", operation_id="write_item")
+    def write(payload: dict[str, Any]) -> dict[str, Any]:
+        return {"ok": True, "payload": payload}
+
+    app.include_router(command_bus.router)
+    return TestClient(app)
+
+
+def _get_manifest(client: TestClient) -> dict[str, Any]:
+    response = client.get(
+        "/api/guardian/commands/manifest",
+        headers={"X-API-Key": "test-key", "X-User-Id": "operator"},
+    )
+    assert response.status_code == 200
+    return response.json()
+
+
+def _command_id(manifest: dict[str, Any], *, method: str, path: str) -> str:
+    for command in manifest.get("commands", []):
+        if (
+            command.get("method") == method
+            and command.get("path_template") == path
+        ):
+            return str(command["command_id"])
+    raise AssertionError(f"missing command for {method} {path}")
+
+
+def test_invoke_rejects_missing_actor(monkeypatch) -> None:
+    client = _build_client(monkeypatch)
+    manifest = _get_manifest(client)
+    health_command_id = _command_id(manifest, method="GET", path="/health")
+
+    response = client.post(
+        "/api/guardian/commands/invoke",
+        headers={"X-API-Key": "test-key", "X-User-Id": "operator"},
+        json={
+            "invoke_version": "1.0",
+            "command_id": health_command_id,
+            "arguments": {},
+        },
+    )
+    assert response.status_code == 422
+
+
+def test_invoke_rejects_unsupported_version(monkeypatch) -> None:
+    client = _build_client(monkeypatch)
+    manifest = _get_manifest(client)
+    health_command_id = _command_id(manifest, method="GET", path="/health")
+
+    response = client.post(
+        "/api/guardian/commands/invoke",
+        headers={"X-API-Key": "test-key", "X-User-Id": "operator"},
+        json={
+            "invoke_version": "9.9",
+            "command_id": health_command_id,
+            "actor": {"kind": "human", "id": "operator"},
+            "arguments": {},
+        },
+    )
+    assert response.status_code == 400
+    payload = response.json()["detail"]
+    assert payload["error"] == "unsupported_invoke_version"
+    assert payload["supported_invoke_versions"] == ["1.0"]
+
+
+def test_invoke_rejects_actor_claim_mismatch(monkeypatch) -> None:
+    client = _build_client(monkeypatch)
+    manifest = _get_manifest(client)
+    health_command_id = _command_id(manifest, method="GET", path="/health")
+
+    response = client.post(
+        "/api/guardian/commands/invoke",
+        headers={"X-API-Key": "test-key", "X-User-Id": "operator"},
+        json={
+            "invoke_version": "1.0",
+            "command_id": health_command_id,
+            "actor": {"kind": "human", "id": "someone-else"},
+            "arguments": {},
+        },
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"]["error"] == "actor_claim_not_permitted"
+
+
+def test_invoke_blocks_mutating_commands_and_emits_blocked_event(
+    monkeypatch,
+) -> None:
+    client = _build_client(monkeypatch)
+    manifest = _get_manifest(client)
+    write_command_id = _command_id(manifest, method="POST", path="/write")
+
+    response = client.post(
+        "/api/guardian/commands/invoke",
+        headers={"X-API-Key": "test-key", "X-User-Id": "operator"},
+        json={
+            "invoke_version": "1.0",
+            "command_id": write_command_id,
+            "actor": {"kind": "human", "id": "operator"},
+            "arguments": {"body": {"value": 1}},
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "blocked"
+    assert payload["error"] == "phase1_write_blocked"
+
+    events = command_bus._store.list_events_after(
+        run_id=payload["run_id"],
+        after_seq=0,
+    )
+    assert [event["event_type"] for event in events] == [
+        "run.created",
+        "run.blocked",
+    ]
+
+
+def test_invoke_blocks_recursive_command_targets(monkeypatch) -> None:
+    client = _build_client(monkeypatch)
+    manifest = _get_manifest(client)
+    self_command_id = _command_id(
+        manifest, method="GET", path="/api/guardian/commands/manifest"
+    )
+
+    response = client.post(
+        "/api/guardian/commands/invoke",
+        headers={"X-API-Key": "test-key", "X-User-Id": "operator"},
+        json={
+            "invoke_version": "1.0",
+            "command_id": self_command_id,
+            "actor": {"kind": "human", "id": "operator"},
+            "arguments": {},
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "blocked"
+    assert payload["error"] == "recursion_guard_blocked"
+
+    events = command_bus._store.list_events_after(
+        run_id=payload["run_id"],
+        after_seq=0,
+    )
+    assert [event["event_type"] for event in events] == [
+        "run.created",
+        "run.blocked",
+    ]
+
+
+def test_invoke_read_only_uses_loopback_http_and_persists(monkeypatch) -> None:
+    captured: list[dict[str, Any]] = []
+
+    class _FakeResponse:
+        status_code = 200
+        headers = {"content-type": "application/json"}
+
+        @property
+        def text(self) -> str:
+            return '{"ok": true}'
+
+        def json(self) -> dict[str, bool]:
+            return {"ok": True}
+
+    class _FakeAsyncClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            _ = args, kwargs
+
+        async def __aenter__(self) -> "_FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+            _ = exc_type, exc, tb
+
+        async def request(self, **kwargs: Any) -> _FakeResponse:
+            captured.append(dict(kwargs))
+            return _FakeResponse()
+
+    monkeypatch.setenv(
+        "GUARDIAN_COMMAND_BUS_LOOPBACK_BASE", "http://127.0.0.1:9999"
+    )
+    monkeypatch.setattr(
+        "guardian.command_bus.loopback_http_adapter.httpx.AsyncClient",
+        _FakeAsyncClient,
+    )
+
+    client = _build_client(monkeypatch)
+    manifest = _get_manifest(client)
+    health_command_id = _command_id(manifest, method="GET", path="/health")
+
+    response = client.post(
+        "/api/guardian/commands/invoke",
+        headers={"X-API-Key": "test-key", "X-User-Id": "operator"},
+        json={
+            "invoke_version": "1.0",
+            "command_id": health_command_id,
+            "actor": {"kind": "human", "id": "operator"},
+            "arguments": {"query": {"check": "true"}},
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "completed"
+    assert payload["inline_result"]["status_code"] == 200
+    assert payload["inline_result"]["body"] == {"ok": True}
+
+    assert len(captured) == 1
+    assert captured[0]["method"] == "GET"
+    assert captured[0]["url"] == "http://127.0.0.1:9999/health"
+    assert captured[0]["params"] == {"check": "true"}
+    captured_headers = {k.lower(): v for k, v in captured[0]["headers"].items()}
+    assert captured_headers["x-api-key"] == "test-key"
+    assert captured_headers["x-user-id"] == "operator"
+
+    events = command_bus._store.list_events_after(
+        run_id=payload["run_id"],
+        after_seq=0,
+    )
+    assert [event["event_type"] for event in events] == [
+        "run.created",
+        "run.started",
+        "run.completed",
+    ]
+
+
+def test_redaction_is_deterministic_and_hash_is_stable(monkeypatch) -> None:
+    client = _build_client(monkeypatch)
+    manifest = _get_manifest(client)
+    write_command_id = _command_id(manifest, method="POST", path="/write")
+
+    body = {
+        "invoke_version": "1.0",
+        "command_id": write_command_id,
+        "actor": {"kind": "human", "id": "operator"},
+        "arguments": {
+            "query": {"token": "abc123"},
+            "headers": {"Authorization": "Bearer secret", "X-Api-Key": "k1"},
+            "body": {"nested": {"password": "pw"}},
+        },
+    }
+    first = client.post(
+        "/api/guardian/commands/invoke",
+        headers={"X-API-Key": "test-key", "X-User-Id": "operator"},
+        json=body,
+    )
+    second = client.post(
+        "/api/guardian/commands/invoke",
+        headers={"X-API-Key": "test-key", "X-User-Id": "operator"},
+        json=body,
+    )
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+    run1 = command_bus._store.get_run(first.json()["run_id"])
+    run2 = command_bus._store.get_run(second.json()["run_id"])
+    assert run1 is not None and run2 is not None
+    assert run1["args_hash"] == run2["args_hash"]
+    assert run1["args_redacted"] == run2["args_redacted"]
+    assert run1["args_redacted"]["query"]["token"] == "[REDACTED]"
+    assert run1["args_redacted"]["headers"]["Authorization"] == "[REDACTED]"
+    assert run1["args_redacted"]["headers"]["X-Api-Key"] == "[REDACTED]"
+    assert run1["args_redacted"]["body"]["nested"]["password"] == "[REDACTED]"

--- a/tests/routes/test_command_bus_phase1_manifest.py
+++ b/tests/routes/test_command_bus_phase1_manifest.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from guardian.routes import command_bus
+
+
+def _build_client(monkeypatch) -> TestClient:
+    monkeypatch.setenv("GUARDIAN_API_KEY", "test-key")
+    monkeypatch.setenv("DEBUG", "1")
+    command_bus.configure_db(None)
+
+    app = FastAPI()
+
+    @app.get("/health", operation_id="health_check")
+    def health() -> dict[str, bool]:
+        return {"ok": True}
+
+    app.include_router(command_bus.router)
+    return TestClient(app)
+
+
+def _find_command(manifest: dict, *, method: str, path_template: str) -> dict:
+    for command in manifest.get("commands", []):
+        if (
+            command.get("method") == method
+            and command.get("path_template") == path_template
+        ):
+            return command
+    raise AssertionError(f"command not found for {method} {path_template}")
+
+
+def test_manifest_includes_versions_capabilities_and_stable_ids(
+    monkeypatch,
+) -> None:
+    client = _build_client(monkeypatch)
+
+    response = client.get(
+        "/api/guardian/commands/manifest",
+        headers={"X-API-Key": "test-key", "X-User-Id": "operator"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["manifest_version"] == "1.0"
+    assert payload["generated_at"]
+    capabilities = payload["capabilities"]
+    assert capabilities["invoke_versions_supported"] == ["1.0"]
+    assert capabilities["event_protocol_version"] == "1.0"
+    assert "run.blocked" in capabilities["event_types_supported"]
+    assert capabilities["approval_modes_supported"] == [
+        "none",
+        "blocked_phase1",
+    ]
+    assert capabilities["max_payload_bytes"] > 0
+
+    health = _find_command(payload, method="GET", path_template="/health")
+    assert health["command_id"] == "op::health_check"
+    assert "route::GET::/health" in health["aliases"]
+    assert health["layer"] == "raw"
+    assert health["risk"] == "read_only"
+    assert health["effect"] == "read"
+    assert health["idempotency"] == "safe"
+    assert health["approval_mode"] == "none"
+    assert set(health["input_schema"].keys()) == {
+        "path_params",
+        "query",
+        "headers",
+        "body",
+    }


### PR DESCRIPTION
## Summary

- **Title:** Introduce Phase 1 Unified Command Bus (Manifest + Invoke + Events + Persistence)
- **Context:**  
  This PR establishes the foundational command bus architecture for Codexify, enabling a manifest-driven command registry, versioned invoke protocol, structured event lifecycle, and durable ledger persistence.  
  The goal is to formalize execution contracts, enforce protocol boundaries, and create a deterministic invocation layer with auditability and idempotency support.

---

## Changes

### Files Touched (High-Level)

- `guardian/command_bus/` (new package)
  - `contracts.py` – protocol constants and Pydantic schemas
  - `manifest.py` – manifest generation
  - `invoke.py` – invocation pipeline
  - `store.py` – persistence layer
  - `loopback_http_adapter.py` – raw adapter for phase 1 execution
  - `redaction_policy.py` – event/output safety controls
- `guardian/routes/command_bus.py` – API exposure
- `guardian/db/models.py` – schema additions
- `guardian/db/migrations/..._add_command_bus_phase1_tables.py`
- Tests:
  - `test_command_bus_phase1_manifest.py`
  - `test_command_bus_phase1_invoke.py`
  - `test_command_bus_phase1_events.py`
- `docs/Future-Features/PLAN.md` – long-range architectural roadmap

---

### Key Diffs

- Introduced **versioned protocol constants** (`MANIFEST_VERSION`, `INVOKE_VERSION`, `EVENT_PROTOCOL_VERSION`)
- Defined canonical contracts:
  - `InvokeRequest`
  - `CommandSpec`
  - `ManifestResponse`
  - `CapabilitiesSpec`
- Implemented:
  - Manifest endpoint with capabilities negotiation
  - Invoke pipeline with actor identity, idempotency key, and strict schema validation
  - Event lifecycle (`run.created`, `run.started`, `run.completed`, `run.failed`, `run.blocked`)
  - Payload size enforcement (`MAX_PAYLOAD_BYTES`)
- Added persistent action ledger for audit and replay safety
- Included loopback HTTP adapter for deterministic phase-1 execution
- Added migration for command bus tables
- Established integration + contract test coverage

---

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

---

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [x] Lint/typecheck pass
- [x] Tests pass (unit + integration)
- [x] Security/Privacy Check: no secrets committed; local-first defaults
- [x] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [x] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

---

## Screenshots / Logs

- Manifest endpoint returns versioned command registry with capabilities negotiation.
- Invoke flow produces deterministic event lifecycle and durable ledger entry.
- Contract tests validate strict schema enforcement and version compatibility.

---

## Risks & Rollback

- **Risk level:** Medium  
  (Introduces new protocol surface + persistence layer)
- **Rollback plan:**  
  Revert to prior tag (e.g., `vX.Y.Z`) and remove command bus migration tables.  
  Stash failures in `artifacts/failures/<timestamp>`.

---

## Next Steps

- Phase 2: Provider abstraction beyond loopback raw adapter
- Phase 2: Approval workflow expansion beyond `blocked_phase1`
- Phase 2: Event streaming over WebSocket channel
- Expand manifest to support layered (non-raw) command definitions
- Link to run-manifest stages affected: Command Execution / Persistence / Eventing