### PR TITLE
tighten tauri bootstrap runtime readiness gating

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,9 +18,10 @@ import {
   createStartingLocalServicesState,
   createWaitingForReadyState,
   formatBootstrapStepResult,
-  formatRuntimeHealthCheckResult,
+  formatRuntimeReadinessResult,
   hasDismissedWelcomeScreen,
   mapRuntimePreflightFailureToState,
+  mapRuntimeReadinessFailureToState,
   openDockerDesktopDownloadPage,
   runComposeUp,
   runRuntimeBootstrapPreflight,
@@ -142,9 +143,10 @@ function WelcomeScreen({ onEnter }: { onEnter: () => void }) {
               className="max-w-xl text-sm leading-6 sm:text-[15px]"
               style={{ color: "var(--muted)" }}
             >
-              The local setup step completed, Docker Compose is up, and the
-              runtime health checks are green. Enter when you want the full
-              workspace surface to become interactive.
+              The backend process is reachable, startup has completed, Redis
+              and chat health are green, and the local beta readiness contract
+              is satisfied. Enter when you want the full workspace surface to
+              become interactive.
             </p>
           </div>
 
@@ -209,7 +211,8 @@ function WelcomeScreen({ onEnter }: { onEnter: () => void }) {
                 style={{ color: "var(--text)" }}
               >
                 This welcome screen is dismissed per local profile so repeat
-                launches can go straight to the workspace once startup is green.
+                launches can go straight to the workspace once the local beta
+                loop is green.
               </p>
             </div>
           </div>
@@ -521,14 +524,19 @@ export default function App() {
           if (runId !== bootstrapRunRef.current) return;
           const liveDetail = appendBootstrapDetail(
             detail,
-            formatRuntimeHealthCheckResult(healthResult),
+            formatRuntimeReadinessResult(healthResult),
             `Readiness probe ${attempt}`
           );
           setBootstrapState(
-            createWaitingForReadyState(preflight, liveDetail, {
-              ...stepResults,
-              "health-check": healthResult,
-            })
+            createWaitingForReadyState(
+              preflight,
+              liveDetail,
+              {
+                ...stepResults,
+                "health-check": healthResult,
+              },
+              healthResult
+            )
           );
         },
       });
@@ -540,7 +548,7 @@ export default function App() {
         "health-check": readiness.lastCheck,
       };
       detail = appendDiagnostics(
-        formatRuntimeHealthCheckResult(readiness.lastCheck),
+        formatRuntimeReadinessResult(readiness.lastCheck),
         readiness.ok
           ? `Readiness succeeded after ${readiness.attempts} probe(s) in ${Math.round(
               readiness.elapsedMs / 1000
@@ -552,21 +560,23 @@ export default function App() {
 
       if (!readiness.ok) {
         setBootstrapState(
-          createFailedRuntimeBootstrapState({
-            title: "Codexify did not become ready in time",
-            message:
-              "Docker Compose started, but the runtime health checks never reached a usable state. Retry to rerun setup, compose startup, and readiness from the beginning.",
-            detail,
-            failureKind: "health-check-failed",
+          mapRuntimeReadinessFailureToState(
             preflight,
-            stepResults,
-          })
+            readiness.lastCheck,
+            detail,
+            stepResults
+          )
         );
         return;
       }
 
       setBootstrapState(
-        createReadyForWelcomeState(preflight, detail, stepResults)
+        createReadyForWelcomeState(
+          preflight,
+          detail,
+          stepResults,
+          readiness.lastCheck
+        )
       );
       advanceToWelcomeOrWorkspace(runId);
     },

--- a/frontend/src/components/bootstrap/BootstrapGate.tsx
+++ b/frontend/src/components/bootstrap/BootstrapGate.tsx
@@ -194,9 +194,9 @@ export default function BootstrapGate({
     },
     {
       id: PHASE_STEP_MAP.readiness,
-      label: "Waiting for Codexify to become ready",
+      label: "Waiting for local beta runtime",
       description:
-        "Poll the real backend health/readiness surfaces until the stack is genuinely usable.",
+        "Poll /ping, /health, /health/chat, and /health/llm until the supported local beta loop is genuinely usable.",
     },
   ] as const;
 
@@ -328,7 +328,7 @@ export default function BootstrapGate({
             )}
             {state.status === "ready-for-welcome" && (
               <p className="text-sm" style={{ color: "var(--muted)" }}>
-                Runtime checks are green. Opening the welcome screen next.
+                Local beta readiness checks are green. Opening the welcome screen next.
               </p>
             )}
           </div>

--- a/frontend/src/lib/runtimeBootstrap.ts
+++ b/frontend/src/lib/runtimeBootstrap.ts
@@ -33,11 +33,20 @@ export type HealthEndpointCheck = {
   responseExcerpt?: string;
 };
 
-export type RuntimeHealthCheckResult = BootstrapStepResult & {
+export type RuntimeReadinessResult = BootstrapStepResult & {
   step: "health-check";
   ready: boolean;
+  backendReachable: boolean;
+  startupReady: boolean;
+  redisReady: boolean;
+  chatReady: boolean;
+  llmReady?: boolean;
   checks: HealthEndpointCheck[];
 };
+
+export type RuntimeReadiness = RuntimeReadinessResult;
+
+export type RuntimeHealthCheckResult = RuntimeReadinessResult;
 
 export type RuntimeBootstrapStatus =
   | "checking-requirements"
@@ -64,7 +73,7 @@ export type RuntimeReadinessWaitResult = {
   ok: boolean;
   attempts: number;
   elapsedMs: number;
-  lastCheck: RuntimeHealthCheckResult;
+  lastCheck: RuntimeReadinessResult;
 };
 
 const WELCOME_DISMISSED_STORAGE_KEY = "cfy.bootstrap.welcomeDismissed";
@@ -87,6 +96,12 @@ function normalizeFailureKind(value: unknown): string | undefined {
 function normalizeExitCode(value: unknown): number | undefined {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function normalizeOptionalBoolean(value: unknown): boolean | undefined {
+  if (value === true) return true;
+  if (value === false) return false;
+  return undefined;
 }
 
 function normalizeEndpointCheck(payload: unknown): HealthEndpointCheck {
@@ -121,7 +136,7 @@ function normalizeStepResult(
       : {};
 
   return {
-    ok: asBoolean(source.ok),
+    ok: asBoolean(source.ok ?? source.ready),
     step: normalizeStep(source.step, fallbackStep),
     detail: normalizeText(source.detail),
     command: normalizeText(source.command),
@@ -158,9 +173,9 @@ export function normalizeRuntimePreflight(payload: unknown): RuntimePreflight {
   return preflight;
 }
 
-export function normalizeRuntimeHealthCheck(
+export function normalizeRuntimeReadiness(
   payload: unknown
-): RuntimeHealthCheckResult {
+): RuntimeReadinessResult {
   const base = normalizeStepResult(payload, "health-check");
   const source =
     payload && typeof payload === "object"
@@ -171,9 +186,23 @@ export function normalizeRuntimeHealthCheck(
   return {
     ...base,
     step: "health-check",
-    ready: asBoolean(source.ready),
+    ok: asBoolean(source.ok ?? source.ready),
+    ready: asBoolean(source.ready ?? source.ok),
+    backendReachable: asBoolean(
+      source.backendReachable ?? source.backend_reachable
+    ),
+    startupReady: asBoolean(source.startupReady ?? source.startup_ready),
+    redisReady: asBoolean(source.redisReady ?? source.redis_ready),
+    chatReady: asBoolean(source.chatReady ?? source.chat_ready),
+    llmReady: normalizeOptionalBoolean(source.llmReady ?? source.llm_ready),
     checks: rawChecks.map((item) => normalizeEndpointCheck(item)),
   };
+}
+
+export function normalizeRuntimeHealthCheck(
+  payload: unknown
+): RuntimeReadinessResult {
+  return normalizeRuntimeReadiness(payload);
 }
 
 type RuntimeBootstrapBuildOptions = {
@@ -214,6 +243,104 @@ function formatPreflightDetail(preflight: RuntimePreflight): string | undefined 
     lines.push("", preflight.detail);
   }
   return lines.join("\n").trim() || undefined;
+}
+
+type RuntimeReadinessPhase = "waiting" | "failed";
+
+type RuntimeReadinessCopy = {
+  title: string;
+  message: string;
+  failureKind: string;
+};
+
+function describeRuntimeReadinessCopy(
+  readiness: RuntimeReadinessResult | null | undefined,
+  phase: RuntimeReadinessPhase
+): RuntimeReadinessCopy {
+  const generic =
+    phase === "waiting"
+      ? {
+          title: "Waiting for local beta runtime",
+          message:
+            "Codexify is polling the real local readiness surfaces until the supported beta loop is usable.",
+          failureKind: "readiness-waiting",
+        }
+      : {
+          title: "Codexify did not become ready in time",
+          message:
+            "The local beta runtime never satisfied the readiness contract. Retry the bootstrap or inspect the technical details below.",
+          failureKind: "readiness-failed",
+        };
+
+  if (!readiness) {
+    return generic;
+  }
+
+  if (!readiness.backendReachable) {
+    return phase === "waiting"
+      ? {
+          title: "Backend is still starting",
+          message:
+            "The backend process has not responded to /ping yet, so the workspace stays locked until the local API comes up.",
+          failureKind: "backend-unreachable",
+        }
+      : {
+          title: "Backend never became reachable",
+          message:
+            "Compose started, but the backend process never answered /ping. Retry startup from the beginning once the local API is available.",
+          failureKind: "backend-unreachable",
+        };
+  }
+
+  if (!readiness.startupReady) {
+    return phase === "waiting"
+      ? {
+          title: "Backend is warming up",
+          message:
+            "The backend responds, but /health has not reported a completed startup yet. Postgres-backed initialization may still be finishing.",
+          failureKind: "startup-not-ready",
+        }
+      : {
+          title: "Backend startup did not finish",
+          message:
+            "The backend answered /ping, but /health never reached a usable state. Retry the bootstrap so Postgres-backed startup can complete cleanly.",
+          failureKind: "startup-not-ready",
+        };
+  }
+
+  if (!readiness.redisReady || !readiness.chatReady) {
+    return phase === "waiting"
+      ? {
+          title: "Redis or chat workers are still warming up",
+          message:
+            "The backend is up, but /health/chat still reports the Redis or worker-backed completion path as unavailable.",
+          failureKind: "chat-path-unavailable",
+        }
+      : {
+          title: "Redis or chat workers are unavailable",
+          message:
+            "The backend is up, but /health/chat never reported a healthy completion path. The workspace stays locked until Redis, queueing, and worker heartbeat are green.",
+          failureKind: "chat-path-unavailable",
+        };
+  }
+
+  if (readiness.llmReady === false) {
+    return phase === "waiting"
+      ? {
+          title: "Model health is still red",
+          message:
+            "The backend and queue surfaces are up, but /health/llm still reports the model path as unavailable.",
+          failureKind: "llm-unavailable",
+        }
+      : {
+          title: "Model health did not recover",
+          message:
+            "The backend and queue surfaces are up, but /health/llm never became healthy. Retry once the model path is green.",
+          failureKind: "llm-unavailable",
+        };
+  }
+
+  return generic;
 }
 
 export function shouldRunRuntimeBootstrap(): boolean {
@@ -330,12 +457,14 @@ export function createStartingLocalServicesState(
 export function createWaitingForReadyState(
   preflight: RuntimePreflight,
   detail?: string,
-  stepResults: Partial<Record<BootstrapStep, BootstrapStepResult>> = {}
+  stepResults: Partial<Record<BootstrapStep, BootstrapStepResult>> = {},
+  readiness?: RuntimeReadinessResult | null
 ): RuntimeBootstrapState {
+  const copy = describeRuntimeReadinessCopy(readiness, "waiting");
   return buildRuntimeBootstrapState(
     "waiting-for-ready",
-    "Waiting for Codexify to become ready",
-    "Codexify is polling the existing local readiness surfaces instead of sleeping blindly. The workspace stays locked until those checks pass.",
+    copy.title,
+    copy.message,
     { detail, preflight, stepResults }
   );
 }
@@ -343,13 +472,40 @@ export function createWaitingForReadyState(
 export function createReadyForWelcomeState(
   preflight: RuntimePreflight,
   detail?: string,
-  stepResults: Partial<Record<BootstrapStep, BootstrapStepResult>> = {}
+  stepResults: Partial<Record<BootstrapStep, BootstrapStepResult>> = {},
+  readiness?: RuntimeReadinessResult | null
 ): RuntimeBootstrapState {
+  const modelStatus =
+    readiness && typeof readiness.llmReady === "boolean"
+      ? readiness.llmReady
+        ? " The model health surface is green too."
+        : " The model health surface is still red."
+      : "";
   return buildRuntimeBootstrapState(
     "ready-for-welcome",
-    "Ready for welcome",
-    "Docker preflight passed, setup completed, Compose is up, and the runtime health checks succeeded. Transitioning into the welcome screen now.",
+    "Local beta runtime is ready",
+    `Docker preflight passed, setup completed, Compose is up, and the local beta readiness checks succeeded.${modelStatus} Transitioning into the welcome screen now.`,
     { detail, preflight, stepResults }
+  );
+}
+
+export function mapRuntimeReadinessFailureToState(
+  preflight: RuntimePreflight,
+  readiness: RuntimeReadinessResult | null,
+  detail?: string,
+  stepResults: Partial<Record<BootstrapStep, BootstrapStepResult>> = {}
+): RuntimeBootstrapState {
+  const copy = describeRuntimeReadinessCopy(readiness, "failed");
+  return buildRuntimeBootstrapState(
+    "failed",
+    copy.title,
+    copy.message,
+    {
+      detail,
+      failureKind: copy.failureKind,
+      preflight,
+      stepResults,
+    }
   );
 }
 
@@ -417,14 +573,29 @@ export function formatBootstrapStepResult(result: BootstrapStepResult): string {
   return lines.join("\n").trim();
 }
 
-export function formatRuntimeHealthCheckResult(
-  result: RuntimeHealthCheckResult
+export function formatRuntimeReadinessResult(
+  result: RuntimeReadinessResult
 ): string {
   const lines = [
     `step=${result.step}`,
     `ok=${result.ok}`,
     `ready=${result.ready}`,
+    `backendReachable=${result.backendReachable}`,
+    `startupReady=${result.startupReady}`,
+    `redisReady=${result.redisReady}`,
+    `chatReady=${result.chatReady}`,
   ];
+  if (typeof result.llmReady === "boolean") {
+    lines.push(`llmReady=${result.llmReady}`);
+  } else {
+    lines.push("llmReady=not-gated");
+  }
+  if (result.command) {
+    lines.push(`command=${result.command}`);
+  }
+  if (typeof result.exitCode === "number") {
+    lines.push(`exitCode=${result.exitCode}`);
+  }
   for (const check of result.checks) {
     lines.push(
       "",
@@ -445,6 +616,12 @@ export function formatRuntimeHealthCheckResult(
     lines.push("", result.detail);
   }
   return lines.join("\n").trim();
+}
+
+export function formatRuntimeHealthCheckResult(
+  result: RuntimeReadinessResult
+): string {
+  return formatRuntimeReadinessResult(result);
 }
 
 export async function runRuntimeBootstrapPreflight(): Promise<RuntimePreflight> {
@@ -511,17 +688,21 @@ export async function runComposeUp(): Promise<BootstrapStepResult> {
   }
 }
 
-export async function runRuntimeHealthCheck(): Promise<RuntimeHealthCheckResult> {
+export async function runRuntimeReadinessCheck(): Promise<RuntimeReadinessResult> {
   try {
     const payload = await invokeTauriCommand<unknown>(
-      "desktop_runtime_health_check"
+      "desktop_runtime_readiness_check"
     );
-    return normalizeRuntimeHealthCheck(payload);
+    return normalizeRuntimeReadiness(payload);
   } catch (error) {
     return {
       ok: false,
       ready: false,
       step: "health-check",
+      backendReachable: false,
+      startupReady: false,
+      redisReady: false,
+      chatReady: false,
       checks: [],
       detail:
         error instanceof Error
@@ -534,7 +715,7 @@ export async function runRuntimeHealthCheck(): Promise<RuntimeHealthCheckResult>
 type RuntimeReadinessWaitOptions = {
   timeoutMs?: number;
   intervalMs?: number;
-  onPoll?: (result: RuntimeHealthCheckResult, attempt: number) => void;
+  onPoll?: (result: RuntimeReadinessResult, attempt: number) => void;
 };
 
 function sleep(ms: number): Promise<void> {
@@ -548,13 +729,13 @@ export async function waitForRuntimeReady(
   const intervalMs = Math.max(500, options.intervalMs ?? 1_500);
   const startedAt = Date.now();
   let attempts = 0;
-  let lastCheck = await runRuntimeHealthCheck();
+  let lastCheck = await runRuntimeReadinessCheck();
   attempts += 1;
   options.onPoll?.(lastCheck, attempts);
 
   while (!lastCheck.ready && Date.now() - startedAt < timeoutMs) {
     await sleep(intervalMs);
-    lastCheck = await runRuntimeHealthCheck();
+    lastCheck = await runRuntimeReadinessCheck();
     attempts += 1;
     options.onPoll?.(lastCheck, attempts);
   }
@@ -565,6 +746,10 @@ export async function waitForRuntimeReady(
     elapsedMs: Date.now() - startedAt,
     lastCheck,
   };
+}
+
+export async function runRuntimeHealthCheck(): Promise<RuntimeReadinessResult> {
+  return runRuntimeReadinessCheck();
 }
 
 export function hasDismissedWelcomeScreen(): boolean {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use serde_json::Value;
 use std::collections::HashSet;
 use std::env;
 use std::fs;
@@ -73,15 +74,25 @@ pub struct HealthEndpointCheck {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RuntimeHealthCheckResult {
+pub struct RuntimeReadiness {
     pub ok: bool,
     pub step: String,
     pub ready: bool,
+    pub backend_reachable: bool,
+    pub startup_ready: bool,
+    pub redis_ready: bool,
+    pub chat_ready: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llm_ready: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
     pub checks: Vec<HealthEndpointCheck>,
 }
+
+#[allow(dead_code)]
+pub type RuntimeHealthCheckResult = RuntimeReadiness;
 
 #[derive(Debug, Clone, Copy)]
 enum FailureKind {
@@ -591,17 +602,17 @@ fn truncate_chars(value: &str, max_chars: usize) -> String {
     value.chars().take(max_chars).collect::<String>()
 }
 
-fn probe_http_endpoint(url: &str, allow_client_errors: bool) -> HealthEndpointCheck {
+struct HttpResponseProbe {
+    status_line: String,
+    status_code: Option<u16>,
+    body: String,
+}
+
+fn fetch_http_response(url: &str) -> Result<HttpResponseProbe, String> {
     let parsed = match parse_http_url(url) {
         Ok(parsed) => parsed,
         Err(detail) => {
-            return HealthEndpointCheck {
-                endpoint: url.to_string(),
-                ok: false,
-                status_code: None,
-                detail: Some(detail),
-                response_excerpt: None,
-            }
+            return Err(detail);
         }
     };
 
@@ -610,23 +621,11 @@ fn probe_http_endpoint(url: &str, allow_client_errors: bool) -> HealthEndpointCh
         Ok(mut addrs) => match addrs.next() {
             Some(addr) => addr,
             None => {
-                return HealthEndpointCheck {
-                    endpoint: url.to_string(),
-                    ok: false,
-                    status_code: None,
-                    detail: Some(format!("No socket addresses resolved for {address}")),
-                    response_excerpt: None,
-                }
+                return Err(format!("No socket addresses resolved for {address}"));
             }
         },
         Err(err) => {
-            return HealthEndpointCheck {
-                endpoint: url.to_string(),
-                ok: false,
-                status_code: None,
-                detail: Some(format!("Failed to resolve {address}: {err}")),
-                response_excerpt: None,
-            }
+            return Err(format!("Failed to resolve {address}: {err}"));
         }
     };
 
@@ -634,13 +633,7 @@ fn probe_http_endpoint(url: &str, allow_client_errors: bool) -> HealthEndpointCh
     let mut stream = match TcpStream::connect_timeout(&socket_addr, timeout) {
         Ok(stream) => stream,
         Err(err) => {
-            return HealthEndpointCheck {
-                endpoint: url.to_string(),
-                ok: false,
-                status_code: None,
-                detail: Some(format!("TCP connect failed: {err}")),
-                response_excerpt: None,
-            }
+            return Err(format!("TCP connect failed: {err}"));
         }
     };
 
@@ -653,24 +646,12 @@ fn probe_http_endpoint(url: &str, allow_client_errors: bool) -> HealthEndpointCh
     );
 
     if let Err(err) = stream.write_all(request.as_bytes()) {
-        return HealthEndpointCheck {
-            endpoint: url.to_string(),
-            ok: false,
-            status_code: None,
-            detail: Some(format!("Failed to write request: {err}")),
-            response_excerpt: None,
-        };
+        return Err(format!("Failed to write request: {err}"));
     }
 
     let mut response = String::new();
     if let Err(err) = stream.read_to_string(&mut response) {
-        return HealthEndpointCheck {
-            endpoint: url.to_string(),
-            ok: false,
-            status_code: None,
-            detail: Some(format!("Failed to read response: {err}")),
-            response_excerpt: None,
-        };
+        return Err(format!("Failed to read response: {err}"));
     }
 
     let mut lines = response.lines();
@@ -685,29 +666,140 @@ fn probe_http_endpoint(url: &str, allow_client_errors: bool) -> HealthEndpointCh
         .unwrap_or_default()
         .trim()
         .to_string();
-    let response_excerpt = if body.is_empty() {
-        None
-    } else {
-        Some(truncate_chars(&body, 240))
-    };
 
-    let ok = match status_code {
-        Some(code) if allow_client_errors => (200..500).contains(&code),
-        Some(code) => (200..300).contains(&code),
-        None => false,
-    };
-    let detail = if status_line.is_empty() {
-        Some("Missing HTTP status line in response.".to_string())
-    } else {
-        Some(status_line)
-    };
-
-    HealthEndpointCheck {
-        endpoint: url.to_string(),
-        ok,
+    Ok(HttpResponseProbe {
+        status_line,
         status_code,
-        detail,
-        response_excerpt,
+        body,
+    })
+}
+
+#[allow(dead_code)]
+fn probe_http_endpoint(url: &str, allow_client_errors: bool) -> HealthEndpointCheck {
+    match fetch_http_response(url) {
+        Ok(response) => {
+            let response_excerpt = if response.body.is_empty() {
+                None
+            } else {
+                Some(truncate_chars(&response.body, 240))
+            };
+
+            let ok = match response.status_code {
+                Some(code) if allow_client_errors => (200..500).contains(&code),
+                Some(code) => (200..300).contains(&code),
+                None => false,
+            };
+            let detail = if response.status_line.is_empty() {
+                Some("Missing HTTP status line in response.".to_string())
+            } else {
+                Some(response.status_line)
+            };
+
+            HealthEndpointCheck {
+                endpoint: url.to_string(),
+                ok,
+                status_code: response.status_code,
+                detail,
+                response_excerpt,
+            }
+        }
+        Err(detail) => HealthEndpointCheck {
+            endpoint: url.to_string(),
+            ok: false,
+            status_code: None,
+            detail: Some(detail),
+            response_excerpt: None,
+        },
+    }
+}
+
+fn parse_json_body(body: &str) -> Option<Value> {
+    serde_json::from_str(body).ok()
+}
+
+fn json_bool_field(value: &Value, key: &str) -> Option<bool> {
+    value.get(key).and_then(|entry| entry.as_bool())
+}
+
+fn json_string_field(value: &Value, key: &str) -> Option<String> {
+    value.get(key).and_then(|entry| entry.as_str()).and_then(|text| {
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+fn json_status_matches(value: &Value, expected: &str) -> bool {
+    json_string_field(value, "status")
+        .map(|status| status.eq_ignore_ascii_case(expected))
+        .unwrap_or(false)
+}
+
+fn bool_label(value: bool) -> &'static str {
+    if value {
+        "true"
+    } else {
+        "false"
+    }
+}
+
+fn option_bool_label(value: Option<bool>) -> String {
+    match value {
+        Some(true) => "true".to_string(),
+        Some(false) => "false".to_string(),
+        None => "not-gated".to_string(),
+    }
+}
+
+fn probe_http_endpoint_with_body(
+    url: &str,
+    allow_client_errors: bool,
+) -> (HealthEndpointCheck, Option<String>) {
+    match fetch_http_response(url) {
+        Ok(response) => {
+            let body = if response.body.is_empty() {
+                None
+            } else {
+                Some(response.body.clone())
+            };
+            let response_excerpt = body
+                .as_deref()
+                .map(|body| truncate_chars(body, 240));
+            let ok = match response.status_code {
+                Some(code) if allow_client_errors => (200..500).contains(&code),
+                Some(code) => (200..300).contains(&code),
+                None => false,
+            };
+            let detail = if response.status_line.is_empty() {
+                Some("Missing HTTP status line in response.".to_string())
+            } else {
+                Some(response.status_line)
+            };
+
+            (
+                HealthEndpointCheck {
+                    endpoint: url.to_string(),
+                    ok,
+                    status_code: response.status_code,
+                    detail,
+                    response_excerpt,
+                },
+                body,
+            )
+        }
+        Err(detail) => (
+            HealthEndpointCheck {
+                endpoint: url.to_string(),
+                ok: false,
+                status_code: None,
+                detail: Some(detail),
+                response_excerpt: None,
+            },
+            None,
+        ),
     }
 }
 
@@ -1132,8 +1224,7 @@ pub fn desktop_compose_up() -> BootstrapStepResult {
     }
 }
 
-#[tauri::command]
-pub fn desktop_runtime_health_check() -> RuntimeHealthCheckResult {
+fn runtime_readiness_snapshot() -> RuntimeReadiness {
     let backend_base_url = trim_trailing_slash(&env_first(
         &[
             "CODEXIFY_DESKTOP_BACKEND_URL",
@@ -1143,23 +1234,92 @@ pub fn desktop_runtime_health_check() -> RuntimeHealthCheckResult {
         "http://127.0.0.1:8888",
     ));
     let ping_url = combine_url(&backend_base_url, "/ping");
-    let llm_health_url = combine_url(&backend_base_url, "/api/health/llm");
+    let health_url = combine_url(&backend_base_url, "/health");
+    let chat_health_url = combine_url(&backend_base_url, "/health/chat");
+    let llm_health_url = combine_url(&backend_base_url, "/health/llm");
 
-    let checks = vec![
-        probe_http_endpoint(&ping_url, false),
-        probe_http_endpoint(&llm_health_url, true),
-    ];
-    let ready = checks.iter().all(|check| check.ok);
+    let (ping_check, _ping_body) = probe_http_endpoint_with_body(&ping_url, false);
+    let (health_check, health_body) =
+        probe_http_endpoint_with_body(&health_url, false);
+    let (chat_check, chat_body) =
+        probe_http_endpoint_with_body(&chat_health_url, false);
+    let (llm_check, llm_body) =
+        probe_http_endpoint_with_body(&llm_health_url, false);
+
+    let health_json = health_body.as_deref().and_then(parse_json_body);
+    let chat_json = chat_body.as_deref().and_then(parse_json_body);
+    let llm_json = llm_body.as_deref().and_then(parse_json_body);
+
+    let backend_reachable = ping_check.ok;
+    let startup_ready = health_check.ok
+        && health_json
+            .as_ref()
+            .map(|value| json_status_matches(value, "ok"))
+            .unwrap_or(false);
+
+    let chat_completion_service = chat_json
+        .as_ref()
+        .and_then(|value| value.get("completion_service"));
+    let redis_ready = chat_completion_service
+        .and_then(|value| json_bool_field(value, "redis_reachable"))
+        .unwrap_or(false);
+    let chat_ready = chat_completion_service
+        .and_then(|value| json_bool_field(value, "ok"))
+        .unwrap_or(false);
+    let chat_status_reason = chat_completion_service
+        .and_then(|value| json_string_field(value, "status_reason"))
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let llm_provider = llm_json
+        .as_ref()
+        .and_then(|value| json_string_field(value, "provider"));
+    let llm_status = llm_json
+        .as_ref()
+        .and_then(|value| json_string_field(value, "status"))
+        .unwrap_or_else(|| "unknown".to_string());
+    let llm_ready = match llm_provider.as_deref() {
+        Some(provider) if provider.eq_ignore_ascii_case("local") => Some(
+            llm_check.ok
+                && llm_json
+                    .as_ref()
+                    .map(|value| json_status_matches(value, "online"))
+                    .unwrap_or(false),
+        ),
+        Some(_) => None,
+        None => Some(false),
+    };
+
+    let ready =
+        backend_reachable && startup_ready && redis_ready && chat_ready && llm_ready.unwrap_or(true);
+
     let detail = {
-        let mut lines = vec![format!("backendBaseUrl={backend_base_url}")];
-        for check in &checks {
+        let mut lines = vec![
+            format!("backendBaseUrl={backend_base_url}"),
+            format!("backendReachable={}", bool_label(backend_reachable)),
+            format!("startupReady={}", bool_label(startup_ready)),
+            format!("redisReady={}", bool_label(redis_ready)),
+            format!("chatReady={}", bool_label(chat_ready)),
+            format!("chatStatusReason={chat_status_reason}"),
+            format!(
+                "llmProvider={}",
+                llm_provider.as_deref().unwrap_or("unknown")
+            ),
+            format!("llmStatus={llm_status}"),
+            format!("llmReady={}", option_bool_label(llm_ready)),
+            format!("ready={}", bool_label(ready)),
+        ];
+
+        let checks = [&ping_check, &health_check, &chat_check, &llm_check];
+        for check in checks {
             let status_fragment = check
                 .status_code
                 .map(|code| format!(" statusCode={code}"))
                 .unwrap_or_default();
             lines.push(format!(
                 "{} -> ok={}{}",
-                check.endpoint, check.ok, status_fragment
+                check.endpoint,
+                bool_label(check.ok),
+                status_fragment
             ));
             if let Some(detail) = &check.detail {
                 lines.push(detail.clone());
@@ -1169,6 +1329,7 @@ pub fn desktop_runtime_health_check() -> RuntimeHealthCheckResult {
             }
             lines.push(String::new());
         }
+
         let rendered = join_lines(lines);
         if rendered.trim().is_empty() {
             None
@@ -1177,12 +1338,29 @@ pub fn desktop_runtime_health_check() -> RuntimeHealthCheckResult {
         }
     };
 
-    RuntimeHealthCheckResult {
+    RuntimeReadiness {
         ok: ready,
         step: "health-check".to_string(),
         ready,
+        backend_reachable,
+        startup_ready,
+        redis_ready,
+        chat_ready,
+        llm_ready,
         detail,
-        command: Some(format!("GET {ping_url}; GET {llm_health_url}")),
-        checks,
+        command: Some(format!(
+            "GET {ping_url}; GET {health_url}; GET {chat_health_url}; GET {llm_health_url}"
+        )),
+        checks: vec![ping_check, health_check, chat_check, llm_check],
     }
+}
+
+#[tauri::command]
+pub fn desktop_runtime_readiness_check() -> RuntimeReadiness {
+    runtime_readiness_snapshot()
+}
+
+#[tauri::command]
+pub fn desktop_runtime_health_check() -> RuntimeReadiness {
+    runtime_readiness_snapshot()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ pub fn run() {
             commands::desktop_runtime_preflight_check,
             commands::desktop_run_setup_cli,
             commands::desktop_compose_up,
+            commands::desktop_runtime_readiness_check,
             commands::desktop_runtime_health_check
         ])
         .run(tauri::generate_context!())


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
