### PR TITLE
Refactor provider governance rules and add runtime stability audit template

### DIFF
--- a/docs/Codexify/RELEASE.md
+++ b/docs/Codexify/RELEASE.md
@@ -2,6 +2,15 @@
 
 This project follows [Semantic Versioning](https://semver.org/).
 
+## Recent Release Notes
+
+### 2026-03-17 - Provider Governance Policy Synchronization
+
+- Documented the canonical provider-governance map now enforced by the registry as the implementation source of truth.
+- Recorded the current provider classifications exactly as implemented: `discovery_backed` (`alibaba`, `minimax`), `static_authorized` (`openai`, `groq`), `local_only` (`local`), and `disabled` (`anthropic`, `gemini`).
+- Recorded that router-side discovery validation derives from registry policy instead of a duplicated router-local provider list.
+- Synchronized release and architecture documentation with the current provider contract without changing runtime behavior.
+
 ## Versioning Guidelines
 - Increment **MAJOR** for incompatible API changes.
 - Increment **MINOR** for backward compatible functionality.

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -1,5 +1,5 @@
 Purpose: Capture Codexify's current runtime architecture in one place so onboarding, estimation, and design review start from implemented behavior rather than assumptions.
-Last updated: 2026-03-11
+Last updated: 2026-03-17
 Source anchors:
 - docker-compose.yml
 - src-tauri/
@@ -76,6 +76,19 @@ Source anchors:
 ### Unverified runtime
 
 - Production deployment outside Docker Compose is `Unverified`; no Kubernetes, Nomad, or other infra manifests were found in this repo.
+
+## Provider Governance Contract
+
+The configured provider is not the same thing as discovered provider inventory. Configuration selects the execution surface. Discovered inventory is only the live model list fetched by the registry for providers whose governance policy expects discovery.
+
+`guardian/core/provider_registry.py` is the canonical source of provider-governance truth. Router behavior, catalog behavior, health reporting, and runtime model-selection checks should derive from that registry contract rather than from provider-specific hardcoded lists.
+
+| Governance category | Providers | Operational meaning | Live discovery expected | Routing validates against discovered inventory | Configured defaults allowed during degraded discovery | Local-only / unavailable |
+|---|---|---|---|---|---|---|
+| `discovery_backed` | `alibaba`, `minimax` | Provider is routed through the canonical registry and expected to expose a live model index. | Yes | Yes | Yes | No |
+| `static_authorized` | `openai`, `groq` | Provider is supported for routed execution through static model descriptors plus credential and egress authorization. | No | No | No | No |
+| `local_only` | `local` | Provider is intentionally local-first and does not depend on cloud discovery or remote authorization. | No | No | No | Yes, intentionally local-only |
+| `disabled` | `anthropic`, `gemini` | Provider remains explicitly classified in the registry but is unavailable for routed execution under the current contract. | No | No | No | Yes, unavailable |
 
 ## Critical Paths
 

--- a/docs/infra/system_architecture.md
+++ b/docs/infra/system_architecture.md
@@ -310,6 +310,19 @@ graph TB
     Apply --> Component[Component Config]
 ```
 
+## Provider Governance Policy
+
+Provider governance is an implementation contract, not a router-local convention. The configured provider selects which execution surface the runtime will call. Discovered inventory is separate and only applies to providers whose governance category expects live discovery.
+
+The registry is the canonical provider-governance source of truth. Router behavior should derive from registry policy rather than from provider-specific hardcoded lists, and catalog, health, and runtime behavior should stay aligned with that same contract.
+
+| Governance category | Providers | Operational meaning | Live discovery expected | Routing validates against discovered inventory | Configured defaults allowed during degraded discovery | Local-only / unavailable |
+|---|---|---|---|---|---|---|
+| `discovery_backed` | `alibaba`, `minimax` | Routed provider with registry-managed live inventory discovery. | Yes | Yes | Yes | No |
+| `static_authorized` | `openai`, `groq` | Routed provider authorized by config and credentials with static model descriptors. | No | No | No | No |
+| `local_only` | `local` | Intentionally local execution path with no live cloud inventory contract. | No | No | No | Yes, intentionally local-only |
+| `disabled` | `anthropic`, `gemini` | Explicitly known to the registry but unavailable for routed execution in the current implementation. | No | No | No | Yes, unavailable |
+
 ## 📝 Documentation Structure
 
 ```mermaid

--- a/docs/runtime-stability-audit.md
+++ b/docs/runtime-stability-audit.md
@@ -1,0 +1,306 @@
+# Codexify Runtime Stability Audit
+
+## Purpose
+
+Use this document as the weekly operational audit for Codexify runtime stabilization.
+It is intended to measure runtime reliability on the supported path, capture concrete evidence, record recurring failure classes, and define the fixes required before the runtime can be scored higher.
+
+## Audit Metadata
+
+- Audit Window: `[YYYY-MM-DD to YYYY-MM-DD]`
+- Environment: `[local Docker Compose / staging / other supported runtime]`
+- Branch / Commit Range: `[branch name] / [commit SHA or commit range]`
+- Owner: `[name]`
+- Audit Version: `v1.0`
+
+## Executive Summary
+
+- Overall Stability Index: `[__/60]`
+- Rating Band: `[unstable / fragile / improving / stabilizing / beta-ready core]`
+- Summary: `[2-4 sentence operational summary of current runtime state]`
+- Top Regressions This Week:
+  - `[regression 1]`
+  - `[regression 2]`
+  - `[regression 3]`
+- Primary Blockers:
+  - `[blocker 1]`
+  - `[blocker 2]`
+- Recommended Release Posture: `[hold / continue stabilization / limited internal validation only]`
+
+## Weighted Stability Index
+
+Score each category with an integer value from `0` up to its weight.
+Do not increase a score without direct evidence from the current audit window.
+
+| Category | Weight | Score | Notes |
+| --- | ---: | ---: | --- |
+| Core Loop Reliability | 15 | `[__/15]` | `[brief reason]` |
+| Retrieval / Context Integrity | 12 | `[__/12]` | `[brief reason]` |
+| Queue / Worker Health | 12 | `[__/12]` | `[brief reason]` |
+| Contract Stability | 12 | `[__/12]` | `[brief reason]` |
+| Operator Confidence | 9 | `[__/9]` | `[brief reason]` |
+| **Total** | **60** | `[/60]` | `[overall read]` |
+
+### Rating Bands
+
+- `0-19 = unstable`
+- `20-29 = fragile`
+- `30-39 = improving`
+- `40-49 = stabilizing`
+- `50-60 = beta-ready core`
+
+### Suggested First Target Thresholds
+
+- `40+ = stabilizing`
+- `50+ = beta-ready core`
+
+## Core Loop Reliability
+
+### Goal
+
+Confirm that the supported user-critical runtime loops complete end to end without stalls, silent drops, duplicate side effects, or manual intervention.
+
+### Audit Questions
+
+- Do the primary user flows start, progress, and complete on the supported path?
+- Are turns, tasks, and persisted state transitions visible and internally consistent?
+- Are retries idempotent, or do they create duplicate messages, tasks, or records?
+- Does restart or transient failure leave the runtime in a recoverable state?
+
+### Score
+
+`[__/15]`
+
+### Evidence
+
+- `[test run, manual scenario, logs, traces, screenshots, issue links]`
+
+### Failure Patterns Seen
+
+- `[stuck turn]`
+- `[duplicate completion]`
+- `[orphaned task]`
+- `[manual restart required]`
+
+### Current Assessment
+
+`[short paragraph describing the present state of the core loop]`
+
+### Required Fixes Before Score Can Increase
+
+- `[required fix 1]`
+- `[required fix 2]`
+
+## Retrieval / Context Integrity
+
+### Goal
+
+Verify that retrieval, context assembly, and context delivery remain correct, bounded, and explainable under normal and degraded runtime conditions.
+
+### Audit Questions
+
+- Does retrieval return relevant, expected records for supported queries?
+- Is the context window assembled from the correct sources in the correct order?
+- Are empty, partial, or stale retrieval results surfaced clearly instead of failing silently?
+- Do source references, metadata, and context payloads match what downstream consumers expect?
+
+### Score
+
+`[__/12]`
+
+### Evidence
+
+- `[retrieval logs, API payloads, rendered context, issue links]`
+
+### Failure Patterns Seen
+
+- `[wrong document returned]`
+- `[missing context despite indexed data]`
+- `[stale cache or stale embedding state]`
+- `[context payload shape drift]`
+
+### Current Assessment
+
+`[short paragraph describing current retrieval and context quality]`
+
+### Required Fixes Before Score Can Increase
+
+- `[required fix 1]`
+- `[required fix 2]`
+
+## Queue / Worker Health
+
+### Goal
+
+Confirm that queued runtime work is accepted, processed, observed, and recovered correctly without hidden backlog growth or silent worker failure.
+
+### Audit Questions
+
+- Are queue-backed jobs enqueued and acknowledged reliably?
+- Are workers healthy, connected, and consuming the expected job classes?
+- Is backlog growth visible and bounded during normal usage?
+- Do retries, dead-letter paths, and failure signals behave as intended?
+
+### Score
+
+`[__/12]`
+
+### Evidence
+
+- `[queue metrics, worker logs, retry counts, failure samples, issue links]`
+
+### Failure Patterns Seen
+
+- `[queue unavailable]`
+- `[worker crash loop]`
+- `[jobs stuck pending]`
+- `[retry storm or dead-letter growth]`
+
+### Current Assessment
+
+`[short paragraph describing current queue and worker behavior]`
+
+### Required Fixes Before Score Can Increase
+
+- `[required fix 1]`
+- `[required fix 2]`
+
+## Contract Stability
+
+### Goal
+
+Measure whether runtime-facing contracts remain stable across backend routes, frontend consumers, worker payloads, and persisted records.
+
+### Audit Questions
+
+- Are request and response shapes aligned across all supported runtime surfaces?
+- Do worker payloads, event payloads, and persisted records use the same field names and meanings?
+- Are versioned or deprecated fields handled explicitly instead of implicitly?
+- Did this audit window expose any deterministic break caused by contract drift?
+
+### Score
+
+`[__/12]`
+
+### Evidence
+
+- `[API payloads, schema diffs, failing requests, issue links]`
+
+### Failure Patterns Seen
+
+- `[response shape mismatch]`
+- `[missing required field]`
+- `[renamed key without compatibility path]`
+- `[frontend expects sync response but backend returns async task handle]`
+
+### Current Assessment
+
+`[short paragraph describing the current contract state]`
+
+### Required Fixes Before Score Can Increase
+
+- `[required fix 1]`
+- `[required fix 2]`
+
+## Operator Confidence
+
+### Goal
+
+Assess whether an operator can understand runtime state quickly enough to diagnose issues, confirm recovery, and make release decisions with evidence rather than guesswork.
+
+### Audit Questions
+
+- Are failures observable through logs, metrics, health checks, or explicit UI state?
+- Can an operator distinguish between degraded, blocked, and healthy runtime behavior?
+- Are the current runbooks and recovery steps sufficient for the recurring failures seen this week?
+- Can the team explain why the system failed without speculative debugging?
+
+### Score
+
+`[__/9]`
+
+### Evidence
+
+- `[health endpoints, dashboards, logs, runbook links, screenshots, issue links]`
+
+### Failure Patterns Seen
+
+- `[silent failure]`
+- `[misleading healthy status]`
+- `[missing trace or correlation path]`
+- `[operator needed ad hoc database or shell inspection to diagnose]`
+
+### Current Assessment
+
+`[short paragraph describing current operator confidence]`
+
+### Required Fixes Before Score Can Increase
+
+- `[required fix 1]`
+- `[required fix 2]`
+
+## Known Bugs by Class
+
+### Structural Bugs
+
+| Bug / Symptom | Surface | Severity | Evidence | Status |
+| --- | --- | --- | --- | --- |
+| `[bug]` | `[component]` | `[high/medium/low]` | `[link or note]` | `[open/in progress/verified]` |
+
+### Contract Bugs
+
+| Bug / Symptom | Surface | Severity | Evidence | Status |
+| --- | --- | --- | --- | --- |
+| `[bug]` | `[component]` | `[high/medium/low]` | `[link or note]` | `[open/in progress/verified]` |
+
+### Edge-Case Runtime Bugs
+
+| Bug / Symptom | Surface | Severity | Evidence | Status |
+| --- | --- | --- | --- | --- |
+| `[bug]` | `[component]` | `[high/medium/low]` | `[link or note]` | `[open/in progress/verified]` |
+
+### UX / Observability Bugs
+
+| Bug / Symptom | Surface | Severity | Evidence | Status |
+| --- | --- | --- | --- | --- |
+| `[bug]` | `[component]` | `[high/medium/low]` | `[link or note]` | `[open/in progress/verified]` |
+
+## Regression Watchlist
+
+Track regressions that are either recurring, recently fixed, or likely to return under load, restart, or configuration drift.
+
+| Regression Risk | Why It Matters | Detection Signal | Last Seen | Owner | Status |
+| --- | --- | --- | --- | --- | --- |
+| `[regression]` | `[impact]` | `[log, metric, failed scenario, or test]` | `[YYYY-MM-DD]` | `[name]` | `[watching/fixed/reopened]` |
+
+## Next Hardening Tasks
+
+| Priority | Task | Why Now | Blocking Signal | Owner | Target Window | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| `P0` | `[task]` | `[reason]` | `[what it unblocks]` | `[name]` | `[date or audit window]` | `[planned/in progress/done]` |
+| `P1` | `[task]` | `[reason]` | `[what it unblocks]` | `[name]` | `[date or audit window]` | `[planned/in progress/done]` |
+| `P2` | `[task]` | `[reason]` | `[what it unblocks]` | `[name]` | `[date or audit window]` | `[planned/in progress/done]` |
+
+## Release Readiness Read
+
+- Current Read: `[not ready / internal only / limited beta verification / beta-ready core]`
+- Release-Critical Blockers:
+  - `[blocker 1]`
+  - `[blocker 2]`
+- Evidence Supporting This Read:
+  - `[evidence 1]`
+  - `[evidence 2]`
+- Conditions Required Before Promotion:
+  - `[condition 1]`
+  - `[condition 2]`
+
+Use this section to state the release decision for the current audit window.
+Do not mark the runtime as ready if the weighted score, recurring blocker class, or direct evidence disagree.
+
+## Suggested Weekly Cadence
+
+1. Gather incident notes, failed test runs, operator observations, and open runtime bugs from the current week.
+2. Re-run the supported runtime path on the current branch or release candidate.
+3. Fill the weighted index with evidence from the current audit window only.
+4. Update bug classes and regression watchlist with anything newly observed or newly resolved.
+5. Record the release readiness read and assign the next hardening tasks before the week closes.

--- a/guardian/core/ai_router.py
+++ b/guardian/core/ai_router.py
@@ -13,14 +13,16 @@ from guardian.core.provider_registry import default_model_for_provider
 from guardian.core.provider_registry import (
     normalize_provider as normalize_registry_provider,
 )
-from guardian.core.provider_registry import validate_provider_model_selection
+from guardian.core.provider_registry import (
+    provider_routing_requires_discovered_inventory,
+    validate_provider_model_selection,
+)
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_OPENAI_BASE = "https://api.openai.com"
 _DEFAULT_GROQ_BASE = "https://api.groq.com"
 _DEFAULT_ALIBABA_BASE = "https://dashscope-us.aliyuncs.com/compatible-mode/v1"
-_DYNAMIC_DISCOVERY_VALIDATED_PROVIDERS = {"alibaba", "minimax"}
 
 
 @dataclass(frozen=True)
@@ -531,7 +533,7 @@ def chat_with_ai(
             ),
         )
 
