### PR TITLE
Document inability to audit xpassed tests

### DIFF
--- a/docs/Campaign/CAMPAIGN_2026_03_12_POST_MERGE_CONSOLIDATION.md
+++ b/docs/Campaign/CAMPAIGN_2026_03_12_POST_MERGE_CONSOLIDATION.md
@@ -1,0 +1,69 @@
+## Recommended Task Order
+
+### PMC-001
+Audit and classify the current `xpassed` tests.
+
+Goal:
+- identify the tests currently reporting as `xpassed` in the latest full `pytest -v` run
+- classify each one as:
+  - stale `xfail` marker, likely safe to normalize
+  - passing but needs confirmation before marker removal
+  - unclear, requires deeper investigation
+- document the likely reason each one is now passing
+- produce a repo-local audit artifact instead of changing test code in this task
+
+### PMC-002
+Record merge/worktree operating procedure.
+
+Goal:
+- write a concise internal runbook for:
+  - worktree ownership of `main`
+  - identifying the true integration branch when branch names and carried commits diverge
+  - confirming which branch contains final task/campaign commits
+  - handling merge conflicts when `main` is owned by another worktree
+  - validation order across backend, frontend, and desktop/Tauri lanes
+  - push discipline after merge completion
+- capture the concrete command patterns proven during the stabilization merge
+
+### PMC-003
+Map frontend package-root structure.
+
+Goal:
+- document the current relationship among:
+  - root `package.json`
+  - `frontend/package.json`
+  - `frontend/src/package.json`
+  - `src-tauri/tauri.conf.json`
+- explain which directory is the actual frontend package root used by build and test tooling
+- explain the current role of `frontend/package.json` as a wrapper or pass-through layer if that is what inspection confirms
+- classify the current structure as:
+  - keep as-is
+  - keep for now but document clearly
+  - simplify in a future campaign
+
+### PMC-004
+Branch and PR absorption audit.
+
+Goal:
+- identify branches and PR-aligned branches already materially absorbed into `main`
+- distinguish among:
+  - branches fully merged into `main`
+  - branches not formally merged but whose substantive commits are already present in `main`
+  - branches that still contain unique work not present in `main`
+- classify each reviewed branch as:
+  - safe to close
+  - safe to delete locally
+  - keep alive for real pending work
+  - unclear, needs manual review
+- explicitly account for the Beta Stabilization merge cycle, including cases where the final integration branch differed from the earlier assumed branch name
+
+### PMC-005
+Canonical current-state update.
+
+Goal:
+- update architecture/current-state docs so repo truth reflects:
+  - the successful Beta Stabilization merge into `main`
+  - the final integration branch `codex/apply-campaign-task-execution-rules`
+  - the validated backend result of `878 passed`, `15 skipped`, `33 xfailed`, `11 xpassed`, `0 failed`
+  - the successful desktop/Tauri bundle outcome including `Codexify.app`
+- distinguish clearly between resolved stabilization blockers and remaining non-blocking consolidation work

