### PR TITLE
Free Docker build cache before migration db startup

### DIFF
--- a/.github/workflows/guardian-ci.yml
+++ b/.github/workflows/guardian-ci.yml
@@ -329,6 +329,16 @@ jobs:
         if: ${{ needs.changes.outputs.run_backend == 'true' }}
         run: docker compose build backend
 
+      - name: Reclaim Docker build cache before starting database
+        if: ${{ needs.changes.outputs.run_backend == 'true' }}
+        shell: bash
+        run: |
+          set -euxo pipefail
+          docker system df || true
+          docker builder prune -af
+          docker image prune -f || true
+          docker system df || true
+
       - name: Start database
         if: ${{ needs.changes.outputs.run_backend == 'true' }}
         shell: bash


### PR DESCRIPTION
## Summary
- reclaim disposable Docker build cache in `Migration Contract (Container)` after `docker compose build backend`
- keep the fix scoped to GitHub runner disk pressure during Postgres image extraction/startup
- leave application and feature branch code unchanged

## Why
Fresh runs on PRs #90, #91, and #92 now clear backend tests and codemap, but still fail the migration contract job with `no space left on device` while starting the database container on GitHub runners.

## Validation
- `docker compose config`
- `docker compose build backend`
- `docker builder prune -af` reclaimed 10.44GB locally
- `docker compose up -d db`
- `docker compose exec -T db pg_isready -U codexify -d Codexify`
- `docker compose run --rm --no-deps -e DATABASE_URL=postgresql://codexify:codexify@db:5432/Codexify -e TEST_DATABASE_URL=postgresql://codexify:codexify@db:5432/Codexify --entrypoint python backend -m pytest /app/tests/test_migrations.py -v`