-    if provider_name in _DYNAMIC_DISCOVERY_VALIDATED_PROVIDERS:
+    if provider_routing_requires_discovered_inventory(provider_name):
         valid, reason = validate_provider_model_selection(
             provider_id=provider_name,
             model_id=target_model,

--- a/guardian/core/config.py
+++ b/guardian/core/config.py
@@ -9,6 +9,14 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 _DEFAULT_ALIBABA_API_BASE = (
     "https://dashscope-us.aliyuncs.com/compatible-mode/v1"
 )
+ROUTER_SUPPORTED_LLM_PROVIDERS: tuple[str, ...] = (
+    "local",
+    "groq",
+    "openai",
+    "alibaba",
+    "minimax",
+)
+_ROUTER_SUPPORTED_LLM_PROVIDER_TEXT = ", ".join(ROUTER_SUPPORTED_LLM_PROVIDERS)
 logger = logging.getLogger(__name__)
 
 
@@ -32,7 +40,8 @@ class Settings(BaseSettings):
     LLM_PROVIDER: str = Field(
         default="local",
         description=(
-            "The LLM provider to use ('local', 'groq', 'openai', 'alibaba', 'minimax')."
+            "The LLM provider to use. Runtime-supported values: "
+            f"{_ROUTER_SUPPORTED_LLM_PROVIDER_TEXT}."
         ),
     )
     CODEXIFY_CONFIG_SOURCE: str = Field(
@@ -824,7 +833,9 @@ def validate_llm_config(
         return
 
     raise LLMConfigError(
-        f"Unsupported LLM_PROVIDER: {provider or '<empty>'} (expected one of: local, groq, openai, alibaba, minimax)"
+        "Unsupported LLM_PROVIDER: "
+        f"{provider or '<empty>'} (expected one of: "
+        f"{_ROUTER_SUPPORTED_LLM_PROVIDER_TEXT})"
     )
 
 

--- a/guardian/core/provider_registry.py
+++ b/guardian/core/provider_registry.py
@@ -6,7 +6,8 @@ decisions used by catalog, health, router, and worker code.
 
 from __future__ import annotations
 
-from typing import Any, Iterable
+from dataclasses import dataclass
+from typing import Any, Iterable, Literal
 
 import requests
 from requests import exceptions as req_exc
@@ -14,37 +15,120 @@ from requests import exceptions as req_exc
 from guardian.core.config import LLMConfigError, Settings, validate_llm_config
 from guardian.core.egress import EgressDeniedError, assert_egress_allowed
 
-PROVIDER_ORDER = (
-    "openai",
-    "anthropic",
-    "gemini",
-    "groq",
-    "alibaba",
-    "minimax",
-    "local",
+ProviderGovernanceClassification = Literal[
+    "discovery_backed",
+    "static_authorized",
+    "local_only",
+    "disabled",
+]
+
+
+@dataclass(frozen=True)
+class ProviderGovernanceRule:
+    provider: str
+    label: str
+    governance_classification: ProviderGovernanceClassification
+    live_discovery_expected: bool
+    routing_validate_discovered_inventory: bool
+    configured_defaults_allowed_during_degraded_discovery: bool
+    local_only: bool
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "governance_classification": self.governance_classification,
+            "live_discovery_expected": self.live_discovery_expected,
+            "routing_validate_discovered_inventory": (
+                self.routing_validate_discovered_inventory
+            ),
+            "configured_defaults_allowed_during_degraded_discovery": (
+                self.configured_defaults_allowed_during_degraded_discovery
+            ),
+            "local_only": self.local_only,
+        }
+
+
+_PROVIDER_GOVERNANCE_RULES: tuple[ProviderGovernanceRule, ...] = (
+    ProviderGovernanceRule(
+        provider="openai",
+        label="OpenAI",
+        governance_classification="static_authorized",
+        live_discovery_expected=False,
+        routing_validate_discovered_inventory=False,
+        configured_defaults_allowed_during_degraded_discovery=False,
+        local_only=False,
+    ),
+    ProviderGovernanceRule(
+        provider="anthropic",
+        label="Anthropic",
+        governance_classification="disabled",
+        live_discovery_expected=False,
+        routing_validate_discovered_inventory=False,
+        configured_defaults_allowed_during_degraded_discovery=False,
+        local_only=False,
+    ),
+    ProviderGovernanceRule(
+        provider="gemini",
+        label="Gemini",
+        governance_classification="disabled",
+        live_discovery_expected=False,
+        routing_validate_discovered_inventory=False,
+        configured_defaults_allowed_during_degraded_discovery=False,
+        local_only=False,
+    ),
+    ProviderGovernanceRule(
+        provider="groq",
+        label="Groq",
+        governance_classification="static_authorized",
+        live_discovery_expected=False,
+        routing_validate_discovered_inventory=False,
+        configured_defaults_allowed_during_degraded_discovery=False,
+        local_only=False,
+    ),
+    ProviderGovernanceRule(
+        provider="alibaba",
+        label="Alibaba / DashScope",
+        governance_classification="discovery_backed",
+        live_discovery_expected=True,
+        routing_validate_discovered_inventory=True,
+        configured_defaults_allowed_during_degraded_discovery=True,
+        local_only=False,
+    ),
+    ProviderGovernanceRule(
+        provider="minimax",
+        label="MiniMax",
+        governance_classification="discovery_backed",
+        live_discovery_expected=True,
+        routing_validate_discovered_inventory=True,
+        configured_defaults_allowed_during_degraded_discovery=True,
+        local_only=False,
+    ),
+    ProviderGovernanceRule(
+        provider="local",
+        label="Local",
+        governance_classification="local_only",
+        live_discovery_expected=False,
+        routing_validate_discovered_inventory=False,
+        configured_defaults_allowed_during_degraded_discovery=False,
+        local_only=True,
+    ),
 )
 
+_PROVIDER_GOVERNANCE_BY_ID = {
+    rule.provider: rule for rule in _PROVIDER_GOVERNANCE_RULES
+}
+
+PROVIDER_ORDER = tuple(rule.provider for rule in _PROVIDER_GOVERNANCE_RULES)
+
 PROVIDER_LABELS = {
-    "openai": "OpenAI",
-    "anthropic": "Anthropic",
-    "gemini": "Gemini",
-    "groq": "Groq",
-    "alibaba": "Alibaba / DashScope",
-    "minimax": "MiniMax",
-    "local": "Local",
+    rule.provider: rule.label for rule in _PROVIDER_GOVERNANCE_RULES
 }
 
 CLOUD_PROVIDERS = {
-    "openai",
-    "anthropic",
-    "gemini",
-    "groq",
-    "alibaba",
-    "minimax",
+    rule.provider for rule in _PROVIDER_GOVERNANCE_RULES if not rule.local_only
 }
 
 _AUTO_MODEL_SENTINELS = {"", "auto"}
-_DYNAMIC_MODEL_PROVIDERS = {"alibaba", "minimax"}
 _MODEL_INDEX_NON_CHAT_HINTS = (
     "audio",
     "asr",
@@ -140,6 +224,42 @@ def normalize_model_id(model_id: str | None) -> str:
     if normalized.lower() in _AUTO_MODEL_SENTINELS:
         return ""
     return normalized
+
+
+def _provider_governance_rule(
+    provider_id: str | None,
+) -> ProviderGovernanceRule | None:
+    return _PROVIDER_GOVERNANCE_BY_ID.get(normalize_provider(provider_id))
+
+
+def provider_governance(provider_id: str | None) -> dict[str, Any]:
+    rule = _provider_governance_rule(provider_id)
+    if rule is None:
+        normalized = normalize_provider(provider_id)
+        raise ValueError(f"Unsupported provider: {normalized or '<empty>'}")
+    return rule.as_dict()
+
+
+def provider_governance_contract() -> dict[str, dict[str, Any]]:
+    return {
+        rule.provider: rule.as_dict() for rule in _PROVIDER_GOVERNANCE_RULES
+    }
+
+
+def provider_routing_requires_discovered_inventory(
+    provider_id: str | None,
+) -> bool:
+    rule = _provider_governance_rule(provider_id)
+    return bool(rule and rule.routing_validate_discovered_inventory)
+
+
+def provider_allows_default_during_degraded_discovery(
+    provider_id: str | None,
+) -> bool:
+    rule = _provider_governance_rule(provider_id)
+    return bool(
+        rule and rule.configured_defaults_allowed_during_degraded_discovery
+    )
 
 
 def _normalize_reason(message: str) -> str:
@@ -542,8 +662,12 @@ def _discover_dynamic_provider_models(
 
 def provider_authorized(provider_id: str, settings: Settings) -> bool:
     provider = normalize_provider(provider_id)
-    if provider == "local":
+    governance = _provider_governance_rule(provider)
+
+    if governance and governance.local_only:
         return True
+    if governance and governance.governance_classification == "disabled":
+        return False
     if provider == "openai":
         return _has_real_api_key(
             str(getattr(settings, "OPENAI_API_KEY", "") or "")
@@ -586,6 +710,9 @@ def provider_availability(
     authorized: bool | None = None,
 ) -> tuple[bool, str | None]:
     provider = normalize_provider(provider_id)
+    governance = _provider_governance_rule(provider)
+    if governance is None:
+        return False, "Unsupported provider"
     authorized_value = (
         provider_authorized(provider, settings)
         if authorized is None
@@ -606,9 +733,6 @@ def provider_availability(
             assert_egress_allowed(provider, settings=settings)
         except EgressDeniedError as exc:
             return False, _normalize_reason(str(exc))
-
-    if provider not in PROVIDER_ORDER:
-        return False, "Unsupported provider"
 
     return True, None
 
@@ -653,6 +777,7 @@ def resolve_provider_capability(
     settings: Settings,
 ) -> dict[str, Any]:
     provider = normalize_provider(provider_id)
+    governance = _provider_governance_rule(provider)
     authorized = provider_authorized(provider, settings)
     available, disabled_reason = provider_availability(
         provider,
@@ -661,20 +786,23 @@ def resolve_provider_capability(
     )
     default_model = default_model_for_provider(provider, settings)
 
-    if provider == "local":
+    if governance and governance.local_only:
         models: list[dict[str, Any]] = []
         model_index = {
             "source": "local",
             "state": "available",
         }
-    elif provider in _DYNAMIC_MODEL_PROVIDERS:
+    elif governance and governance.live_discovery_expected:
         models, model_index = _discover_dynamic_provider_models(
             provider,
             settings,
             available=available,
             disabled_reason=disabled_reason,
         )
-        if model_index["state"] != "available" and not default_model:
+        if model_index["state"] != "available" and (
+            not default_model
+            or not provider_allows_default_during_degraded_discovery(provider)
+        ):
             available = False
             disabled_reason = (
                 str(
@@ -692,7 +820,9 @@ def resolve_provider_capability(
             "model_count": len(models),
         }
 
-    enabled = bool(available) and (provider == "local" or bool(authorized))
+    enabled = bool(available) and (
+        bool(governance and governance.local_only) or bool(authorized)
+    )
     return {
         "id": provider,
         "authorized": authorized,
@@ -778,9 +908,10 @@ def validate_provider_model_selection(
     if model not in provider_model_ids:
         model_index = capability["model_index"]
         if (
-            provider in _DYNAMIC_MODEL_PROVIDERS
+            provider_routing_requires_discovered_inventory(provider)
             and normalize_model_id(capability["default_model"]) == model
             and str(model_index.get("state") or "").strip() != "available"
+            and provider_allows_default_during_degraded_discovery(provider)
         ):
             return True, None
         return (

--- a/guardian/tests/core/test_provider_registry.py
+++ b/guardian/tests/core/test_provider_registry.py
@@ -1,8 +1,13 @@
 import requests
 
-from guardian.core.config import Settings
+from guardian.core.config import ROUTER_SUPPORTED_LLM_PROVIDERS, Settings
 from guardian.core.provider_registry import (
+    PROVIDER_ORDER,
     get_provider_model_descriptors,
+    provider_allows_default_during_degraded_discovery,
+    provider_governance,
+    provider_governance_contract,
+    provider_routing_requires_discovered_inventory,
     resolve_provider_capability,
     resolve_provider_for_model,
     validate_provider_model_selection,
@@ -170,3 +175,84 @@ def test_resolve_provider_for_model_only_matches_discovered_dynamic_models(
         == "minimax"
     )
     assert resolve_provider_for_model("not-real", settings=settings) is None
+
+
+def test_provider_governance_contract_classifies_every_known_provider_once():
+    contract = provider_governance_contract()
+
+    assert set(contract) == set(PROVIDER_ORDER)
+    assert len(contract) == len(PROVIDER_ORDER)
+    assert all(
+        entry["provider"] == provider for provider, entry in contract.items()
+    )
+
+    discovery_backed = {
+        provider
+        for provider, entry in contract.items()
+        if entry["governance_classification"] == "discovery_backed"
+    }
+    static_authorized = {
+        provider
+        for provider, entry in contract.items()
+        if entry["governance_classification"] == "static_authorized"
+    }
+    local_only = {
+        provider
+        for provider, entry in contract.items()
+        if entry["governance_classification"] == "local_only"
+    }
+    disabled = {
+        provider
+        for provider, entry in contract.items()
+        if entry["governance_classification"] == "disabled"
+    }
+
+    assert discovery_backed == {"alibaba", "minimax"}
+    assert static_authorized == {"openai", "groq"}
+    assert local_only == {"local"}
+    assert disabled == {"anthropic", "gemini"}
+    assert discovery_backed.isdisjoint(static_authorized)
+    assert discovery_backed | static_authorized | local_only == set(
+        ROUTER_SUPPORTED_LLM_PROVIDERS
+    )
+
+
+def test_provider_governance_contract_is_internally_consistent():
+    contract = provider_governance_contract()
+
+    for provider, entry in contract.items():
+        assert provider_governance(provider) == entry
+        assert (
+            provider_routing_requires_discovered_inventory(provider)
+            is entry["routing_validate_discovered_inventory"]
+        )
+        assert (
+            provider_allows_default_during_degraded_discovery(provider)
+            is entry["configured_defaults_allowed_during_degraded_discovery"]
+        )
+
+        classification = entry["governance_classification"]
+        if classification == "discovery_backed":
+            assert entry["live_discovery_expected"] is True
+            assert entry["routing_validate_discovered_inventory"] is True
+            assert (
+                entry["configured_defaults_allowed_during_degraded_discovery"]
+                is True
+            )
+            assert entry["local_only"] is False
+        elif classification == "local_only":
+            assert entry["live_discovery_expected"] is False
+            assert entry["routing_validate_discovered_inventory"] is False
+            assert (
+                entry["configured_defaults_allowed_during_degraded_discovery"]
+                is False
+            )
+            assert entry["local_only"] is True
+        else:
+            assert entry["live_discovery_expected"] is False
+            assert entry["routing_validate_discovered_inventory"] is False
+            assert (
+                entry["configured_defaults_allowed_during_degraded_discovery"]
+                is False
+            )
+            assert entry["local_only"] is False


### PR DESCRIPTION
## Summary
- centralize provider governance rules in the registry and reuse them for routing, availability, and degraded-discovery behavior
- align supported `LLM_PROVIDER` messaging with the runtime-supported provider list in config
- add coverage for provider governance contract invariants and supported-provider classifications
- add a weekly runtime stability audit template for tracking reliability, regressions, and release readiness

## Testing
- Not run (not requested)