### PR TITLE
runner: stabilize task artifact paths by campaign and task identity

### DIFF
--- a/codex_runner/runner.py
+++ b/codex_runner/runner.py
@@ -760,6 +760,15 @@ def to_lower_snake(value: str) -> str:
     return re.sub(r"_+", "_", cleaned).strip("_") or "task"
 
 
+def safe_task_id_for_path(task_id: str) -> str:
+    lowered = task_id.lower()
+    safe = re.sub(r"[^a-z0-9_-]+", "-", lowered)
+    safe = re.sub(r"-{2,}", "-", safe).strip("-") or "task"
+    if safe != lowered:
+        safe = f"{safe}-{sha256_text(task_id)[:8]}"
+    return safe
+
+
 def ensure_mapping_block(text: str) -> str:
     if MAPPING_START in text and MAPPING_END in text:
         return text
@@ -837,13 +846,15 @@ def materialize_campaign_artifacts(
         (DEFAULT_CAMPAIGN_DIR / campaign_doc_name).as_posix()
     )
 
-    task_dir_rel = DEFAULT_TASKS_DIR / f"{slug}_{date_underscore}"
+    task_dir_rel = DEFAULT_TASKS_DIR / f"{slug}_{date_underscore}_{seq}"
     task_dir_abs = repo_root / task_dir_rel
     task_dir_abs.mkdir(parents=True, exist_ok=True)
 
     for task in sorted(campaign["tasks"].values(), key=lambda item: item["id"]):
+        task_id = str(task["id"])
+        safe_task_id = safe_task_id_for_path(task_id)
         task_file_name = (
-            f"TASK_{to_lower_snake(task['slug'])}_{date_underscore}.md"
+            f"TASK_{safe_task_id}_{to_lower_snake(task['slug'])}.md"
         )
         task_rel = task_dir_rel / task_file_name
         task_abs = repo_root / task_rel
@@ -851,7 +862,7 @@ def materialize_campaign_artifacts(
             content = task["task_artifact_markdown"].rstrip() + "\n"
             text_write(task_abs, content)
             touched.append(str(task_rel.as_posix()))
-        campaign["materialized"]["task_artifact_paths"][task["id"]] = str(
+        campaign["materialized"]["task_artifact_paths"][task_id] = str(
             task_rel.as_posix()
         )
 

--- a/tests/codex_runner/test_runner_v2.py
+++ b/tests/codex_runner/test_runner_v2.py
@@ -1,6 +1,18 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+root_str = str(ROOT)
+if root_str in sys.path:
+    sys.path.remove(root_str)
+sys.path.insert(0, root_str)
+
+sys.modules.pop("codex_runner", None)
+sys.modules.pop("codex_runner.runner", None)
 
 from codex_runner import runner
 
@@ -17,6 +29,30 @@ def _sample_task(task_id: str = "TASK-001", slug: str = "alpha") -> dict:
         "task_artifact_markdown": "# Task",
         "activation_prompt": "Do task",
         "dependencies": [],
+    }
+
+
+def _sample_campaign(
+    *,
+    date: str = "2026-03-12",
+    slug: str = "alpha",
+    seq: str = "001",
+    tasks: list[dict] | None = None,
+) -> dict:
+    campaign_id = f"{date}::{slug}::{seq}"
+    task_map = {task["id"]: task for task in (tasks or [])}
+    return {
+        "campaign_id": campaign_id,
+        "campaign_slug": slug,
+        "campaign_date": date,
+        "campaign_seq": seq,
+        "depends_on": [],
+        "campaign_markdown": "# Campaign",
+        "tasks": task_map,
+        "materialized": {
+            "campaign_doc_path": None,
+            "task_artifact_paths": {},
+        },
     }
 
 
@@ -176,3 +212,51 @@ def test_normalize_repo_relative_path_rejects_parent_segments() -> None:
         runner.normalize_repo_relative_path("backend/app.py")
         == "backend/app.py"
     )
+
+
+def test_task_artifact_paths_do_not_collide_across_campaigns(
+    tmp_path: runner.Path,
+) -> None:
+    task_a = _sample_task("TASK-001-A", "alpha")
+    task_b = _sample_task("TASK-001-B", "alpha")
+    campaign_a = _sample_campaign(
+        date="2026-03-12", slug="alpha", seq="001", tasks=[task_a]
+    )
+    campaign_b = _sample_campaign(
+        date="2026-03-12", slug="alpha", seq="002", tasks=[task_b]
+    )
+
+    runner.materialize_campaign_artifacts(tmp_path, campaign_a)
+    runner.materialize_campaign_artifacts(tmp_path, campaign_b)
+
+    path_a = campaign_a["materialized"]["task_artifact_paths"][task_a["id"]]
+    path_b = campaign_b["materialized"]["task_artifact_paths"][task_b["id"]]
+
+    assert path_a != path_b
+    assert "alpha_2026_03_12_001" in path_a
+    assert "alpha_2026_03_12_002" in path_b
+    assert (tmp_path / path_a).exists()
+    assert (tmp_path / path_b).exists()
+
+
+def test_task_artifact_paths_stable_when_tasks_reordered(
+    tmp_path: runner.Path,
+) -> None:
+    task_two = _sample_task("TASK-002", "beta")
+    task_three = _sample_task("TASK-003", "gamma")
+    campaign = _sample_campaign(
+        date="2026-03-12", slug="alpha", seq="001", tasks=[task_two, task_three]
+    )
+
+    runner.materialize_campaign_artifacts(tmp_path, campaign)
+    path_before = campaign["materialized"]["task_artifact_paths"][
+        task_two["id"]
+    ]
+
+    task_one = _sample_task("TASK-001", "alpha")
+    campaign["tasks"][task_one["id"]] = task_one
+    runner.materialize_campaign_artifacts(tmp_path, campaign)
+    path_after = campaign["materialized"]["task_artifact_paths"][task_two["id"]]
+
+    assert path_before == path_after
+    assert (tmp_path / path_before).exists()


### PR DESCRIPTION
## Summary

- Title: Stabilize task artifact paths by campaign and task identity  
- Context: Task artifact paths were previously derived from slug + date, which could lead to collisions across campaigns and instability when task ordering changed. This introduces deterministic, collision-resistant paths scoped by campaign identity and task ID.

## Changes

- Files touched (high-level):
  - `codex_runner/runner.py`
  - `tests/codex_runner/test_runner_v2.py`

- Key diffs:
  - Introduced `safe_task_id_for_path()` to normalize and hash task IDs when necessary.
  - Updated task directory structure to include campaign sequence (`slug_date_seq`) to prevent cross-campaign collisions.
  - Switched task artifact filenames to include `safe_task_id` instead of relying on slug + date.
  - Ensured `task_artifact_paths` are keyed consi