### PR TITLE
Add audit remediation targets document for durability and tool execution gaps

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,7 @@
 # Security Policy
+> Historical archive notice
+> This document is preserved as historical or conceptual lineage and is not a canonical source for current Codexify runtime behavior.
+> For current architecture and diagram source selection, use `/docs/architecture/kb-validity-matrix.md`, `/docs/architecture/README.md`, and `/docs/architecture/00-current-state.md`.
 
 ## Security Overview
 

--- a/docs/Codexify/INSTALLER.md
+++ b/docs/Codexify/INSTALLER.md
@@ -1,4 +1,7 @@
 # Bundled Installer
+> Legacy notice
+> This document is retained for historical context and does not describe Codexify's current runtime architecture, supported install path, or present product identity.
+> Before using any documentation for architecture or diagram work, read `/docs/architecture/kb-validity-matrix.md`. For current runtime truth, start with `/docs/architecture/README.md` and `/docs/architecture/00-current-state.md`.
 
 This project can be distributed as a single installer bundling Codexify and required Ollama models.
 

--- a/docs/Codexify/README.md
+++ b/docs/Codexify/README.md
@@ -1,4 +1,7 @@
 cd # 🧠 guardian-backend_v2
+> Legacy notice
+> This document is retained for historical context and does not describe Codexify's current runtime architecture, supported install path, or present product identity.
+> Before using any documentation for architecture or diagram work, read `/docs/architecture/kb-validity-matrix.md`. For current runtime truth, start with `/docs/architecture/README.md` and `/docs/architecture/00-current-state.md`.
 
 
      💠Codexify💠

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -39,7 +39,7 @@ Before generating architecture diagrams, read the [`KB Validity Matrix`](./kb-va
 - [Data and Storage](./data-and-storage.md): storage systems, key tables, invariants, and data risk hotspots.
 - [Config and Ops](./config-and-ops.md): env vars, config resolution, supported run paths, health checks, logging, and debugging cues.
 - [Modules and Ownership](./modules-and-ownership.md): subsystem map, dependency edges, and blast radius guidance.
-- [Runtime Diagrams v1](./runtime-diagrams-v1.md): first-pass current runtime diagram pack derived only from the validated runtime source set.
+- [Runtime Diagrams v1](./runtime-diagrams-v1.md): first-pass current runtime diagram pack with source-scoped evidence notes and confidence labels.
 - [Roadmap Signals](./roadmap-signals.md): planning guidance derived from the current codebase; not a first-pass runtime diagram source.
 - [Tech Debt and Risks](./tech-debt-and-risks.md): evidence-backed current risk register; use for risk overlays, not baseline topology.
 - [Completion Pipeline](./completion_pipeline.md): older completion deep dive; supplementary only and verify against current routes/workers.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,5 +1,5 @@
 Purpose: Provide a KB-first entry point into Codexify's current architecture so humans and AI can orient quickly, find the right source files, and plan changes with an accurate map.
-Last updated: 2026-03-11
+Last updated: 2026-03-19
 Source anchors:
 - docs/architecture/
 - guardian/guardian_api.py
@@ -22,19 +22,29 @@ Codexify is a local-first chat and knowledge workspace built around a FastAPI ba
 
 When you need current-state interpretation instead of structural architecture, begin with [`00-current-state.md`](./00-current-state.md). It is the live operational truth layer for release readiness, supported install path, active blockers, and short-horizon priorities.
 
+## KB Validity and Diagram Source Sets
+
+Before generating architecture diagrams, read the [`KB Validity Matrix`](./kb-validity-matrix.md).
+
+- Use the validity matrix before using docs as diagram inputs.
+- For first-pass runtime architecture diagrams, use only `Runtime Diagram Source Set v1`.
+- Treat [`00-current-state.md`](./00-current-state.md) as the short-horizon override when older or broader docs conflict with present release reality.
+- Do not use quarantined legacy docs as source inputs, especially Threadspace / `guardian-backend_v2` / obsolete installer-era material.
+
 ## Doc Map
 
 - [`00-current-state.md`](./00-current-state.md): live operational truth, current release/readiness interpretation, and short-horizon priorities.
-- [System Overview](./system-overview.md): runtime components, topology, and critical paths.
-- [Critical Flows](./flows.md): step-by-step operational flows with Mermaid diagrams and failure modes.
+- [System Overview](./system-overview.md): current runtime components, topology, and critical paths.
+- [Critical Flows](./flows.md): current trigger-to-output runtime flows with failure modes.
 - [Data and Storage](./data-and-storage.md): storage systems, key tables, invariants, and data risk hotspots.
-- [Config and Ops](./config-and-ops.md): env vars, config resolution, run commands, health checks, logging, and debugging cues.
+- [Config and Ops](./config-and-ops.md): env vars, config resolution, supported run paths, health checks, logging, and debugging cues.
 - [Modules and Ownership](./modules-and-ownership.md): subsystem map, dependency edges, and blast radius guidance.
-- [Roadmap Signals](./roadmap-signals.md): derived planning constraints, refactor leverage points, and sequencing suggestions.
-- [Tech Debt and Risks](./tech-debt-and-risks.md): evidence-backed risk register.
-- [Completion Pipeline](./completion_pipeline.md): older deep dive on completion internals; treat as supplementary and verify against current routes/workers.
-- [Inference Providers](./providers.md): provider notes; verify against current catalog/router behavior before relying on it.
-- [Guardian Agent Delegation Recon](./guardian-agent-delegation-recon.md): focused notes on delegation and agent runtime work.
+- [Runtime Diagrams v1](./runtime-diagrams-v1.md): first-pass current runtime diagram pack derived only from the validated runtime source set.
+- [Roadmap Signals](./roadmap-signals.md): planning guidance derived from the current codebase; not a first-pass runtime diagram source.
+- [Tech Debt and Risks](./tech-debt-and-risks.md): evidence-backed current risk register; use for risk overlays, not baseline topology.
+- [Completion Pipeline](./completion_pipeline.md): older completion deep dive; supplementary only and verify against current routes/workers.
+- [Inference Providers](./providers.md): provider notes; supplementary only and verify against current catalog/router/health behavior.
+- [Guardian Agent Delegation Recon](./guardian-agent-delegation-recon.md): focused planning/recon notes on delegation and agent runtime work.
 - [Solo Operator Runtime Bootcamp](./solo-operator-runtime-bootcamp.md): operational bootstrapping guide for solo runtime work.
 
 ## Where Do I Change X?

--- a/docs/architecture/kb-validity-matrix.md
+++ b/docs/architecture/kb-validity-matrix.md
@@ -1,0 +1,104 @@
+# KB Validity Matrix
+
+## Purpose
+
+- This file classifies the Codexify documentation corpus before architecture diagram generation.
+- It separates current runtime truth from design canon, roadmap/speculation, and legacy identity drift.
+
+## Interpretation Rules
+
+- For short-horizon operational truth, `00-current-state.md` wins.
+- For current runtime topology, prefer the architecture KB set updated in March 2026.
+- Older deep dives may be referenced only when explicitly marked supplementary.
+- Legacy Threadspace / `guardian-backend_v2` documents are not valid runtime diagram inputs.
+
+## Classification Legend
+
+- `authoritative_now`: current runtime or KB routing truth for March 2026; safe to treat as present-state evidence within the file's stated scope.
+- `supplementary_verify_against_code`: useful context, but verify against current code and the March 2026 KB set before using it.
+- `design_canon_not_runtime_truth`: valid for UI or conceptual diagrams, not for first-pass current runtime topology.
+- `historical_archive`: retained for history only; do not use as a first-pass architecture diagram source.
+- `misleading_identity_drift`: legacy material likely to confuse current product identity, supported install path, or present runtime behavior; quarantine it from first-pass diagramming.
+
+## Audit Matrix
+
+Audit notes:
+
+- Actual repo paths are listed below when the requested shorthand path points to a file stored elsewhere in this repo.
+- Not present at audit time: `/docs/architecture/RELEASE.md`, `/Thread-Artifact-Lineage.md`.
+
+| path | domain | status | safe_for_runtime_diagrams | safe_for_ui_diagrams | reason | recommended_action |
+|---|---|---|---|---|---|---|
+| `/docs/architecture/00-current-state.md` | release / operational truth | `authoritative_now` | yes | no | Explicitly declares itself the canonical short-form source of truth for release readiness, supported install path, and active blockers. | Read first and let it override older or broader docs on short-horizon reality. |
+| `/docs/architecture/README.md` | KB routing | `authoritative_now` | yes | no | Current KB entrypoint updated in March 2026 and aligned to the current architecture set. | Use as the routing layer after reading this matrix. |
+| `/docs/architecture/system-overview.md` | runtime topology | `authoritative_now` | yes | no | Explicitly frames itself as current runtime architecture and topology, with March 2026 source anchors. | Use as the base node-and-boundary source for runtime diagrams. |
+| `/docs/architecture/flows.md` | runtime flows | `authoritative_now` | yes | no | Documents implemented trigger-to-output flows with concrete route, worker, and queue anchors. | Use for sequence and flow diagrams after `system-overview.md`. |
+| `/docs/architecture/data-and-storage.md` | persistence and invariants | `authoritative_now` | yes | no | Maps current storage systems, entities, and invariants used by the runtime. | Use for data-store, entity, and persistence-boundary diagrams. |
+| `/docs/architecture/config-and-ops.md` | runtime config and operator truth | `authoritative_now` | yes | no | Updated March 2026 and scoped to current config precedence, health surfaces, worker dependencies, and supported run paths. | Use to constrain deployment/runtime diagrams to supported paths. |
+| `/docs/architecture/modules-and-ownership.md` | subsystem map | `authoritative_now` | yes | no | Describes current subsystem seams and dependency edges with explicit code anchors. | Use for component maps and ownership overlays. |
+| `/docs/architecture/roadmap-signals.md` | planning guidance | `supplementary_verify_against_code` | no | no | The file explicitly surfaces planning signals, refactor leverage, and sequencing suggestions rather than present-state topology. | Use only for future-state annotations after the current runtime diagram is complete. |
+| `/docs/architecture/tech-debt-and-risks.md` | current risk register | `authoritative_now` | no | no | March 2026 evidence-backed risk register is current, but it is not a topology source. | Use after baseline diagramming to annotate risk hotspots or release caveats. |
+| `/docs/architecture/completion_pipeline.md` | older completion deep dive | `supplementary_verify_against_code` | no | no | Useful runtime detail, but it is an older deep dive and the KB entrypoint already warns to verify it against current routes/workers. | Use only as a secondary detail source after `flows.md` and code verification. |
+| `/docs/architecture/providers.md` | provider notes | `supplementary_verify_against_code` | no | no | Provider behavior can drift from catalog/router/runtime truth; this file is narrower than the March 2026 operator docs. | Verify against current provider registry, catalog, health, and code before using it. |
+| `/docs/architecture/guardian-agent-delegation-recon.md` | delegation planning recon | `supplementary_verify_against_code` | no | no | Explicit planning/recon document mixing `Verified`, `Inference`, and missing-doc notes rather than canonical runtime topology. | Use only for future delegation planning, not first-pass runtime diagramming. |
+| `/docs/architecture/solo-operator-runtime-bootcamp.md` | operational runbook | `supplementary_verify_against_code` | no | no | Practical operator training guide, not a runtime architecture source. | Use for operator onboarding only. |
+| `/docs/dev/ARTIFACT1—UI-Token-Constitution.md` | UI token canon | `design_canon_not_runtime_truth` | no | yes | Canonical token law for visual language and component styling, not backend/runtime topology. | Use for UI styling diagrams only. |
+| `/docs/dev/ARTIFACT1B—CODEXIFY-STRUCTURAL-LAYOUT-SPECIFICATION.md` | UI layout canon | `design_canon_not_runtime_truth` | no | yes | Canonical layout skeleton for screens and containers, not implemented backend topology. | Use for page/layout diagrams only. |
+| `/docs/dev/ARTIFACT3—Codexify-UI-Rendering-Protocol.md` | UI rendering canon | `design_canon_not_runtime_truth` | no | yes | Canonical rendering rules for tokens and components; not a runtime systems map. | Use for UI component/rendering diagrams only. |
+| `/docs/dev/ARTIFACT4—COGNITIVE-DIAGNOSTICS-CANON.md` | diagnostics UI canon | `design_canon_not_runtime_truth` | no | yes | Canonical placement and behavior rules for diagnostics surfaces; not runtime topology truth. | Use for diagnostics UI diagrams only. |
+| `/docs/dev/ARTIFACT7--CODEXIFY-PERCEPTUAL-STACK-SPEC.md` | perceptual/cognitive canon | `design_canon_not_runtime_truth` | no | yes | Canonical conceptual stack for perception and diagnostics; useful for conceptual or UI-adjacent diagrams, not current runtime topology. | Use only for conceptual or UI-facing cognitive diagrams. |
+| `/docs/Codexify/Codexify-System-Specification.md` | extracted system spec | `design_canon_not_runtime_truth` | no | no | 2025 extracted spec mixes implemented and aspirational capabilities, providers, and modules. | Use only for explicitly labeled conceptual or future-state diagrams, never as runtime truth. |
+| `/docs/Future-Features/federation_manifest.md` | federation concept | `design_canon_not_runtime_truth` | no | no | Future-facing node architecture and sync design, not part of the current release promise. | Use only for conceptual federation diagrams after the current runtime baseline is drawn. |
+| `/docs/Future-Features/Event_Graph.md` | event-graph concept | `design_canon_not_runtime_truth` | no | no | Conceptual spec for a future event graph and agent playbook system. | Use only for future-state conceptual diagrams. |
+| `/docs/Future-Features/federated_diff_sync.md` | distributed sync concept | `design_canon_not_runtime_truth` | no | no | Future-facing CRDT-inspired diff sync design, not current implemented topology. | Use only for future sync design work. |
+| `/docs/infra/persona_system_architecture.md` | legacy persona architecture | `historical_archive` | no | no | Mermaid architecture references older Rust/Tauri persona flows and does not define the March 2026 runtime. | Retain for history only; do not use for first-pass diagrams. |
+| `/docs/infra/system_architecture.md` | legacy system overview | `misleading_identity_drift` | no | no | Presents GuardianOS, thread manager, plugin system, and agent topology as if current; conflicts with the March 2026 KB. | Quarantine from diagram generation. |
+| `/docs/infra/context-report.md` | generated 2025 snapshot | `historical_archive` | no | no | Dated context dump with mixed legacy paths and tool output, not a maintained KB source. | Use only as historical audit evidence. |
+| `/docs/infra/sync-contract.md` | extracted sync contract | `design_canon_not_runtime_truth` | no | no | Minimal contract note is insufficient to stand in for the current runtime sync implementation. | Use only when drafting future sync protocol docs. |
+| `/docs/guardian/iddb_policy_v1.md` | identity data policy | `design_canon_not_runtime_truth` | no | no | Policy/design contract for identity handling, not a description of current runtime topology. | Use only for conceptual identity/privacy diagrams or policy discussions. |
+| `/docs/infra/system_integrity_ledger.md` | historical audit ledger | `historical_archive` | no | no | Dated integrity ledger and action items are historical and not maintained as runtime truth. | Retain only as historical context. |
+| `/SECURITY.md` | current security posture overview | `supplementary_verify_against_code` | no | no | Useful current security narrative, but it includes planned enhancements and is not a topology source. | Use only for security overlays after code and KB verification. |
+| `/docs/Codexify/SECURITY.md` | legacy security policy | `historical_archive` | no | no | External program/version policy doc is not tied to the March 2026 runtime KB. | Do not use for architecture diagram generation. |
+| `/docs/Codexify/INSTALLER.md` | legacy install/distribution path | `misleading_identity_drift` | no | no | Describes bundled installer and wheel/Ollama packaging that conflicts with the current supported Docker Compose install path. | Quarantine from current runtime/source-set work. |
+| `/docs/infra/INTERNAL_DOCS.md` | legacy internal architecture | `misleading_identity_drift` | no | no | Presents GuardianOS, plugin-system, and meta-cognition topology that conflicts with the March 2026 runtime docs. | Quarantine from first-pass diagramming. |
+| `/README.md` | repo entrypoint | `supplementary_verify_against_code` | no | no | Useful current onboarding overview, but the March 2026 architecture KB is the more precise diagram source set. | Use for repo orientation only; defer diagram work to the KB matrix and runtime source set. |
+| `/docs/Codexify/README.md` | legacy README | `misleading_identity_drift` | no | no | Starts with `guardian-backend_v2` and describes an obsolete GuardianOS-style architecture and install path. | Quarantine from first-pass diagramming. |
+
+## Required Judgments
+
+- The March 2026 architecture KB set is treated as `authoritative_now`, except where the file explicitly frames itself as planning-only. In this audit, that exception is `/docs/architecture/roadmap-signals.md`.
+- `/docs/architecture/completion_pipeline.md` and `/docs/architecture/providers.md` are `supplementary_verify_against_code`.
+- The UI token, layout, rendering, diagnostics, and perceptual canons under `/docs/dev/ARTIFACT*.md` are `design_canon_not_runtime_truth`. They can inform UI diagrams, but they must not be treated as current backend/runtime topology without verification.
+- Docs that still present `Threadspace`, `guardian-backend_v2`, GuardianOS/plugin-system topology, or obsolete packaged-installer assumptions are classified as `historical_archive` or `misleading_identity_drift` based on how likely they are to confuse present product identity, supported install path, or current runtime behavior.
+- `misleading_identity_drift` is used when a file could actively confuse current product identity, supported install path, or present runtime behavior. `historical_archive` is used when a file is primarily dated context rather than an active identity hazard.
+
+## Diagram Source Sets
+
+### Runtime Diagram Source Set v1
+
+- `/docs/architecture/00-current-state.md`
+- `/docs/architecture/README.md`
+- `/docs/architecture/system-overview.md`
+- `/docs/architecture/flows.md`
+- `/docs/architecture/data-and-storage.md`
+- `/docs/architecture/config-and-ops.md`
+- `/docs/architecture/modules-and-ownership.md`
+
+### UI Diagram Source Set v1
+
+- `/docs/dev/ARTIFACT1—UI-Token-Constitution.md`
+- `/docs/dev/ARTIFACT1B—CODEXIFY-STRUCTURAL-LAYOUT-SPECIFICATION.md`
+- `/docs/dev/ARTIFACT3—Codexify-UI-Rendering-Protocol.md`
+- `/docs/dev/ARTIFACT4—COGNITIVE-DIAGNOSTICS-CANON.md`
+- `/docs/dev/ARTIFACT7--CODEXIFY-PERCEPTUAL-STACK-SPEC.md`
+
+### Quarantined From First-Pass Diagramming
+
+- `/docs/Codexify/README.md`
+- `/docs/Codexify/INSTALLER.md`
+- `/docs/infra/INTERNAL_DOCS.md`
+- `/docs/infra/system_architecture.md`
+- `/docs/infra/persona_system_architecture.md`
+- `/docs/Codexify/SECURITY.md`
+- `/docs/infra/context-report.md`
+- `/docs/infra/system_integrity_ledger.md`

--- a/docs/architecture/runtime-diagrams-v1.md
+++ b/docs/architecture/runtime-diagrams-v1.md
@@ -21,7 +21,15 @@ This document is the first-pass runtime diagram pack derived only from the valid
 - Optional or not-currently-active systems are labeled explicitly.
 - Quarantined legacy docs were not used.
 
-## Diagram 1: Runtime Topology Overview
+## Diagram legend
+
+- `durable`: persisted state or system-of-record surfaces that the validated runtime docs treat as restart-stable.
+- `operational / ephemeral`: queues, locks, event transport, or process-local state that keep the runtime moving but are not primary durable truth.
+- `optional`: present in current runtime docs but not required for the baseline supported path.
+- `feature-flagged`: available only when explicit runtime flags or policy enable it.
+- `release-bounded exclusion`: intentionally omitted from v1 because the validated runtime docs do not treat it as part of the present release promise.
+
+## Diagram 1: Runtime Topology Overview (high confidence)
 
 ```mermaid
 flowchart LR
@@ -29,7 +37,7 @@ flowchart LR
 
     subgraph clients["Client Boundary"]
         browser["Browser"]
-        tauri["Tauri desktop shell (optional)"]
+        tauri["Tauri desktop shell<br/>(optional client shell)"]
         frontend["React frontend"]
         client_state["Local/session storage"]
     end
@@ -40,7 +48,7 @@ flowchart LR
         workers["Worker layer<br/>chat, chat-embed, document-embed, warmup, cron"]
         context["Context + retrieval orchestration"]
         ingestion["Media + document ingestion"]
-        command["Command bus + legacy tools shim"]
+        command["Command bus + legacy tools shim<br/>(beta / internal-only surfaces)"]
     end
 
     subgraph durable["Durable stores"]
@@ -54,7 +62,7 @@ flowchart LR
     end
 
     subgraph optional["Optional / feature-flagged"]
-        neo4j["Neo4j<br/>optional graph context and logging"]
+        neo4j["Neo4j<br/>optional / feature-flagged graph context<br/>(not part of baseline release path)"]
     end
 
     subgraph model_boundary["Model execution boundary"]
@@ -92,7 +100,13 @@ flowchart LR
 
 Supported runtime topology is the local Docker Compose stack. Non-Compose deployment remains unverified in the validated source set.
 
-## Diagram 2: Chat Completion Sequence
+### Evidence notes
+
+- Primary sources: `/docs/architecture/00-current-state.md`, `/docs/architecture/system-overview.md`, `/docs/architecture/config-and-ops.md`
+- Conservative assumptions: worker types are collapsed into one worker layer, event surfaces are grouped into one runtime boundary, and provider execution is shown as one policy-shaped boundary rather than per-provider lanes.
+- Explicit exclusions: non-Compose deployment detail, one-shot bootstrap services, federation/sync surfaces, and provider inventory/governance nuance beyond the current execution boundary.
+
+## Diagram 2: Chat Completion Sequence (high confidence)
 
 ```mermaid
 sequenceDiagram
@@ -104,7 +118,7 @@ sequenceDiagram
     participant Ctx as Context broker
     participant PG as Postgres
     participant Vec as Vector store
-    participant Neo as Neo4j (optional)
+    participant Neo as Neo4j (optional / feature-flagged)
     participant LLM as Model provider
     participant Stream as Task event surface
 
@@ -132,12 +146,20 @@ sequenceDiagram
     API-->>FE: Updated thread/messages
 ```
 
-## Diagram 3: Data and Storage Boundaries
+This sequence keeps the baseline completion loop focused on the current enqueue -> worker -> retrieval -> persist -> task-event path documented in the validated runtime set.
+
+### Evidence notes
+
+- Primary sources: `/docs/architecture/flows.md`, `/docs/architecture/system-overview.md`, `/docs/architecture/00-current-state.md`
+- Conservative assumptions: the task-event surface is shown as one actor, context assembly is compressed to its stable data dependencies, and the user-message step is collapsed into the request lane so the completion path stays readable.
+- Explicit exclusions: provider catalog nuance, failure/retry branches, memory/sensor/federated context branches, and any future delegation or orchestration lanes.
+
+## Diagram 3: Data and Storage Boundaries (high confidence)
 
 ```mermaid
 flowchart TB
     subgraph runtime["Runtime surfaces"]
-        frontend["React frontend / Tauri shell"]
+        frontend["React frontend / optional Tauri client shell"]
         backend["FastAPI routes + workers"]
     end
 
@@ -157,7 +179,7 @@ flowchart TB
     end
 
     subgraph optional["Optional / feature-flagged"]
-        neo4j["Neo4j<br/>optional graph context and logging"]
+        neo4j["Neo4j<br/>optional / feature-flagged graph context<br/>(not part of baseline release path)"]
     end
 
     frontend <--> browser_state
@@ -172,7 +194,13 @@ flowchart TB
 
 This boundary map emphasizes durable state versus operational transport. Redis is operationally critical but not the system of record; Postgres remains the durable source of truth in the validated runtime set.
 
-## Diagram 4: Subsystem / Ownership Map
+### Evidence notes
+
+- Primary sources: `/docs/architecture/data-and-storage.md`, `/docs/architecture/system-overview.md`, `/docs/architecture/00-current-state.md`
+- Conservative assumptions: routes and workers share one runtime access node, vector storage is shown as one logical retrieval store, and file/object storage is grouped as one artifact boundary.
+- Explicit exclusions: entity-level schema detail, unverified retention/encryption claims, experimental sync durability, and backend-specific vector implementation detail.
+
+## Diagram 4: Subsystem / Ownership Map (moderate confidence)
 
 ```mermaid
 flowchart LR
@@ -226,6 +254,12 @@ flowchart LR
 
 This is a seam map, not a call graph. It groups subsystem boundaries and conservative dependency direction; it does not enumerate every route, file, or runtime edge.
 
+### Evidence notes
+
+- Primary sources: `/docs/architecture/modules-and-ownership.md`, `/docs/architecture/system-overview.md`, `/docs/architecture/README.md`
+- Conservative assumptions: subsystem clusters are grouped at seam level rather than file level, queue/workers/persistence are collapsed into one platform lane, and command bus plus legacy tools are shown together because the validated docs describe them as coexisting runtime surfaces.
+- Explicit exclusions: experimental federation/sync boundary detail, collaboration/websocket detail, formal team ownership labels, and file-level hotspot rendering.
+
 ## Omitted / intentionally excluded areas
 
 - Experimental federation and sync surfaces are not diagrammed in v1 because `00-current-state.md` says federation and sync durability are not part of the present release promise.
@@ -238,3 +272,7 @@ This is a seam map, not a call graph. It groups subsystem boundaries and conserv
 ## Diagram quality notes
 
 This is a first-pass runtime baseline intended to be refined after human review. Adjust edge granularity, labels, and scope only when the change can be justified from the validated runtime source set or freshly re-verified current runtime evidence.
+
+## Reviewer guidance
+
+This pack is intended as a baseline runtime map. Resolve disagreements by checking the validated runtime source set first. If a diagram edge cannot be justified from that source set, remove it or downgrade the diagram's confidence. Future diagram variants should branch from this baseline rather than bypassing it.

--- a/docs/architecture/runtime-diagrams-v1.md
+++ b/docs/architecture/runtime-diagrams-v1.md
@@ -1,0 +1,240 @@
+# Codexify Runtime Diagrams v1
+
+## Purpose
+
+This document is the first-pass runtime diagram pack derived only from the validated runtime KB source set. It is a baseline runtime view for peer review, not a final presentation artifact.
+
+## Source set used
+
+- `/docs/architecture/00-current-state.md`
+- `/docs/architecture/README.md`
+- `/docs/architecture/system-overview.md`
+- `/docs/architecture/flows.md`
+- `/docs/architecture/data-and-storage.md`
+- `/docs/architecture/config-and-ops.md`
+- `/docs/architecture/modules-and-ownership.md`
+
+## Interpretation constraints
+
+- `00-current-state.md` overrides broader docs on short-horizon release reality.
+- These diagrams reflect the current runtime baseline, not aspirational architecture.
+- Optional or not-currently-active systems are labeled explicitly.
+- Quarantined legacy docs were not used.
+
+## Diagram 1: Runtime Topology Overview
+
+```mermaid
+flowchart LR
+    user["User"]
+
+    subgraph clients["Client Boundary"]
+        browser["Browser"]
+        tauri["Tauri desktop shell (optional)"]
+        frontend["React frontend"]
+        client_state["Local/session storage"]
+    end
+
+    subgraph runtime["Supported local runtime (Docker Compose)"]
+        backend["FastAPI backend"]
+        event_surface["Event surfaces<br/>/api/events and /api/tasks/*/events"]
+        workers["Worker layer<br/>chat, chat-embed, document-embed, warmup, cron"]
+        context["Context + retrieval orchestration"]
+        ingestion["Media + document ingestion"]
+        command["Command bus + legacy tools shim"]
+    end
+
+    subgraph durable["Durable stores"]
+        postgres["Postgres<br/>system of record"]
+        vector["Vector store<br/>message and document embeddings"]
+        media_store["File/object storage<br/>media and generated artifacts"]
+    end
+
+    subgraph operational["Operational transport"]
+        redis["Redis<br/>queues, locks, task events, heartbeats"]
+    end
+
+    subgraph optional["Optional / feature-flagged"]
+        neo4j["Neo4j<br/>optional graph context and logging"]
+    end
+
+    subgraph model_boundary["Model execution boundary"]
+        provider["Local or cloud model provider<br/>selected by runtime config and policy"]
+    end
+
+    user --> browser
+    user --> tauri
+    browser --> frontend
+    tauri --> frontend
+    frontend <--> client_state
+    frontend --> backend
+    frontend --> event_surface
+    backend --> event_surface
+    postgres --> event_surface
+    redis --> event_surface
+    event_surface --> frontend
+    backend --> context
+    backend --> ingestion
+    backend --> command
+    backend <--> postgres
+    backend <--> redis
+    workers <--> redis
+    workers <--> postgres
+    workers --> context
+    workers --> vector
+    workers --> provider
+    context <--> postgres
+    context <--> vector
+    context -. feature-flagged .-> neo4j
+    ingestion --> media_store
+    ingestion --> postgres
+    ingestion --> redis
+```
+
+Supported runtime topology is the local Docker Compose stack. Non-Compose deployment remains unverified in the validated source set.
+
+## Diagram 2: Chat Completion Sequence
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant FE as React frontend
+    participant API as Chat API route
+    participant Redis as Redis queue/task transport
+    participant Worker as Chat worker
+    participant Ctx as Context broker
+    participant PG as Postgres
+    participant Vec as Vector store
+    participant Neo as Neo4j (optional)
+    participant LLM as Model provider
+    participant Stream as Task event surface
+
+    U->>FE: Submit message and request completion
+    FE->>API: POST /api/chat/{thread_id}/complete
+    API->>Redis: Acquire turn lock
+    API->>Redis: Enqueue ChatCompletionTask
+    API-->>FE: task_id, turn_id, messages_url, trace_url
+    FE->>Stream: Subscribe to /api/tasks/{task_id}/events
+    Worker->>Redis: Dequeue task and emit task.running
+    Worker->>Ctx: Assemble context
+    Ctx->>PG: Load messages, project scope, linked docs
+    Ctx->>Vec: Run semantic retrieval
+    opt graph context enabled
+        Ctx->>Neo: Fetch graph snippets
+    end
+    Ctx-->>Worker: Context bundle
+    Worker->>LLM: Completion request
+    LLM-->>Worker: Assistant output
+    Worker->>PG: Persist assistant message and audit/domain events
+    Worker->>Redis: Publish task.completed and release turn lock
+    Redis-->>Stream: Task events available
+    Stream-->>FE: Task lifecycle updates
+    FE->>API: Refresh messages_url
+    API-->>FE: Updated thread/messages
+```
+
+## Diagram 3: Data and Storage Boundaries
+
+```mermaid
+flowchart TB
+    subgraph runtime["Runtime surfaces"]
+        frontend["React frontend / Tauri shell"]
+        backend["FastAPI routes + workers"]
+    end
+
+    subgraph durable["Durable / persisted state"]
+        postgres["Postgres<br/>threads, messages, projects, memories,<br/>document metadata, audit, command runs,<br/>cron runs, events_outbox"]
+        vector["Vector store<br/>semantic corpus for messages and documents"]
+        media["File/object storage<br/>uploaded/generated media and artifacts"]
+    end
+
+    subgraph operational["Operational / ephemeral transport"]
+        redis["Redis<br/>chat/document/cron queues,<br/>turn locks, task events, heartbeats"]
+        buses["In-process buses<br/>fallback event fanout and sync subscription"]
+    end
+
+    subgraph client_local["Client-local state"]
+        browser_state["Local/session storage<br/>auth/session state, runtime overrides,<br/>drafts, UI preferences"]
+    end
+
+    subgraph optional["Optional / feature-flagged"]
+        neo4j["Neo4j<br/>optional graph context and logging"]
+    end
+
+    frontend <--> browser_state
+    frontend --> backend
+    backend <--> postgres
+    backend <--> redis
+    backend <--> vector
+    backend <--> media
+    backend -. process-local only .-> buses
+    backend -. optional / feature-flagged .-> neo4j
+```
+
+This boundary map emphasizes durable state versus operational transport. Redis is operationally critical but not the system of record; Postgres remains the durable source of truth in the validated runtime set.
+
+## Diagram 4: Subsystem / Ownership Map
+
+```mermaid
+flowchart LR
+    subgraph frontend_boundary["Frontend boundary"]
+        shell["Frontend shell + session spine"]
+        transport["Frontend transport + auth client"]
+    end
+
+    subgraph api_boundary["API / route layer"]
+        bootstrap["API bootstrap + auth/exposure boundary"]
+        chat["Chat routes + thread lifecycle"]
+        media["Media/document routes"]
+        command["Command bus + legacy tools shim<br/>(command bus internal-only in supported beta)"]
+        cron["Cron routes + scheduled automation"]
+    end
+
+    subgraph core_services["Core services"]
+        completion["Completion assembly + chat worker"]
+        retrieval["Context + retrieval broker"]
+        prompt["Prompt + profile system"]
+        provider["Provider routing + catalog"]
+        embed["Embedding + vector indexing"]
+    end
+
+    subgraph platform["Queue / workers / persistence"]
+        queue["Queue + task transport"]
+        persistence["Persistence + durable events"]
+    end
+
+    shell --> transport
+    transport --> bootstrap
+    bootstrap --> chat
+    bootstrap --> media
+    bootstrap --> command
+    bootstrap --> cron
+    chat --> queue
+    chat --> persistence
+    queue --> completion
+    queue --> embed
+    completion --> retrieval
+    completion --> prompt
+    completion --> provider
+    retrieval --> persistence
+    media --> queue
+    media --> persistence
+    embed --> persistence
+    command --> persistence
+    cron --> queue
+    cron --> persistence
+```
+
+This is a seam map, not a call graph. It groups subsystem boundaries and conservative dependency direction; it does not enumerate every route, file, or runtime edge.
+
+## Omitted / intentionally excluded areas
+
+- Experimental federation and sync surfaces are not diagrammed in v1 because `00-current-state.md` says federation and sync durability are not part of the present release promise.
+- Future federation concepts and other future-feature architecture documents are excluded.
+- Legacy Threadspace / GuardianOS / installer-era material is excluded.
+- UI canon, token, layout, and rendering diagrams are excluded.
+- Roadmap-only material and supplementary deep dives are excluded.
+- Speculative provider or future architecture details that exceed the validated runtime source set are excluded.
+
+## Diagram quality notes
+
+This is a first-pass runtime baseline intended to be refined after human review. Adjust edge granularity, labels, and scope only when the change can be justified from the validated runtime source set or freshly re-verified current runtime evidence.

--- a/docs/audits/history/next-actions.md
+++ b/docs/audits/history/next-actions.md
@@ -1,0 +1,23 @@
+# Codexify Audit — Active Remediation Targets
+
+## Current Focus
+
+### Durability & Recovery
+
+- Define Redis outage behavior
+- Define replay semantics for chat / ingestion / cron
+- Ensure idempotency coverage across execution paths
+
+### Tool Execution Consistency
+
+- Reduce reliance on legacy /tools
+- Move toward durable command-bus execution
+- Eliminate process-local job state
+
+## Frozen Domains (no expansion)
+
+- Core Loop Integrity
+- Primitive Stability
+- Observability
+
+No new features in these domains until weakest domains reach >= 2

--- a/docs/infra/INTERNAL_DOCS.md
+++ b/docs/infra/INTERNAL_DOCS.md
@@ -1,4 +1,7 @@
 # 🧠 Codexify Internal Architecture
+> Legacy notice
+> This document is retained for historical context and does not describe Codexify's current runtime architecture, supported install path, or present product identity.
+> Before using any documentation for architecture or diagram work, read `/docs/architecture/kb-validity-matrix.md`. For current runtime truth, start with `/docs/architecture/README.md` and `/docs/architecture/00-current-state.md`.
 
 This document details the internal architecture and self-awareness capabilities of the Codexify system. It serves as both documentation for developers and a reference for the system's own understanding of its capabilities.
 

--- a/docs/infra/persona_system_architecture.md
+++ b/docs/infra/persona_system_architecture.md
@@ -1,4 +1,7 @@
 # Memory‑Aware Persona System Architecture
+> Historical archive notice
+> This document is preserved as historical or conceptual lineage and is not a canonical source for current Codexify runtime behavior.
+> For current architecture and diagram source selection, use `/docs/architecture/kb-validity-matrix.md`, `/docs/architecture/README.md`, and `/docs/architecture/00-current-state.md`.
 
 This document provides a visual overview of the **Memory‑Aware Persona System** used in Codexify. The diagrams are written in **Mermaid** syntax, which is supported by GitHub, VS Code, and many Markdown viewers.
 

--- a/docs/infra/system_architecture.md
+++ b/docs/infra/system_architecture.md
@@ -1,4 +1,7 @@
 # Codexify System Architecture
+> Legacy notice
+> This document is retained for historical context and does not describe Codexify's current runtime architecture, supported install path, or present product identity.
+> Before using any documentation for architecture or diagram work, read `/docs/architecture/kb-validity-matrix.md`. For current runtime truth, start with `/docs/architecture/README.md` and `/docs/architecture/00-current-state.md`.
 
 ## 🏗️ System Overview
 


### PR DESCRIPTION
## Summary
- add `docs/audits/history/next-actions.md` to capture active remediation targets
- document current focus areas for durability, recovery, and tool execution consistency
- mark stable domains as frozen until weaker areas are improved

## Testing
- Not run (not requested)