### PR TITLE
Treat turn_id metadata persistence as best-effort in chat worker

### DIFF
--- a/guardian/tests/workers/test_chat_worker_turn_metadata.py
+++ b/guardian/tests/workers/test_chat_worker_turn_metadata.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from guardian.tasks.types import ChatCompletionTask
+from guardian.workers import chat_worker
+
+
+def test_metadata_persistence_failure_is_non_fatal(monkeypatch):
+    events: list[str] = []
+    run_calls: list[bool] = []
+
+    def fake_run_chat_completion_task(task, **kwargs):
+        run_calls.append(bool(kwargs.get("persist_assistant_message")))
+        return {"message_id": 321, "provider": "local", "model": "x"}
+
+    monkeypatch.setattr(
+        chat_worker, "run_chat_completion_task", fake_run_chat_completion_task
+    )
+    monkeypatch.setattr(chat_worker, "is_cancelled", lambda *_args: False)
+    monkeypatch.setattr(chat_worker, "clear_cancelled", lambda *_args: None)
+    monkeypatch.setattr(
+        chat_worker,
+        "release_turn_lock",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_persist_turn_id_metadata",
+        lambda **_kwargs: False,
+    )
+
+    def fake_publish(_task_id: str, event_type: str, _data: dict):
+        events.append(event_type)
+
+    monkeypatch.setattr(chat_worker, "_safe_publish", fake_publish)
+
+    task = ChatCompletionTask(thread_id=10, origin="api|turn_id=11111111-1111-1111-1111-111111111111")
+    chat_worker._run_chat_task(task)
+
+    assert run_calls == [True]
+    assert "task.completed" in events
+    assert "task.failed" not in events

--- a/guardian/workers/chat_worker.py
+++ b/guardian/workers/chat_worker.py
@@ -228,14 +228,14 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
         if turn_id and not _persist_turn_id_metadata(
             thread_id=task.thread_id, message_id=message_id, turn_id=turn_id
         ):
-            logger.error(
-                "[chat-worker] completion_turn_metadata_missing thread_id=%s turn_id=%s task_id=%s message_id=%s",
-                task.thread_id,
-                turn_id,
-                task.task_id,
-                message_id,
+            logger.warning(
+                "turn_id metadata persistence failed",
+                extra={
+                    "thread_id": task.thread_id,
+                    "message_id": message_id,
+                    "turn_id": turn_id,
+                },
             )
-            raise RuntimeError("assistant_message_turn_metadata_missing")
 
         logger.info(
             "[chat-worker] assistant_message_persisted thread_id=%s turn_id=%s task_id=%s assistant_message_id=%s",


### PR DESCRIPTION
### Motivation
- The chat worker previously treated failure to persist `turn_id` metadata as a fatal error which could mark a task as failed even after the assistant message was persisted, producing an inconsistent lifecycle and possible duplicate responses. 
- The metadata write is auxiliary (correlation/dedupe) and must not determine completion success. 

### Description
- Replaced the fatal error path in `guardian/workers/chat_worker.py` so that when `_persist_turn_id_metadata(...)` returns `False` the worker now logs a warning with structured context instead of raising an exception. 
- The warning includes `thread_id`, `message_id`, and `turn_id` via the `extra` payload to preserve observability. 
- Added a regression test `guardian/tests/workers/test_chat_worker_turn_metadata.py` that simulates `_persist_turn_id_metadata()` returning `False` and asserts the worker still emits `task.completed` and does not emit `task.failed`. 

### Testing
- Ran `pytest -q guardian/tests/workers/test_chat_worker_turn_metadata.py` which initially failed during test collection in this environment due to an unrelated SQLAlchemy `DATABASE_URL` parsing error raised by global `conftest` initialization. 
- Re-ran the test with an explicit SQLite URL which isolates the test: `DATABASE_URL=sqlite:////tmp/codexify-test.db pytest -q guardian/tests/workers/test_chat_worker_turn_metadata.py`, and the test passed. 
- The test validates that `run_chat_completion_task` was invoked with `persist_assistant_message=True`, `task.completed` was published, and `task.failed` was not published.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a9cf66e57c832d897c608e26f10d47)