### PR TITLE
Treat turn-id metadata persistence as non-fatal in chat worker

### DIFF
--- a/guardian/tests/workers/test_chat_worker_completion_semantics.py
+++ b/guardian/tests/workers/test_chat_worker_completion_semantics.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from guardian.tasks.types import ChatCompletionTask
 from guardian.workers import chat_worker
 
@@ -19,7 +21,7 @@ def _build_task(
     return task
 
 
-def test_metadata_persistence_failure_is_non_fatal(monkeypatch):
+def _stubbed_success_setup(monkeypatch):
     published: list[tuple[str, dict]] = []
 
     monkeypatch.setattr(
@@ -50,17 +52,52 @@ def test_metadata_persistence_failure_is_non_fatal(monkeypatch):
         "_find_assistant_message_id_by_turn_id",
         lambda **_kwargs: None,
     )
+    return published
+
+
+def test_metadata_persistence_false_is_non_fatal(monkeypatch, caplog):
+    published = _stubbed_success_setup(monkeypatch)
     monkeypatch.setattr(
         chat_worker,
         "_persist_turn_id_metadata",
         lambda **_kwargs: False,
     )
 
-    chat_worker._run_chat_task(_build_task())
+    with caplog.at_level(logging.WARNING):
+        chat_worker._run_chat_task(_build_task())
 
     event_types = [event_type for event_type, _payload in published]
     assert "task.completed" in event_types
     assert "task.failed" not in event_types
+    assert any(
+        "turn_id_metadata_persist_failed reason=persist_returned_false"
+        in record.message
+        for record in caplog.records
+    )
+
+
+def test_metadata_persistence_exception_is_non_fatal(monkeypatch, caplog):
+    published = _stubbed_success_setup(monkeypatch)
+
+    def _raise_persist(**_kwargs):
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr(
+        chat_worker,
+        "_persist_turn_id_metadata",
+        _raise_persist,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        chat_worker._run_chat_task(_build_task())
+
+    event_types = [event_type for event_type, _payload in published]
+    assert "task.completed" in event_types
+    assert "task.failed" not in event_types
+    assert any(
+        "turn_id_metadata_persist_failed reason=exception" in record.message
+        for record in caplog.records
+    )
 
 
 def test_worker_failure_before_assistant_emit_marks_failed_and_emits_completion_error(

--- a/guardian/workers/chat_worker.py
+++ b/guardian/workers/chat_worker.py
@@ -94,28 +94,19 @@ def _persist_turn_id_metadata(
         )
         return False
 
-    try:
-        with connect() as conn, conn.cursor() as cur:
-            cur.execute(
-                """
-                UPDATE chat_messages
-                SET extra_meta = COALESCE(extra_meta, '{}'::jsonb) || %s::jsonb
-                WHERE thread_id = %s
-                  AND id = %s
-                RETURNING id
-                """,
-                (json.dumps({"turn_id": turn_id}), thread_id, message_id),
-            )
-            row = cur.fetchone()
-            return bool(row)
-    except Exception:
-        logger.debug(
-            "[chat-worker] failed to persist turn_id metadata thread_id=%s message_id=%s",
-            thread_id,
-            message_id,
-            exc_info=True,
+    with connect() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE chat_messages
+            SET extra_meta = COALESCE(extra_meta, '{}'::jsonb) || %s::jsonb
+            WHERE thread_id = %s
+              AND id = %s
+            RETURNING id
+            """,
+            (json.dumps({"turn_id": turn_id}), thread_id, message_id),
         )
-        return False
+        row = cur.fetchone()
+        return bool(row)
 
 
 def _coerce_row_message_id(row: Any) -> int | None:
@@ -336,16 +327,31 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
             )
             raise RuntimeError("assistant_message_missing")
 
-        if turn_id and not _persist_turn_id_metadata(
-            thread_id=task.thread_id, message_id=message_id, turn_id=turn_id
-        ):
-            logger.warning(
-                "[chat-worker] completion_turn_metadata_missing thread_id=%s turn_id=%s task_id=%s message_id=%s",
-                task.thread_id,
-                turn_id,
-                task.task_id,
-                message_id,
-            )
+        if turn_id:
+            try:
+                persisted = _persist_turn_id_metadata(
+                    thread_id=task.thread_id,
+                    message_id=message_id,
+                    turn_id=turn_id,
+                )
+                if not persisted:
+                    logger.warning(
+                        "[chat-worker] turn_id_metadata_persist_failed reason=persist_returned_false thread_id=%s turn_id=%s task_id=%s message_id=%s",
+                        task.thread_id,
+                        turn_id,
+                        task.task_id,
+                        message_id,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "[chat-worker] turn_id_metadata_persist_failed reason=exception thread_id=%s turn_id=%s task_id=%s message_id=%s err=%s",
+                    task.thread_id,
+                    turn_id,
+                    task.task_id,
+                    message_id,
+                    exc,
+                    exc_info=True,
+                )
         if turn_id:
             canonical_message_id = _find_assistant_message_id_by_turn_id(
                 thread_id=task.thread_id,


### PR DESCRIPTION
### Motivation
- Prevent metadata persistence failures from flipping an otherwise-successful assistant completion into `task.failed` by treating turn-id metadata updates as best-effort.
- Preserve client-visible completion semantics: assistant message durability remains the success boundary while metadata is for observability/deduping only.

### Description
- Change `_persist_turn_id_metadata` in `guardian/workers/chat_worker.py` to stop swallowing DB exceptions internally so callers can observe failures (exceptions now propagate from the DB call site). 
- Update `_run_chat_task` to wrap the metadata persistence call in a local `try/except` and to demote failures to warning-level structured logs (`turn_id_metadata_persist_failed`) while continuing the normal completion path.
- When `_persist_turn_id_metadata` returns `False`, emit a warning with `reason=persist_returned_false`, and when it raises, emit a warning with `reason=exception` including identifiers and the exception.
- Add unit tests in `guardian/tests/workers/test_chat_worker_completion_semantics.py` to assert that both a `False` return and an exception from `_persist_turn_id_metadata` do not cause `task.failed` and that warnings are logged, while preserving the existing failure behavior when message persistence itself fails.

### Testing
- Ran the modified unit tests: `DATABASE_URL=sqlite:////tmp/codexify-test.db pytest -q guardian/tests/workers/test_chat_worker_completion_semantics.py` and all tests in that file passed.
- Noted that running the tests without setting a local `DATABASE_URL` fails during top-level test import due to global DB URL parsing, which is unrelated to the change and was avoided by using the SQLite test DB URL; tests relevant to this PR succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a9d14c785c832d8c029653965205a2)