### PR TITLE
Introduce canonical service plugin facade

### DIFF
--- a/guardian/core/plugins.py
+++ b/guardian/core/plugins.py
@@ -1,35 +1,48 @@
-"""Centralized plugin loading helpers for runtime and manifest-based plugins."""
+"""Canonical facade for service-plugin discovery and invocation."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+import json
 import logging
+from typing import Any
+
+import requests
 from threading import Lock
-from urllib.parse import urlparse
 
 from guardian.plugin_loader import plugin_loader as _runtime_plugin_loader
-from guardian.plugins.plugin_loader import (
-    load_all_manifests as _load_manifest_plugins,
-)
+from guardian.plugins.plugin_loader import load_all_manifests
 from guardian.plugins.plugin_manifest import PluginManifest
 
 logger = logging.getLogger(__name__)
 
 _RUNTIME_LOADER_LOCK = Lock()
-_ALLOWED_ENTRYPOINT_SCHEMES = {"http", "https"}
+
+HEALTH_TIMEOUT_SECONDS = 2
+INVOKE_TIMEOUT_SECONDS = 10
+_PROTOCOL_VERSION = "1.0"
+
+
+@dataclass
+class PluginFacadeError(Exception):
+    """Stable facade error for plugin discovery and invocation failures."""
+
+    code: str
+    message: str
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"{self.code}: {self.message}"
+
+
 
 
 def get_runtime_plugin_loader():
-    """Return the singleton runtime plugin loader instance."""
+    """Return the singleton legacy runtime plugin loader instance."""
     return _runtime_plugin_loader
 
 
 def load_runtime_plugins():
-    """
-    Load runtime plugins through a single guarded entrypoint.
-
-    Loader invocation is idempotent for non-empty registries to avoid
-    accidental duplicate initialization across call sites.
-    """
+    """Load runtime plugins once for compatibility with legacy callers."""
     loader = get_runtime_plugin_loader()
     with _RUNTIME_LOADER_LOCK:
         if not getattr(loader, "plugins", {}):
@@ -37,66 +50,222 @@ def load_runtime_plugins():
     return loader
 
 
-def _has_safe_entrypoint(manifest: PluginManifest) -> bool:
-    parsed = urlparse(manifest.entrypoint)
-    return parsed.scheme in _ALLOWED_ENTRYPOINT_SCHEMES and bool(parsed.netloc)
-
-
 def list_plugin_manifests() -> list[PluginManifest]:
-    """Load plugin manifests with dedupe and basic entrypoint validation."""
-    manifests = _load_manifest_plugins()
-    filtered: list[PluginManifest] = []
-    seen_ids: set[str] = set()
+    """Return installed plugins from canonical validated manifest discovery."""
+    return load_all_manifests()
 
-    for manifest in manifests:
-        if manifest.id in seen_ids:
-            logger.warning(
-                "[plugins] duplicate plugin id skipped: %s", manifest.id
-            )
-            continue
-        if not _has_safe_entrypoint(manifest):
-            logger.warning(
-                "[plugins] unsafe plugin entrypoint skipped: %s (%s)",
-                manifest.id,
-                manifest.entrypoint,
-            )
-            continue
-        seen_ids.add(manifest.id)
-        filtered.append(manifest)
-
-    return filtered
 
 
 def get_plugin_manifest_by_id(plugin_id: str) -> PluginManifest | None:
-    """Return a plugin manifest by id from the centralized manifest list."""
+    """Return the installed manifest for a plugin id."""
     for manifest in list_plugin_manifests():
         if manifest.id == plugin_id:
             return manifest
     return None
 
 
-def get_plugin_manifest_by_capability(
+
+def find_plugins_by_capability_action(
     capability: str,
-) -> PluginManifest | None:
-    """Return the first plugin manifest declaring the requested capability."""
-    wanted = capability.strip().lower()
+    action: str,
+) -> list[PluginManifest]:
+    """Return manifests that advertise a callable (capability, action) pair."""
+    return [
+        manifest
+        for manifest in list_plugin_manifests()
+        if manifest.supports_operation(capability, action)
+    ]
+
+
+
+
+def get_plugin_manifest_by_capability(capability: str) -> PluginManifest | None:
+    """Compatibility helper for legacy TTS lookup by capability id only."""
+    wanted = capability.strip()
     if not wanted:
         return None
 
     for manifest in list_plugin_manifests():
-        capabilities = {
-            cap.strip().lower() for cap in (manifest.capabilities or []) if cap
-        }
-        if wanted in capabilities:
+        if any(cap.id == wanted for cap in manifest.capabilities):
             return manifest
-
     return None
 
 
+def _invoke_url(base_url: str) -> str:
+    return f"{base_url}/invoke"
+
+
+
+def _health_url(base_url: str) -> str:
+    return f"{base_url}/health"
+
+
+
+def _build_context(context: dict[str, Any] | None) -> dict[str, Any]:
+    defaults = {"request_id": "", "thread_id": None, "user_id": None}
+    if context:
+        defaults.update(context)
+    return defaults
+
+
+
+def _build_envelope(
+    *,
+    plugin_id: str,
+    capability: str,
+    action: str,
+    input: dict[str, Any],
+    context: dict[str, Any] | None,
+) -> dict[str, Any]:
+    return {
+        "protocol_version": _PROTOCOL_VERSION,
+        "plugin_id": plugin_id,
+        "capability": capability,
+        "action": action,
+        "input": input,
+        "context": _build_context(context),
+    }
+
+
+
+def _normalize_response(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise PluginFacadeError(
+            code="invalid_response",
+            message="plugin response must be a JSON object",
+        )
+    if "ok" not in payload:
+        raise PluginFacadeError(
+            code="invalid_response",
+            message="plugin response missing 'ok'",
+        )
+    if payload["ok"] is True:
+        return payload
+    if payload["ok"] is False:
+        raise PluginFacadeError(
+            code="remote_error",
+            message=str(payload.get("error") or "plugin reported an error"),
+        )
+    raise PluginFacadeError(
+        code="invalid_response",
+        message="plugin response field 'ok' must be a boolean",
+    )
+
+
+
+def _safe_json(response: requests.Response) -> dict[str, Any]:
+    try:
+        payload = response.json()
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise PluginFacadeError(
+            code="invalid_response",
+            message=f"plugin returned malformed JSON: {exc}",
+        ) from exc
+    return _normalize_response(payload)
+
+
+
+def invoke_plugin(
+    plugin_id: str,
+    capability: str,
+    action: str,
+    input: dict[str, Any],
+    context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Invoke a specific plugin service endpoint using the canonical envelope."""
+    manifest = get_plugin_manifest_by_id(plugin_id)
+    if manifest is None:
+        raise PluginFacadeError(
+            code="not_found",
+            message=f"plugin '{plugin_id}' not found",
+        )
+    if not manifest.supports_operation(capability, action):
+        raise PluginFacadeError(
+            code="not_found",
+            message=(
+                f"plugin '{plugin_id}' does not support "
+                f"{capability}/{action}"
+            ),
+        )
+
+    envelope = _build_envelope(
+        plugin_id=plugin_id,
+        capability=capability,
+        action=action,
+        input=input,
+        context=context,
+    )
+
+    try:
+        response = requests.post(
+            _invoke_url(manifest.base_url),
+            json=envelope,
+            timeout=INVOKE_TIMEOUT_SECONDS,
+        )
+    except requests.Timeout as exc:
+        raise PluginFacadeError(
+            code="timeout",
+            message=f"plugin invoke timed out for '{plugin_id}'",
+        ) from exc
+    except requests.RequestException as exc:
+        raise PluginFacadeError(
+            code="transport_failure",
+            message=f"plugin invoke transport failure for '{plugin_id}'",
+        ) from exc
+
+    return _safe_json(response)
+
+
+
+def invoke_capability(
+    capability: str,
+    action: str,
+    input: dict[str, Any],
+    context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Invoke a capability/action pair when exactly one plugin supports it."""
+    manifests = find_plugins_by_capability_action(capability, action)
+    if not manifests:
+        raise PluginFacadeError(
+            code="not_found",
+            message=f"no plugin found for {capability}/{action}",
+        )
+    if len(manifests) > 1:
+        plugin_ids = ", ".join(sorted(manifest.id for manifest in manifests))
+        raise PluginFacadeError(
+            code="ambiguous",
+            message=f"multiple plugins found for {capability}/{action}: {plugin_ids}",
+        )
+    return invoke_plugin(manifests[0].id, capability, action, input, context)
+
+
+
+def probe_plugin_health(plugin_id: str) -> dict[str, Any]:
+    """Fetch /health metadata without affecting installation state."""
+    manifest = get_plugin_manifest_by_id(plugin_id)
+    if manifest is None:
+        raise PluginFacadeError(code="not_found", message="plugin not found")
+
+    try:
+        response = requests.get(_health_url(manifest.base_url), timeout=HEALTH_TIMEOUT_SECONDS)
+        return response.json()
+    except requests.Timeout as exc:
+        raise PluginFacadeError(code="timeout", message="health check timed out") from exc
+    except requests.RequestException as exc:
+        raise PluginFacadeError(code="transport_failure", message="health check failed") from exc
+    except ValueError as exc:
+        raise PluginFacadeError(code="invalid_response", message="health response is not JSON") from exc
+
+
 __all__ = [
+    "PluginFacadeError",
+    "find_plugins_by_capability_action",
     "get_plugin_manifest_by_capability",
-    "get_plugin_manifest_by_id",
     "get_runtime_plugin_loader",
+    "get_plugin_manifest_by_id",
+    "invoke_capability",
+    "invoke_plugin",
     "list_plugin_manifests",
     "load_runtime_plugins",
+    "probe_plugin_health",
 ]

--- a/guardian/plugins/plugin_loader.py
+++ b/guardian/plugins/plugin_loader.py
@@ -1,79 +1,71 @@
-"""
-Plugin Loader
-~~~~~~~~~~~~~
+"""Canonical manifest discovery for service plugins."""
 
-Loads plugin manifests from the plugins directory. Each plugin is expected
-to have a manifest.json file in its subdirectory.
-"""
+from __future__ import annotations
 
 import json
 import logging
 from pathlib import Path
-from typing import List
+
+from pydantic import ValidationError
 
 from .plugin_manifest import PluginManifest
 
 logger = logging.getLogger(__name__)
 
-# Plugin directory at project root
-PLUGIN_DIR = Path(__file__).parent.parent.parent / "plugins"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_DIR = REPO_ROOT / "plugins"
 
 
-def load_all_manifests() -> List[PluginManifest]:
-    """
-    Load all plugin manifests from the plugins directory.
+class PluginDiscoveryError(Exception):
+    """Raised when manifest discovery fails deterministically."""
 
-    Scans the plugins directory for subdirectories containing manifest.json
-    files and parses them into PluginManifest objects.
 
-    Returns:
-        List of validated PluginManifest objects
-    """
-    manifests: List[PluginManifest] = []
+class DuplicatePluginIdError(PluginDiscoveryError):
+    """Raised when duplicate plugin ids are discovered."""
 
-    if not PLUGIN_DIR.exists():
-        logger.warning(
-            "[plugin_loader] Plugin directory not found: %s", PLUGIN_DIR
-        )
+
+def _manifest_files(plugin_dir: Path = PLUGIN_DIR) -> list[Path]:
+    return sorted(plugin_dir.glob("*/manifest.json"))
+
+
+def load_all_manifests(plugin_dir: Path = PLUGIN_DIR) -> list[PluginManifest]:
+    """Load and validate canonical v1 manifests from plugins/*/manifest.json."""
+    manifests: list[PluginManifest] = []
+    seen_manifest_by_id: dict[str, Path] = {}
+
+    if not plugin_dir.exists():
         return manifests
 
-    for manifest_file in PLUGIN_DIR.glob("*/manifest.json"):
+    for manifest_file in _manifest_files(plugin_dir):
         try:
-            with manifest_file.open() as f:
-                data = json.load(f)
-                manifest = PluginManifest(**data)
-                manifests.append(manifest)
-                logger.debug(
-                    "[plugin_loader] Loaded plugin: %s (%s)",
-                    manifest.name,
-                    manifest.id,
-                )
-        except json.JSONDecodeError as e:
-            logger.error(
-                "[plugin_loader] Invalid JSON in %s: %s", manifest_file, e
-            )
-        except Exception as e:
-            logger.error(
-                "[plugin_loader] Failed to load manifest %s: %s",
+            with manifest_file.open("r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+            manifest = PluginManifest.model_validate(payload)
+        except (json.JSONDecodeError, ValidationError) as exc:
+            logger.warning(
+                "[plugin_loader] skipping invalid manifest %s: %s",
                 manifest_file,
-                e,
+                exc,
             )
+            continue
 
-    logger.info("[plugin_loader] Loaded %d plugin(s)", len(manifests))
+        existing = seen_manifest_by_id.get(manifest.id)
+        if existing is not None:
+            message = (
+                f"duplicate plugin id '{manifest.id}' in "
+                f"{existing} and {manifest_file}"
+            )
+            raise DuplicatePluginIdError(message)
+
+        seen_manifest_by_id[manifest.id] = manifest_file
+        manifests.append(manifest)
+
     return manifests
 
 
-def get_plugin_by_id(plugin_id: str) -> PluginManifest | None:
-    """
-    Get a specific plugin manifest by ID.
-
-    Args:
-        plugin_id: The unique plugin identifier
-
-    Returns:
-        PluginManifest if found, None otherwise
-    """
-    for manifest in load_all_manifests():
+def get_plugin_by_id(plugin_id: str, plugin_dir: Path = PLUGIN_DIR) -> PluginManifest | None:
+    """Get a manifest by plugin id from canonical manifest discovery."""
+    for manifest in load_all_manifests(plugin_dir=plugin_dir):
         if manifest.id == plugin_id:
             return manifest
     return None

--- a/guardian/plugins/plugin_manifest.py
+++ b/guardian/plugins/plugin_manifest.py
@@ -1,57 +1,117 @@
-"""
-Plugin Manifest Schema
-~~~~~~~~~~~~~~~~~~~~~~
+"""Canonical v1 service-plugin manifest types and validation."""
 
-Defines the manifest schema for Codexify plugins. Plugins use this
-schema to register themselves, expose capabilities, and optionally
-render UI panels.
-"""
+from __future__ import annotations
 
-from typing import List, Literal, Optional
+from typing import Any
+from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class PluginCapability(BaseModel):
+    """Capability declaration for a service plugin."""
+
+    id: str = Field(..., min_length=1)
+    actions: list[str] = Field(..., min_length=1)
+
+    @field_validator("id")
+    @classmethod
+    def _validate_id(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("capability id must be non-empty")
+        return cleaned
+
+    @field_validator("actions")
+    @classmethod
+    def _validate_actions(cls, value: list[str]) -> list[str]:
+        cleaned: list[str] = []
+        for action in value:
+            normalized = action.strip()
+            if not normalized:
+                raise ValueError("capability actions must be non-empty")
+            cleaned.append(normalized)
+        return cleaned
 
 
 class PluginManifest(BaseModel):
-    """
-    Schema for plugin manifests.
+    """Canonical v1 manifest schema for HTTP service plugins."""
 
-    Plugins register themselves via a manifest.json file that conforms
-    to this schema. The manifest declares the plugin's identity,
-    entrypoint, required permissions, and optional UI configuration.
-    """
+    schema_version: str = Field(...)
+    id: str = Field(..., min_length=1)
+    name: str = Field(..., min_length=1)
+    version: str = Field(..., min_length=1)
+    description: str | None = None
+    base_url: str = Field(...)
+    capabilities: list[PluginCapability] = Field(...)
+    extensions: dict[str, Any] | None = None
 
-    id: str = Field(..., description="Unique plugin identifier")
-    name: str = Field(..., description="Human-readable plugin name")
-    entrypoint: str = Field(
-        ...,
-        description="Plugin entrypoint URL (e.g., 'http://localhost:8080/rpc')",
-    )
-    permissions: List[str] = Field(
-        default_factory=list,
-        description="Required permissions (e.g., 'threads.read', 'document.write')",
-    )
-    capabilities: Optional[List[str]] = Field(
-        default_factory=list,
-        description="Declared capabilities (e.g., 'tts', 'speakable', 'audio')",
-    )
-    ui_panel: Optional[bool] = Field(
-        default=False, description="Whether the plugin renders a UI panel"
-    )
-    ui_position: Optional[Literal["left", "right", "floating"]] = Field(
-        default="right", description="Position of the UI panel"
-    )
+    model_config = ConfigDict(extra="forbid")
 
-    model_config = ConfigDict(
-        json_schema_extra={
-            "example": {
-                "id": "codex",
-                "name": "Codex Plugin",
-                "entrypoint": "http://localhost:8081/rpc",
-                "permissions": ["threads.read", "document.write"],
-                "capabilities": [],
-                "ui_panel": True,
-                "ui_position": "right",
-            }
+    @field_validator("schema_version")
+    @classmethod
+    def _validate_schema_version(cls, value: str) -> str:
+        if value != "1.0":
+            raise ValueError("schema_version must be '1.0'")
+        return value
+
+    @field_validator("id", "name", "version")
+    @classmethod
+    def _validate_text_fields(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("field must be non-empty")
+        return cleaned
+
+    @field_validator("base_url")
+    @classmethod
+    def _validate_base_url(cls, value: str) -> str:
+        cleaned = value.strip()
+        parsed = urlparse(cleaned)
+        if parsed.scheme not in {"http", "https"}:
+            raise ValueError("base_url must use http or https")
+        if not parsed.netloc:
+            raise ValueError("base_url must include a host")
+        if parsed.path not in ("", "/"):
+            raise ValueError("base_url must not include a path")
+        if parsed.query:
+            raise ValueError("base_url must not include a query")
+        if parsed.fragment:
+            raise ValueError("base_url must not include a fragment")
+        return f"{parsed.scheme}://{parsed.netloc}".rstrip("/")
+
+    @field_validator("capabilities")
+    @classmethod
+    def _validate_capabilities_present(cls, value: list[PluginCapability]) -> list[PluginCapability]:
+        if not value:
+            raise ValueError("capabilities must not be empty")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_no_duplicate_operations(self) -> "PluginManifest":
+        operations: set[tuple[str, str]] = set()
+        duplicates: set[tuple[str, str]] = set()
+        for capability in self.capabilities:
+            for action in capability.actions:
+                key = (capability.id, action)
+                if key in operations:
+                    duplicates.add(key)
+                operations.add(key)
+
+        if duplicates:
+            dupes = ", ".join(f"{cap}:{act}" for cap, act in sorted(duplicates))
+            raise ValueError(f"duplicate capability/action pairs: {dupes}")
+
+        return self
+
+    def supports_operation(self, capability: str, action: str) -> bool:
+        """Return True when the manifest declares the capability/action pair."""
+        return (capability, action) in self.operations()
+
+    def operations(self) -> set[tuple[str, str]]:
+        """Callable operations represented as (capability, action) pairs."""
+        return {
+            (capability.id, action)
+            for capability in self.capabilities
+            for action in capability.actions
         }
-    )

--- a/guardian/tests/test_plugin_manifest.py
+++ b/guardian/tests/test_plugin_manifest.py
@@ -1,61 +1,180 @@
 import json
-import shutil
-import unittest
-from pathlib import Path
 
-from guardian.plugin_loader import PluginLoader
+import pytest
+from pydantic import ValidationError
+
+from guardian.plugins import plugin_loader
+from guardian.plugins.plugin_loader import DuplicatePluginIdError
+from guardian.plugins.plugin_manifest import PluginManifest
 
 
-class TestPluginLoader(unittest.TestCase):
-    def setUp(self):
-        self.plugin_dir = Path(
-            "tests/test_plugins"
-        )  # Use a dedicated test directory
-        self.plugin_loader = PluginLoader()
-        self.plugin_loader.plugin_dir = self.plugin_dir
-        self.manifest_path = self.plugin_dir / "plugin_manifest.json"
-        # Create test plugin directory and manifest
-        self.plugin_dir.mkdir(parents=True, exist_ok=True)
-        with open(self.manifest_path, "w") as f:
-            json.dump({}, f)
+def _write_manifest(base, plugin_dir, payload):
+    path = base / plugin_dir
+    path.mkdir(parents=True)
+    with (path / "manifest.json").open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle)
 
-    def tearDown(self):
-        # Clean up test plugin directory
-        if self.plugin_dir.exists():
-            shutil.rmtree(self.plugin_dir)
 
-    def test_update_manifest(self):
-        # Create a dummy plugin directory and metadata
-        dummy_plugin_path = self.plugin_dir / "dummy_plugin"
-        dummy_plugin_path.mkdir()
-        metadata = {
-            "name": "dummy_plugin",
-            "version": "0.1.0",
-            "description": "Dummy plugin for testing",
-            "author": "Test Author",
-            "dependencies": [],
-            "capabilities": [],
+def test_accepts_valid_v1_manifest_and_normalizes_base_url():
+    manifest = PluginManifest.model_validate(
+        {
+            "schema_version": "1.0",
+            "id": "alpha",
+            "name": "Alpha",
+            "version": "1.2.3",
+            "description": "desc",
+            "base_url": "https://example.com/",
+            "capabilities": [{"id": "chat", "actions": ["reply"]}],
+            "extensions": {"x": True},
         }
-        with open(dummy_plugin_path / "plugin.json", "w") as f:
-            json.dump(metadata, f)
+    )
 
-        # Load the dummy plugin
-        plugin = self.plugin_loader.load_plugin(dummy_plugin_path)
-        self.assertIsNotNone(plugin)
-        if plugin:
-            self.plugin_loader.plugins[plugin.name] = plugin
-
-        # Update the manifest
-        self.plugin_loader.update_manifest()
-
-        # Check manifest content
-        with open(self.manifest_path) as f:
-            manifest = json.load(f)
-
-        self.assertIn("active_plugins", manifest)
-        self.assertIn("disabled_plugins", manifest)
-        self.assertIn("dummy_plugin", manifest["active_plugins"])
+    assert manifest.base_url == "https://example.com"
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.parametrize(
+    "base_url",
+    ["ftp://example.com", "file:///tmp/nope", "wss://example.com"],
+)
+def test_rejects_non_http_base_url(base_url):
+    with pytest.raises(ValidationError):
+        PluginManifest.model_validate(
+            {
+                "schema_version": "1.0",
+                "id": "alpha",
+                "name": "Alpha",
+                "version": "1.2.3",
+                "base_url": base_url,
+                "capabilities": [{"id": "chat", "actions": ["reply"]}],
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://example.com/path",
+        "https://example.com?x=1",
+        "https://example.com#frag",
+    ],
+)
+def test_rejects_base_url_with_path_query_or_fragment(base_url):
+    with pytest.raises(ValidationError):
+        PluginManifest.model_validate(
+            {
+                "schema_version": "1.0",
+                "id": "alpha",
+                "name": "Alpha",
+                "version": "1.2.3",
+                "base_url": base_url,
+                "capabilities": [{"id": "chat", "actions": ["reply"]}],
+            }
+        )
+
+
+def test_rejects_duplicate_capability_action_pairs_within_manifest():
+    with pytest.raises(ValidationError):
+        PluginManifest.model_validate(
+            {
+                "schema_version": "1.0",
+                "id": "alpha",
+                "name": "Alpha",
+                "version": "1.2.3",
+                "base_url": "https://example.com",
+                "capabilities": [
+                    {"id": "chat", "actions": ["reply", "reply"]}
+                ],
+            }
+        )
+
+
+def test_only_validated_manifests_are_listed_as_installed(tmp_path):
+    _write_manifest(
+        tmp_path,
+        "good",
+        {
+            "schema_version": "1.0",
+            "id": "good",
+            "name": "Good",
+            "version": "1.0.0",
+            "base_url": "https://good.example",
+            "capabilities": [{"id": "chat", "actions": ["reply"]}],
+        },
+    )
+    _write_manifest(
+        tmp_path,
+        "bad",
+        {
+            "schema_version": "1.0",
+            "id": "bad",
+            "name": "Bad",
+            "version": "1.0.0",
+            "base_url": "ftp://bad.example",
+            "capabilities": [{"id": "chat", "actions": ["reply"]}],
+        },
+    )
+
+    manifests = plugin_loader.load_all_manifests(plugin_dir=tmp_path)
+
+    assert [manifest.id for manifest in manifests] == ["good"]
+
+
+def test_unhealthy_plugins_remain_installed_if_manifest_is_valid(tmp_path):
+    _write_manifest(
+        tmp_path,
+        "good",
+        {
+            "schema_version": "1.0",
+            "id": "good",
+            "name": "Good",
+            "version": "1.0.0",
+            "base_url": "https://good.example",
+            "capabilities": [{"id": "chat", "actions": ["reply"]}],
+        },
+    )
+
+    manifests = plugin_loader.load_all_manifests(plugin_dir=tmp_path)
+
+    assert len(manifests) == 1
+    assert manifests[0].id == "good"
+
+
+def test_canonical_discovery_uses_plugins_manifest_json_only(tmp_path):
+    (tmp_path / "one").mkdir(parents=True)
+    with (tmp_path / "one" / "plugin.json").open("w", encoding="utf-8") as handle:
+        json.dump({}, handle)
+    with (tmp_path / "one" / "manifest.yaml").open("w", encoding="utf-8") as handle:
+        handle.write("id: no")
+
+    _write_manifest(
+        tmp_path,
+        "two",
+        {
+            "schema_version": "1.0",
+            "id": "two",
+            "name": "Two",
+            "version": "1.0.0",
+            "base_url": "https://two.example",
+            "capabilities": [{"id": "chat", "actions": ["reply"]}],
+        },
+    )
+
+    manifests = plugin_loader.load_all_manifests(plugin_dir=tmp_path)
+
+    assert [manifest.id for manifest in manifests] == ["two"]
+
+
+def test_rejects_duplicate_plugin_ids_across_discovery(tmp_path):
+    payload = {
+        "schema_version": "1.0",
+        "id": "dup",
+        "name": "Dup",
+        "version": "1.0.0",
+        "base_url": "https://dup.example",
+        "capabilities": [{"id": "chat", "actions": ["reply"]}],
+    }
+    _write_manifest(tmp_path, "one", payload)
+    _write_manifest(tmp_path, "two", payload)
+
+    with pytest.raises(DuplicatePluginIdError):
+        plugin_loader.load_all_manifests(plugin_dir=tmp_path)

--- a/tests/core/test_plugins.py
+++ b/tests/core/test_plugins.py
@@ -1,111 +1,168 @@
+import pytest
+import requests
+
 from guardian.core import plugins as core_plugins
 from guardian.plugins.plugin_manifest import PluginManifest
 
 
-class DummyRuntimeLoader:
-    def __init__(self, plugins=None):
-        self.plugins = plugins or {}
-        self.load_calls = 0
-
-    def load_all_plugins(self):
-        self.load_calls += 1
-        self.plugins["loaded"] = object()
-
-
-def _manifest(
-    plugin_id: str,
-    *,
-    entrypoint: str,
-    capabilities: list[str] | None = None,
-) -> PluginManifest:
-    return PluginManifest(
-        id=plugin_id,
-        name=plugin_id,
-        entrypoint=entrypoint,
-        permissions=[],
-        capabilities=capabilities or [],
+def _manifest(plugin_id: str, cap_action: tuple[str, str]) -> PluginManifest:
+    capability, action = cap_action
+    return PluginManifest.model_validate(
+        {
+            "schema_version": "1.0",
+            "id": plugin_id,
+            "name": plugin_id,
+            "version": "0.1.0",
+            "base_url": "https://plugin.example",
+            "capabilities": [{"id": capability, "actions": [action]}],
+        }
     )
 
 
-def test_load_runtime_plugins_loads_once_when_empty(monkeypatch):
-    loader = DummyRuntimeLoader()
-    monkeypatch.setattr(
-        core_plugins,
-        "get_runtime_plugin_loader",
-        lambda: loader,
-    )
+def test_invoke_capability_fails_on_zero_matches(monkeypatch):
+    monkeypatch.setattr(core_plugins, "list_plugin_manifests", lambda: [])
 
-    loaded = core_plugins.load_runtime_plugins()
+    with pytest.raises(core_plugins.PluginFacadeError) as exc_info:
+        core_plugins.invoke_capability("chat", "reply", input={})
 
-    assert loaded is loader
-    assert loader.load_calls == 1
+    assert exc_info.value.code == "not_found"
 
 
-def test_load_runtime_plugins_skips_reload_when_registry_present(monkeypatch):
-    loader = DummyRuntimeLoader(plugins={"existing": object()})
-    monkeypatch.setattr(
-        core_plugins,
-        "get_runtime_plugin_loader",
-        lambda: loader,
-    )
-
-    loaded = core_plugins.load_runtime_plugins()
-
-    assert loaded is loader
-    assert loader.load_calls == 0
-
-
-def test_list_plugin_manifests_filters_duplicate_ids_and_unsafe_entrypoints(
-    monkeypatch,
-):
+def test_invoke_capability_fails_on_multiple_matches(monkeypatch):
     manifests = [
-        _manifest(
-            "tts_plugin",
-            entrypoint="http://localhost:7101",
-            capabilities=["tts"],
-        ),
-        _manifest(
-            "tts_plugin",
-            entrypoint="https://example.invalid",
-            capabilities=["tts"],
-        ),
-        _manifest("unsafe_plugin", entrypoint="file:///tmp/plugin"),
-        _manifest("safe_plugin", entrypoint="https://localhost:7201"),
+        _manifest("a", ("chat", "reply")),
+        _manifest("b", ("chat", "reply")),
     ]
+    monkeypatch.setattr(core_plugins, "list_plugin_manifests", lambda: manifests)
 
+    with pytest.raises(core_plugins.PluginFacadeError) as exc_info:
+        core_plugins.invoke_capability("chat", "reply", input={})
+
+    assert exc_info.value.code == "ambiguous"
+
+
+def test_explicit_plugin_invocation_works_when_multiple_share_operation(monkeypatch):
+    manifests = [
+        _manifest("a", ("chat", "reply")),
+        _manifest("b", ("chat", "reply")),
+    ]
+    monkeypatch.setattr(core_plugins, "list_plugin_manifests", lambda: manifests)
+
+    sent = {}
+
+    class DummyResponse:
+        def json(self):
+            return {"ok": True, "output": {"message": "hello"}}
+
+    def fake_post(url, json, timeout):
+        sent["url"] = url
+        sent["json"] = json
+        sent["timeout"] = timeout
+        return DummyResponse()
+
+    monkeypatch.setattr(core_plugins.requests, "post", fake_post)
+    result = core_plugins.invoke_plugin(
+        "a",
+        "chat",
+        "reply",
+        input={"prompt": "hi"},
+        context={"request_id": "req-1"},
+    )
+
+    assert result == {"ok": True, "output": {"message": "hello"}}
+    assert sent["url"] == "https://plugin.example/invoke"
+    assert sent["timeout"] == core_plugins.INVOKE_TIMEOUT_SECONDS
+    assert sent["json"] == {
+        "protocol_version": "1.0",
+        "plugin_id": "a",
+        "capability": "chat",
+        "action": "reply",
+        "input": {"prompt": "hi"},
+        "context": {
+            "request_id": "req-1",
+            "thread_id": None,
+            "user_id": None,
+        },
+    }
+
+
+def test_invoke_plugin_normalizes_timeout(monkeypatch):
     monkeypatch.setattr(
         core_plugins,
-        "_load_manifest_plugins",
-        lambda: manifests,
+        "list_plugin_manifests",
+        lambda: [_manifest("a", ("chat", "reply"))],
     )
 
-    filtered = core_plugins.list_plugin_manifests()
+    def raise_timeout(*_args, **_kwargs):
+        raise requests.Timeout("boom")
 
-    assert [manifest.id for manifest in filtered] == [
-        "tts_plugin",
-        "safe_plugin",
-    ]
+    monkeypatch.setattr(core_plugins.requests, "post", raise_timeout)
+
+    with pytest.raises(core_plugins.PluginFacadeError) as exc_info:
+        core_plugins.invoke_plugin("a", "chat", "reply", input={})
+
+    assert exc_info.value.code == "timeout"
 
 
-def test_get_plugin_manifest_by_capability_is_case_insensitive(monkeypatch):
-    manifests = [
-        _manifest(
-            "non_tts",
-            entrypoint="https://localhost:7000",
-            capabilities=["vision"],
-        ),
-        _manifest(
-            "voice",
-            entrypoint="https://localhost:7101",
-            capabilities=["TTS", "audio"],
-        ),
-    ]
+def test_invoke_plugin_normalizes_transport_failure(monkeypatch):
     monkeypatch.setattr(
-        core_plugins, "list_plugin_manifests", lambda: manifests
+        core_plugins,
+        "list_plugin_manifests",
+        lambda: [_manifest("a", ("chat", "reply"))],
     )
 
-    manifest = core_plugins.get_plugin_manifest_by_capability("tts")
+    def raise_transport(*_args, **_kwargs):
+        raise requests.ConnectionError("boom")
 
-    assert manifest is not None
-    assert manifest.id == "voice"
-    assert core_plugins.get_plugin_manifest_by_capability("missing") is None
+    monkeypatch.setattr(core_plugins.requests, "post", raise_transport)
+
+    with pytest.raises(core_plugins.PluginFacadeError) as exc_info:
+        core_plugins.invoke_plugin("a", "chat", "reply", input={})
+
+    assert exc_info.value.code == "transport_failure"
+
+
+def test_invoke_plugin_normalizes_malformed_json(monkeypatch):
+    monkeypatch.setattr(
+        core_plugins,
+        "list_plugin_manifests",
+        lambda: [_manifest("a", ("chat", "reply"))],
+    )
+
+    class BadJsonResponse:
+        def json(self):
+            raise ValueError("invalid")
+
+    monkeypatch.setattr(
+        core_plugins.requests,
+        "post",
+        lambda *_args, **_kwargs: BadJsonResponse(),
+    )
+
+    with pytest.raises(core_plugins.PluginFacadeError) as exc_info:
+        core_plugins.invoke_plugin("a", "chat", "reply", input={})
+
+    assert exc_info.value.code == "invalid_response"
+
+
+def test_invoke_plugin_normalizes_non_conforming_response(monkeypatch):
+    monkeypatch.setattr(
+        core_plugins,
+        "list_plugin_manifests",
+        lambda: [_manifest("a", ("chat", "reply"))],
+    )
+
+    class InvalidResponse:
+        def json(self):
+            return {"output": {"message": "missing ok"}}
+
+    monkeypatch.setattr(
+        core_plugins.requests,
+        "post",
+        lambda *_args, **_kwargs: InvalidResponse(),
+    )
+
+    with pytest.raises(core_plugins.PluginFacadeError) as exc_info:
+        core_plugins.invoke_plugin("a", "chat", "reply", input={})
+
+    assert exc_info.value.code == "invalid_response"


### PR DESCRIPTION
### Motivation
- Provide a narrow, validated v1 substrate for service plugins so discovery, validation, and invocation are centralized and deterministic.
- Prevent leaking raw HTTP/client errors and normalize invocation behavior and errors at the facade layer to make higher-level code robust and testable.
- Define a single canonical discovery location and manifest schema to prepare for future migration without changing existing UI/permissions or migrating live integrations.

### Description
- Add a canonical v1 manifest model with capability/action modeling, strict validation, base_url normalization, and duplicate (capability,action) rejection in `guardian/plugins/plugin_manifest.py` (`PluginManifest`, `PluginCapability`, `supports_operation`, `operations`).
- Implement canonical repository-root discovery of `plugins/<id>/manifest.json` only, skip invalid manifests, and deterministically raise on duplicate plugin ids in `guardian/plugins/plugin_loader.py` (`load_all_manifests`, `get_plugin_by_id`, `DuplicatePluginIdError`).
- Replace/introduce a unified runtime facade in `guardian/core/plugins.py` exposing `list_plugin_manifests`, `get_plugin_manifest_by_id`, `find_plugins_by_capability_action`, `invoke_plugin`, and `invoke_capability`, plus compatibility shims `get_runtime_plugin_loader` and `load_runtime_plugins` for legacy consumers; centralize envelope shaping and error normalization (`PluginFacadeError`, `_build_envelope`, `_safe_json`, `_normalize_response`, `probe_plugin_health`).
- Update devtools/inspection usage remains read-only by routing `guardian/routes/devtools.py` to the new canonical facade's `list_plugin_manifests` (no UI or permission changes were added).
- Add/replace backend tests covering manifest validation, canonical discovery semantics, and invocation behavior/error normalization in `guardian/tests/test_plugin_manifest.py` and `tests/core/test_plugins.py`.

### Testing
- Ran targeted backend tests (with isolated import-time startup): `PYTHONPATH=. DATABASE_URL=sqlite:////tmp/codexify_test.db LOCAL_DATABASE_URL=sqlite:////tmp/codexify_test.db pytest -v --noconftest tests/core/test_plugins.py guardian/tests/test_plugin_manifest.py` and received: `19 passed`.
- A plain `pytest -v tests/core/test_plugins.py guardian/tests/test_plugin_manifest.py` run failed during global collection due to unrelated repository import-time issues (pre-existing startup errors unrelated to this change); the focused run above validated the new manifest/discovery/facade behavior.
- Git commit: `0321d2e5109083d80ebf644c1d88a3ca95f99c22`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab2d1654f8832da92570a65020cfc7)