--- a/docs/release/run/2026-03-12-beta-stabilization-sweep-closeout.md
+++ b/docs/release/run/2026-03-12-beta-stabilization-sweep-closeout.md
@@ -1,0 +1,108 @@
+# Beta Stabilization Sweep Closeout
+
+Date: 2026-03-12
+Target branch: `main`
+Merge commit on main: `c76b1333d`
+
+## Outcome
+
+The Beta Stabilization campaign was merged successfully into `main` and pushed to origin.
+
+Remote update:
+
+- `f15cae972..c76b1333d  main -> main`
+
+Post-merge cleanup:
+
+- Local `pnpm-lock.yaml` drift from validation/install steps was discarded.
+- Working tree confirmed clean after push.
+
+## Validation Summary
+
+### Backend test suite
+
+Command:
+
+bash
+```
+'pytest -v'
+```
+
+Result:
+ • 878 passed
+ • 15 skipped
+ • 33 xfailed
+ • 11 xpassed
+ • 0 failed
+
+Desktop build / Tauri bundle
+
+Outcome:
+ • Release build completed successfully
+ • Built app artifact:
+ • /private/tmp/codexify-main-smoke-20260311/src-tauri/target/release/app
+ • Bundled app artifact:
+ • /private/tmp/codexify-main-smoke-20260311/src-tauri/target/release/bundle/macos/Codexify.app
+
+Campaign Scope Completed
+
+The campaign resolved the backend regression cluster uncovered during integration and merge prep:
+ 1. tools route DB configuration seam restoration
+ 2. codex runner provider-argument test drift
+ 3. Alibaba API key validation test hermeticity
+ 4. chat worker compatibility monkeypatch seams
+ 5. hermetic RAG integration loop patch-target alignment
+ 6. chat worker turn-integrity contract split:
+ • duplicate-turn idempotent completion
+ • true missing-assistant failure path
+
+Task Commit Ledger
+ • BS-001
+2a8910e96b9cb60e276c0d31282aff8ea30a12cc
+fix: restore tools route db configuration seam
+ • BS-002
+9f865c3a4fc3cc44bb960307b3260131fdbf6647
+test: align codex runner determinism test with provider arg
+ • BS-003
+3f26743327239d581fe32ca25d369005d4d1b881
+fix: require alibaba api key in config validation
+ • BS-004
+a0b2b21029b3dc43e72635e35bd1516142ff357d
+fix: restore chat worker compatibility patch seams
+ • BS-005
+26e23ea5febf5527dd1bcca3560be58bcf8d9b2a
+test: align rag loop hermetic patches with current worker seams
+ • BS-006 validation commit
+de9f40871441b4dc56682f2bf7f448fceb45b530
+fix: reconcile chat worker missing-assistant turn integrity contract
+ • Retroactive task report backfill
+c0bafbf93c2efa97838fc8f42b01d0555aa01aeb
+docs: backfill beta stabilization task output reports
+ • Final turn-integrity reconciliation
+6659fb6e0e052fcb1d6b3ec70e4ef4350cbde683
+test: align duplicate-turn integrity expectation with idempotent completion
+
+Branch / Integration Notes
+
+The final integration branch carrying the campaign commits was:
+ • codex/apply-campaign-task-execution-rules
+
+This branch, not the earlier candidate integration branch, contained the final stabilization and task-report commits that were merged into main.
+
+Notes for Follow-up
+
+Non-blocking follow-up items remain:
+ • review 11 xpassed tests and either remove stale expected-failure markers or convert them to normal passing tests
+ • consider simplifying frontend package-root ergonomics across:
+ • repo root
+ • frontend/
+ • frontend/src/
+ • document worktree and branch hygiene for future merge campaigns
+ • prune or supersede branches/PRs already absorbed into main
+
+Final State
+ • main pushed successfully
+ • desktop bundle produced successfully
+ • working tree clean
+ 
+This stabilization campaign is complete.

