### PR TITLE
Introduce canonical service plugin facade

### DIFF
--- a/guardian/core/plugins.py
+++ b/guardian/core/plugins.py
@@ -1,84 +1,46 @@
-"""Canonical service plugin facade for discovery and invocation."""
+"""Canonical facade for service-plugin discovery and invocation."""
 
 from __future__ import annotations
 
+import json
 import logging
-import uuid
+from dataclasses import dataclass
 from threading import Lock
-from typing import Any, Mapping
+from typing import Any
 
 import requests
 
 from guardian.plugin_loader import plugin_loader as _runtime_plugin_loader
-from guardian.plugins.plugin_loader import (
-    load_all_manifests as _load_manifest_plugins,
-)
+from guardian.plugins.plugin_loader import load_all_manifests
 from guardian.plugins.plugin_manifest import PluginManifest
 
 logger = logging.getLogger(__name__)
 
 _RUNTIME_LOADER_LOCK = Lock()
-HEALTH_TIMEOUT_SECONDS = 2.0
-INVOKE_TIMEOUT_SECONDS = 10.0
-PROTOCOL_VERSION = "1.0"
 
-ERROR_NOT_FOUND = "not_found"
-ERROR_AMBIGUOUS = "ambiguous"
-ERROR_TIMEOUT = "timeout"
-ERROR_TRANSPORT_FAILURE = "transport_failure"
-ERROR_INVALID_RESPONSE = "invalid_response"
-ERROR_REMOTE_ERROR = "remote_error"
-
-_INVOKE_HEADERS = {
-    "Accept": "application/json",
-    "Content-Type": "application/json",
-}
+HEALTH_TIMEOUT_SECONDS = 2
+INVOKE_TIMEOUT_SECONDS = 10
+_PROTOCOL_VERSION = "1.0"
 
 
-class PluginFacadeError(RuntimeError):
-    """Stable error surface for plugin facade consumers."""
+@dataclass
+class PluginFacadeError(Exception):
+    """Stable facade error for plugin discovery and invocation failures."""
 
-    def __init__(
-        self,
-        *,
-        code: str,
-        message: str,
-        plugin_id: str | None = None,
-        capability: str | None = None,
-        action: str | None = None,
-        details: Any | None = None,
-    ):
-        super().__init__(message)
-        self.code = code
-        self.message = message
-        self.plugin_id = plugin_id
-        self.capability = capability
-        self.action = action
-        self.details = details
+    code: str
+    message: str
 
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "code": self.code,
-            "message": self.message,
-            "plugin_id": self.plugin_id,
-            "capability": self.capability,
-            "action": self.action,
-            "details": self.details,
-        }
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"{self.code}: {self.message}"
 
 
 def get_runtime_plugin_loader():
-    """Return the singleton runtime plugin loader instance."""
+    """Return the singleton legacy runtime plugin loader instance."""
     return _runtime_plugin_loader
 
 
 def load_runtime_plugins():
-    """
-    Load runtime plugins through a single guarded entrypoint.
-
-    Loader invocation is idempotent for non-empty registries to avoid
-    accidental duplicate initialization across call sites.
-    """
+    """Load runtime plugins once for compatibility with legacy callers."""
     loader = get_runtime_plugin_loader()
     with _RUNTIME_LOADER_LOCK:
         if not getattr(loader, "plugins", {}):
@@ -87,12 +49,12 @@ def load_runtime_plugins():
 
 
 def list_plugin_manifests() -> list[PluginManifest]:
-    """Return manifests validated via the canonical discovery path."""
-    return _load_manifest_plugins()
+    """Return installed plugins from canonical validated manifest discovery."""
+    return load_all_manifests()
 
 
 def get_plugin_manifest_by_id(plugin_id: str) -> PluginManifest | None:
-    """Return a plugin manifest by id from the centralized manifest list."""
+    """Return the installed manifest for a plugin id."""
     for manifest in list_plugin_manifests():
         if manifest.id == plugin_id:
             return manifest
@@ -100,361 +62,204 @@ def get_plugin_manifest_by_id(plugin_id: str) -> PluginManifest | None:
 
 
 def find_plugins_by_capability_action(
-    capability: str, action: str
+    capability: str,
+    action: str,
 ) -> list[PluginManifest]:
-    """Return all plugins advertising the capability/action pair."""
-    wanted_capability = capability.strip()
-    wanted_action = action.strip()
-    if not wanted_capability or not wanted_action:
-        return []
+    """Return manifests that advertise a callable (capability, action) pair."""
+    return [
+        manifest
+        for manifest in list_plugin_manifests()
+        if manifest.supports_operation(capability, action)
+    ]
 
-    matches: list[PluginManifest] = []
+
+def get_plugin_manifest_by_capability(capability: str) -> PluginManifest | None:
+    """Compatibility helper for legacy TTS lookup by capability id only."""
+    wanted = capability.strip()
+    if not wanted:
+        return None
+
     for manifest in list_plugin_manifests():
