### PR TITLE
Make turn_id metadata persistence non-fatal in chat worker

### DIFF
--- a/guardian/tests/workers/test_chat_worker_turn_metadata.py
+++ b/guardian/tests/workers/test_chat_worker_turn_metadata.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import uuid
+
+from guardian.tasks.types import ChatCompletionTask
+from guardian.workers import chat_worker
+
+
+def _task_with_turn_id() -> ChatCompletionTask:
+    turn_id = str(uuid.uuid4())
+    return ChatCompletionTask(
+        task_id="task-1",
+        thread_id=123,
+        origin=f"test|turn_id={turn_id}",
+    )
+
+
+def test_metadata_persist_failure_does_not_fail_task(monkeypatch, caplog):
+    published: list[str] = []
+
+    monkeypatch.setattr(chat_worker, "is_cancelled", lambda *_: False)
+    monkeypatch.setattr(chat_worker, "clear_cancelled", lambda *_: None)
+    monkeypatch.setattr(chat_worker, "release_turn_lock", lambda *_: True)
+    monkeypatch.setattr(
+        chat_worker,
+        "run_chat_completion_task",
+        lambda *args, **kwargs: {"message_id": 77, "provider": "local"},
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_persist_turn_id_metadata",
+        lambda **kwargs: False,
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_safe_publish",
+        lambda _task_id, event_type, _data: published.append(event_type),
+    )
+
+    caplog.set_level("WARNING")
+    chat_worker._run_chat_task(_task_with_turn_id())
+
+    assert "task.completed" in published
+    assert "task.failed" not in published
+    assert "completion_turn_metadata_missing" in caplog.text
+
+
+def test_missing_assistant_message_id_still_fails_task(monkeypatch):
+    published: list[str] = []
+
+    monkeypatch.setattr(chat_worker, "is_cancelled", lambda *_: False)
+    monkeypatch.setattr(chat_worker, "clear_cancelled", lambda *_: None)
+    monkeypatch.setattr(chat_worker, "release_turn_lock", lambda *_: True)
+    monkeypatch.setattr(
+        chat_worker,
+        "run_chat_completion_task",
+        lambda *args, **kwargs: {"message_id": None},
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_safe_publish",
+        lambda _task_id, event_type, _data: published.append(event_type),
+    )
+
+    chat_worker._run_chat_task(_task_with_turn_id())
+
+    assert "task.failed" in published
+    assert "task.completed" not in published

--- a/guardian/workers/chat_worker.py
+++ b/guardian/workers/chat_worker.py
@@ -228,14 +228,13 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
         if turn_id and not _persist_turn_id_metadata(
             thread_id=task.thread_id, message_id=message_id, turn_id=turn_id
         ):
-            logger.error(
+            logger.warning(
                 "[chat-worker] completion_turn_metadata_missing thread_id=%s turn_id=%s task_id=%s message_id=%s",
                 task.thread_id,
                 turn_id,
                 task.task_id,
                 message_id,
             )
-            raise RuntimeError("assistant_message_turn_metadata_missing")
 
         logger.info(
             "[chat-worker] assistant_message_persisted thread_id=%s turn_id=%s task_id=%s assistant_message_id=%s",


### PR DESCRIPTION
### Motivation
- Prevent situations where the assistant message is persisted but the worker reports the task as failed due to turn_id metadata write errors, which causes downstream retries and duplicate assistant messages.

### Description
- Updated `guardian/workers/chat_worker.py` so a failed `_persist_turn_id_metadata(...)` call logs a warning instead of raising after the assistant message has been persisted. 
- Preserved existing behavior where a missing assistant `message_id` still raises and results in `task.failed`.
- Added `guardian/tests/workers/test_chat_worker_turn_metadata.py` with tests asserting that metadata persistence failure does not cause `task.failed` and that missing `message_id` still causes failure.

### Testing
- Ran `DATABASE_URL=sqlite:////tmp/codexify-test.db pytest -q guardian/tests/workers/test_chat_worker_turn_metadata.py` and the tests passed.
- Running the test without setting `DATABASE_URL` at the environment level fails during test bootstrap due to the repository-wide `conftest.py` expecting a valid SQLAlchemy `DATABASE_URL`, which is an expected environment limitation unrelated to the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a9d066603c832dbf90e03deb4a1752)