### PR TITLE
runtime: supported profile helpers on clean ancestry

### DIFF
--- a/guardian/core/ai_router.py
+++ b/guardian/core/ai_router.py
@@ -543,7 +543,25 @@ def _resolve_local_base(settings: Settings) -> str:
         raise HTTPException(
             status_code=400, detail="LOCAL_BASE_URL is not configured"
         )
-    return base_url.rstrip("/")
+    normalized_base = base_url.rstrip("/")
+
+    from guardian.core.supported_profile import get_active_supported_profile
+
+    manifest = get_active_supported_profile()
+    if manifest is not None:
+        expected_base = str(
+            manifest.provider_contract.get("LOCAL_BASE_URL") or ""
+        ).strip()
+        expected_base = expected_base.rstrip("/")
+        if expected_base and normalized_base != expected_base:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Supported profile {manifest.name} requires "
+                    f"LOCAL_BASE_URL={expected_base}"
+                ),
+            )
+    return normalized_base
 
 
 def call_local(

--- a/guardian/core/config.py
+++ b/guardian/core/config.py
@@ -107,6 +107,10 @@ class Settings(BaseSettings):
         default="library2/ministral-3:8b",
         description="Local chat model identifier for Ollama.",
     )
+    LOCAL_CHAT_MODEL: str = Field(
+        default="library2/ministral-3:8b",
+        description="Local chat model identifier used by supported profile validation.",
+    )
     LOCAL_EMBEDDING_MODEL: str | None = Field(
         default=None,
         description=(
@@ -645,6 +649,25 @@ def _normalize_embedding_provider(provider: str | None) -> str:
     return normalized
 
 
+def _validate_supported_profile_contract(settings: Settings) -> None:
+    from guardian.core.supported_profile import (
+        get_active_supported_profile,
+        validate_supported_profile_runtime,
+    )
+
+    manifest = get_active_supported_profile()
+    if manifest is None:
+        return
+
+    mismatches = validate_supported_profile_runtime(manifest, settings=settings)
+    if mismatches:
+        detail = "; ".join(mismatches)
+        raise LLMConfigError(
+            "supported profile requires blessed local gateway contract: "
+            f"{detail}"
+        )
+
+
 def validate_llm_config(
     settings: Settings, provider_override: str | None = None
 ) -> None:
@@ -665,6 +688,7 @@ def validate_llm_config(
     if provider == "local":
         if not settings.LOCAL_BASE_URL:
             raise LLMConfigError("LOCAL_BASE_URL is not configured")
+        _validate_supported_profile_contract(settings)
         return
 
     if provider == "openai":
@@ -674,6 +698,7 @@ def validate_llm_config(
             )
         if not settings.OPENAI_API_KEY:
             raise LLMConfigError("OPENAI_API_KEY is not configured")
+        _validate_supported_profile_contract(settings)
         return
 
     if provider == "groq":
@@ -683,6 +708,7 @@ def validate_llm_config(
             )
         if not settings.GROQ_API_KEY:
             raise LLMConfigError("GROQ_API_KEY is not configured")
+        _validate_supported_profile_contract(settings)
         return
 
     if provider == "alibaba":
@@ -701,6 +727,7 @@ def validate_llm_config(
                 "LLM_PROVIDER is 'alibaba' but required environment variable(s) are missing: "
                 f"{missing_text}. Set {missing_text} in your backend environment."
             )
+        _validate_supported_profile_contract(settings)
         return
 
     if provider == "minimax":
@@ -727,6 +754,7 @@ def validate_llm_config(
             raise LLMConfigError(
                 "MINIMAX_API_FLAVOR must be one of: openai, anthropic."
             )
+        _validate_supported_profile_contract(settings)
         return
 
     raise LLMConfigError(

--- a/guardian/core/public_exposure.py
+++ b/guardian/core/public_exposure.py
@@ -72,11 +72,13 @@ class PublicExposureMiddleware:
         exposure_mode: str = DEFAULT_EXPOSURE_MODE,
         routes_file: str = DEFAULT_ROUTES_FILE,
         profile: str = DEFAULT_PROFILE,
+        internal_only_paths: set[str] | None = None,
     ) -> None:
         self.app = app
         self.exposure_mode = (exposure_mode or DEFAULT_EXPOSURE_MODE).strip()
         self.routes_file = routes_file or DEFAULT_ROUTES_FILE
         self.profile = profile or DEFAULT_PROFILE
+        self.internal_only_paths = internal_only_paths or set()
         self._allowlist = PublicAllowlist.deny_all()
         if self.exposure_mode == PUBLIC_ALLOWLIST_MODE:
             self._allowlist = PublicAllowlist.load(
@@ -97,7 +99,15 @@ class PublicExposureMiddleware:
 
         method = str(scope.get("method", "GET"))
         path = str(scope.get("path", "/"))
-        if self._allowlist.is_allowed(method=method, path=path):
+        normalized_path = _normalize_path(path)
+        if normalized_path in self.internal_only_paths:
+            response = JSONResponse(
+                status_code=403,
+                content={"ok": False, "error": "forbidden"},
+            )
+            await response(scope, receive, send)
+            return
+        if self._allowlist.is_allowed(method=method, path=normalized_path):
             await self.app(scope, receive, send)
             return
 

--- a/guardian/core/supported_profile.py
+++ b/guardian/core/supported_profile.py
@@ -1,0 +1,342 @@
+"""Supported runtime profile loader and validation helpers."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SUPPORTED_PROFILE_ENV = "CODEXIFY_SUPPORTED_PROFILE"
+SUPPORTED_PROFILE_DIR_ENV = "CODEXIFY_SUPPORTED_PROFILE_DIR"
+DEFAULT_SUPPORTED_PROFILE_NAME = "v1-local-core-web-mcp"
+DEFAULT_SUPPORTED_PROFILE_DIR = "config/supported_profiles"
+
+
+class SupportedProfileError(ValueError):
+    """Raised when a supported profile is invalid or mismatched."""
+
+
+@dataclass(frozen=True)
+class SupportedProfileManifest:
+    name: str
+    version: int
+    surface: str
+    required_services: tuple[str, ...]
+    optional_services: tuple[str, ...]
+    public_extensions: tuple[str, ...]
+    internal_extensions: tuple[str, ...]
+    enabled_routes: tuple[str, ...]
+    internal_only_routes: tuple[str, ...]
+    quarantined_routes: tuple[str, ...]
+    provider_contract: dict[str, Any]
+    criticality: dict[str, dict[str, tuple[str, ...]]]
+
+    def route_status(self, label: str) -> str:
+        normalized = str(label or "").strip()
+        if normalized in self.quarantined_routes:
+            return "quarantined"
+        if normalized in self.internal_only_routes:
+            return "internal_only"
+        if normalized in self.enabled_routes:
+            return "enabled"
+        return "quarantined"
+
+    def allows_route(self, label: str) -> bool:
+        return self.route_status(label) != "quarantined"
+
+    def route_summary(self) -> dict[str, str]:
+        labels = (
+            list(self.enabled_routes)
+            + list(self.internal_only_routes)
+            + list(self.quarantined_routes)
+        )
+        return {label: self.route_status(label) for label in labels}
+
+
+def get_requested_supported_profile_name() -> str | None:
+    raw = (os.getenv(SUPPORTED_PROFILE_ENV) or "").strip()
+    return raw or None
+
+
+def _resolve_profiles_dir(profiles_dir: str | None = None) -> Path:
+    raw = (
+        str(profiles_dir or os.getenv(SUPPORTED_PROFILE_DIR_ENV) or "").strip()
+        or DEFAULT_SUPPORTED_PROFILE_DIR
+    )
+    path = Path(raw)
+    if path.is_absolute():
+        return path
+    cwd_path = Path.cwd() / path
+    if cwd_path.exists():
+        return cwd_path
+    repo_root = Path(__file__).resolve().parents[2]
+    return repo_root / path
+
+
+def _normalize_str_sequence(raw: Any, label: str) -> tuple[str, ...]:
+    if raw is None:
+        return tuple()
+    if not isinstance(raw, list):
+        raise SupportedProfileError(f"{label} must be a list")
+    values: list[str] = []
+    for item in raw:
+        if not isinstance(item, str) or not item.strip():
+            raise SupportedProfileError(
+                f"{label} entries must be non-empty strings"
+            )
+        values.append(item.strip())
+    return tuple(values)
+
+
+def _normalize_criticality(raw: Any) -> dict[str, dict[str, tuple[str, ...]]]:
+    if not isinstance(raw, dict):
+        raise SupportedProfileError("criticality must be a mapping")
+    normalized: dict[str, dict[str, tuple[str, ...]]] = {}
+    for tier_name, payload in raw.items():
+        if not isinstance(tier_name, str) or not tier_name.strip():
+            raise SupportedProfileError(
+                "criticality tier names must be strings"
+            )
+        if not isinstance(payload, dict):
+            raise SupportedProfileError(
+                f"criticality tier {tier_name!r} must be a mapping"
+            )
+        normalized[tier_name.strip()] = {
+            "services": _normalize_str_sequence(
+                payload.get("services"), f"criticality.{tier_name}.services"
+            ),
+            "routes": _normalize_str_sequence(
+                payload.get("routes"), f"criticality.{tier_name}.routes"
+            ),
+        }
+    return normalized
+
+
+def _coerce_provider_contract(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise SupportedProfileError("provider_contract must be a mapping")
+    normalized: dict[str, Any] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str) or not key.strip():
+            raise SupportedProfileError(
+                "provider_contract keys must be non-empty strings"
+            )
+        normalized[key.strip()] = value
+    return normalized
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise SupportedProfileError(f"supported profile file not found: {path}")
+    with path.open("r", encoding="utf-8") as handle:
+        payload = yaml.safe_load(handle)
+    if not isinstance(payload, dict):
+        raise SupportedProfileError("supported profile root must be a mapping")
+    return payload
+
+
+def _manifest_from_payload(payload: dict[str, Any]) -> SupportedProfileManifest:
+    name = str(payload.get("name") or "").strip()
+    if not name:
+        raise SupportedProfileError("name is required")
+    version = payload.get("version")
+    if not isinstance(version, int) or version < 1:
+        raise SupportedProfileError("version must be a positive integer")
+    surface = str(payload.get("surface") or "").strip()
+    if not surface:
+        raise SupportedProfileError("surface is required")
+
+    extension_posture = payload.get("extension_posture")
+    if not isinstance(extension_posture, dict):
+        raise SupportedProfileError("extension_posture must be a mapping")
+
+    route_posture = payload.get("route_posture")
+    if not isinstance(route_posture, dict):
+        raise SupportedProfileError("route_posture must be a mapping")
+
+    enabled_routes = _normalize_str_sequence(
+        route_posture.get("enabled"), "route_posture.enabled"
+    )
+    internal_only_routes = _normalize_str_sequence(
+        route_posture.get("internal_only"), "route_posture.internal_only"
+    )
+    quarantined_routes = _normalize_str_sequence(
+        route_posture.get("quarantined"), "route_posture.quarantined"
+    )
+
+    overlap = (
+        set(enabled_routes) & set(internal_only_routes)
+        or set(enabled_routes) & set(quarantined_routes)
+        or set(internal_only_routes) & set(quarantined_routes)
+    )
+    if overlap:
+        raise SupportedProfileError(
+            f"route_posture contains overlapping labels: {sorted(overlap)!r}"
+        )
+
+    return SupportedProfileManifest(
+        name=name,
+        version=version,
+        surface=surface,
+        required_services=_normalize_str_sequence(
+            payload.get("required_services"), "required_services"
+        ),
+        optional_services=_normalize_str_sequence(
+            payload.get("optional_services"), "optional_services"
+        ),
+        public_extensions=_normalize_str_sequence(
+            extension_posture.get("public"), "extension_posture.public"
+        ),
+        internal_extensions=_normalize_str_sequence(
+            extension_posture.get("internal"), "extension_posture.internal"
+        ),
+        enabled_routes=enabled_routes,
+        internal_only_routes=internal_only_routes,
+        quarantined_routes=quarantined_routes,
+        provider_contract=_coerce_provider_contract(
+            payload.get("provider_contract")
+        ),
+        criticality=_normalize_criticality(payload.get("criticality")),
+    )
+
+
+@lru_cache(maxsize=16)
+def load_supported_profile(
+    profile_name: str,
+    *,
+    profiles_dir: str | None = None,
+) -> SupportedProfileManifest:
+    normalized_name = str(profile_name or "").strip()
+    if not normalized_name:
+        raise SupportedProfileError("profile_name is required")
+    directory = _resolve_profiles_dir(profiles_dir)
+    return _manifest_from_payload(
+        _load_yaml(directory / f"{normalized_name}.yaml")
+    )
+
+
+def get_active_supported_profile() -> SupportedProfileManifest | None:
+    profile_name = get_requested_supported_profile_name()
+    if not profile_name:
+        return None
+    return load_supported_profile(profile_name)
+
+
+def _normalize_expected(value: Any) -> Any:
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, bool):
+        return bool(value)
+    return value
+
+
+def supported_profile_actual_provider_contract(
+    settings: Any,
+) -> dict[str, Any]:
+    local_chat_model = (
+        str(getattr(settings, "LOCAL_CHAT_MODEL", "") or "").strip()
+        or (os.getenv("LOCAL_CHAT_MODEL") or "").strip()
+    )
+    return {
+        "LLM_PROVIDER": str(
+            getattr(settings, "LLM_PROVIDER", "") or ""
+        ).strip(),
+        "ALLOW_CLOUD_PROVIDERS": bool(
+            getattr(settings, "ALLOW_CLOUD_PROVIDERS", False)
+        ),
+        "CODEXIFY_LOCAL_ONLY_MODE": bool(
+            getattr(settings, "CODEXIFY_LOCAL_ONLY_MODE", False)
+        ),
+        "CODEXIFY_EGRESS_ALLOWLIST": str(
+            getattr(settings, "CODEXIFY_EGRESS_ALLOWLIST", "") or ""
+        ).strip(),
+        "LOCAL_BASE_URL": str(
+            getattr(settings, "LOCAL_BASE_URL", "") or ""
+        ).strip(),
+        "LOCAL_API_KEY": str(
+            getattr(settings, "LOCAL_API_KEY", "") or ""
+        ).strip(),
+        "LOCAL_LLM_MODEL": str(
+            getattr(settings, "LOCAL_LLM_MODEL", "") or ""
+        ).strip(),
+        "LOCAL_CHAT_MODEL": local_chat_model
+        or str(getattr(settings, "LOCAL_LLM_MODEL", "") or "").strip(),
+    }
+
+
+def validate_supported_profile_runtime(
+    manifest: SupportedProfileManifest,
+    *,
+    settings: Any,
+    enabled_routes: set[str] | None = None,
+) -> list[str]:
+    mismatches: list[str] = []
+    actual_contract = supported_profile_actual_provider_contract(settings)
+    for key, expected in manifest.provider_contract.items():
+        actual = actual_contract.get(key)
+        if _normalize_expected(actual) != _normalize_expected(expected):
+            mismatches.append(
+                f"{key} expected {expected!r} but found {actual!r}"
+            )
+
+    route_set = {
+        str(label).strip()
+        for label in (enabled_routes or set())
+        if str(label).strip()
+    }
+    if route_set:
+        for label in manifest.enabled_routes + manifest.internal_only_routes:
+            if label not in route_set:
+                mismatches.append(f"required route {label!r} is not mounted")
+        for label in manifest.quarantined_routes:
+            if label in route_set:
+                mismatches.append(f"quarantined route {label!r} is mounted")
+
+    return mismatches
+
+
+def build_supported_profile_runtime_state(
+    manifest: SupportedProfileManifest,
+    *,
+    settings: Any,
+    enabled_routes: set[str] | None = None,
+) -> dict[str, Any]:
+    actual_contract = supported_profile_actual_provider_contract(settings)
+    route_set = {
+        str(label).strip()
+        for label in (enabled_routes or set())
+        if str(label).strip()
+    }
+    mismatches = validate_supported_profile_runtime(
+        manifest, settings=settings, enabled_routes=route_set
+    )
+    route_summary = manifest.route_summary()
+    mounted_routes = sorted(route_set) if route_set else []
+    return {
+        "name": manifest.name,
+        "version": manifest.version,
+        "surface": manifest.surface,
+        "public_extensions": list(manifest.public_extensions),
+        "internal_extensions": list(manifest.internal_extensions),
+        "provider_contract": {
+            "expected": dict(manifest.provider_contract),
+            "actual": actual_contract,
+        },
+        "criticality": {
+            tier: {
+                "services": list(payload.get("services", ())),
+                "routes": list(payload.get("routes", ())),
+            }
+            for tier, payload in manifest.criticality.items()
+        },
+        "routes": {
+            "declared": route_summary,
+            "mounted": mounted_routes,
+        },
+        "valid": len(mismatches) == 0,
+        "mismatches": mismatches,
+    }

--- a/guardian/guardian_api.py
+++ b/guardian/guardian_api.py
@@ -38,6 +38,7 @@ from fastapi import (
     UploadFile,
 )
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.openapi.utils import get_openapi
 from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
 from pydantic import BaseModel
 
@@ -78,6 +79,10 @@ from guardian.core.public_exposure import (
     PublicExposureMiddleware,
 )
 from guardian.core.storage import ensure_storage_base_path
+from guardian.core.supported_profile import (
+    build_supported_profile_runtime_state,
+    get_active_supported_profile,
+)
 from guardian.queue import task_events
 from guardian.queue.redis_queue import cancel as cancel_task
 from guardian.queue.redis_queue import enqueue
@@ -157,6 +162,7 @@ def _env_bool(name: str, default: bool) -> bool:
 
 
 _BETA_CORE_ONLY = _env_bool("CODEXIFY_BETA_CORE_ONLY", default=False)
+_SUPPORTED_PROFILE_MANIFEST = get_active_supported_profile()
 
 
 def _include_router(
@@ -167,6 +173,19 @@ def _include_router(
     default_enabled: bool = True,
     core_surface: bool = False,
 ) -> None:
+    profile_manifest = _SUPPORTED_PROFILE_MANIFEST
+    profile_status = (
+        profile_manifest.route_status(label)
+        if profile_manifest is not None
+        else "enabled"
+    )
+    if profile_status == "quarantined":
+        logger.info(
+            "[routers] quarantined %s (supported_profile=%s)",
+            label,
+            profile_manifest.name if profile_manifest is not None else "none",
+        )
+        return
     if _BETA_CORE_ONLY and not core_surface:
         logger.info(
             "[routers] quarantined %s (CODEXIFY_BETA_CORE_ONLY=true)",
@@ -176,7 +195,34 @@ def _include_router(
     if not _env_bool(flag_name, default=default_enabled):
         logger.info("[routers] quarantined %s (%s=false)", label, flag_name)
         return
+    route_count_before = len(app.routes)
     include_fn()
+    if profile_manifest is not None:
+        enabled_labels = getattr(
+            app.state, "supported_profile_enabled_labels", None
+        )
+        if enabled_labels is None:
+            enabled_labels = set()
+            app.state.supported_profile_enabled_labels = enabled_labels
+        enabled_labels.add(label)
+        if profile_status == "internal_only":
+            hidden_paths = getattr(
+                app.state, "supported_profile_hidden_paths", None
+            )
+            if hidden_paths is None:
+                hidden_paths = set()
+                app.state.supported_profile_hidden_paths = hidden_paths
+            for route in app.routes[route_count_before:]:
+                path = getattr(route, "path", None)
+                if isinstance(path, str) and path:
+                    hidden_paths.add(path)
+            app.openapi_schema = None
+            logger.info(
+                "[routers] enabled %s as internal-only via supported profile %s",
+                label,
+                profile_manifest.name,
+            )
+            return
     logger.info("[routers] enabled %s", label)
 
 
@@ -486,6 +532,10 @@ app = FastAPI(
     version="1.0.0",
     lifespan=app_lifespan,
 )
+app.state.supported_profile_manifest = _SUPPORTED_PROFILE_MANIFEST
+app.state.supported_profile = None
+app.state.supported_profile_hidden_paths = set()
+app.state.supported_profile_enabled_labels = set()
 
 exposure_mode = os.getenv("GUARDIAN_EXPOSURE_MODE", DEFAULT_EXPOSURE_MODE)
 public_routes_file = os.getenv(
@@ -498,6 +548,7 @@ app.add_middleware(
     exposure_mode=exposure_mode,
     routes_file=public_routes_file,
     profile=public_profile,
+    internal_only_paths=app.state.supported_profile_hidden_paths,
 )
 logger.info(
     "[public_exposure] mode=%s profile=%s routes_file=%s",
@@ -505,6 +556,52 @@ logger.info(
     public_profile,
     public_routes_file,
 )
+
+
+def _refresh_supported_profile_state(
+    app: FastAPI, settings: Any
+) -> dict[str, Any] | None:
+    manifest = getattr(app.state, "supported_profile_manifest", None)
+    if manifest is None:
+        app.state.supported_profile = None
+        return None
+
+    enabled_routes = set(
+        getattr(app.state, "supported_profile_enabled_labels", set())
+    )
+    state = build_supported_profile_runtime_state(
+        manifest,
+        settings=settings,
+        enabled_routes=enabled_routes,
+    )
+    app.state.supported_profile = state
+    if not state["valid"]:
+        detail = "; ".join(state["mismatches"])
+        raise RuntimeError(f"supported profile drift: {detail}")
+    return state
+
+
+def _custom_openapi() -> dict[str, Any]:
+    if app.openapi_schema:
+        return app.openapi_schema
+
+    schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        description=app.description,
+        routes=app.routes,
+    )
+    hidden_paths = set(
+        getattr(app.state, "supported_profile_hidden_paths", set())
+    )
+    paths = schema.get("paths", {})
+    for path in hidden_paths:
+        paths.pop(path, None)
+    app.openapi_schema = schema
+    return schema
+
+
+app.openapi = _custom_openapi
 
 
 def _get_request_id(request: Request) -> str:

--- a/guardian/queue/turn_lock.py
+++ b/guardian/queue/turn_lock.py
@@ -2,15 +2,35 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
-from typing import Optional
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
 
 from guardian.queue.redis_queue import _with_reconnect
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_TTL_SECONDS = 180
+
+
+@dataclass(frozen=True)
+class TurnLockEnvelope:
+    thread_id: int
+    owner_task_id: str
+    turn_id: str
+    acquired_at: str
+    renewed_at: str
+    lease_expires_at: str
+    lease_ttl_seconds: int
+    lease_token: str
+    source: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
 
 
 def _lock_ttl_seconds() -> int:
@@ -22,6 +42,140 @@ def _lock_ttl_seconds() -> int:
     return max(15, value)
 
 
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _utc_now_iso() -> str:
+    return _utc_now().isoformat()
+
+
+def _coerce_lock_ttl_seconds(ttl_seconds: int | None) -> int:
+    return max(1, int(ttl_seconds or _lock_ttl_seconds()))
+
+
+def _coerce_text(raw: Any) -> str | None:
+    if raw is None:
+        return None
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8")
+    return str(raw)
+
+
+def _parse_iso8601(raw: str | None) -> datetime | None:
+    text = str(raw or "").strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def build_turn_lock_envelope(
+    thread_id: int,
+    owner_task_id: str,
+    *,
+    turn_id: str | None = None,
+    ttl_seconds: int | None = None,
+    source: str | None = None,
+    acquired_at: str | None = None,
+    renewed_at: str | None = None,
+    lease_token: str | None = None,
+) -> TurnLockEnvelope:
+    ttl = _coerce_lock_ttl_seconds(ttl_seconds)
+    acquired_dt = _parse_iso8601(acquired_at) or _utc_now()
+    renewed_dt = _parse_iso8601(renewed_at) or acquired_dt
+    lease_expires_at = renewed_dt + timedelta(seconds=ttl)
+    return TurnLockEnvelope(
+        thread_id=int(thread_id),
+        owner_task_id=str(owner_task_id),
+        turn_id=str(turn_id or uuid.uuid4()),
+        acquired_at=acquired_dt.isoformat(),
+        renewed_at=renewed_dt.isoformat(),
+        lease_expires_at=lease_expires_at.isoformat(),
+        lease_ttl_seconds=ttl,
+        lease_token=str(lease_token or uuid.uuid4()),
+        source=str(source).strip() or None if source is not None else None,
+    )
+
+
+def _envelope_from_mapping(payload: dict[str, Any]) -> TurnLockEnvelope | None:
+    try:
+        thread_id = int(payload.get("thread_id") or 0)
+        owner_task_id = str(payload.get("owner_task_id") or "").strip()
+        acquired_at = str(payload.get("acquired_at") or "").strip()
+        renewed_at = str(payload.get("renewed_at") or "").strip()
+        lease_expires_at = str(payload.get("lease_expires_at") or "").strip()
+        lease_token = str(payload.get("lease_token") or "").strip()
+    except Exception:
+        return None
+
+    if not (
+        thread_id
+        and owner_task_id
+        and acquired_at
+        and renewed_at
+        and lease_expires_at
+        and lease_token
+    ):
+        return None
+
+    return TurnLockEnvelope(
+        thread_id=thread_id,
+        owner_task_id=owner_task_id,
+        turn_id=str(payload.get("turn_id") or uuid.uuid4()),
+        acquired_at=acquired_at,
+        renewed_at=renewed_at,
+        lease_expires_at=lease_expires_at,
+        lease_ttl_seconds=int(
+            payload.get("lease_ttl_seconds") or _DEFAULT_TTL_SECONDS
+        ),
+        lease_token=lease_token,
+        source=str(payload.get("source") or "").strip() or None,
+    )
+
+
+def _decode_turn_lock_value(raw: Any) -> TurnLockEnvelope | None:
+    text = _coerce_text(raw)
+    if not text:
+        return None
+    try:
+        payload = json.loads(text)
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return _envelope_from_mapping(payload)
+
+
+def _serialize_turn_lock(lock: TurnLockEnvelope) -> str:
+    return json.dumps(lock.as_dict(), separators=(",", ":"), sort_keys=True)
+
+
+def _expected_owner_and_token(
+    expected: str | TurnLockEnvelope,
+) -> tuple[str, str]:
+    if isinstance(expected, TurnLockEnvelope):
+        return expected.owner_task_id, expected.lease_token
+    return str(expected), ""
+
+
+def _matches_expected_lock(
+    current_raw: Any, expected: str | TurnLockEnvelope
+) -> bool:
+    owner_task_id, lease_token = _expected_owner_and_token(expected)
+    current_text = _coerce_text(current_raw)
+    current_lock = _decode_turn_lock_value(current_raw)
+    if current_lock is not None:
+        if current_lock.owner_task_id != owner_task_id:
+            return False
+        if lease_token and current_lock.lease_token != lease_token:
+            return False
+        return True
+    return current_text == owner_task_id
+
+
 def turn_lock_key(thread_id: int) -> str:
     return f"turn_lock:{int(thread_id)}"
 
@@ -31,39 +185,145 @@ def acquire_turn_lock(
     owner: str,
     *,
     ttl_seconds: int | None = None,
-) -> bool:
+    turn_id: str | None = None,
+    source: str | None = None,
+    return_envelope: bool = False,
+) -> bool | TurnLockEnvelope | None:
     """Acquire a per-thread lock using SET NX EX semantics."""
     key = turn_lock_key(thread_id)
-    ttl = max(1, int(ttl_seconds or _lock_ttl_seconds()))
+    ttl = _coerce_lock_ttl_seconds(ttl_seconds)
+    envelope = build_turn_lock_envelope(
+        thread_id,
+        owner,
+        turn_id=turn_id,
+        ttl_seconds=ttl,
+        source=source,
+    )
+    value = (
+        _serialize_turn_lock(envelope)
+        if return_envelope or turn_id is not None or source is not None
+        else owner
+    )
 
     def _acquire(client) -> bool:
-        return bool(client.set(key, owner, nx=True, ex=ttl))
+        return bool(client.set(key, value, nx=True, ex=ttl))
 
     acquired = bool(_with_reconnect(_acquire))
     if not acquired:
         logger.info("[turn-lock] in-flight thread_id=%s key=%s", thread_id, key)
-    return acquired
+        return None if return_envelope else False
+    return envelope if return_envelope else True
 
 
-def release_turn_lock(thread_id: int, owner: str) -> bool:
+def renew_turn_lock(
+    thread_id: int,
+    lock: TurnLockEnvelope,
+    *,
+    ttl_seconds: int | None = None,
+    return_envelope: bool = False,
+) -> bool | TurnLockEnvelope | None:
+    ttl = _coerce_lock_ttl_seconds(ttl_seconds)
+    renewed = build_turn_lock_envelope(
+        thread_id,
+        lock.owner_task_id,
+        turn_id=lock.turn_id,
+        ttl_seconds=ttl,
+        source=lock.source,
+        acquired_at=lock.acquired_at,
+        renewed_at=_utc_now_iso(),
+        lease_token=lock.lease_token,
+    )
+    key = turn_lock_key(thread_id)
+
+    def _renew(client) -> bool:
+        return bool(client.set(key, _serialize_turn_lock(renewed), ex=ttl))
+
+    updated = bool(_with_reconnect(_renew))
+    if not updated:
+        return None if return_envelope else False
+    return renewed if return_envelope else True
+
+
+def release_turn_lock(thread_id: int, owner: str | TurnLockEnvelope) -> bool:
     """Release lock only when current owner matches."""
     key = turn_lock_key(thread_id)
 
     def _release(client) -> bool:
-        released = client.eval(
-            """
-            if redis.call('GET', KEYS[1]) == ARGV[1] then
-                return redis.call('DEL', KEYS[1])
-            end
-            return 0
-            """,
-            1,
-            key,
-            owner,
-        )
-        return bool(released)
+        owner_task_id, lease_token = _expected_owner_and_token(owner)
+        if hasattr(client, "eval"):
+            try:
+                released = client.eval(
+                    """
+                    local value = redis.call('GET', KEYS[1])
+                    if not value then
+                        return 0
+                    end
+                    if value == ARGV[1] and ARGV[2] == '' then
+                        return redis.call('DEL', KEYS[1])
+                    end
+                    local ok, payload = pcall(cjson.decode, value)
+                    if ok and payload and payload.owner_task_id == ARGV[1] then
+                        if ARGV[2] == '' or payload.lease_token == ARGV[2] then
+                            return redis.call('DEL', KEYS[1])
+                        end
+                    end
+                    return 0
+                    """,
+                    1,
+                    key,
+                    owner_task_id,
+                    lease_token,
+                )
+                return bool(released)
+            except Exception:
+                logger.debug(
+                    "[turn-lock] eval release fallback thread_id=%s",
+                    thread_id,
+                    exc_info=True,
+                )
+        current = client.get(key)
+        if not _matches_expected_lock(current, owner):
+            return False
+        return bool(client.delete(key))
 
     return bool(_with_reconnect(_release))
+
+
+def clear_turn_lock(
+    thread_id: int,
+    expected: str | TurnLockEnvelope | None = None,
+) -> bool:
+    key = turn_lock_key(thread_id)
+
+    def _clear(client) -> bool:
+        if expected is None:
+            return bool(client.delete(key))
+        current = client.get(key)
+        if not _matches_expected_lock(current, expected):
+            return False
+        return bool(client.delete(key))
+
+    return bool(_with_reconnect(_clear))
+
+
+def get_turn_lock(thread_id: int) -> TurnLockEnvelope | None:
+    key = turn_lock_key(thread_id)
+
+    def _get_lock(client) -> TurnLockEnvelope | None:
+        return _decode_turn_lock_value(client.get(key))
+
+    return _with_reconnect(_get_lock)
+
+
+def turn_lock_is_stale(
+    lock: TurnLockEnvelope,
+    *,
+    now: datetime | None = None,
+) -> bool:
+    lease_expires_at = _parse_iso8601(lock.lease_expires_at)
+    if lease_expires_at is None:
+        return False
+    return lease_expires_at <= (now or _utc_now())
 
 
 def get_turn_lock_owner(thread_id: int) -> str | None:
@@ -72,6 +332,10 @@ def get_turn_lock_owner(thread_id: int) -> str | None:
 
     def _get_owner(client) -> str | None:
         value = client.get(key)
-        return str(value) if value is not None else None
+        lock = _decode_turn_lock_value(value)
+        if lock is not None:
+            return lock.owner_task_id
+        text = _coerce_text(value)
+        return text if text is not None else None
 
     return _with_reconnect(_get_owner)

--- a/guardian/routes/chat.py
+++ b/guardian/routes/chat.py
@@ -15,6 +15,7 @@ import asyncio
 import json
 import logging
 import uuid
+from dataclasses import asdict
 from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
@@ -37,7 +38,15 @@ from guardian.depth import (
 )
 from guardian.queue import task_events
 from guardian.queue.redis_queue import enqueue, enqueue_chat_embed
-from guardian.queue.turn_lock import acquire_turn_lock, release_turn_lock
+from guardian.queue.turn_lock import (
+    TurnLockEnvelope,
+    acquire_turn_lock,
+    build_turn_lock_envelope,
+    clear_turn_lock,
+    get_turn_lock,
+    release_turn_lock,
+    turn_lock_is_stale,
+)
 from guardian.tasks.types import ChatCompletionTask
 from guardian.voice.audio_assets import list_message_audio_assets
 
@@ -56,6 +65,57 @@ def _completion_service_unavailable(reason: str) -> HTTPException:
             "message": COMPLETION_SERVICE_UNAVAILABLE_MESSAGE,
         },
     )
+
+
+def _task_terminal_event(_task_id: str) -> dict[str, Any] | None:
+    return None
+
+
+def _chat_worker_heartbeat_age_seconds() -> float | None:
+    return None
+
+
+def _turn_lock_payload(
+    lock: TurnLockEnvelope | None,
+    *,
+    thread_id: int,
+    owner: str,
+    turn_id: str,
+) -> dict[str, Any]:
+    if isinstance(lock, TurnLockEnvelope):
+        return asdict(lock)
+    return asdict(
+        build_turn_lock_envelope(
+            thread_id,
+            owner,
+            turn_id=turn_id,
+            source="api:chat.complete",
+        )
+    )
+
+
+def _recover_orphaned_turn_lock(thread_id: int) -> bool:
+    stale_lock = get_turn_lock(thread_id)
+    if stale_lock is None or not turn_lock_is_stale(stale_lock):
+        return False
+    if _task_terminal_event(stale_lock.owner_task_id) is not None:
+        return False
+
+    heartbeat_age = _chat_worker_heartbeat_age_seconds()
+    if heartbeat_age is not None and heartbeat_age <= float(
+        stale_lock.lease_ttl_seconds
+    ):
+        return False
+
+    cleared = clear_turn_lock(thread_id, expected=stale_lock)
+    if cleared and hasattr(chatlog_db, "write_audit_log"):
+        chatlog_db.write_audit_log(
+            "recover_orphaned_turn_lock",
+            "chat_thread",
+            str(thread_id),
+            user_id="system",
+        )
+    return cleared
 
 
 # =========================
@@ -1510,7 +1570,24 @@ async def chat_complete(
         logger.warning("[chat.complete] turn lock unavailable: %s", exc)
         raise _completion_service_unavailable("turn_lock_unavailable")
     if not locked:
-        raise HTTPException(status_code=429, detail="turn_in_flight")
+        if _recover_orphaned_turn_lock(thread_id):
+            try:
+                locked = acquire_turn_lock(thread_id, task.turn_lock_owner)
+            except Exception as exc:
+                logger.warning(
+                    "[chat.complete] turn lock unavailable after recovery: %s",
+                    exc,
+                )
+                raise _completion_service_unavailable("turn_lock_unavailable")
+        if not locked:
+            raise HTTPException(status_code=429, detail="turn_in_flight")
+
+    task.turn_lock = _turn_lock_payload(
+        locked if isinstance(locked, TurnLockEnvelope) else None,
+        thread_id=thread_id,
+        owner=task.turn_lock_owner,
+        turn_id=turn_id,
+    )
 
     try:
         enqueue(task, "codexify:queue:chat")

--- a/guardian/routes/health.py
+++ b/guardian/routes/health.py
@@ -14,7 +14,7 @@ import time
 from uuid import uuid4
 
 import requests
-from fastapi import APIRouter, Depends, Query, Response
+from fastapi import APIRouter, Depends, Query, Request, Response
 
 from guardian.core import metrics
 from guardian.core.dependencies import DB_BACKEND, get_database_dsn
@@ -125,9 +125,13 @@ def _normalize_health_provider(raw_provider: str) -> str:
 
 
 @router.get("/health")
-def health():
+def health(request: Request):
     """Base health check endpoint for system-level monitoring."""
-    return {"status": "ok"}
+    payload = {"status": "ok"}
+    supported_profile = getattr(request.app.state, "supported_profile", None)
+    if supported_profile is not None:
+        payload["supported_profile"] = supported_profile
+    return payload
 
 
 @router.get("/health/llm")

--- a/tests/core/test_supported_profile.py
+++ b/tests/core/test_supported_profile.py
@@ -1,0 +1,15 @@
+from guardian.core.supported_profile import load_supported_profile
+
+
+def test_v1_supported_profile_manifest_loads() -> None:
+    manifest = load_supported_profile("v1-local-core-web-mcp")
+
+    assert manifest.name == "v1-local-core-web-mcp"
+    assert manifest.provider_contract["LLM_PROVIDER"] == "local"
+    assert (
+        manifest.provider_contract["LOCAL_BASE_URL"]
+        == "http://host.docker.internal:11434/v1"
+    )
+    assert manifest.route_status("command_bus") == "internal_only"
+    assert manifest.route_status("tools") == "quarantined"
+    assert manifest.route_status("media") == "enabled"

--- a/tests/core/test_supported_profile_provider.py
+++ b/tests/core/test_supported_profile_provider.py
@@ -1,0 +1,60 @@
+import pytest
+from fastapi import HTTPException
+
+from guardian.core.ai_router import _resolve_local_base
+from guardian.core.config import LLMConfigError, Settings, validate_llm_config
+
+
+def _supported_profile_settings(**overrides) -> Settings:
+    defaults = {
+        "LLM_PROVIDER": "local",
+        "ALLOW_CLOUD_PROVIDERS": False,
+        "CODEXIFY_LOCAL_ONLY_MODE": True,
+        "CODEXIFY_EGRESS_ALLOWLIST": "",
+        "LOCAL_BASE_URL": "http://host.docker.internal:11434/v1",
+        "LOCAL_API_KEY": "local",
+        "LOCAL_LLM_MODEL": "library2/ministral-3:8b",
+        "LOCAL_CHAT_MODEL": "library2/ministral-3:8b",
+        "LLM_MODEL": "library2/ministral-3:8b",
+    }
+    defaults.update(overrides)
+    return Settings(**defaults)
+
+
+def test_validate_llm_config_accepts_supported_profile_local_contract(
+    monkeypatch,
+):
+    monkeypatch.setenv("CODEXIFY_SUPPORTED_PROFILE", "v1-local-core-web-mcp")
+    settings = _supported_profile_settings()
+
+    validate_llm_config(settings)
+
+
+def test_validate_llm_config_rejects_supported_profile_provider_drift(
+    monkeypatch,
+):
+    monkeypatch.setenv("CODEXIFY_SUPPORTED_PROFILE", "v1-local-core-web-mcp")
+    settings = _supported_profile_settings(
+        LLM_PROVIDER="groq",
+        ALLOW_CLOUD_PROVIDERS=True,
+        CODEXIFY_LOCAL_ONLY_MODE=False,
+        CODEXIFY_EGRESS_ALLOWLIST="groq",
+    )
+
+    with pytest.raises(LLMConfigError, match="blessed local gateway contract"):
+        validate_llm_config(settings, provider_override="local")
+
+
+def test_resolve_local_base_rejects_supported_profile_gateway_drift(
+    monkeypatch,
+):
+    monkeypatch.setenv("CODEXIFY_SUPPORTED_PROFILE", "v1-local-core-web-mcp")
+    settings = _supported_profile_settings(
+        LOCAL_BASE_URL="http://127.0.0.1:11434/v1"
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        _resolve_local_base(settings)
+
+    assert exc.value.status_code == 400
+    assert "host.docker.internal:11434/v1" in str(exc.value.detail)

--- a/tests/core/test_supported_profile_quarantine.py
+++ b/tests/core/test_supported_profile_quarantine.py
@@ -1,0 +1,48 @@
+import importlib
+from contextlib import contextmanager
+
+from fastapi.testclient import TestClient
+
+
+@contextmanager
+def _build_supported_profile_client(monkeypatch):
+    monkeypatch.setenv("GUARDIAN_API_KEY", "test-api-key")
+    monkeypatch.setenv("ENABLE_CONNECTOR_WORKER", "0")
+    monkeypatch.setenv("GUARDIAN_EXPOSURE_MODE", "local_safe")
+    monkeypatch.setenv("CODEXIFY_SUPPORTED_PROFILE", "v1-local-core-web-mcp")
+
+    import guardian.guardian_api as guardian_api
+
+    guardian_api = importlib.reload(guardian_api)
+    client = TestClient(guardian_api.app)
+    try:
+        yield client
+    finally:
+        client.close()
+        from guardian.core import event_bus
+
+        event_bus.reset()
+        importlib.reload(guardian_api)
+
+
+def test_supported_profile_quarantines_legacy_tools_and_hides_command_bus_schema(
+    monkeypatch,
+) -> None:
+    with _build_supported_profile_client(monkeypatch) as client:
+        headers = {"X-API-Key": "test-api-key"}
+
+        assert (
+            client.get("/api/tools/manifest", headers=headers).status_code
+            == 404
+        )
+        assert client.get("/tools/manifest", headers=headers).status_code == 404
+
+        command_manifest = client.get(
+            "/api/guardian/commands/manifest", headers=headers
+        )
+        assert command_manifest.status_code == 200
+
+        openapi = client.get("/openapi.json").json()
+        assert "/api/guardian/commands/manifest" not in openapi.get("paths", {})
+        assert "/api/tools/manifest" not in openapi.get("paths", {})
+        assert "/tools/manifest" not in openapi.get("paths", {})

--- a/tests/core/test_supported_profile_startup.py
+++ b/tests/core/test_supported_profile_startup.py
@@ -1,9 +1,24 @@
 import importlib
 import os
+from contextlib import contextmanager
 from unittest.mock import MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
+
+_GUARDIAN_API_ENV_KEYS = (
+    "GUARDIAN_API_KEY",
+    "ENABLE_CONNECTOR_WORKER",
+    "CODEXIFY_SUPPORTED_PROFILE",
+    "LLM_PROVIDER",
+    "ALLOW_CLOUD_PROVIDERS",
+    "CODEXIFY_LOCAL_ONLY_MODE",
+    "CODEXIFY_EGRESS_ALLOWLIST",
+    "LOCAL_BASE_URL",
+    "LOCAL_API_KEY",
+    "LOCAL_LLM_MODEL",
+    "LOCAL_CHAT_MODEL",
+)
 
 
 def _fake_db() -> MagicMock:
@@ -104,27 +119,55 @@ def _load_guardian_api(monkeypatch, **env_overrides):
     return guardian_api
 
 
-def test_supported_profile_health_reports_active_profile(monkeypatch) -> None:
-    guardian_api = _load_guardian_api(monkeypatch)
-    guardian_api._refresh_supported_profile_state(
-        guardian_api.app, guardian_api.get_settings()
-    )
+def _snapshot_guardian_api_env() -> dict[str, str | None]:
+    return {key: os.environ.get(key) for key in _GUARDIAN_API_ENV_KEYS}
 
-    client = TestClient(guardian_api.app)
+
+def _restore_guardian_api_env(snapshot: dict[str, str | None]) -> None:
+    for key, value in snapshot.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+@contextmanager
+def _loaded_guardian_api(monkeypatch, **env_overrides):
+    snapshot = _snapshot_guardian_api_env()
+    guardian_api = _load_guardian_api(monkeypatch, **env_overrides)
     try:
-        response = client.get("/health")
-        assert response.status_code == 200
-        payload = response.json()
-        assert payload["status"] == "ok"
-        assert payload["supported_profile"]["name"] == "v1-local-core-web-mcp"
-        assert payload["supported_profile"]["valid"] is True
+        yield guardian_api
     finally:
-        client.close()
+        _restore_guardian_api_env(snapshot)
+        from guardian.core import event_bus
+
+        event_bus.reset()
+        importlib.reload(guardian_api)
 
 
-def test_supported_profile_startup_fails_on_provider_drift(monkeypatch) -> None:
-    guardian_api = _load_guardian_api(monkeypatch, LLM_PROVIDER="groq")
-    with pytest.raises(RuntimeError, match="supported profile drift"):
+def test_supported_profile_health_reports_active_profile(monkeypatch) -> None:
+    with _loaded_guardian_api(monkeypatch) as guardian_api:
         guardian_api._refresh_supported_profile_state(
             guardian_api.app, guardian_api.get_settings()
         )
+
+        client = TestClient(guardian_api.app)
+        try:
+            response = client.get("/health")
+            assert response.status_code == 200
+            payload = response.json()
+            assert payload["status"] == "ok"
+            assert (
+                payload["supported_profile"]["name"] == "v1-local-core-web-mcp"
+            )
+            assert payload["supported_profile"]["valid"] is True
+        finally:
+            client.close()
+
+
+def test_supported_profile_startup_fails_on_provider_drift(monkeypatch) -> None:
+    with _loaded_guardian_api(monkeypatch, LLM_PROVIDER="groq") as guardian_api:
+        with pytest.raises(RuntimeError, match="supported profile drift"):
+            guardian_api._refresh_supported_profile_state(
+                guardian_api.app, guardian_api.get_settings()
+            )

--- a/tests/core/test_supported_profile_startup.py
+++ b/tests/core/test_supported_profile_startup.py
@@ -1,0 +1,130 @@
+import importlib
+import os
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _fake_db() -> MagicMock:
+    db = MagicMock()
+    db.ensure_sync_job_support.return_value = None
+    db.sync_inference_provider_rows_from_catalog.return_value = {
+        "provider_rows": 0,
+        "providers_created": 0,
+        "providers_updated": 0,
+        "runtime_created": 0,
+    }
+    return db
+
+
+def _load_guardian_api(monkeypatch, **env_overrides):
+    fake_db = _fake_db()
+    monkeypatch.setenv("GUARDIAN_API_KEY", "test-api-key")
+    monkeypatch.setenv("ENABLE_CONNECTOR_WORKER", "0")
+    monkeypatch.setenv("CODEXIFY_SUPPORTED_PROFILE", "v1-local-core-web-mcp")
+    monkeypatch.setenv(
+        "LLM_PROVIDER", env_overrides.pop("LLM_PROVIDER", "local")
+    )
+    monkeypatch.setenv(
+        "ALLOW_CLOUD_PROVIDERS",
+        env_overrides.pop("ALLOW_CLOUD_PROVIDERS", "false"),
+    )
+    monkeypatch.setenv(
+        "CODEXIFY_LOCAL_ONLY_MODE",
+        env_overrides.pop("CODEXIFY_LOCAL_ONLY_MODE", "true"),
+    )
+    monkeypatch.setenv(
+        "CODEXIFY_EGRESS_ALLOWLIST",
+        env_overrides.pop("CODEXIFY_EGRESS_ALLOWLIST", ""),
+    )
+    monkeypatch.setenv(
+        "LOCAL_BASE_URL",
+        env_overrides.pop(
+            "LOCAL_BASE_URL", "http://host.docker.internal:11434/v1"
+        ),
+    )
+    monkeypatch.setenv(
+        "LOCAL_API_KEY", env_overrides.pop("LOCAL_API_KEY", "local")
+    )
+    monkeypatch.setenv(
+        "LOCAL_LLM_MODEL",
+        env_overrides.pop("LOCAL_LLM_MODEL", "library2/ministral-3:8b"),
+    )
+    monkeypatch.setenv(
+        "LOCAL_CHAT_MODEL",
+        env_overrides.pop("LOCAL_CHAT_MODEL", "library2/ministral-3:8b"),
+    )
+    for key, value in env_overrides.items():
+        monkeypatch.setenv(key, value)
+
+    import guardian.core.dependencies as dependencies
+
+    monkeypatch.setattr(dependencies, "init_database", lambda: fake_db)
+
+    import guardian.guardian_api as guardian_api
+
+    guardian_api = importlib.reload(guardian_api)
+    monkeypatch.setattr(
+        guardian_api.dependencies, "init_database", lambda: fake_db
+    )
+    monkeypatch.setattr(guardian_api, "chatlog_db", fake_db)
+    monkeypatch.setattr(guardian_api, "ensure_default_project", lambda: None)
+    monkeypatch.setattr(guardian_api, "init_services", lambda _db: None)
+    monkeypatch.setattr(
+        guardian_api.memory, "bind_dependencies", lambda **_: None
+    )
+    monkeypatch.setattr(guardian_api, "load_guardian_db_from_env", lambda: None)
+    monkeypatch.setattr(guardian_api.metrics, "set_db_backend", lambda *_: None)
+    monkeypatch.setattr(
+        guardian_api.task_events, "publish", lambda *_a, **_k: None
+    )
+    monkeypatch.setattr(guardian_api, "enqueue", lambda *_a, **_k: None)
+    settings = guardian_api.get_settings()
+    settings.LLM_PROVIDER = os.getenv("LLM_PROVIDER", "local")
+    settings.ALLOW_CLOUD_PROVIDERS = (
+        os.getenv("ALLOW_CLOUD_PROVIDERS", "false").strip().lower() == "true"
+    )
+    settings.CODEXIFY_LOCAL_ONLY_MODE = (
+        os.getenv("CODEXIFY_LOCAL_ONLY_MODE", "true").strip().lower() == "true"
+    )
+    settings.CODEXIFY_EGRESS_ALLOWLIST = os.getenv(
+        "CODEXIFY_EGRESS_ALLOWLIST", ""
+    )
+    settings.LOCAL_BASE_URL = os.getenv(
+        "LOCAL_BASE_URL", "http://host.docker.internal:11434/v1"
+    )
+    settings.LOCAL_API_KEY = os.getenv("LOCAL_API_KEY", "local")
+    settings.LOCAL_LLM_MODEL = os.getenv(
+        "LOCAL_LLM_MODEL", "library2/ministral-3:8b"
+    )
+    settings.LOCAL_CHAT_MODEL = os.getenv(
+        "LOCAL_CHAT_MODEL", "library2/ministral-3:8b"
+    )
+    return guardian_api
+
+
+def test_supported_profile_health_reports_active_profile(monkeypatch) -> None:
+    guardian_api = _load_guardian_api(monkeypatch)
+    guardian_api._refresh_supported_profile_state(
+        guardian_api.app, guardian_api.get_settings()
+    )
+
+    client = TestClient(guardian_api.app)
+    try:
+        response = client.get("/health")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["status"] == "ok"
+        assert payload["supported_profile"]["name"] == "v1-local-core-web-mcp"
+        assert payload["supported_profile"]["valid"] is True
+    finally:
+        client.close()
+
+
+def test_supported_profile_startup_fails_on_provider_drift(monkeypatch) -> None:
+    guardian_api = _load_guardian_api(monkeypatch, LLM_PROVIDER="groq")
+    with pytest.raises(RuntimeError, match="supported profile drift"):
+        guardian_api._refresh_supported_profile_state(
+            guardian_api.app, guardian_api.get_settings()
+        )

--- a/tests/core/test_turn_lock_recovery.py
+++ b/tests/core/test_turn_lock_recovery.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from guardian.queue.turn_lock import TurnLockEnvelope, build_turn_lock_envelope
+
+os.environ.setdefault("CODEXIFY_EMBEDDINGS_BACKEND", "mock")
+os.environ.setdefault("STORAGE_BASE_PATH", "/tmp/test_media")
+os.environ.setdefault("ENABLE_BLIP_MODEL", "false")
+os.environ.setdefault("GUARDIAN_ENABLE_MONDREAM", "0")
+os.environ.setdefault("ENABLE_CONNECTOR_WORKER", "0")
+
+
+@pytest.fixture
+def mock_db():
+    mock = MagicMock()
+    mock.list_messages.return_value = [
+        {
+            "id": 1,
+            "thread_id": 1,
+            "role": "user",
+            "content": "Test message",
+            "created_at": "2026-03-13T12:00:00",
+        }
+    ]
+    mock.get_chat_thread.return_value = {
+        "id": 1,
+        "user_id": "test_user",
+        "title": "Test Thread",
+        "summary": "",
+        "project_id": 1,
+    }
+    mock.write_audit_log.return_value = None
+    return mock
+
+
+@pytest.fixture
+def test_client(mock_db, monkeypatch, tmp_path):
+    monkeypatch.setenv("STORAGE_BASE_PATH", str(tmp_path / "media"))
+    with patch("logging.info"):
+        with patch("guardian.guardian_api.chatlog_db", mock_db):
+            with patch("guardian.core.dependencies.chatlog_db", mock_db):
+                with patch("guardian.routes.chat.chatlog_db", mock_db):
+                    with patch(
+                        "guardian.guardian_api.event_bus"
+                    ) as mock_event_bus:
+                        mock_event_bus.emit_event.return_value = None
+                        from guardian.guardian_api import app, require_api_key
+
+                        app.dependency_overrides[
+                            require_api_key
+                        ] = lambda: "test-api-key"
+                        client = TestClient(app)
+                        try:
+                            yield client
+                        finally:
+                            app.dependency_overrides.clear()
+
+
+def _stale_lock(thread_id: int = 1) -> TurnLockEnvelope:
+    lock = build_turn_lock_envelope(
+        thread_id,
+        "task-stale",
+        turn_id="44444444-4444-4444-8444-444444444444",
+        ttl_seconds=30,
+        source="worker:chat",
+    )
+    return TurnLockEnvelope(
+        thread_id=lock.thread_id,
+        owner_task_id=lock.owner_task_id,
+        turn_id=lock.turn_id,
+        acquired_at="2026-03-13T12:00:00+00:00",
+        renewed_at="2026-03-13T12:00:00+00:00",
+        lease_expires_at="2026-03-13T12:00:30+00:00",
+        lease_ttl_seconds=30,
+        lease_token=lock.lease_token,
+        source=lock.source,
+    )
+
+
+def test_complete_recovers_orphaned_turn_lock(
+    test_client, mock_db, monkeypatch
+):
+    captured: dict[str, object] = {}
+    acquire_calls = {"count": 0}
+
+    def _acquire(*args, **kwargs):
+        acquire_calls["count"] += 1
+        if acquire_calls["count"] == 1:
+            return None
+        return build_turn_lock_envelope(
+            args[0],
+            args[1],
+            turn_id=kwargs.get("turn_id"),
+            source=kwargs.get("source"),
+        )
+
+    monkeypatch.setattr("guardian.routes.chat.acquire_turn_lock", _acquire)
+    monkeypatch.setattr(
+        "guardian.routes.chat.get_turn_lock", lambda *_: _stale_lock()
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat.turn_lock_is_stale", lambda *_: True
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat._task_terminal_event", lambda *_: None
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat._chat_worker_heartbeat_age_seconds",
+        lambda: None,
+    )
+    cleared: list[tuple[int, str]] = []
+    monkeypatch.setattr(
+        "guardian.routes.chat.clear_turn_lock",
+        lambda thread_id, expected=None: cleared.append(
+            (thread_id, getattr(expected, "owner_task_id", ""))
+        )
+        or True,
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat.enqueue",
+        lambda task, queue_name: captured.update(
+            {"task": task, "queue_name": queue_name}
+        ),
+    )
+
+    response = test_client.post("/chat/1/complete", json={})
+
+    assert response.status_code == 200
+    assert cleared == [(1, "task-stale")]
+    assert mock_db.write_audit_log.call_args[0] == (
+        "recover_orphaned_turn_lock",
+        "chat_thread",
+        "1",
+    )
+    assert mock_db.write_audit_log.call_args.kwargs == {"user_id": "system"}
+    task = captured["task"]
+    assert getattr(task, "turn_lock_owner") == getattr(task, "task_id")
+    assert getattr(task, "turn_lock")["turn_id"]
+
+
+def test_complete_keeps_active_turn_lock_in_place(
+    test_client, mock_db, monkeypatch
+):
+    monkeypatch.setattr(
+        "guardian.routes.chat.acquire_turn_lock",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat.get_turn_lock", lambda *_: _stale_lock()
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat.turn_lock_is_stale", lambda *_: False
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat._task_terminal_event", lambda *_: None
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat._chat_worker_heartbeat_age_seconds",
+        lambda: 1.0,
+    )
+    clear_spy = MagicMock(return_value=False)
+    monkeypatch.setattr("guardian.routes.chat.clear_turn_lock", clear_spy)
+
+    response = test_client.post("/chat/1/complete", json={})
+
+    assert response.status_code == 429
+    assert response.json()["detail"] == "turn_in_flight"
+    clear_spy.assert_not_called()
+    mock_db.write_audit_log.assert_not_called()

--- a/tests/queue/test_turn_lock.py
+++ b/tests/queue/test_turn_lock.py
@@ -1,0 +1,87 @@
+from guardian.queue import turn_lock
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+
+    def set(
+        self,
+        key: str,
+        value: str,
+        ex: int | None = None,
+        nx: bool = False,
+    ) -> bool | None:
+        _ = ex
+        if nx and key in self.values:
+            return None
+        self.values[key] = value
+        return True
+
+    def get(self, key: str) -> str | None:
+        return self.values.get(key)
+
+    def delete(self, key: str) -> int:
+        if key not in self.values:
+            return 0
+        del self.values[key]
+        return 1
+
+
+def test_turn_lock_acquire_stores_structured_envelope(monkeypatch):
+    client = _FakeRedis()
+    monkeypatch.setattr(turn_lock, "_with_reconnect", lambda fn: fn(client))
+
+    acquired = turn_lock.acquire_turn_lock(
+        11,
+        "task-11",
+        turn_id="11111111-1111-4111-8111-111111111111",
+        source="test",
+        return_envelope=True,
+    )
+
+    assert isinstance(acquired, turn_lock.TurnLockEnvelope)
+    assert acquired.thread_id == 11
+    assert acquired.owner_task_id == "task-11"
+    assert acquired.turn_id == "11111111-1111-4111-8111-111111111111"
+    assert acquired.source == "test"
+    assert turn_lock.get_turn_lock_owner(11) == "task-11"
+
+
+def test_turn_lock_renew_preserves_lease_token(monkeypatch):
+    client = _FakeRedis()
+    monkeypatch.setattr(turn_lock, "_with_reconnect", lambda fn: fn(client))
+
+    acquired = turn_lock.acquire_turn_lock(
+        17,
+        "task-17",
+        turn_id="22222222-2222-4222-8222-222222222222",
+        source="test",
+        return_envelope=True,
+    )
+    renewed = turn_lock.renew_turn_lock(
+        17,
+        acquired,
+        return_envelope=True,
+    )
+
+    assert isinstance(renewed, turn_lock.TurnLockEnvelope)
+    assert renewed.owner_task_id == "task-17"
+    assert renewed.turn_id == "22222222-2222-4222-8222-222222222222"
+    assert renewed.lease_token == acquired.lease_token
+    assert renewed.acquired_at == acquired.acquired_at
+
+
+def test_turn_lock_release_by_envelope(monkeypatch):
+    client = _FakeRedis()
+    monkeypatch.setattr(turn_lock, "_with_reconnect", lambda fn: fn(client))
+
+    acquired = turn_lock.acquire_turn_lock(
+        23,
+        "task-23",
+        turn_id="33333333-3333-4333-8333-333333333333",
+        return_envelope=True,
+    )
+
+    assert turn_lock.release_turn_lock(23, acquired) is True
+    assert turn_lock.get_turn_lock(23) is None

--- a/tests/routes/test_command_bus_internal_surface.py
+++ b/tests/routes/test_command_bus_internal_surface.py
@@ -1,0 +1,43 @@
+import importlib
+from contextlib import contextmanager
+
+from fastapi.testclient import TestClient
+
+
+@contextmanager
+def _build_public_allowlist_client(monkeypatch):
+    monkeypatch.setenv("GUARDIAN_API_KEY", "test-api-key")
+    monkeypatch.setenv("ENABLE_CONNECTOR_WORKER", "0")
+    monkeypatch.setenv("GUARDIAN_EXPOSURE_MODE", "public_allowlist")
+    monkeypatch.setenv("GUARDIAN_PUBLIC_PROFILE", "connectors_runtime")
+    monkeypatch.setenv(
+        "GUARDIAN_PUBLIC_ROUTES_FILE", "config/public_routes.yaml"
+    )
+    monkeypatch.setenv("CODEXIFY_SUPPORTED_PROFILE", "v1-local-core-web-mcp")
+
+    import guardian.guardian_api as guardian_api
+
+    guardian_api = importlib.reload(guardian_api)
+    client = TestClient(guardian_api.app)
+    try:
+        yield client
+    finally:
+        client.close()
+        from guardian.core import event_bus
+
+        event_bus.reset()
+        importlib.reload(guardian_api)
+
+
+def test_public_allowlist_blocks_internal_command_bus_surface(
+    monkeypatch,
+) -> None:
+    with _build_public_allowlist_client(monkeypatch) as client:
+        headers = {"X-API-Key": "test-api-key"}
+
+        response = client.get(
+            "/api/guardian/commands/manifest", headers=headers
+        )
+
+        assert response.status_code == 403
+        assert response.json() == {"ok": False, "error": "forbidden"}

--- a/tests/routes/test_command_bus_internal_surface.py
+++ b/tests/routes/test_command_bus_internal_surface.py
@@ -1,11 +1,34 @@
 import importlib
+import os
 from contextlib import contextmanager
 
 from fastapi.testclient import TestClient
 
+_GUARDIAN_API_ENV_KEYS = (
+    "GUARDIAN_API_KEY",
+    "ENABLE_CONNECTOR_WORKER",
+    "GUARDIAN_EXPOSURE_MODE",
+    "GUARDIAN_PUBLIC_PROFILE",
+    "GUARDIAN_PUBLIC_ROUTES_FILE",
+    "CODEXIFY_SUPPORTED_PROFILE",
+)
+
+
+def _snapshot_guardian_api_env() -> dict[str, str | None]:
+    return {key: os.environ.get(key) for key in _GUARDIAN_API_ENV_KEYS}
+
+
+def _restore_guardian_api_env(snapshot: dict[str, str | None]) -> None:
+    for key, value in snapshot.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
 
 @contextmanager
 def _build_public_allowlist_client(monkeypatch):
+    snapshot = _snapshot_guardian_api_env()
     monkeypatch.setenv("GUARDIAN_API_KEY", "test-api-key")
     monkeypatch.setenv("ENABLE_CONNECTOR_WORKER", "0")
     monkeypatch.setenv("GUARDIAN_EXPOSURE_MODE", "public_allowlist")
@@ -23,6 +46,7 @@ def _build_public_allowlist_client(monkeypatch):
         yield client
     finally:
         client.close()
+        _restore_guardian_api_env(snapshot)
         from guardian.core import event_bus
 
         event_bus.reset()


### PR DESCRIPTION
## Summary
- Supersedes #89 with a clean branch cut from `origin/main`.
- Cherry-picks `1198f9930` and adds one runtime-only repair commit to make the supported-profile and turn-lock recovery surfaces self-contained on `main`.
- Excludes unrelated polluted ancestry from `b64f7e7a9`, `4b5a7ae1f`, `314e75be0`, `9ca9907ff`, and `5b0194274`.

## Validation
- `pytest -q tests/core/test_supported_profile.py tests/core/test_supported_profile_provider.py tests/core/test_supported_profile_quarantine.py tests/core/test_supported_profile_startup.py tests/core/test_turn_lock_recovery.py tests/queue/test_turn_lock.py tests/routes/test_command_bus_internal_surface.py`

## Notes
- The original PR branch carried unrelated docs/frontend ancestry, so this replacement branch starts from the refreshed `origin/main` state on March 15, 2026.
- Runtime-only follow-up changes were kept strictly to supported-profile enforcement, internal-surface quarantine, health reporting, and turn-lock recovery helpers required by the cherry-picked tests.