### PR TITLE
Add ResonantOS wallet plugin scaffold

### DIFF
--- a/docs/audits/codexify_platform_rediness_audit_v2.md
+++ b/docs/audits/codexify_platform_rediness_audit_v2.md
@@ -1,0 +1,474 @@
+Codexify Platform Readiness Audit v2
+
+1. Purpose
+
+This document defines the Codexify Platform Readiness Audit, a formal framework used to determine whether Codexify has progressed from:
+
+prototype → early-adopter capable platform
+
+The audit evaluates architectural maturity, not feature count.
+
+Its purpose is to:
+
+Identify structural weaknesses in the runtime system
+
+Prioritize engineering effort based on platform risk
+
+Prevent uncontrolled feature expansion before substrate stability
+
+This audit acts as a governance instrument for Codexify architecture.
+
+1. Audit Philosophy
+
+Codexify is a local-first AI operating substrate composed of:
+
+FastAPI backend
+
+Postgres system-of-record
+
+Redis task/event transport
+
+Worker execution model
+
+Vector retrieval layers
+
+Multi-surface clients
+
+The primary runtime path is:
+
+Human intent
+  → Thread context
+  → Completion orchestration
+  → Provider execution
+  → Persistence
+  → Event emission
+
+This pipeline represents the core loop of the platform.
+
+completion_pipeline
+
+Platform readiness depends on whether this loop is:
+
+reliable
+
+observable
+
+restart-safe
+
+extensible
+
+1. Scoring Model
+
+Each domain receives a score from 0-3.
+
+Score Meaning
+0 Absent
+1 Partial / fragile
+2 Operational
+3 Extensible / ecosystem-ready
+Interpretation Rule
+
+Platform maturity is determined by the weakest domain, not the aggregate score.
+
+A system with advanced features but weak infrastructure remains a prototype.
+
+1. Audit Domains
+A. Core Loop Integrity
+Purpose
+
+Evaluate whether the system’s primary execution pipeline is deterministic, observable, and resilient.
+
+Codexify’s core runtime path is:
+
+UI → Chat API → Redis Queue → Worker
+     → Context Broker → Provider
+     → Persist Assistant Message
+     → Emit Task Events
+
+This flow defines the platform’s operational backbone.
+
+completion_pipeline
+
+Evaluation Criteria
+
+Thread messages are durably persisted.
+
+Completion tasks enqueue reliably.
+
+Workers process tasks deterministically.
+
+Provider responses are validated before persistence.
+
+Task lifecycle events are emitted and traceable.
+
+Evidence Sources
+
+guardian/routes/chat.py
+
+guardian/workers/chat_worker.py
+
+guardian/context/broker.py
+
+guardian/queue/task_events.py
+
+guardian/core/ai_router.py
+
+Failure Indicators
+
+Examples of structural weaknesses:
+
+completions lost due to Redis outages
+
+worker crashes leaving threads locked
+
+missing task lifecycle events
+
+assistant outputs not persisted
+
+B. Primitive Stability
+Purpose
+
+Verify that the system’s core primitives and data contracts are stable.
+
+Codexify primitives include:
+
+Threads
+
+Messages
+
+Tools
+
+Documents / Media
+
+Jobs
+
+Events
+
+Personas
+
+Federation Peers
+
+These primitives must have:
+
+clear lifecycle states
+
+stable schema contracts
+
+explicit ownership boundaries.
+
+Evaluation Criteria
+
+Data models enforce invariants.
+
+lifecycle transitions are documented.
+
+APIs expose predictable behavior.
+
+persistence layers enforce constraints.
+
+Evidence Sources
+
+guardian/db/models.py
+
+docs/data-and-storage.md
+
+docs/modules-and-ownership.md
+
+Failure Indicators
+
+schema changes frequently break runtime flows
+
+inconsistent entity lifecycle rules
+
+hidden side effects in persistence logic
+
+C. Extension Boundary
+Purpose
+
+Determine whether Codexify behaves as a platform substrate, not a monolithic application.
+
+New capabilities should be composable using existing primitives rather than modifying kernel logic.
+
+Extension Surfaces
+
+Examples:
+
+Tool execution
+
+Connectors
+
+Cron jobs
+
+Provider routing
+
+External automation
+
+Alternate clients
+
+Evaluation Criteria
+
+Tools can be registered without editing core runtime code.
+
+Provider selection can be changed through configuration.
+
+Cron jobs operate through durable execution paths.
+
+External clients can use the same APIs as the web UI.
+
+Evidence Sources
+
+guardian/routes/tools.py
+
+guardian/routes/cron.py
+
+guardian/core/ai_router.py
+
+Failure Indicators
+
+new workflows require editing core worker logic
+
+provider switching requires code changes
+
+client surfaces require backend forks
+
+D. Observability
+Purpose
+
+Evaluate whether engineers can understand system behavior without modifying code.
+
+Observability must support:
+
+debugging
+
+operations
+
+incident response
+
+Evaluation Criteria
+
+failures produce actionable logs
+
+task lifecycle events are emitted
+
+health endpoints expose system state
+
+request tracing is possible.
+
+Evidence Sources
+
+/health endpoints
+
+task event streams
+
+worker logs
+
+runtime metrics
+
+Failure Indicators
+
+debugging requires reproducing issues locally
+
+failures lack contextual logs
+
+operators cannot trace request flow
+
+E. Durability and Recovery
+Purpose
+
+Ensure the system survives process crashes, restarts, and degraded dependencies.
+
+Codexify relies on:
+
+Postgres for durable state
+
+Redis queues for task transport
+
+workers for execution
+
+These layers must recover safely.
+
+Evaluation Criteria
+
+jobs survive process restarts
+
+retries are idempotent
+
+degraded modes are explicit
+
+execution traces allow replay.
+
+Evidence Sources
+
+queue retry configuration
+
+idempotency keys
+
+worker restart behavior
+
+persistence semantics
+
+Failure Indicators
+
+tasks lost on restart
+
+duplicate executions corrupt state
+
+incomplete workflows after crashes
+
+F. Alternate Surface Readiness
+Purpose
+
+Determine whether Codexify supports multiple client surfaces operating over the same backend substrate.
+
+Examples:
+
+Web UI
+
+Mobile clients
+
+CLI
+
+Voice interfaces
+
+automation agents
+
+The backend must function as a client-agnostic runtime.
+
+Evaluation Criteria
+
+APIs are not coupled to the web frontend
+
+authentication supports multiple clients
+
+workflows behave consistently across surfaces
+
+Evidence Sources
+
+API contracts
+
+auth middleware
+
+client usage patterns
+
+Failure Indicators
+
+backend assumes frontend behavior
+
+hidden coupling to UI components
+
+surface-specific logic inside core services
+
+G. Federation Readiness
+Purpose
+
+Evaluate the system’s ability to participate in multi-node context sharing.
+
+Federation allows:
+
+peer nodes
+
+context exchange
+
+collaborative cognition networks.
+
+Evaluation Criteria
+
+peer identity model exists
+
+sync semantics are defined
+
+conflict resolution policies exist
+
+federation failure modes are known.
+
+Evidence Sources
+
+federation routes
+
+sync protocol definitions
+
+trust policy configuration
+
+Failure Indicators
+
+peers cannot verify identity
+
+sync creates inconsistent state
+
+partial replication corrupts context
+
+H. Governance Readiness
+Purpose
+
+Ensure the platform can evolve without violating core architectural guarantees.
+
+Governance requires:
+
+explicit invariants
+
+versioned contracts
+
+change control.
+
+Evaluation Criteria
+
+architectural invariants documented
+
+extension authority defined
+
+identity/privacy boundaries enforced
+
+architecture decisions recorded.
+
+Evidence Sources
+
+architecture decision records
+
+IDDB policy documentation
+
+permission models
+
+1. Scoring Template
+Domain Score (0-3) Notes
+Core Loop Integrity  
+Primitive Stability  
+Extension Boundary  
+Observability  
+Durability & Recovery  
+Alternate Surface Readiness  
+Federation Readiness  
+Governance Readiness  
+2. Phase Gate Definition
+
+Codexify is Early-Adopter Ready only when all minimum thresholds are met.
+
+Minimum Gates
+Core Loop Integrity ≥ 2
+Primitive Stability ≥ 2
+Observability ≥ 2
+Durability & Recovery ≥ 2
+Extension Boundary ≥ 2
+
+If any one of these domains fails its threshold, the system remains in prototype stage.
+
+1. Audit Execution Method
+
+The audit should be run periodically during development:
+
+Review each domain using the evidence sources.
+
+Assign scores based on observable runtime behavior.
+
+Document weaknesses and architectural risks.
+
+Prioritize engineering work on the lowest-scoring domain.
+
+This process forms a continuous architectural control loop.
+
+1. Guiding Principle
+
+Codexify is not merely a product.
+
+It is a substrate for cognition infrastructure.
+
+Platform maturity is achieved not when the system is feature-rich, but when its foundations are reliable, extensible, and governable.