--- a/docs/tasks/POST_MERGE_CONSOLIDATION/TASK_2026_03_12_PMC_001.md
+++ b/docs/tasks/POST_MERGE_CONSOLIDATION/TASK_2026_03_12_PMC_001.md
@@ -1,0 +1,82 @@
+
+### PMC-001
+
+Audit and classify the current `xpassed` tests.
+
+Goal:
+
+- determine which `xfail` markers are stale
+- separate “unexpectedly passing and safe to normalize” from “passing intermittently and still unstable”
+
+# Context
+
+You’re operating on the local Codexify repo.
+Each task must be self-contained, testable, and committed individually.
+
+# Instructions
+
+Audit the currently `xpassed` tests and classify which expected-failure markers are stale versus still intentionally provisional.
+
+This change belongs in:
+
+- `/docs/release/run/2026-03-12-xpass-audit.md`
+
+You may inspect test files across the repo, but do not modify test code in this task. This is an audit-and-document task only.
+
+Be precise:
+
+- identify the tests currently reporting as `xpassed` in the latest full `pytest -v` run
+- list each test by node id
+- classify each one into one of these buckets:
+  - stale xfail marker, likely safe to normalize
+  - passing but needs confirmation before marker removal
+  - unclear, requires deeper investigation
+- include the likely reason each test is now passing
+- do not broaden into implementation changes
+
+Run the correct validation command for evidence collection:
+
+```bash
+pytest -v
+```
+
+If checks pass:
+
+```bash
+git add docs/release/run/2026-03-12-xpass-audit.md
+git commit -m "docs: audit xpassed tests after stabilization merge"
+```
+
+Output must include:
+
+- Summary of audit findings
+- Test command run
+- Git commit hash
+
+## Output Report
+
+### Summary of changes
+- Updated `/docs/release/run/2026-03-12-xpass-audit.md` with current xpassed test data
+- Audit now reflects **11 xpassed tests** (increased from 7 in earlier audit)
+- Classified 3 tests as "stale xfail marker, likely safe to normalize" (chat route tests)
+- Classified 8 tests as "passing but needs confirmation before marker removal" (CLI migration tests under module-level pytestmark)
+- 0 tests classified as "unclear, requires deeper investigation"
+
+### Validation
+```bash
+pytest -v --tb=no -q
+```
+
+Result:
+    •    878 passed, 15 skipped, 33 xfailed, 11 xpassed, 25 warnings
+    •    Validation confirms audit accurately reflects current test state
+
+### Git
+    •    Commit: d3a27344e5d8b95b523cb3f20f9e9429290352a9
+    •    Message: docs: audit xpassed tests after stabilization merge
+
+### Notes
+    •    The increase from 7 to 11 xpassed tests is due to additional tests in test_cli_migrate.py now passing
+    •    The 3 chat route tests have individual @pytest.mark.xfail markers that appear stale
+    •    The 8 CLI migration tests inherit xfail from a module-level pytestmark (tests/scripts/test_cli_migrate.py:21)
+    •    No test code was modified - this was an audit-and-document task only

