### PR TITLE
Add runtime stability audit template

### DIFF
--- a/docs/runtime-stability-audit.md
+++ b/docs/runtime-stability-audit.md
@@ -1,0 +1,306 @@
+# Codexify Runtime Stability Audit
+
+## Purpose
+
+Use this document as the weekly operational audit for Codexify runtime stabilization.
+It is intended to measure runtime reliability on the supported path, capture concrete evidence, record recurring failure classes, and define the fixes required before the runtime can be scored higher.
+
+## Audit Metadata
+
+- Audit Window: `[YYYY-MM-DD to YYYY-MM-DD]`
+- Environment: `[local Docker Compose / staging / other supported runtime]`
+- Branch / Commit Range: `[branch name] / [commit SHA or commit range]`
+- Owner: `[name]`
+- Audit Version: `v1.0`
+
+## Executive Summary
+
+- Overall Stability Index: `[__/60]`
+- Rating Band: `[unstable / fragile / improving / stabilizing / beta-ready core]`
+- Summary: `[2-4 sentence operational summary of current runtime state]`
+- Top Regressions This Week:
+  - `[regression 1]`
+  - `[regression 2]`
+  - `[regression 3]`
+- Primary Blockers:
+  - `[blocker 1]`
+  - `[blocker 2]`
+- Recommended Release Posture: `[hold / continue stabilization / limited internal validation only]`
+
+## Weighted Stability Index
+
+Score each category with an integer value from `0` up to its weight.
+Do not increase a score without direct evidence from the current audit window.
+
+| Category | Weight | Score | Notes |
+| --- | ---: | ---: | --- |
+| Core Loop Reliability | 15 | `[__/15]` | `[brief reason]` |
+| Retrieval / Context Integrity | 12 | `[__/12]` | `[brief reason]` |
+| Queue / Worker Health | 12 | `[__/12]` | `[brief reason]` |
+| Contract Stability | 12 | `[__/12]` | `[brief reason]` |
+| Operator Confidence | 9 | `[__/9]` | `[brief reason]` |
+| **Total** | **60** | `[/60]` | `[overall read]` |
+
+### Rating Bands
+
+- `0-19 = unstable`
+- `20-29 = fragile`
+- `30-39 = improving`
+- `40-49 = stabilizing`
+- `50-60 = beta-ready core`
+
+### Suggested First Target Thresholds
+
+- `40+ = stabilizing`
+- `50+ = beta-ready core`
+
+## Core Loop Reliability
+
+### Goal
+
+Confirm that the supported user-critical runtime loops complete end to end without stalls, silent drops, duplicate side effects, or manual intervention.
+
+### Audit Questions
+
+- Do the primary user flows start, progress, and complete on the supported path?
+- Are turns, tasks, and persisted state transitions visible and internally consistent?
+- Are retries idempotent, or do they create duplicate messages, tasks, or records?
+- Does restart or transient failure leave the runtime in a recoverable state?
+
+### Score
+
+`[__/15]`
+
+### Evidence
+
+- `[test run, manual scenario, logs, traces, screenshots, issue links]`
+
+### Failure Patterns Seen
+
+- `[stuck turn]`
+- `[duplicate completion]`
+- `[orphaned task]`
+- `[manual restart required]`
+
+### Current Assessment
+
+`[short paragraph describing the present state of the core loop]`
+
+### Required Fixes Before Score Can Increase
+
+- `[required fix 1]`
+- `[required fix 2]`
+
+## Retrieval / Context Integrity
+
+### Goal
+
+Verify that retrieval, context assembly, and context delivery remain correct, bounded, and explainable under normal and degraded runtime conditions.
+
+### Audit Questions
+
+- Does retrieval return relevant, expected records for supported queries?
+- Is the context window assembled from the correct sources in the correct order?
+- Are empty, partial, or stale retrieval results surfaced clearly instead of failing silently?
+- Do source references, metadata, and context payloads match what downstream consumers expect?
+
+### Score
+
+`[__/12]`
+
+### Evidence
+
+- `[retrieval logs, API payloads, rendered context, issue links]`
+
+### Failure Patterns Seen
+
+- `[wrong document returned]`
+- `[missing context despite indexed data]`
+- `[stale cache or stale embedding state]`
+- `[context payload shape drift]`
+
+### Current Assessment
+
+`[short paragraph describing current retrieval and context quality]`
+
+### Required Fixes Before Score Can Increase
+
+- `[required fix 1]`
+- `[required fix 2]`
+
+## Queue / Worker Health
+
+### Goal
+
+Confirm that queued runtime work is accepted, processed, observed, and recovered correctly without hidden backlog growth or silent worker failure.
+
+### Audit Questions
+
+- Are queue-backed jobs enqueued and acknowledged reliably?
+- Are workers healthy, connected, and consuming the expected job classes?
+- Is backlog growth visible and bounded during normal usage?
+- Do retries, dead-letter paths, and failure signals behave as intended?
+
+### Score
+
+`[__/12]`
+
+### Evidence
+
+- `[queue metrics, worker logs, retry counts, failure samples, issue links]`
+
+### Failure Patterns Seen
+
+- `[queue unavailable]`
+- `[worker crash loop]`
+- `[jobs stuck pending]`
+- `[retry storm or dead-letter growth]`
+
+### Current Assessment
+
+`[short paragraph describing current queue and worker behavior]`
+
+### Required Fixes Before Score Can Increase
+
+- `[required fix 1]`
+- `[required fix 2]`
+
+## Contract Stability
+
+### Goal
+
+Measure whether runtime-facing contracts remain stable across backend routes, frontend consumers, worker payloads, and persisted records.
+
+### Audit Questions
+
+- Are request and response shapes aligned across all supported runtime surfaces?
+- Do worker payloads, event payloads, and persisted records use the same field names and meanings?
+- Are versioned or deprecated fields handled explicitly instead of implicitly?
+- Did this audit window expose any deterministic break caused by contract drift?
+
+### Score
+
+`[__/12]`
+
+### Evidence
+
+- `[API payloads, schema diffs, failing requests, issue links]`
+
+### Failure Patterns Seen
+
+- `[response shape mismatch]`
+- `[missing required field]`
+- `[renamed key without compatibility path]`
+- `[frontend expects sync response but backend returns async task handle]`
+
+### Current Assessment
+
+`[short paragraph describing the current contract state]`
+
+### Required Fixes Before Score Can Increase
+
+- `[required fix 1]`
+- `[required fix 2]`
+
+## Operator Confidence
+
+### Goal
+
+Assess whether an operator can understand runtime state quickly enough to diagnose issues, confirm recovery, and make release decisions with evidence rather than guesswork.
+
+### Audit Questions
+
+- Are failures observable through logs, metrics, health checks, or explicit UI state?
+- Can an operator distinguish between degraded, blocked, and healthy runtime behavior?
+- Are the current runbooks and recovery steps sufficient for the recurring failures seen this week?
+- Can the team explain why the system failed without speculative debugging?
+
+### Score
+
+`[__/9]`
+
+### Evidence
+
+- `[health endpoints, dashboards, logs, runbook links, screenshots, issue links]`
+
+### Failure Patterns Seen
+
+- `[silent failure]`
+- `[misleading healthy status]`
+- `[missing trace or correlation path]`
+- `[operator needed ad hoc database or shell inspection to diagnose]`
+
+### Current Assessment
+
+`[short paragraph describing current operator confidence]`
+
+### Required Fixes Before Score Can Increase
+
+- `[required fix 1]`
+- `[required fix 2]`
+
+## Known Bugs by Class
+
+### Structural Bugs
+
+| Bug / Symptom | Surface | Severity | Evidence | Status |
+| --- | --- | --- | --- | --- |
+| `[bug]` | `[component]` | `[high/medium/low]` | `[link or note]` | `[open/in progress/verified]` |
+
+### Contract Bugs
+
+| Bug / Symptom | Surface | Severity | Evidence | Status |
+| --- | --- | --- | --- | --- |
+| `[bug]` | `[component]` | `[high/medium/low]` | `[link or note]` | `[open/in progress/verified]` |
+
+### Edge-Case Runtime Bugs
+
+| Bug / Symptom | Surface | Severity | Evidence | Status |
+| --- | --- | --- | --- | --- |
+| `[bug]` | `[component]` | `[high/medium/low]` | `[link or note]` | `[open/in progress/verified]` |
+
+### UX / Observability Bugs
+
+| Bug / Symptom | Surface | Severity | Evidence | Status |
+| --- | --- | --- | --- | --- |
+| `[bug]` | `[component]` | `[high/medium/low]` | `[link or note]` | `[open/in progress/verified]` |
+
+## Regression Watchlist
+
+Track regressions that are either recurring, recently fixed, or likely to return under load, restart, or configuration drift.
+
+| Regression Risk | Why It Matters | Detection Signal | Last Seen | Owner | Status |
+| --- | --- | --- | --- | --- | --- |
+| `[regression]` | `[impact]` | `[log, metric, failed scenario, or test]` | `[YYYY-MM-DD]` | `[name]` | `[watching/fixed/reopened]` |
+
+## Next Hardening Tasks
+
+| Priority | Task | Why Now | Blocking Signal | Owner | Target Window | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| `P0` | `[task]` | `[reason]` | `[what it unblocks]` | `[name]` | `[date or audit window]` | `[planned/in progress/done]` |
+| `P1` | `[task]` | `[reason]` | `[what it unblocks]` | `[name]` | `[date or audit window]` | `[planned/in progress/done]` |
+| `P2` | `[task]` | `[reason]` | `[what it unblocks]` | `[name]` | `[date or audit window]` | `[planned/in progress/done]` |
+
+## Release Readiness Read
+
+- Current Read: `[not ready / internal only / limited beta verification / beta-ready core]`
+- Release-Critical Blockers:
+  - `[blocker 1]`
+  - `[blocker 2]`
+- Evidence Supporting This Read:
+  - `[evidence 1]`
+  - `[evidence 2]`
+- Conditions Required Before Promotion:
+  - `[condition 1]`
+  - `[condition 2]`
+
+Use this section to state the release decision for the current audit window.
+Do not mark the runtime as ready if the weighted score, recurring blocker class, or direct evidence disagree.
+
+## Suggested Weekly Cadence
+
+1. Gather incident notes, failed test runs, operator observations, and open runtime bugs from the current week.
+2. Re-run the supported runtime path on the current branch or release candidate.
+3. Fill the weighted index with evidence from the current audit window only.
+4. Update bug classes and regression watchlist with anything newly observed or newly resolved.
+5. Record the release readiness read and assign the next hardening tasks before the week closes.


### PR DESCRIPTION
## Summary
- add a reusable `docs/runtime-stability-audit.md` template for weekly runtime stabilization reviews
- define a weighted 60-point stability index across core loop reliability, retrieval/context integrity, queue/worker health, contract stability, and operator confidence
- include fill-in sections for evidence, failure patterns, known bug classes, regression watchlist, hardening tasks, release readiness, and weekly cadence

## Testing
- Not run (not requested)