--- a/guardian/plugins/resonantos_wallet/__init__.py
+++ b/guardian/plugins/resonantos_wallet/__init__.py
@@ -1,0 +1,8 @@
+"""
+Public entry points for the ResonantOS wallet scaffold plugin.
+"""
+
+from .manifest import RESONANTOS_WALLET_MANIFEST
+from .plugin import ResonantOSWalletPlugin
+
+__all__ = ["RESONANTOS_WALLET_MANIFEST", "ResonantOSWalletPlugin"]

--- a/guardian/plugins/resonantos_wallet/manifest.py
+++ b/guardian/plugins/resonantos_wallet/manifest.py
@@ -1,0 +1,63 @@
+"""
+Manifest declaration for the ResonantOS wallet scaffold plugin.
+"""
+
+from __future__ import annotations
+
+from .types import WalletPluginManifest
+
+RESONANTOS_WALLET_MANIFEST = WalletPluginManifest(
+    id="resonantos_wallet",
+    name="ResonantOS Wallet",
+    version="0.1.0",
+    enabled=False,
+    autoload=False,
+    status="disabled",
+    wiring_status="not_wired",
+    runtime_mode="external_bridge",
+    signing_mode="delegated_signer",
+    description=(
+        "Scaffold-only plumbing for a future ResonantOS wallet bridge. "
+        "This package is importable in isolation for tests and future wiring, "
+        "but it is not loaded, registered, or invoked by Codexify startup."
+    ),
+    capabilities=[
+        {
+            "id": "wallet_summary_read",
+            "category": "read_model",
+            "description": (
+                "Future wallet summary read-model contract only; no RPC wiring "
+                "or signer interaction is implemented here."
+            ),
+        },
+        {
+            "id": "recent_transaction_read",
+            "category": "read_model",
+            "description": (
+                "Future recent transaction read-model contract only; no network "
+                "calls are performed by this scaffold."
+            ),
+        },
+        {
+            "id": "transfer_intent_create",
+            "category": "intent",
+            "description": (
+                "Builds unsigned transfer intent payloads for an external "
+                "delegated signer bridge."
+            ),
+        },
+        {
+            "id": "governance_vote_intent_create",
+            "category": "intent",
+            "description": (
+                "Builds unsigned governance vote intent payloads for an "
+                "external delegated signer bridge."
+            ),
+        },
+    ],
+    security_note=(
+        "Private key custody, direct signing, and transaction submission are "
+        "externalized. This scaffold is limited to read-model and unsigned "
+        "intent plumbing."
+    ),
+)

