### PR TITLE
Fix local Compose Postgres bootstrap auth contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,15 +34,19 @@ CODEXIFY_DESKTOP_BACKEND_URL=http://127.0.0.1:8888
 CODEXIFY_DESKTOP_SHARE_BASE_URL=http://127.0.0.1:5173
 
 # --- Database ---
-DATABASE_URL=postgresql://codexify_user:codexify@localhost:5432/codexify
-GUARDIAN_DATABASE_URL=${DATABASE_URL}
-GUARDIAN_DB_URL=${DATABASE_URL}
-GUARDIAN_DB_PATH=__DISABLE_SQLITE__
-
-# --- Docker Compose overrides (optional) ---
+# Compose-local Postgres contract. Keep these values aligned with docker-compose.yml.
 POSTGRES_USER=codexify
-POSTGRES_PASSWORD=replace-with-postgres-password
+POSTGRES_PASSWORD=codexify
 POSTGRES_DB=Codexify
+PGHOST=db
+PGPORT=5432
+PGUSER=codexify
+PGPASSWORD=codexify
+PGDATABASE=Codexify
+DATABASE_URL=postgresql://codexify:codexify@db:5432/Codexify
+GUARDIAN_DATABASE_URL=postgresql+psycopg://codexify:codexify@db:5432/Codexify
+GUARDIAN_DB_URL=postgresql://codexify:codexify@db:5432/Codexify
+GUARDIAN_DB_PATH=__DISABLE_SQLITE__
 
 # --- Local LLM (Ollama/OpenAI-compatible) ---
 # NOTE: LLM_PROVIDER must be a single provider id (not a comma-separated list).

--- a/.env.template
+++ b/.env.template
@@ -34,15 +34,19 @@ CODEXIFY_DESKTOP_BACKEND_URL=http://127.0.0.1:8888
 CODEXIFY_DESKTOP_SHARE_BASE_URL=http://127.0.0.1:5173
 
 # --- Database ---
-DATABASE_URL=postgresql://codexify_user:codexify@localhost:5432/codexify
-GUARDIAN_DATABASE_URL=${DATABASE_URL}
-GUARDIAN_DB_URL=${DATABASE_URL}
-GUARDIAN_DB_PATH=__DISABLE_SQLITE__
-
-# --- Docker Compose overrides (optional) ---
+# Compose-local Postgres contract. Keep these values aligned with docker-compose.yml.
 POSTGRES_USER=codexify
-POSTGRES_PASSWORD=replace-with-postgres-password
+POSTGRES_PASSWORD=codexify
 POSTGRES_DB=Codexify
+PGHOST=db
+PGPORT=5432
+PGUSER=codexify
+PGPASSWORD=codexify
+PGDATABASE=Codexify
+DATABASE_URL=postgresql://codexify:codexify@db:5432/Codexify
+GUARDIAN_DATABASE_URL=postgresql+psycopg://codexify:codexify@db:5432/Codexify
+GUARDIAN_DB_URL=postgresql://codexify:codexify@db:5432/Codexify
+GUARDIAN_DB_PATH=__DISABLE_SQLITE__
 
 # --- Local LLM (Ollama/OpenAI-compatible) ---
 # NOTE: LLM_PROVIDER must be a single provider id (not a comma-separated list).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,32 @@
 name: codexify
 
+x-postgres-env: &postgres_env
+  POSTGRES_USER: ${POSTGRES_USER:-codexify}
+  POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-codexify}
+  POSTGRES_DB: ${POSTGRES_DB:-Codexify}
+  PGHOST: db
+  PGPORT: "5432"
+  PGUSER: ${POSTGRES_USER:-codexify}
+  PGPASSWORD: ${POSTGRES_PASSWORD:-codexify}
+  PGDATABASE: ${POSTGRES_DB:-Codexify}
+  DATABASE_URL: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
+  GUARDIAN_DATABASE_URL: postgresql+psycopg://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
+  GUARDIAN_DB_URL: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
+  GUARDIAN_DB_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
+  GUARDIAN_CHATLOG_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
+
 services:
   db:
     image: postgres:15
+    env_file: ${CODEXIFY_RUNTIME_ENV_FILE:-.env}
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:-codexify}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-codexify}
-      POSTGRES_DB: ${POSTGRES_DB:-Codexify}
+      <<: *postgres_env
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-codexify} -d ${POSTGRES_DB:-Codexify}"]
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U \"$${POSTGRES_USER:-codexify}\" -d \"$${POSTGRES_DB:-Codexify}\"",
+        ]
       interval: 5s
       timeout: 5s
       retries: 20
@@ -96,9 +114,7 @@ services:
         condition: service_healthy
     env_file: ${CODEXIFY_RUNTIME_ENV_FILE:-.env}
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
-      GUARDIAN_DB_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
-      GUARDIAN_CHATLOG_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
+      <<: *postgres_env
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
       PYTHONUTF8: "1"