-        if manifest.supports_operation(wanted_capability, wanted_action):
-            matches.append(manifest)
-    return matches
+        if any(cap.id == wanted for cap in manifest.capabilities):
+            return manifest
+    return None
 
 
-def _normalize_context(
-    context: Mapping[str, Any] | None,
-) -> dict[str, Any]:
-    context = dict(context or {})
-    request_id = context.get("request_id")
-    if request_id is None or str(request_id).strip() == "":
-        request_id = str(uuid.uuid4())
-
-    return {
-        "request_id": str(request_id),
-        "thread_id": context.get("thread_id"),
-        "user_id": context.get("user_id"),
-    }
+def _invoke_url(base_url: str) -> str:
+    return f"{base_url}/invoke"
 
 
-def _build_invoke_envelope(
+def _health_url(base_url: str) -> str:
+    return f"{base_url}/health"
+
+
+def _build_context(context: dict[str, Any] | None) -> dict[str, Any]:
+    defaults = {"request_id": "", "thread_id": None, "user_id": None}
+    if context:
+        defaults.update(context)
+    return defaults
+
+
+def _build_envelope(
     *,
     plugin_id: str,
     capability: str,
     action: str,
-    input: Any,
-    context: Mapping[str, Any] | None,
+    input: dict[str, Any],
+    context: dict[str, Any] | None,
 ) -> dict[str, Any]:
     return {
-        "protocol_version": PROTOCOL_VERSION,
+        "protocol_version": _PROTOCOL_VERSION,
         "plugin_id": plugin_id,
         "capability": capability,
         "action": action,
         "input": input,
-        "context": _normalize_context(context),
+        "context": _build_context(context),
     }
 
 
-def _parse_response_payload(
-    response: requests.Response,
-    *,
-    plugin_id: str,
-    capability: str,
-    action: str,
-) -> dict[str, Any]:
-    try:
-        payload = response.json()
-    except ValueError as exc:
-        raise PluginFacadeError(
-            code=ERROR_INVALID_RESPONSE,
-            message="Plugin response was not valid JSON",
-            plugin_id=plugin_id,
-            capability=capability,
-            action=action,
-            details={"status_code": response.status_code},
-        ) from exc
-
+def _normalize_response(payload: Any) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise PluginFacadeError(
-            code=ERROR_INVALID_RESPONSE,
-            message="Plugin response payload must be a JSON object",
-            plugin_id=plugin_id,
-            capability=capability,
-            action=action,
-            details={"status_code": response.status_code},
+            code="invalid_response",
+            message="plugin response must be a JSON object",
         )
-    return payload
-
-
-def _handle_transport_error(
-    exc: Exception,
-    *,
-    plugin_id: str,
-    capability: str,
-    action: str,
-) -> None:
-    if isinstance(exc, requests.Timeout):
+    if "ok" not in payload:
         raise PluginFacadeError(
-            code=ERROR_TIMEOUT,
-            message="Plugin invocation timed out",
-            plugin_id=plugin_id,
-            capability=capability,
-            action=action,
-        ) from exc
-
+            code="invalid_response",
+            message="plugin response missing 'ok'",
+        )
+    if payload["ok"] is True:
+        return payload
+    if payload["ok"] is False:
+        raise PluginFacadeError(
+            code="remote_error",
+            message=str(payload.get("error") or "plugin reported an error"),
+        )
     raise PluginFacadeError(
-        code=ERROR_TRANSPORT_FAILURE,
-        message="Plugin transport failure",
-        plugin_id=plugin_id,
-        capability=capability,
-        action=action,
-        details=str(exc),
-    ) from exc
+        code="invalid_response",
+        message="plugin response field 'ok' must be a boolean",
+    )
+
+
+def _safe_json(response: requests.Response) -> dict[str, Any]:
+    try:
+        payload = response.json()
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise PluginFacadeError(
+            code="invalid_response",
+            message=f"plugin returned malformed JSON: {exc}",
+        ) from exc
+    return _normalize_response(payload)
 
 
 def invoke_plugin(
     plugin_id: str,
     capability: str,
     action: str,
-    input: Any,
-    context: Mapping[str, Any] | None = None,
+    input: dict[str, Any],
+    context: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """
-    Invoke a specific plugin for a declared capability/action pair.
-    """
+    """Invoke a specific plugin service endpoint using the canonical envelope."""
     manifest = get_plugin_manifest_by_id(plugin_id)
     if manifest is None:
         raise PluginFacadeError(
-            code=ERROR_NOT_FOUND,
-            message=f"Plugin not found: {plugin_id}",
-            plugin_id=plugin_id,
-            capability=capability,
-            action=action,
+            code="not_found",
+            message=f"plugin '{plugin_id}' not found",
         )
     if not manifest.supports_operation(capability, action):
         raise PluginFacadeError(
-            code=ERROR_NOT_FOUND,
+            code="not_found",
             message=(
-                "Plugin does not advertise capability/action pair: "
-                f"{plugin_id} {capability}/{action}"
+                f"plugin '{plugin_id}' does not support "
+                f"{capability}/{action}"
             ),
-            plugin_id=plugin_id,
-            capability=capability,
-            action=action,
         )
 
-    envelope = _build_invoke_envelope(
+    envelope = _build_envelope(
         plugin_id=plugin_id,
         capability=capability,
         action=action,
         input=input,
         context=context,
     )
-    url = f"{manifest.base_url}/invoke"
 
     try:
         response = requests.post(
-            url,
+            _invoke_url(manifest.base_url),
             json=envelope,
-            headers=_INVOKE_HEADERS,
             timeout=INVOKE_TIMEOUT_SECONDS,
         )
+    except requests.Timeout as exc:
+        raise PluginFacadeError(
+            code="timeout",
+            message=f"plugin invoke timed out for '{plugin_id}'",
+        ) from exc
     except requests.RequestException as exc:
-        _handle_transport_error(
-            exc,
-            plugin_id=plugin_id,
-            capability=capability,
-            action=action,
-        )
-
-    payload = _parse_response_payload(
-        response,
-        plugin_id=plugin_id,
-        capability=capability,
-        action=action,
-    )
-
-    if response.status_code >= 400:
         raise PluginFacadeError(
-            code=ERROR_REMOTE_ERROR,
-            message="Plugin returned an error response",
-            plugin_id=plugin_id,
-            capability=capability,
-            action=action,
-            details={
-                "status_code": response.status_code,
-                "error": payload.get("error"),
-            },
-        )
+            code="transport_failure",
+            message=f"plugin invoke transport failure for '{plugin_id}'",
+        ) from exc
 
-    if payload.get("error") not in (None, ""):
-        raise PluginFacadeError(
-            code=ERROR_REMOTE_ERROR,
-            message="Plugin returned an application error",
-            plugin_id=plugin_id,
-            capability=capability,
-            action=action,
-            details=payload.get("error"),
-        )
-
-    if "ok" in payload and not isinstance(payload["ok"], bool):
-        raise PluginFacadeError(
-            code=ERROR_INVALID_RESPONSE,
-            message="Plugin response field 'ok' must be boolean when present",
-            plugin_id=plugin_id,
-            capability=capability,
-            action=action,
-            details={"status_code": response.status_code},
-        )
-
-    if payload.get("ok") is False and payload.get("error") in (None, ""):
-        raise PluginFacadeError(
-            code=ERROR_INVALID_RESPONSE,
-            message=(
-                "Plugin response marked failure without canonical error payload"
-            ),
-            plugin_id=plugin_id,
-            capability=capability,
-            action=action,
-            details={"status_code": response.status_code},
-        )
-
-    if "output" not in payload:
-        raise PluginFacadeError(
-            code=ERROR_INVALID_RESPONSE,
-            message="Plugin response missing required 'output' field",
-            plugin_id=plugin_id,
-            capability=capability,
-            action=action,
-            details={"status_code": response.status_code},
-        )
-    if not isinstance(payload["output"], dict):
-        raise PluginFacadeError(
-            code=ERROR_INVALID_RESPONSE,
-            message="Plugin response field 'output' must be an object",
-            plugin_id=plugin_id,
-            capability=capability,
-            action=action,
-            details={"status_code": response.status_code},
-        )
-
-    return payload
-
-
-def get_plugin_health(plugin_id: str) -> dict[str, Any]:
-    """
-    Fetch liveness metadata from GET /health for a specific plugin.
-
-    Health does not influence installation/discovery state.
-    """
-    manifest = get_plugin_manifest_by_id(plugin_id)
-    if manifest is None:
-        raise PluginFacadeError(
-            code=ERROR_NOT_FOUND,
-            message=f"Plugin not found: {plugin_id}",
-            plugin_id=plugin_id,
-        )
-
-    url = f"{manifest.base_url}/health"
-    try:
-        response = requests.get(url, timeout=HEALTH_TIMEOUT_SECONDS)
-    except requests.RequestException as exc:
-        _handle_transport_error(
-            exc,
-            plugin_id=plugin_id,
-            capability="health",
-            action="health",
-        )
-
-    payload = _parse_response_payload(
-        response,
-        plugin_id=plugin_id,
-        capability="health",
-        action="health",
-    )
-    if response.status_code >= 400:
-        raise PluginFacadeError(
-            code=ERROR_REMOTE_ERROR,
-            message="Plugin health endpoint returned an error response",
-            plugin_id=plugin_id,
-            capability="health",
-            action="health",
-            details={
-                "status_code": response.status_code,
-                "error": payload.get("error"),
-            },
-        )
-    return payload
+    return _safe_json(response)
 
 
 def invoke_capability(
     capability: str,
     action: str,
-    input: Any,
-    context: Mapping[str, Any] | None = None,
+    input: dict[str, Any],
+    context: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """
-    Invoke by capability/action when exactly one plugin advertises it.
-    """
-    matches = find_plugins_by_capability_action(capability, action)
-    if not matches:
+    """Invoke a capability/action pair when exactly one plugin supports it."""
+    manifests = find_plugins_by_capability_action(capability, action)
+    if not manifests:
         raise PluginFacadeError(
-            code=ERROR_NOT_FOUND,
-            message=(
-                "No plugin advertises capability/action pair: "
-                f"{capability}/{action}"
-            ),
-            capability=capability,
-            action=action,
+            code="not_found",
+            message=f"no plugin found for {capability}/{action}",
         )
-    if len(matches) > 1:
+    if len(manifests) > 1:
+        plugin_ids = ", ".join(sorted(manifest.id for manifest in manifests))
         raise PluginFacadeError(
-            code=ERROR_AMBIGUOUS,
-            message=(
-                "Multiple plugins advertise capability/action pair: "
-                f"{capability}/{action}"
-            ),
-            capability=capability,
-            action=action,
-            details=[manifest.id for manifest in matches],
+            code="ambiguous",
+            message=f"multiple plugins found for {capability}/{action}: {plugin_ids}",
         )
-    return invoke_plugin(
-        matches[0].id,
-        capability=capability,
-        action=action,
-        input=input,
-        context=context,
-    )
+    return invoke_plugin(manifests[0].id, capability, action, input, context)
 
 
-def get_plugin_manifest_by_capability(
-    capability: str,
-) -> PluginManifest | None:
-    """
-    Back-compat helper: return first plugin exposing any action for capability.
-    """
-    wanted = capability.strip().lower()
-    if not wanted:
-        return None
+def probe_plugin_health(plugin_id: str) -> dict[str, Any]:
+    """Fetch /health metadata without affecting installation state."""
+    manifest = get_plugin_manifest_by_id(plugin_id)
+    if manifest is None:
+        raise PluginFacadeError(code="not_found", message="plugin not found")
 
-    for manifest in list_plugin_manifests():
-        capability_ids = {
-            decl.id.strip().lower() for decl in manifest.capabilities
-        }
-        if wanted in capability_ids:
-            return manifest
-
-    return None
+    try:
+        response = requests.get(
+            _health_url(manifest.base_url), timeout=HEALTH_TIMEOUT_SECONDS
+        )
+        return response.json()
+    except requests.Timeout as exc:
+        raise PluginFacadeError(
+            code="timeout", message="health check timed out"
+        ) from exc
+    except requests.RequestException as exc:
+        raise PluginFacadeError(
+            code="transport_failure", message="health check failed"
+        ) from exc
+    except ValueError as exc:
+        raise PluginFacadeError(
+            code="invalid_response", message="health response is not JSON"
+        ) from exc
 
 
 __all__ = [
-    "ERROR_AMBIGUOUS",
-    "ERROR_INVALID_RESPONSE",
-    "ERROR_NOT_FOUND",
-    "ERROR_REMOTE_ERROR",
-    "ERROR_TIMEOUT",
-    "ERROR_TRANSPORT_FAILURE",
     "PluginFacadeError",
     "find_plugins_by_capability_action",
     "get_plugin_manifest_by_capability",
-    "get_plugin_manifest_by_id",
-    "get_plugin_health",
     "get_runtime_plugin_loader",
+    "get_plugin_manifest_by_id",
     "invoke_capability",
     "invoke_plugin",
     "list_plugin_manifests",
     "load_runtime_plugins",
+    "probe_plugin_health",
 ]

--- a/guardian/plugins/plugin_loader.py
+++ b/guardian/plugins/plugin_loader.py
@@ -1,103 +1,73 @@
-"""
-Plugin Loader
-~~~~~~~~~~~~~
+"""Canonical manifest discovery for service plugins."""
 
-Loads plugin manifests from the plugins directory. Each plugin is expected
-to have a manifest.json file in its subdirectory.
-"""
+from __future__ import annotations
 
 import json
 import logging
 from pathlib import Path
-from typing import List
+
+from pydantic import ValidationError
 
 from .plugin_manifest import PluginManifest
 
 logger = logging.getLogger(__name__)
 
-# Plugin directory at project root
-PLUGIN_DIR = Path(__file__).parent.parent.parent / "plugins"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_DIR = REPO_ROOT / "plugins"
 
 
-def load_all_manifests() -> List[PluginManifest]:
-    """
-    Load all plugin manifests from the plugins directory.
+class PluginDiscoveryError(Exception):
+    """Raised when manifest discovery fails deterministically."""
 
-    Scans the plugins directory for subdirectories containing manifest.json
-    files and parses them into PluginManifest objects.
 
-    Returns:
-        List of validated PluginManifest objects
-    """
-    manifests: List[PluginManifest | None] = []
-    manifest_indexes_by_id: dict[str, int] = {}
-    duplicate_ids: set[str] = set()
+class DuplicatePluginIdError(PluginDiscoveryError):
+    """Raised when duplicate plugin ids are discovered."""
 
-    if not PLUGIN_DIR.exists():
-        logger.warning(
-            "[plugin_loader] Plugin directory not found: %s", PLUGIN_DIR
-        )
-        return []
 
-    # Canonical discovery path only: <repo_root>/plugins/<plugin_id>/manifest.json
-    for manifest_file in sorted(PLUGIN_DIR.glob("*/manifest.json")):
+def _manifest_files(plugin_dir: Path = PLUGIN_DIR) -> list[Path]:
+    return sorted(plugin_dir.glob("*/manifest.json"))
+
+
+def load_all_manifests(plugin_dir: Path = PLUGIN_DIR) -> list[PluginManifest]:
+    """Load and validate canonical v1 manifests from plugins/*/manifest.json."""
+    manifests: list[PluginManifest] = []
+    seen_manifest_by_id: dict[str, Path] = {}
+
+    if not plugin_dir.exists():
+        return manifests
+
+    for manifest_file in _manifest_files(plugin_dir):
         try:
-            with manifest_file.open() as f:
-                data = json.load(f)
-                manifest = PluginManifest(**data)
-                existing_index = manifest_indexes_by_id.get(manifest.id)
-                if existing_index is not None:
-                    duplicate_ids.add(manifest.id)
-                    manifests[existing_index] = None
-                    logger.error(
-                        "[plugin_loader] Duplicate plugin id rejected: %s "
-                        "(conflict includes %s)",
-                        manifest.id,
-                        manifest_file,
-                    )
-                    continue
-                manifest_indexes_by_id[manifest.id] = len(manifests)
-                manifests.append(manifest)
-                logger.debug(
-                    "[plugin_loader] Loaded plugin: %s (%s)",
-                    manifest.name,
-                    manifest.id,
-                )
-        except json.JSONDecodeError as e:
-            logger.error(
-                "[plugin_loader] Invalid JSON in %s: %s", manifest_file, e
-            )
-        except Exception as e:
-            logger.error(
-                "[plugin_loader] Failed to load manifest %s: %s",
+            with manifest_file.open("r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+            manifest = PluginManifest.model_validate(payload)
+        except (json.JSONDecodeError, ValidationError) as exc:
+            logger.warning(
+                "[plugin_loader] skipping invalid manifest %s: %s",
                 manifest_file,
-                e,
+                exc,
             )
+            continue
 
-    if duplicate_ids:
-        logger.error(
-            "[plugin_loader] Rejected duplicate plugin id(s): %s",
-            ", ".join(sorted(duplicate_ids)),
-        )
+        existing = seen_manifest_by_id.get(manifest.id)
+        if existing is not None:
+            message = (
+                f"duplicate plugin id '{manifest.id}' in "
+                f"{existing} and {manifest_file}"
+            )
+            raise DuplicatePluginIdError(message)
 
-    loaded_manifests = [
-        manifest for manifest in manifests if manifest is not None
-    ]
-    logger.info("[plugin_loader] Loaded %d plugin(s)", len(loaded_manifests))
-    return loaded_manifests
+        seen_manifest_by_id[manifest.id] = manifest_file
+        manifests.append(manifest)
+
+    return manifests
 
 
-def get_plugin_by_id(plugin_id: str) -> PluginManifest | None:
-    """
-    Get a specific plugin manifest by ID.
-
-    Args:
-        plugin_id: The unique plugin identifier
-
-    Returns:
-        PluginManifest if found, None otherwise
-    """
-    for manifest in load_all_manifests():
+def get_plugin_by_id(
+    plugin_id: str, plugin_dir: Path = PLUGIN_DIR
+) -> PluginManifest | None:
+    """Get a manifest by plugin id from canonical manifest discovery."""
+    for manifest in load_all_manifests(plugin_dir=plugin_dir):
         if manifest.id == plugin_id:
             return manifest
     return None

--- a/guardian/plugins/plugin_manifest.py
+++ b/guardian/plugins/plugin_manifest.py
@@ -1,10 +1,8 @@
-"""
-Canonical service plugin manifest schema (v1).
-"""
+"""Canonical v1 service-plugin manifest types and validation."""
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any
 from urllib.parse import urlparse
 
 from pydantic import (
@@ -15,134 +13,113 @@ from pydantic import (
     model_validator,
 )
 
-_ALLOWED_BASE_URL_SCHEMES = {"http", "https"}
-
 
 class PluginCapability(BaseModel):
-    """Single capability declaration for service plugins."""
+    """Capability declaration for a service plugin."""
 
-    id: str = Field(..., description="Capability namespace identifier")
-    actions: list[str] = Field(
-        ..., description="Actions exposed under this capability"
-    )
-
-    model_config = ConfigDict(extra="forbid")
+    id: str = Field(..., min_length=1)
+    actions: list[str] = Field(..., min_length=1)
 
     @field_validator("id")
     @classmethod
-    def _validate_capability_id(cls, value: str) -> str:
-        value = value.strip()
-        if not value:
+    def _validate_id(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
             raise ValueError("capability id must be non-empty")
-        return value
+        return cleaned
 
     @field_validator("actions")
     @classmethod
-    def _validate_actions(cls, values: list[str]) -> list[str]:
-        if not values:
-            raise ValueError("actions must contain at least one action")
-        normalized: list[str] = []
-        for action in values:
-            action = action.strip()
-            if not action:
-                raise ValueError("action must be non-empty")
-            normalized.append(action)
-        return normalized
+    def _validate_actions(cls, value: list[str]) -> list[str]:
+        cleaned: list[str] = []
+        for action in value:
+            normalized = action.strip()
+            if not normalized:
+                raise ValueError("capability actions must be non-empty")
+            cleaned.append(normalized)
+        return cleaned
 
 
 class PluginManifest(BaseModel):
-    """Validated canonical service plugin manifest."""
+    """Canonical v1 manifest schema for HTTP service plugins."""
 
-    schema_version: Literal["1.0"] = Field(
-        ..., description='Manifest schema version (must be "1.0")'
-    )
-    id: str = Field(..., description="Unique plugin identifier")
-    name: str = Field(..., description="Human-readable plugin name")
-    version: str = Field(..., description="Plugin version")
-    description: str | None = Field(
-        default=None, description="Optional plugin description"
-    )
-    base_url: str = Field(
-        ...,
-        description="Plugin service base URL, e.g. https://plugin.example.com",
-    )
-    capabilities: list[PluginCapability] = Field(
-        ..., description="Capability/action declarations"
-    )
-    extensions: dict[str, Any] | None = Field(
-        default=None,
-        description="Non-authoritative metadata extensions",
-    )
+    schema_version: str = Field(...)
+    id: str = Field(..., min_length=1)
+    name: str = Field(..., min_length=1)
+    version: str = Field(..., min_length=1)
+    description: str | None = None
+    base_url: str = Field(...)
+    capabilities: list[PluginCapability] = Field(...)
+    extensions: dict[str, Any] | None = None
 
     model_config = ConfigDict(extra="forbid")
 
+    @field_validator("schema_version")
+    @classmethod
+    def _validate_schema_version(cls, value: str) -> str:
+        if value != "1.0":
+            raise ValueError("schema_version must be '1.0'")
+        return value
+
     @field_validator("id", "name", "version")
     @classmethod
-    def _validate_required_strings(cls, value: str) -> str:
-        value = value.strip()
-        if not value:
-            raise ValueError("value must be non-empty")
-        return value
+    def _validate_text_fields(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("field must be non-empty")
+        return cleaned
 
     @field_validator("base_url")
     @classmethod
     def _validate_base_url(cls, value: str) -> str:
-        value = value.strip()
-        parsed = urlparse(value)
-        scheme = parsed.scheme.lower()
-        if scheme not in _ALLOWED_BASE_URL_SCHEMES:
+        cleaned = value.strip()
+        parsed = urlparse(cleaned)
+        if parsed.scheme not in {"http", "https"}:
             raise ValueError("base_url must use http or https")
         if not parsed.netloc:
             raise ValueError("base_url must include a host")
-        if parsed.query or parsed.fragment:
-            raise ValueError(
-                "base_url must not include a query string or fragment"
-            )
         if parsed.path not in ("", "/"):
             raise ValueError("base_url must not include a path")
-        return f"{scheme}://{parsed.netloc}".rstrip("/")
+        if parsed.query:
+            raise ValueError("base_url must not include a query")
+        if parsed.fragment:
+            raise ValueError("base_url must not include a fragment")
+        return f"{parsed.scheme}://{parsed.netloc}".rstrip("/")
+
+    @field_validator("capabilities")
+    @classmethod
+    def _validate_capabilities_present(
+        cls, value: list[PluginCapability]
+    ) -> list[PluginCapability]:
+        if not value:
+            raise ValueError("capabilities must not be empty")
+        return value
 
     @model_validator(mode="after")
-    def _validate_unique_operation_pairs(self) -> PluginManifest:
-        seen: set[tuple[str, str]] = set()
+    def _validate_no_duplicate_operations(self) -> PluginManifest:
+        operations: set[tuple[str, str]] = set()
         duplicates: set[tuple[str, str]] = set()
         for capability in self.capabilities:
             for action in capability.actions:
-                pair = (capability.id, action)
-                if pair in seen:
-                    duplicates.add(pair)
-                else:
-                    seen.add(pair)
+                key = (capability.id, action)
+                if key in operations:
+                    duplicates.add(key)
+                operations.add(key)
+
         if duplicates:
-            duplicate_list = ", ".join(
-                f"{capability}:{action}"
-                for capability, action in sorted(duplicates)
-            )
-            raise ValueError(
-                "duplicate capability/action pairs are not allowed: "
-                f"{duplicate_list}"
-            )
+            dupes = ", ".join(f"{cap}:{act}" for cap, act in sorted(duplicates))
+            raise ValueError(f"duplicate capability/action pairs: {dupes}")
+
         return self
 
     def supports_operation(self, capability: str, action: str) -> bool:
-        wanted = (capability.strip(), action.strip())
-        return any(
-            (decl.id, declared_action) == wanted
-            for decl in self.capabilities
-            for declared_action in decl.actions
-        )
+        """Return True when the manifest declares the capability/action pair."""
+        return (capability, action) in self.operations()
 
-    @property
-    def operation_pairs(self) -> set[tuple[str, str]]:
+    def operations(self) -> set[tuple[str, str]]:
+        """Callable operations represented as (capability, action) pairs."""
         return {
-            (decl.id, action)
-            for decl in self.capabilities
-            for action in decl.actions
+            (capability.id, action)
+            for capability in self.capabilities
+            for action in capability.actions
         }
-
-    @property
-    def entrypoint(self) -> str:
-        """
-        Back-compat alias for legacy callers still reading `entrypoint`.
-        """
-        return self.base_url

--- a/guardian/tests/test_plugin_manifest.py
+++ b/guardian/tests/test_plugin_manifest.py
@@ -1,206 +1,182 @@
 import json
-from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
 
 from guardian.plugins import plugin_loader
+from guardian.plugins.plugin_loader import DuplicatePluginIdError
 from guardian.plugins.plugin_manifest import PluginManifest
 
 
-def _manifest_payload(
-    plugin_id: str,
-    *,
-    base_url: str = "https://plugin.example",
-    capabilities=None,
-):
-    return {
-        "schema_version": "1.0",
-        "id": plugin_id,
-        "name": f"{plugin_id} plugin",
-        "version": "1.2.3",
-        "description": "test plugin",
-        "base_url": base_url,
-        "capabilities": capabilities or [{"id": "tts", "actions": ["speak"]}],
-        "extensions": {"owner": "tests"},
-    }
+def _write_manifest(base, plugin_dir, payload):
+    path = base / plugin_dir
+    path.mkdir(parents=True)
+    with (path / "manifest.json").open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle)
 
 
-def _write_manifest(path: Path, payload: dict) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload), encoding="utf-8")
-
-
-def test_accepts_valid_v1_manifest():
-    manifest = PluginManifest(
-        **_manifest_payload("voice", base_url="https://voice.example/")
+def test_accepts_valid_v1_manifest_and_normalizes_base_url():
+    manifest = PluginManifest.model_validate(
+        {
+            "schema_version": "1.0",
+            "id": "alpha",
+            "name": "Alpha",
+            "version": "1.2.3",
+            "description": "desc",
+            "base_url": "https://example.com/",
+            "capabilities": [{"id": "chat", "actions": ["reply"]}],
+            "extensions": {"x": True},
+        }
     )
-    assert manifest.schema_version == "1.0"
-    assert manifest.base_url == "https://voice.example"
-    assert manifest.operation_pairs == {("tts", "speak")}
+
+    assert manifest.base_url == "https://example.com"
 
 
 @pytest.mark.parametrize(
     "base_url",
-    [
-        "ftp://voice.example",
-        "ws://voice.example",
-        "localhost:7101",
-    ],
+    ["ftp://example.com", "file:///tmp/nope", "wss://example.com"],
 )
 def test_rejects_non_http_base_url(base_url):
     with pytest.raises(ValidationError):
-        PluginManifest(**_manifest_payload("voice", base_url=base_url))
+        PluginManifest.model_validate(
+            {
+                "schema_version": "1.0",
+                "id": "alpha",
+                "name": "Alpha",
+                "version": "1.2.3",
+                "base_url": base_url,
+                "capabilities": [{"id": "chat", "actions": ["reply"]}],
+            }
+        )
 
 
 @pytest.mark.parametrize(
     "base_url",
     [
-        "https://voice.example/api",
-        "https://voice.example/?x=1",
-        "https://voice.example/#fragment",
+        "https://example.com/path",
+        "https://example.com?x=1",
+        "https://example.com#frag",
     ],
 )
 def test_rejects_base_url_with_path_query_or_fragment(base_url):
     with pytest.raises(ValidationError):
-        PluginManifest(**_manifest_payload("voice", base_url=base_url))
+        PluginManifest.model_validate(
+            {
+                "schema_version": "1.0",
+                "id": "alpha",
+                "name": "Alpha",
+                "version": "1.2.3",
+                "base_url": base_url,
+                "capabilities": [{"id": "chat", "actions": ["reply"]}],
+            }
+        )
 
 
-def test_rejects_duplicate_capability_action_pairs():
+def test_rejects_duplicate_capability_action_pairs_within_manifest():
     with pytest.raises(ValidationError):
-        PluginManifest(
-            **_manifest_payload(
-                "voice",
-                capabilities=[
-                    {"id": "tts", "actions": ["speak"]},
-                    {"id": "tts", "actions": ["speak"]},
-                ],
-            )
+        PluginManifest.model_validate(
+            {
+                "schema_version": "1.0",
+                "id": "alpha",
+                "name": "Alpha",
+                "version": "1.2.3",
+                "base_url": "https://example.com",
+                "capabilities": [{"id": "chat", "actions": ["reply", "reply"]}],
+            }
         )
 
 
-def test_discovery_lists_only_validated_manifests(tmp_path, monkeypatch):
-    plugins_root = tmp_path / "plugins"
-    monkeypatch.setattr(plugin_loader, "PLUGIN_DIR", plugins_root)
-
+def test_only_validated_manifests_are_listed_as_installed(tmp_path):
     _write_manifest(
-        plugins_root / "voice" / "manifest.json",
-        _manifest_payload("voice", base_url="https://voice.example"),
-    )
-    # Invalid (missing required version): excluded from discovery.
-    invalid = _manifest_payload("broken", base_url="https://broken.example")
-    invalid.pop("version")
-    _write_manifest(plugins_root / "broken" / "manifest.json", invalid)
-
-    manifests = plugin_loader.load_all_manifests()
-    assert [manifest.id for manifest in manifests] == ["voice"]
-
-
-def test_discovery_rejects_duplicate_plugin_ids(tmp_path, monkeypatch):
-    plugins_root = tmp_path / "plugins"
-    monkeypatch.setattr(plugin_loader, "PLUGIN_DIR", plugins_root)
-
-    _write_manifest(
-        plugins_root / "voice_a" / "manifest.json",
-        _manifest_payload("shared"),
+        tmp_path,
+        "good",
+        {
+            "schema_version": "1.0",
+            "id": "good",
+            "name": "Good",
+            "version": "1.0.0",
+            "base_url": "https://good.example",
+            "capabilities": [{"id": "chat", "actions": ["reply"]}],
+        },
     )
     _write_manifest(
-        plugins_root / "voice_b" / "manifest.json",
-        _manifest_payload("shared"),
+        tmp_path,
+        "bad",
+        {
+            "schema_version": "1.0",
+            "id": "bad",
+            "name": "Bad",
+            "version": "1.0.0",
+            "base_url": "ftp://bad.example",
+            "capabilities": [{"id": "chat", "actions": ["reply"]}],
+        },
     )
+
+    manifests = plugin_loader.load_all_manifests(plugin_dir=tmp_path)
+
+    assert [manifest.id for manifest in manifests] == ["good"]
+
+
+def test_unhealthy_plugins_remain_installed_if_manifest_is_valid(tmp_path):
     _write_manifest(
-        plugins_root / "vision" / "manifest.json",
-        _manifest_payload(
-            "vision",
-            capabilities=[{"id": "vision", "actions": ["classify"]}],
-        ),
+        tmp_path,
+        "good",
+        {
+            "schema_version": "1.0",
+            "id": "good",
+            "name": "Good",
+            "version": "1.0.0",
+            "base_url": "https://good.example",
+            "capabilities": [{"id": "chat", "actions": ["reply"]}],
+        },
     )
 
-    first = plugin_loader.load_all_manifests()
-    second = plugin_loader.load_all_manifests()
+    manifests = plugin_loader.load_all_manifests(plugin_dir=tmp_path)
 
-    assert [manifest.id for manifest in first] == ["vision"]
-    assert [manifest.id for manifest in second] == ["vision"]
+    assert len(manifests) == 1
+    assert manifests[0].id == "good"
 
 
-def test_discovery_uses_canonical_path_only(tmp_path, monkeypatch):
-    plugins_root = tmp_path / "plugins"
-    monkeypatch.setattr(plugin_loader, "PLUGIN_DIR", plugins_root)
+def test_canonical_discovery_uses_plugins_manifest_json_only(tmp_path):
+    (tmp_path / "one").mkdir(parents=True)
+    with (tmp_path / "one" / "plugin.json").open(
+        "w", encoding="utf-8"
+    ) as handle:
+        json.dump({}, handle)
+    with (tmp_path / "one" / "manifest.yaml").open(
+        "w", encoding="utf-8"
+    ) as handle:
+        handle.write("id: no")
 
     _write_manifest(
-        plugins_root / "voice" / "manifest.json",
-        _manifest_payload("voice"),
+        tmp_path,
+        "two",
+        {
+            "schema_version": "1.0",
+            "id": "two",
+            "name": "Two",
+            "version": "1.0.0",
+            "base_url": "https://two.example",
+            "capabilities": [{"id": "chat", "actions": ["reply"]}],
+        },
     )
-    _write_manifest(
-        plugins_root / "legacy" / "plugin_manifest.json",
-        _manifest_payload("legacy"),
-    )
-    _write_manifest(
-        plugins_root / "nested" / "child" / "manifest.json",
-        _manifest_payload("nested"),
-    )
 
-    manifests = plugin_loader.load_all_manifests()
-    assert [manifest.id for manifest in manifests] == ["voice"]
+    manifests = plugin_loader.load_all_manifests(plugin_dir=tmp_path)
+
+    assert [manifest.id for manifest in manifests] == ["two"]
 
 
-def test_active_tts_manifest_is_valid_and_discoverable():
-    manifest_path = (
-        Path(__file__).resolve().parents[2]
-        / "plugins"
-        / "chatterbox"
-        / "manifest.json"
-    )
-    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
-    manifest = PluginManifest(**payload)
-    assert manifest.supports_operation("tts", "speak")
+def test_rejects_duplicate_plugin_ids_across_discovery(tmp_path):
+    payload = {
+        "schema_version": "1.0",
+        "id": "dup",
+        "name": "Dup",
+        "version": "1.0.0",
+        "base_url": "https://dup.example",
+        "capabilities": [{"id": "chat", "actions": ["reply"]}],
+    }
+    _write_manifest(tmp_path, "one", payload)
+    _write_manifest(tmp_path, "two", payload)
 
-    discovered_ids = {item.id for item in plugin_loader.load_all_manifests()}
-    assert "chatterbox" in discovered_ids
-
-
-def test_active_tts_manifest_origin_matches_runtime_compose_mapping():
-    repo_root = Path(__file__).resolve().parents[2]
-    manifest_payload = json.loads(
-        (repo_root / "plugins" / "chatterbox" / "manifest.json").read_text(
-            encoding="utf-8"
-        )
-    )
-    manifest = PluginManifest(**manifest_payload)
-    compose_text = (repo_root / "docker-compose.yml").read_text(
-        encoding="utf-8"
-    )
-    backend_block = compose_text.split("  backend:\n", 1)[1].split(
-        "\n  worker-warmup:\n", 1
-    )[0]
-    worker_chat_block = compose_text.split("  worker-chat:\n", 1)[1].split(
-        "\n  worker-voice:\n", 1
-    )[0]
-
-    assert "tts:" in compose_text
-    assert 'ports: ["8000:8000"]' in compose_text
-    assert "- ./plugins:/app/plugins:ro" in backend_block
-    assert "- ./plugins:/app/plugins:ro" in worker_chat_block
-    assert "./plugins/chatterbox:/app/plugins/chatterbox:ro" not in compose_text
-    assert (
-        'CODEXIFY_ASSISTANT_MESSAGE_AUDIO_AUTOGENERATE: "true"'
-        in worker_chat_block
-    )
-    assert manifest.base_url == "http://tts:8000"
-
-
-def test_backend_runtime_image_and_worker_chat_runtime_keep_canonical_plugins():
-    repo_root = Path(__file__).resolve().parents[2]
-    dockerfile_text = (repo_root / "backend" / "Dockerfile").read_text(
-        encoding="utf-8"
-    )
-    compose_text = (repo_root / "docker-compose.yml").read_text(
-        encoding="utf-8"
-    )
-    worker_chat_block = compose_text.split("  worker-chat:\n", 1)[1].split(
-        "\n  worker-voice:\n", 1
-    )[0]
-
-    assert "COPY plugins /app/plugins" in dockerfile_text
-    assert "worker-chat:" in compose_text
-    assert "- ./plugins:/app/plugins:ro" in worker_chat_block
+    with pytest.raises(DuplicatePluginIdError):
+        plugin_loader.load_all_manifests(plugin_dir=tmp_path)

--- a/tests/core/test_plugins.py
+++ b/tests/core/test_plugins.py
@@ -1,395 +1,174 @@
+import pytest
 import requests
 
 from guardian.core import plugins as core_plugins
 from guardian.plugins.plugin_manifest import PluginManifest
 
 
-class DummyRuntimeLoader:
-    def __init__(self, plugins=None):
-        self.plugins = plugins or {}
-        self.load_calls = 0
-
-    def load_all_plugins(self):
-        self.load_calls += 1
-        self.plugins["loaded"] = object()
-
-
-class FakeResponse:
-    def __init__(self, *, status_code=200, payload=None, json_exc=None):
-        self.status_code = status_code
-        self._payload = payload if payload is not None else {}
-        self._json_exc = json_exc
-
-    def json(self):
-        if self._json_exc is not None:
-            raise self._json_exc
-        return self._payload
-
-
-def _manifest(
-    plugin_id: str,
-    *,
-    base_url: str,
-    operations: list[tuple[str, str]] | None = None,
-) -> PluginManifest:
-    operations = operations or [("tts", "speak")]
-    grouped_actions: dict[str, list[str]] = {}
-    for capability, action in operations:
-        grouped_actions.setdefault(capability, []).append(action)
-    return PluginManifest(
-        schema_version="1.0",
-        id=plugin_id,
-        name=plugin_id,
-        version="1.0.0",
-        base_url=base_url,
-        capabilities=[
-            {"id": capability, "actions": actions}
-            for capability, actions in grouped_actions.items()
-        ],
+def _manifest(plugin_id: str, cap_action: tuple[str, str]) -> PluginManifest:
+    capability, action = cap_action
+    return PluginManifest.model_validate(
+        {
+            "schema_version": "1.0",
+            "id": plugin_id,
+            "name": plugin_id,
+            "version": "0.1.0",
+            "base_url": "https://plugin.example",
+            "capabilities": [{"id": capability, "actions": [action]}],
+        }
     )
-
-
-def test_load_runtime_plugins_loads_once_when_empty(monkeypatch):
-    loader = DummyRuntimeLoader()
-    monkeypatch.setattr(
-        core_plugins, "get_runtime_plugin_loader", lambda: loader
-    )
-
-    loaded = core_plugins.load_runtime_plugins()
-
-    assert loaded is loader
-    assert loader.load_calls == 1
-
-
-def test_load_runtime_plugins_skips_reload_when_registry_present(monkeypatch):
-    loader = DummyRuntimeLoader(plugins={"existing": object()})
-    monkeypatch.setattr(
-        core_plugins, "get_runtime_plugin_loader", lambda: loader
-    )
-
-    loaded = core_plugins.load_runtime_plugins()
-
-    assert loaded is loader
-    assert loader.load_calls == 0
-
-
-def test_get_plugin_manifest_by_capability_is_case_insensitive(monkeypatch):
-    manifests = [
-        _manifest(
-            "non_tts",
-            base_url="https://voice-a.example",
-            operations=[("vision", "classify")],
-        ),
-        _manifest(
-            "voice",
-            base_url="https://voice-b.example",
-            operations=[("TTS", "Speak"), ("audio", "mix")],
-        ),
-    ]
-    monkeypatch.setattr(
-        core_plugins, "list_plugin_manifests", lambda: manifests
-    )
-
-    manifest = core_plugins.get_plugin_manifest_by_capability("tts")
-
-    assert manifest is not None
-    assert manifest.id == "voice"
-    assert core_plugins.get_plugin_manifest_by_capability("missing") is None
-
-
-def test_find_plugins_by_capability_action_returns_matching_plugins(
-    monkeypatch,
-):
-    manifests = [
-        _manifest("voice_a", base_url="https://voice-a.example"),
-        _manifest("voice_b", base_url="https://voice-b.example"),
-        _manifest(
-            "vision",
-            base_url="https://vision.example",
-            operations=[("vision", "classify")],
-        ),
-    ]
-    monkeypatch.setattr(
-        core_plugins, "list_plugin_manifests", lambda: manifests
-    )
-
-    matches = core_plugins.find_plugins_by_capability_action("tts", "speak")
-
-    assert [manifest.id for manifest in matches] == ["voice_a", "voice_b"]
-
-
-def test_invoke_plugin_sends_canonical_envelope(monkeypatch):
-    manifest = _manifest("voice", base_url="https://voice.example")
-    monkeypatch.setattr(
-        core_plugins, "list_plugin_manifests", lambda: [manifest]
-    )
-    captured: dict[str, object] = {}
-
-    def _fake_post(url, json, headers, timeout):
-        captured["url"] = url
-        captured["json"] = json
-        captured["headers"] = headers
-        captured["timeout"] = timeout
-        return FakeResponse(payload={"output": {"status": "ok"}})
-
-    monkeypatch.setattr(core_plugins.requests, "post", _fake_post)
-
-    payload = core_plugins.invoke_plugin(
-        "voice",
-        capability="tts",
-        action="speak",
-        input={"text": "hello"},
-        context={
-            "request_id": "req-123",
-            "thread_id": None,
-            "user_id": None,
-            "api_key": "should_not_forward",
-        },
-    )
-
-    assert payload == {"output": {"status": "ok"}}
-    assert captured["url"] == "https://voice.example/invoke"
-    assert captured["timeout"] == core_plugins.INVOKE_TIMEOUT_SECONDS
-    assert captured["headers"] == {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-    }
-    assert "Authorization" not in captured["headers"]
-    assert captured["json"] == {
-        "protocol_version": "1.0",
-        "plugin_id": "voice",
-        "capability": "tts",
-        "action": "speak",
-        "input": {"text": "hello"},
-        "context": {
-            "request_id": "req-123",
-            "thread_id": None,
-            "user_id": None,
-        },
-    }
 
 
 def test_invoke_capability_fails_on_zero_matches(monkeypatch):
     monkeypatch.setattr(core_plugins, "list_plugin_manifests", lambda: [])
 
-    try:
-        core_plugins.invoke_capability("tts", "speak", input={"text": "hello"})
-        raise AssertionError("expected PluginFacadeError")
-    except core_plugins.PluginFacadeError as exc:
-        assert exc.code == core_plugins.ERROR_NOT_FOUND
+    with pytest.raises(core_plugins.PluginFacadeError) as exc_info:
+        core_plugins.invoke_capability("chat", "reply", input={})
+
+    assert exc_info.value.code == "not_found"
 
 
 def test_invoke_capability_fails_on_multiple_matches(monkeypatch):
     manifests = [
-        _manifest("voice_a", base_url="https://voice-a.example"),
-        _manifest("voice_b", base_url="https://voice-b.example"),
+        _manifest("a", ("chat", "reply")),
+        _manifest("b", ("chat", "reply")),
     ]
     monkeypatch.setattr(
         core_plugins, "list_plugin_manifests", lambda: manifests
     )
 
-    try:
-        core_plugins.invoke_capability("tts", "speak", input={"text": "hello"})
-        raise AssertionError("expected PluginFacadeError")
-    except core_plugins.PluginFacadeError as exc:
-        assert exc.code == core_plugins.ERROR_AMBIGUOUS
-        assert exc.details == ["voice_a", "voice_b"]
+    with pytest.raises(core_plugins.PluginFacadeError) as exc_info:
+        core_plugins.invoke_capability("chat", "reply", input={})
+
+    assert exc_info.value.code == "ambiguous"
 
 
-def test_explicit_plugin_invocation_works_with_shared_operation(monkeypatch):
+def test_explicit_plugin_invocation_works_when_multiple_share_operation(
+    monkeypatch,
+):
     manifests = [
-        _manifest("voice_a", base_url="https://voice-a.example"),
-        _manifest("voice_b", base_url="https://voice-b.example"),
+        _manifest("a", ("chat", "reply")),
+        _manifest("b", ("chat", "reply")),
     ]
     monkeypatch.setattr(
         core_plugins, "list_plugin_manifests", lambda: manifests
     )
-    captured: dict[str, object] = {}
 
-    def _fake_post(url, json, headers, timeout):
-        captured["url"] = url
-        captured["plugin_id"] = json["plugin_id"]
-        return FakeResponse(payload={"output": {"plugin": json["plugin_id"]}})
+    sent = {}
 
-    monkeypatch.setattr(core_plugins.requests, "post", _fake_post)
+    class DummyResponse:
+        def json(self):
+            return {"ok": True, "output": {"message": "hello"}}
 
-    payload = core_plugins.invoke_plugin(
-        "voice_b",
-        capability="tts",
-        action="speak",
-        input={"text": "hello"},
+    def fake_post(url, json, timeout):
+        sent["url"] = url
+        sent["json"] = json
+        sent["timeout"] = timeout
+        return DummyResponse()
+
+    monkeypatch.setattr(core_plugins.requests, "post", fake_post)
+    result = core_plugins.invoke_plugin(
+        "a",
+        "chat",
+        "reply",
+        input={"prompt": "hi"},
+        context={"request_id": "req-1"},
     )
 
-    assert payload == {"output": {"plugin": "voice_b"}}
-    assert captured["plugin_id"] == "voice_b"
-    assert captured["url"] == "https://voice-b.example/invoke"
+    assert result == {"ok": True, "output": {"message": "hello"}}
+    assert sent["url"] == "https://plugin.example/invoke"
+    assert sent["timeout"] == core_plugins.INVOKE_TIMEOUT_SECONDS
+    assert sent["json"] == {
+        "protocol_version": "1.0",
+        "plugin_id": "a",
+        "capability": "chat",
+        "action": "reply",
+        "input": {"prompt": "hi"},
+        "context": {
+            "request_id": "req-1",
+            "thread_id": None,
+            "user_id": None,
+        },
+    }
 
 
 def test_invoke_plugin_normalizes_timeout(monkeypatch):
-    manifest = _manifest("voice", base_url="https://voice.example")
     monkeypatch.setattr(
-        core_plugins, "list_plugin_manifests", lambda: [manifest]
+        core_plugins,
+        "list_plugin_manifests",
+        lambda: [_manifest("a", ("chat", "reply"))],
     )
 
-    def _fake_post(url, json, headers, timeout):
-        raise requests.Timeout("timed out")
+    def raise_timeout(*_args, **_kwargs):
+        raise requests.Timeout("boom")
 
-    monkeypatch.setattr(core_plugins.requests, "post", _fake_post)
+    monkeypatch.setattr(core_plugins.requests, "post", raise_timeout)
 
-    try:
-        core_plugins.invoke_plugin(
-            "voice", "tts", "speak", input={"text": "hello"}
-        )
-        raise AssertionError("expected PluginFacadeError")
-    except core_plugins.PluginFacadeError as exc:
-        assert exc.code == core_plugins.ERROR_TIMEOUT
+    with pytest.raises(core_plugins.PluginFacadeError) as exc_info:
+        core_plugins.invoke_plugin("a", "chat", "reply", input={})
+
+    assert exc_info.value.code == "timeout"
 
 
-def test_invoke_plugin_normalizes_connection_failure(monkeypatch):
-    manifest = _manifest("voice", base_url="https://voice.example")
+def test_invoke_plugin_normalizes_transport_failure(monkeypatch):
     monkeypatch.setattr(
-        core_plugins, "list_plugin_manifests", lambda: [manifest]
+        core_plugins,
+        "list_plugin_manifests",
+        lambda: [_manifest("a", ("chat", "reply"))],
     )
 
-    def _fake_post(url, json, headers, timeout):
-        raise requests.ConnectionError("connection refused")
+    def raise_transport(*_args, **_kwargs):
+        raise requests.ConnectionError("boom")
 
-    monkeypatch.setattr(core_plugins.requests, "post", _fake_post)
+    monkeypatch.setattr(core_plugins.requests, "post", raise_transport)
 
-    try:
-        core_plugins.invoke_plugin(
-            "voice", "tts", "speak", input={"text": "hello"}
-        )
-        raise AssertionError("expected PluginFacadeError")
-    except core_plugins.PluginFacadeError as exc:
-        assert exc.code == core_plugins.ERROR_TRANSPORT_FAILURE
+    with pytest.raises(core_plugins.PluginFacadeError) as exc_info:
+        core_plugins.invoke_plugin("a", "chat", "reply", input={})
+
+    assert exc_info.value.code == "transport_failure"
 
 
-def test_invoke_plugin_normalizes_malformed_json_response(monkeypatch):
-    manifest = _manifest("voice", base_url="https://voice.example")
+def test_invoke_plugin_normalizes_malformed_json(monkeypatch):
     monkeypatch.setattr(
-        core_plugins, "list_plugin_manifests", lambda: [manifest]
+        core_plugins,
+        "list_plugin_manifests",
+        lambda: [_manifest("a", ("chat", "reply"))],
     )
 
-    def _fake_post(url, json, headers, timeout):
-        return FakeResponse(status_code=200, json_exc=ValueError("bad json"))
+    class BadJsonResponse:
+        def json(self):
+            raise ValueError("invalid")
 
-    monkeypatch.setattr(core_plugins.requests, "post", _fake_post)
-
-    try:
-        core_plugins.invoke_plugin(
-            "voice", "tts", "speak", input={"text": "hello"}
-        )
-        raise AssertionError("expected PluginFacadeError")
-    except core_plugins.PluginFacadeError as exc:
-        assert exc.code == core_plugins.ERROR_INVALID_RESPONSE
-
-
-def test_invoke_plugin_normalizes_nonconforming_response(monkeypatch):
-    manifest = _manifest("voice", base_url="https://voice.example")
     monkeypatch.setattr(
-        core_plugins, "list_plugin_manifests", lambda: [manifest]
+        core_plugins.requests,
+        "post",
+        lambda *_args, **_kwargs: BadJsonResponse(),
     )
 
-    def _fake_post(url, json, headers, timeout):
-        return FakeResponse(
-            status_code=200, payload={"result": "missing-output"}
-        )
+    with pytest.raises(core_plugins.PluginFacadeError) as exc_info:
+        core_plugins.invoke_plugin("a", "chat", "reply", input={})
 
-    monkeypatch.setattr(core_plugins.requests, "post", _fake_post)
-
-    try:
-        core_plugins.invoke_plugin(
-            "voice", "tts", "speak", input={"text": "hello"}
-        )
-        raise AssertionError("expected PluginFacadeError")
-    except core_plugins.PluginFacadeError as exc:
-        assert exc.code == core_plugins.ERROR_INVALID_RESPONSE
+    assert exc_info.value.code == "invalid_response"
 
 
-def test_invoke_plugin_rejects_non_object_output(monkeypatch):
-    manifest = _manifest("voice", base_url="https://voice.example")
+def test_invoke_plugin_normalizes_non_conforming_response(monkeypatch):
     monkeypatch.setattr(
-        core_plugins, "list_plugin_manifests", lambda: [manifest]
+        core_plugins,
+        "list_plugin_manifests",
+        lambda: [_manifest("a", ("chat", "reply"))],
     )
 
-    def _fake_post(url, json, headers, timeout):
-        return FakeResponse(
-            status_code=200, payload={"output": "not-an-object"}
-        )
+    class InvalidResponse:
+        def json(self):
+            return {"output": {"message": "missing ok"}}
 
-    monkeypatch.setattr(core_plugins.requests, "post", _fake_post)
-
-    try:
-        core_plugins.invoke_plugin(
-            "voice", "tts", "speak", input={"text": "hello"}
-        )
-        raise AssertionError("expected PluginFacadeError")
-    except core_plugins.PluginFacadeError as exc:
-        assert exc.code == core_plugins.ERROR_INVALID_RESPONSE
-
-
-def test_invoke_plugin_rejects_failed_ok_without_error_payload(monkeypatch):
-    manifest = _manifest("voice", base_url="https://voice.example")
     monkeypatch.setattr(
-        core_plugins, "list_plugin_manifests", lambda: [manifest]
+        core_plugins.requests,
+        "post",
+        lambda *_args, **_kwargs: InvalidResponse(),
     )
 
-    def _fake_post(url, json, headers, timeout):
-        return FakeResponse(
-            status_code=200, payload={"ok": False, "output": {}}
-        )
+    with pytest.raises(core_plugins.PluginFacadeError) as exc_info:
+        core_plugins.invoke_plugin("a", "chat", "reply", input={})
 
-    monkeypatch.setattr(core_plugins.requests, "post", _fake_post)
-
-    try:
-        core_plugins.invoke_plugin(
-            "voice", "tts", "speak", input={"text": "hello"}
-        )
-        raise AssertionError("expected PluginFacadeError")
-    except core_plugins.PluginFacadeError as exc:
-        assert exc.code == core_plugins.ERROR_INVALID_RESPONSE
-
-
-def test_invoke_plugin_normalizes_remote_error_response(monkeypatch):
-    manifest = _manifest("voice", base_url="https://voice.example")
-    monkeypatch.setattr(
-        core_plugins, "list_plugin_manifests", lambda: [manifest]
-    )
-
-    def _fake_post(url, json, headers, timeout):
-        return FakeResponse(
-            status_code=500,
-            payload={"error": {"code": "upstream_failure"}},
-        )
-
-    monkeypatch.setattr(core_plugins.requests, "post", _fake_post)
-
-    try:
-        core_plugins.invoke_plugin(
-            "voice", "tts", "speak", input={"text": "hello"}
-        )
-        raise AssertionError("expected PluginFacadeError")
-    except core_plugins.PluginFacadeError as exc:
-        assert exc.code == core_plugins.ERROR_REMOTE_ERROR
-
-
-def test_unhealthy_plugin_still_appears_installed(monkeypatch):
-    manifest = _manifest("voice", base_url="https://voice.example")
-    monkeypatch.setattr(
-        core_plugins, "_load_manifest_plugins", lambda: [manifest]
-    )
-
-    def _fake_get(url, timeout):
-        raise requests.Timeout("health timeout")
-
-    monkeypatch.setattr(core_plugins.requests, "get", _fake_get)
-
-    manifests = core_plugins.list_plugin_manifests()
-
-    assert [m.id for m in manifests] == ["voice"]
-    try:
-        core_plugins.get_plugin_health("voice")
-        raise AssertionError("expected PluginFacadeError")
-    except core_plugins.PluginFacadeError as exc:
-        assert exc.code == core_plugins.ERROR_TIMEOUT
+    assert exc_info.value.code == "invalid_response"


### PR DESCRIPTION
## Summary
- Supersedes #83 with a clean branch cut from refreshed `origin/main`.
- Cherry-picks only `1fe02130c` (`Introduce canonical service plugin facade`).
- Resolves stale-ancestry conflicts strictly in favor of the canonical plugin-facade change only.

## Scope
- `guardian/core/plugins.py`
- `guardian/plugins/plugin_loader.py`
- `guardian/plugins/plugin_manifest.py`
- `guardian/tests/test_plugin_manifest.py`
- `tests/core/test_plugins.py`

## Validation
- `PYTHONPATH=. DATABASE_URL=sqlite:////tmp/codexify_test.db LOCAL_DATABASE_URL=sqlite:////tmp/codexify_test.db pytest -v --noconftest tests/core/test_plugins.py guardian/tests/test_plugin_manifest.py`
- Result: `19 passed`

## Notes
- The original PR branch was based on stale ancestry, so this replacement branch starts from current `origin/main` as of March 15, 2026.
- No unrelated docs, frontend, or other historical branch content was carried into this replacement.