--- a/guardian/plugins/resonantos_wallet/plugin.py
+++ b/guardian/plugins/resonantos_wallet/plugin.py
@@ -1,0 +1,89 @@
+"""
+Side-effect-free ResonantOS wallet plugin scaffold.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Callable
+
+from .manifest import RESONANTOS_WALLET_MANIFEST
+from .types import (
+    PluginHealth,
+    TransferIntentPayload,
+    TransferIntentRequest,
+    TransferIntentResponse,
+    VoteIntentPayload,
+    VoteIntentRequest,
+    VoteIntentResponse,
+    WalletPluginManifest,
+)
+
+
+def _default_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _format_timestamp(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    else:
+        value = value.astimezone(timezone.utc)
+    return value.isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+class ResonantOSWalletPlugin:
+    """
+    Scaffold-only wallet bridge contract.
+
+    Direct signing, private key custody, and outbound RPC submission are out
+    of scope. This class only returns structured manifest, health, and intent
+    payloads for future external bridge wiring.
+    """
+
+    def __init__(
+        self,
+        *,
+        now_factory: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._now_factory = now_factory or _default_now
+
+    def manifest(self) -> WalletPluginManifest:
+        return RESONANTOS_WALLET_MANIFEST.model_copy(deep=True)
+
+    def health_check(self) -> PluginHealth:
+        return PluginHealth(
+            message=(
+                "ResonantOS wallet scaffold is disabled and not wired into "
+                "Codexify startup."
+            )
+        )
+
+    def create_transfer_intent(
+        self, request: TransferIntentRequest
+    ) -> TransferIntentResponse:
+        payload = TransferIntentPayload(
+            source_account=request.source_account.model_copy(deep=True),
+            destination_account_ref=request.destination_account_ref,
+            asset=request.asset.model_copy(deep=True),
+            amount=request.amount,
+            memo=request.memo,
+        )
+        return TransferIntentResponse(
+            created_at=_format_timestamp(self._now_factory()),
+            normalized_payload=payload,
+        )
+
+    def create_vote_intent(
+        self, request: VoteIntentRequest
+    ) -> VoteIntentResponse:
+        payload = VoteIntentPayload(
+            voter_account=request.voter_account.model_copy(deep=True),
+            proposal_id=request.proposal_id,
+            vote_choice=request.vote_choice,
+            rationale=request.rationale,
+        )
+        return VoteIntentResponse(
+            created_at=_format_timestamp(self._now_factory()),
+            normalized_payload=payload,
+        )

--- a/guardian/plugins/resonantos_wallet/types.py
+++ b/guardian/plugins/resonantos_wallet/types.py
@@ -1,0 +1,283 @@
+"""
+Typed contracts for the ResonantOS wallet scaffold plugin.
+
+These models intentionally stop at read-model queries and unsigned intent
+creation. Direct signing, private key custody, and outbound submission remain
+outside this scaffold and must be handled by an external signer bridge.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+def _normalize_required_string(value: str) -> str:
+    value = value.strip()
+    if not value:
+        raise ValueError("value must be non-empty")
+    return value
+
+
+def _normalize_optional_string(value: str | None) -> str | None:
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+class WalletPluginCapability(BaseModel):
+    """Declared scaffold capability with no signing surface."""
+
+    id: Literal[
+        "wallet_summary_read",
+        "recent_transaction_read",
+        "transfer_intent_create",
+        "governance_vote_intent_create",
+    ]
+    category: Literal["read_model", "intent"]
+    description: str = Field(min_length=1)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("description")
+    @classmethod
+    def _validate_description(cls, value: str) -> str:
+        return _normalize_required_string(value)
+
+
+class WalletPluginManifest(BaseModel):
+    """Manifest contract for the disabled ResonantOS wallet scaffold."""
+
+    id: str = Field(min_length=1)
+    name: str = Field(min_length=1)
+    version: str = Field(min_length=1)
+    enabled: bool = False
+    autoload: bool = False
+    status: Literal["disabled"] = "disabled"
+    wiring_status: Literal["not_wired"] = "not_wired"
+    runtime_mode: Literal["external_bridge"] = "external_bridge"
+    signing_mode: Literal["delegated_signer"] = "delegated_signer"
+    description: str = Field(min_length=1)
+    capabilities: list[WalletPluginCapability] = Field(min_length=1)
+    security_note: str = Field(min_length=1)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("id", "name", "version", "description", "security_note")
+    @classmethod
+    def _validate_strings(cls, value: str) -> str:
+        return _normalize_required_string(value)
+
+
+class WalletAccountReference(BaseModel):
+    """Reference to an externally managed wallet account."""
+
+    account_ref: str = Field(
+        min_length=1,
+        description="Stable external wallet account reference.",
+    )
+    chain: str = Field(min_length=1)
+    network: str = Field(min_length=1)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("account_ref", "chain", "network")
+    @classmethod
+    def _validate_strings(cls, value: str) -> str:
+        return _normalize_required_string(value)
+
+
+class AssetReference(BaseModel):
+    """Token or native asset identifier for intent construction."""
+
+    asset_id: str = Field(
+        min_length=1,
+        description="Mint, contract, or native asset identifier.",
+    )
+    symbol: str | None = Field(default=None, max_length=64)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("asset_id")
+    @classmethod
+    def _validate_asset_id(cls, value: str) -> str:
+        return _normalize_required_string(value)
+
+    @field_validator("symbol")
+    @classmethod
+    def _validate_symbol(cls, value: str | None) -> str | None:
+        return _normalize_optional_string(value)
+
+
+class WalletSummaryRequest(BaseModel):
+    """Future read-model request for wallet summary data."""
+
+    account: WalletAccountReference
+    include_recent_transactions: bool = False
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class RecentTransactionRequest(BaseModel):
+    """Future read-model request for recent transaction history."""
+
+    account: WalletAccountReference
+    limit: int = Field(default=10, ge=1, le=100)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class TransferIntentRequest(BaseModel):
+    """Unsigned transfer intent request for a delegated signer bridge."""
+
+    source_account: WalletAccountReference
+    destination_account_ref: str = Field(min_length=1)
+    asset: AssetReference
+    amount: str = Field(
+        min_length=1,
+        description="String amount to preserve wallet-specific precision rules.",
+    )
+    memo: str | None = Field(default=None, max_length=512)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("destination_account_ref", "amount")
+    @classmethod
+    def _validate_strings(cls, value: str) -> str:
+        return _normalize_required_string(value)
+
+    @field_validator("memo")
+    @classmethod
+    def _validate_memo(cls, value: str | None) -> str | None:
+        return _normalize_optional_string(value)
+
+
+class TransferIntentPayload(BaseModel):
+    """Normalized transfer payload returned by the scaffold plugin."""
+
+    source_account: WalletAccountReference
+    destination_account_ref: str = Field(min_length=1)
+    asset: AssetReference
+    amount: str = Field(min_length=1)
+    memo: str | None = Field(default=None, max_length=512)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("destination_account_ref", "amount")
+    @classmethod
+    def _validate_strings(cls, value: str) -> str:
+        return _normalize_required_string(value)
+
+    @field_validator("memo")
+    @classmethod
+    def _validate_memo(cls, value: str | None) -> str | None:
+        return _normalize_optional_string(value)
+
+
+class TransferIntentResponse(BaseModel):
+    """Unsigned transfer intent envelope for future wiring."""
+
+    plugin_id: Literal["resonantos_wallet"] = "resonantos_wallet"
+    intent_type: Literal["transfer"] = "transfer"
+    created_at: str = Field(min_length=1)
+    execution_mode: Literal[
+        "external_signer_required"
+    ] = "external_signer_required"
+    ready_for_submission: bool = False
+    submitted: bool = False
+    normalized_payload: TransferIntentPayload
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("created_at")
+    @classmethod
+    def _validate_created_at(cls, value: str) -> str:
+        return _normalize_required_string(value)
+
+
+class VoteIntentRequest(BaseModel):
+    """Unsigned governance vote intent request for delegated signing."""
+
+    voter_account: WalletAccountReference
+    proposal_id: str = Field(min_length=1)
+    vote_choice: str = Field(min_length=1)
+    rationale: str | None = Field(default=None, max_length=2048)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("proposal_id", "vote_choice")
+    @classmethod
+    def _validate_strings(cls, value: str) -> str:
+        return _normalize_required_string(value)
+
+    @field_validator("rationale")
+    @classmethod
+    def _validate_rationale(cls, value: str | None) -> str | None:
+        return _normalize_optional_string(value)
+
+
+class VoteIntentPayload(BaseModel):
+    """Normalized governance vote payload returned by the scaffold plugin."""
+
+    voter_account: WalletAccountReference
+    proposal_id: str = Field(min_length=1)
+    vote_choice: str = Field(min_length=1)
+    rationale: str | None = Field(default=None, max_length=2048)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("proposal_id", "vote_choice")
+    @classmethod
+    def _validate_strings(cls, value: str) -> str:
+        return _normalize_required_string(value)
+
+    @field_validator("rationale")
+    @classmethod
+    def _validate_rationale(cls, value: str | None) -> str | None:
+        return _normalize_optional_string(value)
+
+
+class VoteIntentResponse(BaseModel):
+    """Unsigned governance vote intent envelope for future wiring."""
+
+    plugin_id: Literal["resonantos_wallet"] = "resonantos_wallet"
+    intent_type: Literal["governance_vote"] = "governance_vote"
+    created_at: str = Field(min_length=1)
+    execution_mode: Literal[
+        "external_signer_required"
+    ] = "external_signer_required"
+    ready_for_submission: bool = False
+    submitted: bool = False
+    normalized_payload: VoteIntentPayload
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("created_at")
+    @classmethod
+    def _validate_created_at(cls, value: str) -> str:
+        return _normalize_required_string(value)
+
+
+class PluginHealth(BaseModel):
+    """Structured health response for a disabled, import-safe scaffold."""
+
+    plugin_id: Literal["resonantos_wallet"] = "resonantos_wallet"
+    healthy: bool = True
+    enabled: bool = False
+    autoload: bool = False
+    status: Literal["disabled"] = "disabled"
+    wiring_status: Literal["not_wired"] = "not_wired"
+    runtime_mode: Literal["external_bridge"] = "external_bridge"
+    signing_mode: Literal["delegated_signer"] = "delegated_signer"
+    ready: bool = False
+    network_configured: bool = False
+    message: str = Field(min_length=1)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("message")
+    @classmethod
+    def _validate_message(cls, value: str) -> str:
+        return _normalize_required_string(value)

