### PR TITLE
fix(voice): allow retries when dedupe points to terminal failed task

### DIFF
--- a/guardian/routes/voice.py
+++ b/guardian/routes/voice.py
@@ -137,10 +137,20 @@ def _get_dedupe_hit(
     task_id = str(payload.get("task_id") or "").strip()
     if not task_id:
         return None
+    status = _task_terminal_status(task_id)
+    if status == "failed":
+        try:
+            client.delete(key)
+        except Exception:
+            logger.debug(
+                "[voice.turn] failed deleting stale dedupe record",
+                exc_info=True,
+            )
+        return None
     return {
         "deduped": True,
         "task_id": task_id,
-        "status": _task_terminal_status(task_id),
+        "status": status,
     }
 
 

--- a/tests/routes/test_voice_routes.py
+++ b/tests/routes/test_voice_routes.py
@@ -61,6 +61,76 @@ def test_normalize_turn_id_valid_uuid_preserved():
     assert voice_route._normalize_turn_id(turn_id) == turn_id
 
 
+def test_get_dedupe_hit_returns_none_and_clears_failed_task_record(monkeypatch):
+    from guardian.routes import voice as voice_route
+
+    key = voice_route._dedupe_key(1, "turn-id", "audio-sha")
+
+    class _DummyRedis:
+        def __init__(self):
+            self.deleted_keys = []
+
+        def get(self, raw_key):
+            if raw_key == key:
+                return '{"task_id":"failed-task"}'
+            return None
+
+        def delete(self, raw_key):
+            self.deleted_keys.append(raw_key)
+
+    redis_client = _DummyRedis()
+    monkeypatch.setattr(
+        "guardian.routes.voice.get_redis_client", lambda: redis_client
+    )
+    monkeypatch.setattr(
+        "guardian.routes.voice._task_terminal_status",
+        lambda _task_id: "failed",
+    )
+
+    hit = voice_route._get_dedupe_hit(
+        thread_id=1,
+        turn_id="turn-id",
+        audio_sha256="audio-sha",
+    )
+
+    assert hit is None
+    assert redis_client.deleted_keys == [key]
+
+
+def test_get_dedupe_hit_keeps_in_flight_task_record(monkeypatch):
+    from guardian.routes import voice as voice_route
+
+    key = voice_route._dedupe_key(1, "turn-id", "audio-sha")
+
+    class _DummyRedis:
+        def get(self, raw_key):
+            if raw_key == key:
+                return '{"task_id":"active-task"}'
+            return None
+
+        def delete(self, _raw_key):
+            raise AssertionError("delete should not be called for active tasks")
+
+    monkeypatch.setattr(
+        "guardian.routes.voice.get_redis_client", lambda: _DummyRedis()
+    )
+    monkeypatch.setattr(
+        "guardian.routes.voice._task_terminal_status",
+        lambda _task_id: "in_flight",
+    )
+
+    hit = voice_route._get_dedupe_hit(
+        thread_id=1,
+        turn_id="turn-id",
+        audio_sha256="audio-sha",
+    )
+
+    assert hit == {
+        "deduped": True,
+        "task_id": "active-task",
+        "status": "in_flight",
+    }
+
 def test_voice_capabilities_contract(test_client, monkeypatch):
     monkeypatch.setattr(
         "guardian.routes.voice.get_voice_runtime_config",


### PR DESCRIPTION
### Motivation
- Retry requests using the same `turn_id` were being blocked by existing dedupe records even when the referenced voice task had already ended in a terminal failed/cancelled state, making transient failures unrecoverable until dedupe TTL expiry. 

### Description
- Update `guardian/routes/voice.py` so `_get_dedupe_hit` checks the referenced task status via `_task_terminal_status` and treats a `"failed"` terminal state as stale. 
- When a dedupe record points to a failed task the code now attempts to delete the stale Redis key and returns `None` so the request can proceed to enqueue a retry. 
- Preserve prior behavior for in-flight or succeeded tasks by returning the dedupe hit and current `status` without deleting the key. 
- Add focused unit tests in `tests/routes/test_voice_routes.py` that assert stale failed-task dedupe records are cleared and that in-flight records remain deduped.

### Testing
- Ran targeted tests: `pytest -q tests/routes/test_voice_routes.py -k "get_dedupe_hit or normalize_turn_id"` which passed. 
- Ran full route test file: `pytest -q tests/routes/test_voice_routes.py` which cannot complete in this environment due to unresolved `${LOCAL_DATABASE_URL}` during `test_client` setup (environment import-time DB URL parsing error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a9d5f619ac832db7343c56cf2193c5)