### PR TITLE
Shorten chat completion fallback timeouts to clear failed completions faster

### DIFF
--- a/frontend/src/features/chat/__tests__/useChat.test.ts
+++ b/frontend/src/features/chat/__tests__/useChat.test.ts
@@ -221,7 +221,7 @@ describe("useChat - completion state management", () => {
     expect(result.current.completionState.startedAt).toBeNull();
   });
 
-  it("keeps completion active after 30s and clears on hard timeout", async () => {
+  it("keeps completion active after slow-path hint and clears on hard timeout", async () => {
     const { result } = renderHook(() => useChat());
 
     act(() => {
@@ -230,16 +230,16 @@ describe("useChat - completion state management", () => {
 
     expect(result.current.completionState.isCompleting).toBe(true);
 
-    // Fast-forward 30 seconds (slow path hint) — should still be completing
+    // Fast-forward slow-path hint window — should still be completing
     act(() => {
-      jest.advanceTimersByTime(30_000);
+      jest.advanceTimersByTime(15_000);
     });
 
     expect(result.current.completionState.isCompleting).toBe(true);
 
-    // Fast-forward to hard timeout (5 minutes)
+    // Fast-forward to hard timeout (30s total)
     act(() => {
-      jest.advanceTimersByTime(5 * 60_000);
+      jest.advanceTimersByTime(15_000);
     });
 
     await waitFor(() => {
@@ -288,7 +288,7 @@ describe("useChat - completion state management", () => {
     expect(result.current.shouldRefresh(1, 5)).toBe(true);
   });
 
-  it("should clear timeout when endCompletion is called before 30s", () => {
+  it("should clear timeout when endCompletion is called before hard timeout", () => {
     const { result } = renderHook(() => useChat());
 
     act(() => {
@@ -307,7 +307,7 @@ describe("useChat - completion state management", () => {
 
     expect(result.current.completionState.isCompleting).toBe(false);
 
-    // Fast-forward another 25 seconds (would be 35s total, past the timeout)
+    // Fast-forward another 25 seconds (would be 35s total, past hard timeout)
     act(() => {
       jest.advanceTimersByTime(25000);
     });

--- a/frontend/src/features/chat/useChat.ts
+++ b/frontend/src/features/chat/useChat.ts
@@ -185,8 +185,8 @@ export type CompletionState = {
   startedAt: number | null;
 };
 
-const COMPLETION_SLOW_PATH_MS = 30_000;
-const COMPLETION_HARD_TIMEOUT_MS = 5 * 60_000; // 5 minutes
+const COMPLETION_SLOW_PATH_MS = 15_000;
+const COMPLETION_HARD_TIMEOUT_MS = 30_000;
 
 export function useChat() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -371,10 +371,12 @@ export function useChat() {
       window.clearTimeout(completionHardTimeoutRef.current);
     }
 
-    // Hint timeout: after 30s, stay in slow-path but keep completion active
+    // Hint timeout: after a short delay, stay in slow-path but keep completion active
     completionSlowTimeoutRef.current = window.setTimeout(() => {
       if (completionGenerationRef.current !== generation) return;
-      console.warn(`[useChat] Completion still in progress after 30s (slow-path)`);
+      console.warn(
+        `[useChat] Completion still in progress after ${COMPLETION_SLOW_PATH_MS}ms (slow-path)`
+      );
       completionSlowTimeoutRef.current = null;
     }, COMPLETION_SLOW_PATH_MS);
 


### PR DESCRIPTION
### Motivation
- Failed/slow completions could leave `isCompletionInFlight` true for minutes and lock the UI; a shorter generic fallback reduces user-impact when a failure path doesn't explicitly clear completion state. 
- Keep the normal success-path behaviour (assistant message → `endCompletion`) unchanged while ensuring failed/cancelled flows don't stall the UI for long.

### Description
- Reduced the slow-path hint from `30_000` to `15_000` and the hard fallback from `5 * 60_000` to `30_000` by updating `COMPLETION_SLOW_PATH_MS` and `COMPLETION_HARD_TIMEOUT_MS` in `frontend/src/features/chat/useChat.ts`.
- Updated the slow-path log to include the configured ms value and retained the existing `clearCompletionState` hard-timeout behavior so successful completions are still finalized by the assistant message and `endCompletion`.
- Adjusted unit test timings and descriptions in `frontend/src/features/chat/__tests__/useChat.test.ts` to match the new `15s` slow-path hint and `30s` hard timeout.

### Testing
- Updated the `useChat` completion-state tests in `frontend/src/features/chat/__tests__/useChat.test.ts` to assert the new timing windows and to verify `endCompletion` clears pending timers.
- Attempted to run `npm test -- --run frontend/src/features/chat/__tests__/useChat.test.ts` but the test run failed in this environment because repository `package.json` files are Git LFS pointer files (invalid JSON), preventing automated test execution here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a9d08c8d64832d8340d97a8c1b028c)