### PR TITLE
runner: canonicalize artifact paths with legacy support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,10 +121,10 @@ gitleaks-report.txt
 gitleaks-report.*
 
 # Local audit outputs
-/docs/_audit_runs/
+/artifacts/audit-runs/
 
 # local reports
-/docs/reports/
+/docs/work/reports/
 
 # Local temp artifacts
 /guardian/temp/
@@ -185,3 +185,8 @@ codex_runner/.github/
 # local runs/audits
 /docs/_audits/
 /docs/_campaign_runs/
+/artifacts/audits/
+/artifacts/campaign-runs/
+
+# Local tooling artifacts
+codex_runner.zip

--- a/codex_ralph_loop/CODEX.md
+++ b/codex_ralph_loop/CODEX.md
@@ -21,7 +21,7 @@ This repo depends on fast-moving tools and specs. Use web research *selectively*
 - Any library/API surface that likely changed since 2024
 2. Do not use web research for timeless basics (JSON, HTTP fundamentals, TypeScript syntax, etc.).
 3. Prefer primary sources (official docs, upstream GitHub repos/releases).
-4. When validating a framework/library behavior, first identify the version used in this repo (for example from `package.json`, lockfiles, or official config), and search against that version’s docs/release notes.
+4. When validating a framework/library behavior, first identify the version used in this repo (for example from `package.json`, lockfiles, or official config), and search against that version’s docs/reference/operator/release notes.
 5. When you rely on web research for a finding, include an **External References** section in the report with:
 - URL
 - Date accessed (today’s date is provided by the runner)

--- a/codex_runner/README.md
+++ b/codex_runner/README.md
@@ -182,7 +182,7 @@ Unknown preset keys are ignored with warnings.
 ## Core guarantees
 
 - Runner owns identifiers (`run_id`, `audit_id`) and artifact paths.
-- Runner owns state (`docs/_campaign_runs/state/state.json`) and transition history.
+- Runner owns state (`artifacts/campaign-runs/state/state.json`) and transition history.
 - Stage B is a proposal; runner merges deterministically and hard-fails on task mutation drift.
 - Campaign mapping edits are restricted to:
   - `<!-- RUNNER_TASK_MAP -->`
@@ -198,8 +198,8 @@ Unknown preset keys are ignored with warnings.
 ## Run metadata
 
 The runner writes `run_meta.json` to:
-- `docs/_audits/YYYY-MM-DD/<audit_id>/run_meta.json`
-- `docs/_campaign_runs/YYYY-MM-DD/<campaign_slug>/<run_id>/run_meta.json`
+- `artifacts/audits/YYYY-MM-DD/<audit_id>/run_meta.json`
+- `artifacts/campaign-runs/YYYY-MM-DD/<campaign_slug>/<run_id>/run_meta.json`
 
 Additional provider traceability in `run_meta.json`:
 - provider name

--- a/codex_runner/runner.py
+++ b/codex_runner/runner.py
@@ -15,13 +15,21 @@ from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-DEFAULT_AUDITS_DIR = Path("docs/_audits")
-DEFAULT_CAMPAIGN_DIR = Path("docs/Campaign")
-DEFAULT_TASKS_DIR = Path("docs/tasks")
-DEFAULT_RUNS_DIR = Path("docs/_campaign_runs")
+DEFAULT_AUDITS_DIR = Path("artifacts/audits")
+DEFAULT_CAMPAIGN_DIR = Path("docs/work/campaigns")
+DEFAULT_TASKS_DIR = Path("docs/work/tasks")
+DEFAULT_RUNS_DIR = Path("artifacts/campaign-runs")
+LEGACY_AUDITS_DIR = Path("docs/_audits")
+LEGACY_CAMPAIGN_DIR = Path("docs/Campaign")
+LEGACY_TASKS_DIR = Path("docs/tasks")
+LEGACY_RUNS_DIR = Path("docs/_campaign_runs")
 STATE_DIR = DEFAULT_RUNS_DIR / "state"
 STATE_PATH = STATE_DIR / "state.json"
 STATE_TRANSITIONS_PATH = STATE_DIR / "state_transitions.jsonl"
