### PR TITLE
Fix completion turn-id poisoning after 429 turn lock responses

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -658,15 +658,10 @@ api.interceptors.response.use(
   (error) => {
     const completionMeta = readCompletionMeta(error?.config);
     if (completionMeta) {
-      const status = Number(error?.response?.status ?? 0);
-      const shouldKeep =
-        status === 429 && completionErrorDetail(error).includes("turn_in_flight");
-      if (!shouldKeep) {
-        clearInFlightCompletionTurnId(
-          completionMeta.threadId,
-          completionMeta.turnId
-        );
-      }
+      clearInFlightCompletionTurnId(
+        completionMeta.threadId,
+        completionMeta.turnId
+      );
     }
 
     if (isBackendTransportError(error)) {

--- a/frontend/src/test/api.completion-turn-lock.test.ts
+++ b/frontend/src/test/api.completion-turn-lock.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import api, {
+  clearInFlightCompletionTurnId,
+  getInFlightCompletionTurnId,
+} from "@/lib/api";
+
+describe("completion turn tracking", () => {
+  afterEach(() => {
+    clearInFlightCompletionTurnId(42);
+  });
+
+  it("drops provisional in-flight turn id after 429 turn_in_flight", async () => {
+    const requestFulfilled = (api.interceptors.request as any).handlers[0]
+      ?.fulfilled;
+    const responseRejected = (api.interceptors.response as any).handlers[0]
+      ?.rejected;
+
+    expect(typeof requestFulfilled).toBe("function");
+    expect(typeof responseRejected).toBe("function");
+
+    const requestConfig = await requestFulfilled({
+      method: "post",
+      url: "/chat/42/complete",
+      data: {},
+      headers: {},
+    });
+
+    const provisionalTurnId = requestConfig.__cfyCompletionTurnId as string;
+    expect(provisionalTurnId).toBeTruthy();
+    expect(getInFlightCompletionTurnId(42)).toBe(provisionalTurnId);
+
+    await expect(
+      responseRejected({
+        config: requestConfig,
+        response: {
+          status: 429,
+          data: {
+            detail: "turn_in_flight",
+          },
+        },
+      })
+    ).rejects.toBeTruthy();
+
+    expect(getInFlightCompletionTurnId(42)).toBeNull();
+  });
+});


### PR DESCRIPTION
### Motivation
- A client-provisional `turn_id` was being preserved after a `429` `turn_in_flight` response, which can poison polling/event matching when the active lock belongs to another in-flight completion.
- The change ensures the client does not hold stale provisional turn ids that prevent the real assistant reply from matching the expected turn.

### Description
- Update the frontend Axios response error interceptor to always call `clearInFlightCompletionTurnId(completionMeta.threadId, completionMeta.turnId)` for failed completion requests, removing stale provisional turn ids (change in `frontend/src/lib/api.ts`).
- Add a unit test that exercises the completion request/response interceptor flow and verifies a provisional in-flight turn id is dropped after a simulated `429 turn_in_flight` rejection (new file `frontend/src/test/api.completion-turn-lock.test.ts`).

### Testing
- Added `frontend/src/test/api.completion-turn-lock.test.ts` which simulates the request interceptor and a `429 turn_in_flight` rejection and asserts the in-flight turn id is cleared.
- Attempted to run the test with `pnpm --dir frontend vitest run src/test/api.completion-turn-lock.test.ts` but the command failed in this environment due to an invalid `package.json` (LFS pointer checkout), so automated test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a9d5656b04832dad19ada6d7938d99)