### PR TITLE
Make chat completion turn-id metadata persistence non-fatal

### DIFF
--- a/guardian/workers/chat_worker.py
+++ b/guardian/workers/chat_worker.py
@@ -336,16 +336,32 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
             )
             raise RuntimeError("assistant_message_missing")
 
-        if turn_id and not _persist_turn_id_metadata(
-            thread_id=task.thread_id, message_id=message_id, turn_id=turn_id
-        ):
-            logger.warning(
-                "[chat-worker] completion_turn_metadata_missing thread_id=%s turn_id=%s task_id=%s message_id=%s",
-                task.thread_id,
-                turn_id,
-                task.task_id,
-                message_id,
-            )
+        if turn_id:
+            metadata_persisted = False
+            try:
+                metadata_persisted = _persist_turn_id_metadata(
+                    thread_id=task.thread_id,
+                    message_id=message_id,
+                    turn_id=turn_id,
+                )
+            except Exception:
+                logger.warning(
+                    "[chat-worker] completion_turn_metadata_exception thread_id=%s turn_id=%s task_id=%s message_id=%s",
+                    task.thread_id,
+                    turn_id,
+                    task.task_id,
+                    message_id,
+                    exc_info=True,
+                )
+
+            if not metadata_persisted:
+                logger.warning(
+                    "[chat-worker] completion_turn_metadata_missing thread_id=%s turn_id=%s task_id=%s message_id=%s",
+                    task.thread_id,
+                    turn_id,
+                    task.task_id,
+                    message_id,
+                )
         if turn_id:
             canonical_message_id = _find_assistant_message_id_by_turn_id(
                 thread_id=task.thread_id,


### PR DESCRIPTION
### Motivation
- Persisting `turn_id` metadata could raise or return false and previously caused the worker to treat completion as failed despite the assistant message being persisted, causing client-visible inconsistency and phantom failures.
- The intent is to ensure assistant completion success is preserved and metadata writes are treated as best-effort so transient DB/schema/backing-store issues don't break normal completion flow.

### Description
- Wrapped the `_persist_turn_id_metadata(...)` call in `_run_chat_task` with a local `try/except` and a `metadata_persisted` flag so exceptions do not bubble into the task failure path (file: `guardian/workers/chat_worker.py`).
- Added warning logs for both raised exceptions (`completion_turn_metadata_exception`) and false-return outcomes (`completion_turn_metadata_missing`) while continuing to the existing dedupe/canonicalization and `task.completed` flow.
- Preserved the existing duplicate-turn check and canonical message selection logic after the best-effort metadata write.

### Testing
- Attempted to run `pytest -q guardian/tests/workers/test_chat_worker_completion_semantics.py` to validate semantics around metadata persistence and completion; the test run failed during test bootstrap with `sqlalchemy.exc.ArgumentError: Could not parse SQLAlchemy URL from given URL string`, which is from global app initialization and unrelated to the change in the worker code.
- The change is small and exercised by existing unit tests in `guardian/tests/workers/test_chat_worker_completion_semantics.py` (which assert metadata persistence failures are non-fatal), but a full run could not be completed in this environment due to the unrelated test environment error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a9d606ebcc832db3f4a5a2aa98f827)