### PR TITLE
Add internal command center MVP route with runs, approvals, and diagnostics

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import DocumentGenModal, {
 import AppShell from "./components/persona/layout/AppShell";
 import { TopBar } from "./components/TopBar";
 import { Button } from "./components/ui/button";
+import CommandCenterPage from "./features/commandCenter/CommandCenterPage";
 import api from "./lib/api";
 import {
   appendBootstrapDetail,
@@ -47,6 +48,11 @@ import { SharePage } from "./pages/SharePage";
  */
 
 const TUNE_ENABLED = (import.meta as any)?.env?.DEV || (import.meta as any)?.env?.VITE_TUNE === "1";
+const COMMAND_CENTER_ENABLED =
+  (import.meta as any)?.env?.DEV ||
+  /^(1|true)$/i.test(
+    String((import.meta as any)?.env?.VITE_ENABLE_COMMAND_CENTER ?? "")
+  );
 
 const DOC_GEN_EXT_MAP: Record<string, string> = {
   markdown: "md",
@@ -69,6 +75,11 @@ function isTuneRoute() {
 function isEventsRoute() {
   if (typeof window === "undefined") return false;
   return window.location.pathname.startsWith("/dev/events");
+}
+
+function isCommandCenterRoute() {
+  if (typeof window === "undefined") return false;
+  return window.location.pathname.startsWith("/command-center");
 }
 
 function isShareRoute() {
@@ -270,12 +281,14 @@ function DevTuneGate() {
 export default function App() {
   const tuneRoute = TUNE_ENABLED && isTuneRoute();
   const eventsRoute = isEventsRoute();
+  const commandCenterRoute = isCommandCenterRoute();
   const shareRoute = isShareRoute();
   const shareToken = shareRoute ? getShareToken() : null;
   const bootstrapEnabled =
     shouldRunRuntimeBootstrap() &&
     !tuneRoute &&
     !eventsRoute &&
+    !commandCenterRoute &&
     !(shareRoute && !!shareToken);
   const [docGenOpen, setDocGenOpen] = React.useState(false);
   const [docGenDraft, setDocGenDraft] = React.useState<DocumentGenInput | null>(
@@ -670,6 +683,9 @@ export default function App() {
         </main>
       </div>
     );
+  }
+  if (commandCenterRoute) {
+    return <CommandCenterPage enabled={COMMAND_CENTER_ENABLED} />;
   }
   if (shareRoute) {
     if (shareToken) {

--- a/frontend/src/features/commandCenter/CommandCenterPage.tsx
+++ b/frontend/src/features/commandCenter/CommandCenterPage.tsx
@@ -19,9 +19,85 @@ type CommandCenterPageProps = {
   enabled: boolean;
 };
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+function firstNumber(...values: unknown[]): number | null {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (!trimmed) continue;
+      const parsed = Number(trimmed);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return null;
+}
+
 function formatTimestamp(value: number | null): string {
   if (!value) return "Not yet";
   return new Date(value).toLocaleString();
+}
+
+function resolveSelectedRunThreadId(run: CommandCenterRun): number | null {
+  const payload = asRecord(run.lastEvent.json);
+  const thread = asRecord(payload?.thread);
+  const task = asRecord(payload?.task);
+  const nestedRun = asRecord(payload?.run);
+  const context = asRecord(payload?.context);
+  const nestedPayload = asRecord(payload?.payload);
+
+  return firstNumber(
+    run.threadId,
+    payload?.thread_id,
+    payload?.threadId,
+    thread?.id,
+    thread?.thread_id,
+    thread?.threadId,
+    nestedRun?.thread_id,
+    nestedRun?.threadId,
+    task?.thread_id,
+    task?.threadId,
+    context?.thread_id,
+    context?.threadId,
+    nestedPayload?.thread_id,
+    nestedPayload?.threadId
+  );
+}
+
+function resolveSelectedRunTraceUrl(run: CommandCenterRun): string | null {
+  const payload = asRecord(run.lastEvent.json);
+  const nestedRun = asRecord(payload?.run);
+  const response = asRecord(payload?.response);
+  const result = asRecord(payload?.result);
+
+  return firstString(
+    run.traceUrl,
+    payload?.trace_url,
+    payload?.traceUrl,
+    nestedRun?.trace_url,
+    nestedRun?.traceUrl,
+    response?.trace_url,
+    response?.traceUrl,
+    result?.trace_url,
+    result?.traceUrl
+  );
 }
 
 function connectionStyle(state: CommandCenterConnectionState): React.CSSProperties {
@@ -178,7 +254,15 @@ export default function CommandCenterPage({
   const [selectedRunKey, setSelectedRunKey] = React.useState<string | null>(null);
 
   const selectedRun = React.useMemo<CommandCenterRun | null>(
-    () => runs.find((run) => run.key === selectedRunKey) ?? null,
+    () => {
+      const run = runs.find((candidate) => candidate.key === selectedRunKey) ?? null;
+      if (!run) return null;
+      return {
+        ...run,
+        threadId: resolveSelectedRunThreadId(run),
+        traceUrl: resolveSelectedRunTraceUrl(run),
+      };
+    },
     [runs, selectedRunKey]
   );
 

--- a/frontend/src/features/commandCenter/CommandCenterPage.tsx
+++ b/frontend/src/features/commandCenter/CommandCenterPage.tsx
@@ -1,0 +1,290 @@
+import * as React from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+import ApprovalsPanel from "@/features/commandCenter/components/ApprovalsPanel";
+import RunDetailDrawer from "@/features/commandCenter/components/RunDetailDrawer";
+import RunsPanel from "@/features/commandCenter/components/RunsPanel";
+import useCommandCenterEvents from "@/features/commandCenter/hooks/useCommandCenterEvents";
+import useHealthSummary from "@/features/commandCenter/hooks/useHealthSummary";
+import type {
+  CommandCenterConnectionState,
+  CommandCenterHealthItem,
+  CommandCenterRun,
+} from "@/features/commandCenter/types";
+
+type CommandCenterPageProps = {
+  enabled: boolean;
+};
+
+function formatTimestamp(value: number | null): string {
+  if (!value) return "Not yet";
+  return new Date(value).toLocaleString();
+}
+
+function connectionStyle(state: CommandCenterConnectionState): React.CSSProperties {
+  switch (state) {
+    case "open":
+      return {
+        background: "rgba(34, 197, 94, 0.12)",
+        borderColor: "rgba(34, 197, 94, 0.35)",
+      };
+    case "connecting":
+      return {
+        background: "rgba(59, 130, 246, 0.12)",
+        borderColor: "rgba(59, 130, 246, 0.35)",
+      };
+    case "error":
+      return {
+        background: "rgba(239, 68, 68, 0.12)",
+        borderColor: "rgba(239, 68, 68, 0.35)",
+      };
+    default:
+      return {
+        background: "rgba(148, 163, 184, 0.12)",
+        borderColor: "rgba(148, 163, 184, 0.28)",
+      };
+  }
+}
+
+function healthStyle(status: CommandCenterHealthItem["status"]): React.CSSProperties {
+  switch (status) {
+    case "OK":
+      return {
+        background: "rgba(34, 197, 94, 0.12)",
+        borderColor: "rgba(34, 197, 94, 0.35)",
+      };
+    case "FAIL":
+      return {
+        background: "rgba(239, 68, 68, 0.12)",
+        borderColor: "rgba(239, 68, 68, 0.35)",
+      };
+    default:
+      return {
+        background: "rgba(148, 163, 184, 0.12)",
+        borderColor: "rgba(148, 163, 184, 0.28)",
+      };
+  }
+}
+
+function HealthStrip({
+  healthItems,
+  lastCheckedAt,
+  loading,
+  onRefresh,
+}: {
+  healthItems: CommandCenterHealthItem[];
+  lastCheckedAt: number | null;
+  loading: boolean;
+  onRefresh: () => Promise<void>;
+}) {
+  return (
+    <Card
+      className="bezel-none rounded-2xl border"
+      style={{
+        background: "color-mix(in srgb, var(--panel-bg) 96%, transparent)",
+        borderColor: "var(--panel-border)",
+      }}
+    >
+      <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <CardTitle className="text-base" style={{ color: "var(--text)" }}>
+            Health Strip
+          </CardTitle>
+          <p className="text-sm" style={{ color: "var(--muted)" }}>
+            Minimal snapshots of the existing health endpoints. Last checked:{" "}
+            {formatTimestamp(lastCheckedAt)}
+          </p>
+        </div>
+        <Button type="button" variant="ghost" size="sm" onClick={() => void onRefresh()}>
+          {loading ? "Refreshing..." : "Refresh"}
+        </Button>
+      </CardHeader>
+      <CardContent className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+        {healthItems.map((item) => (
+          <Card
+            key={item.key}
+            className="bezel-none rounded-xl border"
+            style={{
+              background: "color-mix(in srgb, var(--panel-bg) 96%, transparent)",
+              borderColor: "var(--panel-border)",
+            }}
+          >
+            <CardContent className="space-y-3 p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
+                  {item.label}
+                </div>
+                <Badge
+                  className="border"
+                  style={{
+                    ...healthStyle(item.status),
+                    color: "var(--text)",
+                  }}
+                >
+                  {item.status}
+                </Badge>
+              </div>
+
+              <div className="text-xs" style={{ color: "var(--muted)" }}>
+                Endpoint: {item.endpoint}
+              </div>
+
+              {item.error ? (
+                <div className="text-xs" style={{ color: "var(--muted)" }}>
+                  {item.error}
+                </div>
+              ) : null}
+
+              {(item.raw || item.error) ? (
+                <details className="text-xs" style={{ color: "var(--muted)" }}>
+                  <summary className="cursor-pointer">Details</summary>
+                  <pre
+                    className="mt-2 overflow-x-auto rounded-lg border p-3"
+                    style={{
+                      borderColor: "var(--panel-border)",
+                      background: "rgba(0, 0, 0, 0.12)",
+                      color: "var(--text)",
+                    }}
+                  >
+                    {item.raw ?? item.error}
+                  </pre>
+                </details>
+              ) : null}
+            </CardContent>
+          </Card>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function CommandCenterPage({
+  enabled,
+}: CommandCenterPageProps) {
+  const {
+    approvals,
+    connectionDetail,
+    connectionState,
+    lastEventAt,
+    runs,
+    unauthorized,
+  } = useCommandCenterEvents({ enabled });
+  const { healthItems, lastCheckedAt, loading, refresh } = useHealthSummary({
+    enabled,
+  });
+  const [selectedRunKey, setSelectedRunKey] = React.useState<string | null>(null);
+
+  const selectedRun = React.useMemo<CommandCenterRun | null>(
+    () => runs.find((run) => run.key === selectedRunKey) ?? null,
+    [runs, selectedRunKey]
+  );
+
+  React.useEffect(() => {
+    if (!selectedRunKey) return;
+    if (runs.some((run) => run.key === selectedRunKey)) return;
+    setSelectedRunKey(null);
+  }, [runs, selectedRunKey]);
+
+  if (!enabled) {
+    return (
+      <main
+        className="min-h-screen px-6 py-10"
+        style={{ background: "var(--panel-bg)", color: "var(--text)" }}
+      >
+        <div className="mx-auto flex max-w-2xl items-center justify-center">
+          <Card
+            className="bezel-none w-full rounded-2xl border"
+            style={{
+              background: "color-mix(in srgb, var(--panel-bg) 96%, transparent)",
+              borderColor: "var(--panel-border)",
+            }}
+          >
+            <CardContent className="space-y-3 p-6">
+              <div className="text-lg font-semibold">Command Center not enabled</div>
+              <p className="text-sm" style={{ color: "var(--muted)" }}>
+                Set <code>VITE_ENABLE_COMMAND_CENTER=true</code> to expose this
+                route outside development.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main
+      className="min-h-screen px-4 py-5 sm:px-6 sm:py-8"
+      style={{ background: "var(--panel-bg)", color: "var(--text)" }}
+    >
+      <div className="mx-auto flex max-w-7xl flex-col gap-5">
+        <Card
+          className="bezel-none rounded-2xl border"
+          style={{
+            background: "color-mix(in srgb, var(--panel-bg) 96%, transparent)",
+            borderColor: "var(--panel-border)",
+          }}
+        >
+          <CardContent className="flex flex-col gap-3 p-5 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-1">
+              <div className="text-lg font-semibold">Agent Command Center</div>
+              <p className="text-sm" style={{ color: "var(--muted)" }}>
+                Read-only operational surface for service health, runs, approvals,
+                and task event streams.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <Badge
+                className="border"
+                style={{
+                  ...connectionStyle(connectionState),
+                  color: "var(--text)",
+                }}
+              >
+                {unauthorized ? "unauthorized" : connectionState}
+              </Badge>
+              <div className="text-xs" style={{ color: "var(--muted)" }}>
+                Last event: {formatTimestamp(lastEventAt)}
+              </div>
+              {connectionDetail ? (
+                <div className="text-xs" style={{ color: "var(--muted)" }}>
+                  {connectionDetail}
+                </div>
+              ) : null}
+            </div>
+          </CardContent>
+        </Card>
+
+        <HealthStrip
+          healthItems={healthItems}
+          lastCheckedAt={lastCheckedAt}
+          loading={loading}
+          onRefresh={refresh}
+        />
+
+        <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+          <RunsPanel
+            onSelectRun={(run) => setSelectedRunKey(run.key)}
+            runs={runs}
+            selectedRunKey={selectedRunKey}
+          />
+          <ApprovalsPanel
+            approvals={approvals}
+            onSelectRun={(runKey) => {
+              if (runKey) setSelectedRunKey(runKey);
+            }}
+            selectedRunKey={selectedRunKey}
+          />
+        </div>
+      </div>
+
+      <RunDetailDrawer
+        run={selectedRun}
+        onClose={() => setSelectedRunKey(null)}
+      />
+    </main>
+  );
+}

--- a/frontend/src/features/commandCenter/__tests__/RagTracePanel.test.tsx
+++ b/frontend/src/features/commandCenter/__tests__/RagTracePanel.test.tsx
@@ -1,0 +1,231 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import RagTracePanel from "@/features/commandCenter/components/RagTracePanel";
+import { fetchLatestRagTrace } from "@/lib/api";
+import type { CommandCenterRun } from "@/features/commandCenter/types";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    fetchLatestRagTrace: vi.fn(),
+  };
+});
+
+const fetchLatestRagTraceMock = vi.mocked(fetchLatestRagTrace);
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, reject, resolve };
+}
+
+function buildRun(
+  overrides: Partial<CommandCenterRun> = {}
+): CommandCenterRun {
+  return {
+    eventCount: 1,
+    key: "task_001",
+    lastEvent: {
+      eventId: "evt-1",
+      json: {},
+      kind: "task.completed",
+      raw: "{\"thread_id\":42}",
+      receivedAt: Date.now(),
+      runId: "run_001",
+      sseType: "task.completed",
+      status: null,
+      summary: "Task completed",
+      taskId: "task_001",
+      type: "task.completed",
+    },
+    lastEventAt: Date.now(),
+    lastKind: "task.completed",
+    lastType: "task.completed",
+    runId: "run_001",
+    status: "succeeded",
+    summary: "Task completed",
+    taskId: "task_001",
+    threadId: 42,
+    traceUrl: "/api/chat/debug/rag-trace/42/latest",
+    ...overrides,
+  };
+}
+
+describe("RagTracePanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("renders a loading state while the trace request is in flight", async () => {
+    const pending = deferred<Record<string, unknown>>();
+    fetchLatestRagTraceMock.mockReturnValue(pending.promise);
+
+    render(<RagTracePanel run={buildRun()} />);
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Loading retrieval trace…"
+    );
+
+    pending.resolve({ documents: [], graph: [] });
+    expect(
+      await screen.findByText("No retrieval evidence available for this thread yet.")
+    ).toBeInTheDocument();
+  });
+
+  test("renders explicit empty states for no selected run and no resolvable thread", async () => {
+    const { rerender } = render(<RagTracePanel run={null} />);
+
+    expect(
+      screen.getByText("Select a run to inspect retrieval evidence.")
+    ).toBeInTheDocument();
+    expect(fetchLatestRagTraceMock).not.toHaveBeenCalled();
+
+    rerender(
+      <RagTracePanel
+        run={buildRun({
+          threadId: null,
+          traceUrl: null,
+        })}
+      />
+    );
+
+    expect(
+      await screen.findByText("No resolvable thread available for this run.")
+    ).toBeInTheDocument();
+    expect(fetchLatestRagTraceMock).not.toHaveBeenCalled();
+  });
+
+  test("renders semantic evidence without rewriting the evidence text", async () => {
+    fetchLatestRagTraceMock.mockResolvedValue({
+      documents: [
+        {
+          id: "doc-low",
+          score: 0.42,
+          snippet: "Lower confidence evidence from retrieval.",
+          title: "beta-notes.md",
+        },
+        {
+          id: "doc-high",
+          score: 0.91,
+          snippet: "Original evidence text: keep this wording intact.",
+          title: "alpha-notes.md",
+        },
+      ],
+      graph: [],
+    });
+
+    render(<RagTracePanel run={buildRun()} />);
+
+    expect(await screen.findByRole("heading", { name: "Semantic Results" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Memory Results" })).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Original evidence text: keep this wording intact.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Source: alpha-notes.md")).toBeInTheDocument();
+
+    const highEvidence = screen.getByText(
+      "Original evidence text: keep this wording intact."
+    );
+    const lowEvidence = screen.getByText(
+      "Lower confidence evidence from retrieval."
+    );
+    expect(
+      highEvidence.compareDocumentPosition(lowEvidence) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  test("renders semantic results before memory results and sorts both sections by score", async () => {
+    fetchLatestRagTraceMock.mockResolvedValue({
+      documents: [
+        {
+          id: "sem-low",
+          score: 0.2,
+          snippet: "Semantic evidence with lower score.",
+          title: "semantic-low.md",
+        },
+        {
+          id: "sem-high",
+          score: 0.8,
+          snippet: "Semantic evidence with higher score.",
+          title: "semantic-high.md",
+        },
+      ],
+      memory: [
+        {
+          id: "mem-low",
+          score: 0.1,
+          text: "Memory evidence with lower score.",
+          origin: "memory",
+        },
+        {
+          id: "mem-high",
+          score: 0.7,
+          text: "Memory evidence with higher score.",
+          origin: "memory",
+        },
+      ],
+    });
+
+    render(<RagTracePanel run={buildRun()} />);
+
+    const semanticHeading = await screen.findByRole("heading", {
+      name: "Semantic Results",
+    });
+    const memoryHeading = screen.getByRole("heading", {
+      name: "Memory Results",
+    });
+    expect(
+      semanticHeading.compareDocumentPosition(memoryHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+
+    const highSemantic = screen.getByText("Semantic evidence with higher score.");
+    const lowSemantic = screen.getByText("Semantic evidence with lower score.");
+    expect(
+      highSemantic.compareDocumentPosition(lowSemantic) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+
+    const highMemory = screen.getByText("Memory evidence with higher score.");
+    const lowMemory = screen.getByText("Memory evidence with lower score.");
+    expect(
+      highMemory.compareDocumentPosition(lowMemory) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  test("renders an unavailable state when the resolved thread has no trace yet", async () => {
+    fetchLatestRagTraceMock.mockResolvedValue({
+      documents: [],
+      graph: [],
+    });
+
+    render(<RagTracePanel run={buildRun()} />);
+
+    expect(
+      await screen.findByText("No retrieval evidence available for this thread yet.")
+    ).toBeInTheDocument();
+  });
+
+  test("renders backend errors without exposing a retry action", async () => {
+    fetchLatestRagTraceMock.mockRejectedValue(
+      Object.assign(new Error("trace viewer unavailable"), {
+        response: { data: { detail: "trace viewer unavailable" } },
+      })
+    );
+
+    render(<RagTracePanel run={buildRun()} />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "trace viewer unavailable"
+    );
+    expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/commandCenter/components/ApprovalsPanel.tsx
+++ b/frontend/src/features/commandCenter/components/ApprovalsPanel.tsx
@@ -1,0 +1,114 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+import type { CommandCenterApproval } from "@/features/commandCenter/types";
+
+type ApprovalsPanelProps = {
+  approvals: CommandCenterApproval[];
+  onSelectRun: (runKey: string | null) => void;
+  selectedRunKey: string | null;
+};
+
+function formatTimestamp(value: number): string {
+  return new Date(value).toLocaleString();
+}
+
+export default function ApprovalsPanel({
+  approvals,
+  onSelectRun,
+  selectedRunKey,
+}: ApprovalsPanelProps) {
+  return (
+    <Card
+      className="bezel-none rounded-2xl border"
+      style={{
+        background: "color-mix(in srgb, var(--panel-bg) 96%, transparent)",
+        borderColor: "var(--panel-border)",
+      }}
+    >
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-base" style={{ color: "var(--text)" }}>
+          Approvals
+        </CardTitle>
+        <p className="text-sm" style={{ color: "var(--muted)" }}>
+          Escalation-facing events filtered from the same global SSE stream.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {approvals.length === 0 ? (
+          <div className="rounded-xl border px-4 py-5 text-sm" style={{ borderColor: "var(--panel-border)", color: "var(--muted)" }}>
+            No approval or clarification events detected yet.
+          </div>
+        ) : (
+          approvals.map((approval) => {
+            const selectable = Boolean(approval.runKey);
+            const selected =
+              selectable && approval.runKey != null && approval.runKey === selectedRunKey;
+
+            return (
+              <button
+                key={approval.key}
+                type="button"
+                className="w-full text-left"
+                onClick={() => onSelectRun(approval.runKey)}
+                disabled={!selectable}
+              >
+                <Card
+                  className={cn(
+                    "bezel-none rounded-xl border transition-colors",
+                    selected && "ring-1 ring-[var(--accent)]"
+                  )}
+                  style={{
+                    background:
+                      "color-mix(in srgb, rgba(250, 204, 21, 0.08) 80%, var(--panel-bg))",
+                    borderColor: selected ? "var(--accent)" : "var(--panel-border)",
+                    opacity: selectable ? 1 : 0.72,
+                  }}
+                >
+                  <CardContent className="space-y-3 p-4">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="space-y-1">
+                        <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
+                          {approval.label}
+                        </div>
+                        <div className="text-xs" style={{ color: "var(--muted)" }}>
+                          {approval.summary}
+                        </div>
+                      </div>
+                      <Badge
+                        className="border"
+                        style={{
+                          background: "rgba(250, 204, 21, 0.14)",
+                          borderColor: "rgba(250, 204, 21, 0.35)",
+                          color: "var(--text)",
+                        }}
+                      >
+                        {approval.status ?? "attention"}
+                      </Badge>
+                    </div>
+
+                    <div className="flex flex-wrap gap-2 text-xs" style={{ color: "var(--muted)" }}>
+                      <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
+                        Task: {approval.taskId ?? "—"}
+                      </span>
+                      <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
+                        Run: {approval.runId ?? "—"}
+                      </span>
+                      <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
+                        Seen: {formatTimestamp(approval.receivedAt)}
+                      </span>
+                      <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
+                        {selectable ? "Selectable" : "No run selection available"}
+                      </span>
+                    </div>
+                  </CardContent>
+                </Card>
+              </button>
+            );
+          })
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/commandCenter/components/RagTracePanel.tsx
+++ b/frontend/src/features/commandCenter/components/RagTracePanel.tsx
@@ -1,0 +1,206 @@
+import * as React from "react";
+
+import { Card, CardContent } from "@/components/ui/card";
+
+import useRagTrace from "@/features/commandCenter/hooks/useRagTrace";
+import type {
+  CommandCenterRagTraceItem,
+  CommandCenterRun,
+} from "@/features/commandCenter/types";
+
+type RagTracePanelProps = {
+  run: CommandCenterRun | null;
+};
+
+function itemChromeStyle(): React.CSSProperties {
+  return {
+    background: "color-mix(in srgb, var(--panel-bg) 96%, transparent)",
+    borderColor: "var(--panel-border)",
+  };
+}
+
+function formatScore(score: number | null): string | null {
+  if (score == null) return null;
+  const rounded = score.toFixed(3);
+  return rounded.replace(/0+$/, "").replace(/\.$/, "");
+}
+
+function EmptyState({
+  children,
+  role,
+}: {
+  children: React.ReactNode;
+  role?: "alert" | "status";
+}) {
+  return (
+    <Card className="bezel-none rounded-xl border" style={itemChromeStyle()}>
+      <CardContent
+        className="p-4 text-sm"
+        role={role}
+        style={{ color: "var(--muted)" }}
+      >
+        {children}
+      </CardContent>
+    </Card>
+  );
+}
+
+function MetadataChip({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | null;
+}) {
+  if (!value) return null;
+  return (
+    <span
+      className="rounded-full border px-2 py-1 text-xs"
+      style={{
+        borderColor: "var(--panel-border)",
+        color: "var(--muted)",
+      }}
+    >
+      {label}: {value}
+    </span>
+  );
+}
+
+function EvidenceCard({ item }: { item: CommandCenterRagTraceItem }) {
+  const score = formatScore(item.score);
+
+  return (
+    <Card className="bezel-none rounded-xl border" style={itemChromeStyle()}>
+      <CardContent className="space-y-3 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="text-xs font-semibold uppercase tracking-[0.12em]" style={{ color: "var(--muted)" }}>
+            Evidence {item.id}
+          </div>
+          {score ? (
+            <span
+              className="rounded-full border px-2 py-1 text-xs"
+              style={{
+                borderColor: "var(--panel-border)",
+                color: "var(--muted)",
+              }}
+            >
+              Score: {score}
+            </span>
+          ) : null}
+        </div>
+
+        <div
+          className="whitespace-pre-wrap break-words text-sm leading-6"
+          style={{ color: "var(--text)" }}
+        >
+          {item.text}
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <MetadataChip label="Source" value={item.source} />
+          <MetadataChip label="Silo" value={item.silo} />
+          <MetadataChip label="Origin" value={item.origin} />
+          <MetadataChip label="Depth used" value={item.depthUsed} />
+          <MetadataChip label="Timestamp" value={item.timestamp} />
+          <MetadataChip label="Thread" value={item.threadId} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function EvidenceSection({
+  items,
+  title,
+}: {
+  items: CommandCenterRagTraceItem[];
+  title: string;
+}) {
+  if (items.length === 0) return null;
+
+  return (
+    <section className="space-y-3">
+      <div>
+        <h3 className="text-sm font-semibold" style={{ color: "var(--text)" }}>
+          {title}
+        </h3>
+      </div>
+      <div className="space-y-3">
+        {items.map((item) => (
+          <EvidenceCard key={item.id} item={item} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default function RagTracePanel({ run }: RagTracePanelProps) {
+  const {
+    error,
+    loading,
+    resolvedThreadId,
+    trace,
+    unavailable,
+    unavailableReason,
+  } = useRagTrace(run);
+
+  if (loading) {
+    return <EmptyState role="status">Loading retrieval trace…</EmptyState>;
+  }
+
+  if (error) {
+    return <EmptyState role="alert">{error}</EmptyState>;
+  }
+
+  if (unavailable) {
+    if (unavailableReason === "no_run") {
+      return (
+        <EmptyState>
+          Select a run to inspect retrieval evidence.
+        </EmptyState>
+      );
+    }
+    if (unavailableReason === "no_thread") {
+      return (
+        <EmptyState>
+          No resolvable thread available for this run.
+        </EmptyState>
+      );
+    }
+    return (
+      <EmptyState>
+        No retrieval evidence available for this thread yet.
+      </EmptyState>
+    );
+  }
+
+  if (!trace) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card className="bezel-none rounded-xl border" style={itemChromeStyle()}>
+        <CardContent className="space-y-3 p-4">
+          <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
+            Retrieval Trace
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <span
+              className="rounded-full border px-2 py-1 text-xs"
+              style={{
+                borderColor: "var(--panel-border)",
+                color: "var(--muted)",
+              }}
+            >
+              Resolved thread: {resolvedThreadId ?? trace.resolvedThreadId}
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+
+      <EvidenceSection items={trace.semantic} title="Semantic Results" />
+      <EvidenceSection items={trace.memory} title="Memory Results" />
+    </div>
+  );
+}

--- a/frontend/src/features/commandCenter/components/RunDetailDrawer.tsx
+++ b/frontend/src/features/commandCenter/components/RunDetailDrawer.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import RagTracePanel from "@/features/commandCenter/components/RagTracePanel";
 import {
   Sheet,
   SheetContent,
@@ -136,6 +137,9 @@ export default function RunDetailDrawer({
   onClose,
 }: RunDetailDrawerProps) {
   const auth = useAuthState();
+  const [activeView, setActiveView] = React.useState<"events" | "rag-trace">(
+    "events"
+  );
   const [taskEvents, setTaskEvents] = React.useState<CommandCenterTaskEvent[]>([]);
   const [connectionState, setConnectionState] =
     React.useState<CommandCenterConnectionState>("closed");
@@ -156,6 +160,7 @@ export default function RunDetailDrawer({
 
   React.useEffect(() => {
     setShowRawJson(false);
+    setActiveView("events");
   }, [run?.key]);
 
   React.useEffect(() => {
@@ -314,10 +319,34 @@ export default function RunDetailDrawer({
                     <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
                       Run: {run.runId ?? "—"}
                     </span>
+                    <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
+                      Thread: {run.threadId ?? "—"}
+                    </span>
                   </div>
                 </CardContent>
               </Card>
 
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={activeView === "events" ? "default" : "ghost"}
+                  onClick={() => setActiveView("events")}
+                >
+                  Task Events
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={activeView === "rag-trace" ? "default" : "ghost"}
+                  onClick={() => setActiveView("rag-trace")}
+                >
+                  RAG Trace
+                </Button>
+              </div>
+
+              {activeView === "events" ? (
+                <>
               <div className="flex items-center justify-between gap-3">
                 <div>
                   <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
@@ -403,6 +432,21 @@ export default function RunDetailDrawer({
                         </CardContent>
                       </Card>
                     ))}
+                </div>
+              )}
+                </>
+              ) : (
+                <div className="space-y-3">
+                  <div>
+                    <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
+                      Retrieval Diagnostics
+                    </div>
+                    <div className="text-xs" style={{ color: "var(--muted)" }}>
+                      Latest thread-scoped retrieval evidence from the existing RAG
+                      trace debug endpoint.
+                    </div>
+                  </div>
+                  <RagTracePanel run={run} />
                 </div>
               )}
             </div>

--- a/frontend/src/features/commandCenter/components/RunDetailDrawer.tsx
+++ b/frontend/src/features/commandCenter/components/RunDetailDrawer.tsx
@@ -1,0 +1,414 @@
+import * as React from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import {
+  checkAuthGate,
+  markAuthUnauthenticatedFrom401,
+  useAuthState,
+} from "@/lib/authState";
+import { buildAuthenticatedFetchInit } from "@/lib/api";
+import { GuardianEventSource } from "@/lib/guardianEventSource";
+import { resolveApiUrl } from "@/lib/runtimeConfig";
+
+import type {
+  CommandCenterConnectionState,
+  CommandCenterRun,
+  CommandCenterTaskEvent,
+} from "@/features/commandCenter/types";
+
+const TASK_EVENT_LIMIT = 200;
+
+type RunDetailDrawerProps = {
+  run: CommandCenterRun | null;
+  onClose: () => void;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+function parseTaskJson(raw: string): Record<string, unknown> | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  try {
+    return asRecord(JSON.parse(trimmed));
+  } catch {
+    return null;
+  }
+}
+
+function summarizeTaskEvent(
+  raw: string,
+  json: Record<string, unknown> | null,
+  eventType: string | null
+): string {
+  const summary = firstString(
+    json?.summary,
+    json?.message,
+    json?.error,
+    json?.status
+  );
+  if (summary) return summary;
+  const trimmed = raw.trim();
+  if (trimmed) {
+    return trimmed.length > 160 ? `${trimmed.slice(0, 157)}...` : trimmed;
+  }
+  return eventType ?? "Task event";
+}
+
+function tapMessageEvents(
+  source: GuardianEventSource,
+  onMessage: (event: MessageEvent<string>) => void
+): () => void {
+  const originalDispatchEvent = source.dispatchEvent.bind(source);
+  (source as any).dispatchEvent = (event: Event) => {
+    if (event instanceof MessageEvent) {
+      onMessage(event as MessageEvent<string>);
+    }
+    return originalDispatchEvent(event);
+  };
+  return () => {
+    (source as any).dispatchEvent = originalDispatchEvent;
+  };
+}
+
+function appendTaskEvent(
+  previous: CommandCenterTaskEvent[],
+  next: CommandCenterTaskEvent
+): CommandCenterTaskEvent[] {
+  const appended = [...previous, next];
+  if (appended.length <= TASK_EVENT_LIMIT) return appended;
+  return appended.slice(appended.length - TASK_EVENT_LIMIT);
+}
+
+function connectionStyle(state: CommandCenterConnectionState): React.CSSProperties {
+  switch (state) {
+    case "open":
+      return {
+        background: "rgba(34, 197, 94, 0.12)",
+        borderColor: "rgba(34, 197, 94, 0.35)",
+      };
+    case "connecting":
+      return {
+        background: "rgba(59, 130, 246, 0.12)",
+        borderColor: "rgba(59, 130, 246, 0.35)",
+      };
+    case "error":
+      return {
+        background: "rgba(239, 68, 68, 0.12)",
+        borderColor: "rgba(239, 68, 68, 0.35)",
+      };
+    default:
+      return {
+        background: "rgba(148, 163, 184, 0.12)",
+        borderColor: "rgba(148, 163, 184, 0.28)",
+      };
+  }
+}
+
+function formatTimestamp(value: number | null): string {
+  if (!value) return "Not yet";
+  return new Date(value).toLocaleString();
+}
+
+export default function RunDetailDrawer({
+  run,
+  onClose,
+}: RunDetailDrawerProps) {
+  const auth = useAuthState();
+  const [taskEvents, setTaskEvents] = React.useState<CommandCenterTaskEvent[]>([]);
+  const [connectionState, setConnectionState] =
+    React.useState<CommandCenterConnectionState>("closed");
+  const [connectionDetail, setConnectionDetail] = React.useState<string | null>(
+    null
+  );
+  const [lastEventAt, setLastEventAt] = React.useState<number | null>(null);
+  const [showRawJson, setShowRawJson] = React.useState(false);
+  const sourceRef = React.useRef<GuardianEventSource | null>(null);
+  const open = Boolean(run);
+
+  React.useEffect(() => {
+    const source = sourceRef.current;
+    return () => {
+      source?.close();
+    };
+  }, []);
+
+  React.useEffect(() => {
+    setShowRawJson(false);
+  }, [run?.key]);
+
+  React.useEffect(() => {
+    sourceRef.current?.close();
+    sourceRef.current = null;
+    setTaskEvents([]);
+    setLastEventAt(null);
+    setConnectionState("closed");
+    setConnectionDetail(null);
+
+    if (!open || !run?.taskId) {
+      return;
+    }
+
+    if (!checkAuthGate(auth, "command center task SSE")) {
+      const blocked = auth.ready && auth.status !== "authenticated";
+      setConnectionState("closed");
+      setConnectionDetail(blocked ? "Unauthorized" : "Waiting for authentication");
+      return;
+    }
+
+    const authInit = buildAuthenticatedFetchInit({
+      headers: {
+        Accept: "text/event-stream",
+        "Cache-Control": "no-cache",
+      },
+    });
+    const headers = ((authInit.headers as Record<string, string>) ?? {}) as Record<
+      string,
+      string
+    >;
+    const source = new GuardianEventSource(
+      resolveApiUrl(`/api/tasks/${encodeURIComponent(run.taskId)}/events`),
+      {
+        autoReconnect: true,
+        headers,
+        retryInterval: 3000,
+        withCredentials: authInit.credentials === "include",
+        onUnauthorized: () => {
+          markAuthUnauthenticatedFrom401();
+        },
+      }
+    );
+    sourceRef.current = source;
+    setConnectionState("connecting");
+    setConnectionDetail("Connecting to task stream...");
+
+    const restoreDispatch = tapMessageEvents(source, (message) => {
+      const raw = typeof message.data === "string" ? message.data : String(message.data ?? "");
+      const json = parseTaskJson(raw);
+      const nextEvent: CommandCenterTaskEvent = {
+        eventId: firstString(message.lastEventId),
+        eventType: firstString(message.type) ?? "message",
+        json,
+        raw,
+        receivedAt: Date.now(),
+        summary: summarizeTaskEvent(raw, json, firstString(message.type)),
+      };
+      setTaskEvents((previous) => appendTaskEvent(previous, nextEvent));
+      setLastEventAt(nextEvent.receivedAt);
+    });
+
+    const handleOpen = () => {
+      setConnectionState("open");
+      setConnectionDetail(null);
+    };
+    const handleError = () => {
+      setConnectionState("error");
+      setConnectionDetail("Task event stream disconnected.");
+    };
+    const handleUnauthorized = () => {
+      setConnectionState("closed");
+      setConnectionDetail("Unauthorized");
+    };
+
+    source.addEventListener("open", handleOpen as EventListener);
+    source.addEventListener("error", handleError as EventListener);
+    source.addEventListener("unauthorized", handleUnauthorized as EventListener);
+
+    return () => {
+      restoreDispatch();
+      source.removeEventListener("open", handleOpen as EventListener);
+      source.removeEventListener("error", handleError as EventListener);
+      source.removeEventListener(
+        "unauthorized",
+        handleUnauthorized as EventListener
+      );
+      source.close();
+      if (sourceRef.current === source) {
+        sourceRef.current = null;
+      }
+    };
+  }, [auth.ready, auth.status, auth.token, open, run?.key, run?.taskId]);
+
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) onClose();
+      }}
+    >
+      <SheetContent
+        side="right"
+        className="w-[min(42rem,100vw)] overflow-y-auto border-l"
+        style={{
+          background: "var(--panel-bg)",
+          borderColor: "var(--panel-border)",
+        }}
+      >
+        {run ? (
+          <>
+            <SheetHeader className="space-y-3">
+              <div className="flex items-center justify-between gap-3">
+                <SheetTitle className="text-base" style={{ color: "var(--text)" }}>
+                  Run Detail
+                </SheetTitle>
+                <Badge
+                  className="border"
+                  style={{
+                    ...connectionStyle(connectionState),
+                    color: "var(--text)",
+                  }}
+                >
+                  {connectionState}
+                </Badge>
+              </div>
+              <div className="text-xs" style={{ color: "var(--muted)" }}>
+                Last task event: {formatTimestamp(lastEventAt)}
+              </div>
+              {connectionDetail ? (
+                <div className="text-xs" style={{ color: "var(--muted)" }}>
+                  {connectionDetail}
+                </div>
+              ) : null}
+            </SheetHeader>
+
+            <div className="space-y-4 p-4">
+              <Card
+                className="bezel-none rounded-xl border"
+                style={{
+                  background: "color-mix(in srgb, var(--panel-bg) 94%, transparent)",
+                  borderColor: "var(--panel-border)",
+                }}
+              >
+                <CardContent className="space-y-3 p-4">
+                  <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
+                    Identifiers
+                  </div>
+                  <div className="flex flex-wrap gap-2 text-xs" style={{ color: "var(--muted)" }}>
+                    <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
+                      Grouping key: {run.key}
+                    </span>
+                    <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
+                      Task: {run.taskId ?? "—"}
+                    </span>
+                    <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
+                      Run: {run.runId ?? "—"}
+                    </span>
+                  </div>
+                </CardContent>
+              </Card>
+
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
+                    Task Event Stream
+                  </div>
+                  <div className="text-xs" style={{ color: "var(--muted)" }}>
+                    Live updates from /api/tasks/{"{task_id}"}/events
+                  </div>
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setShowRawJson((current) => !current)}
+                >
+                  {showRawJson ? "Hide Raw JSON" : "Raw JSON"}
+                </Button>
+              </div>
+
+              {!run.taskId ? (
+                <Card
+                  className="bezel-none rounded-xl border"
+                  style={{
+                    background: "color-mix(in srgb, var(--panel-bg) 96%, transparent)",
+                    borderColor: "var(--panel-border)",
+                  }}
+                >
+                  <CardContent className="p-4 text-sm" style={{ color: "var(--muted)" }}>
+                    No task event stream available for this run.
+                  </CardContent>
+                </Card>
+              ) : taskEvents.length === 0 ? (
+                <Card
+                  className="bezel-none rounded-xl border"
+                  style={{
+                    background: "color-mix(in srgb, var(--panel-bg) 96%, transparent)",
+                    borderColor: "var(--panel-border)",
+                  }}
+                >
+                  <CardContent className="p-4 text-sm" style={{ color: "var(--muted)" }}>
+                    Waiting for task events...
+                  </CardContent>
+                </Card>
+              ) : (
+                <div className="space-y-3">
+                  {taskEvents
+                    .slice()
+                    .reverse()
+                    .map((event) => (
+                      <Card
+                        key={`${event.eventId ?? event.receivedAt}:${event.eventType ?? "message"}`}
+                        className="bezel-none rounded-xl border"
+                        style={{
+                          background:
+                            "color-mix(in srgb, var(--panel-bg) 96%, transparent)",
+                          borderColor: "var(--panel-border)",
+                        }}
+                      >
+                        <CardContent className="space-y-2 p-4">
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <div className="text-xs font-medium" style={{ color: "var(--text)" }}>
+                              {event.eventType ?? "message"}
+                            </div>
+                            <div className="text-xs" style={{ color: "var(--muted)" }}>
+                              {formatTimestamp(event.receivedAt)}
+                            </div>
+                          </div>
+                          <div className="text-sm" style={{ color: "var(--text)" }}>
+                            {event.summary}
+                          </div>
+                          {showRawJson ? (
+                            <pre
+                              className="overflow-x-auto rounded-lg border p-3 text-xs"
+                              style={{
+                                borderColor: "var(--panel-border)",
+                                background: "rgba(0, 0, 0, 0.14)",
+                                color: "var(--text)",
+                              }}
+                            >
+                              {event.json ? JSON.stringify(event.json, null, 2) : event.raw}
+                            </pre>
+                          ) : null}
+                        </CardContent>
+                      </Card>
+                    ))}
+                </div>
+              )}
+            </div>
+          </>
+        ) : null}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/frontend/src/features/commandCenter/components/RunsPanel.tsx
+++ b/frontend/src/features/commandCenter/components/RunsPanel.tsx
@@ -1,0 +1,160 @@
+import type { CSSProperties } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+import type { CommandCenterRun } from "@/features/commandCenter/types";
+
+type RunsPanelProps = {
+  onSelectRun: (run: CommandCenterRun) => void;
+  runs: CommandCenterRun[];
+  selectedRunKey: string | null;
+};
+
+function formatTimestamp(value: number | null): string {
+  if (!value) return "Never";
+  return new Date(value).toLocaleString();
+}
+
+function renderStatusStyle(status: CommandCenterRun["status"]): CSSProperties {
+  switch (status) {
+    case "running":
+      return {
+        background: "rgba(59, 130, 246, 0.12)",
+        borderColor: "rgba(59, 130, 246, 0.35)",
+      };
+    case "succeeded":
+      return {
+        background: "rgba(34, 197, 94, 0.12)",
+        borderColor: "rgba(34, 197, 94, 0.35)",
+      };
+    case "failed":
+      return {
+        background: "rgba(239, 68, 68, 0.12)",
+        borderColor: "rgba(239, 68, 68, 0.35)",
+      };
+    case "needs_attention":
+      return {
+        background: "rgba(250, 204, 21, 0.12)",
+        borderColor: "rgba(250, 204, 21, 0.35)",
+      };
+    default:
+      return {
+        background: "rgba(148, 163, 184, 0.12)",
+        borderColor: "rgba(148, 163, 184, 0.28)",
+      };
+  }
+}
+
+function RunRow({
+  onSelectRun,
+  run,
+  selected,
+}: {
+  onSelectRun: (run: CommandCenterRun) => void;
+  run: CommandCenterRun;
+  selected: boolean;
+}) {
+  const displayId = run.taskId ?? run.runId ?? run.key;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelectRun(run)}
+      className="w-full text-left"
+    >
+      <Card
+        className={cn(
+          "bezel-none rounded-xl border transition-colors",
+          selected && "ring-1 ring-[var(--accent)]"
+        )}
+        style={{
+          background: "color-mix(in srgb, var(--panel-bg) 92%, transparent)",
+          borderColor: selected ? "var(--accent)" : "var(--panel-border)",
+        }}
+      >
+        <CardContent className="space-y-3 p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-1">
+              <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
+                {displayId}
+              </div>
+              <div className="text-xs" style={{ color: "var(--muted)" }}>
+                {run.summary}
+              </div>
+            </div>
+            <Badge
+              className="border"
+              style={{
+                ...renderStatusStyle(run.status),
+                color: "var(--text)",
+              }}
+            >
+              {run.status.replace(/_/g, " ")}
+            </Badge>
+          </div>
+
+          <div className="flex flex-wrap gap-2 text-xs" style={{ color: "var(--muted)" }}>
+            <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
+              Task: {run.taskId ?? "—"}
+            </span>
+            <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
+              Run: {run.runId ?? "—"}
+            </span>
+            <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
+              Events: {run.eventCount}
+            </span>
+            <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
+              Last type: {run.lastType ?? run.lastKind ?? "unknown"}
+            </span>
+            <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
+              Updated: {formatTimestamp(run.lastEventAt)}
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+    </button>
+  );
+}
+
+export default function RunsPanel({
+  onSelectRun,
+  runs,
+  selectedRunKey,
+}: RunsPanelProps) {
+  return (
+    <Card
+      className="bezel-none rounded-2xl border"
+      style={{
+        background: "color-mix(in srgb, var(--panel-bg) 96%, transparent)",
+        borderColor: "var(--panel-border)",
+      }}
+    >
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-base" style={{ color: "var(--text)" }}>
+          Runs
+        </CardTitle>
+        <p className="text-sm" style={{ color: "var(--muted)" }}>
+          Derived from the global SSE stream using detected run and task IDs.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {runs.length === 0 ? (
+          <div className="rounded-xl border px-4 py-5 text-sm" style={{ borderColor: "var(--panel-border)", color: "var(--muted)" }}>
+            Waiting for run-identifiable events.
+          </div>
+        ) : (
+          runs.map((run) => (
+            <RunRow
+              key={run.key}
+              onSelectRun={onSelectRun}
+              run={run}
+              selected={run.key === selectedRunKey}
+            />
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/commandCenter/hooks/useCommandCenterEvents.ts
+++ b/frontend/src/features/commandCenter/hooks/useCommandCenterEvents.ts
@@ -1,0 +1,497 @@
+import * as React from "react";
+
+import {
+  checkAuthGate,
+  markAuthUnauthenticatedFrom401,
+  useAuthState,
+} from "@/lib/authState";
+import { buildAuthenticatedFetchInit } from "@/lib/api";
+import { GuardianEventSource } from "@/lib/guardianEventSource";
+import {
+  getRuntimeConfigSync,
+  resolveSseEndpoint,
+} from "@/lib/runtimeConfig";
+
+import type {
+  CommandCenterApproval,
+  CommandCenterConnectionState,
+  CommandCenterEvent,
+  CommandCenterRun,
+  CommandCenterRunStatus,
+} from "@/features/commandCenter/types";
+
+const EVENT_BUFFER_LIMIT = 500;
+const UUIDISH_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type UseCommandCenterEventsOptions = {
+  enabled: boolean;
+};
+
+type UseCommandCenterEventsResult = {
+  approvals: CommandCenterApproval[];
+  connectionDetail: string | null;
+  connectionState: CommandCenterConnectionState;
+  events: CommandCenterEvent[];
+  lastEventAt: number | null;
+  runs: CommandCenterRun[];
+  unauthorized: boolean;
+};
+
+type DerivationResult = {
+  approvals: CommandCenterApproval[];
+  runs: CommandCenterRun[];
+};
+
+type MutableRun = {
+  eventCount: number;
+  key: string;
+  lastEvent: CommandCenterEvent;
+  lastEventAt: number;
+  lastKind: string | null;
+  lastType: string | null;
+  runId: string | null;
+  status: CommandCenterRunStatus;
+  summary: string;
+  taskId: string | null;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+function looksLikeTaskIdentifier(value: string | null): boolean {
+  if (!value) return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  return /^task[_:-]/i.test(trimmed) || UUIDISH_RE.test(trimmed);
+}
+
+function normalizeToken(value: string | null): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase();
+}
+
+function coerceRawPayload(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value ?? "");
+  } catch {
+    return String(value ?? "");
+  }
+}
+
+function parseJson(raw: string): Record<string, unknown> | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  try {
+    return asRecord(JSON.parse(trimmed));
+  } catch {
+    return null;
+  }
+}
+
+function collectRecords(json: Record<string, unknown> | null): Array<Record<string, unknown>> {
+  if (!json) return [];
+  const nestedData = asRecord(json.data);
+  const nestedRun = asRecord(json.run);
+  const nestedDataRun = nestedData ? asRecord(nestedData.run) : null;
+  return [json, nestedData, nestedRun, nestedDataRun].filter(
+    (value): value is Record<string, unknown> => Boolean(value)
+  );
+}
+
+function readKey(records: Array<Record<string, unknown>>, keys: string[]): string | null {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = firstString(record[key]);
+      if (value) return value;
+    }
+  }
+  return null;
+}
+
+function summarizeEvent(
+  raw: string,
+  json: Record<string, unknown> | null,
+  sseType: string | null
+): string {
+  const records = collectRecords(json);
+  const summary = readKey(records, [
+    "summary",
+    "message",
+    "error",
+    "reason",
+    "status",
+  ]);
+  if (summary) return summary;
+  const trimmedRaw = raw.trim();
+  if (trimmedRaw) {
+    return trimmedRaw.length > 160
+      ? `${trimmedRaw.slice(0, 157)}...`
+      : trimmedRaw;
+  }
+  return sseType ?? "Event received";
+}
+
+function normalizeEvent(message: MessageEvent<string>): CommandCenterEvent {
+  const raw = coerceRawPayload(message.data);
+  const json = parseJson(raw);
+  const records = collectRecords(json);
+  const fallbackTaskId = readKey(records, ["id"]);
+  const sseType = firstString(message.type) ?? "message";
+
+  return {
+    eventId: firstString(message.lastEventId),
+    json,
+    kind: readKey(records, ["kind", "event_type", "eventType"]),
+    raw,
+    receivedAt: Date.now(),
+    runId: readKey(records, ["run_id", "runId"]),
+    sseType,
+    status: readKey(records, ["status", "raw_status", "rawStatus"]),
+    summary: summarizeEvent(raw, json, sseType),
+    taskId:
+      readKey(records, ["task_id", "taskId", "task"]) ||
+      (looksLikeTaskIdentifier(fallbackTaskId) ? fallbackTaskId : null),
+    type: readKey(records, ["type"]),
+  };
+}
+
+function deriveRunStatus(event: CommandCenterEvent): CommandCenterRunStatus {
+  const signal = normalizeToken(event.kind ?? event.type ?? event.sseType);
+  if (!signal) return "unknown";
+  if (/(fail|error)/.test(signal)) return "failed";
+  if (/(complete|done|success|succeeded)/.test(signal)) return "succeeded";
+  if (/(start|running|progress)/.test(signal)) return "running";
+  if (/(approval|blocked|clarification)/.test(signal)) return "needs_attention";
+  return "unknown";
+}
+
+function isApprovalEvent(event: CommandCenterEvent): boolean {
+  const haystack = [
+    event.kind,
+    event.type,
+    event.sseType,
+    event.status,
+  ]
+    .map(normalizeToken)
+    .filter(Boolean)
+    .join(" ");
+  if (!haystack) return false;
+  return (
+    haystack.includes("approval") ||
+    haystack.includes("approval_required") ||
+    haystack.includes("clarification_required") ||
+    haystack.includes("blocked_waiting_for_user") ||
+    haystack.includes("run.blocked") ||
+    /\bblocked\b/.test(haystack)
+  );
+}
+
+function humanizeLabel(value: string | null): string {
+  const normalized = firstString(value) ?? "needs_attention";
+  return normalized
+    .replace(/[._]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+function appendBoundedEvent(
+  previous: CommandCenterEvent[],
+  next: CommandCenterEvent
+): CommandCenterEvent[] {
+  const appended = [...previous, next];
+  if (appended.length <= EVENT_BUFFER_LIMIT) return appended;
+  return appended.slice(appended.length - EVENT_BUFFER_LIMIT);
+}
+
+function resolveAlias(aliases: Map<string, string>, key: string): string {
+  let current = key;
+  let next = aliases.get(current);
+  while (next && next !== current) {
+    current = next;
+    next = aliases.get(current);
+  }
+  return current;
+}
+
+function mergeRuns(target: MutableRun, source: MutableRun): MutableRun {
+  return {
+    ...target,
+    eventCount: target.eventCount + source.eventCount,
+    lastEvent:
+      target.lastEventAt >= source.lastEventAt ? target.lastEvent : source.lastEvent,
+    lastEventAt: Math.max(target.lastEventAt, source.lastEventAt),
+    lastKind:
+      target.lastEventAt >= source.lastEventAt ? target.lastKind : source.lastKind,
+    lastType:
+      target.lastEventAt >= source.lastEventAt ? target.lastType : source.lastType,
+    runId: target.runId ?? source.runId,
+    status:
+      target.status !== "unknown"
+        ? target.status
+        : source.status,
+    summary:
+      target.lastEventAt >= source.lastEventAt ? target.summary : source.summary,
+    taskId: target.taskId ?? source.taskId,
+  };
+}
+
+function deriveEvents(events: CommandCenterEvent[]): DerivationResult {
+  const aliases = new Map<string, string>();
+  const runs = new Map<string, MutableRun>();
+  const approvals: CommandCenterApproval[] = [];
+
+  const ensureRun = (key: string, event: CommandCenterEvent): MutableRun => {
+    const existing = runs.get(key);
+    if (existing) return existing;
+    const created: MutableRun = {
+      eventCount: 0,
+      key,
+      lastEvent: event,
+      lastEventAt: event.receivedAt,
+      lastKind: null,
+      lastType: null,
+      runId: null,
+      status: "unknown",
+      summary: event.summary,
+      taskId: null,
+    };
+    runs.set(key, created);
+    return created;
+  };
+
+  const collapse = (primary: string, secondary: string): string => {
+    const resolvedPrimary = resolveAlias(aliases, primary);
+    const resolvedSecondary = resolveAlias(aliases, secondary);
+    if (resolvedPrimary === resolvedSecondary) return resolvedPrimary;
+    const primaryRun = runs.get(resolvedPrimary);
+    const secondaryRun = runs.get(resolvedSecondary);
+    if (secondaryRun) {
+      if (primaryRun) {
+        runs.set(resolvedPrimary, mergeRuns(primaryRun, secondaryRun));
+      } else {
+        runs.set(resolvedPrimary, { ...secondaryRun, key: resolvedPrimary });
+      }
+      runs.delete(resolvedSecondary);
+    }
+    aliases.set(resolvedSecondary, resolvedPrimary);
+    return resolvedPrimary;
+  };
+
+  const resolveRunKey = (event: CommandCenterEvent): string | null => {
+    if (event.taskId) {
+      let primary = resolveAlias(aliases, event.taskId);
+      if (event.runId) {
+        primary = collapse(primary, event.runId);
+      }
+      aliases.set(event.taskId, primary);
+      if (event.runId) aliases.set(event.runId, primary);
+      return primary;
+    }
+
+    if (event.runId) {
+      const primary = resolveAlias(aliases, event.runId);
+      aliases.set(event.runId, primary);
+      return primary;
+    }
+
+    return event.eventId ? resolveAlias(aliases, event.eventId) : null;
+  };
+
+  events.forEach((event, index) => {
+    const key = resolveRunKey(event) ?? `event:${index}:${event.receivedAt}`;
+    const run = ensureRun(key, event);
+    const nextStatus = deriveRunStatus(event);
+
+    run.eventCount += 1;
+    run.lastEvent = event;
+    run.lastEventAt = event.receivedAt;
+    run.lastKind = event.kind;
+    run.lastType = event.type ?? event.sseType;
+    run.runId = event.runId ?? run.runId;
+    run.summary = event.summary;
+    run.taskId = event.taskId ?? run.taskId;
+    if (nextStatus !== "unknown" || run.status === "unknown") {
+      run.status = nextStatus;
+    }
+    runs.set(key, run);
+
+    if (isApprovalEvent(event)) {
+      approvals.push({
+        event,
+        key: `${key}:${index}:${event.receivedAt}`,
+        label: humanizeLabel(event.kind ?? event.type ?? event.sseType ?? event.status),
+        receivedAt: event.receivedAt,
+        runId: event.runId,
+        runKey: key,
+        status: event.status,
+        summary: event.summary,
+        taskId: event.taskId,
+      });
+    }
+  });
+
+  return {
+    approvals: approvals.sort((left, right) => right.receivedAt - left.receivedAt),
+    runs: Array.from(runs.values()).sort(
+      (left, right) => right.lastEventAt - left.lastEventAt
+    ),
+  };
+}
+
+function tapMessageEvents(
+  source: GuardianEventSource,
+  onMessage: (event: MessageEvent<string>) => void
+): () => void {
+  const originalDispatchEvent = source.dispatchEvent.bind(source);
+  (source as any).dispatchEvent = (event: Event) => {
+    if (event instanceof MessageEvent) {
+      onMessage(event as MessageEvent<string>);
+    }
+    return originalDispatchEvent(event);
+  };
+  return () => {
+    (source as any).dispatchEvent = originalDispatchEvent;
+  };
+}
+
+function closeSource(ref: React.MutableRefObject<GuardianEventSource | null>): void {
+  ref.current?.close();
+  ref.current = null;
+}
+
+export function useCommandCenterEvents(
+  options: UseCommandCenterEventsOptions
+): UseCommandCenterEventsResult {
+  const { enabled } = options;
+  const auth = useAuthState();
+  const [events, setEvents] = React.useState<CommandCenterEvent[]>([]);
+  const [connectionState, setConnectionState] =
+    React.useState<CommandCenterConnectionState>("closed");
+  const [lastEventAt, setLastEventAt] = React.useState<number | null>(null);
+  const [unauthorized, setUnauthorized] = React.useState(false);
+  const [connectionDetail, setConnectionDetail] = React.useState<string | null>(
+    null
+  );
+  const sourceRef = React.useRef<GuardianEventSource | null>(null);
+
+  React.useEffect(() => {
+    if (!enabled) {
+      closeSource(sourceRef);
+      setConnectionState("closed");
+      setConnectionDetail("Command Center not enabled.");
+      setUnauthorized(false);
+      return;
+    }
+
+    if (!checkAuthGate(auth, "command center SSE")) {
+      closeSource(sourceRef);
+      setConnectionState("closed");
+      const blocked = auth.ready && auth.status !== "authenticated";
+      setUnauthorized(blocked);
+      setConnectionDetail(blocked ? "Unauthorized" : "Waiting for authentication");
+      return;
+    }
+
+    const authInit = buildAuthenticatedFetchInit({
+      headers: {
+        Accept: "text/event-stream",
+        "Cache-Control": "no-cache",
+      },
+    });
+    const headers = ((authInit.headers as Record<string, string>) ?? {}) as Record<
+      string,
+      string
+    >;
+    const source = new GuardianEventSource(
+      resolveSseEndpoint(getRuntimeConfigSync()),
+      {
+        autoReconnect: true,
+        headers,
+        retryInterval: 3000,
+        withCredentials: authInit.credentials === "include",
+        onUnauthorized: () => {
+          markAuthUnauthenticatedFrom401();
+        },
+      }
+    );
+
+    closeSource(sourceRef);
+    sourceRef.current = source;
+    setConnectionState("connecting");
+    setConnectionDetail("Connecting to live events...");
+    setUnauthorized(false);
+
+    const restoreDispatch = tapMessageEvents(source, (message) => {
+      const normalized = normalizeEvent(message);
+      setEvents((previous) => appendBoundedEvent(previous, normalized));
+      setLastEventAt(normalized.receivedAt);
+    });
+
+    const handleOpen = () => {
+      setConnectionState("open");
+      setConnectionDetail(null);
+      setUnauthorized(false);
+    };
+
+    const handleError = () => {
+      setConnectionState("error");
+      setConnectionDetail("Disconnected from live events.");
+    };
+
+    const handleUnauthorized = () => {
+      setConnectionState("closed");
+      setConnectionDetail("Unauthorized");
+      setUnauthorized(true);
+    };
+
+    source.addEventListener("open", handleOpen as EventListener);
+    source.addEventListener("error", handleError as EventListener);
+    source.addEventListener("unauthorized", handleUnauthorized as EventListener);
+
+    return () => {
+      restoreDispatch();
+      source.removeEventListener("open", handleOpen as EventListener);
+      source.removeEventListener("error", handleError as EventListener);
+      source.removeEventListener(
+        "unauthorized",
+        handleUnauthorized as EventListener
+      );
+      if (sourceRef.current === source) {
+        closeSource(sourceRef);
+      } else {
+        source.close();
+      }
+    };
+  }, [auth.ready, auth.status, auth.token, enabled]);
+
+  const derived = React.useMemo(() => deriveEvents(events), [events]);
+
+  return {
+    approvals: derived.approvals,
+    connectionDetail,
+    connectionState,
+    events,
+    lastEventAt,
+    runs: derived.runs,
+    unauthorized,
+  };
+}
+
+export default useCommandCenterEvents;

--- a/frontend/src/features/commandCenter/hooks/useHealthSummary.ts
+++ b/frontend/src/features/commandCenter/hooks/useHealthSummary.ts
@@ -1,0 +1,262 @@
+import * as React from "react";
+
+import {
+  buildAuthenticatedFetchInit,
+  getBackendOutageRemainingMs,
+} from "@/lib/api";
+import {
+  resolveApiUrl,
+  resolveBackendUrl,
+} from "@/lib/runtimeConfig";
+
+import type {
+  CommandCenterHealthItem,
+  CommandCenterHealthStatus,
+} from "@/features/commandCenter/types";
+
+const POLL_INTERVAL_MS = 15_000;
+
+type UseHealthSummaryOptions = {
+  enabled: boolean;
+};
+
+type UseHealthSummaryResult = {
+  healthItems: CommandCenterHealthItem[];
+  lastCheckedAt: number | null;
+  loading: boolean;
+  refresh: () => Promise<void>;
+};
+
+type HealthDefinition = {
+  key: CommandCenterHealthItem["key"];
+  label: string;
+  paths: Array<{
+    path: string;
+    resolver: "api" | "backend";
+  }>;
+};
+
+const HEALTH_DEFINITIONS: HealthDefinition[] = [
+  {
+    key: "core",
+    label: "Core",
+    paths: [{ path: "/health", resolver: "backend" }],
+  },
+  {
+    key: "llm",
+    label: "LLM",
+    paths: [
+      { path: "/health/llm", resolver: "backend" },
+      { path: "/api/health/llm", resolver: "api" },
+    ],
+  },
+  {
+    key: "deps",
+    label: "Deps",
+    paths: [{ path: "/health/deps", resolver: "backend" }],
+  },
+  {
+    key: "vector",
+    label: "Vector",
+    paths: [{ path: "/health/vector", resolver: "backend" }],
+  },
+  {
+    key: "memory",
+    label: "Memory",
+    paths: [{ path: "/health/memory", resolver: "backend" }],
+  },
+];
+
+function resolveHealthUrl(definition: HealthDefinition, index: number): string {
+  const item = definition.paths[index];
+  return item.resolver === "api"
+    ? resolveApiUrl(item.path)
+    : resolveBackendUrl(item.path);
+}
+
+function toRaw(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed || null;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function classifyStatus(data: Record<string, unknown> | null): CommandCenterHealthStatus {
+  if (!data) return "UNKNOWN";
+  const status = String(data.status ?? "")
+    .trim()
+    .toLowerCase();
+  if (data.ok === true || status === "ok" || status === "online") {
+    return "OK";
+  }
+  if (
+    data.ok === false ||
+    ["error", "offline", "misconfigured", "fail", "failed"].includes(status)
+  ) {
+    return "FAIL";
+  }
+  return "UNKNOWN";
+}
+
+function createDefaultItems(): CommandCenterHealthItem[] {
+  return HEALTH_DEFINITIONS.map((definition) => ({
+    checkedAt: null,
+    endpoint: resolveHealthUrl(definition, 0),
+    error: null,
+    httpStatus: null,
+    key: definition.key,
+    label: definition.label,
+    raw: null,
+    status: "UNKNOWN",
+  }));
+}
+
+async function fetchHealthItem(
+  definition: HealthDefinition
+): Promise<CommandCenterHealthItem> {
+  const authInit = buildAuthenticatedFetchInit({
+    headers: {
+      Accept: "application/json, text/plain, */*",
+      "Cache-Control": "no-cache",
+    },
+  });
+
+  for (let index = 0; index < definition.paths.length; index += 1) {
+    const url = resolveHealthUrl(definition, index);
+    try {
+      const response = await fetch(url, {
+        ...authInit,
+        method: "GET",
+      });
+
+      const contentType = response.headers.get("content-type") || "";
+      const body = contentType.includes("application/json")
+        ? await response.json().catch(() => null)
+        : await response.text().catch(() => null);
+      const record = asRecord(body);
+      const status = response.ok ? classifyStatus(record) : "FAIL";
+
+      if (response.status === 404 && index < definition.paths.length - 1) {
+        continue;
+      }
+
+      return {
+        checkedAt: Date.now(),
+        endpoint: url,
+        error: response.ok ? null : `HTTP ${response.status}`,
+        httpStatus: response.status,
+        key: definition.key,
+        label: definition.label,
+        raw: toRaw(body),
+        status,
+      };
+    } catch (error) {
+      if (index < definition.paths.length - 1) {
+        continue;
+      }
+      const message =
+        error instanceof Error && error.message.trim()
+          ? error.message
+          : "Request failed";
+      return {
+        checkedAt: Date.now(),
+        endpoint: url,
+        error: message,
+        httpStatus: null,
+        key: definition.key,
+        label: definition.label,
+        raw: toRaw(message),
+        status: "FAIL",
+      };
+    }
+  }
+
+  return {
+    checkedAt: Date.now(),
+    endpoint: resolveHealthUrl(definition, definition.paths.length - 1),
+    error: "Request failed",
+    httpStatus: null,
+    key: definition.key,
+    label: definition.label,
+    raw: null,
+    status: "FAIL",
+  };
+}
+
+export function useHealthSummary(
+  options: UseHealthSummaryOptions
+): UseHealthSummaryResult {
+  const { enabled } = options;
+  const [healthItems, setHealthItems] = React.useState<CommandCenterHealthItem[]>(
+    () => createDefaultItems()
+  );
+  const [lastCheckedAt, setLastCheckedAt] = React.useState<number | null>(null);
+  const [loading, setLoading] = React.useState(false);
+
+  const refresh = React.useCallback(async () => {
+    if (!enabled) {
+      setHealthItems(createDefaultItems());
+      setLastCheckedAt(null);
+      setLoading(false);
+      return;
+    }
+
+    if (getBackendOutageRemainingMs() > 0) {
+      setHealthItems((previous) =>
+        previous.map((item) => ({
+          ...item,
+          checkedAt: Date.now(),
+          error: "Backend outage fuse active",
+          raw: "Backend outage fuse active",
+          status: "FAIL",
+        }))
+      );
+      setLastCheckedAt(Date.now());
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const nextItems = await Promise.all(
+        HEALTH_DEFINITIONS.map((definition) => fetchHealthItem(definition))
+      );
+      setHealthItems(nextItems);
+      setLastCheckedAt(Date.now());
+    } finally {
+      setLoading(false);
+    }
+  }, [enabled]);
+
+  React.useEffect(() => {
+    void refresh();
+    if (!enabled) return;
+    const timer = window.setInterval(() => {
+      void refresh();
+    }, POLL_INTERVAL_MS);
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [enabled, refresh]);
+
+  return {
+    healthItems,
+    lastCheckedAt,
+    loading,
+    refresh,
+  };
+}
+
+export default useHealthSummary;

--- a/frontend/src/features/commandCenter/hooks/useRagTrace.ts
+++ b/frontend/src/features/commandCenter/hooks/useRagTrace.ts
@@ -1,0 +1,333 @@
+import * as React from "react";
+
+import { fetchLatestRagTrace } from "@/lib/api";
+
+import type {
+  CommandCenterRagTraceItem,
+  CommandCenterRagTracePayload,
+  CommandCenterRagTraceUnavailableReason,
+  CommandCenterRun,
+} from "@/features/commandCenter/types";
+
+type UseRagTraceResult = {
+  error: string | null;
+  loading: boolean;
+  resolvedThreadId: number | null;
+  trace: CommandCenterRagTracePayload | null;
+  unavailable: boolean;
+  unavailableReason: CommandCenterRagTraceUnavailableReason | null;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function asArray(...values: unknown[]): unknown[] | null {
+  for (const value of values) {
+    if (Array.isArray(value)) return value;
+  }
+  return null;
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = Number(trimmed);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function firstNumber(...values: unknown[]): number | null {
+  for (const value of values) {
+    const parsed = toFiniteNumber(value);
+    if (parsed != null) return parsed;
+  }
+  return null;
+}
+
+function parseThreadIdFromTraceUrl(traceUrl: string | null | undefined): number | null {
+  if (typeof traceUrl !== "string") return null;
+  const match = traceUrl.match(/rag-trace\/(\d+)\/latest/i);
+  if (!match?.[1]) return null;
+  const parsed = Number(match[1]);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function formatError(error: unknown): string {
+  const candidate = error as any;
+  const detail =
+    candidate?.response?.data?.detail ??
+    candidate?.response?.data?.error ??
+    candidate?.message ??
+    "Failed to load RAG trace";
+  return String(detail);
+}
+
+function normalizeText(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed || null;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return null;
+}
+
+function normalizeTraceItem(
+  entry: unknown,
+  index: number,
+  prefix: "semantic" | "memory"
+): CommandCenterRagTraceItem | null {
+  const primitiveText = normalizeText(entry);
+  if (primitiveText) {
+    return {
+      depthUsed: null,
+      id: `${prefix}-${index + 1}`,
+      origin: null,
+      raw: null,
+      score: null,
+      silo: null,
+      source: null,
+      text: primitiveText,
+      threadId: null,
+      timestamp: null,
+    };
+  }
+
+  const record = asRecord(entry);
+  if (!record) return null;
+
+  const metadata = asRecord(record.metadata) ?? asRecord(record.meta);
+  const text = firstString(
+    record.text,
+    record.snippet,
+    record.content,
+    record.body,
+    record.value,
+    record.title
+  );
+  if (!text) return null;
+
+  return {
+    depthUsed: firstString(
+      record.depth_used,
+      record.depthUsed,
+      metadata?.depth_used,
+      metadata?.depthUsed
+    ),
+    id:
+      firstString(
+        record.id,
+        record.node_id,
+        record.nodeId,
+        record.message_id,
+        record.messageId
+      ) ?? `${prefix}-${index + 1}`,
+    origin: firstString(
+      record.origin,
+      metadata?.origin,
+      record.kind,
+      record.type
+    ),
+    raw: record,
+    score: firstNumber(record.score, record.similarity, metadata?.score),
+    silo: firstString(record.silo, metadata?.silo),
+    source: firstString(
+      record.source,
+      metadata?.source,
+      record.title,
+      record.filename,
+      metadata?.filename
+    ),
+    text,
+    threadId: firstString(
+      record.thread_id,
+      record.threadId,
+      metadata?.thread_id,
+      metadata?.threadId
+    ),
+    timestamp: firstString(
+      record.timestamp,
+      record.created_at,
+      record.createdAt,
+      record.updated_at,
+      record.updatedAt,
+      metadata?.timestamp
+    ),
+  };
+}
+
+function sortByScore(items: CommandCenterRagTraceItem[]): CommandCenterRagTraceItem[] {
+  return [...items].sort((left, right) => {
+    if (left.score == null && right.score == null) return 0;
+    if (left.score == null) return 1;
+    if (right.score == null) return -1;
+    return right.score - left.score;
+  });
+}
+
+function normalizeTracePayload(
+  payload: unknown,
+  resolvedThreadId: number
+): CommandCenterRagTracePayload | null {
+  const trace = asRecord(payload);
+  if (!trace) return null;
+
+  const semantic = sortByScore(
+    (asArray(
+      trace.semantic,
+      trace.semantic_results,
+      trace.semanticResults,
+      trace.documents
+    ) ?? [])
+      .map((entry, index) => normalizeTraceItem(entry, index, "semantic"))
+      .filter((entry): entry is CommandCenterRagTraceItem => entry != null)
+  );
+  const memory = sortByScore(
+    (asArray(
+      trace.memory,
+      trace.memory_results,
+      trace.memoryResults,
+      trace.graph
+    ) ?? [])
+      .map((entry, index) => normalizeTraceItem(entry, index, "memory"))
+      .filter((entry): entry is CommandCenterRagTraceItem => entry != null)
+  );
+
+  if (semantic.length === 0 && memory.length === 0) {
+    return null;
+  }
+
+  return {
+    memory,
+    resolvedThreadId,
+    semantic,
+  };
+}
+
+function resolveThreadId(run: CommandCenterRun | null): number | null {
+  if (!run) return null;
+  return firstNumber(run.threadId, parseThreadIdFromTraceUrl(run.traceUrl));
+}
+
+export default function useRagTrace(
+  run: CommandCenterRun | null
+): UseRagTraceResult {
+  const [state, setState] = React.useState<UseRagTraceResult>({
+    error: null,
+    loading: false,
+    resolvedThreadId: null,
+    trace: null,
+    unavailable: true,
+    unavailableReason: "no_run",
+  });
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    if (!run) {
+      setState({
+        error: null,
+        loading: false,
+        resolvedThreadId: null,
+        trace: null,
+        unavailable: true,
+        unavailableReason: "no_run",
+      });
+      return;
+    }
+
+    const resolvedThreadId = resolveThreadId(run);
+    if (resolvedThreadId == null) {
+      setState({
+        error: null,
+        loading: false,
+        resolvedThreadId: null,
+        trace: null,
+        unavailable: true,
+        unavailableReason: "no_thread",
+      });
+      return;
+    }
+
+    setState({
+      error: null,
+      loading: true,
+      resolvedThreadId,
+      trace: null,
+      unavailable: false,
+      unavailableReason: null,
+    });
+
+    void fetchLatestRagTrace(resolvedThreadId)
+      .then((payload) => {
+        if (cancelled) return;
+        const normalized = normalizeTracePayload(payload, resolvedThreadId);
+        if (!normalized) {
+          setState({
+            error: null,
+            loading: false,
+            resolvedThreadId,
+            trace: null,
+            unavailable: true,
+            unavailableReason: "no_trace",
+          });
+          return;
+        }
+        setState({
+          error: null,
+          loading: false,
+          resolvedThreadId,
+          trace: normalized,
+          unavailable: false,
+          unavailableReason: null,
+        });
+      })
+      .catch((error: any) => {
+        if (cancelled) return;
+        if (Number(error?.response?.status ?? 0) === 404) {
+          setState({
+            error: null,
+            loading: false,
+            resolvedThreadId,
+            trace: null,
+            unavailable: true,
+            unavailableReason: "no_trace",
+          });
+          return;
+        }
+        setState({
+          error: formatError(error),
+          loading: false,
+          resolvedThreadId,
+          trace: null,
+          unavailable: false,
+          unavailableReason: null,
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [run]);
+
+  return state;
+}

--- a/frontend/src/features/commandCenter/types.ts
+++ b/frontend/src/features/commandCenter/types.ts
@@ -1,0 +1,75 @@
+export type CommandCenterConnectionState =
+  | "connecting"
+  | "open"
+  | "error"
+  | "closed";
+
+export type CommandCenterRunStatus =
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "needs_attention"
+  | "unknown";
+
+export type CommandCenterHealthStatus = "OK" | "FAIL" | "UNKNOWN";
+
+export type CommandCenterJson = Record<string, unknown> | null;
+
+export interface CommandCenterEvent {
+  eventId: string | null;
+  json: CommandCenterJson;
+  kind: string | null;
+  raw: string;
+  receivedAt: number;
+  runId: string | null;
+  sseType: string | null;
+  status: string | null;
+  summary: string;
+  taskId: string | null;
+  type: string | null;
+}
+
+export interface CommandCenterRun {
+  eventCount: number;
+  key: string;
+  lastEvent: CommandCenterEvent;
+  lastEventAt: number;
+  lastKind: string | null;
+  lastType: string | null;
+  runId: string | null;
+  status: CommandCenterRunStatus;
+  summary: string;
+  taskId: string | null;
+}
+
+export interface CommandCenterApproval {
+  event: CommandCenterEvent;
+  key: string;
+  label: string;
+  receivedAt: number;
+  runId: string | null;
+  runKey: string | null;
+  status: string | null;
+  summary: string;
+  taskId: string | null;
+}
+
+export interface CommandCenterHealthItem {
+  checkedAt: number | null;
+  endpoint: string;
+  error: string | null;
+  httpStatus: number | null;
+  key: "core" | "llm" | "deps" | "vector" | "memory";
+  label: string;
+  raw: string | null;
+  status: CommandCenterHealthStatus;
+}
+
+export interface CommandCenterTaskEvent {
+  eventId: string | null;
+  eventType: string | null;
+  json: CommandCenterJson;
+  raw: string;
+  receivedAt: number;
+  summary: string;
+}

--- a/frontend/src/features/commandCenter/types.ts
+++ b/frontend/src/features/commandCenter/types.ts
@@ -14,6 +14,10 @@ export type CommandCenterRunStatus =
 export type CommandCenterHealthStatus = "OK" | "FAIL" | "UNKNOWN";
 
 export type CommandCenterJson = Record<string, unknown> | null;
+export type CommandCenterRagTraceUnavailableReason =
+  | "no_run"
+  | "no_thread"
+  | "no_trace";
 
 export interface CommandCenterEvent {
   eventId: string | null;
@@ -40,6 +44,8 @@ export interface CommandCenterRun {
   status: CommandCenterRunStatus;
   summary: string;
   taskId: string | null;
+  threadId?: number | null;
+  traceUrl?: string | null;
 }
 
 export interface CommandCenterApproval {
@@ -72,4 +78,23 @@ export interface CommandCenterTaskEvent {
   raw: string;
   receivedAt: number;
   summary: string;
+}
+
+export interface CommandCenterRagTraceItem {
+  depthUsed: string | null;
+  id: string;
+  origin: string | null;
+  raw: Record<string, unknown> | null;
+  score: number | null;
+  silo: string | null;
+  source: string | null;
+  text: string;
+  threadId: string | null;
+  timestamp: string | null;
+}
+
+export interface CommandCenterRagTracePayload {
+  memory: CommandCenterRagTraceItem[];
+  resolvedThreadId: number;
+  semantic: CommandCenterRagTraceItem[];
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -238,6 +238,10 @@ export function buildChatCompletePath(threadId: string | number): string {
   return `/chat/${normalizePathSegment(threadId)}/complete`;
 }
 
+export function buildLatestRagTracePath(threadId: string | number): string {
+  return `/api/chat/debug/rag-trace/${normalizePathSegment(threadId)}/latest`;
+}
+
 function isAbsoluteUrl(value: string): boolean {
   return /^https?:\/\//i.test(value);
 }
@@ -811,5 +815,14 @@ api.interceptors.response.use(
 
 (api as any).getInFlightCompletionTurnId = getInFlightCompletionTurnId;
 (api as any).clearInFlightCompletionTurnId = clearInFlightCompletionTurnId;
+
+export async function fetchLatestRagTrace(
+  threadId: number
+): Promise<Record<string, unknown>> {
+  const response = await api.get<Record<string, unknown>>(
+    buildLatestRagTracePath(threadId)
+  );
+  return response.data;
+}
 
 export default api;


### PR DESCRIPTION
## Summary
- Add a dev-only `/command-center` route outside the main app shell for internal operational visibility
- Subscribe to global SSE events to derive connection state, run summaries, and approval-needed items
- Poll existing health endpoints and render compact service status snapshots
- Add a run detail drawer with live task event streaming and retrieval diagnostics support
- Introduce typed command-center models, hooks, and panels for the new surface

## Testing
- `pnpm test`
- `pnpm --dir frontend/src test`