### PR TITLE
Fix ChatView turn-id cleanup when navigating during completion

### DIFF
--- a/frontend/src/features/chat/ChatView.tsx
+++ b/frontend/src/features/chat/ChatView.tsx
@@ -199,6 +199,7 @@ export function ChatView({
   const inFlightCompletionByThreadRef = useRef<Map<number, string>>(new Map());
   const activeTurnIdRef = useRef<string | null>(null);
   const completionFinalizePendingRef = useRef<Set<number>>(new Set());
+  const lastCompletingThreadIdRef = useRef<number | null>(null);
   const liveSubscriptionCleanupRef = useRef<(() => void) | null>(null);
   const voiceUnavailableMessageIdsRef = useRef<Record<number, true>>({});
   const voiceRouteMissingRef = useRef(false);
@@ -441,6 +442,7 @@ export function ChatView({
   useEffect(() => {
     completionStateRef.current = completionState;
     if (completionState.isCompleting && completionState.activeThreadId != null) {
+      lastCompletingThreadIdRef.current = completionState.activeThreadId;
       const marker =
         completionState.activeTaskId ??
         `thread-${completionState.activeThreadId}`;
@@ -457,9 +459,11 @@ export function ChatView({
       return;
     }
     if (!completionState.isCompleting) {
-      if (activeTurnIdRef.current && threadId != null) {
-        clearTrackedTurnId(threadId, activeTurnIdRef.current);
+      const completingThreadId = lastCompletingThreadIdRef.current;
+      if (completingThreadId != null) {
+        clearTrackedTurnId(completingThreadId, activeTurnIdRef.current);
       }
+      lastCompletingThreadIdRef.current = null;
       setActiveTurnId(null);
       inFlightCompletionByThreadRef.current.clear();
       completionFinalizePendingRef.current.clear();
@@ -736,8 +740,11 @@ export function ChatView({
     if (activeKey && activeKey.startsWith(`${threadId}:`)) {
       stopPollingWithReason("completion-inactive", activeKey);
     }
-    if (activeTurnIdRef.current) {
-      clearTrackedTurnId(threadId, activeTurnIdRef.current);
+    const trackedTurnId = getTrackedTurnId(threadId);
+    if (trackedTurnId) {
+      clearTrackedTurnId(threadId, trackedTurnId);
+    }
+    if (activeTurnIdRef.current && completionStateRef.current.activeThreadId !== threadId) {
       setActiveTurnId(null);
     }
   }, [isCompletingForThread, stopPollingWithReason, threadId]);

--- a/frontend/src/features/chat/__tests__/ChatView.loop-guards.test.tsx
+++ b/frontend/src/features/chat/__tests__/ChatView.loop-guards.test.tsx
@@ -13,6 +13,8 @@ const markRefreshedMock = vi.fn();
 const subscribeMock = vi.fn();
 const apiPostMock = vi.fn();
 const apiGetMock = vi.fn();
+const getInFlightCompletionTurnIdMock = vi.fn();
+const clearInFlightCompletionTurnIdMock = vi.fn();
 const pollOptionsHistory: any[] = [];
 let pollFnRef: (() => Promise<void>) | null = null;
 
@@ -125,6 +127,10 @@ vi.mock("@/lib/api", () => ({
   default: {
     post: (...args: any[]) => apiPostMock(...args),
     get: (...args: any[]) => apiGetMock(...args),
+    getInFlightCompletionTurnId: (...args: any[]) =>
+      getInFlightCompletionTurnIdMock(...args),
+    clearInFlightCompletionTurnId: (...args: any[]) =>
+      clearInFlightCompletionTurnIdMock(...args),
   },
   getBackendOutageRemainingMs: vi.fn(() => 0),
 }));
@@ -139,6 +145,8 @@ describe("ChatView loop guards", () => {
     markRefreshedMock.mockClear();
     apiPostMock.mockReset();
     apiGetMock.mockReset();
+    getInFlightCompletionTurnIdMock.mockReset();
+    clearInFlightCompletionTurnIdMock.mockReset();
     pollFnRef = null;
     pollOptionsHistory.length = 0;
     resetLiveSubscribers();
@@ -513,5 +521,52 @@ describe("ChatView loop guards", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Voice disabled" }));
     expect(apiPostMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears tracked turn id for the thread that completed after navigation", async () => {
+    const trackedTurns = new Map<number, string>([[1, "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"]]);
+    getInFlightCompletionTurnIdMock.mockImplementation((tid?: number | null) => {
+      if (tid == null) return null;
+      return trackedTurns.get(Number(tid)) ?? null;
+    });
+    clearInFlightCompletionTurnIdMock.mockImplementation(
+      (tid?: number | null, expectedTurnId?: string | null) => {
+        if (tid == null) return;
+        const numericTid = Number(tid);
+        const current = trackedTurns.get(numericTid);
+        if (!current) return;
+        if (expectedTurnId && current !== expectedTurnId) return;
+        trackedTurns.delete(numericTid);
+      }
+    );
+
+    const completion = {
+      isCompleting: true,
+      activeTaskId: "task-thread-1",
+      activeThreadId: 1,
+      startedAt: Date.now(),
+    };
+    const { rerender } = render(
+      <ChatView threadId={1} completionState={completion} endCompletion={vi.fn()} />
+    );
+
+    rerender(<ChatView threadId={2} completionState={completion} endCompletion={vi.fn()} />);
+
+    rerender(
+      <ChatView
+        threadId={2}
+        completionState={{ ...completion, isCompleting: false, activeThreadId: null }}
+        endCompletion={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(clearInFlightCompletionTurnIdMock).toHaveBeenCalledWith(
+        1,
+        "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+      );
+    });
+    expect(trackedTurns.has(1)).toBe(false);
+    expect(trackedTurns.has(2)).toBe(false);
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent clearing the wrong thread's in-flight completion turn id when a completion started on thread A but the user navigated to thread B before the completion settled.

### Description
- Track the last thread that was actually completing via `lastCompletingThreadIdRef` and use that stored id when transitioning completion to idle so `clearTrackedTurnId(...)` targets the thread that completed.
- When stopping non-completing cleanup, read the tracked turn id for the currently rendered thread with `getTrackedTurnId(threadId)` and clear that rather than relying on `activeTurnIdRef.current`, and only reset local `activeTurnId` when the thread is not the active completion thread.
- Add a regression test `clears tracked turn id for the thread that completed after navigation` in `frontend/src/features/chat/__tests__/ChatView.loop-guards.test.tsx` that mocks `getInFlightCompletionTurnId` / `clearInFlightCompletionTurnId` and reproduces the navigation-during-completion scenario.

### Testing
- Added unit test `frontend/src/features/chat/__tests__/ChatView.loop-guards.test.tsx::clears tracked turn id for the thread that completed after navigation` which asserts `clearInFlightCompletionTurnId` is called for the original thread and that no stale tracked id remains.
- Attempted to run `npm run vitest -- src/features/chat/__tests__/ChatView.loop-guards.test.tsx` in the workspace, but the environment's `package.json` files are Git LFS pointers (not valid JSON), so tests could not be executed here; CI or a local dev environment should run the new test and existing suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a9d09c1bac832db7bc405492134dac)