### PR TITLE
Fix voice route turn_id fallback to generate unique UUIDs

### DIFF
--- a/guardian/routes/voice.py
+++ b/guardian/routes/voice.py
@@ -90,11 +90,11 @@ def _dedupe_key(thread_id: int, turn_id: str, audio_sha256: str) -> str:
 def _normalize_turn_id(raw: str | None) -> str:
     value = (raw or "").strip()
     if not value:
-        return "legacy"
+        return str(uuid.uuid4())
     try:
         return str(uuid.UUID(value)).lower()
     except Exception:
-        return "legacy"
+        return str(uuid.uuid4())
 
 
 def _task_terminal_status(task_id: str) -> str:

--- a/guardian/tests/test_voice_turn_id_normalization.py
+++ b/guardian/tests/test_voice_turn_id_normalization.py
@@ -1,0 +1,27 @@
+import uuid
+
+from guardian.routes.voice import _normalize_turn_id
+
+
+def test_normalize_turn_id_preserves_valid_uuid() -> None:
+    turn_id = "A0EebC99-9C0B-4EF8-BB6D-6BB9BD380A11"
+
+    normalized = _normalize_turn_id(turn_id)
+
+    assert normalized == "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+
+
+def test_normalize_turn_id_replaces_invalid_with_generated_uuid() -> None:
+    normalized = _normalize_turn_id("not-a-uuid")
+
+    parsed = uuid.UUID(normalized)
+    assert str(parsed) == normalized
+
+
+def test_normalize_turn_id_missing_is_unique_per_request() -> None:
+    first = _normalize_turn_id(None)
+    second = _normalize_turn_id(None)
+
+    assert first != second
+    assert str(uuid.UUID(first)) == first
+    assert str(uuid.UUID(second)) == second


### PR DESCRIPTION
### Motivation
- The voice route normalized missing or invalid `turn_id` values to the constant string `"legacy"`, causing unrelated requests to share a dedupe namespace and return stale completions.
- Each request without a client-supplied `turn_id` must receive a unique per-request identifier so dedupe operates at the request level.

### Description
- Replace the constant fallback in `guardian/routes/voice.py` so `_normalize_turn_id` returns `str(uuid.uuid4())` for missing or invalid values instead of `"legacy"`.
- Preserve valid UUID inputs by normalizing via `str(uuid.UUID(value)).lower()` and generate server-side UUIDs for the other cases in `_normalize_turn_id`.
- Add unit tests at `guardian/tests/test_voice_turn_id_normalization.py` covering valid UUID preservation, invalid `turn_id` replacement, and uniqueness for repeated missing `turn_id` calls.

### Testing
- Running `pytest -q guardian/tests/test_voice_turn_id_normalization.py` initially failed due to repository database bootstrap parsing the SQLAlchemy URL from the environment (automated test environment issue).
- Re-running with an explicit DB URL `DATABASE_URL=sqlite:///./test.db pytest -q guardian/tests/test_voice_turn_id_normalization.py` succeeded and all added tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a9cfa70700832d843801a12f2897c8)