--- a/tests/plugins/test_resonantos_wallet_plugin.py
+++ b/tests/plugins/test_resonantos_wallet_plugin.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import importlib
+import socket
+from datetime import datetime, timezone
+
+from guardian.plugins.resonantos_wallet import (
+    RESONANTOS_WALLET_MANIFEST,
+    ResonantOSWalletPlugin,
+)
+from guardian.plugins.resonantos_wallet.types import (
+    AssetReference,
+    TransferIntentRequest,
+    VoteIntentRequest,
+    WalletAccountReference,
+)
+
+
+def _fixed_now() -> datetime:
+    return datetime(2026, 3, 10, 15, 30, 0, tzinfo=timezone.utc)
+
+
+def _block_network(*args, **kwargs):
+    raise AssertionError("network calls are out of scope for this scaffold")
+
+
+def test_manifest_is_disabled_by_default() -> None:
+    capability_ids = [
+        capability.id for capability in RESONANTOS_WALLET_MANIFEST.capabilities
+    ]
+
+    assert RESONANTOS_WALLET_MANIFEST.id == "resonantos_wallet"
+    assert RESONANTOS_WALLET_MANIFEST.name == "ResonantOS Wallet"
+    assert RESONANTOS_WALLET_MANIFEST.version == "0.1.0"
+    assert RESONANTOS_WALLET_MANIFEST.enabled is False
+    assert RESONANTOS_WALLET_MANIFEST.autoload is False
+    assert RESONANTOS_WALLET_MANIFEST.status == "disabled"
+    assert RESONANTOS_WALLET_MANIFEST.wiring_status == "not_wired"
+    assert RESONANTOS_WALLET_MANIFEST.runtime_mode == "external_bridge"
+    assert RESONANTOS_WALLET_MANIFEST.signing_mode == "delegated_signer"
+    assert capability_ids == [
+        "wallet_summary_read",
+        "recent_transaction_read",
+        "transfer_intent_create",
+        "governance_vote_intent_create",
+    ]
+
+
+def test_plugin_imports_cleanly_without_external_wallet_software() -> None:
+    module = importlib.import_module("guardian.plugins.resonantos_wallet")
+
+    assert module.ResonantOSWalletPlugin is ResonantOSWalletPlugin
+    assert module.RESONANTOS_WALLET_MANIFEST.id == "resonantos_wallet"
+
+
+def test_health_check_reports_disabled_not_wired() -> None:
+    plugin = ResonantOSWalletPlugin()
+
+    health = plugin.health_check()
+
+    assert health.plugin_id == "resonantos_wallet"
+    assert health.healthy is True
+    assert health.enabled is False
+    assert health.autoload is False
+    assert health.status == "disabled"
+    assert health.wiring_status == "not_wired"
+    assert health.runtime_mode == "external_bridge"
+    assert health.signing_mode == "delegated_signer"
+    assert health.ready is False
+    assert health.network_configured is False
+    assert "disabled" in health.message.lower()
+    assert "not wired" in health.message.lower()
+
+
+def test_create_transfer_intent_returns_structured_unsigned_payload(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(socket, "create_connection", _block_network)
+    plugin = ResonantOSWalletPlugin(now_factory=_fixed_now)
+    request = TransferIntentRequest(
+        source_account=WalletAccountReference(
+            account_ref="wallet://primary",
+            chain="solana",
+            network="mainnet-beta",
+        ),
+        destination_account_ref="wallet://counterparty",
+        asset=AssetReference(
+            asset_id="So11111111111111111111111111111111111111112",
+            symbol="SOL",
+        ),
+        amount="1.250000",
+        memo="rent settlement",
+    )
+
+    response = plugin.create_transfer_intent(request)
+
+    assert response.plugin_id == "resonantos_wallet"
+    assert response.intent_type == "transfer"
+    assert response.created_at == "2026-03-10T15:30:00Z"
+    assert response.execution_mode == "external_signer_required"
+    assert response.ready_for_submission is False
+    assert response.submitted is False
+    assert response.normalized_payload.model_dump(mode="json") == {
+        "source_account": {
+            "account_ref": "wallet://primary",
+            "chain": "solana",
+            "network": "mainnet-beta",
+        },
+        "destination_account_ref": "wallet://counterparty",
+        "asset": {
+            "asset_id": "So11111111111111111111111111111111111111112",
+            "symbol": "SOL",
+        },
+        "amount": "1.250000",
+        "memo": "rent settlement",
+    }
+
+
+def test_create_vote_intent_returns_structured_unsigned_payload(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(socket, "create_connection", _block_network)
+    plugin = ResonantOSWalletPlugin(now_factory=_fixed_now)
+    request = VoteIntentRequest(
+        voter_account=WalletAccountReference(
+            account_ref="wallet://governance",
+            chain="solana",
+            network="mainnet-beta",
+        ),
+        proposal_id="proposal-42",
+        vote_choice="approve",
+        rationale="aligns with treasury policy",
+    )
+
+    response = plugin.create_vote_intent(request)
+
+    assert response.plugin_id == "resonantos_wallet"
+    assert response.intent_type == "governance_vote"
+    assert response.created_at == "2026-03-10T15:30:00Z"
+    assert response.execution_mode == "external_signer_required"
+    assert response.ready_for_submission is False
+    assert response.submitted is False
+    assert response.normalized_payload.model_dump(mode="json") == {
+        "voter_account": {
+            "account_ref": "wallet://governance",
+            "chain": "solana",
+            "network": "mainnet-beta",
+        },
+        "proposal_id": "proposal-42",
+        "vote_choice": "approve",
+        "rationale": "aligns with treasury policy",
+    }


### PR DESCRIPTION
## Summary
- add the disabled ResonantOS wallet plugin scaffold with manifest, types, and plugin entry points
- cover the manifest, health check, and intent factories with new isolation-focused tests

## Testing
- Not run (not requested)