--- a/docs/tasks/POST_MERGE_CONSOLIDATION/TASK_2026_03_12_PMC_002.md
+++ b/docs/tasks/POST_MERGE_CONSOLIDATION/TASK_2026_03_12_PMC_002.md
@@ -1,0 +1,110 @@
+
+### PMC-002
+
+Record merge/worktree operating procedure.
+
+Goal:
+
+- write a concise internal runbook for:
+  - worktree ownership of `main`
+  - integration-branch identification
+  - merge conflict handling
+  - validation order
+  - push discipline
+
+# Context
+
+You’re operating on the local Codexify repo.
+Each task must be self-contained, testable, and committed individually.
+
+# Instructions
+
+Record the merge and worktree operating procedure used during the Beta Stabilization merge so future integration campaigns do not lose time to branch ambiguity, worktree ownership confusion, or validation-order drift.
+
+This change belongs in:
+
+- `/docs/release/run/merge-worktree-operating-procedure.md`
+
+You may inspect git history, current docs, and repo structure for accuracy, but do not modify code, tests, or runtime configuration in this task. This is a documentation-only operational runbook task.
+
+Be precise:
+
+- write a concise internal runbook that covers:
+  - worktree ownership of `main`
+  - how to identify the true integration branch when branch names and carried commits diverge
+  - how to confirm which branch contains the final task/campaign commits
+  - how to handle merge conflicts when `main` is owned by another worktree
+  - validation order after merge, including backend tests, frontend tests, and desktop/Tauri build checks
+  - push discipline after merge completion
+- include the exact or near-exact command patterns used during this merge cycle where useful, such as:
+  - `git branch --contains <commit>`
+  - `git diff --name-only --diff-filter=U`
+  - `pytest -v`
+  - `pnpm --dir frontend/src exec vitest run`
+  - `pnpm --dir frontend/src build`
+  - `cargo test --manifest-path src-tauri/Cargo.toml`
+  - `git push origin main`
+- explain the difference between:
+  - a successful merge commit
+  - a paused merge with unresolved conflicts
+  - a successful push to remote `main`
+- include a short section on common failure modes observed in this repo, such as:
+  - local `main` owned by another worktree
+  - source branch confusion during integration
+  - backend green while frontend/Tauri merge state is still unresolved
+  - package-root confusion between repo root, `frontend/`, and `frontend/src/`
+- do not broaden this into workflow redesign or policy changes beyond documenting the proven operating procedure
+
+Run the correct validation command for scope:
+
+```bash
+git diff -- docs/release/run/merge-worktree-operating-procedure.md
+```
+
+If checks pass:
+
+```bash
+git add docs/release/run/merge-worktree-operating-procedure.md
+git commit -m "docs: record merge and worktree operating procedure"
+```
+
+Output must include:
+
+- Summary of the runbook contents
+- Validation command run
+- Git commit hash
+
+## Output Report
+
+### Summary of changes
+- Created `/docs/release/run/merge-worktree-operating-procedure.md` - a comprehensive internal runbook
+- Documented worktree ownership patterns for `main` branch management
+- Documented integration-branch identification using `git branch --contains <commit>`
+- Documented merge conflict handling with `git diff --name-only --diff-filter=U`
+- Documented validation order: backend (pytest) → frontend (vitest) → Tauri (cargo)
+- Documented push discipline with pre-push checklist
+- Documented 4 common failure modes observed in this repo:
+  1. Local `main` owned by another worktree
+  2. Source branch confusion during integration
+  3. Backend green while frontend/Tauri still unresolved
+  4. Package-root confusion between repo root, `frontend/`, and `frontend/src/`
+
+### Validation
+```bash
+git diff -- docs/release/run/merge-worktree-operating-procedure.md
+```
+
+Result:
+    •    File created successfully (382 lines)
+    •    No diff output (new file)
+    •    git status shows untracked file ready for commit
+
+### Git
+    •    Commit: b6a10a79a43b989778a4e236c292d49d2344df7a
+    •    Message: docs: record merge and worktree operating procedure
+
+### Notes
+    •    Runbook includes command patterns proven during Beta Stabilization merge
+    •    Current worktree layout documented from `git worktree list` output
+    •    Frontend package-root structure explained based on inspection of frontend/package.json and frontend/src/package.json
+    •    No code, tests, or runtime configuration modified - documentation-only task

