### PR TITLE
Add daily audit generator and refresh latest audit outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,11 +97,17 @@ check: format lint test
 
 # Build documentation
 docs:
-	mkdocs build
+	@echo "MkDocs is not configured in this repository."
+	@echo "Documentation is maintained as Markdown under docs/, so there is no repo-local MkDocs site to build."
+	@echo "Use ./scripts/preflight.sh for a general repository check, or the relevant task-specific validator for the docs area you changed."
+	@exit 1
 
 # Serve documentation locally
 docs-serve:
-	mkdocs serve
+	@echo "MkDocs is not configured in this repository."
+	@echo "Documentation is maintained as Markdown under docs/, so there is no repo-local MkDocs site to serve."
+	@echo "Use ./scripts/preflight.sh for a general repository check, or the relevant task-specific validator for the docs area you changed."
+	@exit 1
 
 # Build distribution packages
 build: clean


### PR DESCRIPTION
## Summary
- Add `scripts/daily_audit.py` to generate daily audit reports from the platform readiness audit output
- Wire a `daily-audit` Makefile target for one-command generation
- Refresh the `docs/audits/latest` and dated daily audit artifacts for 2026-03-19
- Replace the `docs` Makefile target with a clear failure message since MkDocs is not configured here

## Testing
- Not run (not requested)