### PR TITLE
Fix completion failure unlocks and prevent duplicate assistant turns

### DIFF
--- a/frontend/src/features/chat/ChatView.tsx
+++ b/frontend/src/features/chat/ChatView.tsx
@@ -324,9 +324,31 @@ export function ChatView({
       if (!payload) return;
       const tid = Number(payload.thread_id ?? payload.threadId ?? payload.thread?.id);
       if (!Number.isFinite(tid) || tid !== threadId) return;
+
+      const messageRole = String(payload?.role ?? "").trim().toLowerCase();
+      const incomingTurnId = readMessageTurnId(payload);
+      const incomingMessageId = parseMessageId(payload);
+      if (messageRole === "assistant" && incomingTurnId) {
+        const existingForTurn = messagesRef.current.find((msg) => {
+          if (String(msg.role ?? "").trim().toLowerCase() !== "assistant") return false;
+          return readMessageTurnId(msg) === incomingTurnId;
+        });
+        if (
+          existingForTurn &&
+          Number(existingForTurn.id) !== incomingMessageId
+        ) {
+          debugLog(
+            `completion:duplicate-turn:${incomingTurnId}`,
+            `[chat:completion] dropped duplicate assistant message turn_id=${incomingTurnId}`,
+            5000
+          );
+          return;
+        }
+      }
+
       appendMessage(threadId, payload);
     },
-    [appendMessage, threadId]
+    [appendMessage, debugLog, threadId]
   );
 
   const pollOnce = useCallback(async () => {
@@ -391,7 +413,7 @@ export function ChatView({
         );
         newMessages
           .sort((a, b) => parseMessageId(a) - parseMessageId(b))
-          .forEach((msg) => appendMessage(session.tid, msg));
+          .forEach((msg) => ingestIncoming(msg));
       }
 
       if (maxId > lastMessageIdRef.current) {
@@ -428,7 +450,7 @@ export function ChatView({
       });
       throw err;
     }
-  }, [appendMessage, stopPollingWithReason]);
+  }, [ingestIncoming, stopPollingWithReason]);
 
   usePollWithBackoff(pollOnce, {
     enabled: Boolean(pollSession && activePollKeyRef.current === pollSession.key),
@@ -473,6 +495,73 @@ export function ChatView({
   useEffect(() => {
     endCompletionRef.current = endCompletion;
   }, [endCompletion]);
+
+  useEffect(() => {
+    const clearCompletionOnFailure = (eventType: string, event: any) => {
+      const payload = (event?.data as any)?.data ?? event?.data ?? {};
+      const tid = Number(payload?.thread_id ?? payload?.threadId ?? payload?.thread?.id);
+      if (!Number.isFinite(tid) || tid !== activeThreadRef.current) return;
+
+      const snapshot = completionStateRef.current;
+      if (!snapshot.isCompleting || snapshot.activeThreadId !== tid) return;
+
+      const eventTaskIdRaw = payload?.task_id ?? payload?.taskId;
+      const eventTaskId =
+        typeof eventTaskIdRaw === "string" && eventTaskIdRaw.trim().length > 0
+          ? eventTaskIdRaw.trim()
+          : null;
+      if (
+        snapshot.activeTaskId &&
+        eventTaskId &&
+        snapshot.activeTaskId !== eventTaskId
+      ) {
+        return;
+      }
+
+      if (completionFinalizeTimerRef.current !== null) {
+        window.clearTimeout(completionFinalizeTimerRef.current);
+        completionFinalizeTimerRef.current = null;
+      }
+      completionFinalizePendingRef.current.delete(tid);
+      inFlightCompletionByThreadRef.current.delete(tid);
+      const completionTurnId = activeTurnIdRef.current ?? getTrackedTurnId(tid);
+      if (completionTurnId) {
+        clearTrackedTurnId(tid, completionTurnId);
+        setActiveTurnId((prev) =>
+          prev === completionTurnId ? null : prev
+        );
+      }
+      const activeKey = activePollKeyRef.current;
+      if (activeKey && activeKey.startsWith(`${tid}:`)) {
+        stopPollingWithReason(`worker-${eventType}`, activeKey);
+      }
+      endCompletionRef.current();
+    };
+
+    const offTaskFailed = subscribe("task.failed", (event) => {
+      clearCompletionOnFailure("task.failed", event);
+    });
+    const offTaskCancelled = subscribe("task.cancelled", (event) => {
+      clearCompletionOnFailure("task.cancelled", event);
+    });
+    const offCompletionError = subscribe("completion.error", (event) => {
+      clearCompletionOnFailure("completion.error", event);
+    });
+    const offTaskCompleted = subscribe("task.completed", (event) => {
+      const payload = (event?.data as any)?.data ?? event?.data ?? {};
+      const messageId = parseMessageId(payload);
+      if (messageId > 0) return;
+      clearCompletionOnFailure("task.completed_missing_message", event);
+    });
+
+    return () => {
+      offTaskFailed();
+      offTaskCancelled();
+      offCompletionError();
+      offTaskCompleted();
+    };
+  }, [stopPollingWithReason, subscribe]);
+
 
   useEffect(() => {
     loadMessagesRef.current = loadMessages;

--- a/frontend/src/features/chat/__tests__/ChatView.loop-guards.test.tsx
+++ b/frontend/src/features/chat/__tests__/ChatView.loop-guards.test.tsx
@@ -540,4 +540,113 @@ describe("ChatView loop guards", () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  it("clears active completion immediately on task.failed events", async () => {
+    const endCompletion = vi.fn();
+    const completionState = {
+      isCompleting: true,
+      activeTaskId: "task-failed-1",
+      activeThreadId: 9,
+      startedAt: Date.now(),
+    };
+
+    render(
+      <ChatView
+        threadId={9}
+        completionState={completionState}
+        endCompletion={endCompletion}
+      />
+    );
+
+    await waitFor(() => {
+      expect(activeSubscriberCount("task.failed")).toBe(1);
+    });
+
+    emitLiveEvent("task.failed", {
+      task_id: "task-failed-1",
+      thread_id: 9,
+      error: "assistant_message_missing",
+    });
+
+    await waitFor(() => {
+      expect(endCompletion).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("treats task.completed without assistant message as completion failure", async () => {
+    const endCompletion = vi.fn();
+    const completionState = {
+      isCompleting: true,
+      activeTaskId: "task-no-message",
+      activeThreadId: 11,
+      startedAt: Date.now(),
+    };
+
+    render(
+      <ChatView
+        threadId={11}
+        completionState={completionState}
+        endCompletion={endCompletion}
+      />
+    );
+
+    await waitFor(() => {
+      expect(activeSubscriberCount("task.completed")).toBe(1);
+    });
+
+    emitLiveEvent("task.completed", {
+      task_id: "task-no-message",
+      thread_id: 11,
+      message_id: null,
+    });
+
+    await waitFor(() => {
+      expect(endCompletion).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("drops duplicate assistant messages for the same turn_id", async () => {
+    const endCompletion = vi.fn();
+    const completionState = {
+      isCompleting: false,
+      activeTaskId: null,
+      activeThreadId: null,
+      startedAt: null,
+    };
+    mockMessages = [
+      {
+        id: 301,
+        thread_id: 12,
+        role: "assistant",
+        content: "First response",
+        created_at: "2026-03-05T00:00:00Z",
+        turn_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      },
+    ];
+
+    render(
+      <ChatView
+        threadId={12}
+        completionState={completionState}
+        endCompletion={endCompletion}
+      />
+    );
+
+    await waitFor(() => {
+      expect(activeSubscriberCount("message.created")).toBe(1);
+    });
+
+    emitLiveEvent("message.created", {
+      id: 302,
+      thread_id: 12,
+      role: "assistant",
+      content: "Duplicate response",
+      turn_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    });
+
+    await waitFor(() => {
+      expect(appendMessageMock).toHaveBeenCalledTimes(0);
+    });
+  });
+
 });

--- a/guardian/workers/chat_worker.py
+++ b/guardian/workers/chat_worker.py
@@ -112,6 +112,45 @@ def _persist_turn_id_metadata(
         return False
 
 
+def _find_assistant_message_for_turn(*, thread_id: int, turn_id: str) -> int | None:
+    """Return an existing assistant message id for the turn when present."""
+    if not turn_id:
+        return None
+    chatlog_db = getattr(dependencies, "chatlog_db", None)
+    if chatlog_db is None:
+        return None
+
+    connect = getattr(chatlog_db, "_connect", None)
+    if not callable(connect):
+        return None
+
+    try:
+        with connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id
+                FROM chat_messages
+                WHERE thread_id = %s
+                  AND role = 'assistant'
+                  AND COALESCE(extra_meta, '{}'::jsonb)->>'turn_id' = %s
+                ORDER BY id ASC
+                LIMIT 1
+                """,
+                (thread_id, turn_id),
+            )
+            row = cur.fetchone()
+            if not row:
+                return None
+            return _coerce_message_id(row[0])
+    except Exception:
+        logger.debug(
+            "[chat-worker] failed to check existing turn_id message thread_id=%s turn_id=%s",
+            thread_id,
+            turn_id,
+            exc_info=True,
+        )
+        return None
+
 def _publish_worker_heartbeat(status: str = "idle") -> None:
     payload = {
         "worker": "chat",
@@ -178,6 +217,36 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
     )
 
     try:
+        existing_message_id = _find_assistant_message_for_turn(
+            thread_id=task.thread_id,
+            turn_id=turn_id,
+        )
+        if existing_message_id is not None:
+            duration_ms = int((time.monotonic() - started) * 1000)
+            logger.warning(
+                "[chat-worker] duplicate_turn_detected thread_id=%s turn_id=%s task_id=%s existing_message_id=%s",
+                task.thread_id,
+                turn_id,
+                task.task_id,
+                existing_message_id,
+            )
+            _safe_publish(
+                task.task_id,
+                "task.completed",
+                {
+                    "run_id": run_id,
+                    "duration_ms": duration_ms,
+                    "thread_id": task.thread_id,
+                    "turn_id": turn_id,
+                    "message_id": existing_message_id,
+                    "provider": task.provider,
+                    "model": task.model,
+                    "selection_source": "turn_id_dedupe",
+                    "catalog_version_hash": None,
+                },
+            )
+            return
+
         if is_cancelled(task.task_id):
             _safe_publish(
                 task.task_id,
@@ -228,14 +297,13 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
         if turn_id and not _persist_turn_id_metadata(
             thread_id=task.thread_id, message_id=message_id, turn_id=turn_id
         ):
-            logger.error(
-                "[chat-worker] completion_turn_metadata_missing thread_id=%s turn_id=%s task_id=%s message_id=%s",
+            logger.warning(
+                "[chat-worker] completion_turn_metadata_missing_non_fatal thread_id=%s turn_id=%s task_id=%s message_id=%s",
                 task.thread_id,
                 turn_id,
                 task.task_id,
                 message_id,
             )
-            raise RuntimeError("assistant_message_turn_metadata_missing")
 
         logger.info(
             "[chat-worker] assistant_message_persisted thread_id=%s turn_id=%s task_id=%s assistant_message_id=%s",

--- a/tests/test_chat_worker_turn_integrity.py
+++ b/tests/test_chat_worker_turn_integrity.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from typing import Any
+
+from guardian.tasks.types import ChatCompletionTask
+from guardian.workers import chat_worker
+
+
+def _build_task(*, task_id: str = "task-1", turn_id: str = "11111111-1111-4111-8111-111111111111") -> ChatCompletionTask:
+    task = ChatCompletionTask(
+        task_id=task_id,
+        thread_id=7,
+        provider="local",
+        model="test-model",
+        origin=f"api:chat.complete|turn_id={turn_id}",
+    )
+    task.turn_id = turn_id
+    task.turn_lock_owner = task_id
+    return task
+
+
+def test_metadata_persistence_failure_is_non_fatal(monkeypatch):
+    task = _build_task(task_id="task-meta-warning")
+    published: list[tuple[str, str, dict[str, Any]]] = []
+
+    monkeypatch.setattr(chat_worker, "is_cancelled", lambda *_args: False)
+    monkeypatch.setattr(chat_worker, "clear_cancelled", lambda *_args: None)
+    monkeypatch.setattr(chat_worker, "release_turn_lock", lambda *_args: True)
+    monkeypatch.setattr(
+        chat_worker,
+        "run_chat_completion_task",
+        lambda *_args, **_kwargs: {
+            "message_id": 42,
+            "provider": "local",
+            "model": "test-model",
+            "selection_source": "default",
+            "catalog_version_hash": "abc123",
+        },
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_safe_publish",
+        lambda task_id, event_type, data: published.append((task_id, event_type, data)),
+    )
+    monkeypatch.setattr(chat_worker, "_persist_turn_id_metadata", lambda **_kwargs: False)
+
+    chat_worker._run_chat_task(task)
+
+    event_types = [event_type for _task_id, event_type, _payload in published]
+    assert "task.completed" in event_types
+    assert "task.failed" not in event_types
+
+
+def test_duplicate_turn_short_circuits_new_completion(monkeypatch):
+    task = _build_task(task_id="task-duplicate")
+    published: list[tuple[str, str, dict[str, Any]]] = []
+
+    run_completion_calls = {"count": 0}
+
+    def _run_completion(*_args, **_kwargs):
+        run_completion_calls["count"] += 1
+        return {"message_id": 999}
+
+    monkeypatch.setattr(chat_worker, "is_cancelled", lambda *_args: False)
+    monkeypatch.setattr(chat_worker, "clear_cancelled", lambda *_args: None)
+    monkeypatch.setattr(chat_worker, "release_turn_lock", lambda *_args: True)
+    monkeypatch.setattr(chat_worker, "run_chat_completion_task", _run_completion)
+    monkeypatch.setattr(
+        chat_worker,
+        "_safe_publish",
+        lambda task_id, event_type, data: published.append((task_id, event_type, data)),
+    )
+    monkeypatch.setattr(chat_worker, "_find_assistant_message_for_turn", lambda **_kwargs: 55)
+
+    chat_worker._run_chat_task(task)
+
+    assert run_completion_calls["count"] == 0
+    completed_payloads = [
+        payload
+        for _task_id, event_type, payload in published
+        if event_type == "task.completed"
+    ]
+    assert completed_payloads
+    assert completed_payloads[-1]["message_id"] == 55
+    assert completed_payloads[-1]["selection_source"] == "turn_id_dedupe"
+
+
+def test_missing_assistant_message_marks_task_failed_and_releases_lock(monkeypatch):
+    task = _build_task(task_id="task-missing-assistant")
+    published: list[tuple[str, str, dict[str, Any]]] = []
+    released: list[tuple[int, str]] = []
+
+    monkeypatch.setattr(chat_worker, "is_cancelled", lambda *_args: False)
+    monkeypatch.setattr(chat_worker, "clear_cancelled", lambda *_args: None)
+    monkeypatch.setattr(
+        chat_worker,
+        "run_chat_completion_task",
+        lambda *_args, **_kwargs: {"provider": "local", "model": "test-model"},
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_safe_publish",
+        lambda task_id, event_type, data: published.append((task_id, event_type, data)),
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "release_turn_lock",
+        lambda thread_id, owner: released.append((thread_id, owner)) or True,
+    )
+
+    chat_worker._run_chat_task(task)
+
+    event_types = [event_type for _task_id, event_type, _payload in published]
+    assert "task.failed" in event_types
+    assert released == [(task.thread_id, task.task_id)]


### PR DESCRIPTION
### Motivation
- Prevent in-flight completion state from getting stuck when worker or completion errors occur, and avoid duplicate assistant messages when retries or metadata errors happen.
- Treat metadata persistence failures as recoverable so a successfully persisted assistant message does not cause a task to be marked failed.

### Description
- Worker: added `_find_assistant_message_for_turn` and short-circuit logic to detect an existing assistant message for the same `turn_id` and publish `task.completed` with the existing `message_id` instead of running a new completion (prevents duplicate assistant replies).
- Worker: changed `turn_id` metadata persistence failures from a fatal `RuntimeError` to a logged non-fatal `warning` so tasks are not marked failed when only the metadata write fails.
- Frontend: enhanced `ChatView` ingestion and polling to deduplicate assistant messages by `turn_id` and to immediately clear in-flight completion state when failure signals arrive (`task.failed`, `task.cancelled`, `completion.error`) or when a `task.completed` event arrives without an assistant `message_id`.
- Frontend: adjusted polling replay to route new fetched messages through the deduping `ingestIncoming` helper so duplicate messages are dropped consistently.
- Tests: added `tests/test_chat_worker_turn_integrity.py` with cases for non-fatal metadata persistence, duplicate-turn short-circuit, and missing-assistant failure path; added frontend loop-guard tests to `ChatView.loop-guards` for clearing completion on failure and duplicate-turn suppression.

### Testing
- Ran `pytest -v tests/test_chat_worker_turn_integrity.py`; all tests passed (3 passed). ✅
- Ran `pytest -v tests/routes/test_chat_routes.py`; this suite failed to initialize in this environment because SQLAlchemy attempted to parse an unresolved `${LOCAL_DATABASE_URL}` during fixture setup, so route-level tests could not complete. ⚠️
- Attempted `npx vitest ChatView.loop-guards` for frontend tests; vitest could not bootstrap here because `frontend/package.json` is malformed JSON in this environment, so the frontend tests were not executed. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a9cf44a620832dbd0cdb01bbebd451)