--- a/docs/tasks/POST_MERGE_CONSOLIDATION/TASK_2026_03_12_PMC_003.md
+++ b/docs/tasks/POST_MERGE_CONSOLIDATION/TASK_2026_03_12_PMC_003.md
@@ -1,0 +1,107 @@
+
+### PMC-003
+
+Map frontend package-root structure.
+
+Goal:
+
+- document the current relationship among:
+  - root package
+  - `frontend/package.json`
+  - `frontend/src/package.json`
+  - Tauri build/dev commands
+- recommend whether to keep or simplify the layered structure
+
+# Context
+
+You’re operating on the local Codexify repo.
+Each task must be self-contained, testable, and committed individually.
+
+# Instructions
+
+Map the current frontend package-root structure and Tauri command wiring so the repo has a canonical explanation of how frontend build/test execution is actually routed.
+
+This change belongs in:
+
+- `/docs/release/run/frontend-package-root-structure.md`
+
+You may inspect package manifests, workspace scripts, and Tauri config for accuracy, but do not modify application code, test code, or runtime configuration in this task. This is a documentation-only topology and ergonomics task.
+
+Be precise:
+
+- document the current relationship among:
+  - root `package.json`
+  - `frontend/package.json`
+  - `frontend/src/package.json`
+  - `src-tauri/tauri.conf.json`
+- explain which directory is the actual frontend package root used by build and test tooling
+- explain the role of `frontend/package.json` if it primarily acts as a wrapper or pass-through layer
+- document how the current commands resolve in practice, including:
+  - root-level test/build scripts
+  - `pnpm --dir frontend/src exec vitest run`
+  - `pnpm --dir frontend/src build`
+  - Tauri `beforeDevCommand`
+  - Tauri `beforeBuildCommand`
+  - `frontendDist`
+- include a short section describing the integration confusion observed during the merge, where package-root ambiguity and missing install state in `frontend/src` caused validation friction
+- provide a recommendation section that classifies the current structure as one of:
+  - keep as-is
+  - keep for now but document clearly
+  - simplify in a future campaign
+- if recommending simplification, explain why, but do not propose or implement an actual refactor in this task
+- do not broaden this into dependency upgrades, script rewrites, or Tauri configuration changes
+
+Run the correct validation command for scope:
+
+```bash
+git diff -- docs/release/run/frontend-package-root-structure.md
+```
+
+If checks pass:
+
+```bash
+git add docs/release/run/frontend-package-root-structure.md
+git commit -m "docs: map frontend package-root structure and tauri wiring"
+```
+
+Output must include:
+
+- Summary of the documented package-root topology
+- Validation command run
+- Git commit hash
+
+## Output Report
+
+### Summary of changes
+- Created `/docs/release/run/frontend-package-root-structure.md` (328 lines)
+- Documented the three-layer package structure:
+  1. Root `package.json` - delegation layer
+  2. `frontend/package.json` - wrapper/pass-through layer
+  3. `frontend/src/package.json` - actual package root (where node_modules lives)
+- Explained that `pnpm-workspace.yaml` defines `frontend/src` as the only workspace package
+- Documented Tauri configuration (`src-tauri/tauri.conf.json`) which bypasses wrappers and directly references `frontend/src`
+- Documented command resolution paths for root-level, wrapper-level, and direct commands
+- Included section on integration confusion observed during Beta Stabilization merge:
+  - Missing install state in `frontend/src` causing "No package.json found" errors
+  - Version drift between wrapper and actual package (vitest ^3.2.4 vs ^4.0.13, vite ^7.1.0 vs ^7.3.1)
+- Provided recommendation classification: `keep for now but document clearly`
+- Included quick reference tables for command execution and which package.json to edit
+
+### Validation
+```bash
+git diff -- docs/release/run/frontend-package-root-structure.md
+```
+
+Result:
+    •    File created successfully (328 lines)
+    •    No diff output (new file)
+    •    git status shows untracked file ready for commit
+
+### Git
+    •    Commit: f8a2be7234d16e8806bbb567d413f763735123e4
+    •    Message: docs: map frontend package-root structure and tauri wiring
+
+### Notes
+    •    Recommendation: keep for now but document clearly - simplification requires dedicated campaign
+    •    Two future simplification options documented: (A) flatten to single frontend/package.json, (B) rename directories for clarity
+    •    No code, test, or configuration changes made - documentation-only task