@@ -135,13 +151,11 @@ services:
     entrypoint: ["python", "scripts/chatgpt_import/import_chatgpt.py"]
     env_file: ${CODEXIFY_RUNTIME_ENV_FILE:-.env}
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
+      <<: *postgres_env
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
       PYTHONUTF8: "1"
       PYTHONIOENCODING: utf-8
-      GUARDIAN_DB_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
-      GUARDIAN_CHATLOG_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
       LLM_PROVIDER: "local"
       EMBED_PROVIDER: "local"
       EMBEDDER_PROVIDER: "local"
@@ -226,13 +240,11 @@ services:
       - hf_cache:/root/.cache/huggingface
       - ./models:/models
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
+      <<: *postgres_env
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
       PYTHONUTF8: "1"
       PYTHONIOENCODING: utf-8
-      GUARDIAN_DB_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
-      GUARDIAN_CHATLOG_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
       PORT: "8888"
       # Command bus loopback: required so command execution re-enters the API via HTTP with full authz/middleware.
       GUARDIAN_COMMAND_BUS_LOOPBACK_BASE: "http://backend:8888"
@@ -337,13 +349,11 @@ services:
         condition: service_completed_successfully
     env_file: ${CODEXIFY_RUNTIME_ENV_FILE:-.env}
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
+      <<: *postgres_env
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
       PYTHONUTF8: "1"
       PYTHONIOENCODING: utf-8
-      GUARDIAN_DB_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
-      GUARDIAN_CHATLOG_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
       LLM_PROVIDER: "${LLM_PROVIDER:-local}"
       EMBED_PROVIDER: "local"
       CODEXIFY_EMBEDDINGS_BACKEND: "${CODEXIFY_EMBEDDINGS_BACKEND:-local}"
@@ -399,13 +409,11 @@ services:
         condition: service_completed_successfully
     env_file: ${CODEXIFY_RUNTIME_ENV_FILE:-.env}
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
+      <<: *postgres_env
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
       PYTHONUTF8: "1"
       PYTHONIOENCODING: utf-8
-      GUARDIAN_DB_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
-      GUARDIAN_CHATLOG_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
       LLM_PROVIDER: "local"
       EMBED_PROVIDER: "local"
       CODEXIFY_EMBEDDINGS_BACKEND: "${CODEXIFY_EMBEDDINGS_BACKEND:-local}"
@@ -454,13 +462,11 @@ services:
         condition: service_healthy
     env_file: ${CODEXIFY_RUNTIME_ENV_FILE:-.env}
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
+      <<: *postgres_env
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
       PYTHONUTF8: "1"
       PYTHONIOENCODING: utf-8
-      GUARDIAN_DB_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
-      GUARDIAN_CHATLOG_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
       LLM_PROVIDER: "local"
       EMBED_PROVIDER: "local"
       CODEXIFY_EMBEDDINGS_BACKEND: "${CODEXIFY_EMBEDDINGS_BACKEND:-local}"
@@ -510,13 +516,11 @@ services:
         condition: service_completed_successfully
     env_file: ${CODEXIFY_RUNTIME_ENV_FILE:-.env}
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
+      <<: *postgres_env
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
       PYTHONUTF8: "1"
       PYTHONIOENCODING: utf-8
-      GUARDIAN_DB_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
-      GUARDIAN_CHATLOG_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
       LLM_PROVIDER: "local"
       EMBED_PROVIDER: "local"
       CODEXIFY_EMBEDDINGS_BACKEND: "${CODEXIFY_EMBEDDINGS_BACKEND:-local}"
@@ -569,13 +573,11 @@ services:
         condition: service_completed_successfully
     env_file: ${CODEXIFY_RUNTIME_ENV_FILE:-.env}
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
+      <<: *postgres_env
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
       PYTHONUTF8: "1"
       PYTHONIOENCODING: utf-8
-      GUARDIAN_DB_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
-      GUARDIAN_CHATLOG_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
       LLM_PROVIDER: "local"
       EMBED_PROVIDER: "local"
       CODEXIFY_EMBEDDINGS_BACKEND: "${CODEXIFY_EMBEDDINGS_BACKEND:-local}"
@@ -630,13 +632,11 @@ services:
         condition: service_completed_successfully
     env_file: ${CODEXIFY_RUNTIME_ENV_FILE:-.env}
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
+      <<: *postgres_env
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
       PYTHONUTF8: "1"
       PYTHONIOENCODING: utf-8
-      GUARDIAN_DB_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
-      GUARDIAN_CHATLOG_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
       LLM_PROVIDER: "local"
       EMBED_PROVIDER: "local"
       CODEXIFY_EMBEDDINGS_BACKEND: "${CODEXIFY_EMBEDDINGS_BACKEND:-local}"
