### PR TITLE
Finalize completions when assistant events omit turn metadata

### DIFF
--- a/frontend/src/features/chat/ChatView.tsx
+++ b/frontend/src/features/chat/ChatView.tsx
@@ -372,7 +372,13 @@ export function ChatView({
         if (
           expectedTurnId &&
           messageRole === "assistant" &&
-          readMessageTurnId(msg) === expectedTurnId &&
+          (() => {
+            const messageTurnId = readMessageTurnId(msg);
+            if (messageTurnId) {
+              return messageTurnId === expectedTurnId;
+            }
+            return id > session.lastUserMessageId;
+          })() &&
           id > matchingTurnAssistantId
         ) {
           matchingTurnAssistantId = id;
@@ -583,9 +589,6 @@ export function ChatView({
         observedTurnId &&
         observedTurnId !== expectedTurnId
       ) {
-        return;
-      }
-      if (expectedTurnId && !observedTurnId) {
         return;
       }
       if (messageId > lastAssistantIdRef.current) {

--- a/frontend/src/features/chat/__tests__/ChatView.loop-guards.test.tsx
+++ b/frontend/src/features/chat/__tests__/ChatView.loop-guards.test.tsx
@@ -251,6 +251,35 @@ describe("ChatView loop guards", () => {
     vi.useRealTimers();
   });
 
+
+  it("finalizes completion when assistant event omits turn metadata", async () => {
+    vi.useFakeTimers();
+    const endCompletion = vi.fn();
+    const completion = {
+      isCompleting: true,
+      activeTaskId: "task-2",
+      activeThreadId: 2,
+      startedAt: Date.now(),
+    };
+
+    getInFlightCompletionTurnIdMock.mockReturnValue(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    );
+
+    render(
+      <ChatView threadId={2} completionState={completion} endCompletion={endCompletion} />
+    );
+
+    await waitFor(() => {
+      expect(activeSubscriberCount("message.created")).toBe(1);
+    });
+
+    emitLiveEvent("message.created", { thread_id: 2, role: "assistant", id: 5002 });
+    vi.advanceTimersByTime(200);
+
+    expect(endCompletion).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
   it("uses poll-key idempotency and restarts when depth/profile context changes", async () => {
     const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
     mockMessages = [


### PR DESCRIPTION
### Motivation
- The UI can get stuck with an in-flight completion when the backend appends assistant messages that lack `turn_id` metadata, because ChatView previously ignored assistant events missing a turn identifier whenever an expected turn existed.
- The goal is to ensure completion finalization runs when an assistant reply arrives even if turn metadata persistence failed.

### Description
- Make poll-based matching in `frontend/src/features/chat/ChatView.tsx` treat assistant messages without `turn_id` as a valid expected-turn match when the message is clearly a post-user reply by checking `id > session.lastUserMessageId`.
- Change the live `message.created` handler in `frontend/src/features/chat/ChatView.tsx` to stop dropping assistant events that omit turn metadata while still rejecting explicit, mismatched turn IDs so finalize logic can run.
- Add a regression test `frontend/src/features/chat/__tests__/ChatView.loop-guards.test.tsx` that verifies a completion finalizes when an assistant event arrives without turn metadata.

### Testing
- Attempted to run the focused test with `pnpm -C frontend test -- ChatView.loop-guards.test.tsx`, but the run failed because `frontend/package.json` is a Git LFS pointer in this checkout, producing `Invalid package.json in package.json`.
- No other automated tests were executed in this environment due to the package metadata limitation, and the added unit test could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a9d560fad4832db1b70fde503efa4b)