### PR TITLE
fix(voice): allow turn dedupe retries after failed task

### DIFF
--- a/guardian/routes/voice.py
+++ b/guardian/routes/voice.py
@@ -137,10 +137,20 @@ def _get_dedupe_hit(
     task_id = str(payload.get("task_id") or "").strip()
     if not task_id:
         return None
+    status = _task_terminal_status(task_id)
+    if status == "failed":
+        try:
+            client.delete(key)
+        except Exception:
+            logger.debug(
+                "[voice.turn] failed deleting stale dedupe record",
+                exc_info=True,
+            )
+        return None
     return {
         "deduped": True,
         "task_id": task_id,
-        "status": _task_terminal_status(task_id),
+        "status": status,
     }
 
 

--- a/tests/routes/test_voice_routes.py
+++ b/tests/routes/test_voice_routes.py
@@ -61,6 +61,76 @@ def test_normalize_turn_id_valid_uuid_preserved():
     assert voice_route._normalize_turn_id(turn_id) == turn_id
 
 
+def test_get_dedupe_hit_returns_none_and_clears_failed_task_record(monkeypatch):
+    from guardian.routes import voice as voice_route
+
+    key = voice_route._dedupe_key(1, "turn-id", "audio-sha")
+
+    class _DummyRedis:
+        def __init__(self):
+            self.deleted_keys = []
+
+        def get(self, raw_key):
+            if raw_key == key:
+                return '{"task_id":"failed-task"}'
+            return None
+
+        def delete(self, raw_key):
+            self.deleted_keys.append(raw_key)
+
+    redis_client = _DummyRedis()
+    monkeypatch.setattr(
+        "guardian.routes.voice.get_redis_client", lambda: redis_client
+    )
+    monkeypatch.setattr(
+        "guardian.routes.voice._task_terminal_status",
+        lambda _task_id: "failed",
+    )
+
+    hit = voice_route._get_dedupe_hit(
+        thread_id=1,
+        turn_id="turn-id",
+        audio_sha256="audio-sha",
+    )
+
+    assert hit is None
+    assert redis_client.deleted_keys == [key]
+
+
+def test_get_dedupe_hit_keeps_in_flight_task_record(monkeypatch):
+    from guardian.routes import voice as voice_route
+
+    key = voice_route._dedupe_key(1, "turn-id", "audio-sha")
+
+    class _DummyRedis:
+        def get(self, raw_key):
+            if raw_key == key:
+                return '{"task_id":"active-task"}'
+            return None
+
+        def delete(self, _raw_key):
+            raise AssertionError("delete should not be called for active tasks")
+
+    monkeypatch.setattr(
+        "guardian.routes.voice.get_redis_client", lambda: _DummyRedis()
+    )
+    monkeypatch.setattr(
+        "guardian.routes.voice._task_terminal_status",
+        lambda _task_id: "in_flight",
+    )
+
+    hit = voice_route._get_dedupe_hit(
+        thread_id=1,
+        turn_id="turn-id",
+        audio_sha256="audio-sha",
+    )
+
+    assert hit == {
+        "deduped": True,
+        "task_id": "active-task",
+        "status": "in_flight",
+    }
+
 def test_voice_capabilities_contract(test_client, monkeypatch):
     monkeypatch.setattr(
         "guardian.routes.voice.get_voice_runtime_config",


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