+LEGACY_STATE_PATH = LEGACY_RUNS_DIR / "state" / "state.json"
+LEGACY_STATE_TRANSITIONS_PATH = (
+    LEGACY_RUNS_DIR / "state" / "state_transitions.jsonl"
+)
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 DEFAULT_MEGA_AUDIT_SCHEMA_PATH = (
@@ -460,6 +468,10 @@ def parse_campaign_id(campaign_id: str) -> tuple[str, str, str]:
 def load_state(repo_root: Path) -> dict[str, Any]:
     path = repo_root / STATE_PATH
     if not path.exists():
+        legacy_path = repo_root / LEGACY_STATE_PATH
+        if legacy_path.exists():
+            path = legacy_path
+    if not path.exists():
         return {
             "version": 1,
             "campaigns": {},
@@ -819,32 +831,33 @@ def materialize_campaign_artifacts(
 ) -> list[str]:
     touched: list[str] = []
     date_underscore = campaign["campaign_date"].replace("-", "_")
+    year, month, _ = campaign["campaign_date"].split("-")
     slug = campaign["campaign_slug"]
     seq = campaign["campaign_seq"]
 
     campaign_doc_name = (
         f"CAMPAIGN_{date_underscore}_{to_upper_snake(slug)}_{seq}.md"
     )
-    campaign_doc_path = repo_root / DEFAULT_CAMPAIGN_DIR / campaign_doc_name
+    campaign_dir_rel = DEFAULT_CAMPAIGN_DIR / year / month
+    campaign_doc_path = repo_root / campaign_dir_rel / campaign_doc_name
     campaign_doc_content = ensure_mapping_block(campaign["campaign_markdown"])
     if not campaign_doc_path.exists():
         text_write(campaign_doc_path, campaign_doc_content)
-        touched.append(
-            str((DEFAULT_CAMPAIGN_DIR / campaign_doc_name).as_posix())
-        )
+        touched.append(str((campaign_dir_rel / campaign_doc_name).as_posix()))
 
     campaign["materialized"]["campaign_doc_path"] = str(
-        (DEFAULT_CAMPAIGN_DIR / campaign_doc_name).as_posix()
+        (campaign_dir_rel / campaign_doc_name).as_posix()
     )
 
-    task_dir_rel = DEFAULT_TASKS_DIR / f"{slug}_{date_underscore}"
+    task_dir_rel = DEFAULT_TASKS_DIR / year / month
     task_dir_abs = repo_root / task_dir_rel
     task_dir_abs.mkdir(parents=True, exist_ok=True)
 
-    for task in sorted(campaign["tasks"].values(), key=lambda item: item["id"]):
-        task_file_name = (
-            f"TASK_{to_lower_snake(task['slug'])}_{date_underscore}.md"
-        )
+    for index, task in enumerate(
+        sorted(campaign["tasks"].values(), key=lambda item: item["id"]),
+        start=1,
+    ):
+        task_file_name = f"TASK_{date_underscore}_{index:03d}_{to_lower_snake(task['slug'])}.md"
         task_rel = task_dir_rel / task_file_name
         task_abs = repo_root / task_rel
         if not task_abs.exists():

--- a/codex_runner/tests/test_runner_paths.py
+++ b/codex_runner/tests/test_runner_paths.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import runner
+
+
+def test_load_state_falls_back_to_legacy_state_path(tmp_path: Path) -> None:
+    legacy_path = tmp_path / runner.LEGACY_STATE_PATH
+    legacy_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": 1,
+        "campaigns": {"camp": {}},
+        "task_index_by_id": {},
+        "task_index_by_slug": {},
+    }
+    legacy_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    state = runner.load_state(tmp_path)
+
+    assert state["version"] == 1
+    assert "camp" in state["campaigns"]
+
+
+def test_materialize_campaign_artifacts_uses_year_month_paths(
+    tmp_path: Path,
+) -> None:
+    campaign = {
+        "campaign_date": "2026-02-18",
+        "campaign_slug": "security_alpha",
+        "campaign_seq": "007",
+        "campaign_markdown": "# Campaign",
+        "tasks": {
+            "TASK-B": {
+                "id": "TASK-B",
+                "slug": "beta",
+                "task_artifact_markdown": "# Beta",
+            },
+            "TASK-A": {
+                "id": "TASK-A",
+                "slug": "alpha",
+                "task_artifact_markdown": "# Alpha",
+            },
+        },
+        "materialized": {
+            "campaign_doc_path": "",
+            "task_artifact_paths": {},
+        },
+    }
+
+    touched = runner.materialize_campaign_artifacts(tmp_path, campaign)
+
+    assert (
+        campaign["materialized"]["campaign_doc_path"]
+        == "docs/work/campaigns/2026/02/CAMPAIGN_2026_02_18_SECURITY_ALPHA_007.md"
+    )
+    assert campaign["materialized"]["task_artifact_paths"]["TASK-A"].endswith(
+        "docs/work/tasks/2026/02/TASK_2026_02_18_001_alpha.md"
+    )
+    assert campaign["materialized"]["task_artifact_paths"]["TASK-B"].endswith(
+        "docs/work/tasks/2026/02/TASK_2026_02_18_002_beta.md"
+    )
+    assert any(
+        path.startswith("docs/work/campaigns/2026/02/") for path in touched
+    )

--- a/tests/codex_runner/test_standalone_runner_paths.py
+++ b/tests/codex_runner/test_standalone_runner_paths.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_runner_module():
+    runner_path = (
+        Path(__file__).resolve().parents[2]
+        / "tools"
+        / "codex-runner"
+        / "src"
+        / "codex_runner"
+        / "runner.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "standalone_codex_runner_runner",
+        runner_path,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load runner module from {runner_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+runner = _load_runner_module()
+
+
+def test_validate_campaign_payload_accepts_canonical_paths() -> None:
+    payload = {
+        "campaign_id": "2026-02-18::security_alpha::001",
+        "campaign_slug": "security_alpha",
+        "campaign_doc_path": (
+            "docs/work/campaigns/2026/02/CAMPAIGN_2026_02_18_SECURITY.md"
+        ),
+        "campaign_markdown": "# Campaign",
+        "tasks": [
+            {
+                "id": "TASK-001",
+                "slug": "alpha",
+                "area": "backend",
+                "files": ["backend/app.py"],
+                "tests": ["pytest -q tests/test_app.py"],
+                "commit_message": "TASK-001: implement alpha",
+                "task_artifact_path": (
+                    "docs/work/tasks/2026/02/TASK_2026_02_18_001_alpha.md"
+                ),
+                "task_artifact_markdown": "# Task",
+                "activation_prompt": "Do task",
+            }
+        ],
+    }
+
+    runner.validate_campaign_payload(payload)
+
+
+def test_validate_campaign_payload_accepts_legacy_paths() -> None:
+    payload = {
+        "campaign_id": "2026-02-18::security_alpha::001",
+        "campaign_slug": "security_alpha",
+        "campaign_doc_path": "docs/Campaign/CAMPAIGN_2026_02_18_SECURITY.md",
+        "campaign_markdown": "# Campaign",
+        "tasks": [
+            {
+                "id": "TASK-001",
+                "slug": "alpha",
+                "area": "backend",
+                "files": ["backend/app.py"],
+                "tests": ["pytest -q tests/test_app.py"],
+                "commit_message": "TASK-001: implement alpha",
+                "task_artifact_path": "docs/tasks/TASK_2026_02_18_001_alpha.md",
+                "task_artifact_markdown": "# Task",
+                "activation_prompt": "Do task",
+            }
+        ],
+    }
+
+    runner.validate_campaign_payload(payload)

--- a/tools/codex-runner/src/codex_runner/resources/audits/sample_audit_prompt.md
+++ b/tools/codex-runner/src/codex_runner/resources/audits/sample_audit_prompt.md
@@ -3,11 +3,11 @@ You are producing a Codex Runner campaign audit output. Return JSON that conform
 Requirements:
 - Include campaign_id, campaign_slug, campaign_doc_path, campaign_markdown, and tasks.
 - campaign_doc_path must match:
-  docs/Campaign/CAMPAIGN_YYYY_MM_DD.md
+  docs/work/campaigns/YYYY/MM/CAMPAIGN_YYYY_MM_DD.md
   OR
-  docs/Campaign/CAMPAIGN_YYYY_MM_DD_<UPPER_SNAKE+_->.md
+  docs/work/campaigns/YYYY/MM/CAMPAIGN_YYYY_MM_DD_<UPPER_SNAKE+_->.md
 - task_artifact_path must match:
-  docs/tasks/TASK_YYYY_MM_DD_NNN_lower_snake_slug.md
+  docs/work/tasks/YYYY/MM/TASK_YYYY_MM_DD_NNN_lower_snake_slug.md
   where NNN is a 3-digit zero-padded number.
 - Provide full markdown contents for campaign_markdown and task_artifact_markdown.
 - Provide a fully formed activation_prompt for each task.

--- a/tools/codex-runner/src/codex_runner/resources/schemas/campaign_output.schema.json
+++ b/tools/codex-runner/src/codex_runner/resources/schemas/campaign_output.schema.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c7c9cdb3b06b89c52bf83c906ade15e76b28e5e68715f17a502466c7e4e441c
-size 2063
+oid sha256:63672c38117100502b29fee88f46067a70fb6ac8ea514fdd68620d257f7cd066
+size 2235

--- a/tools/codex-runner/src/codex_runner/runner.py
+++ b/tools/codex-runner/src/codex_runner/runner.py
@@ -15,13 +15,25 @@ from importlib import resources
 from pathlib import Path
 from typing import Any, Iterator
 
-DEFAULT_CAMPAIGN_DIR = Path("docs/Campaign")
-DEFAULT_TASKS_DIR = Path("docs/tasks")
+DEFAULT_CAMPAIGN_DIR = Path("docs/work/campaigns")
+DEFAULT_TASKS_DIR = Path("docs/work/tasks")
+LEGACY_CAMPAIGN_DIR = Path("docs/Campaign")
+LEGACY_TASKS_DIR = Path("docs/tasks")
 
-CAMPAIGN_PATH_PATTERN = re.compile(
-    r"^docs/Campaign/CAMPAIGN_(\d{4})_(\d{2})_(\d{2})(?:_[A-Z0-9_+\-]+)?\.md$"
+CANONICAL_CAMPAIGN_PATH_PATTERN = re.compile(
+    r"^docs/work/campaigns/(?P<year>\d{4})/(?P<month>\d{2})/"
+    r"CAMPAIGN_(?P=year)_(?P=month)_(?P<day>\d{2})"
+    r"(?:_[A-Z0-9_+\-]+)?\.md$"
 )
-TASK_PATH_PATTERN = re.compile(
+LEGACY_CAMPAIGN_PATH_PATTERN = re.compile(
+    r"^docs/Campaign/CAMPAIGN_(?P<year>\d{4})_(?P<month>\d{2})_(?P<day>\d{2})"
+    r"(?:_[A-Z0-9_+\-]+)?\.md$"
+)
+CANONICAL_TASK_PATH_PATTERN = re.compile(
+    r"^docs/work/tasks/(?P<year>\d{4})/(?P<month>\d{2})/"
+    r"TASK_(?P=year)_(?P=month)_\d{2}_\d{3}_[a-z0-9_]+\.md$"
+)
+LEGACY_TASK_PATH_PATTERN = re.compile(
     r"^docs/tasks/TASK_\d{4}_\d{2}_\d{2}_\d{3}_[a-z0-9_]+\.md$"
 )
 
@@ -172,12 +184,14 @@ def validate_campaign_payload(payload: dict[str, Any]) -> None:
         raise RunnerError(f"Missing campaign fields: {', '.join(missing)}")
 
     campaign_path = payload["campaign_doc_path"]
-    if not isinstance(
-        campaign_path, str
-    ) or not CAMPAIGN_PATH_PATTERN.fullmatch(campaign_path):
+    if not isinstance(campaign_path, str) or not match_campaign_path(
+        campaign_path
+    ):
         raise RunnerError(
-            "Invalid campaign_doc_path. Expected format "
-            f"{DEFAULT_CAMPAIGN_DIR}/CAMPAIGN_YYYY_MM_DD[_SUFFIX].md"
+            "Invalid campaign_doc_path. Expected canonical format "
+            f"{DEFAULT_CAMPAIGN_DIR}/YYYY/MM/CAMPAIGN_YYYY_MM_DD[_SUFFIX].md "
+            "or legacy format "
+            f"{LEGACY_CAMPAIGN_DIR}/CAMPAIGN_YYYY_MM_DD[_SUFFIX].md"
         )
 
     tasks = payload["tasks"]
@@ -207,14 +221,28 @@ def validate_campaign_payload(payload: dict[str, Any]) -> None:
                 f"Task {index} missing fields: {', '.join(missing_task_fields)}"
             )
         task_path = task["task_artifact_path"]
-        if not isinstance(task_path, str) or not TASK_PATH_PATTERN.fullmatch(
-            task_path
-        ):
+        if not isinstance(task_path, str) or not match_task_path(task_path):
             raise RunnerError(
                 "Invalid task_artifact_path for task "
-                f"{index}. Expected format {DEFAULT_TASKS_DIR}/"
-                "TASK_YYYY_MM_DD_NNN_lower_snake_slug.md"
+                f"{index}. Expected canonical format {DEFAULT_TASKS_DIR}/"
+                "YYYY/MM/TASK_YYYY_MM_DD_NNN_lower_snake_slug.md "
+                "or legacy format "
+                f"{LEGACY_TASKS_DIR}/TASK_YYYY_MM_DD_NNN_lower_snake_slug.md"
             )
+
+
+def match_campaign_path(campaign_doc_path: str) -> re.Match[str] | None:
+    """Match either the canonical or legacy campaign artifact path."""
+    return CANONICAL_CAMPAIGN_PATH_PATTERN.fullmatch(
+        campaign_doc_path
+    ) or LEGACY_CAMPAIGN_PATH_PATTERN.fullmatch(campaign_doc_path)
+
+
+def match_task_path(task_artifact_path: str) -> re.Match[str] | None:
+    """Match either the canonical or legacy task artifact path."""
+    return CANONICAL_TASK_PATH_PATTERN.fullmatch(
+        task_artifact_path
+    ) or LEGACY_TASK_PATH_PATTERN.fullmatch(task_artifact_path)
 
 
 def write_text_file(path: Path, content: str) -> None:
@@ -345,9 +373,11 @@ def slugify_branch(value: str) -> str:
 
 def campaign_date_from_path(campaign_doc_path: str, *, debug: bool) -> str:
     """Extract the campaign date from the campaign doc path."""
-    match = CAMPAIGN_PATH_PATTERN.fullmatch(campaign_doc_path)
+    match = match_campaign_path(campaign_doc_path)
     if match:
-        year, month, day = match.groups()
+        year = match.group("year")
+        month = match.group("month")
+        day = match.group("day")
         try:
             return date(int(year), int(month), int(day)).strftime("%Y-%m-%d")
         except ValueError:


### PR DESCRIPTION
This is the clean runner-only replacement branch.

It cherry-picks the intended runner hygiene change onto current `main`.

The `.gitignore` conflict was resolved by keeping legacy ignore paths `/docs/_audits/` and `/docs/_campaign_runs/`, while also adding canonical runner artifact ignores `/artifacts/audits/`, `/artifacts/campaign-runs/`, and `codex_runner.zip`.

Validation passed:
- `pytest -q tests/codex_runner/test_runner_v2.py`
- `pytest -q tests/codex_runner/test_standalone_runner_paths.py`
- `pytest -q codex_runner/tests/test_runner_paths.py`

Final clean commit: `efc496713017f1be7c0a7049146bdff09fd8c577`