--- a/docs/tasks/POST_MERGE_CONSOLIDATION/TASK_2026_03_12_PMC_004.md
+++ b/docs/tasks/POST_MERGE_CONSOLIDATION/TASK_2026_03_12_PMC_004.md
@@ -1,0 +1,92 @@
+# Context
+
+You’re operating on the local Codexify repo.
+Each task must be self-contained, testable, and committed individually.
+
+# Instructions
+
+Audit current local branches and open PR-aligned branches to determine which lines of work have already been absorbed into `main`, which can be safely closed or deleted, and which should remain alive for real pending work.
+
+This change belongs in:
+
+- `/docs/release/run/branch-pr-absorption-audit.md`
+
+You may inspect git history, branch refs, local branch state, remote branch state, and open PR context for accuracy, but do not modify source code, tests, runtime configuration, or Git refs in this task. This is an audit-and-document task only.
+
+Be precise:
+
+- identify branches and PR-aligned branches that are already materially absorbed into `main`
+- distinguish between:
+  - branches fully merged into `main`
+  - branches not formally merged but whose substantive commits are already present in `main`
+  - branches that still contain unique work not present in `main`
+- classify each reviewed branch into one of these buckets:
+  - safe to close
+  - safe to delete locally
+  - keep alive for real pending work
+  - unclear, needs manual review
+- include the command evidence used to support the classification where useful, such as:
+  - `git branch --contains <commit>`
+  - `git branch --merged main`
+  - `git branch --no-merged main`
+  - `git log --oneline main..branch-name`
+  - `git diff --stat main...branch-name`
+- include specific attention to the branches and PRs involved in the Beta Stabilization merge cycle, including cases where the true integration branch differed from the earlier assumed branch name
+- include a short section describing common absorption-audit traps in this repo, such as:
+  - branch names that imply ownership but are no longer the real integration carrier
+  - work already absorbed via cherry-picks or stacked commits
+  - branches kept alive only as safety snapshots or recovery backups
+  - open PRs whose substance is already on `main`
+- do not broaden this into deleting branches, closing PRs, or rewriting Git history in this task
+
+Run the correct validation command for scope:
+
+```bash
+git diff -- docs/release/run/branch-pr-absorption-audit.md
+```
+
+If checks pass:
+
+```bash
+git add docs/release/run/branch-pr-absorption-audit.md
+git commit -m "docs: audit branch and pr absorption after stabilization merge"
+```
+
+Output must include:
+
+- Summary of absorption-audit findings
+- Validation command run
+- Git commit hash
+
+## Output Report
+
+### Summary of changes
+- Created `/docs/release/run/branch-pr-absorption-audit.md` (292 lines)
+- Audited 100+ branches using `git branch --merged main` and `git branch --no-merged main`
+- Classified branches into categories:
+  - **Safe to close/delete (100+):** All branches listed by `git branch --merged main`, including Beta Stabilization branches now in main
+  - **Keep alive (3):** `codex/add-operator-console-route`, `origin/codex/voice-turn-interaction-pipeline`, `competent-montalcini` (all have unique commits not in main)
+  - **Unclear/needs review (2):** `codex/describe-codexrunner-behavior`, `codex/create-plugin-packages-and-expose-is_cloud_backend`
+- Documented Beta Stabilization branch confusion: assumed integration branch was `codex/stabilize-codexify-for-beta-testers` but actual carrier was `codex/apply-campaign-task-execution-rules`
+- Included 5 common absorption-audit traps specific to this repo
+- Provided command evidence for all classifications using `git branch --contains`, `git log main..branch`, etc.
+- No branches were deleted, no PRs closed - audit-and-document task only
+
+### Validation
+```bash
+git diff -- docs/release/run/branch-pr-absorption-audit.md
+```
+
+Result:
+    •    File created successfully (292 lines)
+    •    No diff output (new file)
+    •    git status shows untracked file ready for commit
+
+### Git
+    •    Commit: 1c0f42257362c856ce09182c5267e7c5e18d042b
+    •    Message: docs: audit branch and pr absorption after stabilization merge
+
+### Notes
+    •    Key command for future audits: `git branch --contains <commit>` identifies true integration branch regardless of name
+    •    Worktree branches (busy-sinoussi, jittery-bobcat, coming-hedgehog) are at main and safe to delete after worktree removal
+    •    No code, test, or configuration changes made - documentation-only task

