### PR TITLE
Tokenize single-rail header & composer model row

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -127,7 +127,9 @@ COPY backend/requirements-tts.txt /tmp/backend/requirements-tts.txt
 RUN python -m pip install -r /tmp/backend/requirements-tts.txt
 
 # === Final stage: Create minimal runtime image ===
-FROM dhi.io/python:3.11.14-debian13 AS runtime
+ # NOTE: The non-"-dev" runtime image is intentionally hardened/minimal and does not ship with apt.
+ # We use the "-dev" variant here because this stage needs to install ffmpeg via apt-get.
+FROM dhi.io/python:3.11.14-debian13-dev AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -137,14 +139,16 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
+
 # Voice normalization/transcoding dependency (also includes ffprobe).
+# ffmpeg pulls packages (e.g., x11-common) whose postinst calls update-rc.d.
+# Ensure update-rc.d is present via init-system-helpers.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ffmpeg && \
+    apt-get install -y --no-install-recommends ffmpeg init-system-helpers && \
     rm -rf /var/lib/apt/lists/*
 
 # qwen-tts pulls python-sox, which shells out through /bin/sh during import.
 # Keep a POSIX shell available in the runtime image for compatibility.
-COPY --from=builder /usr/bin/bash /bin/sh
 
 # Copy Python site-packages from builder (minimal and secure)
 COPY --from=builder /opt/python/lib/python3.11/site-packages /opt/python/lib/python3.11/site-packages

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -137,6 +137,11 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
+# Voice normalization/transcoding dependency (also includes ffprobe).
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ffmpeg && \
+    rm -rf /var/lib/apt/lists/*
+
 # qwen-tts pulls python-sox, which shells out through /bin/sh during import.
 # Keep a POSIX shell available in the runtime image for compatibility.
 COPY --from=builder /usr/bin/bash /bin/sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -224,10 +224,16 @@ services:
       # This is your local-first provider. From Codexify's POV it's just an API endpoint.
       # NOTE: Keep this set to a model that actually exists on VaultNode (check /api/tags or /v1/models).
       LOCAL_BASE_URL: "${LOCAL_BASE_URL:-http://100.109.4.57:11434}"
+      CODEXIFY_LOCAL_VOICE_BASE_URL: "${CODEXIFY_LOCAL_VOICE_BASE_URL:-http://100.109.4.57:11434}"
       LOCAL_API_KEY: "local"   # Ollama ignores; satisfies SDKs
       LOCAL_CHAT_MODEL: "${LOCAL_CHAT_MODEL}"
       LOCAL_EMBED_MODEL: "/models/bge-large-en-v1.5"
       CODEXIFY_ALLOW_EMBEDDINGS_FALLBACK: "${CODEXIFY_ALLOW_EMBEDDINGS_FALLBACK:-0}"
+      CODEXIFY_VOICE_ROUTES_ENABLED: "${CODEXIFY_VOICE_ROUTES_ENABLED:-true}"
+      CODEXIFY_VOICE_TURNS_ENABLED: "${CODEXIFY_VOICE_TURNS_ENABLED:-false}"
+      CODEXIFY_TTS_PROVIDER: "${CODEXIFY_TTS_PROVIDER:-local_openai_compatible}"
+      CODEXIFY_STT_PROVIDER: "${CODEXIFY_STT_PROVIDER:-local_openai_compatible}"
+      CODEXIFY_DEFAULT_VOICE: "${CODEXIFY_DEFAULT_VOICE:-alloy}"
 
       # --- OpenAI (cloud) ---
       # NOTE: We intentionally do NOT override OPENAI_BASE_URL here.
@@ -360,6 +366,58 @@ services:
       - ./models/bge-large-en-v1.5:/models/bge-large-en-v1.5:ro
     restart: unless-stopped
     command: ["-m", "guardian.workers.chat_worker"]
+
+  worker-voice:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    working_dir: /app
+    entrypoint: ["python"]
+    depends_on:
+      redis:
+        condition: service_healthy
+      backend:
+        condition: service_healthy
+    env_file: .env
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
+      PYTHONUTF8: "1"
+      PYTHONIOENCODING: utf-8
+      GUARDIAN_DB_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
+      GUARDIAN_CHATLOG_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
+      LLM_PROVIDER: "local"
+      EMBED_PROVIDER: "local"
+      GUARDIAN_COMMAND_BUS_LOOPBACK_BASE: "http://backend:8888"
+      CODEXIFY_POLICY_MODE: "${CODEXIFY_POLICY_MODE:-enforce}"
+      LOCAL_BASE_URL: "${LOCAL_BASE_URL:-http://100.109.4.57:11434}"
+      CODEXIFY_LOCAL_VOICE_BASE_URL: "${CODEXIFY_LOCAL_VOICE_BASE_URL:-http://100.109.4.57:11434}"
+      LOCAL_API_KEY: "local"
+      LOCAL_CHAT_MODEL: "${LOCAL_CHAT_MODEL}"
+      LOCAL_COMPAT_FIRST: "${LOCAL_COMPAT_FIRST:-0}"
+      LOCAL_ENABLE_OLLAMA_GENERATE_FALLBACK: "${LOCAL_ENABLE_OLLAMA_GENERATE_FALLBACK:-0}"
+      LOCAL_EMBED_MODEL: "/models/bge-large-en-v1.5"
+      CODEXIFY_ALLOW_EMBEDDINGS_FALLBACK: "${CODEXIFY_ALLOW_EMBEDDINGS_FALLBACK:-0}"
+      CODEXIFY_VOICE_ROUTES_ENABLED: "${CODEXIFY_VOICE_ROUTES_ENABLED:-true}"
+      CODEXIFY_VOICE_TURNS_ENABLED: "${CODEXIFY_VOICE_TURNS_ENABLED:-false}"
+      CODEXIFY_TTS_PROVIDER: "${CODEXIFY_TTS_PROVIDER:-local_openai_compatible}"
+      CODEXIFY_STT_PROVIDER: "${CODEXIFY_STT_PROVIDER:-local_openai_compatible}"
+      CODEXIFY_DEFAULT_VOICE: "${CODEXIFY_DEFAULT_VOICE:-alloy}"
+      REDIS_URL: redis://redis:6379/0
+      HF_HOME: /root/.cache/huggingface
+      HF_HUB_OFFLINE: "1"
+      TRANSFORMERS_OFFLINE: "1"
+      SENTENCE_TRANSFORMERS_HOME: /models
+      NEO4J_BOLT_URL: bolt://neo4j:7687
+    volumes:
+      - ./guardian:/app/codexify
+      - ./guardian:/app/guardian
+      - ./backend:/app/backend
+      - hf_cache:/root/.cache/huggingface
+      - ./models/bge-large-en-v1.5:/models/bge-large-en-v1.5:ro
+    restart: unless-stopped
+    command: ["-m", "guardian.workers.voice_worker"]
 
   worker-document-embed:
     build:

--- a/docs/Campaign/CAMPAIGN_BETA1_CORE_STABILITY.md
+++ b/docs/Campaign/CAMPAIGN_BETA1_CORE_STABILITY.md
@@ -1,0 +1,10 @@
+# CAMPAIGN_BETA1_CORE_STABILITY
+
+## Campaign Mapping (Source of Truth)
+
+- TASK-2026-03-03-001 [`b0ffe43c`, `<COMMIT_B_HASH>`]
+
+## Notes
+
+- Task objective: harden Obsidian frontmatter parsing to fail open on malformed YAML.
+- Implementation commit: `b0ffe43c`.

--- a/docs/chat/production_grade_chat_plan.md
+++ b/docs/chat/production_grade_chat_plan.md
@@ -1,0 +1,300 @@
+# Production-Grade Chat Stabilization Plan
+
+## 1. What “Production Grade Chat” Means (Beta Definition)
+
+Beta scope is reliability-first: durable user message writes and reliable assistant completion visibility.
+
+- Durability rule 1: user message must be persisted in Postgres before completion enqueue is attempted.
+- Durability rule 2: assistant completion persistence is exactly-once at product level.
+- Current gap: there is no first-class completion idempotency key in the current chat completion contract; beta hardening introduces a `turn_id` dedupe target (documented as future interface delta).
+- Delivery rule: no phantom completions. If a task reaches terminal `completed`, UI must converge on the persisted assistant message or present explicit terminal failure.
+- UI invariant: thread view must be reconstructable from `GET /chat/{thread_id}/messages` (or `/api/chat/{thread_id}/messages`) as server truth.
+
+## 2. Current Architecture Reality (What Exists Today)
+
+### Current (verified)
+
+- Postgres is the system of record for threads/messages.
+- Redis is used for completion queueing, per-thread turn locks, and task event streams.
+- Worker chat pipeline is staged as: assemble -> generate -> persist -> emit events.
+- Completion path baseline is:
+1. `POST /chat/{thread_id}/messages` persists user message.
+2. `POST /chat/{thread_id}/complete` enqueues chat completion task.
+3. Worker persists assistant message.
+4. UI converges against authoritative transcript fetch.
+- Thread transcript convergence uses `GET /chat/{thread_id}/messages` as authoritative truth.
+- Existing polling behavior in ChatView is baseline.
+
+### If present (optional; verify per deployment)
+
+- `/api/events` SSE for transcript events (for example `message.created`), only if implemented and enabled in the deployed environment.
+
+### Target (planned)
+
+- `/api/tasks/{task_id}/events` SSE for completion lifecycle state as the primary completion-status channel.
+- Event-first UI updates with polling fallback for transcript convergence.
+
+## 3. Misconceptions to Correct (Steer True)
+
+- Correction 1: background task results must not be pushed into “the next assistant response.”
+- Replacement primitive: task completion creates a durable result event plus an in-app notification banner plus a deep-link to the originating thread/task context.
+- Assistant transcript is a conversation log, not an event bus.
+
+- Correction 2: diagnostics must not leak into chat.
+- Diagnostics (RAG traces, internal sensors, stack traces, infra details) belong in opt-in surfaces such as health/debug panels and task timelines, not the user-facing transcript.
+- Frontend contract: optimistic local state is provisional; server fetch is authoritative truth.
+
+## 4. Core Loop Stabilization Plan (Beta Critical Path)
+
+### Checklist
+
+- Message ordering and consistency:
+- Normalize and render by `created_at ASC, id ASC`.
+- Reconcile fetched transcript to prevent duplicates and out-of-order inserts.
+- Completion idempotency and dedupe:
+- Introduce a completion turn key (`turn_id`) to dedupe duplicate writes for the same turn.
+- Event-first convergence plus polling fallback:
+- Use events when available; always retain guarded polling fallback to `GET /chat/{thread_id}/messages`.
+- Backpressure and request guards:
+- Prevent overlapping completion submissions per thread.
+- Prevent overlapping poll loops for the same in-flight turn.
+- Turn lock policy:
+- Enforce TTL, detect stale lock, and recover safely without silent hangs.
+
+### Correlation / Idempotency Contract (future interface delta)
+
+Define `turn_id` at completion-request acceptance time (UUID).
+
+`turn_id` must flow through:
+- completion enqueue payload,
+- worker task metadata,
+- persisted assistant message row metadata,
+- task events payloads (if/when SSE exists).
+
+`turn_id` enables:
+- dedupe of duplicate completion writes,
+- UI stop condition: stop polling once assistant message with matching `turn_id` arrives,
+- phantom completion detection across logs, metrics, and UI convergence.
+
+### Event and Polling Stop Conditions
+
+Stop completion polling when any of the following occurs:
+- assistant message with matching `turn_id` is visible in authoritative transcript,
+- terminal task failure/cancel event is observed,
+- inactivity timeout is reached and degraded terminal UX is shown.
+
+### Turn Lock TTL and Stuck-Lock Recovery
+
+- TTL policy: default 180s, minimum 15s.
+- Stale-lock recovery:
+- if lock is stale and no active progression signal exists, recover via owner-safe release.
+- emit recovery log and metric for observability.
+- never leave UI in an unbounded pending state.
+
+### UX Definitions
+
+Happy path UX:
+- fast send acknowledgment,
+- pending indicator for in-flight turn,
+- assistant response appears via event or poll convergence,
+- pending indicator clears.
+
+Degraded path UX:
+- clear failure banner with actionable retry,
+- preserve user input state,
+- no infinite spinner.
+
+## 5. Failure Modes and How We Detect Them
+
+### Operational Phantom Completion Definition
+
+- Phantom completion = task reaches terminal `completed` (or server claims completion) but no assistant message exists for `(thread_id, turn_id)` within `N` seconds.
+- Beta default `N`: 20 seconds.
+
+Detection requirements:
+- emit structured log event,
+- increment metric,
+- record visibility latency.
+
+Required structured log fields:
+- `thread_id`
+- `turn_id`
+- `task_id`
+- `task_completed_at`
+- `detected_at`
+- `assistant_message_id` (nullable)
+- `provider`
+- `model`
+- `worker_run_id` (if available)
+
+Metric examples:
+- `chat_phantom_completion_total`
+- `chat_completion_visible_latency_ms`
+
+### Failure-Mode Matrix
+
+| Failure mode | Detection signals (logs/metrics/health/events) | Required user-visible banner | Actionable guidance |
+|---|---|---|---|
+| Redis down / queue unavailable | enqueue failure, `queue_unavailable`, `/health/chat` queue reachability false | “Completions are temporarily unavailable. Your message is saved.” | Retry after service recovery; check queue health |
+| Worker down / task never completes | missing worker heartbeat, task inactivity timeout, no terminal event | “Assistant is delayed. You can retry this turn.” | Retry and inspect worker health |
+| Provider timeout / upstream error | terminal task failure with timeout/upstream classification | “Model provider timed out. Retry or switch provider.” | Retry with fallback provider |
+| Persist succeeded but UI didn’t refresh | DB has assistant row but UI did not converge in SLA | “Reply is ready but not visible yet. Refresh thread.” | Refresh thread; inspect event delivery path |
+| UI refreshed but message missing (DB read mismatch) | completed task + no assistant row for `(thread_id, turn_id)` by `N` seconds | “Completion could not be confirmed. Retry this turn.” | Trigger phantom incident workflow |
+
+### Minimum Metrics Set (Beta)
+
+- enqueue/start/complete/fail counts
+- completion latency
+- lock acquisition failures
+- polling fallback activation count
+- phantom completion mismatch count
+
+Reference metric names:
+- `chat_completion_enqueue_total`
+- `chat_completion_started_total`
+- `chat_completion_completed_total`
+- `chat_completion_failed_total`
+- `chat_completion_latency_ms`
+- `chat_turn_lock_acquire_failed_total`
+- `chat_polling_fallback_activated_total`
+- `chat_phantom_completion_total`
+- `chat_completion_visible_latency_ms`
+
+## 6. Event Delivery Strategy
+
+### Short-term (beta)
+
+Polling is acceptable with controlled cadence:
+
+- base interval: 1.5s
+- capped backoff: 5s
+- jitter: ±20%
+- hard timeout: 5 minutes
+- stop when assistant with matching `turn_id` arrives or completion becomes terminal/inactive
+
+Spinner policy:
+- no spinner beyond 2 minutes without terminal banner and retry action.
+
+### Mid-term
+
+- adopt `/api/tasks/{task_id}/events` SSE for completion lifecycle updates,
+- retain `/api/events` (if present) for transcript updates,
+- keep guarded polling fallback for convergence and disconnect recovery.
+
+### Notifications
+
+- Beta target is in-app notification banner with deep-link to thread + task summary.
+- Notification content must not be appended into assistant chat text.
+- OS-level desktop notifications are out of scope for beta unless already implemented and verified.
+
+## 7. Command Surface Roadmap (@Command.Name)
+
+### Parsing Contract
+
+- Detect `@Command.Name` token.
+- Support quoting and escaping for arguments.
+- Support multi-command input in one message.
+- Fallback to plain chat when parse fails or command is unknown.
+
+### Routing Contract
+
+- command parse result -> command bus/tools invocation -> task events -> structured render block in chat.
+- Commands produce tasks; tasks produce events; chat renders results from structured payloads.
+
+### Safety Boundaries
+
+- read-only commands can auto-run.
+- mutating commands require explicit approval prompt/token.
+- authorization enforced at invoke boundary.
+
+### Output Schema (future interface delta)
+
+Command results are structured blocks, not prose blobs.
+
+Required fields:
+- `status`
+- `run_id`
+- `summary`
+- `details`
+- `actions`
+
+## 8. Flows / Cron / Tools Integration Strategy
+
+### Chat Trigger Mappings (reference targets)
+
+- create flow: `POST /api/flows`
+- update flow: `PATCH /api/flows/{flow_id}`
+- run flow: `POST /api/flows/{flow_id}/run`
+- create cron job: `POST /api/cron/jobs`
+- schedule/update cron job: `PATCH /api/cron/jobs/{job_id}`
+- execute cron job now: `POST /api/cron/jobs/{job_id}/trigger`
+- execute tool task: `POST /api/tools/execute`
+- approval path: `POST /api/tools/approve`
+
+### Result Visibility Model
+
+- task timeline/event stream for lifecycle visibility,
+- final artifact/result block in chat,
+- escalation prompt for approval flows (approval token path),
+- result rendering remains separate from assistant prose channel.
+
+## 9. Implementation Sequencing (1–2 week Beta Path)
+
+### Milestone 1: stop the bleeding
+
+- lock/queue checks before and during completion flow,
+- convergence guarantees from authoritative transcript fetch,
+- degraded UX banners for all terminal failure states.
+
+### Milestone 2: idempotency/dedupe + observability hardening
+
+- implement `turn_id` correlation contract,
+- enforce dedupe target behavior for duplicate completion writes,
+- add phantom detection logs and metrics,
+- add SLA dashboards for visibility and failures.
+
+### Milestone 3: task-event SSE + in-app completion banner deep-linking
+
+- wire completion lifecycle stream consumption,
+- retain polling fallback as resilience path,
+- ship in-app completion banner deep-linking to originating thread/task summary.
+
+### Strict Beta Non-Goals
+
+- no full natural-language command interpreter,
+- no diagnostics in transcript,
+- no injecting background task output into next assistant response,
+- no workflow marketplace/polish before core loop reliability,
+- no new OS-level desktop notification system unless already implemented.
+
+## 10. Acceptance Criteria
+
+Pass/fail criteria:
+
+- Every accepted completion ends in either:
+- persisted assistant message visibility, or
+- explicit terminal failure state.
+- No indefinite spinner without terminal UX.
+- No phantom completion mismatch between task completion claims and thread history.
+- Thread reload reconstructs correct transcript from server truth.
+- `/health/chat` reflects worker heartbeat + queue reachability accurately.
+- Failure-mode banners appear with actionable guidance.
+
+SLA targets (beta):
+- P95 assistant message visibility <= 15s under normal conditions.
+- Terminal failure rendered <= 5s after task failure is known.
+- No spinner longer than 2 minutes without terminal banner + retry.
+
+### Scenario Matrix
+
+| Scenario | Expected behavior | Pass condition |
+|---|---|---|
+| Happy path end-to-end (persist -> enqueue -> worker -> persist -> UI) | Assistant appears in thread with matching correlation key | Visible within SLA and pending clears |
+| Redis down / queue unavailable | Completion not accepted, user message remains durable | Banner shown + retry path available |
+| Worker down / task never completes | Inactivity and heartbeat checks detect stall | Terminal degraded banner shown |
+| Provider timeout / upstream error | Task fails explicitly | Failure banner within SLA |
+| Persist succeeded but UI didn’t refresh | Convergence miss detected | Refresh/retry resolves visibility |
+| UI refreshed but message missing | Phantom detection fires | Metric/log emitted + terminal guidance shown |
+| Reconnection/reload convergence | UI rehydrates from authoritative fetch | No duplicates or gaps |
+| Duplicate submit/overlap guard | Second completion blocked while turn in flight | Single in-flight completion per thread |
+| Stale lock recovery | Stale lock is safely recovered | New completion proceeds after recovery |

--- a/docs/codexify-mvp-roadmap-2026-03-04.md
+++ b/docs/codexify-mvp-roadmap-2026-03-04.md
@@ -1,0 +1,188 @@
+# Codexify MVP Roadmap & Core Loop Plan (2026-03-04)
+
+## Overview & Goals
+Close six core loops end-to-end for local MVP under the rule: “works locally with documented env vars/services configured” is sufficient. Every gap below maps to a Runner-Ready Finding in the audit manifest.
+
+### Core Loop Status Snapshot
+| Core Loop | Code Present | Loop Closed | Notes |
+| --- | --- | --- | --- |
+| RAG Chat (`rag`) | complete | no | Needs LOCAL_BASE_URL + Redis worker health (FINDING-2026-03-04-001, -007). |
+| ChatGPT Migration (`migration`) | complete | yes | API-key protected import path (guardian/routes/migration.py). |
+| Document Upload (`doc-upload`) | complete | no | Postgres/embedding required; UI caches mock docs (FINDING-2026-03-04-004, -006, -010). |
+| Image Gallery (`image-gallery`) | partial | no | Demo fallback masks backend state (FINDING-2026-03-04-005). |
+| Image Generation (`image-gen`) | partial | no | Local provider stub, provider/model env required (FINDING-2026-03-04-003, -002). |
+| Document Generation (`doc-gen`) | complete | no | Shares LLM provider gap with chat/doc-gen (FINDING-2026-03-04-001, -002). |
+
+---
+
+## Core Feature 1: RAG Chat (`rag`)
+**Current State (evidence):**
+- Chat routes enforce API key and enqueue completion tasks (guardian/routes/chat.py:768-1157).
+- Worker persists assistant messages and emits task.completed events (guardian/workers/chat_worker.py:134-165).
+- Frontend expects task_id async flow (frontend/src/features/chat/GuardianChat.tsx:534-579).
+
+**Core Loop Definition**
+1. User creates/selects thread.
+2. User posts message (persisted to DB).
+3. Completion task enqueued and processed by worker.
+4. Assistant message persisted and events emitted.
+5. UI reloads from backend list/events.
+
+**Gap Analysis**
+| Loop step | Current implementation | Gap | Concrete fix (Finding) |
+| --- | --- | --- | --- |
+| 3-4 | Provider defaults to `local`; missing LOCAL_BASE_URL returns 400 | Loop blocked by default env | Add startup check + sample env for LOCAL_BASE_URL/LOCAL_LLM_MODEL or allowlisted cloud provider (FINDING-2026-03-04-001). |
+| 3 | Completion hard-depends on Redis enqueue | No graceful local fallback | Add sync mode for dev harness or health gate in core-loop runner (FINDING-2026-03-04-007). |
+| 3-5 | Cloud providers 403 without allowlist | Cloud path unusable by default | Document minimal allowlist; add cloud profile tests (FINDING-2026-03-04-002). |
+
+**Implementation Tasks**
+1. Add startup validation for LOCAL_BASE_URL (fail-fast with actionable message).  
+2. Implement `QUEUE_MODE=sync` for dev harness to bypass Redis when unavailable.  
+3. Document cloud allowlist snippet and add env sample for Groq/OpenAI.  
+
+**Validation Plan**
+- Manual:  
+  - `GUARDIAN_API_KEY=test LOCAL_BASE_URL=http://localhost:11434 curl -s -X POST http://localhost:8000/api/chat/1/complete -H "X-API-Key: $GUARDIAN_API_KEY" -H "content-type: application/json" -d '{}'`  
+- Automated:  
+  - `pytest -q tests/integration/test_rag_integration_loop.py::test_rag_integration_memory_loop`  
+  - `bash scripts/validate_core_loops.sh --dry-run` to verify selectors.
+
+## Core Feature 2: ChatGPT Migration (`migration`)
+**Current State:** Authenticated import route returns stats and writes messages/embeddings (guardian/routes/migration.py:30-52; backend/rag/chatgpt_migration.py:1020-1073). Tests cover canonical and legacy paths (tests/routes/test_migration_routes.py:76-207).
+
+**Core Loop Definition**
+1. User uploads ChatGPT export.
+2. Backend parses, creates threads/messages.
+3. Stats returned.
+4. Imported threads visible via `/api/chat/threads`.
+
+**Gap Analysis**
+| Loop step | Current implementation | Gap | Concrete fix (Finding) |
+| --- | --- | --- | --- |
+| 1-3 | Legacy rag_upload module exists | Unauth duplicate could be mounted accidentally | Remove/quarantine rag_upload.py (FINDING-2026-03-04-008). |
+
+**Implementation Tasks**
+1. Delete or quarantine `guardian/routes/rag_upload.py`; assert not included in router wiring.  
+
+**Validation Plan**
+- Manual: `curl -s -H "X-API-Key: $GUARDIAN_API_KEY" -F "file=@fixtures/chatgpt_export.json" http://localhost:8000/api/upload-chatgpt-export`  
+- Automated: `pytest -q tests/routes/test_migration_routes.py::test_migration_route_executes_real_ingest_and_embeds`
+
+## Core Feature 3: Document Upload (`doc-upload`)
+**Current State:** Media router requires API key; document upload persists asset and enqueues embed (guardian/routes/media.py:105-1773). Frontend uploader posts to backend and falls back to local preview if upload fails (frontend/src/hooks/useUploader.ts:330-520). Documents view seeds mock/cache before backend list (frontend/src/components/persona/layout/AppShell.tsx:557-724).
+
+**Core Loop Definition**
+1. User uploads a document.
+2. Backend stores asset + embedding task.
+3. List endpoint surfaces stored doc.
+4. UI renders backend documents list.
+
+**Gap Analysis**
+| Loop step | Current implementation | Gap | Concrete fix (Finding) |
+| --- | --- | --- | --- |
+| 2 | DB fallback is Postgres at db:5432 | Dev without DB fails silently | Require DATABASE_URL or add sqlite fallback for media routes (FINDING-2026-03-04-004). |
+| 2 | Embedding backend requires model | Upload fails if model missing | Ship local model or default mock fallback in dev profile (FINDING-2026-03-04-010). |
+| 4 | UI seeds mock/cache docs | Backend failures masked | Add “demo mode” toggle + error banner; disable mock docs in MVP validation (FINDING-2026-03-04-006). |
+
+**Implementation Tasks**
+1. Add explicit dev DATABASE_URL sample and health check for media DB.  
+2. Bundle a small local embedding model path or set CODEXIFY_ALLOW_EMBEDDINGS_FALLBACK=1 in dev harness.  
+3. Add UI flag `CFY_DEMO_DOCS` default false in MVP; surface backend fetch errors.  
+
+**Validation Plan**
+- Manual:  
+  - `GUARDIAN_API_KEY=test DATABASE_URL=sqlite:///./guardian_media.db curl -s -F "file=@README.md" -F "project_id=1" http://localhost:8000/api/media/upload/document`  
+  - `curl -s -H "X-API-Key: $GUARDIAN_API_KEY" "http://localhost:8000/api/media/documents?limit=10"`  
+- Automated:  
+  - `pytest -q tests/routes/test_media_routes.py::TestUploadDedupeAndResolve::test_upload_document_enqueues_embedding_with_asset_metadata`
+
+## Core Feature 4: Image Gallery (`image-gallery`)
+**Current State:** Backend list endpoints return uploaded/generated images (guardian/routes/media.py:1611-1702). Gallery view fetches `/api/media/images` but falls back to demo items on failure (frontend/src/components/gallery/GalleryView.tsx:70-182).
+
+**Core Loop Definition**
+1. User uploads or generates image.
+2. Backend stores and lists images.
+3. UI fetches list.
+4. UI renders backend-derived items.
+
+**Gap Analysis**
+| Loop step | Current implementation | Gap | Concrete fix (Finding) |
+| --- | --- | --- | --- |
+| 3-4 | Demo fallback on fetch failure | Backend not authoritative | Add explicit demo toggle; fail visibly when fetch fails (FINDING-2026-03-04-005). |
+
+**Implementation Tasks**
+1. Add `CFY_DEMO_GALLERY=false` default; show offline banner and empty-state when fetch fails.  
+2. Frontend test to assert backend images render when API is up and demo flag off.  
+
+**Validation Plan**
+- Manual: `curl -s -H "X-API-Key: $GUARDIAN_API_KEY" "http://localhost:8000/api/media/images?limit=10"`  
+- Automated: add Playwright/RTL test that stubs images API and asserts gallery shows backend data, not demo.
+
+## Core Feature 5: Image Generation (`image-gen`)
+**Current State:** Route saves generated bytes to storage and links GeneratedImage (guardian/routes/media.py:1223-1410). ImageGenRouter requires IMAGE_GEN_PROVIDER/MODEL; local provider raises 503 (guardian/image_gen/router.py:18-42; providers/local.py:17-22). Tests mock provider (tests/routes/test_media_routes.py:49-118).
+
+**Core Loop Definition**
+1. User submits prompt.
+2. Image is generated by provider.
+3. Asset persisted and listed.
+4. Gallery displays generated image.
+
+**Gap Analysis**
+| Loop step | Current implementation | Gap | Concrete fix (Finding) |
+| --- | --- | --- | --- |
+| 2 | Local provider unimplemented | Loop blocked offline | Implement local generator or ship documented OpenAI/Stability config (FINDING-2026-03-04-003). |
+| 2-3 | Cloud egress denied by default | 403 until allowlist set | Provide allowlist templates and env samples (FINDING-2026-03-04-002). |
+
+**Implementation Tasks**
+1. Add minimal local generator (e.g., placeholder PNG) for offline validation, gated by CODEXIFY_BETA_CORE_ONLY.  
+2. Provide `IMAGE_GEN_PROVIDER=openai` example with allowlist/env sample and add integration test that persists an asset when provider is available.  
+
+**Validation Plan**
+- Manual:  
+  - Local stub: `IMAGE_GEN_PROVIDER=local curl -s -X POST http://localhost:8000/api/media/generate/image -H "X-API-Key: $GUARDIAN_API_KEY" -H "content-type: application/json" -d '{"prompt":"smoke","project_id":1,"thread_id":1}'`  
+  - OpenAI path: set allowlist/env, repeat curl and verify listing shows new image.  
+- Automated: extend `tests/routes/test_media_routes.py::TestImageGeneration::test_generate_image_success` to run with real provider when configured.
+
+## Core Feature 6: Document Generation (`doc-gen`)
+**Current State:** `/api/documents/generate` persists GeneratedDocument + ThreadDocument link with API-key auth (guardian/routes/documents.py:253-393); tests cover persistence (guardian/tests/test_document_gen_persist_and_link.py:61-119). Uses chat_with_ai provider (guardian/core/ai_router.py:104-139).
+
+**Core Loop Definition**
+1. User requests generated doc.
+2. LLM produces content.
+3. Document stored and linked.
+4. UI lists generated doc.
+
+**Gap Analysis**
+| Loop step | Current implementation | Gap | Concrete fix (Finding) |
+| --- | --- | --- | --- |
+| 2 | Provider defaults to local; LOCAL_BASE_URL required | 400 by default | Add provider config sample and startup validation (FINDING-2026-03-04-001). |
+| 2 | Cloud providers 403 without allowlist | Cloud path blocked | Document allowlist + add cloud profile test (FINDING-2026-03-04-002). |
+
+**Implementation Tasks**
+1. Share chat/doc-gen provider bootstrap (LOCAL_BASE_URL or allowlisted cloud) in `.env.example`.  
+2. Add doc-gen cloud profile test that asserts 403->200 when allowlist/env provided.  
+
+**Validation Plan**
+- Manual: `LOCAL_BASE_URL=http://localhost:11434 GUARDIAN_API_KEY=test curl -s -X POST http://localhost:8000/api/documents/generate -H "X-API-Key: $GUARDIAN_API_KEY" -H "content-type: application/json" -d '{"thread_id":1,"prompt":"draft me a note"}'`  
+- Automated: `pytest -q guardian/tests/test_document_gen_persist_and_link.py::test_document_generate_persists_and_links`
+
+---
+
+## Milestones & Timeline (sequence)
+- **M0 – Config gate**: Enforce LOCAL_BASE_URL check, add dev DATABASE_URL sample, expose egress allowlist templates (Findings 001, 002, 004).  
+- **M1 – Deterministic dev profile**: Queue sync mode, embedding fallback/mock, demo flags default off in UI (Findings 006, 007, 010).  
+- **M2 – Migration hygiene**: Remove rag_upload; rerun migration tests and harness (Finding 008).  
+- **M3 – Media persistence**: Gallery/doc views honor backend as source of truth; error banners + tests (Findings 005, 006).  
+- **M4 – Image generation**: Ship local generator or documented cloud path; add integration test and harness step (Findings 003, 002).  
+- **M5 – End-to-end validation**: Run `scripts/validate_core_loops.sh` in both sync and queue modes; add CI target.
+
+## Risks / Assumptions / Dependencies
+- Redis + worker required for chat completions unless sync mode added (Finding 007).
+- LLM inference endpoint (local or cloud) must be reachable; otherwise chat/doc-gen fail (Finding 001/002).
+- Postgres service required for media/doc/image persistence unless sqlite fallback added (Finding 004).
+- Embedding model availability gates doc uploads; mock fallback acceptable for MVP (Finding 010).
+
+## Deferred Features (parking lot)
+- Rate limiting / SlowAPI integration.
+- Production media signing enforcement (Finding 009) once deployment topology is fixed.
+- Graph/Neo4j sync beyond current optional hook.

--- a/docs/tasks/TASK_2026_03_03_001_harden_obsidian_frontmatter.md
+++ b/docs/tasks/TASK_2026_03_03_001_harden_obsidian_frontmatter.md
@@ -1,0 +1,72 @@
+# TASK-2026-03-03-001: Harden Obsidian Frontmatter Parsing (Beta Core)
+
+## Metadata
+
+- Task-ID: TASK-2026-03-03-001
+- Campaign-ID: CAMPAIGN_BETA1_CORE_STABILITY
+- Branch: codex/explain-ingestobsidian-flag-error
+- Repo root: /Users/resonant_jones/Keep/Resonant_Constructs/Codexify
+- Owner: resonant_jones
+- Risk: LOW
+- Commit mode: two-phase
+
+## Objective
+
+Obsidian ingestion no longer fails on malformed or pseudo-frontmatter; malformed YAML is treated as plain content, ingest continues deterministically, and zero documents are dropped.
+
+## Status
+
+DONE
+
+## What Changed
+
+- Hardened frontmatter parsing in `guardian/cli/ingest_cli.py`.
+- Wrapped YAML parse in defensive `try/except`.
+- On parse failure, parser now returns:
+  - `frontmatter: {}`
+  - `content: <full original file text>`
+- Added deterministic warning logging once per affected file:
+  - `frontmatter_parse_failed:<file_path>`
+- Preserved ingest schema and vector store behavior.
+- No API surface changes.
+
+## Verification
+
+- Direct ingest run used real vault path:
+  - `/Users/resonant_jones/Library/Mobile Documents/iCloud~md~obsidian/Documents/Axis_Node`
+- Command:
+  - `python -m guardian.cli.ingest_cli ingest-obsidian "$OBSIDIAN_DIR"`
+- Result:
+  - `{"ingested": 471, "dir": "/Users/resonant_jones/Library/Mobile Documents/iCloud~md~obsidian/Documents/Axis_Node"}`
+- Exit code:
+  - `0`
+- Expected warning logs observed for malformed frontmatter files.
+- No YAML traceback occurred.
+
+## Commands Run
+
+```bash
+cd /Users/resonant_jones/Keep/Resonant_Constructs/Codexify
+git status --porcelain -uall
+python -m compileall guardian/cli/ingest_cli.py
+source .venv/bin/activate
+export LOCAL_EMBED_MODEL="/Users/resonant_jones/Keep/Resonant_Constructs/Codexify/models/bge-large-en-v1.5"
+export CODEXIFY_EMBEDDINGS_BACKEND=local
+export OBSIDIAN_DIR="/Users/resonant_jones/Library/Mobile Documents/iCloud~md~obsidian/Documents/Axis_Node"
+python -m guardian.cli.ingest_cli ingest-obsidian "$OBSIDIAN_DIR"
+```
+
+## Scope Check
+
+- git status clean before start: yes
+- only allowed files modified: yes
+
+## Commit Info
+
+- Commit mode: two-phase
+- Commit A hash: `b0ffe43c`
+- Commit B hash: recorded in campaign mapping update commit
+
+## Notes
+
+- `guardian/ingestion` path does not exist in this repository; implementation was applied in `guardian/cli/ingest_cli.py`.

--- a/frontend/src/components/ProviderSelect.tsx
+++ b/frontend/src/components/ProviderSelect.tsx
@@ -346,7 +346,7 @@ export function ProviderSelect({
             {providers.map((entry) => (
               <DropdownMenuItem
                 key={entry.id}
-                onSelect={(event) => {
+                onClick={(event) => {
                   event.preventDefault();
                   setActiveProviderId(entry.id);
                 }}

--- a/frontend/src/components/chat/Composer.tsx
+++ b/frontend/src/components/chat/Composer.tsx
@@ -26,7 +26,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import { Send, Sparkles, ImagePlus, Paperclip, X, FileText } from "lucide-react";
+import { Send, Sparkles, ImagePlus, Paperclip, Plus, X, FileText } from "lucide-react";
 import { ModelProvider } from "@/Providers/ModelProvider";
 import api from "@/lib/api";
 
@@ -145,6 +145,9 @@ export function Composer({
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [uploading, setUploading] = useState(false);
 
+  const [addMenuOpen, setAddMenuOpen] = useState(false);
+  const addMenuRef = useRef<HTMLDivElement | null>(null);
+
   type DraftAttachment = {
     id: string;
     file: File;
@@ -226,6 +229,28 @@ export function Composer({
   useEffect(() => {
     autoResize();
   }, [value, autoResize]);
+
+  useEffect(() => {
+    if (!addMenuOpen) return;
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") setAddMenuOpen(false);
+    }
+
+    function onMouseDown(e: MouseEvent) {
+      const el = addMenuRef.current;
+      if (!el) return;
+      if (e.target instanceof Node && el.contains(e.target)) return;
+      setAddMenuOpen(false);
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("mousedown", onMouseDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("mousedown", onMouseDown);
+    };
+  }, [addMenuOpen]);
 
   function stageFiles(files: FileList | File[]) {
     const arr = Array.from(files || []);
@@ -342,6 +367,7 @@ export function Composer({
   // Send handler: uploads attachments (if any) and sends message.
   async function send() {
     if (sending || uploading) return;
+    if (addMenuOpen) setAddMenuOpen(false);
 
     const bodyText = value.trim();
     const hasAttachments = draftAttachments.length > 0;
@@ -492,7 +518,7 @@ export function Composer({
           ref={fileInputRef}
           type="file"
           // Allow docs too; backend route is /api/media/upload/file
-          accept="image/*,application/pdf,text/plain,text/markdown,.md,.txt"
+          accept="application/pdf,text/plain,text/markdown,.md,.txt"
           multiple
           style={{ display: "none" }}
           onChange={(e) => {
@@ -502,51 +528,86 @@ export function Composer({
           }}
         />
 
-        {/* Attach Image */}
-        <Button
-          type="button"
-          size="icon"
-          aria-label="Attach image"
-          title="Attach image"
-          onClick={onPickImageClick}
-          disabled={sending || uploading}
-          className="relative grid h-11 w-11 place-items-center rounded-2xl border focus:outline-none m-0"
-          style={{
-            background:
-              "radial-gradient(120% 120% at 30% 12%, rgba(255,255,255,0.95) 0%, rgba(255,255,255,0.38) 10%, rgba(255,255,255,0.0) 36%), " +
-              `linear-gradient(180deg, ${accentStrong} 0%, color-mix(in srgb, ${accentStrong} 85%, black 15%) 100%)`,
-            color: "#fff",
-            borderColor: "color-mix(in srgb, var(--accent-strong) 70%, white 30%)",
-            boxShadow:
-              "inset 0 1px rgba(255,255,255,0.35), inset 0 -8px 12px rgba(0,0,0,0.28), 0 8px 18px color-mix(in srgb, var(--accent-strong) 55%, black 45%)",
-            outlineColor: "var(--accent-weak)",
-          }}
-        >
-          <ImagePlus className="h-5 w-5" />
-        </Button>
+        {/* Add menu (attachments + creation) */}
+        <div className="relative" ref={addMenuRef}>
+          <Button
+            type="button"
+            size="icon"
+            aria-label="Add"
+            title="Add"
+            onClick={() => setAddMenuOpen((v) => !v)}
+            disabled={sending || uploading}
+            className="relative grid h-11 w-11 place-items-center rounded-2xl border focus:outline-none m-0"
+            style={{
+              background:
+                "radial-gradient(120% 120% at 30% 12%, rgba(255,255,255,0.95) 0%, rgba(255,255,255,0.38) 10%, rgba(255,255,255,0.0) 36%), " +
+                `linear-gradient(180deg, ${accentStrong} 0%, color-mix(in srgb, ${accentStrong} 85%, black 15%) 100%)`,
+              color: "#fff",
+              borderColor: "color-mix(in srgb, var(--accent-strong) 70%, white 30%)",
+              boxShadow:
+                "inset 0 1px rgba(255,255,255,0.35), inset 0 -8px 12px rgba(0,0,0,0.28), 0 8px 18px color-mix(in srgb, var(--accent-strong) 55%, black 45%)",
+              outlineColor: "var(--accent-weak)",
+            }}
+          >
+            <Plus className="h-5 w-5" />
+          </Button>
 
-        {/* Attach File */}
-        <Button
-          type="button"
-          size="icon"
-          aria-label="Attach file"
-          title="Attach file"
-          onClick={onPickFileClick}
-          disabled={sending || uploading}
-          className="relative grid h-11 w-11 place-items-center rounded-2xl border focus:outline-none m-0"
-          style={{
-            background:
-              "radial-gradient(120% 120% at 30% 12%, rgba(255,255,255,0.95) 0%, rgba(255,255,255,0.38) 10%, rgba(255,255,255,0.0) 36%), " +
-              `linear-gradient(180deg, ${accentStrong} 0%, color-mix(in srgb, ${accentStrong} 85%, black 15%) 100%)`,
-            color: "#fff",
-            borderColor: "color-mix(in srgb, var(--accent-strong) 70%, white 30%)",
-            boxShadow:
-              "inset 0 1px rgba(255,255,255,0.35), inset 0 -8px 12px rgba(0,0,0,0.28), 0 8px 18px color-mix(in srgb, var(--accent-strong) 55%, black 45%)",
-            outlineColor: "var(--accent-weak)",
-          }}
-        >
-          <Paperclip className="h-5 w-5" />
-        </Button>
+          {addMenuOpen && (
+            <div
+              role="menu"
+              aria-label="Add menu"
+              className="absolute bottom-14 left-0 z-50 min-w-[220px] overflow-hidden rounded-xl border border-black/10 dark:border-white/10 bg-white/95 dark:bg-black/80 shadow-2xl"
+              style={{ backdropFilter: "blur(10px)" }}
+            >
+              <div className="px-3 py-2 text-[11px] uppercase tracking-wide opacity-70">Attach</div>
+
+              <button
+                type="button"
+                role="menuitem"
+                className="w-full px-3 py-2 text-left text-sm hover:bg-black/5 dark:hover:bg-white/10 flex items-center gap-2"
+                onClick={() => {
+                  setAddMenuOpen(false);
+                  onPickImageClick();
+                }}
+              >
+                <ImagePlus className="h-4 w-4" />
+                <span>Attach image</span>
+              </button>
+
+              <button
+                type="button"
+                role="menuitem"
+                className="w-full px-3 py-2 text-left text-sm hover:bg-black/5 dark:hover:bg-white/10 flex items-center gap-2"
+                onClick={() => {
+                  setAddMenuOpen(false);
+                  onPickFileClick();
+                }}
+              >
+                <Paperclip className="h-4 w-4" />
+                <span>Attach file</span>
+              </button>
+
+              <div className="my-1 h-px bg-black/10 dark:bg-white/10" />
+              <div className="px-3 py-2 text-[11px] uppercase tracking-wide opacity-70">Create</div>
+
+              <button
+                type="button"
+                role="menuitem"
+                className="w-full px-3 py-2 text-left text-sm hover:bg-black/5 dark:hover:bg-white/10 flex items-center gap-2"
+                onClick={() => {
+                  setAddMenuOpen(false);
+                  // If an ImageGen surface exists elsewhere, it should listen for this event.
+                  window.dispatchEvent(
+                    new CustomEvent("cfy:imagegen:open", { detail: { source: "composer" } })
+                  );
+                }}
+              >
+                <Sparkles className="h-4 w-4" />
+                <span>Generate image</span>
+              </button>
+            </div>
+          )}
+        </div>
 
       {/* Open Prompt Library Button: visually prominent, similar styling to Send button */}
         <Button

--- a/frontend/src/components/modals/ImageGenModal.tsx
+++ b/frontend/src/components/modals/ImageGenModal.tsx
@@ -2,22 +2,54 @@
  * ImageGenModal – Universal image generation modal (PCX_UI_QUIKWINS_002)
  *
  * Single source of truth for image generation across Chat, Gallery, and Dashboard.
- * Uses the backend's configurable provider system (Ollama, DALL-E, Stability, Replicate).
  */
 
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import api from "@/lib/api";
 
-const DEFAULT_MODELS = ["dall-e-3", "dall-e-2", "sdxl"];
 const PROJECT_ID_STORAGE_KEYS = [
   "cfy.projectId",
   "cfy.activeProjectId",
   "cfy.lastProjectId",
   "projectId",
 ] as const;
+
+const PROVIDER_STORAGE_KEY = "cfy.imagegen.provider";
+const MODEL_STORAGE_KEY = "cfy.imagegen.model";
+
+type ImageGenProvider = "nano_banana" | "dalle";
+
+const PROVIDER_CONFIG: Record<
+  ImageGenProvider,
+  {
+    label: string;
+    models: string[];
+    defaultModel: string;
+    missingEnv: string;
+  }
+> = {
+  nano_banana: {
+    label: "Nano Banana",
+    models: ["nano-banana"],
+    defaultModel: "nano-banana",
+    missingEnv: "NANO_BANANA_API_KEY",
+  },
+  dalle: {
+    label: "DALL·E",
+    models: ["dall-e-3"],
+    defaultModel: "dall-e-3",
+    missingEnv: "OPENAI_API_KEY",
+  },
+};
+
+const DEFAULT_PROVIDER: ImageGenProvider = "dalle";
+
+const IMAGEGEN_ENDPOINTS = {
+  nano_banana: "/api/media/generate/image",
+  dalle: "/api/media/generate/image",
+} as const;
 
 function parseScopeId(value: unknown): number | null {
   if (value == null) return null;
@@ -50,6 +82,84 @@ function inferProjectIdFromStorage(): number | null {
   return null;
 }
 
+function isValidProvider(value: unknown): value is ImageGenProvider {
+  return value === "nano_banana" || value === "dalle";
+}
+
+function readStoredProvider(): ImageGenProvider {
+  if (typeof window === "undefined") return DEFAULT_PROVIDER;
+  const raw = window.localStorage.getItem(PROVIDER_STORAGE_KEY);
+  if (isValidProvider(raw)) return raw;
+  return DEFAULT_PROVIDER;
+}
+
+function readStoredModel(provider: ImageGenProvider): string {
+  if (typeof window === "undefined") return PROVIDER_CONFIG[provider].defaultModel;
+  const raw = (window.localStorage.getItem(MODEL_STORAGE_KEY) || "").trim();
+  if (!raw) return PROVIDER_CONFIG[provider].defaultModel;
+  if (!PROVIDER_CONFIG[provider].models.includes(raw)) {
+    return PROVIDER_CONFIG[provider].defaultModel;
+  }
+  return raw;
+}
+
+function toImageSrc(data: any): string | null {
+  const directCandidates = [
+    data?.src_url,
+    data?.image_url,
+    data?.url,
+    data?.output_url,
+    data?.result?.src_url,
+    data?.result?.image_url,
+    data?.result?.url,
+  ];
+
+  for (const candidate of directCandidates) {
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+
+  const base64Candidates = [
+    data?.b64_json,
+    data?.image_base64,
+    data?.base64,
+    data?.result?.b64_json,
+    data?.result?.image_base64,
+    Array.isArray(data?.data) ? data.data[0]?.b64_json : undefined,
+  ];
+
+  const mimeType =
+    (typeof data?.mime_type === "string" && data.mime_type) ||
+    (typeof data?.content_type === "string" && data.content_type) ||
+    "image/png";
+
+  for (const candidate of base64Candidates) {
+    if (typeof candidate === "string" && candidate.trim()) {
+      const raw = candidate.trim();
+      if (raw.startsWith("data:")) return raw;
+      return `data:${mimeType};base64,${raw}`;
+    }
+  }
+
+  return null;
+}
+
+function isMissingKeyFailure(provider: ImageGenProvider, err: any): boolean {
+  const status = Number(err?.response?.status || 0);
+  const detail = String(err?.response?.data?.detail || err?.message || "").toLowerCase();
+
+  if (status === 401 || status === 403) return true;
+  if (detail.includes("api key") || detail.includes("not configured") || detail.includes("missing")) {
+    return true;
+  }
+
+  if (provider === "dalle" && detail.includes("openai_api_key")) return true;
+  if (provider === "nano_banana" && detail.includes("nano_banana_api_key")) return true;
+
+  return false;
+}
+
 interface ImageGenModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -69,37 +179,52 @@ export function ImageGenModal({
   userId,
 }: ImageGenModalProps) {
   const [prompt, setPrompt] = useState("");
+  const [provider, setProvider] = useState<ImageGenProvider>(() => readStoredProvider());
   const [model, setModel] = useState(() => {
-    if (typeof window === "undefined") return DEFAULT_MODELS[0];
-    const configured = (window as any).__imageGenModel;
-    if (typeof configured === "string" && configured.trim()) {
-      return configured.trim();
-    }
-    return DEFAULT_MODELS[0];
+    const initialProvider = readStoredProvider();
+    return readStoredModel(initialProvider);
   });
-  const modelOptions = useMemo(() => {
-    if (typeof window === "undefined") return DEFAULT_MODELS;
-    const provided = (window as any).__imageGenModels;
-    if (!Array.isArray(provided)) return DEFAULT_MODELS;
-    const cleaned = provided
-      .map((item) => (typeof item === "string" ? item.trim() : ""))
-      .filter((item) => item);
-    return cleaned.length ? Array.from(new Set(cleaned)) : DEFAULT_MODELS;
-  }, []);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const modelOptions = useMemo(() => PROVIDER_CONFIG[provider].models, [provider]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(PROVIDER_STORAGE_KEY, provider);
+    } catch {
+      // ignore storage errors
+    }
+  }, [provider]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(MODEL_STORAGE_KEY, model);
+    } catch {
+      // ignore storage errors
+    }
+  }, [model]);
+
+  useEffect(() => {
+    const onOpen = () => onOpenChange(true);
+    window.addEventListener("cfy:imagegen:open", onOpen as EventListener);
+    return () => {
+      window.removeEventListener("cfy:imagegen:open", onOpen as EventListener);
+    };
+  }, [onOpenChange]);
+
   const resolveScope = useCallback(() => {
     const resolvedProjectId =
-      parseScopeId(projectId)
-      ?? inferProjectIdFromStorage()
-      ?? inferProjectIdFromPathname()
-      ?? 1;
-    const resolvedThreadId =
-      parseScopeId(threadId)
-      ?? inferThreadIdFromPathname()
-      ?? 1;
+      parseScopeId(projectId) ?? inferProjectIdFromStorage() ?? inferProjectIdFromPathname() ?? 1;
+    const resolvedThreadId = parseScopeId(threadId) ?? inferThreadIdFromPathname() ?? 1;
     return { resolvedProjectId, resolvedThreadId };
   }, [projectId, threadId]);
+
+  const handleProviderChange = (nextProvider: ImageGenProvider) => {
+    setProvider(nextProvider);
+    setModel(PROVIDER_CONFIG[nextProvider].defaultModel);
+    setError(null);
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -109,6 +234,7 @@ export function ImageGenModal({
       setError("Please enter a prompt");
       return;
     }
+
     const trimmedModel = model.trim();
     if (!trimmedModel) {
       setError("Please select a model");
@@ -120,7 +246,8 @@ export function ImageGenModal({
 
     try {
       const { resolvedProjectId, resolvedThreadId } = resolveScope();
-      const response = await api.post("/api/media/generate/image", {
+      const endpoint = IMAGEGEN_ENDPOINTS[provider];
+      const response = await api.post(endpoint, {
         prompt: trimmed,
         model: trimmedModel,
         project_id: resolvedProjectId,
@@ -128,43 +255,60 @@ export function ImageGenModal({
         user_id: userId ?? "default",
       });
 
-      const imageUrl = response.data?.src_url;
-      if (imageUrl) {
-        // Notify parent if callback provided
-        onImageGenerated?.(imageUrl);
-
-        // Broadcast success for gallery refresh
-        try {
-          window.dispatchEvent(new CustomEvent("cfy:gallery:add", {
-            detail: {
-              items: [{
-                src: imageUrl,
-                prompt: trimmed,
-                project_id: resolvedProjectId,
-                thread_id: resolvedThreadId,
-                mock: false,
-                tag: "generated",
-              }],
-            },
-          }));
-        } catch {}
-
-        // Show success toast
-        try {
-          window.dispatchEvent(new CustomEvent("cfy:toast", {
-            detail: { message: "Image generated successfully!", duration: 3000 }
-          }));
-        } catch {}
-
-        // Reset and close
-        setPrompt("");
-        onOpenChange(false);
-      } else {
-        setError("No image URL returned from server");
+      const imageSrc = toImageSrc(response.data);
+      if (!imageSrc) {
+        setError("No image payload returned from server");
+        return;
       }
+
+      // Notify parent if callback provided.
+      onImageGenerated?.(imageSrc);
+
+      // Broadcast success for gallery refresh.
+      try {
+        window.dispatchEvent(
+          new CustomEvent("cfy:gallery:add", {
+            detail: {
+              items: [
+                {
+                  src: imageSrc,
+                  prompt: trimmed,
+                  project_id: resolvedProjectId,
+                  thread_id: resolvedThreadId,
+                  mock: false,
+                  tag: "generated",
+                },
+              ],
+            },
+          })
+        );
+      } catch {
+        // no-op
+      }
+
+      // Show success toast.
+      try {
+        window.dispatchEvent(
+          new CustomEvent("cfy:toast", {
+            detail: { message: "Image generated successfully!", duration: 3000 },
+          })
+        );
+      } catch {
+        // no-op
+      }
+
+      // Reset and close.
+      setPrompt("");
+      onOpenChange(false);
     } catch (err: any) {
-      const message = err?.response?.data?.detail || err?.message || "Failed to generate image";
-      setError(message);
+      if (isMissingKeyFailure(provider, err)) {
+        setError(
+          `API key missing for ${PROVIDER_CONFIG[provider].label}. Add ${PROVIDER_CONFIG[provider].missingEnv} to .env and restart backend.`
+        );
+      } else {
+        const message = err?.response?.data?.detail || err?.message || "Failed to generate image";
+        setError(message);
+      }
     } finally {
       setGenerating(false);
     }
@@ -183,18 +327,65 @@ export function ImageGenModal({
       {/* Modal */}
       <form
         onSubmit={handleSubmit}
-        className="relative z-[1201] w-[min(540px,90vw)] rounded-2xl border p-6 flex flex-col gap-4 shadow-xl"
+        className="relative z-[1201] w-[min(560px,92vw)] rounded-2xl border p-6 flex flex-col gap-4 shadow-xl"
         style={{
           background: "var(--panel-bg)",
           borderColor: "var(--panel-border)",
-          color: "var(--text)"
+          color: "var(--text)",
         }}
       >
         <div>
           <h2 className="text-lg font-semibold">Generate Image</h2>
           <p className="text-sm mt-1 opacity-70" style={{ color: "var(--muted)" }}>
-            Describe the image you want to create. Your configured provider will be used.
+            Choose a provider and model, then describe the image you want.
           </p>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="imageProvider">
+              Provider
+            </label>
+            <select
+              id="imageProvider"
+              value={provider}
+              onChange={(e) => handleProviderChange(e.target.value as ImageGenProvider)}
+              className="w-full rounded-[var(--tile-radius)] border px-3 py-2 text-sm"
+              style={{
+                background: "transparent",
+                borderColor: "var(--panel-border)",
+                color: "var(--text)",
+              }}
+              disabled={generating}
+            >
+              <option value="nano_banana">Nano Banana</option>
+              <option value="dalle">DALL·E</option>
+            </select>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="imageModel">
+              Model
+            </label>
+            <select
+              id="imageModel"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              className="w-full rounded-[var(--tile-radius)] border px-3 py-2 text-sm"
+              style={{
+                background: "transparent",
+                borderColor: "var(--panel-border)",
+                color: "var(--text)",
+              }}
+              disabled={generating}
+            >
+              {modelOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
 
         <div className="space-y-3">
@@ -205,53 +396,24 @@ export function ImageGenModal({
             id="imagePrompt"
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
-            placeholder="e.g., A sunset over mountains, digital art style, vibrant colors"
+            placeholder="e.g., A cinematic sunset over neon-lit mountains"
             rows={4}
             className="w-full rounded-xl"
-            style={{
-              background: "transparent",
-              borderColor: "var(--panel-border)",
-              color: "var(--text)"
-            }}
-            disabled={generating}
-            autoFocus
-          />
-          <div className="text-xs opacity-60">
-            Provider: {(window as any).__imageGenProvider || "Auto (from config)"}
-          </div>
-        </div>
-        <div className="space-y-2">
-          <label className="text-sm font-medium" htmlFor="imageModel">
-            Model
-          </label>
-          <Input
-            id="imageModel"
-            list="imageModelOptions"
-            value={model}
-            onChange={(e) => setModel(e.target.value)}
-            placeholder={DEFAULT_MODELS[0]}
-            className="rounded-[var(--tile-radius)]"
             style={{
               background: "transparent",
               borderColor: "var(--panel-border)",
               color: "var(--text)",
             }}
             disabled={generating}
+            autoFocus
           />
-          <datalist id="imageModelOptions">
-            {modelOptions.map((option) => (
-              <option key={option} value={option} />
-            ))}
-          </datalist>
           <div className="text-xs opacity-60">
-            Defaults to {DEFAULT_MODELS[0]} unless configured.
+            Using endpoint: <code>{IMAGEGEN_ENDPOINTS[provider]}</code>
           </div>
         </div>
 
         {error && (
-          <div className="text-sm font-medium text-red-400 bg-red-400/10 rounded-lg px-3 py-2">
-            {error}
-          </div>
+          <div className="text-sm font-medium text-red-400 bg-red-400/10 rounded-lg px-3 py-2">{error}</div>
         )}
 
         <div className="flex justify-end gap-3 pt-2">

--- a/frontend/src/components/persona/layout/GuardianChatWithSidebar.tsx
+++ b/frontend/src/components/persona/layout/GuardianChatWithSidebar.tsx
@@ -852,12 +852,35 @@ export default function GuardianChatWithSidebar({ guardianName, userName, prefil
       );
     } catch (err) {
       console.warn("[guardian] failed to persist user message", err);
-      // Surface per-thread turn lock errors as a friendly retry prompt.
       const status = (err as any)?.response?.status;
-      const errorCode = (err as any)?.response?.data?.error;
-      const message =
-        status === 429 || errorCode === "turn_in_flight"
-          ? "One moment—finish the current reply first."
+      const payload = (err as any)?.response?.data ?? {};
+      const errorCode = String(payload?.error ?? payload?.code ?? "")
+        .trim()
+        .toLowerCase();
+      const detail = String(payload?.detail ?? payload?.message ?? "")
+        .trim()
+        .toLowerCase();
+      const retryAfterRaw = Number(
+        payload?.retry_after
+          ?? (err as any)?.response?.headers?.["retry-after"]
+          ?? 0
+      );
+      const retryAfterSeconds = Number.isFinite(retryAfterRaw)
+        ? Math.max(0, Math.ceil(retryAfterRaw))
+        : 0;
+
+      // Surface per-thread turn lock errors as a friendly retry prompt.
+      const isTurnInFlight =
+        errorCode === "turn_in_flight"
+        || detail.includes("turn_in_flight")
+        || detail.includes("assistant is responding");
+
+      const message = isTurnInFlight
+        ? "One moment—finish the current reply first."
+        : status === 429
+          ? retryAfterSeconds > 0
+            ? `Too many requests right now. Try again in ${retryAfterSeconds}s.`
+            : "Too many requests right now. Please wait a moment and retry."
           : "Failed to send message.";
       throw new Error(message);
     }

--- a/frontend/src/components/persona/layout/GuardianChatWithSidebar.tsx
+++ b/frontend/src/components/persona/layout/GuardianChatWithSidebar.tsx
@@ -576,14 +576,18 @@ export default function GuardianChatWithSidebar({ guardianName, userName, prefil
       threadsRef.current = merged;
       setThreads(merged);
 
-      const fetchedCount = visible.length;
-      const addedCount = merged.length - existingThreads.length;
+      const rawCount = rawList.length;
+      const nextOffsetFromBackend = Number(data?.next_offset);
+      const computedNextOffset =
+        Number.isFinite(nextOffsetFromBackend) && nextOffsetFromBackend > offset
+          ? nextOffsetFromBackend
+          : offset + rawCount;
       const backendHasMore =
         typeof data?.has_more === "boolean"
           ? data.has_more
-          : fetchedCount >= THREAD_PAGE_SIZE;
-      const hasMore = backendHasMore && (reset || addedCount > 0);
-      paginationRef.current.offset = offset + fetchedCount;
+          : rawCount >= THREAD_PAGE_SIZE;
+      const hasMore = rawCount > 0 && backendHasMore;
+      paginationRef.current.offset = computedNextOffset;
       paginationRef.current.hasMore = hasMore;
       setThreadsHasMore(hasMore);
     } catch (err) {

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -3,7 +3,9 @@ import * as React from "react";
 type Ctx = {
   open: boolean;
   setOpen: (v: boolean) => void;
+  rootRef: React.RefObject<HTMLDivElement | null>;
 };
+
 const DropdownCtx = React.createContext<Ctx | null>(null);
 
 type DropdownMenuProps = {
@@ -12,69 +14,150 @@ type DropdownMenuProps = {
   onOpenChange?: (open: boolean) => void;
 };
 
-export const DropdownMenu = ({ children, open: controlledOpen, onOpenChange }: DropdownMenuProps) => {
+export const DropdownMenu = ({
+  children,
+  open: controlledOpen,
+  onOpenChange,
+}: DropdownMenuProps) => {
   const [uncontrolledOpen, setUncontrolledOpen] = React.useState(false);
+  const rootRef = React.useRef<HTMLDivElement | null>(null);
+
   const isControlled = controlledOpen !== undefined;
   const open = isControlled ? controlledOpen : uncontrolledOpen;
+
   const setOpen = (value: boolean) => {
     if (isControlled) {
       onOpenChange?.(value);
-    } else {
-      setUncontrolledOpen(value);
+      return;
     }
+    setUncontrolledOpen(value);
   };
+
   return (
-    <DropdownCtx.Provider value={{ open, setOpen }}>
-      <div className="relative inline-block">{children}</div>
+    <DropdownCtx.Provider value={{ open, setOpen, rootRef }}>
+      <div ref={rootRef} data-ddm-root className="relative inline-block">
+        {children}
+      </div>
     </DropdownCtx.Provider>
   );
+};
+
+type TriggerProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
 };
 
 export const DropdownMenuTrigger = ({
   asChild,
   children,
+  onClick,
+  onKeyDown,
   ...props
-}: React.HTMLAttributes<HTMLButtonElement> & { asChild?: boolean }) => {
+}: TriggerProps) => {
   const ctx = React.useContext(DropdownCtx)!;
+  const toggle = () => ctx.setOpen(!ctx.open);
+
   if (asChild && React.isValidElement(children)) {
-    return React.cloneElement(children as any, {
-      onClick: (e: any) => {
-        (children as any).props?.onClick?.(e);
-        ctx.setOpen(!ctx.open);
-      },
+    const child = children as React.ReactElement<{
+      onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+      type?: string;
+    }>;
+    const childOnClick = child.props?.onClick;
+
+    return React.cloneElement(child, {
       ...props,
+      onClick: (event: React.MouseEvent<HTMLElement>) => {
+        childOnClick?.(event);
+        onClick?.(event as unknown as React.MouseEvent<HTMLButtonElement>);
+        if (event.defaultPrevented) return;
+        toggle();
+      },
+      type: child.props.type ?? "button",
     });
   }
+
   return (
-    <button onClick={() => ctx.setOpen(!ctx.open)} {...props}>
+    <button
+      type="button"
+      onClick={(event) => {
+        onClick?.(event);
+        if (event.defaultPrevented) return;
+        toggle();
+      }}
+      onKeyDown={(event) => {
+        onKeyDown?.(event);
+        if (event.defaultPrevented) return;
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          toggle();
+        }
+      }}
+      {...props}
+    >
       {children}
     </button>
   );
 };
 
+type DropdownMenuContentProps = React.HTMLAttributes<HTMLDivElement> & {
+  align?: "start" | "end";
+  side?: "top" | "bottom";
+  sideOffset?: number;
+  collisionPadding?: number;
+};
+
 export const DropdownMenuContent = ({
   children,
+  side = "bottom",
+  sideOffset = 8,
+  collisionPadding = 0,
   align,
   className,
+  style,
   ...props
-}: React.HTMLAttributes<HTMLDivElement> & { align?: "start" | "end" }) => {
+}: DropdownMenuContentProps) => {
   const ctx = React.useContext(DropdownCtx)!;
+
   React.useEffect(() => {
-    const onDoc = (e: MouseEvent) => {
-      if (!(e.target as HTMLElement)?.closest("[data-ddm-root]")) ctx.setOpen(false);
+    const onDoc = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (!target) return;
+      const root = ctx.rootRef.current;
+      if (!root) return;
+      if (!root.contains(target)) {
+        ctx.setOpen(false);
+      }
     };
-    document.addEventListener("click", onDoc);
-    return () => document.removeEventListener("click", onDoc);
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
   }, [ctx]);
+
   if (!ctx.open) return null;
+
+  const resolvedOffset = Number.isFinite(Number(sideOffset))
+    ? Math.max(0, Number(sideOffset))
+    : 8;
+  const resolvedCollisionPadding = Number.isFinite(Number(collisionPadding))
+    ? Math.max(0, Number(collisionPadding))
+    : 0;
+
+  const placementStyle: React.CSSProperties = {
+    ...(side === "top"
+      ? { bottom: `calc(100% + ${resolvedOffset}px)` }
+      : { top: `calc(100% + ${resolvedOffset}px)` }),
+    ...(align === "end"
+      ? { right: `${resolvedCollisionPadding}px` }
+      : { left: `${resolvedCollisionPadding}px` }),
+    ...style,
+  };
+
   return (
     <div
       data-ddm-root
       className={
-        "absolute z-50 mt-2 min-w-40 rounded-md border bg-[var(--panel-bg)] p-1 shadow-lg " +
-        (align === "end" ? "right-0" : "left-0") +
+        "absolute z-50 min-w-40 rounded-md border bg-[var(--panel-bg)] p-1 shadow-lg " +
         (className ? " " + className : "")
       }
+      style={placementStyle}
       {...props}
     >
       {children}

--- a/frontend/src/features/chat/ChatView.tsx
+++ b/frontend/src/features/chat/ChatView.tsx
@@ -27,6 +27,7 @@ type PollSession = {
   tid: number;
   reason: string;
   key: string;
+  turnId: string | null;
   startedAt: number;
   lastUserMessageId: number;
   initialAssistantId: number;
@@ -40,10 +41,46 @@ const MESSAGE_POLL_MIN_MS = 1500;
 const MESSAGE_POLL_MAX_MS = 5000;
 const POLL_TIMEOUT_MS = 300_000; // 5 minutes slow-path ceiling
 const COMPLETION_SETTLE_MS = 150;
+const UUID_V4ISH_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function parseMessageId(raw: any): number {
   const value = Number(raw?.id ?? raw?.message_id ?? raw?.messageId);
   return Number.isFinite(value) ? value : 0;
+}
+
+function normalizeTurnId(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  return UUID_V4ISH_RE.test(trimmed) ? trimmed.toLowerCase() : null;
+}
+
+function readMessageTurnId(raw: any): string | null {
+  const direct = normalizeTurnId(raw?.turn_id ?? raw?.turnId);
+  if (direct) return direct;
+
+  const metadataCandidate = raw?.metadata ?? raw?.extra_meta ?? raw?.extraMeta;
+  if (metadataCandidate && typeof metadataCandidate === "object") {
+    const nested = metadataCandidate as Record<string, unknown>;
+    return normalizeTurnId(nested.turn_id ?? nested.turnId);
+  }
+  return null;
+}
+
+function getTrackedTurnId(threadId: number | null | undefined): string | null {
+  const getter = (api as any)?.getInFlightCompletionTurnId;
+  if (typeof getter !== "function") return null;
+  return getter(threadId);
+}
+
+function clearTrackedTurnId(
+  threadId: number | null | undefined,
+  expectedTurnId?: string | null
+): void {
+  const clearer = (api as any)?.clearInFlightCompletionTurnId;
+  if (typeof clearer !== "function") return;
+  clearer(threadId, expectedTurnId);
 }
 
 function getLastUserMessageId(messages: Array<{ id: unknown; role?: string }>): number {
@@ -137,6 +174,7 @@ export function ChatView({
   const [voiceUnavailableMessageIds, setVoiceUnavailableMessageIds] = useState<
     Record<number, true>
   >({});
+  const [activeTurnId, setActiveTurnId] = useState<string | null>(null);
   const [voiceRouteMissing, setVoiceRouteMissing] = useState(false);
   const lastAutoReadMessageIdRef = useRef<number | null>(null);
   const autoReadPrimedRef = useRef(false);
@@ -159,6 +197,7 @@ export function ChatView({
   const messagesRef = useRef(messages);
   const completionFinalizeTimerRef = useRef<number | null>(null);
   const inFlightCompletionByThreadRef = useRef<Map<number, string>>(new Map());
+  const activeTurnIdRef = useRef<string | null>(null);
   const completionFinalizePendingRef = useRef<Set<number>>(new Set());
   const liveSubscriptionCleanupRef = useRef<(() => void) | null>(null);
   const voiceUnavailableMessageIdsRef = useRef<Record<number, true>>({});
@@ -247,6 +286,7 @@ export function ChatView({
       const normalizedUserId = Number.isFinite(lastUserMessageId)
         ? Math.max(0, lastUserMessageId)
         : 0;
+      const turnId = activeTurnIdRef.current;
       const key = buildPollKey(tid, normalizedUserId);
       if (activePollKeyRef.current === key) {
         debugLog(
@@ -265,6 +305,7 @@ export function ChatView({
         tid,
         reason,
         key,
+        turnId,
         startedAt: Date.now(),
         lastUserMessageId: normalizedUserId,
         initialAssistantId: lastAssistantIdRef.current,
@@ -313,6 +354,8 @@ export function ChatView({
 
       let maxId = lastMessageIdRef.current;
       let maxAssistantId = session.initialAssistantId;
+      const expectedTurnId = session.turnId ?? activeTurnIdRef.current;
+      let matchingTurnAssistantId = 0;
       const newMessages: any[] = [];
 
       for (const msg of page) {
@@ -323,6 +366,15 @@ export function ChatView({
         }
         if (msg?.role && msg.role !== "user" && id > maxAssistantId) {
           maxAssistantId = id;
+        }
+        const messageRole = String(msg?.role ?? "").trim().toLowerCase();
+        if (
+          expectedTurnId &&
+          messageRole === "assistant" &&
+          readMessageTurnId(msg) === expectedTurnId &&
+          id > matchingTurnAssistantId
+        ) {
+          matchingTurnAssistantId = id;
         }
         if (id > lastMessageIdRef.current) {
           newMessages.push(msg);
@@ -344,6 +396,22 @@ export function ChatView({
       if (maxAssistantId > lastAssistantIdRef.current) {
         lastAssistantIdRef.current = maxAssistantId;
       }
+
+      if (expectedTurnId && matchingTurnAssistantId > 0) {
+        if (inFlightCompletionByThreadRef.current.has(session.tid)) {
+          inFlightCompletionByThreadRef.current.delete(session.tid);
+          endCompletionRef.current();
+        }
+        clearTrackedTurnId(session.tid, expectedTurnId);
+        if (activeThreadRef.current === session.tid) {
+          setActiveTurnId((prev) =>
+            prev === expectedTurnId ? null : prev
+          );
+        }
+        stopPollingWithReason("assistant-turn-arrived", session.key);
+        return;
+      }
+
       const assistantReplyArrived =
         maxAssistantId > session.initialAssistantId &&
         maxAssistantId > session.lastUserMessageId;
@@ -373,15 +441,30 @@ export function ChatView({
   useEffect(() => {
     completionStateRef.current = completionState;
     if (completionState.isCompleting && completionState.activeThreadId != null) {
-      const marker = completionState.activeTaskId ?? `thread-${completionState.activeThreadId}`;
-      inFlightCompletionByThreadRef.current.set(completionState.activeThreadId, marker);
+      const marker =
+        completionState.activeTaskId ??
+        `thread-${completionState.activeThreadId}`;
+      inFlightCompletionByThreadRef.current.set(
+        completionState.activeThreadId,
+        marker
+      );
+      const currentTurnId = getTrackedTurnId(
+        completionState.activeThreadId
+      );
+      if (currentTurnId !== activeTurnIdRef.current) {
+        setActiveTurnId(currentTurnId);
+      }
       return;
     }
     if (!completionState.isCompleting) {
+      if (activeTurnIdRef.current && threadId != null) {
+        clearTrackedTurnId(threadId, activeTurnIdRef.current);
+      }
+      setActiveTurnId(null);
       inFlightCompletionByThreadRef.current.clear();
       completionFinalizePendingRef.current.clear();
     }
-  }, [completionState]);
+  }, [completionState, threadId]);
 
   useEffect(() => {
     endCompletionRef.current = endCompletion;
@@ -404,6 +487,10 @@ export function ChatView({
   }, [messages]);
 
   useEffect(() => {
+    activeTurnIdRef.current = activeTurnId;
+  }, [activeTurnId]);
+
+  useEffect(() => {
     pollSessionRef.current = pollSession;
   }, [pollSession]);
 
@@ -417,6 +504,7 @@ export function ChatView({
     lastAssistantIdRef.current = 0;
     inFlightCompletionByThreadRef.current.clear();
     completionFinalizePendingRef.current.clear();
+    setActiveTurnId(getTrackedTurnId(threadId));
     const completionSnapshot = completionStateRef.current;
     if (
       completionSnapshot.isCompleting &&
@@ -461,6 +549,7 @@ export function ChatView({
       startPolling(threadId, "poll-context-change", active.lastUserMessageId);
     }
   }, [
+    activeTurnId,
     buildPollKey,
     isCompletingForThread,
     profileKey,
@@ -477,10 +566,22 @@ export function ChatView({
       const messageRole = String(payload?.role ?? "").trim().toLowerCase();
       const tid = Number(payload?.thread_id ?? payload?.threadId ?? payload?.thread?.id);
       const messageId = parseMessageId(payload);
+      const expectedTurnId = activeTurnIdRef.current;
+      const observedTurnId = readMessageTurnId(payload);
 
       ingestIncoming(payload);
 
       if (!Number.isFinite(tid) || messageRole !== "assistant") {
+        return;
+      }
+      if (
+        expectedTurnId &&
+        observedTurnId &&
+        observedTurnId !== expectedTurnId
+      ) {
+        return;
+      }
+      if (expectedTurnId && !observedTurnId) {
         return;
       }
       if (messageId > lastAssistantIdRef.current) {
@@ -521,6 +622,14 @@ export function ChatView({
         }
 
         inFlightCompletionByThreadRef.current.delete(tid);
+        const completionTurnId =
+          activeTurnIdRef.current ?? getTrackedTurnId(tid);
+        if (completionTurnId) {
+          clearTrackedTurnId(tid, completionTurnId);
+          setActiveTurnId((prev) =>
+            prev === completionTurnId ? null : prev
+          );
+        }
         endCompletionRef.current();
 
         const messageCount = messagesRef.current.length;
@@ -626,6 +735,10 @@ export function ChatView({
     const activeKey = activePollKeyRef.current;
     if (activeKey && activeKey.startsWith(`${threadId}:`)) {
       stopPollingWithReason("completion-inactive", activeKey);
+    }
+    if (activeTurnIdRef.current) {
+      clearTrackedTurnId(threadId, activeTurnIdRef.current);
+      setActiveTurnId(null);
     }
   }, [isCompletingForThread, stopPollingWithReason, threadId]);
 

--- a/frontend/src/features/chat/ChatView.tsx
+++ b/frontend/src/features/chat/ChatView.tsx
@@ -36,7 +36,8 @@ type Voice404Classification = "message_not_found" | "route_missing" | "unknown";
 
 const PAGE_SIZE = 100;
 // Keep poll cadence moderate to avoid backend global rate-limit pressure.
-const POLL_INTERVAL_MS = 2000;
+const MESSAGE_POLL_MIN_MS = 1500;
+const MESSAGE_POLL_MAX_MS = 5000;
 const POLL_TIMEOUT_MS = 300_000; // 5 minutes slow-path ceiling
 const COMPLETION_SETTLE_MS = 150;
 
@@ -166,6 +167,8 @@ export function ChatView({
 
   const profileKey = profileId ?? "none";
   const resolvedDepthMode: DepthMode = depthMode ?? "normal";
+  const isCompletingForThread =
+    completionState.isCompleting && completionState.activeThreadId === threadId;
 
   const debugLog = useCallback((key: string, message: string, ttlMs = 1000) => {
     const now = Date.now();
@@ -229,6 +232,14 @@ export function ChatView({
     activePollKeyRef.current = null;
     setPollSession((prev) => (prev ? null : prev));
   }, []);
+
+  const stopPollingWithReason = useCallback(
+    (reason: string, expectedKey?: string) => {
+      debugLog(`poll:stop:${reason}`, `[chat:poll] stop reason=${reason}`, 500);
+      stopPolling(expectedKey);
+    },
+    [debugLog, stopPolling]
+  );
 
   const startPolling = useCallback(
     (tid: number, reason: string, lastUserMessageId: number) => {
@@ -333,11 +344,11 @@ export function ChatView({
       if (maxAssistantId > lastAssistantIdRef.current) {
         lastAssistantIdRef.current = maxAssistantId;
       }
-      if (
+      const assistantReplyArrived =
         maxAssistantId > session.initialAssistantId &&
-        activePollKeyRef.current === session.key
-      ) {
-        stopPolling(session.key);
+        maxAssistantId > session.lastUserMessageId;
+      if (assistantReplyArrived && activePollKeyRef.current === session.key) {
+        stopPollingWithReason("assistant-reply-arrived", session.key);
       }
     } catch (err) {
       logOnce("poll:messages", 10_000, () => {
@@ -345,12 +356,12 @@ export function ChatView({
       });
       throw err;
     }
-  }, [appendMessage, stopPolling]);
+  }, [appendMessage, stopPollingWithReason]);
 
   usePollWithBackoff(pollOnce, {
     enabled: Boolean(pollSession && activePollKeyRef.current === pollSession.key),
-    intervalMs: POLL_INTERVAL_MS,
-    maxBackoffMs: 8_000,
+    intervalMs: MESSAGE_POLL_MIN_MS,
+    maxBackoffMs: MESSAGE_POLL_MAX_MS,
     onErrorKey: "poll:messages",
     logTtlMs: 10_000,
   });
@@ -435,19 +446,28 @@ export function ChatView({
   }, [loadMessages, stopPolling, threadId]);
 
   useEffect(() => {
+    if (!isCompletingForThread) return;
     if (reloadVersion === lastReloadVersionRef.current) return;
     lastReloadVersionRef.current = reloadVersion;
     startPolling(threadId, "completion", getLastUserMessageId(messagesRef.current));
-  }, [reloadVersion, startPolling, threadId]);
+  }, [isCompletingForThread, reloadVersion, startPolling, threadId]);
 
   useEffect(() => {
+    if (!isCompletingForThread) return;
     const active = pollSessionRef.current;
     if (!active || active.tid !== threadId) return;
     const nextKey = buildPollKey(threadId, active.lastUserMessageId);
     if (nextKey !== active.key) {
       startPolling(threadId, "poll-context-change", active.lastUserMessageId);
     }
-  }, [buildPollKey, startPolling, threadId, resolvedDepthMode, profileKey]);
+  }, [
+    buildPollKey,
+    isCompletingForThread,
+    profileKey,
+    resolvedDepthMode,
+    startPolling,
+    threadId,
+  ]);
 
   useEffect(() => {
     liveSubscriptionCleanupRef.current?.();
@@ -593,12 +613,21 @@ export function ChatView({
   }, [messages]);
 
   useEffect(() => {
+    if (!isCompletingForThread) return;
     const lastUserMessageId = getLastUserMessageId(messages);
     if (!Number.isFinite(lastUserMessageId) || lastUserMessageId <= 0) return;
     if (lastUserMessageId <= lastPolledUserIdRef.current) return;
     lastPolledUserIdRef.current = lastUserMessageId;
     startPolling(threadId, "user-message", lastUserMessageId);
-  }, [messages, startPolling, threadId]);
+  }, [isCompletingForThread, messages, startPolling, threadId]);
+
+  useEffect(() => {
+    if (isCompletingForThread) return;
+    const activeKey = activePollKeyRef.current;
+    if (activeKey && activeKey.startsWith(`${threadId}:`)) {
+      stopPollingWithReason("completion-inactive", activeKey);
+    }
+  }, [isCompletingForThread, stopPollingWithReason, threadId]);
 
   useEffect(
     () => () => {

--- a/frontend/src/features/chat/ChatView.tsx
+++ b/frontend/src/features/chat/ChatView.tsx
@@ -284,6 +284,42 @@ export function ChatView({
     [debugLog, stopPolling]
   );
 
+  const clearCompletionAfterFailure = useCallback(
+    (tid: number, reason: string, toastMessage?: string) => {
+      if (!Number.isFinite(tid)) return;
+
+      if (completionFinalizeTimerRef.current !== null) {
+        window.clearTimeout(completionFinalizeTimerRef.current);
+        completionFinalizeTimerRef.current = null;
+      }
+      completionFinalizePendingRef.current.delete(tid);
+
+      const activeKey = activePollKeyRef.current;
+      if (activeKey && activeKey.startsWith(`${tid}:`)) {
+        stopPollingWithReason(reason, activeKey);
+      }
+
+      inFlightCompletionByThreadRef.current.delete(tid);
+
+      const completionTurnId = activeTurnIdRef.current ?? getTrackedTurnId(tid);
+      if (completionTurnId) {
+        clearTrackedTurnId(tid, completionTurnId);
+        if (activeThreadRef.current === tid) {
+          setActiveTurnId((prev) => (prev === completionTurnId ? null : prev));
+        }
+      } else if (activeThreadRef.current === tid) {
+        setActiveTurnId(null);
+      }
+
+      if (toastMessage && activeThreadRef.current === tid) {
+        showToast(toastMessage);
+      }
+
+      endCompletionRef.current();
+    },
+    [showToast, stopPollingWithReason]
+  );
+
   const startPolling = useCallback(
     (tid: number, reason: string, lastUserMessageId: number) => {
       if (!Number.isFinite(tid)) return;
@@ -650,6 +686,85 @@ export function ChatView({
     };
 
     const offMessageCreated = subscribe("message.created", onMessageCreated);
+    const onTerminalTaskEvent = (
+      event: any,
+      eventType: "task.failed" | "task.cancelled" | "completion.error"
+    ) => {
+      const payload = (event.data as any)?.data ?? event.data;
+      const completionSnapshot = completionStateRef.current;
+      if (!completionSnapshot.isCompleting) return;
+
+      const tid = Number(
+        payload?.thread_id ??
+          payload?.threadId ??
+          completionSnapshot.activeThreadId
+      );
+      if (!Number.isFinite(tid)) return;
+      if (completionSnapshot.activeThreadId !== tid) return;
+
+      const incomingTaskId = String(
+        payload?.task_id ?? payload?.taskId ?? ""
+      ).trim();
+      if (
+        completionSnapshot.activeTaskId &&
+        incomingTaskId &&
+        incomingTaskId !== completionSnapshot.activeTaskId
+      ) {
+        return;
+      }
+
+      const shouldToast =
+        eventType === "task.failed" || eventType === "completion.error";
+      clearCompletionAfterFailure(
+        tid,
+        eventType,
+        shouldToast ? "Assistant response failed. Please retry." : undefined
+      );
+    };
+    const onTaskFailed = (event: any) => onTerminalTaskEvent(event, "task.failed");
+    const onTaskCancelled = (event: any) =>
+      onTerminalTaskEvent(event, "task.cancelled");
+    const onCompletionError = (event: any) =>
+      onTerminalTaskEvent(event, "completion.error");
+    const onTaskCompleted = (event: any) => {
+      const payload = (event.data as any)?.data ?? event.data;
+      const completionSnapshot = completionStateRef.current;
+      if (!completionSnapshot.isCompleting) return;
+
+      const tid = Number(
+        payload?.thread_id ??
+          payload?.threadId ??
+          completionSnapshot.activeThreadId
+      );
+      if (!Number.isFinite(tid)) return;
+      if (completionSnapshot.activeThreadId !== tid) return;
+
+      const incomingTaskId = String(
+        payload?.task_id ?? payload?.taskId ?? ""
+      ).trim();
+      if (
+        completionSnapshot.activeTaskId &&
+        incomingTaskId &&
+        incomingTaskId !== completionSnapshot.activeTaskId
+      ) {
+        return;
+      }
+
+      const messageId = Number(payload?.message_id ?? payload?.messageId);
+      if (Number.isFinite(messageId) && messageId > 0) {
+        return;
+      }
+
+      clearCompletionAfterFailure(
+        tid,
+        "task.completed:missing-message",
+        "Assistant response failed. Please retry."
+      );
+    };
+    const offTaskFailed = subscribe("task.failed", onTaskFailed);
+    const offTaskCancelled = subscribe("task.cancelled", onTaskCancelled);
+    const offCompletionError = subscribe("completion.error", onCompletionError);
+    const offTaskCompleted = subscribe("task.completed", onTaskCompleted);
     const onLocal = (evt: Event) => {
       const detail = (evt as CustomEvent).detail || {};
       ingestIncoming(detail.message ?? detail);
@@ -658,6 +773,10 @@ export function ChatView({
 
     const cleanup = () => {
       offMessageCreated();
+      offTaskFailed();
+      offTaskCancelled();
+      offCompletionError();
+      offTaskCompleted();
       window.removeEventListener("cfy:chat:message", onLocal as EventListener);
     };
     liveSubscriptionCleanupRef.current = cleanup;
@@ -668,7 +787,7 @@ export function ChatView({
         liveSubscriptionCleanupRef.current = null;
       }
     };
-  }, [ingestIncoming, stopPolling, subscribe, threadId]);
+  }, [clearCompletionAfterFailure, ingestIncoming, stopPolling, subscribe, threadId]);
 
   useLayoutEffect(() => {
     const el = containerRef.current;

--- a/frontend/src/features/chat/ChatView.tsx
+++ b/frontend/src/features/chat/ChatView.tsx
@@ -35,7 +35,8 @@ type PollSession = {
 type Voice404Classification = "message_not_found" | "route_missing" | "unknown";
 
 const PAGE_SIZE = 100;
-const POLL_INTERVAL_MS = 900;
+// Keep poll cadence moderate to avoid backend global rate-limit pressure.
+const POLL_INTERVAL_MS = 2000;
 const POLL_TIMEOUT_MS = 30000;
 const COMPLETION_SETTLE_MS = 150;
 

--- a/frontend/src/features/chat/ChatView.tsx
+++ b/frontend/src/features/chat/ChatView.tsx
@@ -142,6 +142,8 @@ export function ChatView({
   className,
   bottomPadding = 0,
   autoReadEnabled = false,
+  voiceReadAloudEnabled = false,
+  voiceCapabilitiesFailed = false,
   depthMode = "normal",
   profileId = null,
 }: {
@@ -153,6 +155,8 @@ export function ChatView({
   className?: string;
   bottomPadding?: number;
   autoReadEnabled?: boolean;
+  voiceReadAloudEnabled?: boolean;
+  voiceCapabilitiesFailed?: boolean;
   depthMode?: DepthMode;
   profileId?: string | null;
 }) {
@@ -761,6 +765,12 @@ export function ChatView({
   const playMessageAudio = useCallback(
     async (messageId: number, options?: { manual?: boolean }) => {
       const manual = Boolean(options?.manual);
+      if (!voiceReadAloudEnabled) {
+        if (manual) {
+          showToast("Voice disabled");
+        }
+        return;
+      }
       if (voiceRouteMissingRef.current) {
         if (manual) {
           showToast("Voice disabled");
@@ -807,7 +817,7 @@ export function ChatView({
           if (manual) {
             showToast("Audio unavailable");
           }
-        } else if (classification === "route_missing") {
+        } else if (classification === "route_missing" && voiceCapabilitiesFailed) {
           disableVoiceRoute();
           if (manual) {
             showToast("Voice disabled");
@@ -818,11 +828,22 @@ export function ChatView({
         setPlayingMessageId((prev) => (prev === messageId ? null : prev));
       }
     },
-    [disableVoiceRoute, isVoiceUnavailable, markVoiceUnavailable, showToast]
+    [
+      disableVoiceRoute,
+      isVoiceUnavailable,
+      markVoiceUnavailable,
+      showToast,
+      voiceCapabilitiesFailed,
+      voiceReadAloudEnabled,
+    ]
   );
 
   const handlePlayClick = useCallback(
     (messageId: number) => {
+      if (!voiceReadAloudEnabled) {
+        showToast("Voice disabled");
+        return;
+      }
       if (voiceRouteMissingRef.current) {
         showToast("Voice disabled");
         return;
@@ -833,10 +854,11 @@ export function ChatView({
       }
       void playMessageAudio(messageId, { manual: true });
     },
-    [isVoiceUnavailable, playMessageAudio, showToast]
+    [isVoiceUnavailable, playMessageAudio, showToast, voiceReadAloudEnabled]
   );
 
   useEffect(() => {
+    if (!voiceReadAloudEnabled) return;
     if (!autoReadEnabled) return;
     if (voiceRouteMissingRef.current) return;
 
@@ -861,7 +883,14 @@ export function ChatView({
       return;
     }
     void playMessageAudio(latestId);
-  }, [autoReadEnabled, isVoiceUnavailable, messages, playMessageAudio, voiceRouteMissing]);
+  }, [
+    autoReadEnabled,
+    isVoiceUnavailable,
+    messages,
+    playMessageAudio,
+    voiceReadAloudEnabled,
+    voiceRouteMissing,
+  ]);
 
   const onScroll = async () => {
     const el = containerRef.current;
@@ -946,14 +975,14 @@ export function ChatView({
         {messages.map((m, index) => {
           const messageId = Number(m.id);
           const canPlay = m.role !== "user" && Number.isFinite(messageId);
+          const showPlay =
+            canPlay && voiceReadAloudEnabled && !voiceRouteMissing;
           const messageVoiceUnavailable = Boolean(
             Number.isFinite(messageId) && voiceUnavailableMessageIds[messageId]
           );
-          const playState: BubblePlayState = !canPlay
+          const playState: BubblePlayState = !showPlay
             ? "idle"
-            : voiceRouteMissing
-              ? "disabled"
-              : messageVoiceUnavailable
+            : messageVoiceUnavailable
                 ? "unavailable"
                 : playingMessageId === messageId
                   ? "playing"
@@ -991,7 +1020,7 @@ export function ChatView({
                   })),
                 }}
                 isGuardian={m.role !== "user"}
-                showPlay={canPlay}
+                showPlay={showPlay}
                 playing={playState === "playing"}
                 playState={playState}
                 onPlay={() => {

--- a/frontend/src/features/chat/ChatView.tsx
+++ b/frontend/src/features/chat/ChatView.tsx
@@ -37,7 +37,7 @@ type Voice404Classification = "message_not_found" | "route_missing" | "unknown";
 const PAGE_SIZE = 100;
 // Keep poll cadence moderate to avoid backend global rate-limit pressure.
 const POLL_INTERVAL_MS = 2000;
-const POLL_TIMEOUT_MS = 30000;
+const POLL_TIMEOUT_MS = 300_000; // 5 minutes slow-path ceiling
 const COMPLETION_SETTLE_MS = 150;
 
 function parseMessageId(raw: any): number {
@@ -283,6 +283,7 @@ export function ChatView({
       logOnce("poll:messages:timeout", 10_000, () => {
         console.info(`[chat] polling timed out (${session.reason})`);
       });
+      showToast("Still working; refresh or retry.");
       stopPolling(session.key);
       return;
     }

--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -252,7 +252,14 @@ export function GuardianChat({
 
   const [externalPrefill, setExternalPrefill] = useState<string | undefined>(undefined);
   // Chat state management including completion tracking
-  const { completionState, startCompletion, endCompletion } = useChat();
+  const {
+    completionState,
+    startCompletion,
+    endCompletion,
+    updateCompletionTaskId,
+    isCompletionInFlight,
+    setCompletionInFlight,
+  } = useChat();
   const [turnLocks, setTurnLocks] = useState<Record<number, boolean>>({});
   const [pendingTurnLock, setPendingTurnLock] = useState(false);
   const lastCompletionThreadRef = useRef<number | null>(null);
@@ -438,9 +445,9 @@ export function GuardianChat({
   const isTurnLocked = useCallback(
     (threadId: number | null) => {
       if (threadId == null) return pendingTurnLock;
-      return Boolean(turnLocks[threadId]);
+      return Boolean(turnLocks[threadId]) || isCompletionInFlight(threadId);
     },
-    [pendingTurnLock, turnLocks]
+    [isCompletionInFlight, pendingTurnLock, turnLocks]
   );
   const notifyTurnLocked = () => {
     showToast(TURN_LOCK_TOAST);
@@ -529,22 +536,25 @@ export function GuardianChat({
     },
     [getDepthForThread]
   );
-  type CompletionOutcome = "ok" | "service_unavailable" | "failed";
+  type CompletionOutcome = "ok" | "service_unavailable" | "failed" | "inflight";
   // Helper: ask backend to complete the thread and then refresh
   const completeThread = async (tid: number): Promise<CompletionOutcome> => {
     const payload = buildChatCompletionPayload(depth, activeModelId || "default");
+    const provisionalTaskId = `pending-${Date.now()}`;
+    setCompletionInFlight(tid, true);
+    startCompletion(tid, provisionalTaskId);
     try {
       const response = await api.post(buildChatCompletePath(tid), payload);
       console.log(`[guardian] Completing with depth=${depth}`);
 
       // Capture task_id for completion state tracking
-      const taskId = response?.data?.task_id;
+      const taskId = response?.data?.task_id ?? provisionalTaskId;
       const responseDepth = (response?.data?.depth_mode as DepthMode | undefined) ?? depth;
       lastCompletionDepthRef.current[tid] = responseDepth;
 
       if (taskId) {
         console.debug(`[guardian] Starting completion tracking: task=${taskId}`);
-        startCompletion(tid, taskId);
+        updateCompletionTaskId(taskId);
       }
 
       const traceUrlRaw = response?.data?.trace_url;
@@ -561,6 +571,17 @@ export function GuardianChat({
         detail && typeof detail === "object"
           ? String(detail?.error || detail?.reason || "")
           : String(detail || "");
+      if (statusCode === 429) {
+        logOnce("complete:turn-lock", 5_000, () => {
+          console.warn("[guardian] completion hit turn-lock (429) — waiting for prior turn");
+        });
+        showToast("Finishing previous turn…");
+        setCompletionInFlight(tid, true);
+        if (!completionState.isCompleting || completionState.activeThreadId !== tid) {
+          startCompletion(tid, `turn-lock-${tid}`);
+        }
+        return "inflight";
+      }
       if (
         statusCode === 503 &&
         (reason.includes("completion_service_unavailable") ||
@@ -568,9 +589,11 @@ export function GuardianChat({
           reason.includes("turn_lock_unavailable"))
       ) {
         showToast("Completion service unavailable — check Docker/Redis.");
+        endCompletion();
         return "service_unavailable";
       }
       console.warn("[guardian] completion failed", err);
+      endCompletion();
       return "failed";
     } finally {
       // always nudge the view to reconcile with server state
@@ -932,6 +955,10 @@ export function GuardianChat({
       notifyTurnLocked();
       return;
     }
+    if (effectiveThreadId != null && isCompletionInFlight(effectiveThreadId)) {
+      notifyTurnLocked();
+      return;
+    }
     if (effectiveThreadId != null && requestedProfileId) {
       if (typeof window !== "undefined") {
         sessionStorage.removeItem(`${DRAFT_KEY_PREFIX}${effectiveThreadId}`);
@@ -1003,7 +1030,7 @@ export function GuardianChat({
 
         // Complete the thread and refresh.
         const completionOutcome = await completeThread(numericNewId);
-        if (completionOutcome !== "ok") {
+        if (completionOutcome !== "ok" && completionOutcome !== "inflight") {
           setTurnLockForThread(numericNewId, false);
           if (completionOutcome === "failed") {
             throw new Error("Assistant response failed.");
@@ -1028,16 +1055,16 @@ export function GuardianChat({
         await onSendMessage(text);
 
         // Fire-and-forget completion a beat later so the just-sent message is persisted
-        setTimeout(() => {
-          if (effectiveThreadId == null) return;
-          void (async () => {
-            const completionOutcome = await completeThread(effectiveThreadId);
-            if (completionOutcome !== "ok") {
-              setTurnLockForThread(effectiveThreadId, false);
-              if (completionOutcome === "failed") {
-                showToast("Assistant response failed.");
-              }
-            }
+            setTimeout(() => {
+              if (effectiveThreadId == null) return;
+              void (async () => {
+                const completionOutcome = await completeThread(effectiveThreadId);
+                if (completionOutcome !== "ok" && completionOutcome !== "inflight") {
+                  setTurnLockForThread(effectiveThreadId, false);
+                  if (completionOutcome === "failed") {
+                    showToast("Assistant response failed.");
+                  }
+                }
           })();
         }, 100);
       } catch (error) {

--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -1425,32 +1425,56 @@ export function GuardianChat({
         }}
       >
         <div className="flex flex-col p-4">
-          <div className="mb-2 flex items-center justify-between gap-2 text-xs">
-            <div className="flex items-center gap-2 min-w-0">
-              <span className="opacity-70" style={{ color: "var(--muted)" }}>
-                Turn-based Voice
-              </span>
+          <Composer
+            onSend={handleSendMessage}
+            prefill={externalPrefill ?? prefill}
+            onPrefillConsumed={() => {
+              setExternalPrefill(undefined);
+              onPrefillConsumed?.();
+            }}
+            threadId={effectiveThreadId ?? undefined}
+            isTurnInFlight={isTurnLocked(effectiveThreadId)}
+            draftValue={activeDraft}
+            draftScopeKey={activeSessionTabId ?? "global"}
+            onDraftValueChange={onSessionDraftChange}
+          />
+          {/* Bottom controls bar (aligned to bottom edge) */}
+          <div className="mt-3 flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              {/* Voice mode indicator (icon-only, label via tooltip) */}
+              <button
+                type="button"
+                className="icon-inline"
+                aria-label="Turn-based voice"
+                title="Turn-based voice"
+                style={{ borderRadius: "var(--radius-micro)", opacity: 0.8 }}
+                onClick={() => {
+                  // purely informational affordance for now
+                  console.debug("[guardian] turn-based voice affordance clicked");
+                }}
+              >
+                <Volume2 className="h-4 w-4" />
+              </button>
 
-              {/* RAG Depth Selector (moved from header) */}
+              {/* RAG Depth Selector (icon-only) */}
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <button
                     type="button"
-                    className="inline-flex items-center gap-1 rounded-full border px-2 py-1 text-[11px] transition hover:opacity-90"
+                    className="icon-inline"
                     aria-label="RAG depth selector"
-                    title={`Depth: ${depthLabels[depth]} - ${depthDescriptions[depth]}`}
-                    style={{ borderColor: "var(--panel-border)", color: "var(--text)" }}
+                    title={`RAG Depth: ${depthLabels[depth]} — ${depthDescriptions[depth]}`}
+                    style={{ borderRadius: "var(--radius-micro)" }}
                   >
-                    <Layers className="h-3.5 w-3.5" />
-                    <span className="truncate max-w-[8rem]">{depthLabels[depth]}</span>
-                    <ChevronRight className="h-3.5 w-3.5 rotate-90 opacity-70" />
+                    <Layers className="h-4 w-4" />
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent
+                  side="top"
                   align="start"
-                  sideOffset={8}
+                  sideOffset={10}
                   collisionPadding={12}
-                  className="z-[999] min-w-[16rem] rounded-lg border p-1 shadow-xl"
+                  className="z-[9999] min-w-[16rem] rounded-lg border p-1 shadow-xl"
                   style={{
                     borderColor: "var(--panel-border)",
                     background: "var(--panel-sheet)",
@@ -1493,68 +1517,57 @@ export function GuardianChat({
               </DropdownMenu>
             </div>
 
-            <button
-              type="button"
-              className="rounded-md border px-2 py-1 text-xs hover:opacity-90 disabled:opacity-50"
-              style={{ borderColor: "var(--panel-border)", color: "var(--text)" }}
-              disabled={voiceUploading}
-              onClick={() => {
-                if (effectiveThreadId == null) {
-                  alert("Create or open a thread before starting a voice turn.");
-                  return;
-                }
-                voiceFileInputRef.current?.click();
-              }}
-            >
-              {voiceUploading ? "Processing…" : "Upload Voice Turn"}
-            </button>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                className="rounded-md border px-2 py-1 text-xs hover:opacity-90 disabled:opacity-50"
+                style={{ borderColor: "var(--panel-border)", color: "var(--text)" }}
+                disabled={voiceUploading}
+                onClick={() => {
+                  if (effectiveThreadId == null) {
+                    alert("Create or open a thread before starting a voice turn.");
+                    return;
+                  }
+                  voiceFileInputRef.current?.click();
+                }}
+              >
+                {voiceUploading ? "Processing…" : "Upload Voice Turn"}
+              </button>
 
-            <input
-              ref={voiceFileInputRef}
-              type="file"
-              accept="audio/wav,audio/*"
-              className="hidden"
-              onChange={async (event) => {
-                const file = event.target.files?.[0];
-                event.currentTarget.value = "";
-                if (!file) return;
-                if (effectiveThreadId == null) {
-                  alert("Create or open a thread before starting a voice turn.");
-                  return;
-                }
-                setVoiceUploading(true);
-                try {
-                  const form = new FormData();
-                  form.append("thread_id", String(effectiveThreadId));
-                  form.append("audio_file", file);
-                  form.append("tts_enabled", "true");
-                  await api.post("/api/voice/turn", form, {
-                    headers: { "Content-Type": "multipart/form-data" },
-                    timeout: 180000,
-                  });
-                  triggerReload();
-                } catch (error) {
-                  console.warn("[guardian] voice turn failed", error);
-                  alert("Voice turn failed. Check backend voice configuration.");
-                } finally {
-                  setVoiceUploading(false);
-                }
-              }}
-            />
+              <input
+                ref={voiceFileInputRef}
+                type="file"
+                accept="audio/wav,audio/*"
+                className="hidden"
+                onChange={async (event) => {
+                  const file = event.target.files?.[0];
+                  event.currentTarget.value = "";
+                  if (!file) return;
+                  if (effectiveThreadId == null) {
+                    alert("Create or open a thread before starting a voice turn.");
+                    return;
+                  }
+                  setVoiceUploading(true);
+                  try {
+                    const form = new FormData();
+                    form.append("thread_id", String(effectiveThreadId));
+                    form.append("audio_file", file);
+                    form.append("tts_enabled", "true");
+                    await api.post("/api/voice/turn", form, {
+                      headers: { "Content-Type": "multipart/form-data" },
+                      timeout: 180000,
+                    });
+                    triggerReload();
+                  } catch (error) {
+                    console.warn("[guardian] voice turn failed", error);
+                    alert("Voice turn failed. Check backend voice configuration.");
+                  } finally {
+                    setVoiceUploading(false);
+                  }
+                }}
+              />
+            </div>
           </div>
-          <Composer
-            onSend={handleSendMessage}
-            prefill={externalPrefill ?? prefill}
-            onPrefillConsumed={() => {
-              setExternalPrefill(undefined);
-              onPrefillConsumed?.();
-            }}
-            threadId={effectiveThreadId ?? undefined}
-            isTurnInFlight={isTurnLocked(effectiveThreadId)}
-            draftValue={activeDraft}
-            draftScopeKey={activeSessionTabId ?? "global"}
-            onDraftValueChange={onSessionDraftChange}
-          />
         </div>
       </div>
     </div>

--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -86,6 +86,22 @@ type ResolvedProfileState = {
   modelOverride: string | null;
 };
 
+type VoiceCapabilities = {
+  read_aloud_enabled: boolean;
+  turn_based_enabled: boolean;
+  supported_input_mime: string[];
+  limits: { max_upload_bytes: number; max_duration_s: number } | null;
+};
+
+type VoiceCapabilitiesStatus = "loading" | "ready" | "error";
+
+const DEFAULT_VOICE_CAPABILITIES: VoiceCapabilities = {
+  read_aloud_enabled: false,
+  turn_based_enabled: false,
+  supported_input_mime: ["audio/wav", "audio/x-wav", "audio/webm", "audio/ogg"],
+  limits: null,
+};
+
 const PROFILE_FALLBACK_OPTIONS: SystemProfileOption[] = [
   { id: "default", name: "Default", mode: "cloud" },
   { id: "cloud_mode", name: "Cloud Profile", mode: "cloud" },
@@ -135,6 +151,32 @@ function normalizeLlmHealthRawError(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   return trimmed.length ? trimmed : null;
+}
+
+function normalizeVoiceCapabilities(raw: any): VoiceCapabilities {
+  const limitsRaw = raw?.limits;
+  const maxUploadBytes = Number(limitsRaw?.max_upload_bytes);
+  const maxDurationSeconds = Number(limitsRaw?.max_duration_s);
+  const supportedInputMime = Array.isArray(raw?.supported_input_mime)
+    ? raw.supported_input_mime
+        .map((entry: unknown) => String(entry ?? "").trim().toLowerCase())
+        .filter(Boolean)
+    : DEFAULT_VOICE_CAPABILITIES.supported_input_mime;
+
+  return {
+    read_aloud_enabled: Boolean(raw?.read_aloud_enabled),
+    turn_based_enabled: Boolean(raw?.turn_based_enabled),
+    supported_input_mime: supportedInputMime.length
+      ? supportedInputMime
+      : DEFAULT_VOICE_CAPABILITIES.supported_input_mime,
+    limits:
+      Number.isFinite(maxUploadBytes) && Number.isFinite(maxDurationSeconds)
+        ? {
+            max_upload_bytes: Math.max(0, Math.floor(maxUploadBytes)),
+            max_duration_s: Math.max(0, Math.floor(maxDurationSeconds)),
+          }
+        : null,
+  };
 }
 
 function toUserFacingLlmHealthError(
@@ -288,6 +330,11 @@ export function GuardianChat({
   const [threadTitle, setThreadTitle] = useState<string>(activeThread?.title ?? NEW_THREAD_TITLE);
   const voiceFileInputRef = useRef<HTMLInputElement | null>(null);
   const [voiceUploading, setVoiceUploading] = useState(false);
+  const [voiceCapabilities, setVoiceCapabilities] = useState<VoiceCapabilities>(
+    DEFAULT_VOICE_CAPABILITIES
+  );
+  const [voiceCapabilitiesStatus, setVoiceCapabilitiesStatus] =
+    useState<VoiceCapabilitiesStatus>("loading");
   const [autoReadEnabled, setAutoReadEnabled] = useState<boolean>(() => {
     try {
       return window.localStorage.getItem("cfy.voice.autoRead") === "1";
@@ -327,6 +374,27 @@ export function GuardianChat({
         new CustomEvent("cfy:toast", { detail: { message, kind: "error" } })
       );
     } catch {}
+  }, []);
+  const voiceReadAloudEnabled = voiceCapabilities.read_aloud_enabled;
+  const voiceTurnBasedEnabled = voiceCapabilities.turn_based_enabled;
+  const voiceCapabilitiesFailed = voiceCapabilitiesStatus === "error";
+  const supportedVoiceInputMime = voiceCapabilities.supported_input_mime;
+  const voiceUploadAccept = useMemo(
+    () => supportedVoiceInputMime.join(","),
+    [supportedVoiceInputMime]
+  );
+  const voiceUploadLimitBytes = voiceCapabilities.limits?.max_upload_bytes ?? null;
+
+  const refreshVoiceCapabilities = useCallback(async () => {
+    try {
+      const response = await api.get("/voice/capabilities");
+      setVoiceCapabilities(normalizeVoiceCapabilities(response?.data));
+      setVoiceCapabilitiesStatus("ready");
+    } catch (error) {
+      console.warn("[guardian] voice capabilities unavailable", error);
+      setVoiceCapabilities(DEFAULT_VOICE_CAPABILITIES);
+      setVoiceCapabilitiesStatus("error");
+    }
   }, []);
   const resolveProfileIdFromCommand = useCallback(
     (text: string): string | null => {
@@ -810,6 +878,16 @@ export function GuardianChat({
   useEffect(() => () => triggerReload.cancel(), [triggerReload]);
 
   useEffect(() => {
+    void refreshVoiceCapabilities();
+  }, [effectiveThreadId, refreshVoiceCapabilities]);
+
+  useEffect(() => {
+    if (voiceReadAloudEnabled) return;
+    if (!autoReadEnabled) return;
+    setAutoReadEnabled(false);
+  }, [autoReadEnabled, voiceReadAloudEnabled]);
+
+  useEffect(() => {
     try {
       window.localStorage.setItem("cfy.voice.autoRead", autoReadEnabled ? "1" : "0");
     } catch {}
@@ -1200,10 +1278,29 @@ export function GuardianChat({
       <button
         type="button"
         className="icon-inline"
-        aria-label={autoReadEnabled ? "Disable auto read aloud" : "Enable auto read aloud"}
-        title={autoReadEnabled ? "Auto read aloud: On" : "Auto read aloud: Off"}
-        onClick={() => setAutoReadEnabled((v) => !v)}
-        style={{ borderRadius: "var(--radius-micro)", opacity: autoReadEnabled ? 1 : 0.65 }}
+        aria-label={
+          voiceReadAloudEnabled
+            ? autoReadEnabled
+              ? "Disable auto read aloud"
+              : "Enable auto read aloud"
+            : "Auto read aloud unavailable"
+        }
+        title={
+          voiceReadAloudEnabled
+            ? autoReadEnabled
+              ? "Auto read aloud: On"
+              : "Auto read aloud: Off"
+            : "Read-aloud unavailable"
+        }
+        onClick={() => {
+          if (!voiceReadAloudEnabled) return;
+          setAutoReadEnabled((v) => !v);
+        }}
+        disabled={!voiceReadAloudEnabled}
+        style={{
+          borderRadius: "var(--radius-micro)",
+          opacity: voiceReadAloudEnabled ? (autoReadEnabled ? 1 : 0.65) : 0.45,
+        }}
       >
         <Volume2 className="h-5 w-5" />
       </button>
@@ -1477,6 +1574,8 @@ export function GuardianChat({
             autoReadEnabled={autoReadEnabled}
             depthMode={depth}
             profileId={resolvedProfile.id}
+            voiceReadAloudEnabled={voiceReadAloudEnabled}
+            voiceCapabilitiesFailed={voiceCapabilitiesFailed}
           />
         ) : (
           <div
@@ -1517,20 +1616,20 @@ export function GuardianChat({
           {/* Bottom controls bar (aligned to bottom edge) */}
           <div className="mt-3 flex items-center justify-between gap-2">
             <div className="flex items-center gap-2">
-              {/* Voice mode indicator (icon-only, label via tooltip) */}
-              <button
-                type="button"
-                className="icon-inline"
-                aria-label="Turn-based voice"
-                title="Turn-based voice"
-                style={{ borderRadius: "var(--radius-micro)", opacity: 0.8 }}
-                onClick={() => {
-                  // purely informational affordance for now
-                  console.debug("[guardian] turn-based voice affordance clicked");
-                }}
-              >
-                <Volume2 className="h-4 w-4" />
-              </button>
+              {voiceTurnBasedEnabled ? (
+                <button
+                  type="button"
+                  className="icon-inline"
+                  aria-label="Turn-based voice"
+                  title="Turn-based voice"
+                  style={{ borderRadius: "var(--radius-micro)", opacity: 0.8 }}
+                  onClick={() => {
+                    console.debug("[guardian] turn-based voice affordance clicked");
+                  }}
+                >
+                  <Volume2 className="h-4 w-4" />
+                </button>
+              ) : null}
 
               {/* RAG Depth Selector (icon-only) */}
               <DropdownMenu>
@@ -1594,54 +1693,77 @@ export function GuardianChat({
             </div>
 
             <div className="flex items-center gap-2">
-              <button
-                type="button"
-                className="rounded-md border px-2 py-1 text-xs hover:opacity-90 disabled:opacity-50"
-                style={{ borderColor: "var(--panel-border)", color: "var(--text)" }}
-                disabled={voiceUploading}
-                onClick={() => {
-                  if (effectiveThreadId == null) {
-                    alert("Create or open a thread before starting a voice turn.");
-                    return;
-                  }
-                  voiceFileInputRef.current?.click();
-                }}
-              >
-                {voiceUploading ? "Processing…" : "Upload Voice Turn"}
-              </button>
+              {voiceTurnBasedEnabled ? (
+                <>
+                  <button
+                    type="button"
+                    className="rounded-md border px-2 py-1 text-xs hover:opacity-90 disabled:opacity-50"
+                    style={{ borderColor: "var(--panel-border)", color: "var(--text)" }}
+                    disabled={voiceUploading}
+                    onClick={() => {
+                      if (effectiveThreadId == null) {
+                        alert("Create or open a thread before starting a voice turn.");
+                        return;
+                      }
+                      voiceFileInputRef.current?.click();
+                    }}
+                  >
+                    {voiceUploading ? "Processing…" : "Upload Voice Turn"}
+                  </button>
 
-              <input
-                ref={voiceFileInputRef}
-                type="file"
-                accept="audio/wav,audio/*"
-                className="hidden"
-                onChange={async (event) => {
-                  const file = event.target.files?.[0];
-                  event.currentTarget.value = "";
-                  if (!file) return;
-                  if (effectiveThreadId == null) {
-                    alert("Create or open a thread before starting a voice turn.");
-                    return;
-                  }
-                  setVoiceUploading(true);
-                  try {
-                    const form = new FormData();
-                    form.append("thread_id", String(effectiveThreadId));
-                    form.append("audio_file", file);
-                    form.append("tts_enabled", "true");
-                    await api.post("/api/voice/turn", form, {
-                      headers: { "Content-Type": "multipart/form-data" },
-                      timeout: 180000,
-                    });
-                    triggerReload();
-                  } catch (error) {
-                    console.warn("[guardian] voice turn failed", error);
-                    alert("Voice turn failed. Check backend voice configuration.");
-                  } finally {
-                    setVoiceUploading(false);
-                  }
-                }}
-              />
+                  <input
+                    ref={voiceFileInputRef}
+                    type="file"
+                    accept={voiceUploadAccept}
+                    className="hidden"
+                    onChange={async (event) => {
+                      const file = event.target.files?.[0];
+                      event.currentTarget.value = "";
+                      if (!file) return;
+                      if (effectiveThreadId == null) {
+                        alert("Create or open a thread before starting a voice turn.");
+                        return;
+                      }
+                      const normalizedMime = String(file.type || "")
+                        .trim()
+                        .toLowerCase();
+                      if (
+                        normalizedMime &&
+                        supportedVoiceInputMime.length > 0 &&
+                        !supportedVoiceInputMime.includes(normalizedMime)
+                      ) {
+                        alert(`Unsupported audio type: ${normalizedMime}`);
+                        return;
+                      }
+                      if (
+                        voiceUploadLimitBytes != null &&
+                        file.size > voiceUploadLimitBytes
+                      ) {
+                        const limitMb = (voiceUploadLimitBytes / (1024 * 1024)).toFixed(1);
+                        alert(`Audio file too large. Max ${limitMb} MB.`);
+                        return;
+                      }
+                      setVoiceUploading(true);
+                      try {
+                        const form = new FormData();
+                        form.append("thread_id", String(effectiveThreadId));
+                        form.append("audio_file", file);
+                        form.append("tts_enabled", "true");
+                        await api.post("/voice/turn", form, {
+                          headers: { "Content-Type": "multipart/form-data" },
+                          timeout: 180000,
+                        });
+                        triggerReload();
+                      } catch (error) {
+                        console.warn("[guardian] voice turn failed", error);
+                        alert("Voice turn failed. Check backend voice configuration.");
+                      } finally {
+                        setVoiceUploading(false);
+                      }
+                    }}
+                  />
+                </>
+              ) : null}
             </div>
           </div>
         </div>

--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -25,7 +25,10 @@ import { Thread } from "@/types/ui";
 import { Composer } from "./components";
 import ChatView from "@/features/chat/ChatView";
 import useChat from "@/features/chat/useChat";
-import api, { buildChatCompletePath } from "@/lib/api";
+import api, {
+  buildChatCompletePath,
+  clearInFlightCompletionTurnId,
+} from "@/lib/api";
 import { buildChatCompletionPayload } from "@/lib/chatClient";
 import { useLiveEvents } from "@/hooks/useLiveEvents";
 import FrameCard from "@/components/surface/FrameCard";
@@ -943,13 +946,58 @@ export function GuardianChat({
       const role = String(payload?.role ?? "").trim().toLowerCase();
       if (!Number.isFinite(tid) || role !== "assistant") return;
       setTurnLockForThread(tid, false);
+      clearInFlightCompletionTurnId(tid);
       void fetchTraceForThread(tid, "message-event");
+      if (
+        completionState.isCompleting &&
+        completionState.activeThreadId === tid
+      ) {
+        endCompletion();
+      }
     });
+    const finalizeCompletionFromTaskEvent = (event: any) => {
+      const payload = (event.data as any)?.data ?? event.data;
+      const tid = Number(payload?.thread_id ?? payload?.threadId);
+      if (!Number.isFinite(tid)) return;
+      clearInFlightCompletionTurnId(tid);
+      setTurnLockForThread(tid, false);
+      const eventTaskId = String(
+        payload?.task_id ?? payload?.taskId ?? ""
+      ).trim();
+      if (
+        completionState.isCompleting &&
+        completionState.activeThreadId === tid &&
+        (!completionState.activeTaskId ||
+          !eventTaskId ||
+          eventTaskId === completionState.activeTaskId)
+      ) {
+        endCompletion();
+      }
+    };
+    const offTaskCompleted = subscribe("task.completed", finalizeCompletionFromTaskEvent);
+    const offTaskFailed = subscribe("task.failed", finalizeCompletionFromTaskEvent);
+    const offTaskCancelled = subscribe("task.cancelled", finalizeCompletionFromTaskEvent);
+    const offCompletionError = subscribe(
+      "completion.error",
+      finalizeCompletionFromTaskEvent
+    );
 
     return () => {
       offMessage();
+      offTaskCompleted();
+      offTaskFailed();
+      offTaskCancelled();
+      offCompletionError();
     };
-  }, [fetchTraceForThread, setTurnLockForThread, subscribe]);
+  }, [
+    completionState.activeTaskId,
+    completionState.activeThreadId,
+    completionState.isCompleting,
+    endCompletion,
+    fetchTraceForThread,
+    setTurnLockForThread,
+    subscribe,
+  ]);
   useEffect(() => {
     if (completionState.isCompleting && completionState.activeThreadId != null) {
       lastCompletionThreadRef.current = completionState.activeThreadId;

--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -64,6 +64,7 @@ type LlmHealthSnapshot = {
   provider: string | null;
   model: string | null;
   error: string | null;
+  rawError: string | null;
   checkedAt: number | null;
 };
 
@@ -128,6 +129,49 @@ function normalizeProfileOption(
     modelOverride:
       raw.model_override != null ? String(raw.model_override) : null,
   };
+}
+
+function normalizeLlmHealthRawError(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : null;
+}
+
+function toUserFacingLlmHealthError(
+  rawError: string | null,
+  status: LlmHealthStatus
+): string | null {
+  if (!rawError) return null;
+  const normalized = rawError.toLowerCase();
+
+  if (/allow_cloud_providers\s*=\s*false/i.test(rawError)) {
+    return "Cloud providers are disabled by configuration.";
+  }
+  if (
+    normalized.includes("timeout") ||
+    normalized.includes("timed out") ||
+    normalized.includes("connecttimeout") ||
+    normalized.includes("readtimeout")
+  ) {
+    return "Guardian cannot reach the model endpoint right now. Check connectivity and model service health.";
+  }
+  if (
+    normalized.includes("connection refused") ||
+    normalized.includes("econnrefused") ||
+    normalized.includes("enotfound") ||
+    normalized.includes("httpconnectionpool")
+  ) {
+    return "Guardian cannot connect to the configured model service. Start it or switch providers.";
+  }
+  if (
+    status === "misconfigured" ||
+    normalized.includes("misconfig") ||
+    normalized.includes("invalid model") ||
+    normalized.includes("unknown model")
+  ) {
+    return "Model configuration is invalid. Review provider/model settings.";
+  }
+  return "Guardian cannot reach the model endpoint. Check connectivity and model service availability.";
 }
 
 /**
@@ -252,6 +296,7 @@ export function GuardianChat({
     provider: null,
     model: null,
     error: null,
+    rawError: null,
     checkedAt: null,
   });
   const [availableProfiles, setAvailableProfiles] = useState<SystemProfileOption[]>(PROFILE_FALLBACK_OPTIONS);
@@ -328,22 +373,26 @@ export function GuardianChat({
           : data?.ok
             ? "online"
             : "unknown";
+      const rawError = normalizeLlmHealthRawError(data?.error);
 
       setLlmHealth({
         ok: typeof data?.ok === "boolean" ? data.ok : status === "online",
         status,
         provider: typeof data?.provider === "string" ? data.provider : null,
         model: typeof data?.model === "string" ? data.model : null,
-        error: typeof data?.error === "string" ? data.error : null,
+        error: toUserFacingLlmHealthError(rawError, status),
+        rawError,
         checkedAt: Date.now(),
       });
     } catch (err: any) {
+      const rawError = normalizeLlmHealthRawError(err?.message) || "LLM health check failed";
       setLlmHealth({
         ok: null,
         status: "unknown",
         provider: null,
         model: null,
-        error: err?.message || "LLM health check failed",
+        error: toUserFacingLlmHealthError(rawError, "unknown"),
+        rawError,
         checkedAt: Date.now(),
       });
       logOnce("poll:health-llm", 10_000, () => {
@@ -364,7 +413,7 @@ export function GuardianChat({
   const llmBackendUnavailable =
     llmHealth.status === "offline" || llmHealth.status === "misconfigured";
   const cloudProvidersDisabled = /ALLOW_CLOUD_PROVIDERS\s*=\s*false/i.test(
-    llmHealth.error || ""
+    llmHealth.rawError || ""
   );
   const llmStatusMessage =
     llmHealth.error

--- a/frontend/src/features/chat/__tests__/ChatView.loop-guards.test.tsx
+++ b/frontend/src/features/chat/__tests__/ChatView.loop-guards.test.tsx
@@ -104,15 +104,22 @@ vi.mock("@/features/chat/components/ChatBubble", () => ({
         ? "Playing..."
         : resolved === "unavailable"
           ? "Audio unavailable"
-          : resolved === "disabled"
+        : resolved === "disabled"
             ? "Voice disabled"
             : "Read Aloud";
     const disabled = resolved === "unavailable" || resolved === "disabled";
+    const ariaLabel = label === "Read Aloud" ? "Read message aloud" : label;
     return (
       <div data-testid={`bubble-${message.id}`}>
         <div>{message.content}</div>
         {showPlay ? (
-          <button type="button" onClick={onPlay} disabled={disabled}>
+          <button
+            type="button"
+            onClick={onPlay}
+            disabled={disabled}
+            aria-label={ariaLabel}
+            title={label}
+          >
             {label}
           </button>
         ) : null}
@@ -474,10 +481,18 @@ describe("ChatView loop guards", () => {
     });
 
     const { rerender } = render(
-      <ChatView threadId={1} completionState={completion} endCompletion={endCompletion} />
+      <ChatView
+        threadId={1}
+        completionState={completion}
+        endCompletion={endCompletion}
+        voiceReadAloudEnabled
+        voiceCapabilitiesFailed
+      />
     );
 
-    const firstPlay = await screen.findByRole("button", { name: "Read Aloud" });
+    const firstPlay = await screen.findByRole("button", {
+      name: "Read message aloud",
+    });
     fireEvent.click(firstPlay);
 
     await waitFor(() => {
@@ -501,17 +516,28 @@ describe("ChatView loop guards", () => {
       response: { status: 404, data: { detail: "route_not_found" } },
     });
 
-    rerender(<ChatView threadId={2} completionState={completion} endCompletion={endCompletion} />);
+    rerender(
+      <ChatView
+        threadId={2}
+        completionState={completion}
+        endCompletion={endCompletion}
+        voiceReadAloudEnabled
+        voiceCapabilitiesFailed
+      />
+    );
 
-    const secondPlay = await screen.findByRole("button", { name: "Read Aloud" });
+    const secondPlay = await screen.findByRole("button", {
+      name: "Read message aloud",
+    });
     fireEvent.click(secondPlay);
 
     await waitFor(() => {
       expect(apiPostMock).toHaveBeenCalledTimes(2);
     });
-    expect(await screen.findByRole("button", { name: "Voice disabled" })).toBeDisabled();
-
-    fireEvent.click(screen.getByRole("button", { name: "Voice disabled" }));
-    expect(apiPostMock).toHaveBeenCalledTimes(2);
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "Read message aloud" })
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/features/chat/__tests__/ChatView.loop-guards.test.tsx
+++ b/frontend/src/features/chat/__tests__/ChatView.loop-guards.test.tsx
@@ -250,6 +250,98 @@ describe("ChatView loop guards", () => {
     vi.useRealTimers();
   });
 
+  it("clears completion immediately when task.failed arrives for the active task", async () => {
+    const endCompletion = vi.fn();
+    const completion = {
+      isCompleting: true,
+      activeTaskId: "task-11",
+      activeThreadId: 11,
+      startedAt: Date.now(),
+    };
+
+    render(
+      <ChatView
+        threadId={11}
+        completionState={completion}
+        endCompletion={endCompletion}
+      />
+    );
+
+    await waitFor(() => {
+      expect(activeSubscriberCount("task.failed")).toBe(1);
+    });
+
+    emitLiveEvent("task.failed", {
+      thread_id: 11,
+      task_id: "task-11",
+      error: "boom",
+    });
+
+    await waitFor(() => {
+      expect(endCompletion).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("ignores stale task.failed and only finalizes for the active thread/task", async () => {
+    const endCompletion = vi.fn();
+    const completionThread2 = {
+      isCompleting: true,
+      activeTaskId: "task-2",
+      activeThreadId: 2,
+      startedAt: Date.now(),
+    };
+    const completionThread3 = {
+      isCompleting: true,
+      activeTaskId: "task-3",
+      activeThreadId: 3,
+      startedAt: Date.now(),
+    };
+
+    const { rerender } = render(
+      <ChatView
+        threadId={2}
+        completionState={completionThread2}
+        endCompletion={endCompletion}
+      />
+    );
+
+    await waitFor(() => {
+      expect(activeSubscriberCount("task.failed")).toBe(1);
+    });
+
+    rerender(
+      <ChatView
+        threadId={3}
+        completionState={completionThread3}
+        endCompletion={endCompletion}
+      />
+    );
+
+    await waitFor(() => {
+      expect(activeSubscriberCount("task.failed")).toBe(1);
+    });
+
+    act(() => {
+      emitLiveEvent("task.failed", {
+        thread_id: 2,
+        task_id: "task-2",
+        error: "stale",
+      });
+    });
+    expect(endCompletion).toHaveBeenCalledTimes(0);
+
+    act(() => {
+      emitLiveEvent("task.failed", {
+        thread_id: 3,
+        task_id: "task-3",
+        error: "active",
+      });
+    });
+    await waitFor(() => {
+      expect(endCompletion).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("uses poll-key idempotency and restarts when depth/profile context changes", async () => {
     const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
     mockMessages = [

--- a/frontend/src/features/chat/__tests__/ChatView.loop-guards.test.tsx
+++ b/frontend/src/features/chat/__tests__/ChatView.loop-guards.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import ChatView from "@/features/chat/ChatView";
@@ -12,6 +12,9 @@ const shouldRefreshMock = vi.fn().mockReturnValue(false);
 const markRefreshedMock = vi.fn();
 const subscribeMock = vi.fn();
 const apiPostMock = vi.fn();
+const apiGetMock = vi.fn();
+const pollOptionsHistory: any[] = [];
+let pollFnRef: (() => Promise<void>) | null = null;
 
 const liveSubscribersByType = new Map<string, Set<Subscriber>>();
 let unsubscribeCount = 0;
@@ -70,7 +73,10 @@ vi.mock("@/features/chat/hooks/useChatAutoScroll", async () => {
 });
 
 vi.mock("@/lib/polling/usePollWithBackoff", () => ({
-  usePollWithBackoff: () => {},
+  usePollWithBackoff: (fn: () => Promise<void>, opts: any) => {
+    pollFnRef = fn;
+    pollOptionsHistory.push(opts);
+  },
 }));
 
 vi.mock("@/components/ui/ContextMenu", () => ({
@@ -118,8 +124,9 @@ vi.mock("@/features/chat/components/ChatBubble", () => ({
 vi.mock("@/lib/api", () => ({
   default: {
     post: (...args: any[]) => apiPostMock(...args),
-    get: vi.fn(),
+    get: (...args: any[]) => apiGetMock(...args),
   },
+  getBackendOutageRemainingMs: vi.fn(() => 0),
 }));
 
 describe("ChatView loop guards", () => {
@@ -131,6 +138,9 @@ describe("ChatView loop guards", () => {
     shouldRefreshMock.mockReturnValue(false);
     markRefreshedMock.mockClear();
     apiPostMock.mockReset();
+    apiGetMock.mockReset();
+    pollFnRef = null;
+    pollOptionsHistory.length = 0;
     resetLiveSubscribers();
 
     subscribeMock.mockImplementation((eventType: string, handler: Subscriber) => {
@@ -246,10 +256,10 @@ describe("ChatView loop guards", () => {
     ];
 
     const completion = {
-      isCompleting: false,
-      activeTaskId: null,
-      activeThreadId: null,
-      startedAt: null,
+      isCompleting: true,
+      activeTaskId: "task-1",
+      activeThreadId: 1,
+      startedAt: Date.now(),
     };
     const endCompletion = vi.fn();
 
@@ -281,6 +291,11 @@ describe("ChatView loop guards", () => {
         )
       ).toBe(true);
     });
+
+    expect(pollOptionsHistory.length).toBeGreaterThan(0);
+    const latestOptions = pollOptionsHistory[pollOptionsHistory.length - 1];
+    expect(latestOptions.intervalMs).toBe(1500);
+    expect(latestOptions.maxBackoffMs).toBe(5000);
 
     rerender(
       <ChatView
@@ -317,6 +332,122 @@ describe("ChatView loop guards", () => {
         )
       ).toBe(true);
     });
+  });
+
+  it("does not start polling from reload updates when completion is inactive", async () => {
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    mockMessages = [
+      {
+        id: 201,
+        thread_id: 1,
+        role: "user",
+        content: "hello",
+        created_at: "2026-03-02T00:00:00.000Z",
+      },
+    ];
+    const completion = {
+      isCompleting: false,
+      activeTaskId: null,
+      activeThreadId: null,
+      startedAt: null,
+    };
+
+    const { rerender } = render(
+      <ChatView
+        threadId={1}
+        completionState={completion}
+        endCompletion={vi.fn()}
+        reloadVersion={0}
+      />
+    );
+
+    rerender(
+      <ChatView
+        threadId={1}
+        completionState={completion}
+        endCompletion={vi.fn()}
+        reloadVersion={1}
+      />
+    );
+
+    await waitFor(() => {
+      expect(loadMessagesMock).toHaveBeenCalled();
+    });
+
+    expect(
+      debugSpy.mock.calls.some((call) =>
+        String(call[0]).includes("[chat:poll] start reason=")
+      )
+    ).toBe(false);
+  });
+
+  it("stops polling when assistant reply arrives after user message", async () => {
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    mockMessages = [
+      {
+        id: 301,
+        thread_id: 1,
+        role: "user",
+        content: "pending",
+        created_at: "2026-03-02T00:00:00.000Z",
+      },
+    ];
+    apiGetMock.mockResolvedValue({
+      data: {
+        ok: true,
+        messages: [
+          {
+            id: 302,
+            thread_id: 1,
+            role: "assistant",
+            content: "done",
+            created_at: "2026-03-02T00:00:01.000Z",
+          },
+        ],
+        total: 2,
+      },
+    });
+    const completion = {
+      isCompleting: true,
+      activeTaskId: "task-301",
+      activeThreadId: 1,
+      startedAt: Date.now(),
+    };
+
+    render(
+      <ChatView
+        threadId={1}
+        completionState={completion}
+        endCompletion={vi.fn()}
+        reloadVersion={1}
+      />
+    );
+
+    await waitFor(() => {
+      expect(
+        debugSpy.mock.calls.some((call) =>
+          String(call[0]).includes("[chat:poll] start reason=user-message")
+        )
+      ).toBe(true);
+    });
+
+    expect(pollFnRef).not.toBeNull();
+    await act(async () => {
+      await pollFnRef?.();
+    });
+
+    expect(apiGetMock).toHaveBeenCalledWith("/chat/1/messages", {
+      params: { limit: 100, offset: 0 },
+    });
+    expect(appendMessageMock).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ id: 302, role: "assistant" })
+    );
+    expect(
+      debugSpy.mock.calls.some((call) =>
+        String(call[0]).includes("stop reason=assistant-reply-arrived")
+      )
+    ).toBe(true);
   });
 
   it("classifies voice 404s: message-level unavailable and route-level disable", async () => {

--- a/frontend/src/features/chat/__tests__/GuardianChat.offline-banner.test.tsx
+++ b/frontend/src/features/chat/__tests__/GuardianChat.offline-banner.test.tsx
@@ -49,6 +49,9 @@ vi.mock("@/features/chat/useChat", () => ({
     completionState: { isCompleting: false, activeThreadId: null },
     startCompletion: vi.fn(),
     endCompletion: vi.fn(),
+    updateCompletionTaskId: vi.fn(),
+    isCompletionInFlight: vi.fn(() => false),
+    setCompletionInFlight: vi.fn(),
   }),
 }));
 

--- a/frontend/src/features/chat/__tests__/GuardianChat.offline-banner.test.tsx
+++ b/frontend/src/features/chat/__tests__/GuardianChat.offline-banner.test.tsx
@@ -11,6 +11,7 @@ vi.mock("@/lib/api", () => ({
     patch: vi.fn(),
     delete: vi.fn(),
   },
+  clearInFlightCompletionTurnId: vi.fn(),
   getBackendOutageRemainingMs: vi.fn(() => 0),
 }));
 

--- a/frontend/src/features/chat/__tests__/GuardianChat.offline-banner.test.tsx
+++ b/frontend/src/features/chat/__tests__/GuardianChat.offline-banner.test.tsx
@@ -125,6 +125,12 @@ describe("GuardianChat offline provider reroute", () => {
     );
 
     await screen.findByText("LLM backend offline");
+    expect(screen.queryByText(/ConnectTimeout/i)).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Guardian cannot reach the model endpoint right now. Check connectivity and model service health."
+      )
+    ).toBeInTheDocument();
     const switchButton = screen.getByRole("button", { name: "Switch provider" });
     expect(switchButton).toBeInTheDocument();
     expect(screen.getByTestId("provider-open-signal")).toHaveTextContent("0");

--- a/frontend/src/features/chat/__tests__/useChat.test.ts
+++ b/frontend/src/features/chat/__tests__/useChat.test.ts
@@ -334,6 +334,38 @@ describe("useChat - completion state management", () => {
     expect(result.current.completionState.activeTaskId).toBe("task-second");
     expect(result.current.completionState.activeThreadId).toBe(456);
   });
+
+  it("retains the first assistant message when duplicate turn_id responses arrive", () => {
+    const { result } = renderHook(() => useChat());
+    const turnId = "11111111-1111-4111-8111-111111111111";
+
+    act(() => {
+      result.current.appendMessage(7, {
+        id: 701,
+        thread_id: 7,
+        role: "assistant",
+        content: "first response",
+        created_at: "2026-03-04T00:00:00.000Z",
+        turn_id: turnId,
+      });
+    });
+
+    act(() => {
+      result.current.appendMessage(7, {
+        id: 702,
+        thread_id: 7,
+        role: "assistant",
+        content: "duplicate response",
+        created_at: "2026-03-04T00:00:01.000Z",
+        metadata: { turn_id: turnId },
+      });
+    });
+
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0].id).toBe(701);
+    expect(result.current.messages[0].content).toBe("first response");
+    expect(result.current.messages[0].turn_id).toBe(turnId);
+  });
 });
 
 describe("useChat - loadMessages error hygiene", () => {

--- a/frontend/src/features/chat/__tests__/useChat.test.ts
+++ b/frontend/src/features/chat/__tests__/useChat.test.ts
@@ -1,4 +1,8 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+
+import api from "@/lib/api";
+
 import { parseMessagesResponse, useChat } from "../useChat";
 
 describe("parseMessagesResponse", () => {
@@ -322,5 +326,40 @@ describe("useChat - completion state management", () => {
 
     expect(result.current.completionState.activeTaskId).toBe("task-second");
     expect(result.current.completionState.activeThreadId).toBe(456);
+  });
+});
+
+describe("useChat - loadMessages error hygiene", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("suppresses internal request guard metadata from UI error state", async () => {
+    vi.spyOn(api, "get").mockRejectedValueOnce(
+      Object.assign(new Error("request guard active (1200ms)"), {
+        code: "ERR_CLIENT_RATE_GUARD",
+        waitMs: 1200,
+      })
+    );
+
+    const { result } = renderHook(() => useChat());
+    await act(async () => {
+      await result.current.loadMessages(32);
+    });
+
+    expect(result.current.error).toBeNull();
+  });
+
+  it("maps transport/internal exception text to a stable user-facing message", async () => {
+    vi.spyOn(api, "get").mockRejectedValueOnce(
+      new Error("HTTPConnectionPool(host='100.109.4.57', port=11434): Read timed out")
+    );
+
+    const { result } = renderHook(() => useChat());
+    await act(async () => {
+      await result.current.loadMessages(32);
+    });
+
+    expect(result.current.error).toBe("Unable to refresh messages right now.");
   });
 });

--- a/frontend/src/features/chat/__tests__/useChat.test.ts
+++ b/frontend/src/features/chat/__tests__/useChat.test.ts
@@ -221,7 +221,7 @@ describe("useChat - completion state management", () => {
     expect(result.current.completionState.startedAt).toBeNull();
   });
 
-  it("should auto-clear completion state after 30s timeout", async () => {
+  it("keeps completion active after 30s and clears on hard timeout", async () => {
     const { result } = renderHook(() => useChat());
 
     act(() => {
@@ -230,9 +230,16 @@ describe("useChat - completion state management", () => {
 
     expect(result.current.completionState.isCompleting).toBe(true);
 
-    // Fast-forward 30 seconds
+    // Fast-forward 30 seconds (slow path hint) — should still be completing
     act(() => {
-      jest.advanceTimersByTime(30000);
+      jest.advanceTimersByTime(30_000);
+    });
+
+    expect(result.current.completionState.isCompleting).toBe(true);
+
+    // Fast-forward to hard timeout (5 minutes)
+    act(() => {
+      jest.advanceTimersByTime(5 * 60_000);
     });
 
     await waitFor(() => {

--- a/frontend/src/features/chat/components/ChatBubble.tsx
+++ b/frontend/src/features/chat/components/ChatBubble.tsx
@@ -6,6 +6,7 @@
  */
 import React from "react";
 import { motion } from "framer-motion";
+import { Volume2 } from "lucide-react";
 import { Message, MessageAttachment } from "@/types/ui";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -214,7 +215,7 @@ export function ChatBubble({
   const hasText = Boolean(cleanedContent.trim());
   const resolvedPlayState =
     playState ?? (playing ? "playing" : "idle");
-  const playButtonLabel =
+  const playButtonTitle =
     resolvedPlayState === "playing"
       ? "Playing..."
       : resolvedPlayState === "unavailable"
@@ -222,6 +223,8 @@ export function ChatBubble({
         : resolvedPlayState === "disabled"
           ? "Voice disabled"
           : "Read Aloud";
+  const playButtonAriaLabel =
+    resolvedPlayState === "playing" ? "Playing audio" : "Read message aloud";
   const playDisabled =
     resolvedPlayState === "unavailable" || resolvedPlayState === "disabled";
 
@@ -318,7 +321,7 @@ export function ChatBubble({
             <button
               type="button"
               className={cn(
-                "text-[10px] px-2 py-0.5 rounded border",
+                "inline-flex h-6 w-6 items-center justify-center rounded border",
                 playDisabled ? "opacity-55 cursor-not-allowed" : "opacity-80 hover:opacity-100"
               )}
               style={{
@@ -328,8 +331,10 @@ export function ChatBubble({
               }}
               onClick={playDisabled ? undefined : onPlay}
               disabled={playDisabled}
+              aria-label={playButtonAriaLabel}
+              title={playButtonTitle}
             >
-              {playButtonLabel}
+              <Volume2 className="h-3.5 w-3.5" />
             </button>
           )}
         </div>

--- a/frontend/src/features/chat/useChat.ts
+++ b/frontend/src/features/chat/useChat.ts
@@ -22,6 +22,7 @@ export type ChatMessage = {
   content: string;
   created_at: string;
   attachments?: ChatAttachment[];
+  turn_id?: string | null;
 };
 
 function isInternalPollBackpressureError(error: any): boolean {
@@ -118,6 +119,29 @@ const normalizeAttachments = (raw: any): ChatAttachment[] => {
   return out;
 };
 
+const UUID_V4ISH_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function normalizeTurnId(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  return UUID_V4ISH_RE.test(trimmed) ? trimmed.toLowerCase() : null;
+}
+
+function readTurnId(raw: any): string | null {
+  const direct = normalizeTurnId(raw?.turn_id ?? raw?.turnId);
+  if (direct) return direct;
+  const base = raw?.message && typeof raw.message === "object" ? raw.message : raw;
+  const metadataCandidate =
+    base?.metadata ?? base?.extra_meta ?? base?.extraMeta;
+  if (metadataCandidate && typeof metadataCandidate === "object") {
+    const nested = metadataCandidate as Record<string, unknown>;
+    return normalizeTurnId(nested.turn_id ?? nested.turnId);
+  }
+  return null;
+}
+
 const normalizeMessage = (raw: any, fallbackThreadId?: number): ChatMessage | null => {
   if (!raw) return null;
   const base = raw.message && typeof raw.message === "object" ? raw.message : raw;
@@ -128,6 +152,7 @@ const normalizeMessage = (raw: any, fallbackThreadId?: number): ChatMessage | nu
   const createdAtRaw = base.created_at ?? base.createdAt;
   const createdAt = createdAtRaw ? String(createdAtRaw) : "";
   const attachments = normalizeAttachments(raw);
+  const turnId = readTurnId(raw);
   if (!Number.isFinite(threadId) || !Number.isFinite(id)) return null;
   // Drop true no-op messages, but allow attachment-only messages (uploads).
   const hasText = !!content.trim();
@@ -140,6 +165,7 @@ const normalizeMessage = (raw: any, fallbackThreadId?: number): ChatMessage | nu
     content,
     created_at: createdAt,
     attachments: attachments.length ? attachments : undefined,
+    turn_id: turnId,
   };
 };
 
@@ -166,7 +192,8 @@ const sameMessage = (a: ChatMessage, b: ChatMessage): boolean => {
     && a.thread_id === b.thread_id
     && a.role === b.role
     && a.content === b.content
-    && (a.created_at || "") === (b.created_at || "");
+    && (a.created_at || "") === (b.created_at || "")
+    && (a.turn_id || null) === (b.turn_id || null);
 };
 
 const equalMessageLists = (a: ChatMessage[], b: ChatMessage[]): boolean => {
@@ -177,6 +204,41 @@ const equalMessageLists = (a: ChatMessage[], b: ChatMessage[]): boolean => {
   }
   return true;
 };
+
+function isAssistantWithTurnId(message: ChatMessage): boolean {
+  return (
+    String(message.role || "").trim().toLowerCase() === "assistant" &&
+    Boolean(message.turn_id)
+  );
+}
+
+function findAssistantTurnDuplicateIndex(
+  messages: ChatMessage[],
+  incoming: ChatMessage
+): number {
+  if (!isAssistantWithTurnId(incoming)) return -1;
+  return messages.findIndex((candidate) => {
+    if (!isAssistantWithTurnId(candidate)) return false;
+    return candidate.turn_id === incoming.turn_id;
+  });
+}
+
+function collapseAssistantTurnDuplicates(messages: ChatMessage[]): ChatMessage[] {
+  if (messages.length < 2) return messages;
+  const seenTurns = new Set<string>();
+  const next: ChatMessage[] = [];
+  for (const message of messages) {
+    if (!isAssistantWithTurnId(message)) {
+      next.push(message);
+      continue;
+    }
+    const turnId = message.turn_id as string;
+    if (seenTurns.has(turnId)) continue;
+    seenTurns.add(turnId);
+    next.push(message);
+  }
+  return next;
+}
 
 export type CompletionState = {
   isCompleting: boolean;
@@ -268,7 +330,8 @@ export function useChat() {
         const nextHasMore = offset + page.length < tot;
         setHasMore((prev) => (prev === nextHasMore ? prev : nextHasMore));
         setMessages((prev) => {
-          const next = append ? mergeMessagePages(prev, page) : page;
+          const merged = append ? mergeMessagePages(prev, page) : page;
+          const next = collapseAssistantTurnDuplicates(merged);
           return equalMessageLists(prev, next) ? prev : next;
         });
       } else {
@@ -293,6 +356,15 @@ export function useChat() {
     const incoming = normalizeMessage(raw, threadId);
     if (!incoming || incoming.thread_id !== threadId) return;
     setMessages((prev) => {
+      const turnDuplicateIdx = findAssistantTurnDuplicateIndex(prev, incoming);
+      if (
+        turnDuplicateIdx >= 0 &&
+        prev[turnDuplicateIdx] &&
+        prev[turnDuplicateIdx].id !== incoming.id
+      ) {
+        return prev;
+      }
+
       const idx = prev.findIndex((msg) => msg.id === incoming.id);
       if (idx >= 0) {
         const existing = prev[idx];
@@ -306,7 +378,10 @@ export function useChat() {
         next[idx] = merged;
         return next;
       }
-      const next = [...prev, incoming];
+      const next = collapseAssistantTurnDuplicates([...prev, incoming]);
+      if (next.length === prev.length) {
+        return prev;
+      }
       setTotal((prevTotal) => prevTotal + 1);
       return next;
     });
@@ -483,18 +558,38 @@ function mergeMessagePages(prev: ChatMessage[], page: ChatMessage[]): ChatMessag
   const next = [...prev];
   // Deduplicate by id so SSE inserts do not re-add fetched messages.
   const indexById = new Map<number, number>();
-  next.forEach((msg, idx) => indexById.set(msg.id, idx));
+  const assistantTurnIndex = new Map<string, number>();
+  next.forEach((msg, idx) => {
+    indexById.set(msg.id, idx);
+    if (isAssistantWithTurnId(msg) && msg.turn_id) {
+      if (!assistantTurnIndex.has(msg.turn_id)) {
+        assistantTurnIndex.set(msg.turn_id, idx);
+      }
+    }
+  });
   page.forEach((msg) => {
+    if (isAssistantWithTurnId(msg) && msg.turn_id) {
+      const turnIdx = assistantTurnIndex.get(msg.turn_id);
+      if (turnIdx != null && next[turnIdx]?.id !== msg.id) {
+        return;
+      }
+    }
     const existingIdx = indexById.get(msg.id);
     if (existingIdx == null) {
       indexById.set(msg.id, next.length);
       next.push(msg);
+      if (isAssistantWithTurnId(msg) && msg.turn_id) {
+        assistantTurnIndex.set(msg.turn_id, next.length - 1);
+      }
       return;
     }
     const existing = next[existingIdx];
     if (!sameMessage(existing, msg)) {
       next[existingIdx] = msg;
+      if (isAssistantWithTurnId(msg) && msg.turn_id) {
+        assistantTurnIndex.set(msg.turn_id, existingIdx);
+      }
     }
   });
-  return next;
+  return collapseAssistantTurnDuplicates(next);
 }

--- a/frontend/src/features/chat/useChat.ts
+++ b/frontend/src/features/chat/useChat.ts
@@ -24,6 +24,33 @@ export type ChatMessage = {
   attachments?: ChatAttachment[];
 };
 
+function isInternalPollBackpressureError(error: any): boolean {
+  const code = String(error?.code ?? "").trim().toUpperCase();
+  if (code === "ERR_CLIENT_RATE_GUARD" || code === "ERR_BACKEND_OUTAGE_FUSE") {
+    return true;
+  }
+  const message = String(error?.message ?? "").toLowerCase();
+  return (
+    message.includes("request guard active") ||
+    message.includes("backend outage fuse active")
+  );
+}
+
+function toUserFacingLoadMessagesError(error: any): string | null {
+  if (isInternalPollBackpressureError(error)) {
+    // Internal control-flow signals should never render in the chat surface.
+    return null;
+  }
+  const status = Number(error?.response?.status ?? 0);
+  if (status === 401 || status === 403) {
+    return "You are not authorized to load this thread.";
+  }
+  if (status === 404) {
+    return "Thread not found.";
+  }
+  return "Unable to refresh messages right now.";
+}
+
 /**
  * Safely extract messages from API response.
  * Handles both envelope format { ok, total, messages } and raw array format.
@@ -231,7 +258,7 @@ export function useChat() {
       logOnce("poll:messages", 10_000, () => {
         console.warn(`[useChat] Failed to load messages for thread ${threadId}`, e);
       });
-      setError(e?.message || "Failed to load messages");
+      setError(toUserFacingLoadMessagesError(e));
       setMessages((prev) => (prev.length ? [] : prev));
       setTotal((prev) => (prev === 0 ? prev : 0));
       setHasMore((prev) => (prev === false ? prev : false));

--- a/frontend/src/features/chat/useChat.ts
+++ b/frontend/src/features/chat/useChat.ts
@@ -185,6 +185,9 @@ export type CompletionState = {
   startedAt: number | null;
 };
 
+const COMPLETION_SLOW_PATH_MS = 30_000;
+const COMPLETION_HARD_TIMEOUT_MS = 5 * 60_000; // 5 minutes
+
 export function useChat() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [total, setTotal] = useState(0);
@@ -203,8 +206,24 @@ export function useChat() {
     messageCount: 0,
     timestamp: 0,
   });
-  const completionTimeoutRef = useRef<number | null>(null);
+  const completionSlowTimeoutRef = useRef<number | null>(null);
+  const completionHardTimeoutRef = useRef<number | null>(null);
+  const inFlightCompletionRef = useRef<Record<number, boolean>>({});
   const completionGenerationRef = useRef(0);
+
+  const isCompletionInFlight = useCallback((threadId: number | null | undefined) => {
+    if (threadId == null) return false;
+    return Boolean(inFlightCompletionRef.current[threadId]);
+  }, []);
+
+  const setCompletionInFlight = useCallback((threadId: number, value: boolean) => {
+    if (!Number.isFinite(threadId)) return;
+    if (value) {
+      inFlightCompletionRef.current[threadId] = true;
+    } else {
+      delete inFlightCompletionRef.current[threadId];
+    }
+  }, []);
 
   const clearCompletionState = useCallback(() => {
     setCompletionState((prev) => {
@@ -216,6 +235,9 @@ export function useChat() {
       ) {
         return prev;
       }
+      if (prev.activeThreadId != null) {
+        setCompletionInFlight(prev.activeThreadId, false);
+      }
       return {
         isCompleting: false,
         activeTaskId: null,
@@ -223,7 +245,7 @@ export function useChat() {
         startedAt: null,
       };
     });
-  }, []);
+  }, [setCompletionInFlight]);
 
   const loadMessages = useCallback(async (threadId: number, limit = 50, offset = 0, append = false) => {
     activeThreadRef.current = threadId;
@@ -326,46 +348,81 @@ export function useChat() {
   const startCompletion = useCallback((threadId: number, taskId: string) => {
     const generation = completionGenerationRef.current + 1;
     completionGenerationRef.current = generation;
-    setCompletionState({
-      isCompleting: true,
-      activeTaskId: taskId,
-      activeThreadId: threadId,
-      startedAt: Date.now(),
+    setCompletionInFlight(threadId, true);
+    setCompletionState((prev) => {
+      const startedAt =
+        prev.isCompleting && prev.activeThreadId === threadId
+          ? prev.startedAt ?? Date.now()
+          : Date.now();
+      return {
+        isCompleting: true,
+        activeTaskId: taskId,
+        activeThreadId: threadId,
+        startedAt,
+      };
     });
     console.debug(`[useChat] Started completion tracking: thread=${threadId}, task=${taskId}`);
 
-    // Clear any existing timeout
-    if (completionTimeoutRef.current !== null) {
-      window.clearTimeout(completionTimeoutRef.current);
+    // Clear any existing timeouts
+    if (completionSlowTimeoutRef.current !== null) {
+      window.clearTimeout(completionSlowTimeoutRef.current);
+    }
+    if (completionHardTimeoutRef.current !== null) {
+      window.clearTimeout(completionHardTimeoutRef.current);
     }
 
-    // Set 30s timeout to auto-end completion if no event arrives
-    completionTimeoutRef.current = window.setTimeout(() => {
-      if (completionGenerationRef.current !== generation) {
-        return;
-      }
-      console.warn(`[useChat] Completion timeout reached (30s), clearing state`);
-      completionTimeoutRef.current = null;
+    // Hint timeout: after 30s, stay in slow-path but keep completion active
+    completionSlowTimeoutRef.current = window.setTimeout(() => {
+      if (completionGenerationRef.current !== generation) return;
+      console.warn(`[useChat] Completion still in progress after 30s (slow-path)`);
+      completionSlowTimeoutRef.current = null;
+    }, COMPLETION_SLOW_PATH_MS);
+
+    // Hard timeout: release after extended wait
+    completionHardTimeoutRef.current = window.setTimeout(() => {
+      if (completionGenerationRef.current !== generation) return;
+      console.warn(`[useChat] Completion hard-timeout reached (${COMPLETION_HARD_TIMEOUT_MS}ms), clearing state`);
+      completionHardTimeoutRef.current = null;
       clearCompletionState();
-    }, 30000);
-  }, [clearCompletionState]);
+    }, COMPLETION_HARD_TIMEOUT_MS);
+  }, [clearCompletionState, setCompletionInFlight]);
 
   const endCompletion = useCallback(() => {
     completionGenerationRef.current += 1;
-    if (completionTimeoutRef.current !== null) {
-      window.clearTimeout(completionTimeoutRef.current);
-      completionTimeoutRef.current = null;
+
+    if (completionSlowTimeoutRef.current !== null) {
+      window.clearTimeout(completionSlowTimeoutRef.current);
+      completionSlowTimeoutRef.current = null;
+    }
+    if (completionHardTimeoutRef.current !== null) {
+      window.clearTimeout(completionHardTimeoutRef.current);
+      completionHardTimeoutRef.current = null;
+    }
+    if (completionState.activeThreadId != null) {
+      setCompletionInFlight(completionState.activeThreadId, false);
     }
     console.debug(`[useChat] Ended completion tracking`);
     clearCompletionState();
-  }, [clearCompletionState]);
+  }, [clearCompletionState, completionState.activeThreadId, setCompletionInFlight]);
+
+  const updateCompletionTaskId = useCallback((taskId: string | null) => {
+    setCompletionState((prev) => {
+      if (!prev.isCompleting) return prev;
+      if (prev.activeTaskId === taskId) return prev;
+      return { ...prev, activeTaskId: taskId };
+    });
+  }, []);
 
   useEffect(
     () => () => {
       completionGenerationRef.current += 1;
-      if (completionTimeoutRef.current !== null) {
-        window.clearTimeout(completionTimeoutRef.current);
-        completionTimeoutRef.current = null;
+      if (completionSlowTimeoutRef.current !== null) {
+        window.clearTimeout(completionSlowTimeoutRef.current);
+        completionSlowTimeoutRef.current = null;
+      }
+      if (completionHardTimeoutRef.current !== null) {
+        window.clearTimeout(completionHardTimeoutRef.current);
+        completionHardTimeoutRef.current = null;
       }
     },
     []
@@ -411,6 +468,9 @@ export function useChat() {
     completionState,
     startCompletion,
     endCompletion,
+    updateCompletionTaskId,
+    isCompletionInFlight,
+    setCompletionInFlight,
     shouldRefresh,
     markRefreshed,
   };

--- a/frontend/src/features/settings/SettingsView.tsx
+++ b/frontend/src/features/settings/SettingsView.tsx
@@ -86,26 +86,40 @@ function formatElapsed(startedAt: number, now: number): string {
 
 function extractTaskEventDetail(data: unknown, fallbackType: string): string {
   if (typeof data === "string") {
-    const trimmed = data.trim();
-    if (trimmed) return trimmed;
+    const lines = data
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    if (lines.length > 0) {
+      return lines[lines.length - 1];
+    }
   }
   if (data && typeof data === "object") {
-    const record = data as Record<string, unknown>;
-    const candidates = [
-      record.message,
-      record.detail,
-      record.stage,
-      record.status,
-      record.state,
-      record.error,
-    ];
-    for (const candidate of candidates) {
-      if (typeof candidate === "string" && candidate.trim()) {
-        return candidate.trim();
-      }
+    const records: Array<Record<string, unknown>> = [data as Record<string, unknown>];
+    const top = data as Record<string, unknown>;
+    if (top.data && typeof top.data === "object") {
+      records.push(top.data as Record<string, unknown>);
     }
-    if (typeof record.progress === "number") {
-      return `Progress ${Math.max(0, Math.min(100, record.progress))}%`;
+    if (top.payload && typeof top.payload === "object") {
+      records.push(top.payload as Record<string, unknown>);
+    }
+    for (const record of records) {
+      const candidates = [
+        record.message,
+        record.detail,
+        record.stage,
+        record.status,
+        record.state,
+        record.error,
+      ];
+      for (const candidate of candidates) {
+        if (typeof candidate === "string" && candidate.trim()) {
+          return candidate.trim();
+        }
+      }
+      if (typeof record.progress === "number") {
+        return `Progress ${Math.max(0, Math.min(100, record.progress))}%`;
+      }
     }
   }
   return fallbackType;
@@ -116,44 +130,64 @@ function normalizeTaskEventStatus(
   data: unknown
 ): ImportRuntimeStatus | null {
   const normalizedType = eventType.toLowerCase();
-  const normalizedDataStatus =
-    data && typeof data === "object" && typeof (data as any).status === "string"
-      ? String((data as any).status).toLowerCase()
-      : "";
+  const candidateSignals: string[] = [normalizedType];
+
+  if (typeof data === "string") {
+    const trimmed = data.trim().toLowerCase();
+    if (trimmed) {
+      candidateSignals.push(trimmed);
+    }
+  } else if (data && typeof data === "object") {
+    const records: Array<Record<string, unknown>> = [data as Record<string, unknown>];
+    const top = data as Record<string, unknown>;
+    if (top.data && typeof top.data === "object") {
+      records.push(top.data as Record<string, unknown>);
+    }
+    if (top.payload && typeof top.payload === "object") {
+      records.push(top.payload as Record<string, unknown>);
+    }
+
+    for (const record of records) {
+      const maybeSignals = [
+        record.type,
+        record.event,
+        record.status,
+        record.state,
+        record.stage,
+      ];
+      for (const signal of maybeSignals) {
+        if (typeof signal === "string" && signal.trim()) {
+          candidateSignals.push(signal.toLowerCase());
+        }
+      }
+    }
+  }
+
+  const normalizedSignals = candidateSignals.join(" ");
 
   if (
-    normalizedType.includes("failed") ||
-    normalizedType.includes("cancel") ||
-    normalizedDataStatus.includes("failed") ||
-    normalizedDataStatus.includes("cancel")
+    normalizedSignals.includes("failed") ||
+    normalizedSignals.includes("cancel")
   ) {
     return "failed";
   }
   if (
-    normalizedType.includes("completed") ||
-    normalizedType.includes("succeeded") ||
-    normalizedType.includes("done") ||
-    normalizedDataStatus.includes("completed") ||
-    normalizedDataStatus.includes("succeeded") ||
-    normalizedDataStatus.includes("done")
+    normalizedSignals.includes("completed") ||
+    normalizedSignals.includes("succeeded") ||
+    normalizedSignals.includes("done")
   ) {
     return "succeeded";
   }
   if (
-    normalizedType.includes("running") ||
-    normalizedType.includes("started") ||
-    normalizedType.includes("progress") ||
-    normalizedDataStatus.includes("running") ||
-    normalizedDataStatus.includes("started") ||
-    normalizedDataStatus.includes("progress")
+    normalizedSignals.includes("running") ||
+    normalizedSignals.includes("started") ||
+    normalizedSignals.includes("progress")
   ) {
     return "running";
   }
   if (
-    normalizedType.includes("queued") ||
-    normalizedType.includes("created") ||
-    normalizedDataStatus.includes("queued") ||
-    normalizedDataStatus.includes("created")
+    normalizedSignals.includes("queued") ||
+    normalizedSignals.includes("created")
   ) {
     return "queued";
   }
@@ -397,13 +431,23 @@ export function SettingsView({
       }
 
       const nextStatus = normalizeTaskEventStatus(message.type, payload);
-      const detail = extractTaskEventDetail(payload, message.type);
+      const fallbackDetail =
+        message.type === "message"
+          ? "Import event received."
+          : message.type.replace("task.", "").replace(/\./g, " ");
+      const detail = extractTaskEventDetail(payload, fallbackDetail);
       const now = Date.now();
 
       setImportLastEventAt(now);
       setImportDetail(detail);
       if (nextStatus) {
         setImportStatus(nextStatus);
+        if (isTerminalStatus(nextStatus)) {
+          stream.close();
+          if (importTaskStreamRef.current === stream) {
+            importTaskStreamRef.current = null;
+          }
+        }
       }
     };
 

--- a/frontend/src/features/settings/SettingsView.tsx
+++ b/frontend/src/features/settings/SettingsView.tsx
@@ -22,11 +22,143 @@ import {
   saveDesktopConnectionSettings,
 } from "@/lib/runtimeConfig";
 import {
+  default as api,
   clearRuntimeApiKey,
+  getAuthToken,
+  getDevApiKey,
   readRuntimeApiKey,
   refreshApiBaseUrl,
   setRuntimeApiKey,
 } from "@/lib/api";
+import { GuardianEventSource } from "@/lib/guardianEventSource";
+
+type ImportRuntimeStatus =
+  | "idle"
+  | "queued"
+  | "running"
+  | "succeeded"
+  | "failed";
+
+type StoredChatGPTImportTask = {
+  taskId: string;
+  startedAt: number;
+  status: ImportRuntimeStatus;
+  detail: string;
+  lastEventAt: number;
+};
+
+const CHATGPT_IMPORT_TASK_STORAGE_KEY = "codexify.chatgpt_import_task";
+
+function isChatGPTImportPath(rawUrl: unknown): boolean {
+  if (typeof rawUrl !== "string") return false;
+  try {
+    const parsed = new URL(rawUrl, "http://localhost");
+    const path = parsed.pathname.replace(/\/+$/, "");
+    return (
+      path.endsWith("/upload-chatgpt-export") ||
+      path.endsWith("/api/upload-chatgpt-export")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function statusLabel(status: ImportRuntimeStatus): string {
+  if (status === "queued") return "Queued";
+  if (status === "running") return "Running";
+  if (status === "succeeded") return "Succeeded";
+  if (status === "failed") return "Failed";
+  return "Idle";
+}
+
+function isTerminalStatus(status: ImportRuntimeStatus): boolean {
+  return status === "succeeded" || status === "failed";
+}
+
+function formatElapsed(startedAt: number, now: number): string {
+  if (!Number.isFinite(startedAt) || startedAt <= 0) return "0s";
+  const elapsedSeconds = Math.max(0, Math.floor((now - startedAt) / 1000));
+  const minutes = Math.floor(elapsedSeconds / 60);
+  const seconds = elapsedSeconds % 60;
+  if (minutes <= 0) return `${seconds}s`;
+  return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
+}
+
+function extractTaskEventDetail(data: unknown, fallbackType: string): string {
+  if (typeof data === "string") {
+    const trimmed = data.trim();
+    if (trimmed) return trimmed;
+  }
+  if (data && typeof data === "object") {
+    const record = data as Record<string, unknown>;
+    const candidates = [
+      record.message,
+      record.detail,
+      record.stage,
+      record.status,
+      record.state,
+      record.error,
+    ];
+    for (const candidate of candidates) {
+      if (typeof candidate === "string" && candidate.trim()) {
+        return candidate.trim();
+      }
+    }
+    if (typeof record.progress === "number") {
+      return `Progress ${Math.max(0, Math.min(100, record.progress))}%`;
+    }
+  }
+  return fallbackType;
+}
+
+function normalizeTaskEventStatus(
+  eventType: string,
+  data: unknown
+): ImportRuntimeStatus | null {
+  const normalizedType = eventType.toLowerCase();
+  const normalizedDataStatus =
+    data && typeof data === "object" && typeof (data as any).status === "string"
+      ? String((data as any).status).toLowerCase()
+      : "";
+
+  if (
+    normalizedType.includes("failed") ||
+    normalizedType.includes("cancel") ||
+    normalizedDataStatus.includes("failed") ||
+    normalizedDataStatus.includes("cancel")
+  ) {
+    return "failed";
+  }
+  if (
+    normalizedType.includes("completed") ||
+    normalizedType.includes("succeeded") ||
+    normalizedType.includes("done") ||
+    normalizedDataStatus.includes("completed") ||
+    normalizedDataStatus.includes("succeeded") ||
+    normalizedDataStatus.includes("done")
+  ) {
+    return "succeeded";
+  }
+  if (
+    normalizedType.includes("running") ||
+    normalizedType.includes("started") ||
+    normalizedType.includes("progress") ||
+    normalizedDataStatus.includes("running") ||
+    normalizedDataStatus.includes("started") ||
+    normalizedDataStatus.includes("progress")
+  ) {
+    return "running";
+  }
+  if (
+    normalizedType.includes("queued") ||
+    normalizedType.includes("created") ||
+    normalizedDataStatus.includes("queued") ||
+    normalizedDataStatus.includes("created")
+  ) {
+    return "queued";
+  }
+  return null;
+}
 
 export function SettingsView({
   mode,
@@ -101,6 +233,42 @@ export function SettingsView({
   const [connectionBusy, setConnectionBusy] = useState(false);
   const [connectionMessage, setConnectionMessage] = useState<string | null>(null);
   const [connectionError, setConnectionError] = useState<string | null>(null);
+  const [importTaskId, setImportTaskId] = useState<string | null>(null);
+  const [importStatus, setImportStatus] = useState<ImportRuntimeStatus>("idle");
+  const [importDetail, setImportDetail] = useState("");
+  const [importStartedAt, setImportStartedAt] = useState(0);
+  const [importLastEventAt, setImportLastEventAt] = useState(0);
+  const [importPanelHidden, setImportPanelHidden] = useState(false);
+  const [importNow, setImportNow] = useState(() => Date.now());
+  const importPendingStartedAtRef = useRef(0);
+  const importTaskStreamRef = useRef<GuardianEventSource | null>(null);
+  const isImportActive = importStatus === "queued" || importStatus === "running";
+  const isImportTerminal = isTerminalStatus(importStatus);
+  const shouldShowImportStatusPanel = importStatus !== "idle" && !importPanelHidden;
+  const importElapsed = formatElapsed(importStartedAt, importNow);
+
+  function resetImportStatus() {
+    setImportTaskId(null);
+    setImportStatus("idle");
+    setImportDetail("");
+    setImportStartedAt(0);
+    setImportLastEventAt(0);
+    setImportPanelHidden(false);
+    importPendingStartedAtRef.current = 0;
+    importTaskStreamRef.current?.close();
+    importTaskStreamRef.current = null;
+    if (typeof window !== "undefined") {
+      localStorage.removeItem(CHATGPT_IMPORT_TASK_STORAGE_KEY);
+    }
+  }
+
+  function handleImportPanelAction() {
+    if (isImportTerminal) {
+      resetImportStatus();
+      return;
+    }
+    setImportPanelHidden(true);
+  }
   useEffect(() => setName(guardianName), [guardianName]);
   useEffect(() => setUName(userName), [userName]);
   useEffect(() => setURole(role), [role]);
@@ -114,6 +282,276 @@ export function SettingsView({
     setDesktopApiKeyInput(readRuntimeApiKey() ?? "");
   }, [desktopMode]);
 
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const raw = window.localStorage.getItem(CHATGPT_IMPORT_TASK_STORAGE_KEY);
+    if (!raw) return;
+    try {
+      const parsed = JSON.parse(raw) as Partial<StoredChatGPTImportTask>;
+      const storedTaskId =
+        typeof parsed.taskId === "string" ? parsed.taskId.trim() : "";
+      if (!storedTaskId) {
+        window.localStorage.removeItem(CHATGPT_IMPORT_TASK_STORAGE_KEY);
+        return;
+      }
+      const startedAt =
+        typeof parsed.startedAt === "number" && Number.isFinite(parsed.startedAt)
+          ? parsed.startedAt
+          : Date.now();
+      const status =
+        parsed.status === "queued" ||
+        parsed.status === "running" ||
+        parsed.status === "succeeded" ||
+        parsed.status === "failed"
+          ? parsed.status
+          : "running";
+      setImportTaskId(storedTaskId);
+      setImportStatus(status);
+      setImportStartedAt(startedAt);
+      setImportDetail(
+        typeof parsed.detail === "string" && parsed.detail.trim()
+          ? parsed.detail
+          : "Reattached to background import task."
+      );
+      setImportLastEventAt(
+        typeof parsed.lastEventAt === "number" && Number.isFinite(parsed.lastEventAt)
+          ? parsed.lastEventAt
+          : startedAt
+      );
+      setImportPanelHidden(false);
+    } catch {
+      window.localStorage.removeItem(CHATGPT_IMPORT_TASK_STORAGE_KEY);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!importTaskId) return;
+    const snapshot: StoredChatGPTImportTask = {
+      taskId: importTaskId,
+      startedAt: importStartedAt || Date.now(),
+      status: importStatus,
+      detail: importDetail,
+      lastEventAt: importLastEventAt || Date.now(),
+    };
+    window.localStorage.setItem(
+      CHATGPT_IMPORT_TASK_STORAGE_KEY,
+      JSON.stringify(snapshot)
+    );
+  }, [
+    importTaskId,
+    importStartedAt,
+    importStatus,
+    importDetail,
+    importLastEventAt,
+  ]);
+
+  useEffect(() => {
+    if (importStatus === "idle") return;
+    const timer = window.setInterval(() => {
+      setImportNow(Date.now());
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, [importStatus]);
+
+  useEffect(() => {
+    if (!importTaskId || isImportTerminal) {
+      importTaskStreamRef.current?.close();
+      importTaskStreamRef.current = null;
+      return;
+    }
+
+    const apiKey = readRuntimeApiKey() || getDevApiKey();
+    const authToken = getAuthToken();
+    const headers: Record<string, string> = {};
+    if (authToken) {
+      headers.Authorization = `Bearer ${authToken}`;
+    } else if (apiKey) {
+      headers["X-API-Key"] = apiKey;
+    }
+
+    const stream = new GuardianEventSource(
+      `/api/tasks/${encodeURIComponent(importTaskId)}/events`,
+      {
+        headers,
+        withCredentials: true,
+        autoReconnect: true,
+        retryInterval: 3000,
+      }
+    );
+
+    importTaskStreamRef.current?.close();
+    importTaskStreamRef.current = stream;
+
+    const handleTaskEvent = (event: Event) => {
+      const message = event as MessageEvent<string>;
+      let payload: unknown = message.data;
+      if (typeof payload === "string") {
+        const trimmed = payload.trim();
+        if (!trimmed) return;
+        try {
+          payload = JSON.parse(trimmed);
+        } catch {
+          payload = trimmed;
+        }
+      }
+
+      const nextStatus = normalizeTaskEventStatus(message.type, payload);
+      const detail = extractTaskEventDetail(payload, message.type);
+      const now = Date.now();
+
+      setImportLastEventAt(now);
+      setImportDetail(detail);
+      if (nextStatus) {
+        setImportStatus(nextStatus);
+      }
+    };
+
+    stream.onopen = () => {
+      const now = Date.now();
+      setImportLastEventAt(now);
+      setImportStatus((current) =>
+        current === "queued" ? "running" : current
+      );
+      setImportDetail((current) =>
+        current || "Import task connected. Waiting for updates..."
+      );
+    };
+
+    stream.onerror = () => {
+      const now = Date.now();
+      setImportLastEventAt(now);
+      setImportStatus((current) =>
+        current === "queued" ? "running" : current
+      );
+      setImportDetail((current) =>
+        current || "Import is still running. Waiting for next update..."
+      );
+    };
+
+    const eventTypes = [
+      "message",
+      "task.created",
+      "task.queued",
+      "task.running",
+      "task.started",
+      "task.progress",
+      "task.completed",
+      "task.failed",
+      "task.cancelled",
+    ];
+
+    for (const eventType of eventTypes) {
+      stream.addEventListener(eventType, handleTaskEvent);
+    }
+
+    return () => {
+      for (const eventType of eventTypes) {
+        stream.removeEventListener(eventType, handleTaskEvent);
+      }
+      stream.close();
+      if (importTaskStreamRef.current === stream) {
+        importTaskStreamRef.current = null;
+      }
+    };
+  }, [importTaskId, isImportTerminal]);
+
+  useEffect(() => {
+    const requestInterceptorId = api.interceptors.request.use((config: any) => {
+      if (!isChatGPTImportPath(config?.url)) return config;
+      const startedAt = Date.now();
+      importPendingStartedAtRef.current = startedAt;
+      setImportPanelHidden(false);
+      setImportStartedAt(startedAt);
+      setImportLastEventAt(startedAt);
+      setImportStatus("queued");
+      setImportDetail("Import started. Preparing background task...");
+      setMigrationStepSkipped(false);
+      return config;
+    });
+
+    const responseInterceptorId = api.interceptors.response.use(
+      (response: any) => {
+        if (!isChatGPTImportPath(response?.config?.url)) {
+          return response;
+        }
+
+        const now = Date.now();
+        const startedAt = importPendingStartedAtRef.current || now;
+        importPendingStartedAtRef.current = 0;
+
+        const rawTaskId =
+          response?.data?.task_id ??
+          response?.data?.taskId ??
+          response?.headers?.["x-task-id"] ??
+          response?.headers?.["X-Task-Id"];
+        const taskId =
+          typeof rawTaskId === "string" ? rawTaskId.trim() : String(rawTaskId || "");
+
+        if (taskId) {
+          setImportTaskId(taskId);
+          setImportStartedAt(startedAt);
+          setImportLastEventAt(now);
+          setImportStatus("queued");
+          setImportDetail("Import queued. Live progress is now attached.");
+          return response;
+        }
+
+        const threads = Number(response?.data?.threads_imported ?? 0);
+        const messages = Number(response?.data?.messages_imported ?? 0);
+        setImportTaskId(null);
+        setImportStartedAt(startedAt);
+        setImportLastEventAt(now);
+        setImportStatus("succeeded");
+        setImportDetail(
+          `Import completed. Imported ${threads} thread${
+            threads === 1 ? "" : "s"
+          } and ${messages} message${messages === 1 ? "" : "s"}.`
+        );
+        if (typeof window !== "undefined") {
+          window.localStorage.removeItem(CHATGPT_IMPORT_TASK_STORAGE_KEY);
+        }
+        return response;
+      },
+      (error: any) => {
+        if (!isChatGPTImportPath(error?.config?.url)) {
+          return Promise.reject(error);
+        }
+
+        const now = Date.now();
+        const startedAt = importPendingStartedAtRef.current || now;
+        importPendingStartedAtRef.current = 0;
+        const detail =
+          error?.response?.data?.detail ??
+          error?.response?.data?.error ??
+          error?.message ??
+          "ChatGPT import failed.";
+
+        setImportTaskId(null);
+        setImportStartedAt(startedAt);
+        setImportLastEventAt(now);
+        setImportStatus("failed");
+        setImportDetail(String(detail));
+        if (typeof window !== "undefined") {
+          window.localStorage.removeItem(CHATGPT_IMPORT_TASK_STORAGE_KEY);
+        }
+        return Promise.reject(error);
+      }
+    );
+
+    return () => {
+      api.interceptors.request.eject(requestInterceptorId);
+      api.interceptors.response.eject(responseInterceptorId);
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      importTaskStreamRef.current?.close();
+      importTaskStreamRef.current = null;
+    };
+  }, []);
+
   function handleSave() {
     setGuardianName(name);
     setUserName(uName);
@@ -123,7 +561,7 @@ export function SettingsView({
   }
 
   const [fileLabel, setFileLabel] = useState<string>("");
-  const [uploading, setUploading] = useState(false);
+  const [, setUploading] = useState(false);
   const fileRef = useRef<HTMLInputElement | null>(null);
   function triggerFile() {
     fileRef.current?.click();
@@ -155,7 +593,7 @@ export function SettingsView({
   }
 
   const migrationComplete =
-    migrationStepSkipped || migrationStats !== null;
+    migrationStepSkipped || migrationStats !== null || importStatus === "succeeded";
 
   async function handleSaveConnectionSettings() {
     if (!desktopMode) return;
@@ -499,10 +937,14 @@ export function SettingsView({
               <div className="grid gap-2 sm:grid-cols-2">
                 <Button
                   type="button"
-                  onClick={() => setChatGPTModalOpen(true)}
+                  onClick={() => {
+                    setImportPanelHidden(false);
+                    setChatGPTModalOpen(true);
+                  }}
+                  disabled={isImportActive}
                   className="rounded-[var(--tile-radius,19px)] w-full"
                 >
-                  Import ChatGPT history
+                  {isImportActive ? "Import in progress..." : "Import ChatGPT history"}
                 </Button>
                 <Button
                   type="button"
@@ -513,6 +955,74 @@ export function SettingsView({
                   Download Codexify ZIP export
                 </Button>
               </div>
+
+              {shouldShowImportStatusPanel && (
+                <div className="rounded-[var(--tile-radius,19px)] border border-[var(--panel-border)] p-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="flex items-center gap-2">
+                      {isImportActive && (
+                        <span className="inline-block h-3 w-3 rounded-full border-2 border-white/30 border-t-white animate-spin" />
+                      )}
+                      <span
+                        className="rounded-full border px-2 py-0.5 text-[11px] font-medium"
+                        style={{
+                          borderColor:
+                            importStatus === "failed"
+                              ? "rgba(248, 113, 113, 0.4)"
+                              : importStatus === "succeeded"
+                                ? "rgba(34, 197, 94, 0.4)"
+                                : "rgba(125, 211, 252, 0.4)",
+                          color:
+                            importStatus === "failed"
+                              ? "rgb(254, 202, 202)"
+                              : importStatus === "succeeded"
+                                ? "rgb(134, 239, 172)"
+                                : "rgb(186, 230, 253)",
+                        }}
+                      >
+                        {statusLabel(importStatus)}
+                      </span>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleImportPanelAction}
+                      className="rounded-[var(--tile-radius,19px)]"
+                    >
+                      {isImportTerminal ? "Dismiss" : "Hide"}
+                    </Button>
+                  </div>
+                  <div className="mt-2 text-xs opacity-80">
+                    Elapsed: {importElapsed}
+                    {importLastEventAt > 0 ? " • Live updates active" : ""}
+                  </div>
+                  {importTaskId && (
+                    <div className="mt-1 text-[11px] opacity-70 break-all">
+                      Task ID: {importTaskId}
+                    </div>
+                  )}
+                  <div className="mt-1 text-xs">{importDetail || "Import task running."}</div>
+                  <div className="mt-2 text-xs opacity-70">
+                    You can navigate away; this continues in the background.
+                  </div>
+                </div>
+              )}
+
+              {!shouldShowImportStatusPanel && isImportActive && (
+                <div className="rounded-[var(--tile-radius,19px)] border border-[var(--panel-border)] p-3 text-xs flex items-center justify-between gap-3">
+                  <span>Import is running in the background.</span>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setImportPanelHidden(false)}
+                    className="rounded-[var(--tile-radius,19px)]"
+                  >
+                    Show status
+                  </Button>
+                </div>
+              )}
 
               {!migrationComplete && (
                 <div className="flex justify-end">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -211,12 +211,16 @@ const BACKEND_OUTAGE_BASE_MS = 1000;
 const BACKEND_OUTAGE_MAX_MS = 30000;
 const BACKEND_OUTAGE_LOG_TTL_MS = 5000;
 const REQUEST_GUARD_LOG_TTL_MS = 4000;
+const CHAT_COMPLETE_PATH_RE = /\/chat\/(\d+)\/complete$/i;
+const UUID_V4ISH_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 let backendOutageUntil = 0;
 let backendOutageFailures = 0;
 let lastBackendOutageLogAt = 0;
 let lastRequestGuardLogAt = 0;
 const lastRequestByKey = new Map<string, number>();
+const inFlightCompletionTurnByThread = new Map<number, string>();
 
 function normalizePathSegment(value: string | number): string {
   return encodeURIComponent(String(value).trim());
@@ -317,6 +321,114 @@ function applyBackendOutage(reason: string): void {
 function clearBackendOutage(): void {
   backendOutageFailures = 0;
   backendOutageUntil = 0;
+}
+
+function normalizeCompletionTurnId(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  return UUID_V4ISH_RE.test(trimmed) ? trimmed.toLowerCase() : null;
+}
+
+function generateCompletionTurnId(): string {
+  const randomUUID = (globalThis as any)?.crypto?.randomUUID;
+  if (typeof randomUUID === "function") {
+    try {
+      return String(randomUUID.call((globalThis as any).crypto));
+    } catch {
+      // Fall back below.
+    }
+  }
+  const template = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx";
+  return template.replace(/[xy]/g, (char) => {
+    const value = Math.floor(Math.random() * 16);
+    const nibble = char === "x" ? value : (value & 0x3) | 0x8;
+    return nibble.toString(16);
+  });
+}
+
+function extractCompletionThreadId(url: unknown): number | null {
+  const match = pathFromUrl(url).match(CHAT_COMPLETE_PATH_RE);
+  if (!match || !match[1]) return null;
+  const threadId = Number(match[1]);
+  return Number.isFinite(threadId) ? threadId : null;
+}
+
+function readCompletionPayload(data: unknown): {
+  payload: Record<string, unknown>;
+  wasJsonString: boolean;
+} {
+  if (data && typeof data === "object" && !Array.isArray(data)) {
+    return {
+      payload: { ...(data as Record<string, unknown>) },
+      wasJsonString: false,
+    };
+  }
+  if (typeof data === "string" && data.trim()) {
+    try {
+      const parsed = JSON.parse(data);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return {
+          payload: { ...(parsed as Record<string, unknown>) },
+          wasJsonString: true,
+        };
+      }
+    } catch {
+      // Ignore malformed payloads; we'll replace with an object below.
+    }
+  }
+  return { payload: {}, wasJsonString: false };
+}
+
+function readCompletionMeta(config: unknown): {
+  threadId: number;
+  turnId: string | null;
+} | null {
+  const candidate = config as any;
+  const threadId = Number(candidate?.__cfyCompletionThreadId);
+  if (!Number.isFinite(threadId)) return null;
+  return {
+    threadId,
+    turnId: normalizeCompletionTurnId(candidate?.__cfyCompletionTurnId),
+  };
+}
+
+function completionErrorDetail(error: any): string {
+  const detail = error?.response?.data?.detail;
+  if (typeof detail === "string") return detail.toLowerCase();
+  if (!detail || typeof detail !== "object") return "";
+  return [
+    detail?.error,
+    detail?.reason,
+    detail?.message,
+    detail?.code,
+  ]
+    .filter(Boolean)
+    .map((value) => String(value).toLowerCase())
+    .join(" ");
+}
+
+export function getInFlightCompletionTurnId(
+  threadId: number | null | undefined
+): string | null {
+  if (threadId == null) return null;
+  const normalizedThreadId = Number(threadId);
+  if (!Number.isFinite(normalizedThreadId)) return null;
+  return inFlightCompletionTurnByThread.get(normalizedThreadId) ?? null;
+}
+
+export function clearInFlightCompletionTurnId(
+  threadId: number | null | undefined,
+  expectedTurnId?: string | null
+): void {
+  if (threadId == null) return;
+  const normalizedThreadId = Number(threadId);
+  if (!Number.isFinite(normalizedThreadId)) return;
+  if (expectedTurnId) {
+    const current = inFlightCompletionTurnByThread.get(normalizedThreadId);
+    if (current !== expectedTurnId) return;
+  }
+  inFlightCompletionTurnByThread.delete(normalizedThreadId);
 }
 
 export function getBackendOutageRemainingMs(now = Date.now()): number {
@@ -493,6 +605,23 @@ api.interceptors.request.use((config) => {
     config.url = config.url.replace(/^\/api/, "");
   }
 
+  const isPostCompletionRequest =
+    String(config.method ?? "get").toLowerCase() === "post";
+  const completionThreadId = isPostCompletionRequest
+    ? extractCompletionThreadId(config.url)
+    : null;
+  if (completionThreadId != null) {
+    const { payload, wasJsonString } = readCompletionPayload(config.data);
+    const existingTurnId = getInFlightCompletionTurnId(completionThreadId);
+    const requestedTurnId = normalizeCompletionTurnId(payload.turn_id ?? payload.turnId);
+    const turnId = existingTurnId || requestedTurnId || generateCompletionTurnId();
+    payload.turn_id = turnId;
+    config.data = wasJsonString ? JSON.stringify(payload) : payload;
+    inFlightCompletionTurnByThread.set(completionThreadId, turnId);
+    (config as any).__cfyCompletionThreadId = completionThreadId;
+    (config as any).__cfyCompletionTurnId = turnId;
+  }
+
   const guard = isRequestGuardEnabled()
     ? shouldThrottleDuplicateRequest(config.method, config.url)
     : { throttled: false, waitMs: 0, key: "" };
@@ -515,10 +644,30 @@ api.interceptors.request.use((config) => {
 
 api.interceptors.response.use(
   (response) => {
+    const completionMeta = readCompletionMeta(response?.config);
+    if (completionMeta) {
+      const returnedTurnId = normalizeCompletionTurnId(response?.data?.turn_id);
+      if (returnedTurnId) {
+        inFlightCompletionTurnByThread.set(completionMeta.threadId, returnedTurnId);
+      }
+    }
     clearBackendOutage();
     return response;
   },
   (error) => {
+    const completionMeta = readCompletionMeta(error?.config);
+    if (completionMeta) {
+      const status = Number(error?.response?.status ?? 0);
+      const shouldKeep =
+        status === 429 && completionErrorDetail(error).includes("turn_in_flight");
+      if (!shouldKeep) {
+        clearInFlightCompletionTurnId(
+          completionMeta.threadId,
+          completionMeta.turnId
+        );
+      }
+    }
+
     if (isBackendTransportError(error)) {
       applyBackendOutage("transport");
     } else if (isBackendProxyOutageResponse(error)) {
@@ -535,5 +684,8 @@ api.interceptors.response.use(
     return Promise.reject(error);
   }
 );
+
+(api as any).getInFlightCompletionTurnId = getInFlightCompletionTurnId;
+(api as any).clearInFlightCompletionTurnId = clearInFlightCompletionTurnId;
 
 export default api;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -612,9 +612,9 @@ api.interceptors.request.use((config) => {
     : null;
   if (completionThreadId != null) {
     const { payload, wasJsonString } = readCompletionPayload(config.data);
-    const existingTurnId = getInFlightCompletionTurnId(completionThreadId);
     const requestedTurnId = normalizeCompletionTurnId(payload.turn_id ?? payload.turnId);
-    const turnId = existingTurnId || requestedTurnId || generateCompletionTurnId();
+    // Use per-request turn ids by default; do not carry stale ids between requests.
+    const turnId = requestedTurnId || generateCompletionTurnId();
     payload.turn_id = turnId;
     config.data = wasJsonString ? JSON.stringify(payload) : payload;
     inFlightCompletionTurnByThread.set(completionThreadId, turnId);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -378,6 +378,14 @@ function shouldThrottleDuplicateRequest(
   return { throttled: false, waitMs: 0, key };
 }
 
+function isRequestGuardEnabled(): boolean {
+  const raw = readRuntimeEnv("VITE_ENABLE_REQUEST_GUARD", "true")
+    .trim()
+    .toLowerCase();
+  if (!raw) return true;
+  return !["0", "false", "off", "no"].includes(raw);
+}
+
 export function refreshApiBaseUrl(): string {
   const runtimeConfig = getRuntimeConfigSync();
   api.defaults.baseURL = runtimeConfig.apiBaseUrl;
@@ -482,7 +490,9 @@ api.interceptors.request.use((config) => {
     config.url = config.url.replace(/^\/api/, "");
   }
 
-  const guard = shouldThrottleDuplicateRequest(config.method, config.url);
+  const guard = isRequestGuardEnabled()
+    ? shouldThrottleDuplicateRequest(config.method, config.url)
+    : { throttled: false, waitMs: 0, key: "" };
   if (guard.throttled) {
     const now = Date.now();
     if (now - lastRequestGuardLogAt >= REQUEST_GUARD_LOG_TTL_MS) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -350,12 +350,15 @@ function requestGuardWindowMs(
   const path = pathFromUrl(url);
   if (!path) return 0;
   if (/\/api\/events$|\/events$/.test(path)) return 4000;
-  if (/\/chat\/\d+\/messages$/.test(path)) return 1200;
+  // Allow normal polling, but still damp accidental duplicate bursts.
+  if (/\/chat\/\d+\/messages$/.test(path)) return 500;
   if (/\/chat\/\d+\/profile$/.test(path)) return 5000;
   if (/\/health\/llm$/.test(path)) return 5000;
-  if (/\/llm\/catalog$/.test(path)) return 5000;
+  // Catalog fetches can be intentionally triggered by menu open + refresh polling.
+  if (/\/llm\/catalog$/.test(path)) return 0;
   if (/\/ui\/session$/.test(path)) return 10000;
-  if (/\/projects$/.test(path) || /\/api\/projects$/.test(path)) return 5000;
+  // Project cache and shell hydration may issue close-in-time reads.
+  if (/\/projects$/.test(path) || /\/api\/projects$/.test(path)) return 0;
   return 0;
 }
 

--- a/frontend/src/lib/liveEventsHub.ts
+++ b/frontend/src/lib/liveEventsHub.ts
@@ -47,6 +47,11 @@ const DEFAULT_EVENT_TYPES = [
   "thread.branch",
   "thread.archived",
   "thread.profile.switched",
+  "task.running",
+  "task.completed",
+  "task.failed",
+  "task.cancelled",
+  "completion.error",
   "connector.status",
   "connector.sync",
 ];

--- a/frontend/src/test/api.completion-turn-id.test.ts
+++ b/frontend/src/test/api.completion-turn-id.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import api, {
+  clearInFlightCompletionTurnId,
+  getInFlightCompletionTurnId,
+} from "@/lib/api";
+
+const UUID_V4ISH_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function getRequestInterceptor(): (config: any) => Promise<any> | any {
+  const handlers = (api.interceptors.request as any)?.handlers ?? [];
+  const match = handlers.find(
+    (handler: any) => typeof handler?.fulfilled === "function"
+  );
+  if (!match) {
+    throw new Error("request interceptor not found");
+  }
+  return match.fulfilled;
+}
+
+function parsePayload(data: any): Record<string, any> {
+  if (typeof data === "string") {
+    return JSON.parse(data) as Record<string, any>;
+  }
+  return (data ?? {}) as Record<string, any>;
+}
+
+describe("api completion turn_id generation", () => {
+  const threadId = 4242;
+
+  beforeEach(() => {
+    clearInFlightCompletionTurnId(threadId);
+  });
+
+  afterEach(() => {
+    clearInFlightCompletionTurnId(threadId);
+  });
+
+  it("generates a fresh turn_id for each completion request without explicit turn_id", async () => {
+    const applyInterceptor = getRequestInterceptor();
+
+    const firstConfig = await applyInterceptor({
+      method: "post",
+      url: `/chat/${threadId}/complete`,
+      data: {},
+    });
+    const firstTurnId = String(parsePayload(firstConfig.data).turn_id || "");
+    expect(UUID_V4ISH_RE.test(firstTurnId)).toBe(true);
+    expect(getInFlightCompletionTurnId(threadId)).toBe(firstTurnId);
+
+    const secondConfig = await applyInterceptor({
+      method: "post",
+      url: `/chat/${threadId}/complete`,
+      data: {},
+    });
+    const secondTurnId = String(parsePayload(secondConfig.data).turn_id || "");
+    expect(UUID_V4ISH_RE.test(secondTurnId)).toBe(true);
+    expect(secondTurnId).not.toBe(firstTurnId);
+    expect(getInFlightCompletionTurnId(threadId)).toBe(secondTurnId);
+  });
+
+  it("preserves a valid client-supplied turn_id", async () => {
+    const applyInterceptor = getRequestInterceptor();
+    const explicitTurnId = "11111111-1111-4111-8111-111111111111";
+
+    const config = await applyInterceptor({
+      method: "post",
+      url: `/chat/${threadId}/complete`,
+      data: { turn_id: explicitTurnId },
+    });
+
+    const payload = parsePayload(config.data);
+    expect(payload.turn_id).toBe(explicitTurnId);
+    expect(getInFlightCompletionTurnId(threadId)).toBe(explicitTurnId);
+  });
+});

--- a/guardian/cli/ingest_cli.py
+++ b/guardian/cli/ingest_cli.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from pathlib import Path
 from typing import Dict, List
 
@@ -7,6 +8,8 @@ import typer
 from guardian.vector.store import VectorStore
 
 app = typer.Typer(name="ingest")
+logger = logging.getLogger(__name__)
+_LOGGED_FRONTMATTER_FAILURES: set[str] = set()
 
 
 def _yield_md_files(root: Path):
@@ -15,16 +18,33 @@ def _yield_md_files(root: Path):
             yield p
 
 
-def _parse_frontmatter(text: str) -> Dict:
-    # Minimal frontmatter parser: expects leading --- lines
-    if text.startswith("---\n"):
-        end = text.find("\n---\n", 4)
-        if end != -1:
-            import yaml  # type: ignore
+def _warn_frontmatter_parse_failed(path: str) -> None:
+    if path in _LOGGED_FRONTMATTER_FAILURES:
+        return
+    _LOGGED_FRONTMATTER_FAILURES.add(path)
+    logger.warning("frontmatter_parse_failed:%s", path)
 
-            fm = yaml.safe_load(text[4:end]) or {}
-            content = text[end + 5 :]
-            return {"frontmatter": fm, "content": content}
+
+def _parse_frontmatter(text: str, *, path: str) -> Dict:
+    # Parse frontmatter only when file starts with a leading fence.
+    if text.startswith("---"):
+        first_newline = text.find("\n")
+        if first_newline != -1 and text[:first_newline].strip() == "---":
+            end = text.find("\n---\n", first_newline + 1)
+            if end != -1:
+                try:
+                    import yaml  # type: ignore
+
+                    fm = yaml.safe_load(text[first_newline + 1 : end]) or {}
+                    if not isinstance(fm, dict):
+                        raise ValueError(
+                            "frontmatter must parse to a mapping"
+                        )
+                    content = text[end + 5 :]
+                    return {"frontmatter": fm, "content": content}
+                except Exception:
+                    _warn_frontmatter_parse_failed(path)
+                    return {"frontmatter": {}, "content": text}
     return {"frontmatter": {}, "content": text}
 
 
@@ -35,7 +55,7 @@ def ingest_obsidian(dir: str):
     items: List[Dict] = []
     for md in _yield_md_files(root):
         t = md.read_text(encoding="utf-8", errors="ignore")
-        parsed = _parse_frontmatter(t)
+        parsed = _parse_frontmatter(t, path=str(md))
         fm = parsed["frontmatter"]
         title = fm.get("title") or md.stem
         tags = fm.get("tags") or []

--- a/guardian/depth.py
+++ b/guardian/depth.py
@@ -1,0 +1,105 @@
+"""Depth resolution contract for chat completion APIs."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+DepthMode = Literal["light", "deep"]
+DepthDowngradeReason = Literal[
+    "no_project",
+    "project_identity_depth_light",
+    "policy_gate_rejected",
+    "capability_missing",
+    "server_forced",
+    "unknown",
+]
+ProjectDepthState = Literal["missing", "known", "malformed"]
+KnownRequestDepthToken = Literal["shallow", "normal", "deep", "diagnostic"]
+
+KNOWN_REQUEST_DEPTH_TOKENS: frozenset[str] = frozenset(
+    {"shallow", "normal", "deep", "diagnostic"}
+)
+KNOWN_PROJECT_DEPTH_TOKENS: frozenset[str] = frozenset({"light", "deep"})
+
+
+def normalize_requested_depth_raw(value: str | None) -> str:
+    """Normalize raw request depth from API payload."""
+    return str(value or "deep").strip().lower()
+
+
+def project_requested_depth_mode(requested_depth_raw: str) -> DepthMode:
+    """
+    Binary projection for API contract fields.
+
+    Requested mode is "deep" iff raw request is exactly "deep", otherwise "light".
+    """
+    return "deep" if requested_depth_raw == "deep" else "light"
+
+
+def normalize_project_identity_depth(value: str | None) -> str:
+    """Normalize project identity depth for classification."""
+    return str(value or "").strip().lower()
+
+
+def classify_project_identity_depth(
+    project_identity_depth_raw: str | None,
+) -> ProjectDepthState:
+    """
+    Classify project identity depth according to API contract.
+
+    - None => missing
+    - deep/light => known
+    - anything else => malformed
+    """
+    if project_identity_depth_raw is None:
+        return "missing"
+    normalized = normalize_project_identity_depth(project_identity_depth_raw)
+    if normalized in KNOWN_PROJECT_DEPTH_TOKENS:
+        return "known"
+    return "malformed"
+
+
+def resolve_depth(
+    requested_depth_raw: DepthMode | str,
+    *,
+    thread_has_project: bool,
+    project_depth_state: ProjectDepthState,
+    project_identity_depth_norm: str,
+    policy_allows_deep: bool,
+) -> tuple[DepthMode, DepthDowngradeReason | None]:
+    """
+    Resolve API-facing effective depth and downgrade reason.
+
+    `unknown` is emitted only for malformed requested/project-depth inputs.
+    """
+    requested = str(requested_depth_raw or "").strip().lower()
+    if requested not in KNOWN_REQUEST_DEPTH_TOKENS:
+        return "light", "unknown"
+    if requested != "deep":
+        return "light", None
+
+    if not thread_has_project:
+        return "light", "no_project"
+    if project_depth_state == "malformed":
+        return "light", "unknown"
+    if project_depth_state == "missing":
+        return "light", "project_identity_depth_light"
+    if project_identity_depth_norm != "deep":
+        return "light", "project_identity_depth_light"
+    if not policy_allows_deep:
+        return "light", "policy_gate_rejected"
+    return "deep", None
+
+
+__all__ = [
+    "DepthDowngradeReason",
+    "DepthMode",
+    "KNOWN_REQUEST_DEPTH_TOKENS",
+    "KnownRequestDepthToken",
+    "ProjectDepthState",
+    "classify_project_identity_depth",
+    "normalize_project_identity_depth",
+    "normalize_requested_depth_raw",
+    "project_requested_depth_mode",
+    "resolve_depth",
+]

--- a/guardian/guardian_api.py
+++ b/guardian/guardian_api.py
@@ -254,6 +254,10 @@ from guardian.routes.projects import ensure_default_project
 from guardian.routes.projects import router as projects_router
 from guardian.routes.tools import api_router as api_tools_router
 from guardian.routes.tools import router as tools_router
+from guardian.routes.voice import router as voice_router
+from guardian.voice.config import get_voice_runtime_config
+from guardian.voice.runtime import SUPPORTED_INPUT_MIME
+from guardian.voice.service import validate_voice_runtime_dependencies
 
 # =========================
 # Application Lifespan Management
@@ -287,6 +291,15 @@ async def app_lifespan(app: FastAPI):
         logger.info("[graph] Knowledge graph context: ENABLED (Neo4j)")
     else:
         logger.info("[graph] Knowledge graph context: disabled")
+
+    try:
+        voice_cfg = get_voice_runtime_config()
+        validate_voice_runtime_dependencies(
+            routes_enabled=voice_cfg.routes_enabled,
+            accepted_mime=SUPPORTED_INPUT_MIME,
+        )
+    except Exception as exc:
+        logger.warning("[startup] voice dependency validation failed: %s", exc)
 
     # Initialize database via shared initializer (idempotent)
     db = dependencies.init_database()
@@ -706,6 +719,12 @@ _include_router(
     label="media",
     flag_name="CODEXIFY_ENABLE_MEDIA_ROUTES",
     include_fn=lambda: app.include_router(media_router, prefix="/api/media"),
+    core_surface=True,
+)
+_include_router(
+    label="voice",
+    flag_name="CODEXIFY_VOICE_ROUTES_ENABLED",
+    include_fn=lambda: app.include_router(voice_router),
     core_surface=True,
 )
 _include_router(

--- a/guardian/guardian_api.py
+++ b/guardian/guardian_api.py
@@ -733,18 +733,24 @@ _include_router(
     flag_name="CODEXIFY_ENABLE_CODEX_ROUTES",
     include_fn=lambda: app.include_router(codex_router),
 )
-_embedding_backend = _resolve_embedding_backend(get_settings())
-if _embedding_backend == "local":
+
+
+def _include_codexify_router() -> None:
+    # Import lazily so startup does not eagerly initialize embedding stack.
     from guardian.routes.codexify_router import router as codexify_router
 
+    app.include_router(codexify_router)
+
+
+_embedding_backend = _resolve_embedding_backend(get_settings())
+if _embedding_backend == "local":
     _include_router(
         label="codexify",
         flag_name="CODEXIFY_ENABLE_CODEXIFY_ROUTES",
-        include_fn=lambda: app.include_router(codexify_router),
+        include_fn=_include_codexify_router,
     )
 else:
-    # Codexify router initializes a local vector store at import time.
-    # Skip it when local embeddings are not explicitly selected.
+    # Skip codexify routes when local embeddings are not explicitly selected.
     get_local_embed_model(strict=False)
     logger.info(
         "[routers] Skipping codexify router (embedding_backend=%s)",

--- a/guardian/routes/chat.py
+++ b/guardian/routes/chat.py
@@ -649,8 +649,12 @@ def _ensure_default_project_id() -> Optional[int]:
     """
     if not chatlog_db:
         return None
+    ensure_default_project = getattr(chatlog_db, "ensure_default_project", None)
+    if not callable(ensure_default_project):
+        # Some DB backends (e.g., PostgresChatLogDB) may not implement this shim.
+        return None
     try:
-        pid = chatlog_db.ensure_default_project()
+        pid = ensure_default_project()
         return int(pid) if pid is not None else None
     except Exception as exc:  # pragma: no cover - defensive guard
         logger.warning("[chat] failed to ensure default project: %s", exc)
@@ -1103,6 +1107,31 @@ async def chat_complete(
         thread_project_id = _coerce_positive_int(
             thread_exists.get("project_id")
         )
+    if thread_project_id is None:
+        try:
+            # Optional backend seam: infer project association from thread profile.
+            profile_getter = getattr(chatlog_db, "get_thread_profile", None)
+            if callable(profile_getter):
+                profile = profile_getter(thread_id)
+                inferred_project_id: Any = None
+                if isinstance(profile, dict):
+                    inferred_project_id = profile.get("project_id")
+                    if not isinstance(inferred_project_id, int):
+                        thread_payload = profile.get("thread")
+                        if isinstance(thread_payload, dict):
+                            inferred_project_id = thread_payload.get(
+                                "project_id"
+                            )
+                if isinstance(inferred_project_id, int):
+                    thread_project_id = _coerce_positive_int(
+                        inferred_project_id
+                    )
+        except Exception as exc:
+            logger.debug(
+                "[chat.complete] failed to infer project_id from thread profile thread_id=%s err=%s",
+                thread_id,
+                exc,
+            )
     thread_has_project = thread_project_id is not None
 
     project_identity_depth_raw: str | None = None

--- a/guardian/routes/chat.py
+++ b/guardian/routes/chat.py
@@ -23,6 +23,16 @@ from starlette.responses import StreamingResponse
 
 from guardian.cognition.identity_policy import can_run_deep_identity_modeling
 from guardian.core.event_graph import get_event_writer
+from guardian.depth import (
+    DepthDowngradeReason,
+    DepthMode,
+    ProjectDepthState,
+    classify_project_identity_depth,
+    normalize_project_identity_depth,
+    normalize_requested_depth_raw,
+    project_requested_depth_mode,
+    resolve_depth,
+)
 from guardian.queue import task_events
 from guardian.queue.redis_queue import enqueue, enqueue_chat_embed
 from guardian.queue.turn_lock import acquire_turn_lock, release_turn_lock
@@ -760,6 +770,19 @@ async def _build_doc_context_override(
         return None
 
 
+def map_internal_depth_mode(
+    requested_depth_raw: str, effective_depth_mode: DepthMode
+) -> str:
+    """
+    Map API contract depth to runtime/broker depth_mode.
+
+    Contract-only task: internal RAG/broker depth behavior must remain unchanged.
+    """
+    if requested_depth_raw == "deep":
+        return "deep" if effective_depth_mode == "deep" else "normal"
+    return requested_depth_raw
+
+
 # =========================
 # Chat Threads API
 # =========================
@@ -1069,36 +1092,82 @@ async def chat_complete(
             status_code=400, detail="Thread has no usable context"
         )
 
-    requested_depth_mode = str(body.depth_mode or "deep").strip().lower()
-    effective_depth_mode = body.depth_mode
+    requested_depth_raw = normalize_requested_depth_raw(body.depth_mode)
+    # Binary projection: deep iff raw request is exactly "deep".
+    requested_depth_mode: DepthMode = project_requested_depth_mode(
+        requested_depth_raw
+    )
+    depth_downgrade_reason: DepthDowngradeReason | None = None
     thread_project_id: Optional[int] = None
     if isinstance(thread_exists, dict):
         thread_project_id = _coerce_positive_int(
             thread_exists.get("project_id")
         )
-    if requested_depth_mode == "deep":
-        project_depth = "light"
-        getter = getattr(chatlog_db, "get_project_identity_depth", None)
-        if callable(getter):
-            try:
-                project_depth = str(
-                    getter(thread_project_id) or "light"
-                ).lower()
-            except Exception:
-                project_depth = "light"
-        if not can_run_deep_identity_modeling(project_depth):
-            effective_depth_mode = "normal"
-            logger.info(
-                "[chat.complete] downgraded depth_mode=deep to normal thread_id=%s project_id=%s identity_depth=%s",
+    thread_has_project = thread_project_id is not None
+
+    project_identity_depth_raw: str | None = None
+    project_identity_depth_norm = normalize_project_identity_depth(None)
+    project_depth_state: ProjectDepthState = "missing"
+    policy_allows_deep = False
+
+    if requested_depth_raw == "deep" and thread_has_project:
+        try:
+            getter = getattr(chatlog_db, "get_project_identity_depth", None)
+            if callable(getter):
+                raw_project_depth = getter(thread_project_id)
+                project_identity_depth_raw = (
+                    None
+                    if raw_project_depth is None
+                    else str(raw_project_depth)
+                )
+            else:
+                project_identity_depth_raw = "__missing_project_depth_getter__"
+            project_identity_depth_norm = normalize_project_identity_depth(
+                project_identity_depth_raw
+            )
+            project_depth_state = classify_project_identity_depth(
+                project_identity_depth_raw
+            )
+            if project_depth_state == "known":
+                policy_allows_deep = bool(
+                    can_run_deep_identity_modeling(project_identity_depth_norm)
+                )
+        except Exception:
+            logger.exception(
+                "[chat.complete] depth resolution failed thread_id=%s project_id=%s",
                 thread_id,
                 thread_project_id,
-                project_depth,
             )
+            project_identity_depth_raw = "__depth_resolution_exception__"
+            project_identity_depth_norm = normalize_project_identity_depth(
+                project_identity_depth_raw
+            )
+            project_depth_state = classify_project_identity_depth(
+                project_identity_depth_raw
+            )
+            policy_allows_deep = False
 
-    effective_depth = str(effective_depth_mode or "deep").strip().lower()
+    effective_depth_mode, depth_downgrade_reason = resolve_depth(
+        requested_depth_raw,
+        thread_has_project=thread_has_project,
+        project_depth_state=project_depth_state,
+        project_identity_depth_norm=project_identity_depth_norm,
+        policy_allows_deep=policy_allows_deep,
+    )
+    if requested_depth_mode == "deep" and effective_depth_mode == "light":
+        logger.info(
+            "[chat.complete] downgraded depth_mode=deep thread_id=%s project_id=%s reason=%s",
+            thread_id,
+            thread_project_id,
+            depth_downgrade_reason,
+        )
+
+    internal_depth_mode = map_internal_depth_mode(
+        requested_depth_raw, effective_depth_mode
+    )
     doc_context_override = await _build_doc_context_override(
         thread_id=thread_id,
-        depth_mode=effective_depth,
+        depth_mode=internal_depth_mode,
         project_id=thread_project_id,
     )
     merged_system_override = user_system_override
@@ -1114,7 +1183,7 @@ async def chat_complete(
         provider=provider,
         model=body.model,
         max_context=body.max_context,
-        depth_mode=effective_depth_mode,
+        depth_mode=internal_depth_mode,
         system_override=merged_system_override,
         origin="api:chat.complete",
     )
@@ -1167,7 +1236,10 @@ async def chat_complete(
         "ok": True,
         "task_id": task.task_id,
         "thread_id": thread_id,
-        "depth_mode": effective_depth_mode,
+        "depth_mode": internal_depth_mode,
+        "requested_depth_mode": requested_depth_mode,
+        "effective_depth_mode": effective_depth_mode,
+        "depth_downgrade_reason": depth_downgrade_reason,
         "messages_url": messages_url,
         "trace_url": trace_url,
     }

--- a/guardian/routes/chat.py
+++ b/guardian/routes/chat.py
@@ -98,11 +98,14 @@ except ModuleNotFoundError:
 
 # Optional Neo4j imports for graph sync
 try:
+    from neomodel import db as neo4j_db
+
     from guardian.graph.connection import connect_neo4j
     from guardian.graph.models import MessageNode, ThreadNode, UserNode
 
     NEO4J_SYNC_AVAILABLE = True
 except Exception:
+    neo4j_db = None
     NEO4J_SYNC_AVAILABLE = False
 
 # LLM configuration validation
@@ -287,6 +290,40 @@ def _derive_thread_title_from_content(content: str) -> str:
     return first_line
 
 
+def _merge_neo4j_message_edge(
+    *, message_node: Any, target_node: Any, rel_type: str
+) -> None:
+    """
+    Merge MessageNode->Target relationship with anchored MATCH clauses.
+
+    This avoids Neo4j cartesian-product planner warnings emitted by OGM
+    generated queries for disconnected MATCH patterns.
+    """
+    if neo4j_db is None:
+        return
+    if rel_type == "SENT_BY":
+        query = """
+        MATCH (them) WHERE elementId(them) = $them
+        MATCH (us)   WHERE elementId(us)   = $self
+        MERGE(us)-[r:`SENT_BY`]->(them)
+        """
+    elif rel_type == "PART_OF":
+        query = """
+        MATCH (them) WHERE elementId(them) = $them
+        MATCH (us)   WHERE elementId(us)   = $self
+        MERGE(us)-[r:`PART_OF`]->(them)
+        """
+    else:
+        raise ValueError(f"Unsupported relationship type: {rel_type}")
+    neo4j_db.cypher_query(
+        query,
+        {
+            "them": str(target_node.element_id),
+            "self": str(message_node.element_id),
+        },
+    )
+
+
 def _persist_message_to_thread(
     *,
     thread_id: int,
@@ -457,8 +494,16 @@ def _persist_message_to_thread(
             if isinstance(neo_msg, list):
                 neo_msg = neo_msg[0]
 
-            neo_msg.user.connect(neo_user)
-            neo_msg.thread.connect(neo_thread)
+            _merge_neo4j_message_edge(
+                message_node=neo_msg,
+                target_node=neo_user,
+                rel_type="SENT_BY",
+            )
+            _merge_neo4j_message_edge(
+                message_node=neo_msg,
+                target_node=neo_thread,
+                rel_type="PART_OF",
+            )
 
         except Exception as e:
             logger.warning("[Neo4j Sync Error] %s", e, exc_info=True)

--- a/guardian/routes/chat.py
+++ b/guardian/routes/chat.py
@@ -12,7 +12,9 @@ Frontend contract (primary calls today):
 """
 
 import asyncio
+import json
 import logging
+import uuid
 from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
@@ -189,6 +191,7 @@ class ChatCompletionRequest(BaseModel):
     max_context: Optional[int] = 50
     provider: Optional[str] = None
     system_override: Optional[str] = None
+    turn_id: Optional[str] = None
     depth_mode: Optional[
         str
     ] = "deep"  # "shallow", "normal", "deep", "diagnostic"
@@ -725,6 +728,98 @@ def _coerce_positive_int(raw: Any) -> Optional[int]:
     return value if value > 0 else None
 
 
+def _normalize_turn_id(raw: Any) -> str:
+    """Return a normalized UUID turn_id; generate one when missing/invalid."""
+    if isinstance(raw, str):
+        candidate = raw.strip()
+        if candidate:
+            try:
+                return str(uuid.UUID(candidate))
+            except ValueError:
+                logger.debug(
+                    "[chat.complete] invalid turn_id=%s; generating server-side UUID",
+                    candidate,
+                )
+    return str(uuid.uuid4())
+
+
+def _coerce_message_meta(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return dict(raw)
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return {}
+        try:
+            parsed = json.loads(text)
+        except Exception:
+            return {}
+        return dict(parsed) if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _coerce_message_id(raw: Any) -> int | None:
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def _fetch_message_extra_meta(
+    *, thread_id: int, message_ids: list[int]
+) -> dict[int, dict[str, Any]]:
+    if not message_ids:
+        return {}
+    connect = getattr(chatlog_db, "_connect", None)
+    if not callable(connect):
+        return {}
+
+    try:
+        with connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT id, extra_meta
+                    FROM chat_messages
+                    WHERE thread_id = %s
+                      AND id = ANY(%s::int[])
+                    """,
+                    (thread_id, message_ids),
+                )
+                rows = cur.fetchall() or []
+    except Exception:
+        logger.debug(
+            "[chat.messages] failed to backfill extra_meta thread_id=%s",
+            thread_id,
+            exc_info=True,
+        )
+        return {}
+
+    backfill: dict[int, dict[str, Any]] = {}
+    for row in rows:
+        raw_id: Any = None
+        raw_meta: Any = None
+        if isinstance(row, dict):
+            raw_id = row.get("id")
+            raw_meta = row.get("extra_meta")
+        elif hasattr(row, "keys"):
+            row_map = dict(row)  # psycopg row mapping
+            raw_id = row_map.get("id")
+            raw_meta = row_map.get("extra_meta")
+        elif isinstance(row, (list, tuple)) and len(row) >= 2:
+            raw_id = row[0]
+            raw_meta = row[1]
+
+        message_id = _coerce_message_id(raw_id)
+        if message_id is None:
+            continue
+        meta = _coerce_message_meta(raw_meta)
+        if meta:
+            backfill[message_id] = meta
+    return backfill
+
+
 def _build_scoped_doc_override(
     docs_bundle: Dict[str, Any] | None,
     *,
@@ -1092,8 +1187,45 @@ def chat_list_messages(
         offset=offset,
         exclude_kinds=exclude_kinds,
     )
+    normalized_items: list[dict[str, Any]] = []
+    missing_meta_ids: list[int] = []
+    for raw_item in items:
+        if not isinstance(raw_item, dict):
+            continue
+        item = dict(raw_item)
+        message_id = _coerce_message_id(item.get("id"))
+        metadata = _coerce_message_meta(item.get("metadata"))
+        if not metadata:
+            metadata = _coerce_message_meta(item.get("extra_meta"))
+        if metadata:
+            item["metadata"] = metadata
+            turn_id_raw = metadata.get("turn_id")
+            if isinstance(turn_id_raw, str) and turn_id_raw.strip():
+                item["turn_id"] = turn_id_raw.strip()
+        elif message_id is not None:
+            missing_meta_ids.append(message_id)
+        normalized_items.append(item)
+
+    if missing_meta_ids:
+        backfill = _fetch_message_extra_meta(
+            thread_id=thread_id,
+            message_ids=missing_meta_ids,
+        )
+        if backfill:
+            for item in normalized_items:
+                message_id = _coerce_message_id(item.get("id"))
+                if message_id is None or "metadata" in item:
+                    continue
+                metadata = backfill.get(message_id)
+                if not metadata:
+                    continue
+                item["metadata"] = metadata
+                turn_id_raw = metadata.get("turn_id")
+                if isinstance(turn_id_raw, str) and turn_id_raw.strip():
+                    item["turn_id"] = turn_id_raw.strip()
+
     total = chatlog_db.count_messages(thread_id)
-    return {"ok": True, "total": total, "messages": items}
+    return {"ok": True, "total": total, "messages": normalized_items}
 
 
 @router.post("/{thread_id}/complete")
@@ -1105,6 +1237,8 @@ async def chat_complete(
     """
     Enqueue an assistant reply for the given thread and return a task id.
     """
+    turn_id = _normalize_turn_id(body.turn_id)
+
     provider = str(
         body.provider
         or (llm_settings.LLM_PROVIDER if llm_settings else CHAT_PROVIDER)
@@ -1259,9 +1393,11 @@ async def chat_complete(
         max_context=body.max_context,
         depth_mode=internal_depth_mode,
         system_override=merged_system_override,
-        origin="api:chat.complete",
+        # Encode turn_id into origin so it survives dataclass serialization.
+        origin=f"api:chat.complete|turn_id={turn_id}",
     )
     task.turn_lock_owner = task.task_id
+    task.turn_id = turn_id
 
     try:
         locked = acquire_turn_lock(thread_id, task.turn_lock_owner)
@@ -1291,7 +1427,12 @@ async def chat_complete(
         task_events.publish(
             task.task_id,
             "task.created",
-            {"type": task.type, "thread_id": thread_id, "origin": task.origin},
+            {
+                "type": task.type,
+                "thread_id": thread_id,
+                "origin": task.origin,
+                "turn_id": turn_id,
+            },
         )
     except Exception:
         logger.debug("[chat.complete] task.created emit failed", exc_info=True)
@@ -1309,6 +1450,7 @@ async def chat_complete(
     return {
         "ok": True,
         "task_id": task.task_id,
+        "turn_id": turn_id,
         "thread_id": thread_id,
         "depth_mode": internal_depth_mode,
         "requested_depth_mode": requested_depth_mode,

--- a/guardian/routes/codexify_router.py
+++ b/guardian/routes/codexify_router.py
@@ -1,5 +1,7 @@
+import logging
 import re
 import time
+from threading import Lock
 from typing import Any, List, Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException
@@ -11,6 +13,7 @@ from guardian.core.dependencies import get_current_user, require_api_key
 from guardian.vector.store import VectorStore
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 MAX_CODEXIFY_TEXT_CHARS = 12_000
 MAX_EMBED_TEXT_CHARS = 20_000
@@ -54,9 +57,23 @@ class SearchRequest(BaseModel):
 
 
 # ----------------------------------------------------------------------
-# Global unified vector store
+# Global unified vector store (lazily initialized)
 # ----------------------------------------------------------------------
-vector_store = VectorStore()
+vector_store: VectorStore | None = None
+_vector_store_lock = Lock()
+
+
+def _get_vector_store() -> VectorStore:
+    global vector_store
+    if vector_store is not None:
+        return vector_store
+
+    with _vector_store_lock:
+        if vector_store is None:
+            vector_store = VectorStore()
+            logger.info("[codexify] vector store initialized on first use")
+
+    return vector_store
 
 
 def _normalize_user_namespace(user_id: str) -> str:
@@ -217,7 +234,7 @@ async def embed_endpoint(
         md["owner_user_id"] = current_user
 
         # VectorStore handles embedding internally now
-        vector_store.add_texts([{"text": payload.text, "meta": md}])
+        _get_vector_store().add_texts([{"text": payload.text, "meta": md}])
 
         return {
             "message": "Embedding stored successfully",
@@ -255,7 +272,7 @@ async def search_endpoint(
             action="vector:read",
             resource=f"ns:{namespace}",
         )
-        results = vector_store.search(
+        results = _get_vector_store().search(
             payload.query,
             k=5,
             namespace=namespace,

--- a/guardian/routes/voice.py
+++ b/guardian/routes/voice.py
@@ -90,11 +90,11 @@ def _dedupe_key(thread_id: int, turn_id: str, audio_sha256: str) -> str:
 def _normalize_turn_id(raw: str | None) -> str:
     value = (raw or "").strip()
     if not value:
-        return "legacy"
+        return str(uuid.uuid4())
     try:
         return str(uuid.UUID(value)).lower()
     except Exception:
-        return "legacy"
+        return str(uuid.uuid4())
 
 
 def _task_terminal_status(task_id: str) -> str:

--- a/guardian/routes/voice.py
+++ b/guardian/routes/voice.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
+import os
 import time
-from typing import Any, Optional
+from functools import lru_cache
+from typing import Any
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from pydantic import BaseModel
@@ -17,7 +19,6 @@ from guardian.db.models import ChatMessage
 from guardian.queue import task_events
 from guardian.queue.redis_queue import enqueue
 from guardian.queue.turn_lock import acquire_turn_lock, turn_lock_key
-from guardian.tasks.types import VoiceTurnTask
 from guardian.voice.audio_assets import (
     compute_text_hash,
     find_cached_asset,
@@ -35,6 +36,8 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/voice", tags=["Voice"])
 
 VOICE_QUEUE_NAME = os.getenv("VOICE_QUEUE_NAME", "codexify:queue:voice")
+_TRUTHY = {"1", "true", "yes", "on"}
+_FALSY = {"0", "false", "no", "off"}
 
 
 class SpeakRequest(BaseModel):
@@ -49,6 +52,29 @@ class SpeakResponse(BaseModel):
     audio_asset: dict[str, Any]
     cached: bool
     text_hash: str
+
+
+@lru_cache(maxsize=1)
+def _get_voice_turn_task_cls():
+    try:
+        from guardian.tasks.types import VoiceTurnTask
+    except Exception:
+        return None
+    return VoiceTurnTask
+
+
+def _voice_turns_enabled(cfg) -> bool:
+    explicit = (os.getenv("CODEXIFY_ENABLE_VOICE_TURNS") or "").strip().lower()
+    if explicit in _TRUTHY:
+        return True
+    if explicit in _FALSY:
+        return False
+    return str(getattr(cfg, "mode", "") or "").strip().lower() not in {
+        "",
+        "off",
+        "disabled",
+        "none",
+    }
 
 
 async def _await_terminal_task_event(
@@ -110,6 +136,17 @@ async def voice_turn(
     system_override: str | None = Form(None),
     api_key: str = Depends(require_api_key),
 ):
+    cfg = get_voice_runtime_config()
+    if not _voice_turns_enabled(cfg):
+        raise HTTPException(status_code=403, detail="voice_turns_disabled")
+
+    voice_turn_task_cls = _get_voice_turn_task_cls()
+    if voice_turn_task_cls is None:
+        raise HTTPException(
+            status_code=503,
+            detail="voice_turn_task_unavailable",
+        )
+
     if not chatlog_db or not hasattr(chatlog_db, "get_chat_thread"):
         raise HTTPException(status_code=503, detail="chat_db_unavailable")
 
@@ -118,7 +155,6 @@ async def voice_turn(
         raise HTTPException(status_code=404, detail="thread_not_found")
 
     audio_bytes = await audio_file.read()
-    cfg = get_voice_runtime_config()
     try:
         duration = enforce_audio_input_limits(
             audio_bytes,
@@ -128,7 +164,7 @@ async def voice_turn(
     except VoiceValidationError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
-    task = VoiceTurnTask(
+    task = voice_turn_task_cls(
         thread_id=thread_id,
         audio_b64=base64.b64encode(audio_bytes).decode("ascii"),
         audio_mime=audio_file.content_type,

--- a/guardian/routes/voice.py
+++ b/guardian/routes/voice.py
@@ -1,24 +1,40 @@
-"""Voice turn + message read-aloud routes."""
+"""Voice capabilities, turn-based ingest, and message read-aloud routes."""
 
 from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
+import json
 import logging
 import os
 import time
+import uuid
 from functools import lru_cache
 from typing import Any
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Response,
+    UploadFile,
+)
 from pydantic import BaseModel
 
 from guardian.core.db import load_guardian_db_from_env
 from guardian.core.dependencies import chatlog_db, require_api_key
-from guardian.db.models import ChatMessage
+from guardian.core.storage import create_storage_from_env
+from guardian.db.models import ChatMessage, MessageAudioAsset
 from guardian.queue import task_events
-from guardian.queue.redis_queue import enqueue
-from guardian.queue.turn_lock import acquire_turn_lock, turn_lock_key
+from guardian.queue.redis_queue import enqueue, get_redis_client
+from guardian.queue.turn_lock import (
+    acquire_turn_lock,
+    release_turn_lock,
+    turn_lock_key,
+)
 from guardian.voice.audio_assets import (
     compute_text_hash,
     find_cached_asset,
@@ -26,18 +42,22 @@ from guardian.voice.audio_assets import (
 )
 from guardian.voice.client import synthesize
 from guardian.voice.config import get_voice_runtime_config
-from guardian.voice.service import (
-    VoiceValidationError,
-    enforce_audio_input_limits,
+from guardian.voice.runtime import (
+    STREAM_PROXY_ENABLED,
+    SUPPORTED_INPUT_MIME,
+    SUPPORTED_STT_PROVIDERS,
+    SUPPORTED_TTS_PROVIDERS,
+    VOICE_HEARTBEAT_KEY,
+    VOICE_QUEUE_NAME,
 )
+from guardian.voice.service import VoiceValidationError, normalize_audio_input
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/voice", tags=["Voice"])
+_storage = create_storage_from_env()
 
-VOICE_QUEUE_NAME = os.getenv("VOICE_QUEUE_NAME", "codexify:queue:voice")
-_TRUTHY = {"1", "true", "yes", "on"}
-_FALSY = {"0", "false", "no", "off"}
+_DEDUPE_KEY_PREFIX = "codexify:voice:turn:dedupe"
 
 
 class SpeakRequest(BaseModel):
@@ -63,18 +83,149 @@ def _get_voice_turn_task_cls():
     return VoiceTurnTask
 
 
-def _voice_turns_enabled(cfg) -> bool:
-    explicit = (os.getenv("CODEXIFY_ENABLE_VOICE_TURNS") or "").strip().lower()
-    if explicit in _TRUTHY:
-        return True
-    if explicit in _FALSY:
-        return False
-    return str(getattr(cfg, "mode", "") or "").strip().lower() not in {
-        "",
-        "off",
-        "disabled",
-        "none",
+def _dedupe_key(thread_id: int, turn_id: str, audio_sha256: str) -> str:
+    return f"{_DEDUPE_KEY_PREFIX}:{thread_id}:{turn_id}:{audio_sha256}"
+
+
+def _normalize_turn_id(raw: str | None) -> str:
+    value = (raw or "").strip()
+    if not value:
+        return "legacy"
+    try:
+        return str(uuid.UUID(value)).lower()
+    except Exception:
+        return "legacy"
+
+
+def _task_terminal_status(task_id: str) -> str:
+    stream_key = f"codexify:task:{task_id}:events"
+    try:
+        client = get_redis_client()
+        rows = client.xrevrange(stream_key, count=20)
+    except Exception:
+        return "in_flight"
+
+    for _, fields in rows or []:
+        event_type = str(fields.get("type") or "").strip().lower()
+        if event_type == "task.completed":
+            return "succeeded"
+        if event_type in {"task.failed", "task.cancelled"}:
+            return "failed"
+    return "in_flight"
+
+
+def _get_dedupe_hit(
+    *,
+    thread_id: int,
+    turn_id: str,
+    audio_sha256: str,
+) -> dict[str, Any] | None:
+    key = _dedupe_key(thread_id, turn_id, audio_sha256)
+    try:
+        client = get_redis_client()
+        raw = client.get(key)
+    except Exception:
+        return None
+
+    if not raw:
+        return None
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return None
+
+    task_id = str(payload.get("task_id") or "").strip()
+    if not task_id:
+        return None
+    return {
+        "deduped": True,
+        "task_id": task_id,
+        "status": _task_terminal_status(task_id),
     }
+
+
+def _set_dedupe_record(
+    *,
+    thread_id: int,
+    turn_id: str,
+    audio_sha256: str,
+    task_id: str,
+    ttl_seconds: int,
+) -> None:
+    key = _dedupe_key(thread_id, turn_id, audio_sha256)
+    payload = {
+        "task_id": task_id,
+        "created_at": int(time.time()),
+    }
+    try:
+        client = get_redis_client()
+        client.setex(key, max(1, int(ttl_seconds)), json.dumps(payload))
+    except Exception:
+        logger.debug("[voice.turn] failed writing dedupe record", exc_info=True)
+
+
+def _voice_worker_available() -> bool:
+    try:
+        client = get_redis_client()
+        return bool(client.get(VOICE_HEARTBEAT_KEY))
+    except Exception:
+        return False
+
+
+def _configured_provider(
+    provider: str | None,
+    *,
+    supported: tuple[str, ...],
+    local_voice_base_url: str | None,
+) -> str | None:
+    value = str(provider or "").strip().lower()
+    if not value:
+        return None
+    if value not in supported:
+        return None
+    if (
+        value in {"local_openai_compatible", "whispercpp"}
+        and not local_voice_base_url
+    ):
+        return None
+    return value
+
+
+def _load_message(message_id: int) -> ChatMessage | None:
+    db = chatlog_db or load_guardian_db_from_env()
+    if not db or not hasattr(db, "get_session"):
+        return None
+    with db.get_session() as session:
+        row = session.query(ChatMessage).filter_by(id=message_id).first()
+        return row
+
+
+def _load_audio_asset(asset_id: int) -> MessageAudioAsset | None:
+    db = chatlog_db or load_guardian_db_from_env()
+    if not db or not hasattr(db, "get_session"):
+        return None
+    with db.get_session() as session:
+        return session.query(MessageAudioAsset).filter_by(id=asset_id).first()
+
+
+def _content_type_for_format(fmt: str | None) -> str:
+    value = str(fmt or "wav").strip().lower()
+    if value in {"mp3", "mpeg"}:
+        return "audio/mpeg"
+    if value in {"ogg", "opus"}:
+        return "audio/ogg"
+    return "audio/wav"
+
+
+def _with_stream_url(asset: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(asset or {})
+    if not STREAM_PROXY_ENABLED:
+        payload.pop("stream_url", None)
+        return payload
+    asset_id = payload.get("id")
+    if isinstance(asset_id, int) and asset_id > 0:
+        payload["stream_url"] = f"/api/voice/audio/{asset_id}"
+    return payload
 
 
 async def _await_terminal_task_event(
@@ -112,19 +263,113 @@ async def _await_terminal_task_event(
                 return event_type, (event.get("data") or {})
 
 
-def _load_message(message_id: int) -> ChatMessage | None:
-    db = chatlog_db or load_guardian_db_from_env()
-    if not db or not hasattr(db, "get_session"):
-        return None
-    with db.get_session() as session:
-        row = session.query(ChatMessage).filter_by(id=message_id).first()
-        return row
+@router.get("/capabilities")
+def voice_capabilities(
+    response: Response,
+    api_key: str = Depends(require_api_key),
+):
+    cfg = get_voice_runtime_config()
+    response.headers["Cache-Control"] = "private, max-age=30"
+
+    routes_enabled = bool(cfg.routes_enabled)
+    turns_config_enabled = bool(cfg.turns_enabled)
+    tts_configured = _configured_provider(
+        cfg.tts_provider,
+        supported=SUPPORTED_TTS_PROVIDERS,
+        local_voice_base_url=cfg.local_voice_base_url,
+    )
+    stt_configured = _configured_provider(
+        cfg.stt_provider,
+        supported=SUPPORTED_STT_PROVIDERS,
+        local_voice_base_url=cfg.local_voice_base_url,
+    )
+    worker_present = _voice_worker_available()
+
+    read_aloud_enabled = bool(routes_enabled and tts_configured)
+    turn_based_enabled = bool(
+        routes_enabled
+        and turns_config_enabled
+        and stt_configured
+        and worker_present
+    )
+
+    read_aloud_reason = None
+    if not read_aloud_enabled:
+        if not routes_enabled:
+            read_aloud_reason = "routes_disabled"
+        elif not cfg.tts_provider:
+            read_aloud_reason = "provider_missing"
+        elif not tts_configured:
+            read_aloud_reason = "misconfigured"
+        else:
+            read_aloud_reason = "unknown"
+
+    turn_based_reason = None
+    if not turn_based_enabled:
+        if not routes_enabled:
+            turn_based_reason = "routes_disabled"
+        elif not turns_config_enabled:
+            turn_based_reason = "feature_gated"
+        elif not stt_configured:
+            turn_based_reason = "misconfigured"
+        elif not worker_present:
+            turn_based_reason = "worker_missing"
+        else:
+            turn_based_reason = "unknown"
+
+    return {
+        "read_aloud_enabled": read_aloud_enabled,
+        "turn_based_enabled": turn_based_enabled,
+        "read_aloud_reason": read_aloud_reason,
+        "turn_based_reason": turn_based_reason,
+        "voice_routes_enabled": routes_enabled,
+        "voice_turns_enabled": turns_config_enabled,
+        "stream_proxy_enabled": bool(STREAM_PROXY_ENABLED),
+        "provider_default": cfg.tts_provider,
+        "voice_default": (
+            os.getenv("CODEXIFY_DEFAULT_VOICE") or "alloy"
+        ).strip(),
+        "providers_supported": {
+            "tts": list(SUPPORTED_TTS_PROVIDERS),
+            "stt": list(SUPPORTED_STT_PROVIDERS),
+        },
+        "providers_configured": {
+            "tts": tts_configured,
+            "stt": stt_configured,
+        },
+        "supported_input_mime": list(SUPPORTED_INPUT_MIME),
+        "limits": {
+            "max_upload_bytes": cfg.input_max_bytes,
+            "max_duration_s": cfg.max_duration_seconds,
+        },
+    }
+
+
+@router.get("/audio/{asset_id}")
+def stream_audio_asset(
+    asset_id: int,
+    api_key: str = Depends(require_api_key),
+):
+    if not STREAM_PROXY_ENABLED:
+        raise HTTPException(status_code=404, detail="route_not_found")
+    asset = _load_audio_asset(asset_id)
+    if not asset:
+        raise HTTPException(status_code=404, detail="audio_asset_not_found")
+
+    try:
+        raw = _storage.download_file(asset.src_url)
+    except Exception:
+        raise HTTPException(status_code=404, detail="audio_asset_not_found")
+
+    media_type = _content_type_for_format(asset.internal_format)
+    return Response(content=raw, media_type=media_type)
 
 
 @router.post("/turn")
 async def voice_turn(
     thread_id: int = Form(...),
     audio_file: UploadFile = File(...),
+    turn_id: str | None = Form(None),
     stt_provider: str | None = Form(None),
     tts_enabled: bool = Form(True),
     tts_provider: str | None = Form(None),
@@ -134,40 +379,68 @@ async def voice_turn(
     completion_model: str | None = Form(None),
     depth_mode: str | None = Form(None),
     system_override: str | None = Form(None),
+    max_context: int | None = Form(None),
     api_key: str = Depends(require_api_key),
 ):
     cfg = get_voice_runtime_config()
-    if not _voice_turns_enabled(cfg):
+
+    # 1) Feature gate
+    if not cfg.turns_enabled:
         raise HTTPException(status_code=403, detail="voice_turns_disabled")
 
-    voice_turn_task_cls = _get_voice_turn_task_cls()
-    if voice_turn_task_cls is None:
-        raise HTTPException(
-            status_code=503,
-            detail="voice_turn_task_unavailable",
-        )
+    # 2) Worker heartbeat gate
+    if not _voice_worker_available():
+        raise HTTPException(status_code=503, detail="voice_worker_missing")
 
     if not chatlog_db or not hasattr(chatlog_db, "get_chat_thread"):
         raise HTTPException(status_code=503, detail="chat_db_unavailable")
-
     thread = chatlog_db.get_chat_thread(thread_id)
     if not thread:
         raise HTTPException(status_code=404, detail="thread_not_found")
 
-    audio_bytes = await audio_file.read()
+    voice_turn_task_cls = _get_voice_turn_task_cls()
+    if voice_turn_task_cls is None:
+        raise HTTPException(
+            status_code=503, detail="voice_turn_task_unavailable"
+        )
+
+    audio_raw = await audio_file.read()
+
+    # 3) MIME + limits + normalization
     try:
-        duration = enforce_audio_input_limits(
-            audio_bytes,
+        normalized_audio, normalized_mime, audio_meta = normalize_audio_input(
+            audio_raw,
             audio_file.content_type,
             cfg=cfg,
         )
     except VoiceValidationError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        detail = str(exc)
+        if detail.startswith("payload_too_large:"):
+            raise HTTPException(status_code=413, detail="payload_too_large")
+        if detail.startswith("duration_exceeded:"):
+            raise HTTPException(status_code=400, detail="duration_exceeded")
+        if detail.startswith("invalid_mime:"):
+            raise HTTPException(status_code=400, detail=detail)
+        if detail == "normalization_failed":
+            raise HTTPException(status_code=400, detail="normalization_failed")
+        raise HTTPException(status_code=400, detail=detail)
+
+    normalized_turn_id = _normalize_turn_id(turn_id)
+    audio_sha256 = hashlib.sha256(audio_raw).hexdigest()
+
+    # 4) Dedupe before lock/enqueue
+    dedupe_hit = _get_dedupe_hit(
+        thread_id=thread_id,
+        turn_id=normalized_turn_id,
+        audio_sha256=audio_sha256,
+    )
+    if dedupe_hit:
+        return dedupe_hit
 
     task = voice_turn_task_cls(
         thread_id=thread_id,
-        audio_b64=base64.b64encode(audio_bytes).decode("ascii"),
-        audio_mime=audio_file.content_type,
+        audio_b64=base64.b64encode(normalized_audio).decode("ascii"),
+        audio_mime=normalized_mime,
         stt_provider=stt_provider,
         tts_enabled=bool(tts_enabled),
         tts_provider=tts_provider,
@@ -175,30 +448,29 @@ async def voice_turn(
         output_format=output_format,
         completion_provider=completion_provider,
         completion_model=completion_model,
+        max_context=max_context,
         depth_mode=depth_mode,
         system_override=system_override,
-        origin="api:voice.turn",
+        turn_id=normalized_turn_id,
+        origin=f"api:voice.turn|turn_id={normalized_turn_id}",
     )
     task.turn_lock_owner = task.task_id
 
+    # 5) Acquire lock
     try:
         locked = acquire_turn_lock(thread_id, task.turn_lock_owner)
     except Exception as exc:
         logger.warning("[voice.turn] turn lock unavailable: %s", exc)
         raise HTTPException(status_code=503, detail="turn_lock_unavailable")
-
     if not locked:
         raise HTTPException(status_code=429, detail="turn_in_flight")
 
+    # 6) Enqueue
     try:
         enqueue(task, VOICE_QUEUE_NAME)
     except Exception as exc:
         logger.warning("[voice.turn] queue unavailable: %s", exc)
-        # Lock owner is task_id; lock TTL is short and worker never received task.
-        # To avoid stale lock on queue failure we release immediately.
         try:
-            from guardian.queue.turn_lock import release_turn_lock
-
             release_turn_lock(thread_id, task.turn_lock_owner)
         except Exception:
             logger.debug(
@@ -206,6 +478,14 @@ async def voice_turn(
                 exc_info=True,
             )
         raise HTTPException(status_code=503, detail="queue_unavailable")
+
+    _set_dedupe_record(
+        thread_id=thread_id,
+        turn_id=normalized_turn_id,
+        audio_sha256=audio_sha256,
+        task_id=task.task_id,
+        ttl_seconds=cfg.turn_dedupe_ttl_seconds,
+    )
 
     try:
         task_events.publish(
@@ -215,14 +495,17 @@ async def voice_turn(
                 "type": task.type,
                 "thread_id": thread_id,
                 "origin": task.origin,
+                "turn_id": normalized_turn_id,
                 "lock": turn_lock_key(thread_id),
-                "duration_seconds": duration,
+                "duration_seconds": audio_meta.get("duration_seconds"),
+                "sample_rate_hz": audio_meta.get("sample_rate_hz"),
+                "channels": audio_meta.get("channels"),
+                "size_bytes": audio_meta.get("size_bytes"),
             },
         )
     except Exception:
         logger.debug("[voice.turn] task.created emit failed", exc_info=True)
 
-    # Route waits for terminal event while worker executes internally.
     wait_budget = (
         cfg.stt_timeout_seconds
         + cfg.completion_timeout_seconds
@@ -242,14 +525,24 @@ async def voice_turn(
         payload.setdefault("task_id", task.task_id)
         payload.setdefault("thread_id", thread_id)
         payload.setdefault("status", "succeeded")
+        payload.setdefault("deduped", False)
         return payload
 
     if event_type == "task.cancelled":
         raise HTTPException(status_code=409, detail="voice_turn_cancelled")
 
     error = str(payload.get("error") or "voice_turn_failed")
-    if error.startswith("voice_validation:"):
-        raise HTTPException(status_code=400, detail=error)
+    if error.startswith("voice_validation:invalid_mime:"):
+        raise HTTPException(
+            status_code=400,
+            detail=error.removeprefix("voice_validation:"),
+        )
+    if error.startswith("voice_validation:payload_too_large"):
+        raise HTTPException(status_code=413, detail="payload_too_large")
+    if error.startswith("voice_validation:duration_exceeded"):
+        raise HTTPException(status_code=400, detail="duration_exceeded")
+    if error.startswith("voice_validation:normalization_failed"):
+        raise HTTPException(status_code=400, detail="normalization_failed")
     if error.endswith("_timeout"):
         raise HTTPException(status_code=504, detail=error)
     raise HTTPException(status_code=500, detail=error)
@@ -289,7 +582,7 @@ def speak_message(
         if cached:
             return SpeakResponse(
                 message_id=message_id,
-                audio_asset=cached,
+                audio_asset=_with_stream_url(cached),
                 cached=True,
                 text_hash=text_hash,
             )
@@ -314,11 +607,14 @@ def speak_message(
         voice=voice,
         audio_bytes=audio_bytes,
         audio_format=fmt,
-        delivery_variants_json={"requested_format": output_format},
+        delivery_variants_json={
+            "requested_format": output_format,
+            "stream_proxy_enabled": bool(STREAM_PROXY_ENABLED),
+        },
     )
     return SpeakResponse(
         message_id=message_id,
-        audio_asset=asset,
+        audio_asset=_with_stream_url(asset),
         cached=False,
         text_hash=text_hash,
     )

--- a/guardian/tasks/types.py
+++ b/guardian/tasks/types.py
@@ -81,6 +81,49 @@ class ChatCompletionTask(BaseTask):
 
 
 @dataclass
+class VoiceTurnTask(BaseTask):
+    type: str = "voice_turn"
+    thread_id: int = 0
+    audio_b64: str = ""
+    audio_mime: str | None = None
+    stt_provider: str | None = None
+    tts_enabled: bool = True
+    tts_provider: str | None = None
+    voice: str | None = None
+    output_format: str | None = None
+    completion_provider: str | None = None
+    completion_model: str | None = None
+    max_context: int | None = 50
+    depth_mode: str | None = "normal"
+    system_override: str | None = None
+    turn_id: str | None = None
+    turn_lock_owner: str | None = None
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> VoiceTurnTask:
+        base = _base_kwargs(payload or {})
+        base.setdefault("type", cls.type)
+        return cls(
+            thread_id=int(payload.get("thread_id") or 0),
+            audio_b64=str(payload.get("audio_b64") or ""),
+            audio_mime=payload.get("audio_mime"),
+            stt_provider=payload.get("stt_provider"),
+            tts_enabled=bool(payload.get("tts_enabled", True)),
+            tts_provider=payload.get("tts_provider"),
+            voice=payload.get("voice"),
+            output_format=payload.get("output_format"),
+            completion_provider=payload.get("completion_provider"),
+            completion_model=payload.get("completion_model"),
+            max_context=payload.get("max_context"),
+            depth_mode=payload.get("depth_mode"),
+            system_override=payload.get("system_override"),
+            turn_id=payload.get("turn_id"),
+            turn_lock_owner=payload.get("turn_lock_owner"),
+            **base,
+        )
+
+
+@dataclass
 class CronExecutionTask(BaseTask):
     """Queue payload for executing a cron run."""
 
@@ -106,6 +149,7 @@ class CronExecutionTask(BaseTask):
 TASK_TYPE_REGISTRY: dict[str, type[BaseTask]] = {
     "warmup": WarmupTask,
     "chat_completion": ChatCompletionTask,
+    "voice_turn": VoiceTurnTask,
     "cron.execute": CronExecutionTask,
 }
 

--- a/guardian/tests/workers/test_chat_worker_completion_semantics.py
+++ b/guardian/tests/workers/test_chat_worker_completion_semantics.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from guardian.tasks.types import ChatCompletionTask
+from guardian.workers import chat_worker
+
+TURN_ID = "11111111-1111-4111-8111-111111111111"
+
+
+def _build_task(
+    *, thread_id: int = 11, turn_id: str = TURN_ID
+) -> ChatCompletionTask:
+    task = ChatCompletionTask(
+        thread_id=thread_id,
+        provider="groq",
+        model="moonshotai-kimi-k2-instruct-9050",
+    )
+    task.turn_id = turn_id
+    task.turn_lock_owner = f"lock-{thread_id}"
+    return task
+
+
+def test_metadata_persistence_failure_is_non_fatal(monkeypatch):
+    published: list[tuple[str, dict]] = []
+
+    monkeypatch.setattr(
+        chat_worker,
+        "_safe_publish",
+        lambda _task_id, event_type, data: published.append(
+            (event_type, dict(data or {}))
+        ),
+    )
+    monkeypatch.setattr(
+        chat_worker, "_safe_emit_live_event", lambda *a, **k: None
+    )
+    monkeypatch.setattr(chat_worker, "is_cancelled", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        chat_worker, "release_turn_lock", lambda *_a, **_k: True
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "run_chat_completion_task",
+        lambda *_a, **_k: {
+            "message_id": 501,
+            "provider": "groq",
+            "model": "moonshotai-kimi-k2-instruct-9050",
+        },
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_find_assistant_message_id_by_turn_id",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_persist_turn_id_metadata",
+        lambda **_kwargs: False,
+    )
+
+    chat_worker._run_chat_task(_build_task())
+
+    event_types = [event_type for event_type, _payload in published]
+    assert "task.completed" in event_types
+    assert "task.failed" not in event_types
+
+
+def test_worker_failure_before_assistant_emit_marks_failed_and_emits_completion_error(
+    monkeypatch,
+):
+    published: list[tuple[str, dict]] = []
+    mirrored_live_events: list[tuple[str, dict]] = []
+
+    monkeypatch.setattr(
+        chat_worker,
+        "_safe_publish",
+        lambda _task_id, event_type, data: published.append(
+            (event_type, dict(data or {}))
+        ),
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_safe_emit_live_event",
+        lambda event_type, payload: mirrored_live_events.append(
+            (event_type, dict(payload or {}))
+        ),
+    )
+    monkeypatch.setattr(chat_worker, "is_cancelled", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        chat_worker, "release_turn_lock", lambda *_a, **_k: True
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_find_assistant_message_id_by_turn_id",
+        lambda **_kwargs: None,
+    )
+
+    def _raise_failure(*_a, **_k):
+        raise RuntimeError("provider crashed")
+
+    monkeypatch.setattr(chat_worker, "run_chat_completion_task", _raise_failure)
+
+    task = _build_task(thread_id=17)
+    chat_worker._run_chat_task(task)
+
+    assert any(event_type == "task.failed" for event_type, _ in published)
+    assert any(
+        event_type == "completion.error"
+        for event_type, _ in mirrored_live_events
+    )
+    completion_error_payload = next(
+        payload
+        for event_type, payload in mirrored_live_events
+        if event_type == "completion.error"
+    )
+    assert completion_error_payload.get("task_id") == task.task_id
+    assert completion_error_payload.get("thread_id") == 17
+
+
+def test_duplicate_turn_is_prevented_before_new_completion(monkeypatch):
+    published: list[tuple[str, dict]] = []
+
+    monkeypatch.setattr(
+        chat_worker,
+        "_safe_publish",
+        lambda _task_id, event_type, data: published.append(
+            (event_type, dict(data or {}))
+        ),
+    )
+    monkeypatch.setattr(
+        chat_worker, "_safe_emit_live_event", lambda *a, **k: None
+    )
+    monkeypatch.setattr(chat_worker, "is_cancelled", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        chat_worker, "release_turn_lock", lambda *_a, **_k: True
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_find_assistant_message_id_by_turn_id",
+        lambda **_kwargs: 90210,
+    )
+
+    completion_called = False
+
+    def _should_not_run(*_a, **_k):
+        nonlocal completion_called
+        completion_called = True
+        return {"message_id": 1}
+
+    monkeypatch.setattr(
+        chat_worker, "run_chat_completion_task", _should_not_run
+    )
+
+    chat_worker._run_chat_task(_build_task(thread_id=23))
+
+    assert completion_called is False
+    completed_payload = next(
+        payload
+        for event_type, payload in published
+        if event_type == "task.completed"
+    )
+    assert completed_payload.get("message_id") == 90210
+    assert completed_payload.get("deduplicated") is True

--- a/guardian/tts/providers/local_openai_compatible_provider.py
+++ b/guardian/tts/providers/local_openai_compatible_provider.py
@@ -25,6 +25,7 @@ class LocalOpenAICompatibleProvider(TTSProvider):
     ):
         self.base_url = (
             base_url
+            or os.getenv("CODEXIFY_LOCAL_VOICE_BASE_URL")
             or os.getenv("CODEXIFY_LOCAL_TTS_BASE_URL")
             or os.getenv("LOCAL_BASE_URL")
             or "http://localhost:11434/v1"

--- a/guardian/tts/tts_manager.py
+++ b/guardian/tts/tts_manager.py
@@ -62,7 +62,8 @@ class TTSManager:
                 },
                 "local": {"enabled": True},
                 "local_openai_compatible": {
-                    "base_url": os.getenv("CODEXIFY_LOCAL_TTS_BASE_URL")
+                    "base_url": os.getenv("CODEXIFY_LOCAL_VOICE_BASE_URL")
+                    or os.getenv("CODEXIFY_LOCAL_TTS_BASE_URL")
                     or os.getenv("LOCAL_BASE_URL"),
                     "api_key": os.getenv("LOCAL_API_KEY", "local"),
                     "model": os.getenv("CODEXIFY_LOCAL_TTS_MODEL")

--- a/guardian/voice/audio_assets.py
+++ b/guardian/voice/audio_assets.py
@@ -6,11 +6,13 @@ import hashlib
 import os
 from datetime import datetime
 from typing import Any
+from urllib.parse import urlsplit
 
 from sqlalchemy.exc import IntegrityError
 
 from guardian.core.db import GuardianDB, load_guardian_db_from_env
 from guardian.core.dependencies import chatlog_db
+from guardian.core.media_signing import sign_media_url
 from guardian.core.storage import create_storage_from_env
 from guardian.db.models import MessageAudioAsset
 
@@ -132,10 +134,12 @@ def save_message_audio_asset(
         return _serialize_asset(row)
 
 
-def _maybe_sign_url(url: str | None) -> str | None:
-    if not url:
-        return url
+def _looks_like_remote_url(url: str) -> bool:
+    lowered = (url or "").strip().lower()
+    return lowered.startswith("http://") or lowered.startswith("https://")
 
+
+def _sign_with_storage_signer(url: str) -> tuple[str, int | None]:
     for method_name in ("sign_url", "get_signed_url", "signed_url"):
         signer = getattr(_storage, method_name, None)
         if not callable(signer):
@@ -144,20 +148,68 @@ def _maybe_sign_url(url: str | None) -> str | None:
             signed = signer(url)
         except Exception:
             continue
-        if isinstance(signed, str) and signed:
-            return signed
 
-    return url
+        if isinstance(signed, str) and signed:
+            return signed, None
+        if isinstance(signed, dict):
+            signed_url = str(
+                signed.get("url") or signed.get("src_url") or ""
+            ).strip()
+            if not signed_url:
+                continue
+            expires_at = signed.get("expires_at") or signed.get(
+                "url_expires_at"
+            )
+            try:
+                expires_at_int = (
+                    int(expires_at) if expires_at is not None else None
+                )
+            except Exception:
+                expires_at_int = None
+            return signed_url, expires_at_int
+    return url, None
+
+
+def _sign_local_media_url(url: str) -> str:
+    candidate = (url or "").strip()
+    if candidate.startswith("/media/"):
+        return sign_media_url(candidate)
+
+    parsed = urlsplit(candidate)
+    if parsed.scheme or parsed.netloc:
+        return candidate
+
+    normalized = candidate.lstrip("/")
+    if normalized.startswith("media/"):
+        return sign_media_url(f"/{normalized}")
+    return sign_media_url(f"/media/{normalized}")
+
+
+def _signed_asset_url(url: str | None) -> tuple[str | None, int | None]:
+    if not url:
+        return url, None
+
+    candidate = str(url).strip()
+    if not candidate:
+        return None, None
+
+    if _looks_like_remote_url(candidate):
+        return _sign_with_storage_signer(candidate)
+
+    # Local /media paths or local storage keys always use Guardian media signing.
+    return _sign_local_media_url(candidate), None
 
 
 def _serialize_asset(asset: MessageAudioAsset) -> dict[str, Any]:
+    signed_src, expires_at = _signed_asset_url(asset.src_url)
     return {
         "id": asset.id,
         "message_id": asset.message_id,
         "provider": asset.provider,
         "voice": asset.voice,
         "text_hash": asset.text_hash,
-        "src_url": _maybe_sign_url(asset.src_url),
+        "src_url": signed_src,
+        "url_expires_at": expires_at,
         "internal_format": asset.internal_format,
         "delivery_variants_json": asset.delivery_variants_json or {},
         "duration_seconds": asset.duration_seconds,

--- a/guardian/voice/audio_assets.py
+++ b/guardian/voice/audio_assets.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import os
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from sqlalchemy.exc import IntegrityError
 
@@ -132,6 +132,24 @@ def save_message_audio_asset(
         return _serialize_asset(row)
 
 
+def _maybe_sign_url(url: str | None) -> str | None:
+    if not url:
+        return url
+
+    for method_name in ("sign_url", "get_signed_url", "signed_url"):
+        signer = getattr(_storage, method_name, None)
+        if not callable(signer):
+            continue
+        try:
+            signed = signer(url)
+        except Exception:
+            continue
+        if isinstance(signed, str) and signed:
+            return signed
+
+    return url
+
+
 def _serialize_asset(asset: MessageAudioAsset) -> dict[str, Any]:
     return {
         "id": asset.id,
@@ -139,7 +157,7 @@ def _serialize_asset(asset: MessageAudioAsset) -> dict[str, Any]:
         "provider": asset.provider,
         "voice": asset.voice,
         "text_hash": asset.text_hash,
-        "src_url": asset.src_url,
+        "src_url": _maybe_sign_url(asset.src_url),
         "internal_format": asset.internal_format,
         "delivery_variants_json": asset.delivery_variants_json or {},
         "duration_seconds": asset.duration_seconds,

--- a/guardian/voice/config.py
+++ b/guardian/voice/config.py
@@ -2,13 +2,39 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass
 
+from guardian.voice.runtime import (
+    STREAM_PROXY_ENABLED,
+    voice_routes_enabled,
+    voice_turns_enabled,
+)
+
 _TRUTHY = {"1", "true", "yes", "on"}
+_LOGGER = logging.getLogger(__name__)
+_WARNED_LEGACY_KEYS: set[str] = set()
 
 
-def _get_int(name: str, default: int, *, minimum: int = 1) -> int:
+def _warn_legacy_once(name: str, replacement: str) -> None:
+    if name in _WARNED_LEGACY_KEYS:
+        return
+    _WARNED_LEGACY_KEYS.add(name)
+    _LOGGER.warning(
+        "[voice.config] legacy env %s is deprecated; use %s",
+        name,
+        replacement,
+    )
+
+
+def _get_int(
+    name: str,
+    default: int,
+    *,
+    minimum: int = 1,
+    maximum: int | None = None,
+) -> int:
     raw = (os.getenv(name) or "").strip()
     if not raw:
         return default
@@ -16,7 +42,10 @@ def _get_int(name: str, default: int, *, minimum: int = 1) -> int:
         value = int(raw)
     except Exception:
         value = default
-    return max(minimum, value)
+    value = max(minimum, value)
+    if maximum is not None:
+        value = min(maximum, value)
+    return value
 
 
 def _get_bool(name: str, default: bool = False) -> bool:
@@ -29,33 +58,100 @@ def _get_bool(name: str, default: bool = False) -> bool:
 @dataclass(frozen=True)
 class VoiceRuntimeConfig:
     mode: str
+    routes_enabled: bool
+    turns_enabled: bool
     stt_provider: str
     tts_provider: str
+    local_voice_base_url: str | None
+    stream_proxy_enabled: bool
     stt_timeout_seconds: int
     completion_timeout_seconds: int
     tts_timeout_seconds: int
     input_max_bytes: int
     output_max_bytes: int
     max_duration_seconds: int
+    turn_dedupe_ttl_seconds: int
     internal_format: str
     delivery_formats: tuple[str, ...]
     bake_models: bool
     service_url: str | None
 
 
+def _resolve_mode() -> str:
+    mode = (os.getenv("CODEXIFY_VOICE_MODE") or "").strip().lower()
+    return mode or "off"
+
+
+def _resolve_local_voice_base_url() -> str | None:
+    explicit = (os.getenv("CODEXIFY_LOCAL_VOICE_BASE_URL") or "").strip()
+    if explicit:
+        return explicit
+
+    stt_base = (os.getenv("CODEXIFY_STT_BASE_URL") or "").strip()
+    if stt_base:
+        _warn_legacy_once(
+            "CODEXIFY_STT_BASE_URL", "CODEXIFY_LOCAL_VOICE_BASE_URL"
+        )
+        return stt_base
+
+    legacy_tts = (os.getenv("CODEXIFY_LOCAL_TTS_BASE_URL") or "").strip()
+    if legacy_tts:
+        _warn_legacy_once(
+            "CODEXIFY_LOCAL_TTS_BASE_URL", "CODEXIFY_LOCAL_VOICE_BASE_URL"
+        )
+        return legacy_tts
+
+    legacy_stt = (os.getenv("CODEXIFY_LOCAL_STT_BASE_URL") or "").strip()
+    if legacy_stt:
+        _warn_legacy_once(
+            "CODEXIFY_LOCAL_STT_BASE_URL", "CODEXIFY_LOCAL_VOICE_BASE_URL"
+        )
+        return legacy_stt
+
+    fallback = (os.getenv("LOCAL_BASE_URL") or "").strip()
+    if fallback:
+        _warn_legacy_once("LOCAL_BASE_URL", "CODEXIFY_LOCAL_VOICE_BASE_URL")
+        return fallback
+    return None
+
+
+def _normalize_provider(provider: str, *, kind: str) -> str:
+    value = (provider or "").strip().lower()
+    if not value:
+        return ""
+    if value in {"whisper_local", "whispercpp"}:
+        return "whispercpp"
+    if value in {"local_openai_compatible", "openai_compatible_local"}:
+        return "local_openai_compatible"
+    if kind == "tts" and value in {"local"}:
+        return "local_openai_compatible"
+    return value
+
+
 def get_voice_runtime_config() -> VoiceRuntimeConfig:
-    mode = (os.getenv("CODEXIFY_VOICE_MODE") or "off").strip().lower()
-    stt_provider = (
-        (os.getenv("CODEXIFY_STT_PROVIDER") or "whisper_local").strip().lower()
-    )
+    mode = _resolve_mode()
+    if os.getenv("CODEXIFY_VOICE_MODE") is not None:
+        _warn_legacy_once("CODEXIFY_VOICE_MODE", "CODEXIFY_*_PROVIDER flags")
+    local_voice_base_url = _resolve_local_voice_base_url()
+
+    explicit_stt = (os.getenv("CODEXIFY_STT_PROVIDER") or "").strip().lower()
+    if explicit_stt:
+        stt_provider = _normalize_provider(explicit_stt, kind="stt")
+    else:
+        # Canonical local-first default.
+        stt_provider = "local_openai_compatible"
 
     explicit_tts = (os.getenv("CODEXIFY_TTS_PROVIDER") or "").strip().lower()
     if explicit_tts:
-        tts_provider = explicit_tts
-    elif mode == "local":
-        tts_provider = "local_openai_compatible"
+        tts_provider = _normalize_provider(explicit_tts, kind="tts")
     else:
-        tts_provider = "elevenlabs"
+        # Canonical local-first default.
+        tts_provider = "local_openai_compatible"
+
+    if os.getenv("CODEXIFY_ENABLE_VOICE_TURNS") is not None:
+        _warn_legacy_once(
+            "CODEXIFY_ENABLE_VOICE_TURNS", "CODEXIFY_VOICE_TURNS_ENABLED"
+        )
 
     delivery_formats_raw = (
         os.getenv("CODEXIFY_VOICE_DELIVERY_FORMATS") or "wav,mp3"
@@ -70,8 +166,12 @@ def get_voice_runtime_config() -> VoiceRuntimeConfig:
 
     return VoiceRuntimeConfig(
         mode=mode,
+        routes_enabled=voice_routes_enabled(),
+        turns_enabled=voice_turns_enabled(),
         stt_provider=stt_provider,
         tts_provider=tts_provider,
+        local_voice_base_url=local_voice_base_url,
+        stream_proxy_enabled=STREAM_PROXY_ENABLED,
         stt_timeout_seconds=_get_int("CODEXIFY_STT_TIMEOUT_SECONDS", 20),
         completion_timeout_seconds=_get_int(
             "CODEXIFY_VOICE_COMPLETION_TIMEOUT_SECONDS", 60
@@ -85,6 +185,12 @@ def get_voice_runtime_config() -> VoiceRuntimeConfig:
         ),
         max_duration_seconds=_get_int(
             "CODEXIFY_VOICE_MAX_DURATION_SECONDS", 120
+        ),
+        turn_dedupe_ttl_seconds=_get_int(
+            "CODEXIFY_VOICE_TURN_DEDUPE_TTL_SECONDS",
+            600,
+            minimum=300,
+            maximum=900,
         ),
         internal_format=(os.getenv("CODEXIFY_VOICE_INTERNAL_FORMAT") or "wav")
         .strip()

--- a/guardian/voice/runtime.py
+++ b/guardian/voice/runtime.py
@@ -1,0 +1,69 @@
+"""Shared voice runtime constants and feature-flag helpers."""
+
+from __future__ import annotations
+
+import os
+
+VOICE_QUEUE_NAME = os.getenv("VOICE_QUEUE_NAME", "codexify:queue:voice")
+VOICE_HEARTBEAT_KEY = os.getenv(
+    "VOICE_HEARTBEAT_KEY", "codexify:worker:voice:heartbeat"
+)
+VOICE_HEARTBEAT_TTL_SECONDS = int(
+    os.getenv("VOICE_HEARTBEAT_TTL_SECONDS", "30")
+)
+VOICE_HEARTBEAT_INTERVAL_SECONDS = int(
+    os.getenv("VOICE_HEARTBEAT_INTERVAL_SECONDS", "10")
+)
+
+STREAM_PROXY_ENABLED = os.getenv(
+    "CODEXIFY_VOICE_STREAM_PROXY_ENABLED", "0"
+).strip().lower() in {"1", "true", "yes", "on"}
+
+SUPPORTED_TTS_PROVIDERS = (
+    "local_openai_compatible",
+    "elevenlabs",
+    "minimax",
+)
+SUPPORTED_STT_PROVIDERS = (
+    "local_openai_compatible",
+    "whispercpp",
+)
+SUPPORTED_INPUT_MIME = (
+    "audio/wav",
+    "audio/x-wav",
+    "audio/webm",
+    "audio/ogg",
+)
+
+_TRUTHY = {"1", "true", "yes", "on"}
+_FALSY = {"0", "false", "no", "off"}
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    normalized = str(raw).strip().lower()
+    if normalized in _TRUTHY:
+        return True
+    if normalized in _FALSY:
+        return False
+    return default
+
+
+def voice_routes_enabled() -> bool:
+    return _env_bool("CODEXIFY_VOICE_ROUTES_ENABLED", True)
+
+
+def voice_turns_enabled() -> bool:
+    explicit = os.getenv("CODEXIFY_VOICE_TURNS_ENABLED")
+    if explicit is not None:
+        return str(explicit).strip().lower() in _TRUTHY
+
+    legacy = os.getenv("CODEXIFY_ENABLE_VOICE_TURNS")
+    if legacy is not None:
+        return str(legacy).strip().lower() in _TRUTHY
+
+    # Legacy fallback: only explicit turn-like modes imply enabled.
+    mode = (os.getenv("CODEXIFY_VOICE_MODE") or "").strip().lower()
+    return mode in {"turns", "turn", "turn_based", "turn-based"}

--- a/guardian/voice/service.py
+++ b/guardian/voice/service.py
@@ -21,8 +21,20 @@ import requests
 from guardian.tts.tts_manager import TTSManager
 from guardian.voice.config import VoiceRuntimeConfig, get_voice_runtime_config
 from guardian.voice.manifest import load_manifest
+from guardian.voice.runtime import SUPPORTED_INPUT_MIME
 
 logger = logging.getLogger(__name__)
+
+_CANONICAL_INPUT_MIME = "audio/wav"
+_INPUT_MIME_ALIASES = {
+    "audio/x-wav": "audio/wav",
+}
+_INPUT_MIME_TO_EXT = {
+    "audio/wav": "wav",
+    "audio/x-wav": "wav",
+    "audio/webm": "webm",
+    "audio/ogg": "ogg",
+}
 
 
 class VoiceServiceError(RuntimeError):
@@ -39,6 +51,50 @@ class VoiceTimeoutError(VoiceServiceError):
 
 class VoiceProviderError(VoiceServiceError):
     """Provider-level execution failure."""
+
+
+def _normalize_input_mime(mime_type: str | None) -> str:
+    raw = str(mime_type or "").strip().lower()
+    normalized = _INPUT_MIME_ALIASES.get(raw, raw)
+    if normalized in SUPPORTED_INPUT_MIME:
+        return normalized
+    if raw in SUPPORTED_INPUT_MIME:
+        return raw
+    raise VoiceValidationError(f"invalid_mime:{raw or '<missing>'}")
+
+
+def ffmpeg_available() -> bool:
+    return bool(shutil.which("ffmpeg"))
+
+
+def ffprobe_available() -> bool:
+    return bool(shutil.which("ffprobe"))
+
+
+def validate_voice_runtime_dependencies(
+    *,
+    routes_enabled: bool,
+    accepted_mime: tuple[str, ...] = SUPPORTED_INPUT_MIME,
+) -> None:
+    if not routes_enabled:
+        return
+
+    requires_normalization = any(
+        mime not in {"audio/wav", "audio/x-wav"} for mime in accepted_mime
+    )
+    if not requires_normalization:
+        return
+
+    missing: list[str] = []
+    if not ffmpeg_available():
+        missing.append("ffmpeg")
+    if not ffprobe_available():
+        missing.append("ffprobe")
+    if missing:
+        logger.warning(
+            "[voice] missing runtime dependencies for non-WAV ingest: %s",
+            ",".join(missing),
+        )
 
 
 def _openai_endpoint(base_url: str, suffix: str) -> str:
@@ -110,25 +166,74 @@ def enforce_audio_input_limits(
     *,
     cfg: VoiceRuntimeConfig | None = None,
 ) -> float | None:
+    _, _, meta = normalize_audio_input(audio_bytes, mime_type, cfg=cfg)
+    return meta.get("duration_seconds")
+
+
+def normalize_audio_input(
+    audio_bytes: bytes,
+    mime_type: str | None,
+    *,
+    cfg: VoiceRuntimeConfig | None = None,
+) -> tuple[bytes, str, dict[str, Any]]:
     config = cfg or get_voice_runtime_config()
+    normalized_mime = _normalize_input_mime(mime_type)
     size = len(audio_bytes)
     if size <= 0:
         raise VoiceValidationError("empty_audio")
     if size > config.input_max_bytes:
         raise VoiceValidationError(
-            f"audio_too_large:{size}>{config.input_max_bytes}"
+            f"payload_too_large:{size}>{config.input_max_bytes}"
         )
 
-    duration = detect_audio_duration_seconds(audio_bytes, mime_type)
+    output_bytes = audio_bytes
+    output_mime = normalized_mime
+    if normalized_mime != _CANONICAL_INPUT_MIME:
+        source_ext = _INPUT_MIME_TO_EXT.get(normalized_mime)
+        if not source_ext or not ffmpeg_available():
+            raise VoiceValidationError("normalization_failed")
+        try:
+            output_bytes = _transcode_with_ffmpeg(
+                audio_bytes,
+                source_ext=source_ext,
+                target_ext="wav",
+            )
+        except Exception as exc:
+            logger.warning(
+                "[voice] normalization failed mime=%s err=%s", mime_type, exc
+            )
+            raise VoiceValidationError("normalization_failed")
+        output_mime = _CANONICAL_INPUT_MIME
+
+    duration = detect_audio_duration_seconds(output_bytes, output_mime)
     if duration is None:
-        raise VoiceValidationError(
-            "audio_duration_unknown:provide wav or install ffprobe"
-        )
+        raise VoiceValidationError("normalization_failed")
     if duration > config.max_duration_seconds:
         raise VoiceValidationError(
-            f"audio_too_long:{duration:.2f}>{config.max_duration_seconds}"
+            f"duration_exceeded:{duration:.2f}>{config.max_duration_seconds}"
         )
-    return duration
+
+    sample_rate = None
+    channels = None
+    if output_mime == _CANONICAL_INPUT_MIME:
+        try:
+            with wave.open(io.BytesIO(output_bytes), "rb") as wav_fp:
+                sample_rate = int(wav_fp.getframerate() or 0) or None
+                channels = int(wav_fp.getnchannels() or 0) or None
+        except Exception:
+            sample_rate = None
+            channels = None
+
+    return (
+        output_bytes,
+        output_mime,
+        {
+            "duration_seconds": duration,
+            "sample_rate_hz": sample_rate,
+            "channels": channels,
+            "size_bytes": len(output_bytes),
+        },
+    )
 
 
 def _request_transcription_openai_compatible(
@@ -188,9 +293,15 @@ def transcribe_audio(
             os.getenv("CODEXIFY_STT_MOCK_TEXT") or "mock transcript"
         ).strip()
 
-    if active_provider == "whisper_local":
+    if active_provider in {
+        "whisper_local",
+        "whispercpp",
+        "local_openai_compatible",
+    }:
         base_url = (
-            os.getenv("CODEXIFY_STT_BASE_URL")
+            cfg.local_voice_base_url
+            or os.getenv("CODEXIFY_LOCAL_VOICE_BASE_URL")
+            or os.getenv("CODEXIFY_STT_BASE_URL")
             or os.getenv("CODEXIFY_LOCAL_STT_BASE_URL")
             or os.getenv("LOCAL_BASE_URL")
             or "http://localhost:11434"

--- a/guardian/workers/chat_worker.py
+++ b/guardian/workers/chat_worker.py
@@ -52,6 +52,12 @@ _TURN_ID_ORIGIN_RE = re.compile(
     r"(?:^|\|)turn_id=(?P<turn_id>[a-f0-9-]{36})(?:\||$)",
     flags=re.IGNORECASE,
 )
+_MIRRORED_LIVE_EVENT_TYPES = {
+    "task.running",
+    "task.completed",
+    "task.failed",
+    "task.cancelled",
+}
 
 
 def _coerce_message_id(raw: Any) -> int | None:
@@ -112,6 +118,55 @@ def _persist_turn_id_metadata(
         return False
 
 
+def _coerce_row_message_id(row: Any) -> int | None:
+    if row is None:
+        return None
+    if isinstance(row, dict):
+        return _coerce_message_id(row.get("id"))
+    if isinstance(row, (tuple, list)):
+        return _coerce_message_id(row[0] if row else None)
+    try:
+        return _coerce_message_id(row["id"])  # type: ignore[index]
+    except Exception:
+        return _coerce_message_id(getattr(row, "id", None))
+
+
+def _find_assistant_message_id_by_turn_id(
+    *, thread_id: int, turn_id: str
+) -> int | None:
+    if not turn_id:
+        return None
+    chatlog_db = getattr(dependencies, "chatlog_db", None)
+    if chatlog_db is None:
+        return None
+    connect = getattr(chatlog_db, "_connect", None)
+    if not callable(connect):
+        return None
+    try:
+        with connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id
+                FROM chat_messages
+                WHERE thread_id = %s
+                  AND role = 'assistant'
+                  AND COALESCE(extra_meta, '{}'::jsonb)->>'turn_id' = %s
+                ORDER BY id ASC
+                LIMIT 1
+                """,
+                (thread_id, turn_id),
+            )
+            return _coerce_row_message_id(cur.fetchone())
+    except Exception:
+        logger.debug(
+            "[chat-worker] failed turn_id lookup thread_id=%s turn_id=%s",
+            thread_id,
+            turn_id,
+            exc_info=True,
+        )
+        return None
+
+
 def _publish_worker_heartbeat(status: str = "idle") -> None:
     payload = {
         "worker": "chat",
@@ -128,6 +183,17 @@ def _publish_worker_heartbeat(status: str = "idle") -> None:
         )
     except Exception as exc:
         logger.debug("[chat-worker] heartbeat update failed: %s", exc)
+
+
+def _safe_emit_live_event(event_type: str, payload: dict[str, Any]) -> None:
+    try:
+        event_bus.emit_event(event_type, payload)
+    except Exception as exc:
+        logger.debug(
+            "[chat-worker] failed to mirror live event type=%s err=%s",
+            event_type,
+            exc,
+        )
 
 
 def _safe_publish(task_id: str, event_type: str, data: dict) -> None:
@@ -150,6 +216,11 @@ def _safe_publish(task_id: str, event_type: str, data: dict) -> None:
             task_id,
             exc,
         )
+
+    if event_type in _MIRRORED_LIVE_EVENT_TYPES:
+        mirror_payload = dict(payload)
+        mirror_payload.setdefault("task_id", task_id)
+        _safe_emit_live_event(event_type, mirror_payload)
 
 
 def _run_chat_task(task: ChatCompletionTask) -> None:
@@ -199,6 +270,46 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
             )
             return
 
+        if turn_id:
+            existing_message_id = _find_assistant_message_id_by_turn_id(
+                thread_id=task.thread_id,
+                turn_id=turn_id,
+            )
+            if existing_message_id is not None:
+                duration_ms = int((time.monotonic() - started) * 1000)
+                logger.warning(
+                    "[chat-worker] duplicate_turn_prevented thread_id=%s turn_id=%s task_id=%s message_id=%s",
+                    task.thread_id,
+                    turn_id,
+                    task.task_id,
+                    existing_message_id,
+                )
+                _safe_publish(
+                    task.task_id,
+                    "task.completed",
+                    {
+                        "run_id": run_id,
+                        "duration_ms": duration_ms,
+                        "thread_id": task.thread_id,
+                        "turn_id": turn_id,
+                        "message_id": existing_message_id,
+                        "deduplicated": True,
+                        "provider": task.provider,
+                        "model": task.model,
+                    },
+                )
+                logger.info(
+                    "[task] completed type=%s id=%s run_id=%s thread=%s turn_id=%s message_id=%s deduplicated=%s",
+                    task.type,
+                    task.task_id,
+                    run_id,
+                    task.thread_id,
+                    turn_id,
+                    existing_message_id,
+                    True,
+                )
+                return
+
         result = run_chat_completion_task(
             task,
             token_callback=lambda token: _safe_publish(
@@ -228,14 +339,31 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
         if turn_id and not _persist_turn_id_metadata(
             thread_id=task.thread_id, message_id=message_id, turn_id=turn_id
         ):
-            logger.error(
+            logger.warning(
                 "[chat-worker] completion_turn_metadata_missing thread_id=%s turn_id=%s task_id=%s message_id=%s",
                 task.thread_id,
                 turn_id,
                 task.task_id,
                 message_id,
             )
-            raise RuntimeError("assistant_message_turn_metadata_missing")
+        if turn_id:
+            canonical_message_id = _find_assistant_message_id_by_turn_id(
+                thread_id=task.thread_id,
+                turn_id=turn_id,
+            )
+            if (
+                canonical_message_id is not None
+                and canonical_message_id != message_id
+            ):
+                logger.warning(
+                    "[chat-worker] completion_duplicate_turn_detected thread_id=%s turn_id=%s task_id=%s canonical_message_id=%s duplicate_message_id=%s",
+                    task.thread_id,
+                    turn_id,
+                    task.task_id,
+                    canonical_message_id,
+                    message_id,
+                )
+                message_id = canonical_message_id
 
         logger.info(
             "[chat-worker] assistant_message_persisted thread_id=%s turn_id=%s task_id=%s assistant_message_id=%s",
@@ -290,17 +418,25 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
         )
     except Exception as exc:
         duration_ms = int((time.monotonic() - started) * 1000)
+        failure_payload = {
+            "run_id": run_id,
+            "duration_ms": duration_ms,
+            "error": str(exc),
+            "error_type": exc.__class__.__name__,
+            "thread_id": task.thread_id,
+            "origin": task.origin,
+            "turn_id": turn_id,
+        }
         _safe_publish(
             task.task_id,
             "task.failed",
+            failure_payload,
+        )
+        _safe_emit_live_event(
+            "completion.error",
             {
-                "run_id": run_id,
-                "duration_ms": duration_ms,
-                "error": str(exc),
-                "error_type": exc.__class__.__name__,
-                "thread_id": task.thread_id,
-                "origin": task.origin,
-                "turn_id": turn_id,
+                **failure_payload,
+                "task_id": task.task_id,
             },
         )
         logger.exception(

--- a/guardian/workers/chat_worker.py
+++ b/guardian/workers/chat_worker.py
@@ -13,6 +13,7 @@ import re
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any
 
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
@@ -47,6 +48,68 @@ _MEDIA_DB: GuardianDB | None = None
 _MEDIA_MARKER_RE = re.compile(
     r"<!--\s*cfy-media:(image|document):([a-fA-F0-9-]+)\s*-->"
 )
+_TURN_ID_ORIGIN_RE = re.compile(
+    r"(?:^|\|)turn_id=(?P<turn_id>[a-f0-9-]{36})(?:\||$)",
+    flags=re.IGNORECASE,
+)
+
+
+def _coerce_message_id(raw: Any) -> int | None:
+    try:
+        value = int(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def _extract_turn_id(task: ChatCompletionTask) -> str:
+    explicit = str(getattr(task, "turn_id", "") or "").strip()
+    if explicit:
+        return explicit
+    origin = str(getattr(task, "origin", "") or "")
+    match = _TURN_ID_ORIGIN_RE.search(origin)
+    return match.group("turn_id").strip().lower() if match else ""
+
+
+def _persist_turn_id_metadata(
+    *, thread_id: int, message_id: int, turn_id: str
+) -> bool:
+    """Persist turn correlation key in chat_messages.extra_meta."""
+    if not turn_id:
+        return True
+    chatlog_db = getattr(dependencies, "chatlog_db", None)
+    if chatlog_db is None:
+        return False
+
+    connect = getattr(chatlog_db, "_connect", None)
+    if not callable(connect):
+        logger.debug(
+            "[chat-worker] chatlog_db has no _connect; skipping turn metadata update"
+        )
+        return False
+
+    try:
+        with connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE chat_messages
+                SET extra_meta = COALESCE(extra_meta, '{}'::jsonb) || %s::jsonb
+                WHERE thread_id = %s
+                  AND id = %s
+                RETURNING id
+                """,
+                (json.dumps({"turn_id": turn_id}), thread_id, message_id),
+            )
+            row = cur.fetchone()
+            return bool(row)
+    except Exception:
+        logger.debug(
+            "[chat-worker] failed to persist turn_id metadata thread_id=%s message_id=%s",
+            thread_id,
+            message_id,
+            exc_info=True,
+        )
+        return False
 
 
 def _publish_worker_heartbeat(status: str = "idle") -> None:
@@ -92,6 +155,7 @@ def _safe_publish(task_id: str, event_type: str, data: dict) -> None:
 def _run_chat_task(task: ChatCompletionTask) -> None:
     run_id = uuid.uuid4().hex
     started = time.monotonic()
+    turn_id = _extract_turn_id(task)
     _safe_publish(
         task.task_id,
         "task.running",
@@ -100,15 +164,17 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
             "type": task.type,
             "origin": task.origin,
             "thread_id": task.thread_id,
+            "turn_id": turn_id,
         },
     )
     logger.info(
-        "[task] running type=%s id=%s run_id=%s origin=%s thread=%s",
+        "[task] running type=%s id=%s run_id=%s origin=%s thread=%s turn_id=%s",
         task.type,
         task.task_id,
         run_id,
         task.origin,
         task.thread_id,
+        turn_id,
     )
 
     try:
@@ -120,14 +186,16 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
                     "run_id": run_id,
                     "thread_id": task.thread_id,
                     "origin": task.origin,
+                    "turn_id": turn_id,
                 },
             )
             clear_cancelled(task.task_id)
             logger.info(
-                "[task] cancelled type=%s id=%s run_id=%s",
+                "[task] cancelled type=%s id=%s run_id=%s turn_id=%s",
                 task.type,
                 task.task_id,
                 run_id,
+                turn_id,
             )
             return
 
@@ -147,6 +215,35 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
             cancel_check=lambda: is_cancelled(task.task_id),
             persist_assistant_message=True,
         )
+        message_id = _coerce_message_id(result.get("message_id"))
+        if message_id is None:
+            logger.error(
+                "[chat-worker] completion_missing_message thread_id=%s turn_id=%s task_id=%s",
+                task.thread_id,
+                turn_id,
+                task.task_id,
+            )
+            raise RuntimeError("assistant_message_missing")
+
+        if turn_id and not _persist_turn_id_metadata(
+            thread_id=task.thread_id, message_id=message_id, turn_id=turn_id
+        ):
+            logger.error(
+                "[chat-worker] completion_turn_metadata_missing thread_id=%s turn_id=%s task_id=%s message_id=%s",
+                task.thread_id,
+                turn_id,
+                task.task_id,
+                message_id,
+            )
+            raise RuntimeError("assistant_message_turn_metadata_missing")
+
+        logger.info(
+            "[chat-worker] assistant_message_persisted thread_id=%s turn_id=%s task_id=%s assistant_message_id=%s",
+            task.thread_id,
+            turn_id,
+            task.task_id,
+            message_id,
+        )
         duration_ms = int((time.monotonic() - started) * 1000)
         _safe_publish(
             task.task_id,
@@ -155,7 +252,8 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
                 "run_id": run_id,
                 "duration_ms": duration_ms,
                 "thread_id": task.thread_id,
-                "message_id": result.get("message_id"),
+                "turn_id": turn_id,
+                "message_id": message_id,
                 "provider": result.get("provider"),
                 "model": result.get("model"),
                 "selection_source": result.get("selection_source"),
@@ -163,11 +261,13 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
             },
         )
         logger.info(
-            "[task] completed type=%s id=%s run_id=%s thread=%s",
+            "[task] completed type=%s id=%s run_id=%s thread=%s turn_id=%s message_id=%s",
             task.type,
             task.task_id,
             run_id,
             task.thread_id,
+            turn_id,
+            message_id,
         )
     except ChatTaskCancelled:
         _safe_publish(
@@ -177,14 +277,16 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
                 "run_id": run_id,
                 "thread_id": task.thread_id,
                 "origin": task.origin,
+                "turn_id": turn_id,
             },
         )
         clear_cancelled(task.task_id)
         logger.info(
-            "[task] cancelled type=%s id=%s run_id=%s",
+            "[task] cancelled type=%s id=%s run_id=%s turn_id=%s",
             task.type,
             task.task_id,
             run_id,
+            turn_id,
         )
     except Exception as exc:
         duration_ms = int((time.monotonic() - started) * 1000)
@@ -198,17 +300,21 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
                 "error_type": exc.__class__.__name__,
                 "thread_id": task.thread_id,
                 "origin": task.origin,
+                "turn_id": turn_id,
             },
         )
         logger.exception(
-            "[task] failed type=%s id=%s run_id=%s err=%s",
+            "[task] failed type=%s id=%s run_id=%s turn_id=%s err=%s",
             task.type,
             task.task_id,
             run_id,
+            turn_id,
             exc,
         )
     finally:
-        owner = (task.turn_lock_owner or "").strip()
+        owner = str(getattr(task, "turn_lock_owner", "") or "").strip()
+        if not owner:
+            owner = str(task.task_id or "").strip()
         if owner:
             try:
                 released = release_turn_lock(task.thread_id, owner)
@@ -274,11 +380,22 @@ def run_forever() -> None:
                     task.task_id,
                 )
                 continue
+            if isinstance(payload, dict):
+                raw_turn_id = payload.get("turn_id")
+                if isinstance(raw_turn_id, str) and raw_turn_id.strip():
+                    task.turn_id = raw_turn_id.strip()
+                raw_owner = payload.get("turn_lock_owner")
+                if isinstance(raw_owner, str) and raw_owner.strip():
+                    task.turn_lock_owner = raw_owner.strip()
             if is_cancelled(task.task_id):
                 _safe_publish(
                     task.task_id,
                     "task.cancelled",
-                    {"type": task.type, "origin": task.origin},
+                    {
+                        "type": task.type,
+                        "origin": task.origin,
+                        "turn_id": _extract_turn_id(task),
+                    },
                 )
                 clear_cancelled(task.task_id)
                 logger.info(

--- a/guardian/workers/graph_backfill_worker.py
+++ b/guardian/workers/graph_backfill_worker.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
 
+from neomodel import db as neo4j_db
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -80,6 +81,33 @@ def _resolve_database_url() -> str:
 
 def _iter_threads(db) -> Iterable[models.ChatThread]:
     return db.query(models.ChatThread).all()
+
+
+def _merge_message_edge(
+    *, message_node: MessageNode, target_node: object, rel_type: str
+) -> None:
+    """Merge graph edges with anchored MATCH clauses (no cartesian pattern)."""
+    if rel_type == "SENT_BY":
+        query = """
+        MATCH (them) WHERE elementId(them) = $them
+        MATCH (us)   WHERE elementId(us)   = $self
+        MERGE(us)-[r:`SENT_BY`]->(them)
+        """
+    elif rel_type == "PART_OF":
+        query = """
+        MATCH (them) WHERE elementId(them) = $them
+        MATCH (us)   WHERE elementId(us)   = $self
+        MERGE(us)-[r:`PART_OF`]->(them)
+        """
+    else:
+        raise ValueError(f"Unsupported relationship type: {rel_type}")
+    neo4j_db.cypher_query(
+        query,
+        {
+            "them": str(getattr(target_node, "element_id")),
+            "self": str(message_node.element_id),
+        },
+    )
 
 
 def backfill_graph(batch_size: int = 500) -> int:
@@ -182,9 +210,17 @@ def backfill_graph(batch_size: int = 500) -> int:
                             f"Expected MessageNode, got {type(msg_node)}"
                         )
                     if not msg_node.user.is_connected(user_node):
-                        msg_node.user.connect(user_node)
+                        _merge_message_edge(
+                            message_node=msg_node,
+                            target_node=user_node,
+                            rel_type="SENT_BY",
+                        )
                     if not msg_node.thread.is_connected(thread_node):
-                        msg_node.thread.connect(thread_node)
+                        _merge_message_edge(
+                            message_node=msg_node,
+                            target_node=thread_node,
+                            rel_type="PART_OF",
+                        )
                     processed_total += 1
 
                 # Update status after each thread so progress is visible in logs.

--- a/guardian/workers/voice_worker.py
+++ b/guardian/workers/voice_worker.py
@@ -6,8 +6,10 @@ Executes STT -> shared completion -> optional TTS, then emits terminal task even
 from __future__ import annotations
 
 import base64
+import json
 import logging
 import os
+import time
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FutureTimeoutError
 
@@ -19,7 +21,12 @@ from guardian.core.chat_completion_service import (
     run_chat_completion_task,
 )
 from guardian.queue import task_events
-from guardian.queue.redis_queue import clear_cancelled, dequeue, is_cancelled
+from guardian.queue.redis_queue import (
+    clear_cancelled,
+    dequeue,
+    get_redis_client,
+    is_cancelled,
+)
 from guardian.queue.turn_lock import release_turn_lock
 from guardian.tasks.types import (
     ChatCompletionTask,
@@ -29,11 +36,17 @@ from guardian.tasks.types import (
 from guardian.voice.audio_assets import save_message_audio_asset
 from guardian.voice.client import synthesize, transcribe
 from guardian.voice.config import get_voice_runtime_config
+from guardian.voice.runtime import (
+    VOICE_HEARTBEAT_INTERVAL_SECONDS,
+    VOICE_HEARTBEAT_KEY,
+    VOICE_HEARTBEAT_TTL_SECONDS,
+    VOICE_QUEUE_NAME,
+)
 from guardian.voice.service import VoiceTimeoutError, VoiceValidationError
 
 logger = logging.getLogger(__name__)
 
-QUEUE_NAME = os.getenv("VOICE_QUEUE_NAME", "codexify:queue:voice")
+QUEUE_NAME = VOICE_QUEUE_NAME
 CONCURRENCY = int(os.getenv("VOICE_WORKER_CONCURRENCY", "1"))
 
 
@@ -42,6 +55,24 @@ def _safe_publish(task_id: str, event_type: str, data: dict) -> None:
         task_events.publish(task_id, event_type, data)
     except Exception as exc:
         logger.warning("[voice-worker] failed to publish event: %s", exc)
+
+
+def _publish_worker_heartbeat(status: str = "idle") -> None:
+    payload = {
+        "worker": "voice",
+        "status": status,
+        "queue": QUEUE_NAME,
+        "ts": int(time.time()),
+    }
+    try:
+        client = get_redis_client()
+        client.setex(
+            VOICE_HEARTBEAT_KEY,
+            max(5, VOICE_HEARTBEAT_TTL_SECONDS),
+            json.dumps(payload),
+        )
+    except Exception as exc:
+        logger.debug("[voice-worker] heartbeat update failed: %s", exc)
 
 
 def _run_voice_task(task: VoiceTurnTask) -> None:
@@ -118,6 +149,9 @@ def _run_voice_task(task: VoiceTurnTask) -> None:
             },
         )
 
+        completion_origin = "worker:voice_turn"
+        if task.turn_id:
+            completion_origin = f"{completion_origin}|turn_id={task.turn_id}"
         completion_task = ChatCompletionTask(
             thread_id=task.thread_id,
             provider=task.completion_provider,
@@ -125,9 +159,10 @@ def _run_voice_task(task: VoiceTurnTask) -> None:
             max_context=task.max_context,
             depth_mode=task.depth_mode,
             system_override=task.system_override,
-            origin="worker:voice_turn",
-            turn_lock_owner=task.turn_lock_owner,
+            origin=completion_origin,
         )
+        if task.turn_id:
+            completion_task.turn_id = task.turn_id
 
         try:
             from guardian.core.config import settings as llm_settings
@@ -280,13 +315,20 @@ def _initialize_worker() -> None:
 
 def run_forever() -> None:
     _initialize_worker()
+    _publish_worker_heartbeat("starting")
     logger.info(
         "[voice-worker] started queue=%s concurrency=%s",
         QUEUE_NAME,
         CONCURRENCY,
     )
     with ThreadPoolExecutor(max_workers=CONCURRENCY) as executor:
+        last_heartbeat = 0.0
         while True:
+            now = time.time()
+            if now - last_heartbeat >= max(1, VOICE_HEARTBEAT_INTERVAL_SECONDS):
+                _publish_worker_heartbeat("idle")
+                last_heartbeat = now
+
             try:
                 payload = dequeue(QUEUE_NAME, block=True, timeout=5)
             except RedisTimeoutError:
@@ -294,6 +336,9 @@ def run_forever() -> None:
 
             if not payload:
                 continue
+
+            _publish_worker_heartbeat("active")
+            last_heartbeat = time.time()
 
             try:
                 task = task_from_dict(payload)

--- a/tests/core/test_depth_resolution.py
+++ b/tests/core/test_depth_resolution.py
@@ -1,0 +1,126 @@
+"""Unit tests for chat depth-resolution contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from guardian.depth import (
+    classify_project_identity_depth,
+    normalize_project_identity_depth,
+    normalize_requested_depth_raw,
+    project_requested_depth_mode,
+    resolve_depth,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, "deep"),
+        ("deep", "deep"),
+        ("  DEEP  ", "deep"),
+        ("normal", "normal"),
+        ("weird", "weird"),
+    ],
+)
+def test_normalize_requested_depth_raw(raw, expected):
+    assert normalize_requested_depth_raw(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("requested_raw", "expected"),
+    [
+        ("deep", "deep"),
+        ("normal", "light"),
+        ("diagnostic", "light"),
+        ("weird", "light"),
+    ],
+)
+def test_project_requested_depth_mode(requested_raw, expected):
+    assert project_requested_depth_mode(requested_raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected_norm", "expected_state"),
+    [
+        (None, "", "missing"),
+        ("deep", "deep", "known"),
+        ("  light  ", "light", "known"),
+        ("DEEPER", "deeper", "malformed"),
+    ],
+)
+def test_project_identity_depth_normalization_and_classification(
+    raw, expected_norm, expected_state
+):
+    assert normalize_project_identity_depth(raw) == expected_norm
+    assert classify_project_identity_depth(raw) == expected_state
+
+
+def test_resolve_depth_non_deep_known_request():
+    assert resolve_depth(
+        "normal",
+        thread_has_project=True,
+        project_depth_state="known",
+        project_identity_depth_norm="deep",
+        policy_allows_deep=True,
+    ) == ("light", None)
+
+
+def test_resolve_depth_deep_no_project():
+    assert resolve_depth(
+        "deep",
+        thread_has_project=False,
+        project_depth_state="missing",
+        project_identity_depth_norm="",
+        policy_allows_deep=False,
+    ) == ("light", "no_project")
+
+
+def test_resolve_depth_deep_project_light():
+    assert resolve_depth(
+        "deep",
+        thread_has_project=True,
+        project_depth_state="known",
+        project_identity_depth_norm="light",
+        policy_allows_deep=False,
+    ) == ("light", "project_identity_depth_light")
+
+
+def test_resolve_depth_deep_project_deep_policy_rejected():
+    assert resolve_depth(
+        "deep",
+        thread_has_project=True,
+        project_depth_state="known",
+        project_identity_depth_norm="deep",
+        policy_allows_deep=False,
+    ) == ("light", "policy_gate_rejected")
+
+
+def test_resolve_depth_deep_project_deep_policy_allowed():
+    assert resolve_depth(
+        "deep",
+        thread_has_project=True,
+        project_depth_state="known",
+        project_identity_depth_norm="deep",
+        policy_allows_deep=True,
+    ) == ("deep", None)
+
+
+def test_resolve_depth_malformed_requested_is_unknown():
+    assert resolve_depth(
+        "not-a-depth",
+        thread_has_project=False,
+        project_depth_state="missing",
+        project_identity_depth_norm="",
+        policy_allows_deep=False,
+    ) == ("light", "unknown")
+
+
+def test_resolve_depth_malformed_project_depth_is_unknown():
+    assert resolve_depth(
+        "deep",
+        thread_has_project=True,
+        project_depth_state="malformed",
+        project_identity_depth_norm="banana",
+        policy_allows_deep=False,
+    ) == ("light", "unknown")

--- a/tests/routes/test_chat_routes.py
+++ b/tests/routes/test_chat_routes.py
@@ -428,6 +428,201 @@ class TestChatCompletePost:
         assert getattr(task, "turn_lock_owner") == data["task_id"]
         assert captured.get("queue_name") == "codexify:queue:chat"
 
+    def test_complete_depth_contract_non_deep_request(
+        self, test_client, mock_db, monkeypatch
+    ):
+        mock_db.get_chat_thread.return_value = {"id": 1, "project_id": 7}
+        mock_db.list_messages.return_value = [
+            {"role": "user", "content": "Hello"}
+        ]
+        monkeypatch.setattr(
+            "guardian.routes.chat.acquire_turn_lock", lambda *a, **k: True
+        )
+        monkeypatch.setattr(
+            "guardian.routes.chat.enqueue", lambda *a, **k: None
+        )
+
+        response = test_client.post(
+            "/chat/1/complete", json={"depth_mode": "diagnostic"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "requested_depth_mode" in data
+        assert "effective_depth_mode" in data
+        assert "depth_downgrade_reason" in data
+        assert data["requested_depth_mode"] == "light"
+        assert data["effective_depth_mode"] == "light"
+        assert data["depth_downgrade_reason"] is None
+        # Internal legacy runtime depth_mode remains unchanged for non-deep.
+        assert data["depth_mode"] == "diagnostic"
+        assert data["depth_downgrade_reason"] not in {
+            "capability_missing",
+            "server_forced",
+        }
+
+    def test_complete_depth_contract_deep_no_project(
+        self, test_client, mock_db, monkeypatch
+    ):
+        mock_db.get_chat_thread.return_value = {"id": 1, "project_id": None}
+        mock_db.list_messages.return_value = [
+            {"role": "user", "content": "Hello"}
+        ]
+        monkeypatch.setattr(
+            "guardian.routes.chat.acquire_turn_lock", lambda *a, **k: True
+        )
+        monkeypatch.setattr(
+            "guardian.routes.chat.enqueue", lambda *a, **k: None
+        )
+
+        response = test_client.post(
+            "/chat/1/complete", json={"depth_mode": "deep"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["requested_depth_mode"] == "deep"
+        assert data["effective_depth_mode"] == "light"
+        assert data["depth_downgrade_reason"] == "no_project"
+        assert data["depth_mode"] == "normal"
+        assert data["depth_downgrade_reason"] not in {
+            "capability_missing",
+            "server_forced",
+        }
+
+    def test_complete_depth_contract_deep_project_light(
+        self, test_client, mock_db, monkeypatch
+    ):
+        mock_db.get_chat_thread.return_value = {"id": 1, "project_id": 7}
+        mock_db.get_project_identity_depth.return_value = "light"
+        mock_db.list_messages.return_value = [
+            {"role": "user", "content": "Hello"}
+        ]
+        monkeypatch.setattr(
+            "guardian.routes.chat.acquire_turn_lock", lambda *a, **k: True
+        )
+        monkeypatch.setattr(
+            "guardian.routes.chat.enqueue", lambda *a, **k: None
+        )
+
+        response = test_client.post(
+            "/chat/1/complete", json={"depth_mode": "deep"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["requested_depth_mode"] == "deep"
+        assert data["effective_depth_mode"] == "light"
+        assert data["depth_downgrade_reason"] == "project_identity_depth_light"
+        assert data["depth_mode"] == "normal"
+        assert data["depth_downgrade_reason"] not in {
+            "capability_missing",
+            "server_forced",
+        }
+
+    def test_complete_depth_contract_deep_policy_rejected(
+        self, test_client, mock_db, monkeypatch
+    ):
+        mock_db.get_chat_thread.return_value = {"id": 1, "project_id": 7}
+        mock_db.get_project_identity_depth.return_value = "deep"
+        mock_db.list_messages.return_value = [
+            {"role": "user", "content": "Hello"}
+        ]
+        monkeypatch.setattr(
+            "guardian.routes.chat.can_run_deep_identity_modeling",
+            lambda *_a, **_k: False,
+        )
+        monkeypatch.setattr(
+            "guardian.routes.chat.acquire_turn_lock", lambda *a, **k: True
+        )
+        monkeypatch.setattr(
+            "guardian.routes.chat.enqueue", lambda *a, **k: None
+        )
+
+        response = test_client.post(
+            "/chat/1/complete", json={"depth_mode": "deep"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["requested_depth_mode"] == "deep"
+        assert data["effective_depth_mode"] == "light"
+        assert data["depth_downgrade_reason"] == "policy_gate_rejected"
+        assert data["depth_mode"] == "normal"
+        assert data["depth_downgrade_reason"] not in {
+            "capability_missing",
+            "server_forced",
+        }
+
+    def test_complete_depth_contract_deep_allowed(
+        self, test_client, mock_db, monkeypatch
+    ):
+        mock_db.get_chat_thread.return_value = {"id": 1, "project_id": 7}
+        mock_db.get_project_identity_depth.return_value = "deep"
+        mock_db.list_messages.return_value = [
+            {"role": "user", "content": "Hello"}
+        ]
+        monkeypatch.setattr(
+            "guardian.routes.chat.can_run_deep_identity_modeling",
+            lambda *_a, **_k: True,
+        )
+        monkeypatch.setattr(
+            "guardian.routes.chat.acquire_turn_lock", lambda *a, **k: True
+        )
+        monkeypatch.setattr(
+            "guardian.routes.chat.enqueue", lambda *a, **k: None
+        )
+
+        response = test_client.post(
+            "/chat/1/complete", json={"depth_mode": "deep"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["requested_depth_mode"] == "deep"
+        assert data["effective_depth_mode"] == "deep"
+        assert data["depth_downgrade_reason"] is None
+        assert data["depth_mode"] == "deep"
+        assert data["depth_downgrade_reason"] not in {
+            "capability_missing",
+            "server_forced",
+        }
+
+    def test_complete_depth_contract_exception_logs_once(
+        self, test_client, mock_db, monkeypatch
+    ):
+        mock_db.get_chat_thread.return_value = {"id": 1, "project_id": 7}
+        mock_db.get_project_identity_depth.side_effect = RuntimeError("boom")
+        mock_db.list_messages.return_value = [
+            {"role": "user", "content": "Hello"}
+        ]
+        exception_spy = MagicMock()
+        monkeypatch.setattr(
+            "guardian.routes.chat.logger.exception", exception_spy
+        )
+        monkeypatch.setattr(
+            "guardian.routes.chat.acquire_turn_lock", lambda *a, **k: True
+        )
+        monkeypatch.setattr(
+            "guardian.routes.chat.enqueue", lambda *a, **k: None
+        )
+
+        response = test_client.post(
+            "/chat/1/complete", json={"depth_mode": "deep"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["requested_depth_mode"] == "deep"
+        assert data["effective_depth_mode"] == "light"
+        assert data["depth_downgrade_reason"] == "unknown"
+        assert data["depth_mode"] == "normal"
+        assert exception_spy.call_count == 1
+        assert data["depth_downgrade_reason"] not in {
+            "capability_missing",
+            "server_forced",
+        }
+
     def test_complete_with_model_override(
         self, test_client, mock_db, monkeypatch
     ):

--- a/tests/routes/test_voice_routes.py
+++ b/tests/routes/test_voice_routes.py
@@ -8,17 +8,219 @@ def _dummy_audio_file():
     return {"audio_file": ("voice.wav", b"RIFF....WAVE", "audio/wav")}
 
 
+def _runtime_cfg(**overrides):
+    base = {
+        "mode": "off",
+        "routes_enabled": True,
+        "turns_enabled": False,
+        "stt_provider": "local_openai_compatible",
+        "tts_provider": "local_openai_compatible",
+        "local_voice_base_url": "http://localhost:11434",
+        "stream_proxy_enabled": False,
+        "stt_timeout_seconds": 1,
+        "completion_timeout_seconds": 1,
+        "tts_timeout_seconds": 1,
+        "input_max_bytes": 15 * 1024 * 1024,
+        "output_max_bytes": 15 * 1024 * 1024,
+        "max_duration_seconds": 120,
+        "turn_dedupe_ttl_seconds": 600,
+        "internal_format": "wav",
+        "delivery_formats": ("wav",),
+        "bake_models": False,
+        "service_url": None,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_voice_capabilities_contract(test_client, monkeypatch):
+    monkeypatch.setattr(
+        "guardian.routes.voice.get_voice_runtime_config",
+        lambda: _runtime_cfg(turns_enabled=False),
+    )
+    monkeypatch.setattr(
+        "guardian.routes.voice._voice_worker_available", lambda: False
+    )
+
+    response = test_client.get("/api/voice/capabilities")
+
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "private, max-age=30"
+    payload = response.json()
+    assert payload["read_aloud_enabled"] is True
+    assert payload["turn_based_enabled"] is False
+    assert payload["turn_based_reason"] == "feature_gated"
+    assert payload["voice_routes_enabled"] is True
+    assert payload["voice_turns_enabled"] is False
+    assert payload["providers_supported"]["tts"]
+    assert payload["providers_supported"]["stt"]
+    assert payload["providers_configured"]["tts"] == "local_openai_compatible"
+    assert payload["providers_configured"]["stt"] == "local_openai_compatible"
+    assert payload["limits"]["max_upload_bytes"] == 15 * 1024 * 1024
+    assert payload["limits"]["max_duration_s"] == 120
+
+
+def test_voice_capabilities_marks_local_provider_misconfigured(
+    test_client, monkeypatch
+):
+    monkeypatch.setattr(
+        "guardian.routes.voice.get_voice_runtime_config",
+        lambda: _runtime_cfg(local_voice_base_url=None),
+    )
+    monkeypatch.setattr(
+        "guardian.routes.voice._voice_worker_available", lambda: True
+    )
+
+    response = test_client.get("/api/voice/capabilities")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["read_aloud_enabled"] is False
+    assert payload["read_aloud_reason"] == "misconfigured"
+    assert payload["providers_configured"]["tts"] is None
+    assert payload["providers_configured"]["stt"] is None
+
+
+def test_voice_turn_worker_missing_fails_before_lock(test_client, monkeypatch):
+    monkeypatch.setattr(
+        "guardian.routes.voice.get_voice_runtime_config",
+        lambda: _runtime_cfg(turns_enabled=True),
+    )
+    monkeypatch.setattr(
+        "guardian.routes.voice._voice_worker_available", lambda: False
+    )
+
+    lock_calls = {"count": 0}
+
+    def _acquire_lock(*args, **kwargs):
+        lock_calls["count"] += 1
+        return True
+
+    monkeypatch.setattr(
+        "guardian.routes.voice.acquire_turn_lock", _acquire_lock
+    )
+
+    response = test_client.post(
+        "/api/voice/turn",
+        data={"thread_id": "1", "tts_enabled": "true"},
+        files=_dummy_audio_file(),
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "voice_worker_missing"
+    assert lock_calls["count"] == 0
+
+
+def test_voice_turn_dedupe_hit(test_client, monkeypatch):
+    monkeypatch.setattr(
+        "guardian.routes.voice.get_voice_runtime_config",
+        lambda: _runtime_cfg(turns_enabled=True),
+    )
+    monkeypatch.setattr(
+        "guardian.routes.voice._voice_worker_available", lambda: True
+    )
+    monkeypatch.setattr(
+        "guardian.routes.voice.chatlog_db",
+        SimpleNamespace(get_chat_thread=lambda *_: {"id": 1}),
+    )
+    monkeypatch.setattr(
+        "guardian.routes.voice.normalize_audio_input",
+        lambda *_a, **_k: (
+            b"wav-bytes",
+            "audio/wav",
+            {
+                "duration_seconds": 1.0,
+                "sample_rate_hz": 16000,
+                "channels": 1,
+                "size_bytes": 9,
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        "guardian.routes.voice._get_dedupe_hit",
+        lambda **_k: {
+            "deduped": True,
+            "task_id": "existing-task",
+            "status": "in_flight",
+        },
+    )
+
+    lock_calls = {"count": 0}
+
+    def _acquire_lock(*args, **kwargs):
+        lock_calls["count"] += 1
+        return True
+
+    monkeypatch.setattr(
+        "guardian.routes.voice.acquire_turn_lock", _acquire_lock
+    )
+
+    response = test_client.post(
+        "/api/voice/turn",
+        data={"thread_id": "1", "tts_enabled": "true"},
+        files=_dummy_audio_file(),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload == {
+        "deduped": True,
+        "task_id": "existing-task",
+        "status": "in_flight",
+    }
+    assert lock_calls["count"] == 0
+
+
 def test_voice_turn_completed(test_client, mock_db, monkeypatch):
+    monkeypatch.setattr(
+        "guardian.routes.voice.get_voice_runtime_config",
+        lambda: _runtime_cfg(turns_enabled=True),
+    )
+    monkeypatch.setattr(
+        "guardian.routes.voice._voice_worker_available", lambda: True
+    )
     monkeypatch.setattr("guardian.routes.voice.chatlog_db", mock_db)
+    monkeypatch.setattr(
+        "guardian.routes.voice.normalize_audio_input",
+        lambda *_a, **_k: (
+            b"wav-bytes",
+            "audio/wav",
+            {
+                "duration_seconds": 1.0,
+                "sample_rate_hz": 16000,
+                "channels": 1,
+                "size_bytes": 9,
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        "guardian.routes.voice._get_dedupe_hit", lambda **_k: None
+    )
     monkeypatch.setattr(
         "guardian.routes.voice.acquire_turn_lock", lambda *a, **k: True
     )
     monkeypatch.setattr("guardian.routes.voice.enqueue", lambda *a, **k: None)
     monkeypatch.setattr(
-        "guardian.routes.voice.enforce_audio_input_limits", lambda *a, **k: 1.0
+        "guardian.routes.voice.task_events.publish", lambda *a, **k: None
     )
     monkeypatch.setattr(
-        "guardian.routes.voice.task_events.publish", lambda *a, **k: None
+        "guardian.routes.voice._set_dedupe_record", lambda **_k: None
+    )
+
+    class _DummyVoiceTurnTask:
+        type = "voice_turn"
+
+        def __init__(self, **kwargs):
+            self.task_id = "voice-task-1"
+            self.origin = kwargs.get("origin", "test")
+            self.turn_lock_owner = kwargs.get("turn_lock_owner")
+            self.thread_id = kwargs.get("thread_id", 0)
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    monkeypatch.setattr(
+        "guardian.routes.voice._get_voice_turn_task_cls",
+        lambda: _DummyVoiceTurnTask,
     )
 
     await_mock = AsyncMock(
@@ -49,10 +251,17 @@ def test_voice_turn_completed(test_client, mock_db, monkeypatch):
     payload = response.json()
     assert payload["status"] == "succeeded"
     assert payload["thread_id"] == 1
-    assert payload["task_id"]
+    assert payload["task_id"] == "voice-task-1"
 
 
 def test_voice_turn_lock_conflict(test_client, monkeypatch):
+    monkeypatch.setattr(
+        "guardian.routes.voice.get_voice_runtime_config",
+        lambda: _runtime_cfg(turns_enabled=True),
+    )
+    monkeypatch.setattr(
+        "guardian.routes.voice._voice_worker_available", lambda: True
+    )
     monkeypatch.setattr(
         "guardian.routes.voice.chatlog_db",
         SimpleNamespace(get_chat_thread=lambda *_: {"id": 1}),
@@ -61,7 +270,20 @@ def test_voice_turn_lock_conflict(test_client, monkeypatch):
         "guardian.routes.voice.acquire_turn_lock", lambda *a, **k: False
     )
     monkeypatch.setattr(
-        "guardian.routes.voice.enforce_audio_input_limits", lambda *a, **k: 1.0
+        "guardian.routes.voice.normalize_audio_input",
+        lambda *_a, **_k: (
+            b"wav-bytes",
+            "audio/wav",
+            {
+                "duration_seconds": 1.0,
+                "sample_rate_hz": 16000,
+                "channels": 1,
+                "size_bytes": 9,
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        "guardian.routes.voice._get_dedupe_hit", lambda **_k: None
     )
 
     response = test_client.post(
@@ -76,6 +298,10 @@ def test_voice_turn_lock_conflict(test_client, monkeypatch):
 
 def test_speak_message_returns_cached_asset(test_client, monkeypatch):
     monkeypatch.setattr(
+        "guardian.routes.voice.STREAM_PROXY_ENABLED",
+        True,
+    )
+    monkeypatch.setattr(
         "guardian.routes.voice._load_message",
         lambda *_: SimpleNamespace(id=55, content="hello world"),
     )
@@ -88,6 +314,7 @@ def test_speak_message_returns_cached_asset(test_client, monkeypatch):
             "voice": "alloy",
             "text_hash": "abc",
             "src_url": "/media/audio/messages/55.wav",
+            "url_expires_at": None,
             "internal_format": "wav",
         },
     )
@@ -102,3 +329,5 @@ def test_speak_message_returns_cached_asset(test_client, monkeypatch):
     assert payload["message_id"] == 55
     assert payload["cached"] is True
     assert payload["audio_asset"]["src_url"].endswith("55.wav")
+    assert payload["audio_asset"]["url_expires_at"] is None
+    assert payload["audio_asset"]["stream_url"] == "/api/voice/audio/9"

--- a/tests/routes/test_voice_routes.py
+++ b/tests/routes/test_voice_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -31,6 +32,33 @@ def _runtime_cfg(**overrides):
     }
     base.update(overrides)
     return SimpleNamespace(**base)
+
+
+def test_normalize_turn_id_missing_generates_unique_uuid_fallbacks():
+    from guardian.routes import voice as voice_route
+
+    first = voice_route._normalize_turn_id(None)
+    second = voice_route._normalize_turn_id("")
+
+    assert first != second
+    assert str(uuid.UUID(first)) == first
+    assert str(uuid.UUID(second)) == second
+
+
+def test_normalize_turn_id_invalid_replaced_with_uuid():
+    from guardian.routes import voice as voice_route
+
+    normalized = voice_route._normalize_turn_id("not-a-uuid")
+
+    assert normalized != "legacy"
+    assert str(uuid.UUID(normalized)) == normalized
+
+
+def test_normalize_turn_id_valid_uuid_preserved():
+    from guardian.routes import voice as voice_route
+
+    turn_id = str(uuid.uuid4())
+    assert voice_route._normalize_turn_id(turn_id) == turn_id
 
 
 def test_voice_capabilities_contract(test_client, monkeypatch):
@@ -169,6 +197,68 @@ def test_voice_turn_dedupe_hit(test_client, monkeypatch):
         "status": "in_flight",
     }
     assert lock_calls["count"] == 0
+
+
+def test_voice_turn_missing_turn_id_uses_unique_per_request_turn_ids(
+    test_client, monkeypatch
+):
+    monkeypatch.setattr(
+        "guardian.routes.voice.get_voice_runtime_config",
+        lambda: _runtime_cfg(turns_enabled=True),
+    )
+    monkeypatch.setattr(
+        "guardian.routes.voice._voice_worker_available", lambda: True
+    )
+    monkeypatch.setattr(
+        "guardian.routes.voice.chatlog_db",
+        SimpleNamespace(get_chat_thread=lambda *_: {"id": 1}),
+    )
+    monkeypatch.setattr(
+        "guardian.routes.voice.normalize_audio_input",
+        lambda *_a, **_k: (
+            b"wav-bytes",
+            "audio/wav",
+            {
+                "duration_seconds": 1.0,
+                "sample_rate_hz": 16000,
+                "channels": 1,
+                "size_bytes": 9,
+            },
+        ),
+    )
+
+    observed_turn_ids: list[str] = []
+
+    def _record_dedupe_hit(**kwargs):
+        observed_turn_ids.append(str(kwargs.get("turn_id") or ""))
+        return {
+            "deduped": True,
+            "task_id": f"existing-task-{len(observed_turn_ids)}",
+            "status": "in_flight",
+        }
+
+    monkeypatch.setattr(
+        "guardian.routes.voice._get_dedupe_hit",
+        _record_dedupe_hit,
+    )
+
+    first = test_client.post(
+        "/api/voice/turn",
+        data={"thread_id": "1", "tts_enabled": "true"},
+        files=_dummy_audio_file(),
+    )
+    second = test_client.post(
+        "/api/voice/turn",
+        data={"thread_id": "1", "tts_enabled": "true"},
+        files=_dummy_audio_file(),
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert len(observed_turn_ids) == 2
+    assert observed_turn_ids[0] != observed_turn_ids[1]
+    assert str(uuid.UUID(observed_turn_ids[0])) == observed_turn_ids[0]
+    assert str(uuid.UUID(observed_turn_ids[1])) == observed_turn_ids[1]
 
 
 def test_voice_turn_completed(test_client, mock_db, monkeypatch):

--- a/tests/voice/test_audio_assets_signing.py
+++ b/tests/voice/test_audio_assets_signing.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from guardian.voice import audio_assets
+
+
+def test_signed_asset_url_signs_local_media_path(monkeypatch):
+    monkeypatch.setenv("GUARDIAN_MEDIA_URL_SECRET", "voice-test-secret")
+
+    signed_url, expires_at = audio_assets._signed_asset_url(
+        "/media/audio/messages/123.wav"
+    )
+
+    assert signed_url.startswith("/media/audio/messages/123.wav?sig=")
+    assert expires_at is None
+
+
+def test_signed_asset_url_signs_local_storage_key(monkeypatch):
+    monkeypatch.setenv("GUARDIAN_MEDIA_URL_SECRET", "voice-test-secret")
+
+    signed_url, expires_at = audio_assets._signed_asset_url(
+        "audio/messages/abc.wav"
+    )
+
+    assert signed_url.startswith("/media/audio/messages/abc.wav?sig=")
+    assert expires_at is None
+
+
+def test_signed_asset_url_uses_storage_signer_for_remote(monkeypatch):
+    class _DummyStorage:
+        def sign_url(self, url: str):
+            return {"url": f"{url}?token=signed", "expires_at": 1700000000000}
+
+    monkeypatch.setattr(audio_assets, "_storage", _DummyStorage())
+
+    signed_url, expires_at = audio_assets._signed_asset_url(
+        "https://example.com/audio/1.wav"
+    )
+
+    assert signed_url == "https://example.com/audio/1.wav?token=signed"
+    assert expires_at == 1700000000000


### PR DESCRIPTION
## Summary
- added tokenized tab sizing/transition vars and applied them to the SessionRail tabs so the rail stays single-row without inline geometry
- merged the header and rail into one bar, kept provider chip there, and moved the model picker to the Composer control row alongside depth/tools
- derived `isCloud` canonically for header badges, kept sidebar fallback heuristic strictly display-only, and kept profile switching in the overflow menu

## Testing
- Not run (not requested)