### PR TITLE
Trim backend build context and target runtime image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -60,7 +60,7 @@ venv
 /src-tauri
 /tests
 /tools
-/guardian/codemap
+/guardian/codemap/codemap.json
 /guardian/tts_output
 /guardian/*.backup
 /guardian/*.old

--- a/.dockerignore
+++ b/.dockerignore
@@ -40,3 +40,27 @@ venv
 # test/cache
 .cache
 .pytest_cache
+
+# backend image build only needs dependency manifests plus guardian/, backend/,
+# plugins/, and scripts/; exclude unrelated or runtime-mounted repo areas.
+/.github
+/.chroma
+/archive
+/artifacts
+/codex_ralph_loop
+/codex_runner
+/codex_tasks
+/codexify-ui-triage
+/cypress
+/data
+/docker
+/docs
+/frontend
+/models
+/src-tauri
+/tests
+/tools
+/guardian/codemap
+/guardian/tts_output
+/guardian/*.backup
+/guardian/*.old

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,7 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+      target: runtime
     working_dir: /app
     entrypoint: ["python"]
     depends_on:
@@ -127,6 +128,7 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+      target: runtime
     working_dir: /app
     profiles:
       - cli
@@ -174,6 +176,7 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+      target: runtime
     image: codexify-backend
     working_dir: /app
     entrypoint: ["python"]
@@ -200,6 +203,7 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+      target: runtime
     working_dir: /app
     entrypoint: ["python"]
     ports: ["8888:8888"]
@@ -321,6 +325,7 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+      target: runtime
     working_dir: /app
     entrypoint: ["python"]
     depends_on:
@@ -382,6 +387,7 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+      target: runtime
     working_dir: /app
     entrypoint: ["python"]
     depends_on:
@@ -438,6 +444,7 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+      target: runtime
     working_dir: /app
     entrypoint: ["python"]
     depends_on:
@@ -491,6 +498,7 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+      target: runtime
     working_dir: /app
     entrypoint: ["python"]
     depends_on:
@@ -549,6 +557,7 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+      target: runtime
     working_dir: /app
     entrypoint: ["python"]
     depends_on:
@@ -607,6 +616,7 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+      target: runtime
     working_dir: /app
     profiles:
       - backfill
@@ -662,6 +672,7 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+      target: runtime
     working_dir: /app
     profiles:
       - backfill
@@ -712,6 +723,7 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+      target: runtime
     working_dir: /app
     profiles:
       - cli
@@ -737,6 +749,7 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+      target: runtime
     working_dir: /app
     profiles:
       - cli


### PR DESCRIPTION
## Summary
- shrink the repo-root Docker build context by ignoring tracked artifact, frontend, docs, and runtime-mounted paths the backend image never copies
- set all non-TTS services that build from `backend/Dockerfile` to target the plain `runtime` stage explicitly
- leave the dedicated `tts` service on the heavier `tts-runtime` stage

## Why
`Migration Contract (Container)` was failing on multiple PRs at the backend image build step because CI was exhausting disk. The local build trace showed two contributors:
- an overly broad repo-root build context
- backend-style services defaulting to the Dockerfile's final `tts-runtime` stage, which drags in the extra `builder-tts` dependency graph even when the service is not the TTS runtime

## Validation
- `GUARDIAN_API_KEY=ci OPENAI_API_KEY=local docker compose --progress plain build backend`
- after the fix, the backend build used the `runtime` stage and no longer entered `builder-tts` or `tts-runtime`
- the rerun transferred only `59.15kB` of build context and completed successfully