@@ -690,13 +690,11 @@ services:
         condition: service_completed_successfully
     env_file: ${CODEXIFY_RUNTIME_ENV_FILE:-.env}
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
+      <<: *postgres_env
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
       PYTHONUTF8: "1"
       PYTHONIOENCODING: utf-8
-      GUARDIAN_DB_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
-      GUARDIAN_CHATLOG_DSN: postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}
       # Command bus loopback base (Docker): never use localhost for cross-container calls.
       GUARDIAN_COMMAND_BUS_LOOPBACK_BASE: "http://backend:8888"
       CODEXIFY_POLICY_MODE: "${CODEXIFY_POLICY_MODE:-enforce}"

--- a/guardian/config/db_defaults.py
+++ b/guardian/config/db_defaults.py
@@ -7,12 +7,13 @@ from typing import Final
 
 _DEFAULT_COMPOSE_DSN: Final[
     str
-] = "postgresql://guardian:guardian@db:5432/guardian"
+] = "postgresql://codexify:codexify@db:5432/Codexify"
 
 # Compute the default DSN once, honoring any pre-existing environment overrides.
 DEFAULT_PG_DSN: Final[str] = (
-    os.getenv("GUARDIAN_DB_URL")
-    or os.getenv("DATABASE_URL")
+    os.getenv("DATABASE_URL")
+    or os.getenv("GUARDIAN_DATABASE_URL")
+    or os.getenv("GUARDIAN_DB_URL")
     or _DEFAULT_COMPOSE_DSN
 )
 

--- a/guardian/core/db_seed.py
+++ b/guardian/core/db_seed.py
@@ -6,6 +6,7 @@ Initializes baseline data like the default project if the database is empty.
 import logging
 import os
 
