### PR TITLE
ci: reclaim Docker space before migration backend build

### DIFF
--- a/.github/workflows/guardian-ci.yml
+++ b/.github/workflows/guardian-ci.yml
@@ -325,6 +325,16 @@ jobs:
         if: ${{ needs.changes.outputs.run_backend == 'true' }}
         run: .github/scripts/create-ci-env.sh .env
 
+      - name: Reclaim Docker space before backend build
+        if: ${{ needs.changes.outputs.run_backend == 'true' }}
+        shell: bash
+        run: |
+          set -euxo pipefail
+          docker system df || true
+          docker builder prune -af
+          docker image prune -f || true
+          docker system df || true
+
       - name: Build backend image
         if: ${{ needs.changes.outputs.run_backend == 'true' }}
         run: docker compose build backend


### PR DESCRIPTION
## Summary

- Title: Reclaim Docker space before backend image build in CI  
- Context: CI runners can accumulate Docker layers and build cache across jobs, leading to disk pressure and intermittent build failures. This adds a pre-build cleanup step to ensure sufficient space and more predictable backend image builds.

## Changes

- Files touched (high-level):
  - `.github/workflows/guardian-ci.yml`

- Key diffs:
  - Added a CI step **“Reclaim Docker space before backend build”** gated behind `run_backend`.
  - Executes:
    - `docker system df` (pre/post visibility)
    - `docker builder prune -af` (aggressive build cache cleanup)
    - `docker image prune -f` (remove unused images)
  - Positioned cleanup immediately before `docker compose build backend`.

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [x] Lint/typecheck pass
- [x] Tests pass (unit/integration as applicable)
- [x] Security/Privacy Check: no secrets committed; local-first defaults
- [x] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [x] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

- CI logs will show before/after `docker system df` output for visibility into reclaimed space.

## Risks & Rollback

- Risk level: low  
- Potential impact: slightly longer CI runtime due to prune step  
- Rollback plan: remove the cleanup step from workflow if unnecessary or if it impacts caching performance

## Next Steps

- Monitor CI stability and disk usage trends post-merge  
- Evaluate whether partial pruning (less aggressive than `-af`) provides a better cache/performance tradeoff  
- Consider adding alerts or metrics for disk pressure on runners