### PR TITLE
Fix CI bootstrap for optional security headers dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "google-cloud-texttospeech",
     "typer>=0.12.3",
     "slowapi>=0.1.8",
-    "fastapi-security-headers>=1.3.0",
     "prometheus-client>=0.20.0",
 ]
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- remove `fastapi-security-headers>=1.3.0` from mandatory project dependencies
- keep the existing optional `ImportError` fallback in `guardian/server/app.py` as the runtime behavior
- isolate the shared packaging fix so feature PRs `#91` and `#92` stay untouched

## Validation
- `python3.11 -m venv /tmp/codexify-ci-packaging-py311-20260315`
- `/tmp/codexify-ci-packaging-py311-20260315/bin/pip install -e .`
- `/tmp/codexify-ci-packaging-py311-20260315/bin/pip install pytest pytest-asyncio`
- `/tmp/codexify-ci-packaging-py311-20260315/bin/python -m pytest --version`
