### PR TITLE
Make local model preparation optional for backend startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,6 +174,8 @@ services:
       dockerfile: backend/Dockerfile
     image: codexify-backend
     working_dir: /app
+    profiles:
+      - local-embeddings
     entrypoint: ["python"]
     volumes:
       - ./models:/models
@@ -241,6 +243,7 @@ services:
       LOCAL_API_KEY: "local"   # Ollama ignores; satisfies SDKs
       LOCAL_CHAT_MODEL: "${LOCAL_CHAT_MODEL}"
       LOCAL_EMBED_MODEL: "/models/bge-large-en-v1.5"
+      LOCAL_EMBEDDINGS_REQUIRED: "${LOCAL_EMBEDDINGS_REQUIRED:-0}"
       CODEXIFY_ALLOW_EMBEDDINGS_FALLBACK: "${CODEXIFY_ALLOW_EMBEDDINGS_FALLBACK:-0}"
 
       # --- OpenAI (cloud) ---
@@ -266,9 +269,29 @@ services:
         condition: service_completed_successfully
       graph-init:
         condition: service_completed_successfully
-      model-prep:
-        condition: service_completed_successfully
-    command: ["/app/backend/scripts/docker/run_backend.py"]
+    command:
+      - -c
+      - |
+        import os
+        import pathlib
+        import runpy
+        import sys
+
+        required = os.getenv("LOCAL_EMBEDDINGS_REQUIRED", "0").strip().lower() in {"1", "true", "yes", "on"}
+        model_dir = pathlib.Path(os.getenv("LOCAL_EMBED_MODEL", "/models/bge-large-en-v1.5"))
+
+        if required and not model_dir.exists():
+          print(
+              f"[backend] ERROR: LOCAL_EMBEDDINGS_REQUIRED=1 but model directory is missing: {model_dir}",
+              file=sys.stderr,
+          )
+          print(
+              "[backend] Run `docker compose --profile local-embeddings run --rm model-prep` or mount a pre-provisioned model.",
+              file=sys.stderr,
+          )
+          raise SystemExit(1)
+
+        runpy.run_path("/app/backend/scripts/docker/run_backend.py", run_name="__main__")
 
   worker-warmup:
     build:


### PR DESCRIPTION
### Motivation
- Decouple backend availability from the local model-prep step so the backend can start even if local embedding prep is skipped or fails (useful for remote providers or pre-provisioned models). 
- Preserve an explicit, deterministic failure mode when local embeddings are required so deployments that need local models still fail fast with a clear remediation path.

### Description
- Put the `model-prep` service behind a dedicated `local-embeddings` compose profile so it only runs when requested (`--profile local-embeddings`).
- Remove the backend hard `depends_on: model-prep: service_completed_successfully` and replace the backend `command` with a small Python wrapper that checks `LOCAL_EMBEDDINGS_REQUIRED` and the `LOCAL_EMBED_MODEL` directory, failing with a clear error and remediation hint if required and missing.
- Add `LOCAL_EMBEDDINGS_REQUIRED` to the backend environment wiring with a safe default of `0` so the default behavior allows backend startup when local prep is skipped.
- Keep existing worker/service dependencies that still reference `model-prep` so behavior remains deterministic when the profile is enabled.

### Testing
- Parsed `docker-compose.yml` with `python` and `yaml.safe_load()` and confirmed the compose file loads successfully and that the `backend` service no longer depends on `model-prep` (check returned `backend_has_model_dep False`).
- Attempted `docker compose config` validation but the `docker` CLI is not available in this environment, so full compose validation could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a9d0bb5b00832dac40ce261c70f65e)