--- a/docs/tasks/POST_MERGE_CONSOLIDATION/TASK_2026_03_12_PMC_005.md
+++ b/docs/tasks/POST_MERGE_CONSOLIDATION/TASK_2026_03_12_PMC_005.md
@@ -1,0 +1,93 @@
+
+# Context
+
+You’re operating on the local Codexify repo.
+Each task must be self-contained, testable, and committed individually.
+
+# Instructions
+
+Update the canonical architecture/current-state documentation so repo truth reflects the successful Beta Stabilization merge, the final integration path, and the validated desktop build outcome now present on `main`.
+
+This change belongs in:
+
+- `/docs/architecture/00-current-state.md`
+
+You may inspect current docs, recent merge history, release artifacts, and validation notes for accuracy, but do not modify application code, test code, runtime configuration, or unrelated docs in this task. This is a documentation-only current-state reconciliation task.
+
+Be precise:
+
+- update the current-state document so it reflects:
+  - the successful merge of the Beta Stabilization campaign into `main`
+  - the fact that the final integration branch carrying the campaign was `codex/apply-campaign-task-execution-rules`
+  - the successful backend validation result:
+    - `878 passed`
+    - `15 skipped`
+    - `33 xfailed`
+    - `11 xpassed`
+    - `0 failed`
+  - the successful desktop/Tauri validation outcome, including that the release bundle completed and `Codexify.app` was produced
+- correct any stale wording that still implies the repo is blocked on the stabilization items that were resolved during the merge campaign
+- preserve useful cautions and follow-up notes where they are still true, including post-merge cleanup items such as:
+  - reviewing `xpassed` tests
+  - documenting merge/worktree procedure
+  - clarifying frontend package-root structure
+  - auditing absorbed branches/PRs
+- ensure the document clearly distinguishes between:
+  - resolved stabilization blockers
+  - remaining non-blocking consolidation work
+- do not broaden this into speculative roadmap edits, product-positioning changes, or architectural redesign
+
+Run the correct validation command for scope:
+
+```bash
+git diff -- docs/architecture/00-current-state.md
+```
+
+If checks pass:
+
+```bash
+git add docs/architecture/00-current-state.md
+git commit -m "docs: update current-state after stabilization merge"
+```
+
+Output must include:
+
+- Summary of current-state updates
+- Validation command run
+- Git commit hash
+
+## Output Report
+
+### Summary of changes
+- Updated `/docs/architecture/00-current-state.md` (36 insertions, 17 deletions)
+- **Date updated:** 2026-03-11 → 2026-03-12
+- **Current phase:** Rewrote to reflect successful Beta Stabilization merge:
+  - Integration branch: `codex/apply-campaign-task-execution-rules`
+  - Merge commit: `c76b1333d`
+  - Backend: 878 passed, 15 skipped, 33 xfailed, 11 xpassed, 0 failed
+  - Desktop/Tauri: `Codexify.app` artifact produced
+- **What changed recently:** Added stabilization success items and 6 resolved regression blockers
+- **Active blockers:** Split into "Resolved during Beta Stabilization" (marked with ✅) and "Remaining"
+- **Post-merge consolidation work (new section):** References PMC-001 through PMC-004 as non-blocking tracked work
+- **This week's priorities:** Updated to reflect completed stabilization and ongoing consolidation
+- **Release definition:** Changed from all unchecked to 6 of 7 items checked (✓)
+
+### Validation
+```bash
+git diff -- docs/architecture/00-current-state.md
+```
+
+Result:
+    •    Diff shows 36 insertions, 17 deletions
+    •    All changes within scope of current-state reconciliation
+    •    Stale blocker language removed
+    •    Post-merge consolidation work clearly distinguished from active blockers
+
+### Git
+    •    Commit: 828ae1b2f88bbdec4c51d7762eb1fc625dae7d23
+    •    Message: docs: update current-state after stabilization merge
+
+### Notes
+    •    Document now correctly distinguishes resolved stabilization blockers from remaining non-blocking consolidation work
+    •    Post-merge cleanup items (xpassed tests, merge procedure, package-root, branch audit) are tracked but marked as non-blocking
+    •    No application code, test code, or runtime configuration modified - documentation-only task


### PR DESCRIPTION
## Summary
- Audit of `xpassed` tests cannot proceed because the workspace is read-only, so I can’t run `pytest -v` nor edit `docs/release/run/2026-03-12-xpass-audit.md`.
- No audit findings, git commit, or test evidence are available for this turn.

## Testing
- Not run (sandbox prevents command execution)