### PR TITLE
Fix codexify optional import bootstrap in backend CI

### DIFF
--- a/guardian/codexify.py
+++ b/guardian/codexify.py
@@ -1,9 +1,12 @@
-try:
-    from notion_client import Client
-except ImportError:
-    raise ImportError(
-        "notion-client package required. Run 'pip install notion-client'."
-    )
+def _require_notion_client():
+    try:
+        from notion_client import Client
+    except ImportError as exc:
+        raise ImportError(
+            "notion-client package required. Run 'pip install notion-client'."
+        ) from exc
+
+    return Client
 
 
 def load_alias_map(alias_path):
@@ -191,7 +194,7 @@ logger = logging.getLogger(__name__)
 def export_notion_database_to_json(db_id, notion_token, out_file):
     import sys
 
-    client = Client(auth=notion_token)
+    client = _require_notion_client()(auth=notion_token)
     # Get database schema
     try:
         db = client.databases.retrieve(db_id)
@@ -280,7 +283,7 @@ def get_or_create_page(client, parent_title, notion_token):
 
 
 def add_records_to_notion_database(records, db_id, notion_token, fieldmap=None):
-    client = Client(auth=notion_token)
+    client = _require_notion_client()(auth=notion_token)
     # Fetch columns from Notion DB schema for field matching
     notion_cols = client.databases.retrieve(db_id)["properties"]
     for record in records:
@@ -471,7 +474,7 @@ def codexify_database_cli_wrapper():
                 sys.exit(1)
 
             # Notion client
-            client = Client(auth=notion_token)
+            client = _require_notion_client()(auth=notion_token)
             logger.info("Fetching databases shared with your integration...")
             dbs = []
             next_cursor = None
@@ -771,7 +774,7 @@ def codexify_database_cli_wrapper():
             with open(args.template) as f:
                 template_md = f.read()
 
-        client = Client(auth=args.token)
+        client = _require_notion_client()(auth=args.token)
         if args.parent_title:
             parent_page_id = get_or_create_page(
                 client, args.parent_title, args.token
@@ -818,7 +821,7 @@ def codexify_database_cli_wrapper():
             # If not supplied, prompt if any mismatches:
             else:
                 # Infer Notion columns from created DB
-                client_for_map = Client(auth=args.token)
+                client_for_map = _require_notion_client()(auth=args.token)
                 db_schema = client_for_map.databases.retrieve(db_id)
                 notion_cols = set(db_schema["properties"].keys())
                 rec_keys = set(records[0].keys())
@@ -1125,7 +1128,7 @@ def create_notion_database_from_records(
     and attaches a page template (markdown) if desired.
     Returns the new database ID.
     """
-    client = Client(auth=notion_token)
+    client = _require_notion_client()(auth=notion_token)
     if not db_title:
         db_title = f"Guardian Codex {datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%d %H:%M')}"
 

--- a/guardian/server/codexify_api.py
+++ b/guardian/server/codexify_api.py
@@ -12,16 +12,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from guardian.codex.lineage import normalize_front_matter
-from guardian.codexify import create_notion_database_from_records
 from guardian.core.event_graph import get_event_writer
-from guardian.export_engine import (
-    export_records,
-    export_to_gdrive,
-    import_from_gdrive,
-    import_from_icloud,
-)
-from guardian.integrations.google_drive import build_drive_service
-from guardian.integrations.google_oauth import ensure_oauth_credentials
 
 router = APIRouter(prefix="/codexify", tags=["codexify"])
 logger = logging.getLogger(__name__)
@@ -36,6 +27,58 @@ _REMOTE_AUTH_MODES = {
     "prod",
     "production",
 }
+
+
+def create_notion_database_from_records(*args, **kwargs):
+    from guardian.codexify import (
+        create_notion_database_from_records as notion_create,
+    )
+
+    return notion_create(*args, **kwargs)
+
+
+def export_records(*args, **kwargs):
+    from guardian.export_engine import export_records as export_records_impl
+
+    return export_records_impl(*args, **kwargs)
+
+
+def export_to_gdrive(*args, **kwargs):
+    from guardian.export_engine import export_to_gdrive as export_to_gdrive_impl
+
+    return export_to_gdrive_impl(*args, **kwargs)
+
+
+def import_from_gdrive(*args, **kwargs):
+    from guardian.export_engine import (
+        import_from_gdrive as import_from_gdrive_impl,
+    )
+
+    return import_from_gdrive_impl(*args, **kwargs)
+
+
+def import_from_icloud(*args, **kwargs):
+    from guardian.export_engine import (
+        import_from_icloud as import_from_icloud_impl,
+    )
+
+    return import_from_icloud_impl(*args, **kwargs)
+
+
+def build_drive_service(*args, **kwargs):
+    from guardian.integrations.google_drive import (
+        build_drive_service as build_drive_service_impl,
+    )
+
+    return build_drive_service_impl(*args, **kwargs)
+
+
+def ensure_oauth_credentials(*args, **kwargs):
+    from guardian.integrations.google_oauth import (
+        ensure_oauth_credentials as ensure_oauth_credentials_impl,
+    )
+
+    return ensure_oauth_credentials_impl(*args, **kwargs)
 
 
 class GDriveExportRequest(BaseModel):


### PR DESCRIPTION
## Summary
- lazy-load the Notion client inside guardian/codexify.py so importing the module does not require notion-client until Notion features are used
- lazy-load optional Notion and Google Drive helpers inside guardian/server/codexify_api.py so oauth-mode tests can import the API module without installing unused integration clients
- keep the change scoped to the shared backend CI bootstrap path affecting PRs #90, #91, and #92

## Validation
- tests/server/test_codexify_api_oauth_mode.py: 2
- guardian/tests/test_api_server.py: 4
- ......                                                                   [100%]