+from guardian.config.db_defaults import DEFAULT_PG_DSN
 from guardian.core.default_project import (
     DEFAULT_PROJECT_DESCRIPTION,
     DEFAULT_PROJECT_NAME,
@@ -18,9 +19,7 @@ logger = logging.getLogger(__name__)
 def seed():
     """Insert baseline data into the database."""
     # Use env var or default
-    dsn = os.environ.get(
-        "DATABASE_URL", "postgresql://guardian:guardian@db:5432/guardian"
-    )
+    dsn = os.environ.get("DATABASE_URL") or DEFAULT_PG_DSN
     db = PgDB(dsn)
     existing = db.list_projects()
     if not existing:

--- a/guardian/cron/scheduler.py
+++ b/guardian/cron/scheduler.py
@@ -9,6 +9,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
 
+from guardian.config.db_defaults import DEFAULT_PG_DSN
 from guardian.core import event_bus
 from guardian.core.db import GuardianDB
 from guardian.db import models as db_models
@@ -20,7 +21,6 @@ CRON_QUEUE_NAME = os.getenv("CRON_QUEUE_NAME", "codexify:queue:cron")
 SCHEDULER_POLL_SECONDS = max(
     1, int(os.getenv("CRON_SCHEDULER_POLL_SECONDS", "30"))
 )
-_DEFAULT_DB_URL = "postgresql://guardian:guardian@db:5432/guardian"
 _INTERVAL_RE = re.compile(r"^\*/([1-9]\d*) \* \* \* \*$")
 
 
@@ -72,7 +72,7 @@ def _is_due(
 def _resolve_db(db: GuardianDB | None) -> GuardianDB:
     if db is not None:
         return db
-    db_url = os.getenv("DATABASE_URL", _DEFAULT_DB_URL)
+    db_url = os.getenv("DATABASE_URL") or DEFAULT_PG_DSN
     return GuardianDB(db_url)
 
 

--- a/guardian/routes/media.py
+++ b/guardian/routes/media.py
@@ -31,6 +31,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import or_
 from sqlalchemy.exc import IntegrityError
 
+from guardian.config.db_defaults import DEFAULT_PG_DSN
 from guardian.core.db import GuardianDB, load_guardian_db_from_env
 from guardian.core.default_project import canonicalize_default_project
 from guardian.core.dependencies import verify_api_key
@@ -218,9 +219,7 @@ def _get_db() -> GuardianDB:
             type(resolved),
         )
 
-    db_url = os.getenv(
-        "DATABASE_URL", "postgresql://guardian:guardian@db:5432/guardian"
-    )
+    db_url = os.getenv("DATABASE_URL") or DEFAULT_PG_DSN
     return GuardianDB(db_url)
 
 

--- a/guardian/tests/test_pgdsn_default.py
+++ b/guardian/tests/test_pgdsn_default.py
@@ -2,8 +2,28 @@ import importlib
 import os
 
 
+def test_default_pg_dsn_prefers_database_url(monkeypatch):
+    monkeypatch.setenv(
+        "DATABASE_URL", "postgresql://runtime:runtime@db:5432/runtime"
+    )
+    monkeypatch.setenv(
+        "GUARDIAN_DATABASE_URL",
+        "postgresql://override:override@db:5432/override",
+    )
+    monkeypatch.delenv("GUARDIAN_DB_URL", raising=False)
+
+    import guardian.config.db_defaults as db_defaults
+
+    importlib.reload(db_defaults)
+
+    assert db_defaults.DEFAULT_PG_DSN == (
+        "postgresql://runtime:runtime@db:5432/runtime"
+    )
+
+
 def test_default_pg_dsn_uses_compose_host(monkeypatch):
     monkeypatch.delenv("GUARDIAN_DB_URL", raising=False)
+    monkeypatch.delenv("GUARDIAN_DATABASE_URL", raising=False)
     monkeypatch.delenv("DATABASE_URL", raising=False)
 
     # Reload module so the default is recomputed without env overrides
@@ -11,4 +31,6 @@ def test_default_pg_dsn_uses_compose_host(monkeypatch):
 
     importlib.reload(db_defaults)
 
-    assert "db:5432" in db_defaults.DEFAULT_PG_DSN
+    assert db_defaults.DEFAULT_PG_DSN == (
+        "postgresql://codexify:codexify@db:5432/Codexify"
+    )

--- a/guardian/voice/audio_assets.py
+++ b/guardian/voice/audio_assets.py
@@ -10,6 +10,7 @@ from urllib.parse import urlsplit
 
 from sqlalchemy.exc import IntegrityError
 
+from guardian.config.db_defaults import DEFAULT_PG_DSN
 from guardian.core.db import GuardianDB, load_guardian_db_from_env
 from guardian.core.dependencies import chatlog_db
 from guardian.core.media_signing import sign_media_url
@@ -21,9 +22,7 @@ _AUDIO_STATUS_VALUES = {"pending", "ready", "failed"}
 
 
 def _database_url() -> str:
-    return os.getenv(
-        "DATABASE_URL", "postgresql://guardian:guardian@db:5432/guardian"
-    )
+    return os.getenv("DATABASE_URL") or DEFAULT_PG_DSN
 
 
 def _db() -> Any:

--- a/guardian/workers/cron_worker.py
+++ b/guardian/workers/cron_worker.py
@@ -10,6 +10,7 @@ from typing import Any, Callable
 
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
+from guardian.config.db_defaults import DEFAULT_PG_DSN
 from guardian.core import event_bus
 from guardian.core.db import GuardianDB
 from guardian.cron.executor import execute_cron_job
@@ -19,7 +20,6 @@ from guardian.queue.redis_queue import dequeue
 logger = logging.getLogger(__name__)
 
 QUEUE_NAME = os.getenv("CRON_QUEUE_NAME", "codexify:queue:cron")
-_DEFAULT_DB_URL = "postgresql://guardian:guardian@db:5432/guardian"
 _MAX_ERROR_LENGTH = 512
 
 
@@ -30,7 +30,7 @@ def _utc_now() -> datetime:
 def _resolve_db(db: GuardianDB | None) -> GuardianDB:
     if db is not None:
         return db
-    db_url = os.getenv("DATABASE_URL", _DEFAULT_DB_URL)
+    db_url = os.getenv("DATABASE_URL") or DEFAULT_PG_DSN
     return GuardianDB(db_url)
 
 

--- a/guardian/workers/document_embed_worker.py
+++ b/guardian/workers/document_embed_worker.py
@@ -11,6 +11,7 @@ from typing import Any, Callable
 
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
+from guardian.config.db_defaults import DEFAULT_PG_DSN
 from guardian.core.db import GuardianDB
 from guardian.db.models import UploadedDocument
 from guardian.queue.document_embed_queue import (
@@ -21,15 +22,13 @@ from guardian.services.document_chunking import chunk_document_text
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_DB_URL = "postgresql://guardian:guardian@db:5432/guardian"
-
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
 def _get_db() -> GuardianDB:
-    db_url = os.getenv("DATABASE_URL", _DEFAULT_DB_URL)
+    db_url = os.getenv("DATABASE_URL") or DEFAULT_PG_DSN
     return GuardianDB(db_url)
 
 


### PR DESCRIPTION
## Summary
- Unified the local Compose Postgres credential contract across `db`, `migrator`, `backend`, and worker/one-shot services
- Updated the committed env templates to match the local runtime DSN and credentials
- Removed hardcoded legacy DB fallbacks from runtime helpers so they resolve from one shared contract

## Testing
- `docker compose config`
- `docker compose up -d db`
- `docker compose up -d migrator`
- `docker compose logs migrator --tail=200`
- `docker compose up -d backend`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm test`