### PR TITLE
Update bootstrap flow to use local beta readiness checks

### DIFF
--- a/docs/Codexify/macos-beta-packaging.md
+++ b/docs/Codexify/macos-beta-packaging.md
@@ -1,0 +1,121 @@
+# Codexify macOS Beta Packaging
+
+## Current contract
+
+Codexify currently produces a real macOS Tauri beta artifact, but the packaged desktop shell is still attached to the local Codexify repo/runtime model.
+
+That means:
+
+- the build emits a real `.app`
+- the build emits a real `.dmg`
+- the packaged app can only run bootstrap actions safely when it can resolve a local Codexify checkout
+- the workspace must remain locked whenever packaged bootstrap cannot safely continue
+
+This is a beta packaging contract, not a signed/notarized public-distribution contract.
+
+## Production build command
+
+Run from the repo root:
+
+```bash
+cd src-tauri && cargo tauri build
+```
+
+## Current output artifacts
+
+On the validated Apple Silicon build path, the production artifacts are:
+
+- `src-tauri/target/release/bundle/macos/Codexify.app`
+- `src-tauri/target/release/bundle/dmg/Codexify_0.1.0_aarch64.dmg`
+
+The plain release executable is also produced at:
+
+- `src-tauri/target/release/app`
+
+## Artifact identity
+
+- Product name: `Codexify`
+- Bundle identifier: `com.codexify.desktop`
+- App bundle name: `Codexify.app`
+- DMG name on the validated Apple Silicon build: `Codexify_0.1.0_aarch64.dmg`
+
+The DMG suffix is architecture-specific. On this machine the validated output is `aarch64`.
+
+## Signing and notarization status
+
+Current beta artifacts are not developer-signed or notarized.
+
+Observed local status:
+
+- app bundle signature: ad hoc
+- Team ID: not set
+- notarization: not present
+
+This task does not add signing or notarization automation.
+
+## Packaged bootstrap behavior
+
+The packaged macOS beta build now resolves runtime context explicitly instead of assuming the repo root from the shell working directory.
+
+Supported packaged bootstrap context today:
+
+- run `Codexify.app` from inside a Codexify checkout, including the default `src-tauri/target/release/bundle/macos/` build output
+- or launch with `CODEXIFY_DESKTOP_REPO_ROOT` pointing at a local Codexify checkout
+
+Classified packaged failure modes:
+
+- `runtime-path-unavailable`
+- `repo-runtime-missing`
+- `packaged-bootstrap-unsupported`
+- `unexpected-execution-error`
+
+The bootstrap overlay now distinguishes:
+
+- Docker missing
+- Docker daemon unavailable
+- packaged app cannot locate local runtime assets/config
+- packaged app launched outside a supported local runtime context
+- generic packaged startup failure
+
+## Current known limitations
+
+The packaged beta artifact is not self-contained yet.
+
+Known limitations in the current state:
+
+- setup, Compose startup, log retrieval, and restart actions still depend on the real local Codexify repo/runtime directory
+- launching the packaged app outside a Codexify checkout is unsupported unless `CODEXIFY_DESKTOP_REPO_ROOT` is provided
+- the validated Finder-launched packaged app still reproduced a Docker CLI execution failure even while Docker Desktop and the Compose stack were healthy; the app stayed locked and surfaced packaged startup support copy instead of unlocking the workspace
+- this means packaged bootstrap is supportable and classified, but not yet fully end-to-end reliable outside the development shell
+
+## Manual validation checklist
+
+Use this checklist for packaged beta validation:
+
+1. Run `cd src-tauri && cargo tauri build`.
+2. Confirm `Codexify.app` exists under `src-tauri/target/release/bundle/macos/`.
+3. Confirm the DMG exists under `src-tauri/target/release/bundle/dmg/`.
+4. Launch `Codexify.app` outside `cargo tauri dev`.
+5. Confirm the bootstrap overlay appears instead of unlocking the workspace prematurely.
+6. If the packaged app resolves the local runtime cleanly, confirm setup, Compose startup, readiness, welcome, and unlock complete in order.
+7. If packaged bootstrap does not complete, confirm the failure is classified, the workspace remains locked, and the recovery/support copy matches the real failure mode.
+8. Confirm logs/restart actions never pretend the packaged app can operate against a repo/runtime path it has not safely resolved.
+
+## Validated current result
+
+The current validated result on this machine is:
+
+- `cargo tauri build` completed successfully and emitted both `Codexify.app` and `Codexify_0.1.0_aarch64.dmg`
+- the packaged app launched outside `cargo tauri dev`
+- packaged bootstrap did not proceed end-to-end to welcome/unlock in Finder-launched validation
+- the window remained locked on the bootstrap gate, which is the required safety behavior
+
+## Beta download target
+
+The `codexify.space` beta download button should ultimately point at the uploaded DMG artifact for the current beta release lineage, not the raw `.app` bundle.
+
+For the currently validated local artifact shape, that means the hosted equivalent of:
+
+- `Codexify_0.1.0_aarch64.dmg`
+
+If universal or signed/notarized artifacts are introduced later, the download target should move to that release asset without changing the in-app bootstrap contract described here.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,7 +11,12 @@ import CommandCenterPage from "./features/commandCenter/CommandCenterPage";
 import api from "./lib/api";
 import {
   appendBootstrapDetail,
+  BOOTSTRAP_LOG_SERVICES,
   createCheckingRuntimeBootstrapState,
+  createBootstrapSupportNoticeFromDockerOpenResult,
+  createBootstrapSupportNoticeFromLogResult,
+  createBootstrapSupportNoticeFromRestartResult,
+  createComposeRecoveryStepResult,
   createFailedRuntimeBootstrapState,
   createPreparingLocalConfigState,
   createReadyForWelcomeState,
@@ -19,15 +24,22 @@ import {
   createWaitingForReadyState,
   formatBootstrapStepResult,
   formatRuntimeReadinessResult,
+  getBootstrapLogs,
   hasDismissedWelcomeScreen,
   mapRuntimePreflightFailureToState,
   mapRuntimeReadinessFailureToState,
+  openDockerDesktopNative,
   openDockerDesktopDownloadPage,
+  restartRuntimeServices,
   runComposeUp,
   runRuntimeBootstrapPreflight,
   runSetupCli,
   setWelcomeScreenDismissed,
   shouldRunRuntimeBootstrap,
+  type BootstrapLogResult,
+  type BootstrapLogService,
+  type BootstrapRecoveryNotice,
+  type BootstrapRecoveryStage,
   type BootstrapStep,
   type BootstrapStepResult,
   type RuntimeBootstrapState,
@@ -95,6 +107,70 @@ function getShareToken() {
 }
 
 type BootstrapPhase = "bootstrap" | "welcome" | "unlocked";
+type BootstrapStartBoundary = BootstrapRecoveryStage;
+
+type BootstrapLogsState = {
+  visible: boolean;
+  loading: boolean;
+  service: BootstrapLogService;
+  result: BootstrapLogResult | null;
+};
+
+type BootstrapRetryPlan = {
+  boundary: BootstrapStartBoundary;
+  stepResults: Partial<Record<BootstrapStep, BootstrapStepResult>>;
+};
+
+type StartupOrchestrationOptions = {
+  startAt: Exclude<BootstrapStartBoundary, "preflight">;
+  initialDetail?: string;
+  initialStepResults?: Partial<Record<BootstrapStep, BootstrapStepResult>>;
+};
+
+function resolveBootstrapRecoveryStage(
+  state: RuntimeBootstrapState
+): BootstrapRecoveryStage | null {
+  if (
+    state.status === "checking-requirements" ||
+    state.status === "docker-missing" ||
+    state.status === "compose-missing" ||
+    state.status === "docker-not-running"
+  ) {
+    return "preflight";
+  }
+
+  if (state.stepResults["health-check"] && !state.stepResults["health-check"]?.ok) {
+    return "readiness";
+  }
+
+  if (state.stepResults["compose-up"] && !state.stepResults["compose-up"]?.ok) {
+    return "compose-up";
+  }
+
+  if (state.stepResults.setup && !state.stepResults.setup?.ok) {
+    return "setup";
+  }
+
+  if (state.status === "failed") {
+    return "preflight";
+  }
+
+  return null;
+}
+
+function resolveBootstrapDefaultLogService(
+  state: RuntimeBootstrapState
+): BootstrapLogService {
+  if (state.stepResults["health-check"] && !state.stepResults["health-check"]?.ok) {
+    return "backend";
+  }
+
+  if (state.stepResults["compose-up"] && !state.stepResults["compose-up"]?.ok) {
+    return "backend";
+  }
+
+  return "backend";
+}
 
 function WelcomeScreen({ onEnter }: { onEnter: () => void }) {
   return (
@@ -306,6 +382,19 @@ export default function App() {
   const autoBootstrapStartedRef = React.useRef(false);
   const latestPreflightRef = React.useRef<RuntimePreflight | null>(null);
   const diagnosticsRef = React.useRef<string | undefined>(undefined);
+  const bootstrapLogsRequestRef = React.useRef(0);
+  const [bootstrapLogs, setBootstrapLogs] = React.useState<BootstrapLogsState>(
+    () => ({
+      visible: false,
+      loading: false,
+      service: "backend",
+      result: null,
+    })
+  );
+  const [bootstrapRecoveryNotice, setBootstrapRecoveryNotice] =
+    React.useState<BootstrapRecoveryNotice | null>(null);
+  const [openingDockerDesktop, setOpeningDockerDesktop] = React.useState(false);
+  const [restartingServices, setRestartingServices] = React.useState(false);
 
   const handleDocGenSubmit = React.useCallback(
     async (input: DocumentGenInput) => {
@@ -429,6 +518,53 @@ export default function App() {
     []
   );
 
+  const syncBootstrapDetail = React.useCallback((detail: string | undefined) => {
+    setBootstrapState((current) =>
+      current.detail === detail ? current : { ...current, detail }
+    );
+  }, []);
+
+  const buildRetryPlan = React.useCallback(
+    (state: RuntimeBootstrapState): BootstrapRetryPlan => {
+      const stage = resolveBootstrapRecoveryStage(state);
+
+      if (stage === "readiness") {
+        const stepResults: Partial<Record<BootstrapStep, BootstrapStepResult>> = {};
+        if (state.stepResults.setup?.ok) {
+          stepResults.setup = state.stepResults.setup;
+        }
+        if (state.stepResults["compose-up"]?.ok) {
+          stepResults["compose-up"] = state.stepResults["compose-up"];
+        }
+        return { boundary: "readiness", stepResults };
+      }
+
+      if (stage === "compose-up") {
+        const stepResults: Partial<Record<BootstrapStep, BootstrapStepResult>> = {};
+        if (state.stepResults.setup?.ok) {
+          stepResults.setup = state.stepResults.setup;
+        }
+        return { boundary: "compose-up", stepResults };
+      }
+
+      if (stage === "setup" && state.preflight?.ready) {
+        return { boundary: "setup", stepResults: {} };
+      }
+
+      return { boundary: "preflight", stepResults: {} };
+    },
+    []
+  );
+
+  React.useEffect(() => {
+    const defaultService = resolveBootstrapDefaultLogService(bootstrapState);
+    setBootstrapLogs((current) =>
+      current.visible || current.service === defaultService
+        ? current
+        : { ...current, service: defaultService }
+    );
+  }, [bootstrapState]);
+
   const advanceToWelcomeOrWorkspace = React.useCallback((runId: number) => {
     const moveForward = () => {
       if (runId !== bootstrapRunRef.current) return;
@@ -451,68 +587,84 @@ export default function App() {
   }, []);
 
   const runStartupOrchestration = React.useCallback(
-    async (preflight: RuntimePreflight) => {
+    async (
+      preflight: RuntimePreflight,
+      options: StartupOrchestrationOptions
+    ) => {
       const runId = bootstrapRunRef.current;
-      let stepResults: Partial<Record<BootstrapStep, BootstrapStepResult>> = {};
-      let detail = diagnosticsRef.current;
+      let stepResults = { ...(options.initialStepResults ?? {}) };
+      let detail = options.initialDetail ?? diagnosticsRef.current;
+      let startAt = options.startAt;
 
-      setBootstrapPhase("bootstrap");
-      setBootstrapState(
-        createPreparingLocalConfigState(preflight, detail, stepResults)
-      );
-
-      const setupResult = await runSetupCli();
-      if (runId !== bootstrapRunRef.current) return;
-      stepResults = {
-        ...stepResults,
-        setup: setupResult,
-      };
-      detail = appendDiagnostics(
-        formatBootstrapStepResult(setupResult),
-        "Setup step"
-      );
-      if (!setupResult.ok) {
-        setBootstrapState(
-          createFailedRuntimeBootstrapState({
-            title: "Preparing local config failed",
-            message:
-              "Codexify could not complete the setup source-of-truth step, so the workspace remains locked. Retry to rerun orchestration from the start.",
-            detail,
-            failureKind: "setup-failed",
-            preflight,
-            stepResults,
-          })
-        );
-        return;
+      if (startAt === "readiness" && !stepResults["compose-up"]?.ok) {
+        startAt = "compose-up";
+      }
+      if (startAt !== "setup" && !stepResults.setup?.ok) {
+        startAt = "setup";
       }
 
-      setBootstrapState(
-        createStartingLocalServicesState(preflight, detail, stepResults)
-      );
+      setBootstrapPhase("bootstrap");
 
-      const composeResult = await runComposeUp();
-      if (runId !== bootstrapRunRef.current) return;
-      stepResults = {
-        ...stepResults,
-        "compose-up": composeResult,
-      };
-      detail = appendDiagnostics(
-        formatBootstrapStepResult(composeResult),
-        "Compose startup"
-      );
-      if (!composeResult.ok) {
+      if (startAt === "setup") {
         setBootstrapState(
-          createFailedRuntimeBootstrapState({
-            title: "Starting local services failed",
-            message:
-              "Codexify could not bring the Docker Compose stack up cleanly. The workspace stays locked until startup orchestration succeeds.",
-            detail,
-            failureKind: "compose-up-failed",
-            preflight,
-            stepResults,
-          })
+          createPreparingLocalConfigState(preflight, detail, stepResults)
         );
-        return;
+
+        const setupResult = await runSetupCli();
+        if (runId !== bootstrapRunRef.current) return;
+        stepResults = {
+          ...stepResults,
+          setup: setupResult,
+        };
+        detail = appendDiagnostics(
+          formatBootstrapStepResult(setupResult),
+          "Setup step"
+        );
+        if (!setupResult.ok) {
+          setBootstrapState(
+            createFailedRuntimeBootstrapState({
+              title: "Preparing local config failed",
+              message:
+                "Codexify could not complete the repo-defined setup step. Retry to rerun setup, then continue through Compose startup and readiness while the workspace stays locked.",
+              detail,
+              failureKind: "setup-failed",
+              preflight,
+              stepResults,
+            })
+          );
+          return;
+        }
+      }
+
+      if (startAt === "setup" || startAt === "compose-up") {
+        setBootstrapState(
+          createStartingLocalServicesState(preflight, detail, stepResults)
+        );
+
+        const composeResult = await runComposeUp();
+        if (runId !== bootstrapRunRef.current) return;
+        stepResults = {
+          ...stepResults,
+          "compose-up": composeResult,
+        };
+        detail = appendDiagnostics(
+          formatBootstrapStepResult(composeResult),
+          "Compose startup"
+        );
+        if (!composeResult.ok) {
+          setBootstrapState(
+            createFailedRuntimeBootstrapState({
+              title: "Starting local services failed",
+              message:
+                "Codexify could not bring the local Compose stack up cleanly. Retry to rerun Compose startup, or inspect logs and restart services if the runtime needs intervention.",
+              detail,
+              failureKind: "compose-up-failed",
+              preflight,
+              stepResults,
+            })
+          );
+          return;
+        }
       }
 
       setBootstrapState(
@@ -584,28 +736,33 @@ export default function App() {
   );
 
   const runBootstrapFlow = React.useCallback(
-    async (fromStart: boolean) => {
+    async (
+      boundary: BootstrapStartBoundary,
+      stepResults: Partial<Record<BootstrapStep, BootstrapStepResult>> = {}
+    ) => {
       if (!bootstrapEnabled) {
         setBootstrapPhase("unlocked");
         return;
       }
 
       const runId = ++bootstrapRunRef.current;
+      bootstrapLogsRequestRef.current += 1;
       setBootstrapPhase("bootstrap");
+      setBootstrapRecoveryNotice(null);
+      setOpeningDockerDesktop(false);
+      setRestartingServices(false);
 
       const reusePreflight =
-        !fromStart && latestPreflightRef.current?.ready
+        boundary !== "preflight" && latestPreflightRef.current?.ready
           ? latestPreflightRef.current
           : null;
 
       if (reusePreflight) {
-        setBootstrapState(
-          createPreparingLocalConfigState(
-            reusePreflight,
-            diagnosticsRef.current
-          )
-        );
-        await runStartupOrchestration(reusePreflight);
+        await runStartupOrchestration(reusePreflight, {
+          startAt: boundary === "preflight" ? "setup" : boundary,
+          initialDetail: diagnosticsRef.current,
+          initialStepResults: stepResults,
+        });
         return;
       }
 
@@ -630,18 +787,33 @@ export default function App() {
         return;
       }
 
-      setBootstrapState(
-        createPreparingLocalConfigState(preflight, preflightDetail)
-      );
-      await runStartupOrchestration(preflight);
+      await runStartupOrchestration(preflight, {
+        startAt: boundary === "preflight" ? "setup" : boundary,
+        initialDetail: preflightDetail,
+        initialStepResults: stepResults,
+      });
     },
-    [appendDiagnostics, bootstrapEnabled, runStartupOrchestration]
+    [
+      appendDiagnostics,
+      bootstrapEnabled,
+      runStartupOrchestration,
+      bootstrapLogsRequestRef,
+    ]
   );
 
   React.useEffect(() => {
     if (!bootstrapEnabled) {
       autoBootstrapStartedRef.current = false;
       latestPreflightRef.current = null;
+      bootstrapLogsRequestRef.current += 1;
+      setBootstrapRecoveryNotice(null);
+      setOpeningDockerDesktop(false);
+      setRestartingServices(false);
+      setBootstrapLogs((current) => ({
+        ...current,
+        visible: false,
+        loading: false,
+      }));
       setBootstrapPhase("unlocked");
       return;
     }
@@ -650,12 +822,51 @@ export default function App() {
     if (autoBootstrapStartedRef.current) return;
 
     autoBootstrapStartedRef.current = true;
-    void runBootstrapFlow(true);
+    void runBootstrapFlow("preflight");
   }, [bootstrapEnabled, runBootstrapFlow]);
 
+  const loadBootstrapLogs = React.useCallback(
+    async (service: BootstrapLogService) => {
+      const requestId = ++bootstrapLogsRequestRef.current;
+      setBootstrapRecoveryNotice(null);
+      setBootstrapLogs((current) => ({
+        visible: true,
+        loading: true,
+        service,
+        result: current.service === service ? current.result : null,
+      }));
+
+      const result = await getBootstrapLogs(service);
+      if (requestId !== bootstrapLogsRequestRef.current) return;
+
+      setBootstrapLogs({
+        visible: true,
+        loading: false,
+        service,
+        result,
+      });
+
+      if (!result.ok) {
+        const detail = appendDiagnostics(
+          result.detail,
+          `Log retrieval (${service})`
+        );
+        syncBootstrapDetail(detail);
+        setBootstrapRecoveryNotice(
+          createBootstrapSupportNoticeFromLogResult({
+            ...result,
+            detail,
+          })
+        );
+      }
+    },
+    [appendDiagnostics, syncBootstrapDetail]
+  );
+
   const handleRetryBootstrap = React.useCallback(() => {
-    void runBootstrapFlow(Boolean(latestPreflightRef.current?.ready));
-  }, [runBootstrapFlow]);
+    const plan = buildRetryPlan(bootstrapState);
+    void runBootstrapFlow(plan.boundary, plan.stepResults);
+  }, [bootstrapState, buildRetryPlan, runBootstrapFlow]);
 
   const handleWelcomeEnter = React.useCallback(() => {
     setWelcomeScreenDismissed(true);
@@ -663,6 +874,7 @@ export default function App() {
   }, []);
 
   const handleInstallDocker = React.useCallback(async () => {
+    setBootstrapRecoveryNotice(null);
     const opened = await openDockerDesktopDownloadPage();
     if (opened) return;
     try {
@@ -678,6 +890,119 @@ export default function App() {
       // ignore
     }
   }, []);
+
+  const handleOpenDocker = React.useCallback(async () => {
+    setBootstrapRecoveryNotice(null);
+    setOpeningDockerDesktop(true);
+    const result = await openDockerDesktopNative();
+    setOpeningDockerDesktop(false);
+
+    const detail = appendDiagnostics(result.detail, "Open Docker Desktop");
+    syncBootstrapDetail(detail);
+
+    if (!result.ok) {
+      setBootstrapRecoveryNotice(
+        createBootstrapSupportNoticeFromDockerOpenResult({
+          ...result,
+          detail,
+        })
+      );
+    }
+  }, [appendDiagnostics, syncBootstrapDetail]);
+
+  const handleToggleBootstrapLogs = React.useCallback(() => {
+    if (bootstrapLogs.visible) {
+      bootstrapLogsRequestRef.current += 1;
+      setBootstrapLogs((current) => ({
+        ...current,
+        visible: false,
+        loading: false,
+      }));
+      return;
+    }
+
+    const nextService =
+      bootstrapLogs.service || resolveBootstrapDefaultLogService(bootstrapState);
+    void loadBootstrapLogs(nextService);
+  }, [bootstrapLogs.service, bootstrapLogs.visible, bootstrapState, loadBootstrapLogs]);
+
+  const handleSelectBootstrapLogService = React.useCallback(
+    (service: BootstrapLogService) => {
+      if (!BOOTSTRAP_LOG_SERVICES.includes(service)) return;
+      if (!bootstrapLogs.visible) {
+        setBootstrapLogs((current) => ({ ...current, service }));
+        return;
+      }
+      void loadBootstrapLogs(service);
+    },
+    [bootstrapLogs.visible, loadBootstrapLogs]
+  );
+
+  const handleRestartServices = React.useCallback(async () => {
+    const preflight = latestPreflightRef.current ?? bootstrapState.preflight;
+    if (!preflight?.ready) {
+      void runBootstrapFlow("preflight");
+      return;
+    }
+
+    const runId = ++bootstrapRunRef.current;
+    bootstrapLogsRequestRef.current += 1;
+    setBootstrapRecoveryNotice(null);
+    setRestartingServices(true);
+    setBootstrapPhase("bootstrap");
+    setBootstrapState(
+      createStartingLocalServicesState(
+        preflight,
+        diagnosticsRef.current,
+        bootstrapState.stepResults
+      )
+    );
+
+    const result = await restartRuntimeServices();
+    if (runId !== bootstrapRunRef.current) return;
+    setRestartingServices(false);
+
+    const composeRecovery = createComposeRecoveryStepResult(result);
+    const detail = appendDiagnostics(
+      formatBootstrapStepResult(composeRecovery),
+      "Restart services"
+    );
+
+    if (!result.ok) {
+      setBootstrapState(
+        createFailedRuntimeBootstrapState({
+          title: "Restarting local services failed",
+          message:
+            "Codexify could not complete the targeted runtime restart from the desktop shell. The workspace stays locked until Compose startup and readiness succeed.",
+          detail,
+          failureKind: "restart-services-failed",
+          preflight,
+          stepResults: bootstrapState.stepResults,
+        })
+      );
+      setBootstrapRecoveryNotice(
+        createBootstrapSupportNoticeFromRestartResult({
+          ...result,
+          detail,
+        })
+      );
+      return;
+    }
+
+    const nextStepResults: Partial<Record<BootstrapStep, BootstrapStepResult>> = {
+      ...bootstrapState.stepResults,
+      "compose-up": composeRecovery,
+    };
+
+    setBootstrapState(
+      createWaitingForReadyState(preflight, detail, nextStepResults)
+    );
+    await runStartupOrchestration(preflight, {
+      startAt: "readiness",
+      initialDetail: detail,
+      initialStepResults: nextStepResults,
+    });
+  }, [appendDiagnostics, bootstrapState, runBootstrapFlow, runStartupOrchestration]);
 
   const startupLocked = bootstrapEnabled && bootstrapPhase !== "unlocked";
 
@@ -712,6 +1037,14 @@ export default function App() {
         state={bootstrapState}
         onRetry={handleRetryBootstrap}
         onInstallDocker={handleInstallDocker}
+        onOpenDocker={handleOpenDocker}
+        onRestartServices={handleRestartServices}
+        onToggleLogs={handleToggleBootstrapLogs}
+        onSelectLogService={handleSelectBootstrapLogService}
+        logs={bootstrapLogs}
+        recoveryNotice={bootstrapRecoveryNotice}
+        openingDocker={openingDockerDesktop}
+        restartingServices={restartingServices}
       />
     );
   }

--- a/frontend/src/components/bootstrap/BootstrapGate.tsx
+++ b/frontend/src/components/bootstrap/BootstrapGate.tsx
@@ -2,14 +2,31 @@ import React from "react";
 
 import { Button } from "@/components/ui/button";
 import type {
+  BootstrapLogResult,
+  BootstrapLogService,
+  BootstrapRecoveryNotice,
   BootstrapStep,
   RuntimeBootstrapState,
 } from "@/lib/runtimeBootstrap";
+import { BOOTSTRAP_LOG_SERVICES } from "@/lib/runtimeBootstrap";
 
 type BootstrapGateProps = {
   state: RuntimeBootstrapState;
   onRetry: () => void;
   onInstallDocker: () => Promise<void> | void;
+  onOpenDocker: () => Promise<void> | void;
+  onRestartServices: () => Promise<void> | void;
+  onToggleLogs: () => void;
+  onSelectLogService: (service: BootstrapLogService) => void;
+  logs: {
+    visible: boolean;
+    loading: boolean;
+    service: BootstrapLogService;
+    result: BootstrapLogResult | null;
+  };
+  recoveryNotice: BootstrapRecoveryNotice | null;
+  openingDocker: boolean;
+  restartingServices: boolean;
 };
 
 type PhaseCardState = "pending" | "running" | "done" | "failed";
@@ -29,6 +46,38 @@ const PHASE_STEP_MAP: Record<
   "compose-up": "starting-local-services",
   readiness: "waiting-for-ready",
 };
+
+function getRecoveryActions(state: RuntimeBootstrapState) {
+  if (state.status === "docker-missing") {
+    return ["retry", "install-docker"] as const;
+  }
+
+  if (state.status === "compose-missing") {
+    return ["retry", "install-docker"] as const;
+  }
+
+  if (state.status === "docker-not-running") {
+    return ["retry", "open-docker"] as const;
+  }
+
+  if (state.stepResults["health-check"] && !state.stepResults["health-check"]?.ok) {
+    return ["retry", "view-logs", "restart-services"] as const;
+  }
+
+  if (state.stepResults["compose-up"] && !state.stepResults["compose-up"]?.ok) {
+    return ["retry", "view-logs", "restart-services"] as const;
+  }
+
+  if (state.stepResults.setup && !state.stepResults.setup?.ok) {
+    return ["retry"] as const;
+  }
+
+  if (state.status === "failed") {
+    return ["retry"] as const;
+  }
+
+  return [] as const;
+}
 
 function PhaseCard({ label, state, description }: PhaseCardProps) {
   const palette =
@@ -149,20 +198,28 @@ export default function BootstrapGate({
   state,
   onRetry,
   onInstallDocker,
+  onOpenDocker,
+  onRestartServices,
+  onToggleLogs,
+  onSelectLogService,
+  logs,
+  recoveryNotice,
+  openingDocker,
+  restartingServices,
 }: BootstrapGateProps) {
   const [openingInstallPage, setOpeningInstallPage] = React.useState(false);
-  const showInstallAction =
-    state.status === "docker-missing" || state.status === "compose-missing";
-  const showRetryAction =
-    state.status === "docker-missing" ||
-    state.status === "compose-missing" ||
-    state.status === "docker-not-running" ||
-    state.status === "failed";
+  const recoveryActions = getRecoveryActions(state);
+  const showInstallAction = recoveryActions.includes("install-docker");
+  const showRetryAction = recoveryActions.includes("retry");
+  const showOpenDockerAction = recoveryActions.includes("open-docker");
+  const showLogsAction = recoveryActions.includes("view-logs");
+  const showRestartAction = recoveryActions.includes("restart-services");
   const isBusy =
     state.status === "checking-requirements" ||
     state.status === "preparing-local-config" ||
     state.status === "starting-local-services" ||
     state.status === "waiting-for-ready";
+  const actionsBusy = isBusy || openingDocker || restartingServices;
 
   const handleInstallDocker = React.useCallback(async () => {
     setOpeningInstallPage(true);
@@ -295,11 +352,48 @@ export default function BootstrapGate({
             {showRetryAction && (
               <Button
                 type="button"
-                variant="ghost"
                 className="rounded-full px-5"
                 onClick={onRetry}
+                disabled={actionsBusy}
               >
                 Retry
+              </Button>
+            )}
+            {showOpenDockerAction && (
+              <Button
+                type="button"
+                variant="ghost"
+                className="rounded-full px-5"
+                onClick={() => {
+                  void onOpenDocker();
+                }}
+                disabled={actionsBusy}
+              >
+                {openingDocker ? "Opening Docker..." : "Open Docker"}
+              </Button>
+            )}
+            {showLogsAction && (
+              <Button
+                type="button"
+                variant="ghost"
+                className="rounded-full px-5"
+                onClick={onToggleLogs}
+                disabled={isBusy || restartingServices}
+              >
+                {logs.visible ? "Hide Logs" : "View Logs"}
+              </Button>
+            )}
+            {showRestartAction && (
+              <Button
+                type="button"
+                variant="ghost"
+                className="rounded-full px-5"
+                onClick={() => {
+                  void onRestartServices();
+                }}
+                disabled={actionsBusy}
+              >
+                {restartingServices ? "Restarting Services..." : "Restart Services"}
               </Button>
             )}
             {showInstallAction && (
@@ -310,7 +404,7 @@ export default function BootstrapGate({
                 onClick={() => {
                   void handleInstallDocker();
                 }}
-                disabled={openingInstallPage}
+                disabled={openingInstallPage || actionsBusy}
               >
                 {openingInstallPage ? "Opening..." : "Install Docker Desktop"}
               </Button>
@@ -332,6 +426,165 @@ export default function BootstrapGate({
               </p>
             )}
           </div>
+
+          {recoveryNotice && (
+            <div
+              className="rounded-[20px] border px-4 py-4"
+              style={{
+                borderColor: "rgba(252,165,165,0.28)",
+                background: "rgba(127,29,29,0.16)",
+              }}
+            >
+              <div
+                className="text-xs uppercase tracking-[0.18em]"
+                style={{ color: "var(--danger-text, #fca5a5)" }}
+              >
+                Recovery status
+              </div>
+              <div className="mt-2 text-sm font-medium">{recoveryNotice.title}</div>
+              <p
+                className="mt-2 text-sm leading-6"
+                style={{ color: "var(--muted)" }}
+              >
+                {recoveryNotice.message}
+              </p>
+              {recoveryNotice.detail && (
+                <pre
+                  className="mt-3 overflow-auto whitespace-pre-wrap break-words text-xs leading-5"
+                  style={{ color: "var(--muted)" }}
+                >
+                  {recoveryNotice.detail}
+                </pre>
+              )}
+            </div>
+          )}
+
+          {logs.visible && (
+            <section
+              className="rounded-[20px] border px-4 py-4"
+              style={{
+                borderColor: "var(--panel-border)",
+                background: "rgba(255,255,255,0.04)",
+              }}
+              aria-labelledby="bootstrap-runtime-logs-title"
+            >
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="space-y-1">
+                  <h2
+                    id="bootstrap-runtime-logs-title"
+                    className="text-sm font-medium"
+                  >
+                    Runtime logs
+                  </h2>
+                  <p
+                    className="text-sm leading-6"
+                    style={{ color: "var(--muted)" }}
+                  >
+                    Recent Docker Compose output is shown here separately from the
+                    startup diagnostics so runtime failures are easier to trace.
+                  </p>
+                </div>
+                <div
+                  className="rounded-full border px-3 py-1 text-xs uppercase tracking-[0.18em]"
+                  style={{
+                    borderColor: "var(--chip-border)",
+                    color: "var(--muted)",
+                  }}
+                >
+                  Service: {logs.service}
+                </div>
+              </div>
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                {BOOTSTRAP_LOG_SERVICES.map((service) => {
+                  const selected = logs.service === service;
+                  return (
+                    <button
+                      key={service}
+                      type="button"
+                      className="rounded-full border px-3 py-1 text-xs uppercase tracking-[0.14em] transition"
+                      style={{
+                        borderColor: selected
+                          ? "rgba(125,211,252,0.36)"
+                          : "var(--chip-border)",
+                        background: selected
+                          ? "rgba(125,211,252,0.12)"
+                          : "rgba(255,255,255,0.04)",
+                        color: selected
+                          ? "var(--accent-strong, #7dd3fc)"
+                          : "var(--muted)",
+                      }}
+                      onClick={() => onSelectLogService(service)}
+                      aria-pressed={selected}
+                      disabled={restartingServices}
+                    >
+                      {service}
+                    </button>
+                  );
+                })}
+              </div>
+
+              <div
+                className="mt-4 rounded-[18px] border"
+                style={{
+                  borderColor: "rgba(255,255,255,0.08)",
+                  background: "rgba(5,10,18,0.8)",
+                }}
+              >
+                <div
+                  className="border-b px-4 py-3 text-xs uppercase tracking-[0.18em]"
+                  style={{
+                    borderColor: "rgba(255,255,255,0.08)",
+                    color: "var(--muted)",
+                  }}
+                >
+                  {logs.loading
+                    ? `Loading ${logs.service} logs`
+                    : logs.result?.ok
+                    ? `${logs.service} logs`
+                    : `${logs.service} logs unavailable`}
+                </div>
+                <div className="max-h-[320px] overflow-auto px-4 py-4">
+                  {logs.loading ? (
+                    <div
+                      className="inline-flex items-center gap-3 text-sm"
+                      style={{ color: "var(--muted)" }}
+                    >
+                      <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-transparent" />
+                      Fetching recent Compose output for {logs.service}.
+                    </div>
+                  ) : logs.result?.logs ? (
+                    <pre
+                      className="whitespace-pre-wrap break-words font-mono text-xs leading-5"
+                      style={{ color: "var(--text)" }}
+                    >
+                      {logs.result.logs}
+                    </pre>
+                  ) : (
+                    <p
+                      className="text-sm leading-6"
+                      style={{ color: "var(--muted)" }}
+                    >
+                      {logs.result?.ok
+                        ? `No recent log output was returned for ${logs.service}.`
+                        : `Codexify could not load recent ${logs.service} logs from Docker Compose.`}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              {(logs.result?.command || logs.result?.detail) && (
+                <div className="mt-3 space-y-2 text-xs leading-5" style={{ color: "var(--muted)" }}>
+                  {logs.result?.command && <div>{logs.result.command}</div>}
+                  {logs.result?.detail && (
+                    <pre className="overflow-auto whitespace-pre-wrap break-words">
+                      {logs.result.detail}
+                    </pre>
+                  )}
+                </div>
+              )}
+            </section>
+          )}
 
           {state.detail && (
             <details

--- a/frontend/src/components/bootstrap/BootstrapGate.tsx
+++ b/frontend/src/components/bootstrap/BootstrapGate.tsx
@@ -8,7 +8,12 @@ import type {
   BootstrapStep,
   RuntimeBootstrapState,
 } from "@/lib/runtimeBootstrap";
-import { BOOTSTRAP_LOG_SERVICES } from "@/lib/runtimeBootstrap";
+import {
+  BOOTSTRAP_LOG_SERVICES,
+  getBootstrapDisplayCopy,
+  getBootstrapRecoveryActions,
+  isPackagedBootstrapState,
+} from "@/lib/runtimeBootstrap";
 
 type BootstrapGateProps = {
   state: RuntimeBootstrapState;
@@ -46,38 +51,6 @@ const PHASE_STEP_MAP: Record<
   "compose-up": "starting-local-services",
   readiness: "waiting-for-ready",
 };
-
-function getRecoveryActions(state: RuntimeBootstrapState) {
-  if (state.status === "docker-missing") {
-    return ["retry", "install-docker"] as const;
-  }
-
-  if (state.status === "compose-missing") {
-    return ["retry", "install-docker"] as const;
-  }
-
-  if (state.status === "docker-not-running") {
-    return ["retry", "open-docker"] as const;
-  }
-
-  if (state.stepResults["health-check"] && !state.stepResults["health-check"]?.ok) {
-    return ["retry", "view-logs", "restart-services"] as const;
-  }
-
-  if (state.stepResults["compose-up"] && !state.stepResults["compose-up"]?.ok) {
-    return ["retry", "view-logs", "restart-services"] as const;
-  }
-
-  if (state.stepResults.setup && !state.stepResults.setup?.ok) {
-    return ["retry"] as const;
-  }
-
-  if (state.status === "failed") {
-    return ["retry"] as const;
-  }
-
-  return [] as const;
-}
 
 function PhaseCard({ label, state, description }: PhaseCardProps) {
   const palette =
@@ -208,7 +181,9 @@ export default function BootstrapGate({
   restartingServices,
 }: BootstrapGateProps) {
   const [openingInstallPage, setOpeningInstallPage] = React.useState(false);
-  const recoveryActions = getRecoveryActions(state);
+  const recoveryActions = getBootstrapRecoveryActions(state);
+  const displayCopy = getBootstrapDisplayCopy(state);
+  const packaged = isPackagedBootstrapState(state);
   const showInstallAction = recoveryActions.includes("install-docker");
   const showRetryAction = recoveryActions.includes("retry");
   const showOpenDockerAction = recoveryActions.includes("open-docker");
@@ -318,14 +293,37 @@ export default function BootstrapGate({
               id="bootstrap-gate-title"
               className="text-2xl font-semibold tracking-[-0.02em] sm:text-3xl"
             >
-              {state.title}
+              {displayCopy.title}
             </h1>
             <p
               className="max-w-3xl text-sm leading-6 sm:text-[15px]"
               style={{ color: "var(--muted)" }}
             >
-              {state.message}
+              {displayCopy.message}
             </p>
+            {packaged && (
+              <div
+                className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs uppercase tracking-[0.18em]"
+                style={{
+                  borderColor: "var(--chip-border)",
+                  background: "rgba(255,255,255,0.04)",
+                  color: "var(--muted)",
+                }}
+              >
+                macOS beta artifact
+                <span
+                  className="h-2 w-2 rounded-full"
+                  style={{
+                    background:
+                      state.status === "ready-for-welcome"
+                        ? "var(--accent-strong, #7dd3fc)"
+                        : state.status === "failed"
+                        ? "var(--danger-text, #fca5a5)"
+                        : "#fbbf24",
+                  }}
+                />
+              </div>
+            )}
           </div>
 
           <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">

--- a/frontend/src/lib/runtimeBootstrap.ts
+++ b/frontend/src/lib/runtimeBootstrap.ts
@@ -15,6 +15,26 @@ export type RuntimePreflight = {
 
 export type BootstrapStep = "setup" | "compose-up" | "health-check";
 
+export type BootstrapRecoveryStage =
+  | "preflight"
+  | "setup"
+  | "compose-up"
+  | "readiness";
+
+export type BootstrapRecoveryAction =
+  | "retry"
+  | "view-logs"
+  | "open-docker"
+  | "restart-services"
+  | "install-docker";
+
+export type BootstrapLogService =
+  | "backend"
+  | "worker-chat"
+  | "db"
+  | "redis"
+  | "migrator";
+
 export type BootstrapStepResult = {
   ok: boolean;
   step: BootstrapStep;
@@ -48,6 +68,41 @@ export type RuntimeReadiness = RuntimeReadinessResult;
 
 export type RuntimeHealthCheckResult = RuntimeReadinessResult;
 
+export type BootstrapDockerOpenResult = {
+  ok: boolean;
+  detail?: string;
+  command?: string;
+};
+
+export type BootstrapLogResult = {
+  ok: boolean;
+  service: BootstrapLogService;
+  detail?: string;
+  logs?: string;
+  command?: string;
+  exitCode?: number;
+};
+
+export type BootstrapRestartResult = {
+  ok: boolean;
+  detail?: string;
+  command?: string;
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+  services: string[];
+};
+
+export type BootstrapRecoveryNotice = {
+  kind:
+    | "logs-unavailable"
+    | "docker-open-failed"
+    | "restart-services-failed";
+  title: string;
+  message: string;
+  detail?: string;
+};
+
 export type RuntimeBootstrapStatus =
   | "checking-requirements"
   | "docker-missing"
@@ -79,6 +134,13 @@ export type RuntimeReadinessWaitResult = {
 const WELCOME_DISMISSED_STORAGE_KEY = "cfy.bootstrap.welcomeDismissed";
 const DOCKER_DESKTOP_DOWNLOAD_URL =
   "https://www.docker.com/products/docker-desktop/";
+export const BOOTSTRAP_LOG_SERVICES: BootstrapLogService[] = [
+  "backend",
+  "worker-chat",
+  "db",
+  "redis",
+  "migrator",
+];
 
 function asBoolean(value: unknown): boolean {
   return value === true;
@@ -102,6 +164,15 @@ function normalizeOptionalBoolean(value: unknown): boolean | undefined {
   if (value === true) return true;
   if (value === false) return false;
   return undefined;
+}
+
+function normalizeBootstrapLogService(
+  value: unknown,
+  fallback: BootstrapLogService
+): BootstrapLogService {
+  return BOOTSTRAP_LOG_SERVICES.includes(value as BootstrapLogService)
+    ? (value as BootstrapLogService)
+    : fallback;
 }
 
 function normalizeEndpointCheck(payload: unknown): HealthEndpointCheck {
@@ -143,6 +214,65 @@ function normalizeStepResult(
     stdout: normalizeText(source.stdout),
     stderr: normalizeText(source.stderr),
     exitCode: normalizeExitCode(source.exitCode),
+  };
+}
+
+function normalizeBootstrapDockerOpenResult(
+  payload: unknown
+): BootstrapDockerOpenResult {
+  const source =
+    payload && typeof payload === "object"
+      ? (payload as Record<string, unknown>)
+      : {};
+
+  return {
+    ok: asBoolean(source.ok),
+    detail: normalizeText(source.detail),
+    command: normalizeText(source.command),
+  };
+}
+
+function normalizeBootstrapLogResult(
+  payload: unknown,
+  fallbackService: BootstrapLogService
+): BootstrapLogResult {
+  const source =
+    payload && typeof payload === "object"
+      ? (payload as Record<string, unknown>)
+      : {};
+
+  return {
+    ok: asBoolean(source.ok),
+    service: normalizeBootstrapLogService(source.service, fallbackService),
+    detail: normalizeText(source.detail),
+    logs: normalizeText(source.logs),
+    command: normalizeText(source.command),
+    exitCode: normalizeExitCode(source.exitCode),
+  };
+}
+
+function normalizeBootstrapRestartResult(
+  payload: unknown
+): BootstrapRestartResult {
+  const source =
+    payload && typeof payload === "object"
+      ? (payload as Record<string, unknown>)
+      : {};
+
+  const services = Array.isArray(source.services)
+    ? source.services
+        .map((entry) => normalizeText(entry))
+        .filter((entry): entry is string => Boolean(entry))
+    : [];
+
+  return {
+    ok: asBoolean(source.ok),
+    detail: normalizeText(source.detail),
+    command: normalizeText(source.command),
+    stdout: normalizeText(source.stdout),
+    stderr: normalizeText(source.stderr),
+    exitCode: normalizeExitCode(source.exitCode),
+    services,
   };
 }
 
@@ -268,7 +398,7 @@ function describeRuntimeReadinessCopy(
       : {
           title: "Codexify did not become ready in time",
           message:
-            "The local beta runtime never satisfied the readiness contract. Retry the bootstrap or inspect the technical details below.",
+            "The local beta runtime never satisfied the readiness contract. Retry the readiness checks first, then restart services if the runtime still looks wedged.",
           failureKind: "readiness-failed",
         };
 
@@ -287,7 +417,7 @@ function describeRuntimeReadinessCopy(
       : {
           title: "Backend never became reachable",
           message:
-            "Compose started, but the backend process never answered /ping. Retry startup from the beginning once the local API is available.",
+            "Compose started, but the backend process never answered /ping. Retry the readiness gate first, then restart services if the API is still unavailable.",
           failureKind: "backend-unreachable",
         };
   }
@@ -303,7 +433,7 @@ function describeRuntimeReadinessCopy(
       : {
           title: "Backend startup did not finish",
           message:
-            "The backend answered /ping, but /health never reached a usable state. Retry the bootstrap so Postgres-backed startup can complete cleanly.",
+            "The backend answered /ping, but /health never reached a usable state. Retry readiness first so startup can settle, then restart services if it stays stuck.",
           failureKind: "startup-not-ready",
         };
   }
@@ -319,7 +449,7 @@ function describeRuntimeReadinessCopy(
       : {
           title: "Redis or chat workers are unavailable",
           message:
-            "The backend is up, but /health/chat never reported a healthy completion path. The workspace stays locked until Redis, queueing, and worker heartbeat are green.",
+            "The backend is up, but /health/chat never reported a healthy completion path. View logs or restart services if Redis, queueing, or worker heartbeat stay red.",
           failureKind: "chat-path-unavailable",
         };
   }
@@ -335,7 +465,7 @@ function describeRuntimeReadinessCopy(
       : {
           title: "Model health did not recover",
           message:
-            "The backend and queue surfaces are up, but /health/llm never became healthy. Retry once the model path is green.",
+            "The backend and queue surfaces are up, but /health/llm never became healthy. Retry readiness first, then inspect logs or restart services if the model path stays red.",
           failureKind: "llm-unavailable",
         };
   }
@@ -530,6 +660,138 @@ export function createFailedRuntimeBootstrapState(options: {
   );
 }
 
+export function getBootstrapRecoveryStage(
+  state: RuntimeBootstrapState
+): BootstrapRecoveryStage | null {
+  if (
+    state.status === "checking-requirements" ||
+    state.status === "docker-missing" ||
+    state.status === "compose-missing" ||
+    state.status === "docker-not-running"
+  ) {
+    return "preflight";
+  }
+
+  if (state.stepResults["health-check"] && !state.stepResults["health-check"]?.ok) {
+    return "readiness";
+  }
+
+  if (state.stepResults["compose-up"] && !state.stepResults["compose-up"]?.ok) {
+    return "compose-up";
+  }
+
+  if (state.stepResults.setup && !state.stepResults.setup?.ok) {
+    return "setup";
+  }
+
+  if (state.status === "failed") {
+    return "preflight";
+  }
+
+  return null;
+}
+
+export function getBootstrapRecoveryActions(
+  state: RuntimeBootstrapState
+): BootstrapRecoveryAction[] {
+  const stage = getBootstrapRecoveryStage(state);
+
+  if (state.status === "docker-missing") {
+    return ["retry", "install-docker"];
+  }
+
+  if (state.status === "compose-missing") {
+    return ["retry", "install-docker"];
+  }
+
+  if (state.status === "docker-not-running") {
+    return ["retry", "open-docker"];
+  }
+
+  if (stage === "setup") {
+    return ["retry"];
+  }
+
+  if (stage === "compose-up" || stage === "readiness") {
+    return ["retry", "view-logs", "restart-services"];
+  }
+
+  if (stage === "preflight") {
+    return ["retry"];
+  }
+
+  return [];
+}
+
+export function getDefaultBootstrapLogService(
+  state: RuntimeBootstrapState
+): BootstrapLogService {
+  if (state.stepResults["health-check"] && !state.stepResults["health-check"]?.ok) {
+    return "backend";
+  }
+
+  if (state.stepResults["compose-up"] && !state.stepResults["compose-up"]?.ok) {
+    return "backend";
+  }
+
+  return "backend";
+}
+
+export function createBootstrapSupportNoticeFromLogResult(
+  result: BootstrapLogResult
+): BootstrapRecoveryNotice | null {
+  if (result.ok) return null;
+
+  return {
+    kind: "logs-unavailable",
+    title: "Recent logs are unavailable",
+    message: `Codexify could not load recent ${result.service} logs from the local Compose runtime. Retry the log fetch or verify Docker and the service state directly.`,
+    detail: result.detail,
+  };
+}
+
+export function createBootstrapSupportNoticeFromDockerOpenResult(
+  result: BootstrapDockerOpenResult
+): BootstrapRecoveryNotice | null {
+  if (result.ok) return null;
+
+  return {
+    kind: "docker-open-failed",
+    title: "Docker Desktop did not open",
+    message:
+      "Codexify could not launch Docker Desktop through the native macOS open path. Start Docker Desktop manually, wait for the daemon to come up, then retry preflight.",
+    detail: result.detail,
+  };
+}
+
+export function createBootstrapSupportNoticeFromRestartResult(
+  result: BootstrapRestartResult
+): BootstrapRecoveryNotice | null {
+  if (result.ok) return null;
+
+  return {
+    kind: "restart-services-failed",
+    title: "Service restart failed",
+    message:
+      "Codexify could not complete the targeted Compose restart/start recovery flow. Review the command detail and runtime logs before retrying.",
+    detail: result.detail,
+  };
+}
+
+export function createComposeRecoveryStepResult(
+  result: BootstrapRestartResult
+): BootstrapStepResult {
+  return {
+    ok: result.ok,
+    step: "compose-up",
+    detail: result.detail,
+    command: result.command,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    exitCode: result.exitCode,
+  };
+}
+
 export function appendBootstrapDetail(
   current: string | undefined,
   next: string | undefined,
@@ -652,6 +914,62 @@ export async function runRuntimeBootstrapPreflight(): Promise<RuntimePreflight> 
         error instanceof Error
           ? error.message
           : String(error ?? "Unknown error"),
+    };
+  }
+}
+
+export async function openDockerDesktopNative(): Promise<BootstrapDockerOpenResult> {
+  try {
+    const payload = await invokeTauriCommand<unknown>(
+      "desktop_open_docker_desktop"
+    );
+    return normalizeBootstrapDockerOpenResult(payload);
+  } catch (error) {
+    return {
+      ok: false,
+      detail:
+        error instanceof Error
+          ? error.message
+          : String(error ?? "Unknown error"),
+    };
+  }
+}
+
+export async function getBootstrapLogs(
+  service: BootstrapLogService
+): Promise<BootstrapLogResult> {
+  try {
+    const payload = await invokeTauriCommand<unknown>(
+      "desktop_get_bootstrap_logs",
+      { service }
+    );
+    return normalizeBootstrapLogResult(payload, service);
+  } catch (error) {
+    return {
+      ok: false,
+      service,
+      detail:
+        error instanceof Error
+          ? error.message
+          : String(error ?? "Unknown error"),
+    };
+  }
+}
+
+export async function restartRuntimeServices(): Promise<BootstrapRestartResult> {
+  try {
+    const payload = await invokeTauriCommand<unknown>(
+      "desktop_restart_runtime_services"
+    );
+    return normalizeBootstrapRestartResult(payload);
+  } catch (error) {
+    return {
+      ok: false,
+      detail:
+        error instanceof Error
+          ? error.message
+          : String(error ?? "Unknown error"),
+      services: [],
     };
   }
 }

--- a/frontend/src/lib/runtimeBootstrap.ts
+++ b/frontend/src/lib/runtimeBootstrap.ts
@@ -11,6 +11,9 @@ export type RuntimePreflight = {
   ready: boolean;
   failureKind?: string;
   detail?: string;
+  runtimeContext?: "development" | "packaged";
+  repoRoot?: string;
+  packaged?: boolean;
 };
 
 export type BootstrapStep = "setup" | "compose-up" | "health-check";
@@ -39,6 +42,10 @@ export type BootstrapStepResult = {
   ok: boolean;
   step: BootstrapStep;
   detail?: string;
+  failureKind?: string;
+  runtimeContext?: "development" | "packaged";
+  repoRoot?: string;
+  packaged?: boolean;
   command?: string;
   stdout?: string;
   stderr?: string;
@@ -78,6 +85,10 @@ export type BootstrapLogResult = {
   ok: boolean;
   service: BootstrapLogService;
   detail?: string;
+  failureKind?: string;
+  runtimeContext?: "development" | "packaged";
+  repoRoot?: string;
+  packaged?: boolean;
   logs?: string;
   command?: string;
   exitCode?: number;
@@ -86,6 +97,10 @@ export type BootstrapLogResult = {
 export type BootstrapRestartResult = {
   ok: boolean;
   detail?: string;
+  failureKind?: string;
+  runtimeContext?: "development" | "packaged";
+  repoRoot?: string;
+  packaged?: boolean;
   command?: string;
   stdout?: string;
   stderr?: string;
@@ -155,6 +170,12 @@ function normalizeFailureKind(value: unknown): string | undefined {
   return normalizeText(value)?.toLowerCase();
 }
 
+function normalizeRuntimeContext(
+  value: unknown
+): "development" | "packaged" | undefined {
+  return value === "development" || value === "packaged" ? value : undefined;
+}
+
 function normalizeExitCode(value: unknown): number | undefined {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : undefined;
@@ -210,6 +231,10 @@ function normalizeStepResult(
     ok: asBoolean(source.ok ?? source.ready),
     step: normalizeStep(source.step, fallbackStep),
     detail: normalizeText(source.detail),
+    failureKind: normalizeFailureKind(source.failureKind),
+    runtimeContext: normalizeRuntimeContext(source.runtimeContext),
+    repoRoot: normalizeText(source.repoRoot),
+    packaged: normalizeOptionalBoolean(source.packaged),
     command: normalizeText(source.command),
     stdout: normalizeText(source.stdout),
     stderr: normalizeText(source.stderr),
@@ -245,6 +270,10 @@ function normalizeBootstrapLogResult(
     ok: asBoolean(source.ok),
     service: normalizeBootstrapLogService(source.service, fallbackService),
     detail: normalizeText(source.detail),
+    failureKind: normalizeFailureKind(source.failureKind),
+    runtimeContext: normalizeRuntimeContext(source.runtimeContext),
+    repoRoot: normalizeText(source.repoRoot),
+    packaged: normalizeOptionalBoolean(source.packaged),
     logs: normalizeText(source.logs),
     command: normalizeText(source.command),
     exitCode: normalizeExitCode(source.exitCode),
@@ -268,6 +297,10 @@ function normalizeBootstrapRestartResult(
   return {
     ok: asBoolean(source.ok),
     detail: normalizeText(source.detail),
+    failureKind: normalizeFailureKind(source.failureKind),
+    runtimeContext: normalizeRuntimeContext(source.runtimeContext),
+    repoRoot: normalizeText(source.repoRoot),
+    packaged: normalizeOptionalBoolean(source.packaged),
     command: normalizeText(source.command),
     stdout: normalizeText(source.stdout),
     stderr: normalizeText(source.stderr),
@@ -289,6 +322,9 @@ export function normalizeRuntimePreflight(payload: unknown): RuntimePreflight {
     ready: asBoolean(source.ready),
     failureKind: normalizeFailureKind(source.failureKind),
     detail: normalizeText(source.detail),
+    runtimeContext: normalizeRuntimeContext(source.runtimeContext),
+    repoRoot: normalizeText(source.repoRoot),
+    packaged: normalizeOptionalBoolean(source.packaged),
   };
 
   if (
@@ -366,6 +402,15 @@ function formatPreflightDetail(preflight: RuntimePreflight): string | undefined 
     `dockerDaemonReachable=${preflight.dockerDaemonReachable}`,
     `ready=${preflight.ready}`,
   ];
+  if (preflight.runtimeContext) {
+    lines.push(`runtimeContext=${preflight.runtimeContext}`);
+  }
+  if (typeof preflight.packaged === "boolean") {
+    lines.push(`packaged=${preflight.packaged}`);
+  }
+  if (preflight.repoRoot) {
+    lines.push(`repoRoot=${preflight.repoRoot}`);
+  }
   if (preflight.failureKind) {
     lines.push(`failureKind=${preflight.failureKind}`);
   }
@@ -497,11 +542,25 @@ export function mapRuntimePreflightFailureToState(
     preflight.detail
   );
 
-  if (preflight.failureKind === "docker-binary-not-found" || !preflight.dockerCliInstalled) {
+  if (preflight.failureKind === "docker-binary-not-found") {
     return buildRuntimeBootstrapState(
       "docker-missing",
       "Docker Desktop is required",
       "Codexify could not find a usable Docker installation on this machine. Install Docker Desktop, then retry the bootstrap check.",
+      {
+        detail,
+        failureKind: preflight.failureKind,
+        preflight,
+        stepResults,
+      }
+    );
+  }
+
+  if (preflight.packaged && preflight.failureKind === "docker-cli-invocation-failed") {
+    return buildRuntimeBootstrapState(
+      "failed",
+      "Packaged startup could not execute the Docker CLI",
+      "Docker Desktop appears to be installed, but this packaged beta build could not execute the Docker CLI cleanly from the desktop shell. Retry once, then relaunch from the repo build output and review the technical details before assuming Docker is missing.",
       {
         detail,
         failureKind: preflight.failureKind,
@@ -536,6 +595,62 @@ export function mapRuntimePreflightFailureToState(
       "docker-not-running",
       "Docker Desktop is not responding yet",
       "Codexify found Docker on this machine, but the local daemon is not reachable. Start Docker Desktop, wait for it to finish initializing, then retry.",
+      {
+        detail,
+        failureKind: preflight.failureKind,
+        preflight,
+        stepResults,
+      }
+    );
+  }
+
+  if (preflight.failureKind === "repo-runtime-missing") {
+    return buildRuntimeBootstrapState(
+      "failed",
+      "Packaged startup could not find local runtime assets",
+      "Docker is reachable, but this build could not locate the repo-backed Codexify runtime files it needs to run setup and Compose. Keep the app inside a Codexify checkout or point it at a local checkout with CODEXIFY_DESKTOP_REPO_ROOT, then retry.",
+      {
+        detail,
+        failureKind: preflight.failureKind,
+        preflight,
+        stepResults,
+      }
+    );
+  }
+
+  if (preflight.failureKind === "packaged-bootstrap-unsupported") {
+    return buildRuntimeBootstrapState(
+      "failed",
+      "Packaged beta app needs a local Codexify checkout",
+      "This packaged beta build was launched outside a supported local runtime context. The current macOS artifact is still repo-attached for setup, Compose, and recovery commands, so the workspace stays locked until the app is run from a Codexify checkout or an explicit local repo root is provided.",
+      {
+        detail,
+        failureKind: preflight.failureKind,
+        preflight,
+        stepResults,
+      }
+    );
+  }
+
+  if (preflight.failureKind === "runtime-path-unavailable") {
+    return buildRuntimeBootstrapState(
+      "failed",
+      "Codexify could not inspect the packaged startup path",
+      "The desktop bootstrap could not determine where this packaged app is running from, so it cannot safely resolve the local runtime directory. Retry once, then relaunch from the produced Codexify.app inside the repo build output if the path stays unavailable.",
+      {
+        detail,
+        failureKind: preflight.failureKind,
+        preflight,
+        stepResults,
+      }
+    );
+  }
+
+  if (preflight.packaged && preflight.failureKind === "unexpected-execution-error") {
+    return buildRuntimeBootstrapState(
+      "failed",
+      "Packaged startup failed unexpectedly",
+      "The packaged desktop shell hit an unexpected startup error while validating the local runtime context. Retry first, then review the technical details below before trying broader recovery steps.",
       {
         detail,
         failureKind: preflight.failureKind,
@@ -660,6 +775,89 @@ export function createFailedRuntimeBootstrapState(options: {
   );
 }
 
+function stateFailureKind(state: RuntimeBootstrapState): string | undefined {
+  return normalizeFailureKind(
+    state.failureKind ??
+      state.preflight?.failureKind ??
+      state.stepResults["health-check"]?.failureKind ??
+      state.stepResults["compose-up"]?.failureKind ??
+      state.stepResults.setup?.failureKind
+  );
+}
+
+export function isPackagedBootstrapState(state: RuntimeBootstrapState): boolean {
+  return (
+    state.preflight?.packaged === true ||
+    state.stepResults.setup?.packaged === true ||
+    state.stepResults["compose-up"]?.packaged === true ||
+    state.stepResults["health-check"]?.packaged === true
+  );
+}
+
+export function getBootstrapDisplayCopy(state: RuntimeBootstrapState): {
+  title: string;
+  message: string;
+} {
+  const failureKind = stateFailureKind(state);
+  const packaged = isPackagedBootstrapState(state);
+
+  if (failureKind === "repo-runtime-missing") {
+    return {
+      title: "Packaged startup could not find local runtime assets",
+      message:
+        "The desktop shell can see Docker, but it cannot find the Codexify repo runtime files it needs for setup and Compose. Run this build from a Codexify checkout or set CODEXIFY_DESKTOP_REPO_ROOT to a local checkout before retrying.",
+    };
+  }
+
+  if (failureKind === "packaged-bootstrap-unsupported") {
+    return {
+      title: "Packaged beta app needs a local Codexify checkout",
+      message:
+        "This macOS beta artifact is not self-contained yet. Launch the built Codexify.app from inside a Codexify checkout, or provide an explicit local repo root, so bootstrap can reach the real setup and Docker Compose runtime.",
+    };
+  }
+
+  if (failureKind === "runtime-path-unavailable") {
+    return {
+      title: "Codexify could not inspect the packaged startup path",
+      message:
+        "The packaged desktop shell could not determine its runtime path safely, so it kept the workspace locked. Retry once, then relaunch the produced Codexify.app from the repo build output if this keeps happening.",
+    };
+  }
+
+  if (packaged && failureKind === "docker-cli-invocation-failed") {
+    return {
+      title: "Packaged startup could not execute the Docker CLI",
+      message:
+        "Docker Desktop looks installed, but this packaged beta build could not execute the Docker CLI from the desktop shell cleanly. Retry once, then use the technical details below to confirm whether this is a packaged-shell limitation before reinstalling Docker.",
+    };
+  }
+
+  if (packaged && failureKind === "unexpected-execution-error") {
+    return {
+      title: "Packaged startup failed unexpectedly",
+      message:
+        "The macOS beta artifact reached the repo-backed bootstrap path but hit an unexpected execution error. Retry first, then review the technical details below before trying broader recovery.",
+    };
+  }
+
+  if (
+    packaged &&
+    (failureKind === "setup-failed" || failureKind === "compose-up-failed")
+  ) {
+    return {
+      title: "Packaged startup failed",
+      message:
+        "The macOS beta artifact found the local runtime context, but setup or Compose did not complete cleanly. Retry first, then use logs or service restart recovery if the runtime looks partially up.",
+    };
+  }
+
+  return {
+    title: state.title,
+    message: state.message,
+  };
+}
+
 export function getBootstrapRecoveryStage(
   state: RuntimeBootstrapState
 ): BootstrapRecoveryStage | null {
@@ -742,6 +940,20 @@ export function createBootstrapSupportNoticeFromLogResult(
 ): BootstrapRecoveryNotice | null {
   if (result.ok) return null;
 
+  if (
+    result.failureKind === "repo-runtime-missing" ||
+    result.failureKind === "packaged-bootstrap-unsupported" ||
+    result.failureKind === "runtime-path-unavailable"
+  ) {
+    return {
+      kind: "logs-unavailable",
+      title: "Runtime logs are unavailable from this packaged context",
+      message:
+        "Codexify could not read Compose logs because this packaged build does not currently have a safe local runtime path. Reopen the app from a Codexify checkout or provide CODEXIFY_DESKTOP_REPO_ROOT, then retry logs.",
+      detail: result.detail,
+    };
+  }
+
   return {
     kind: "logs-unavailable",
     title: "Recent logs are unavailable",
@@ -768,6 +980,20 @@ export function createBootstrapSupportNoticeFromRestartResult(
   result: BootstrapRestartResult
 ): BootstrapRecoveryNotice | null {
   if (result.ok) return null;
+
+  if (
+    result.failureKind === "repo-runtime-missing" ||
+    result.failureKind === "packaged-bootstrap-unsupported" ||
+    result.failureKind === "runtime-path-unavailable"
+  ) {
+    return {
+      kind: "restart-services-failed",
+      title: "Service restart is unavailable from this packaged context",
+      message:
+        "The packaged app could not reach the real repo-backed Compose runtime safely, so it did not attempt a service restart. Reopen the beta artifact from a Codexify checkout or configure CODEXIFY_DESKTOP_REPO_ROOT first.",
+      detail: result.detail,
+    };
+  }
 
   return {
     kind: "restart-services-failed",
@@ -817,6 +1043,18 @@ export function formatBootstrapStepResult(result: BootstrapStepResult): string {
     `step=${result.step}`,
     `ok=${result.ok}`,
   ];
+  if (result.runtimeContext) {
+    lines.push(`runtimeContext=${result.runtimeContext}`);
+  }
+  if (typeof result.packaged === "boolean") {
+    lines.push(`packaged=${result.packaged}`);
+  }
+  if (result.repoRoot) {
+    lines.push(`repoRoot=${result.repoRoot}`);
+  }
+  if (result.failureKind) {
+    lines.push(`failureKind=${result.failureKind}`);
+  }
   if (result.command) {
     lines.push(`command=${result.command}`);
   }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashSet;
 use std::env;
+use std::ffi::OsStr;
 use std::fs;
 use std::io::{ErrorKind, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
@@ -15,6 +16,12 @@ const NORMALIZED_DOCKER_PATH: &str = "/opt/homebrew/bin:/usr/local/bin:/Applicat
 const BOOTSTRAP_LOG_TAIL_LINES: &str = "200";
 const BOOTSTRAP_LOG_SERVICES: [&str; 5] = ["backend", "worker-chat", "db", "redis", "migrator"];
 const BOOTSTRAP_RESTART_SERVICES: [&str; 5] = ["db", "redis", "migrator", "backend", "worker-chat"];
+const FAILURE_KIND_RUNTIME_PATH_UNAVAILABLE: &str = "runtime-path-unavailable";
+const FAILURE_KIND_REPO_RUNTIME_MISSING: &str = "repo-runtime-missing";
+const FAILURE_KIND_PACKAGED_BOOTSTRAP_UNSUPPORTED: &str = "packaged-bootstrap-unsupported";
+const FAILURE_KIND_UNEXPECTED_EXECUTION_ERROR: &str = "unexpected-execution-error";
+const RUNTIME_CONTEXT_DEVELOPMENT: &str = "development";
+const RUNTIME_CONTEXT_PACKAGED: &str = "packaged";
 
 #[cfg(target_os = "macos")]
 const MACOS_DOCKER_APP_BUNDLE: &str = "/Applications/Docker.app";
@@ -47,6 +54,12 @@ pub struct RuntimePreflight {
     pub detail: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_context: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo_root: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub packaged: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -55,6 +68,14 @@ pub struct BootstrapStepResult {
     pub ok: bool,
     pub step: String,
     pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_context: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo_root: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub packaged: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -118,6 +139,14 @@ pub struct BootstrapLogResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_context: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo_root: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub packaged: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub logs: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
@@ -132,6 +161,14 @@ pub struct BootstrapRestartResult {
     pub services: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_context: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo_root: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub packaged: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -218,6 +255,22 @@ struct ParsedHttpUrl {
     host: String,
     port: u16,
     path: String,
+}
+
+#[derive(Debug)]
+struct ResolvedRuntimeRepo {
+    repo_root: PathBuf,
+    runtime_context: &'static str,
+    packaged: bool,
+    resolution_detail: String,
+}
+
+#[derive(Debug)]
+struct RuntimeRepoResolutionError {
+    failure_kind: &'static str,
+    runtime_context: &'static str,
+    packaged: bool,
+    detail: String,
 }
 
 fn env_first(keys: &[&str], fallback: &str) -> String {
@@ -547,26 +600,222 @@ fn build_preflight_detail(probes: &[CommandProbe]) -> Option<String> {
     }
 }
 
-fn resolve_repo_root() -> Result<PathBuf, String> {
+fn is_repo_runtime_root(candidate: &Path) -> bool {
+    candidate.join("docker-compose.yml").is_file()
+        && candidate.join("guardian").is_dir()
+        && candidate.join("frontend").is_dir()
+        && candidate.join("src-tauri").is_dir()
+}
+
+fn has_repo_runtime_hints(candidate: &Path) -> bool {
+    candidate.join(".git").exists()
+        || candidate.join("docker-compose.yml").exists()
+        || candidate.join("guardian").exists()
+        || candidate.join("frontend").exists()
+        || candidate.join("src-tauri").exists()
+}
+
+fn find_repo_root_from_ancestors(start: &Path) -> Option<PathBuf> {
+    start
+        .ancestors()
+        .find(|candidate| is_repo_runtime_root(candidate))
+        .map(Path::to_path_buf)
+}
+
+fn find_repo_hint_from_ancestors(start: &Path) -> Option<PathBuf> {
+    start
+        .ancestors()
+        .find(|candidate| has_repo_runtime_hints(candidate))
+        .map(Path::to_path_buf)
+}
+
+fn find_macos_app_bundle(path: &Path) -> Option<PathBuf> {
+    path.ancestors().find_map(|candidate| {
+        if candidate.extension() == Some(OsStr::new("app")) {
+            Some(candidate.to_path_buf())
+        } else {
+            None
+        }
+    })
+}
+
+fn build_runtime_resolution_detail(lines: Vec<String>) -> String {
+    join_lines(lines)
+}
+
+fn resolve_repo_root() -> Result<ResolvedRuntimeRepo, RuntimeRepoResolutionError> {
+    let current_exe = env::current_exe().map_err(|err| RuntimeRepoResolutionError {
+        failure_kind: FAILURE_KIND_RUNTIME_PATH_UNAVAILABLE,
+        runtime_context: RUNTIME_CONTEXT_DEVELOPMENT,
+        packaged: false,
+        detail: build_runtime_resolution_detail(vec![
+            "runtime repo resolution: failed".to_string(),
+            format!("currentExeError={err}"),
+        ]),
+    })?;
+
+    let packaged_bundle = find_macos_app_bundle(&current_exe);
+    let packaged = packaged_bundle.is_some();
+    let runtime_context = if packaged {
+        RUNTIME_CONTEXT_PACKAGED
+    } else {
+        RUNTIME_CONTEXT_DEVELOPMENT
+    };
+
+    let mut detail_lines = vec![
+        "runtime repo resolution:".to_string(),
+        format!("runtimeContext={runtime_context}"),
+        format!("packaged={packaged}"),
+        format!("currentExe={}", current_exe.display()),
+    ];
+
+    if let Some(bundle) = &packaged_bundle {
+        detail_lines.push(format!("appBundle={}", bundle.display()));
+    }
+
+    if let Ok(current_dir) = env::current_dir() {
+        detail_lines.push(format!("currentDir={}", current_dir.display()));
+    }
+
+    if let Some(override_root) = env::var_os("CODEXIFY_DESKTOP_REPO_ROOT") {
+        let override_path = PathBuf::from(override_root);
+        detail_lines.push(format!(
+            "repoRootOverride={}",
+            override_path.display()
+        ));
+
+        if is_repo_runtime_root(&override_path) {
+            detail_lines.push("repo root resolved from CODEXIFY_DESKTOP_REPO_ROOT.".to_string());
+            return Ok(ResolvedRuntimeRepo {
+                repo_root: override_path,
+                runtime_context,
+                packaged,
+                resolution_detail: build_runtime_resolution_detail(detail_lines),
+            });
+        }
+
+        detail_lines.push(
+            "The explicit CODEXIFY_DESKTOP_REPO_ROOT override did not contain the required Codexify runtime files."
+                .to_string(),
+        );
+        return Err(RuntimeRepoResolutionError {
+            failure_kind: FAILURE_KIND_REPO_RUNTIME_MISSING,
+            runtime_context,
+            packaged,
+            detail: build_runtime_resolution_detail(detail_lines),
+        });
+    }
+
+    if packaged {
+        if let Some(repo_root) = find_repo_root_from_ancestors(&current_exe) {
+            detail_lines.push(format!(
+                "repo root resolved from packaged executable ancestors: {}",
+                repo_root.display()
+            ));
+            return Ok(ResolvedRuntimeRepo {
+                repo_root,
+                runtime_context,
+                packaged,
+                resolution_detail: build_runtime_resolution_detail(detail_lines),
+            });
+        }
+
+        if let Some(bundle) = &packaged_bundle {
+            if let Some(repo_root) = find_repo_root_from_ancestors(bundle) {
+                detail_lines.push(format!(
+                    "repo root resolved from packaged app bundle ancestors: {}",
+                    repo_root.display()
+                ));
+                return Ok(ResolvedRuntimeRepo {
+                    repo_root,
+                    runtime_context,
+                    packaged,
+                    resolution_detail: build_runtime_resolution_detail(detail_lines),
+                });
+            }
+        }
+
+        if let Some(hint_root) = find_repo_hint_from_ancestors(&current_exe) {
+            detail_lines.push(format!(
+                "Found a partial repo-like ancestor, but the required runtime files were missing: {}",
+                hint_root.display()
+            ));
+            detail_lines.push(
+                "Required files: docker-compose.yml, guardian/, frontend/, and src-tauri/."
+                    .to_string(),
+            );
+            return Err(RuntimeRepoResolutionError {
+                failure_kind: FAILURE_KIND_REPO_RUNTIME_MISSING,
+                runtime_context,
+                packaged,
+                detail: build_runtime_resolution_detail(detail_lines),
+            });
+        }
+
+        detail_lines.push(
+            "The packaged app is not running inside a supported local Codexify repo context."
+                .to_string(),
+        );
+        detail_lines.push(
+            "Supported packaged beta context: run the built .app from a Codexify checkout or set CODEXIFY_DESKTOP_REPO_ROOT explicitly."
+                .to_string(),
+        );
+        return Err(RuntimeRepoResolutionError {
+            failure_kind: FAILURE_KIND_PACKAGED_BOOTSTRAP_UNSUPPORTED,
+            runtime_context,
+            packaged,
+            detail: build_runtime_resolution_detail(detail_lines),
+        });
+    }
+
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let manifest_candidate = manifest_dir
         .parent()
         .map(Path::to_path_buf)
         .unwrap_or_else(|| manifest_dir.clone());
 
-    for candidate in [
-        manifest_candidate,
-        env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-    ] {
-        if candidate.join("docker-compose.yml").is_file()
-            && candidate.join("guardian").is_dir()
-            && candidate.join("frontend").is_dir()
-        {
-            return Ok(candidate);
+    detail_lines.push(format!(
+        "manifestCandidate={}",
+        manifest_candidate.display()
+    ));
+    if let Some(repo_root) = find_repo_root_from_ancestors(&manifest_candidate) {
+        detail_lines.push(format!(
+            "repo root resolved from cargo manifest ancestors: {}",
+            repo_root.display()
+        ));
+        return Ok(ResolvedRuntimeRepo {
+            repo_root,
+            runtime_context,
+            packaged,
+            resolution_detail: build_runtime_resolution_detail(detail_lines),
+        });
+    }
+
+    if let Ok(current_dir) = env::current_dir() {
+        if let Some(repo_root) = find_repo_root_from_ancestors(&current_dir) {
+            detail_lines.push(format!(
+                "repo root resolved from working directory ancestors: {}",
+                repo_root.display()
+            ));
+            return Ok(ResolvedRuntimeRepo {
+                repo_root,
+                runtime_context,
+                packaged,
+                resolution_detail: build_runtime_resolution_detail(detail_lines),
+            });
         }
     }
 
-    Err("Unable to resolve the Codexify repo root from the Tauri runtime.".to_string())
+    detail_lines.push(
+        "Unable to resolve the Codexify repo root from the active development runtime."
+            .to_string(),
+    );
+    Err(RuntimeRepoResolutionError {
+        failure_kind: FAILURE_KIND_REPO_RUNTIME_MISSING,
+        runtime_context,
+        packaged,
+        detail: build_runtime_resolution_detail(detail_lines),
+    })
 }
 
 fn resolve_python_binary(repo_root: &Path) -> PathBuf {
@@ -594,11 +843,17 @@ fn build_step_result(
     stdout: Option<String>,
     stderr: Option<String>,
     exit_code: Option<i32>,
+    context: Option<&ResolvedRuntimeRepo>,
+    failure_kind: Option<&str>,
 ) -> BootstrapStepResult {
     BootstrapStepResult {
         ok,
         step: step.to_string(),
         detail,
+        failure_kind: failure_kind.map(str::to_string),
+        runtime_context: context.map(|resolved| resolved.runtime_context.to_string()),
+        repo_root: context.map(|resolved| resolved.repo_root.display().to_string()),
+        packaged: context.map(|resolved| resolved.packaged),
         command,
         stdout,
         stderr,
@@ -630,12 +885,14 @@ fn render_step_detail(
     }
 }
 
-fn build_compose_runtime_lines(repo_root: &Path) -> Vec<String> {
+fn build_compose_runtime_lines(context: &ResolvedRuntimeRepo) -> Vec<String> {
     vec![
-        format!("repoRoot={}", repo_root.display()),
+        format!("runtimeContext={}", context.runtime_context),
+        format!("packaged={}", context.packaged),
+        format!("repoRoot={}", context.repo_root.display()),
         format!(
             "composeFile={}",
-            repo_root.join("docker-compose.yml").display()
+            context.repo_root.join("docker-compose.yml").display()
         ),
     ]
 }
@@ -1049,6 +1306,28 @@ pub fn desktop_open_external(url: String) -> Result<(), String> {
 
 #[tauri::command]
 pub fn desktop_runtime_preflight_check() -> RuntimePreflight {
+    let runtime_repo = resolve_repo_root();
+    let (runtime_context, packaged, repo_root, runtime_probe, runtime_failure_kind) =
+        match &runtime_repo {
+            Ok(resolved) => (
+                Some(resolved.runtime_context.to_string()),
+                Some(resolved.packaged),
+                Some(resolved.repo_root.display().to_string()),
+                CommandProbe::success(resolved.resolution_detail.clone()),
+                None,
+            ),
+            Err(err) => (
+                Some(err.runtime_context.to_string()),
+                Some(err.packaged),
+                None,
+                CommandProbe::failure(
+                    FailureKind::UnexpectedCommandExecutionError,
+                    err.detail.clone(),
+                ),
+                Some(err.failure_kind.to_string()),
+            ),
+        };
+
     match resolve_docker_binary() {
         Ok(binary) => {
             let resolution_probe = CommandProbe::success(format!(
@@ -1111,9 +1390,18 @@ pub fn desktop_runtime_preflight_check() -> RuntimePreflight {
                 )
             };
 
-            let ready = cli_probe.ok && docker_compose_available && docker_daemon_reachable;
-            let detail =
-                build_preflight_detail(&[resolution_probe, cli_probe, compose_probe, daemon_probe]);
+            let ready = cli_probe.ok
+                && docker_compose_available
+                && docker_daemon_reachable
+                && runtime_repo.is_ok();
+            let detail = build_preflight_detail(&[
+                runtime_probe,
+                resolution_probe,
+                cli_probe,
+                compose_probe,
+                daemon_probe,
+            ]);
+            let failure_kind = failure_kind.or(runtime_failure_kind);
 
             RuntimePreflight {
                 docker_cli_installed: true,
@@ -1122,19 +1410,26 @@ pub fn desktop_runtime_preflight_check() -> RuntimePreflight {
                 ready,
                 detail,
                 failure_kind,
+                runtime_context,
+                repo_root,
+                packaged,
             }
         }
         Err(resolution_probe) => {
             let failure_kind = resolution_probe
                 .failure_kind
-                .map(|kind| kind.as_str().to_string());
+                .map(|kind| kind.as_str().to_string())
+                .or(runtime_failure_kind);
             RuntimePreflight {
                 docker_cli_installed: false,
                 docker_compose_available: false,
                 docker_daemon_reachable: false,
                 ready: false,
-                detail: build_preflight_detail(&[resolution_probe]),
+                detail: build_preflight_detail(&[runtime_probe, resolution_probe]),
                 failure_kind,
+                runtime_context,
+                repo_root,
+                packaged,
             }
         }
     }
@@ -1144,11 +1439,23 @@ pub fn desktop_runtime_preflight_check() -> RuntimePreflight {
 pub fn desktop_run_setup_cli() -> BootstrapStepResult {
     let repo_root = match resolve_repo_root() {
         Ok(path) => path,
-        Err(detail) => {
-            return build_step_result(false, "setup", Some(detail), None, None, None, None)
+        Err(err) => {
+            return BootstrapStepResult {
+                ok: false,
+                step: "setup".to_string(),
+                detail: Some(err.detail),
+                failure_kind: Some(err.failure_kind.to_string()),
+                runtime_context: Some(err.runtime_context.to_string()),
+                repo_root: None,
+                packaged: Some(err.packaged),
+                command: None,
+                stdout: None,
+                stderr: None,
+                exit_code: None,
+            }
         }
     };
-    let python = resolve_python_binary(&repo_root);
+    let python = resolve_python_binary(&repo_root.repo_root);
     let command_display = format!(
         "{} -c <guardian.tui.setup_wizard_app.write_wizard_env>",
         python.display()
@@ -1185,12 +1492,12 @@ payload = {{
 print(json.dumps(payload, indent=2))
 raise SystemExit(code)
 "#,
-        repo_root = repo_root.display().to_string()
+        repo_root = repo_root.repo_root.display().to_string()
     );
 
     match Command::new(&python)
         .args(["-c", &script])
-        .current_dir(&repo_root)
+        .current_dir(&repo_root.repo_root)
         .output()
     {
         Ok(output) => {
@@ -1198,7 +1505,9 @@ raise SystemExit(code)
             let stderr = normalize_output(&output.stderr);
             let detail = render_step_detail(
                 vec![
-                    format!("repoRoot={}", repo_root.display()),
+                    format!("runtimeContext={}", repo_root.runtime_context),
+                    format!("packaged={}", repo_root.packaged),
+                    format!("repoRoot={}", repo_root.repo_root.display()),
                     "setupSource=guardian.cli.memoryos_cli setup".to_string(),
                     "automationPath=guardian.tui.setup_wizard_app.write_wizard_env".to_string(),
                     format!("status={}", output.status),
@@ -1214,6 +1523,8 @@ raise SystemExit(code)
                 stdout,
                 stderr,
                 output.status.code(),
+                Some(&repo_root),
+                None,
             )
         }
         Err(err) => build_step_result(
@@ -1227,6 +1538,8 @@ raise SystemExit(code)
             None,
             None,
             None,
+            Some(&repo_root),
+            Some(FAILURE_KIND_UNEXPECTED_EXECUTION_ERROR),
         ),
     }
 }
@@ -1235,8 +1548,20 @@ raise SystemExit(code)
 pub fn desktop_compose_up() -> BootstrapStepResult {
     let repo_root = match resolve_repo_root() {
         Ok(path) => path,
-        Err(detail) => {
-            return build_step_result(false, "compose-up", Some(detail), None, None, None, None)
+        Err(err) => {
+            return BootstrapStepResult {
+                ok: false,
+                step: "compose-up".to_string(),
+                detail: Some(err.detail),
+                failure_kind: Some(err.failure_kind.to_string()),
+                runtime_context: Some(err.runtime_context.to_string()),
+                repo_root: None,
+                packaged: Some(err.packaged),
+                command: None,
+                stdout: None,
+                stderr: None,
+                exit_code: None,
+            }
         }
     };
     let docker = match resolve_docker_binary() {
@@ -1250,27 +1575,26 @@ pub fn desktop_compose_up() -> BootstrapStepResult {
                 None,
                 None,
                 None,
+                Some(&repo_root),
+                probe.failure_kind.map(FailureKind::as_str),
             )
         }
     };
     let command_display = format!("{} compose up -d", docker.display);
 
     match spawn_docker_command(&docker, &["compose", "up", "-d"])
-        .current_dir(&repo_root)
+        .current_dir(&repo_root.repo_root)
         .output()
     {
         Ok(output) => {
             let stdout = normalize_output(&output.stdout);
             let stderr = normalize_output(&output.stderr);
             let detail = render_step_detail(
-                vec![
-                    format!("repoRoot={}", repo_root.display()),
-                    format!(
-                        "composeFile={}",
-                        repo_root.join("docker-compose.yml").display()
-                    ),
-                    format!("status={}", output.status),
-                ],
+                {
+                    let mut lines = build_compose_runtime_lines(&repo_root);
+                    lines.push(format!("status={}", output.status));
+                    lines
+                },
                 stdout.as_ref(),
                 stderr.as_ref(),
             );
@@ -1282,6 +1606,8 @@ pub fn desktop_compose_up() -> BootstrapStepResult {
                 stdout,
                 stderr,
                 output.status.code(),
+                Some(&repo_root),
+                None,
             )
         }
         Err(err) => build_step_result(
@@ -1292,6 +1618,8 @@ pub fn desktop_compose_up() -> BootstrapStepResult {
             None,
             None,
             None,
+            Some(&repo_root),
+            Some(FAILURE_KIND_UNEXPECTED_EXECUTION_ERROR),
         ),
     }
 }
@@ -1394,6 +1722,10 @@ pub fn desktop_get_bootstrap_logs(service: String) -> BootstrapLogResult {
                 ok: false,
                 service: requested_service,
                 detail: Some(detail),
+                failure_kind: None,
+                runtime_context: None,
+                repo_root: None,
+                packaged: None,
                 logs: None,
                 command: None,
                 exit_code: None,
@@ -1403,11 +1735,15 @@ pub fn desktop_get_bootstrap_logs(service: String) -> BootstrapLogResult {
 
     let repo_root = match resolve_repo_root() {
         Ok(path) => path,
-        Err(detail) => {
+        Err(err) => {
             return BootstrapLogResult {
                 ok: false,
                 service: service.to_string(),
-                detail: Some(detail),
+                detail: Some(err.detail),
+                failure_kind: Some(err.failure_kind.to_string()),
+                runtime_context: Some(err.runtime_context.to_string()),
+                repo_root: None,
+                packaged: Some(err.packaged),
                 logs: None,
                 command: None,
                 exit_code: None,
@@ -1421,6 +1757,10 @@ pub fn desktop_get_bootstrap_logs(service: String) -> BootstrapLogResult {
                 ok: false,
                 service: service.to_string(),
                 detail: Some(probe.detail),
+                failure_kind: probe.failure_kind.map(|kind| kind.as_str().to_string()),
+                runtime_context: Some(repo_root.runtime_context.to_string()),
+                repo_root: Some(repo_root.repo_root.display().to_string()),
+                packaged: Some(repo_root.packaged),
                 logs: None,
                 command: Some(format!("docker compose logs --tail {BOOTSTRAP_LOG_TAIL_LINES} --no-color {service}")),
                 exit_code: None,
@@ -1444,7 +1784,7 @@ pub fn desktop_get_bootstrap_logs(service: String) -> BootstrapLogResult {
             service,
         ],
     )
-    .current_dir(&repo_root)
+    .current_dir(&repo_root.repo_root)
     .output()
     {
         Ok(output) => {
@@ -1463,6 +1803,10 @@ pub fn desktop_get_bootstrap_logs(service: String) -> BootstrapLogResult {
                 ok: output.status.success(),
                 service: service.to_string(),
                 detail: Some(join_lines(detail_lines)),
+                failure_kind: None,
+                runtime_context: Some(repo_root.runtime_context.to_string()),
+                repo_root: Some(repo_root.repo_root.display().to_string()),
+                packaged: Some(repo_root.packaged),
                 logs,
                 command: Some(command_display),
                 exit_code: output.status.code(),
@@ -1472,6 +1816,10 @@ pub fn desktop_get_bootstrap_logs(service: String) -> BootstrapLogResult {
             ok: false,
             service: service.to_string(),
             detail: Some(format!("Failed to execute `{command_display}`: {err}")),
+            failure_kind: Some(FAILURE_KIND_UNEXPECTED_EXECUTION_ERROR.to_string()),
+            runtime_context: Some(repo_root.runtime_context.to_string()),
+            repo_root: Some(repo_root.repo_root.display().to_string()),
+            packaged: Some(repo_root.packaged),
             logs: None,
             command: Some(command_display),
             exit_code: None,
@@ -1483,14 +1831,18 @@ pub fn desktop_get_bootstrap_logs(service: String) -> BootstrapLogResult {
 pub fn desktop_restart_runtime_services() -> BootstrapRestartResult {
     let repo_root = match resolve_repo_root() {
         Ok(path) => path,
-        Err(detail) => {
+        Err(err) => {
             return BootstrapRestartResult {
                 ok: false,
                 services: BOOTSTRAP_RESTART_SERVICES
                     .iter()
                     .map(|service| service.to_string())
                     .collect(),
-                detail: Some(detail),
+                detail: Some(err.detail),
+                failure_kind: Some(err.failure_kind.to_string()),
+                runtime_context: Some(err.runtime_context.to_string()),
+                repo_root: None,
+                packaged: Some(err.packaged),
                 command: None,
                 stdout: None,
                 stderr: None,
@@ -1508,6 +1860,10 @@ pub fn desktop_restart_runtime_services() -> BootstrapRestartResult {
                     .map(|service| service.to_string())
                     .collect(),
                 detail: Some(probe.detail),
+                failure_kind: probe.failure_kind.map(|kind| kind.as_str().to_string()),
+                runtime_context: Some(repo_root.runtime_context.to_string()),
+                repo_root: Some(repo_root.repo_root.display().to_string()),
+                packaged: Some(repo_root.packaged),
                 command: Some(format!(
                     "docker compose restart {} && docker compose up -d {}",
                     ["db", "redis", "backend", "worker-chat"].join(" "),
@@ -1545,7 +1901,7 @@ pub fn desktop_restart_runtime_services() -> BootstrapRestartResult {
             "worker-chat",
         ],
     )
-    .current_dir(&repo_root)
+    .current_dir(&repo_root.repo_root)
     .output();
 
     let up_output = spawn_docker_command(
@@ -1561,7 +1917,7 @@ pub fn desktop_restart_runtime_services() -> BootstrapRestartResult {
             "worker-chat",
         ],
     )
-    .current_dir(&repo_root)
+    .current_dir(&repo_root.repo_root)
     .output();
 
     let mut detail_lines = build_compose_runtime_lines(&repo_root);
@@ -1640,6 +1996,10 @@ pub fn desktop_restart_runtime_services() -> BootstrapRestartResult {
                     detail.unwrap_or_default(),
                     err
                 )),
+                failure_kind: Some(FAILURE_KIND_UNEXPECTED_EXECUTION_ERROR.to_string()),
+                runtime_context: Some(repo_root.runtime_context.to_string()),
+                repo_root: Some(repo_root.repo_root.display().to_string()),
+                packaged: Some(repo_root.packaged),
                 command: Some(combined_command_display),
                 stdout,
                 stderr,
@@ -1655,6 +2015,10 @@ pub fn desktop_restart_runtime_services() -> BootstrapRestartResult {
             .map(|service| service.to_string())
             .collect(),
         detail,
+        failure_kind: None,
+        runtime_context: Some(repo_root.runtime_context.to_string()),
+        repo_root: Some(repo_root.repo_root.display().to_string()),
+        packaged: Some(repo_root.packaged),
         command: Some(combined_command_display),
         stdout,
         stderr,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12,6 +12,12 @@ use std::time::Duration;
 const DESKTOP_KEYCHAIN_SERVICE: &str = "com.codexify.desktop";
 const DESKTOP_KEYCHAIN_ACCOUNT: &str = "guardian_api_key";
 const NORMALIZED_DOCKER_PATH: &str = "/opt/homebrew/bin:/usr/local/bin:/Applications/Docker.app/Contents/Resources/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+const BOOTSTRAP_LOG_TAIL_LINES: &str = "200";
+const BOOTSTRAP_LOG_SERVICES: [&str; 5] = ["backend", "worker-chat", "db", "redis", "migrator"];
+const BOOTSTRAP_RESTART_SERVICES: [&str; 5] = ["db", "redis", "migrator", "backend", "worker-chat"];
+
+#[cfg(target_os = "macos")]
+const MACOS_DOCKER_APP_BUNDLE: &str = "/Applications/Docker.app";
 
 #[cfg(target_os = "macos")]
 const MACOS_DOCKER_CANDIDATES: [&str; 3] = [
@@ -93,6 +99,48 @@ pub struct RuntimeReadiness {
 
 #[allow(dead_code)]
 pub type RuntimeHealthCheckResult = RuntimeReadiness;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BootstrapDockerOpenResult {
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BootstrapLogResult {
+    pub ok: bool,
+    pub service: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logs: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BootstrapRestartResult {
+    pub ok: bool,
+    pub services: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stdout: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stderr: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+}
 
 #[derive(Debug, Clone, Copy)]
 enum FailureKind {
@@ -266,6 +314,20 @@ fn render_probe_output(stdout: &[u8], stderr: &[u8]) -> Vec<String> {
         lines.push(format!("stderr: {stderr}"));
     }
     lines
+}
+
+fn normalize_bootstrap_service(service: &str) -> Result<&'static str, String> {
+    let trimmed = service.trim();
+    BOOTSTRAP_LOG_SERVICES
+        .iter()
+        .copied()
+        .find(|candidate| candidate.eq_ignore_ascii_case(trimmed))
+        .ok_or_else(|| {
+            format!(
+                "Unsupported bootstrap log service `{trimmed}`. Supported services: {}.",
+                BOOTSTRAP_LOG_SERVICES.join(", ")
+            )
+        })
 }
 
 fn build_context_lines(label: &str, binary: &ResolvedDockerBinary) -> Vec<String> {
@@ -566,6 +628,16 @@ fn render_step_detail(
     } else {
         Some(detail)
     }
+}
+
+fn build_compose_runtime_lines(repo_root: &Path) -> Vec<String> {
+    vec![
+        format!("repoRoot={}", repo_root.display()),
+        format!(
+            "composeFile={}",
+            repo_root.join("docker-compose.yml").display()
+        ),
+    ]
 }
 
 fn parse_http_url(url: &str) -> Result<ParsedHttpUrl, String> {
@@ -1221,6 +1293,372 @@ pub fn desktop_compose_up() -> BootstrapStepResult {
             None,
             None,
         ),
+    }
+}
+
+#[tauri::command]
+pub fn desktop_open_docker_desktop() -> BootstrapDockerOpenResult {
+    #[cfg(target_os = "macos")]
+    {
+        let mut detail_lines = vec![
+            "Attempting to open Docker Desktop via macOS Launch Services.".to_string(),
+            format!("appBundle={MACOS_DOCKER_APP_BUNDLE}"),
+        ];
+
+        let primary_command = "open -a Docker";
+        match Command::new("open").args(["-a", "Docker"]).output() {
+            Ok(output) if output.status.success() => {
+                detail_lines.push(format!("status={}", output.status));
+                detail_lines.extend(render_probe_output(&output.stdout, &output.stderr));
+                BootstrapDockerOpenResult {
+                    ok: true,
+                    detail: Some(join_lines(detail_lines)),
+                    command: Some(primary_command.to_string()),
+                }
+            }
+            Ok(output) => {
+                detail_lines.push(format!("primary status={}", output.status));
+                detail_lines.extend(render_probe_output(&output.stdout, &output.stderr));
+
+                let fallback_command = format!("open {MACOS_DOCKER_APP_BUNDLE}");
+                match Command::new("open").arg(MACOS_DOCKER_APP_BUNDLE).output() {
+                    Ok(fallback_output) if fallback_output.status.success() => {
+                        detail_lines.push("Fallback app-bundle open succeeded.".to_string());
+                        detail_lines.push(format!("fallback status={}", fallback_output.status));
+                        detail_lines
+                            .extend(render_probe_output(&fallback_output.stdout, &fallback_output.stderr));
+                        BootstrapDockerOpenResult {
+                            ok: true,
+                            detail: Some(join_lines(detail_lines)),
+                            command: Some(format!("{primary_command} || {fallback_command}")),
+                        }
+                    }
+                    Ok(fallback_output) => {
+                        detail_lines.push("Fallback app-bundle open failed.".to_string());
+                        detail_lines.push(format!("fallback status={}", fallback_output.status));
+                        detail_lines
+                            .extend(render_probe_output(&fallback_output.stdout, &fallback_output.stderr));
+                        detail_lines.push(
+                            "Action: confirm Docker Desktop is installed in /Applications and launch it manually."
+                                .to_string(),
+                        );
+                        BootstrapDockerOpenResult {
+                            ok: false,
+                            detail: Some(join_lines(detail_lines)),
+                            command: Some(format!("{primary_command} || {fallback_command}")),
+                        }
+                    }
+                    Err(err) => {
+                        detail_lines.push(format!("Fallback open execution error: {err}"));
+                        detail_lines.push(
+                            "Action: confirm Docker Desktop is installed in /Applications and launch it manually."
+                                .to_string(),
+                        );
+                        BootstrapDockerOpenResult {
+                            ok: false,
+                            detail: Some(join_lines(detail_lines)),
+                            command: Some(format!("{primary_command} || {fallback_command}")),
+                        }
+                    }
+                }
+            }
+            Err(err) => BootstrapDockerOpenResult {
+                ok: false,
+                detail: Some(format!(
+                    "Failed to execute `{primary_command}` via macOS Launch Services: {err}"
+                )),
+                command: Some(primary_command.to_string()),
+            },
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        BootstrapDockerOpenResult {
+            ok: false,
+            detail: Some(
+                "Docker Desktop launch assistance is currently implemented for macOS only."
+                    .to_string(),
+            ),
+            command: None,
+        }
+    }
+}
+
+#[tauri::command]
+pub fn desktop_get_bootstrap_logs(service: String) -> BootstrapLogResult {
+    let requested_service = service.trim().to_string();
+    let service = match normalize_bootstrap_service(&requested_service) {
+        Ok(service) => service,
+        Err(detail) => {
+            return BootstrapLogResult {
+                ok: false,
+                service: requested_service,
+                detail: Some(detail),
+                logs: None,
+                command: None,
+                exit_code: None,
+            }
+        }
+    };
+
+    let repo_root = match resolve_repo_root() {
+        Ok(path) => path,
+        Err(detail) => {
+            return BootstrapLogResult {
+                ok: false,
+                service: service.to_string(),
+                detail: Some(detail),
+                logs: None,
+                command: None,
+                exit_code: None,
+            }
+        }
+    };
+    let docker = match resolve_docker_binary() {
+        Ok(binary) => binary,
+        Err(probe) => {
+            return BootstrapLogResult {
+                ok: false,
+                service: service.to_string(),
+                detail: Some(probe.detail),
+                logs: None,
+                command: Some(format!("docker compose logs --tail {BOOTSTRAP_LOG_TAIL_LINES} --no-color {service}")),
+                exit_code: None,
+            }
+        }
+    };
+
+    let command_display = format!(
+        "{} compose logs --tail {} --no-color {}",
+        docker.display, BOOTSTRAP_LOG_TAIL_LINES, service
+    );
+
+    match spawn_docker_command(
+        &docker,
+        &[
+            "compose",
+            "logs",
+            "--tail",
+            BOOTSTRAP_LOG_TAIL_LINES,
+            "--no-color",
+            service,
+        ],
+    )
+    .current_dir(&repo_root)
+    .output()
+    {
+        Ok(output) => {
+            let logs = normalize_output(&output.stdout);
+            let stderr = normalize_output(&output.stderr);
+            let mut detail_lines = build_compose_runtime_lines(&repo_root);
+            detail_lines.push(format!("service={service}"));
+            detail_lines.push(format!("status={}", output.status));
+            if let Some(stderr) = &stderr {
+                detail_lines.push(String::new());
+                detail_lines.push("stderr:".to_string());
+                detail_lines.push(stderr.clone());
+            }
+
+            BootstrapLogResult {
+                ok: output.status.success(),
+                service: service.to_string(),
+                detail: Some(join_lines(detail_lines)),
+                logs,
+                command: Some(command_display),
+                exit_code: output.status.code(),
+            }
+        }
+        Err(err) => BootstrapLogResult {
+            ok: false,
+            service: service.to_string(),
+            detail: Some(format!("Failed to execute `{command_display}`: {err}")),
+            logs: None,
+            command: Some(command_display),
+            exit_code: None,
+        },
+    }
+}
+
+#[tauri::command]
+pub fn desktop_restart_runtime_services() -> BootstrapRestartResult {
+    let repo_root = match resolve_repo_root() {
+        Ok(path) => path,
+        Err(detail) => {
+            return BootstrapRestartResult {
+                ok: false,
+                services: BOOTSTRAP_RESTART_SERVICES
+                    .iter()
+                    .map(|service| service.to_string())
+                    .collect(),
+                detail: Some(detail),
+                command: None,
+                stdout: None,
+                stderr: None,
+                exit_code: None,
+            }
+        }
+    };
+    let docker = match resolve_docker_binary() {
+        Ok(binary) => binary,
+        Err(probe) => {
+            return BootstrapRestartResult {
+                ok: false,
+                services: BOOTSTRAP_RESTART_SERVICES
+                    .iter()
+                    .map(|service| service.to_string())
+                    .collect(),
+                detail: Some(probe.detail),
+                command: Some(format!(
+                    "docker compose restart {} && docker compose up -d {}",
+                    ["db", "redis", "backend", "worker-chat"].join(" "),
+                    BOOTSTRAP_RESTART_SERVICES.join(" ")
+                )),
+                stdout: None,
+                stderr: None,
+                exit_code: None,
+            }
+        }
+    };
+
+    let restart_services = ["db", "redis", "backend", "worker-chat"];
+    let restart_command_display = format!(
+        "{} compose restart {}",
+        docker.display,
+        restart_services.join(" ")
+    );
+    let up_command_display = format!(
+        "{} compose up -d {}",
+        docker.display,
+        BOOTSTRAP_RESTART_SERVICES.join(" ")
+    );
+    let combined_command_display =
+        format!("{restart_command_display} && {up_command_display}");
+
+    let restart_output = spawn_docker_command(
+        &docker,
+        &[
+            "compose",
+            "restart",
+            "db",
+            "redis",
+            "backend",
+            "worker-chat",
+        ],
+    )
+    .current_dir(&repo_root)
+    .output();
+
+    let up_output = spawn_docker_command(
+        &docker,
+        &[
+            "compose",
+            "up",
+            "-d",
+            "db",
+            "redis",
+            "migrator",
+            "backend",
+            "worker-chat",
+        ],
+    )
+    .current_dir(&repo_root)
+    .output();
+
+    let mut detail_lines = build_compose_runtime_lines(&repo_root);
+    detail_lines.push(format!(
+        "services={}",
+        BOOTSTRAP_RESTART_SERVICES.join(",")
+    ));
+
+    let mut stdout_sections = Vec::new();
+    let mut stderr_sections = Vec::new();
+
+    match &restart_output {
+        Ok(output) => {
+            detail_lines.push(format!("restartStatus={}", output.status));
+            if let Some(stdout) = normalize_output(&output.stdout) {
+                stdout_sections.push(format!("restart:\n{stdout}"));
+            }
+            if let Some(stderr) = normalize_output(&output.stderr) {
+                stderr_sections.push(format!("restart:\n{stderr}"));
+            }
+        }
+        Err(err) => {
+            detail_lines.push(format!("restartExecutionError={err}"));
+        }
+    }
+
+    match &up_output {
+        Ok(output) => {
+            detail_lines.push(format!("upStatus={}", output.status));
+            if let Some(stdout) = normalize_output(&output.stdout) {
+                stdout_sections.push(format!("up:\n{stdout}"));
+            }
+            if let Some(stderr) = normalize_output(&output.stderr) {
+                stderr_sections.push(format!("up:\n{stderr}"));
+            }
+        }
+        Err(err) => {
+            detail_lines.push(format!("upExecutionError={err}"));
+        }
+    }
+
+    let ok = matches!(&up_output, Ok(output) if output.status.success());
+    if ok && matches!(&restart_output, Ok(output) if !output.status.success()) {
+        detail_lines.push(
+            "Restart step failed, but compose up -d succeeded and recovered the targeted services."
+                .to_string(),
+        );
+    }
+
+    let detail = Some(join_lines(detail_lines));
+    let stdout = if stdout_sections.is_empty() {
+        None
+    } else {
+        Some(stdout_sections.join("\n\n"))
+    };
+    let stderr = if stderr_sections.is_empty() {
+        None
+    } else {
+        Some(stderr_sections.join("\n\n"))
+    };
+    let exit_code = match &up_output {
+        Ok(output) => output.status.code(),
+        Err(_) => None,
+    };
+
+    if let Err(err) = &restart_output {
+        if up_output.is_err() {
+            return BootstrapRestartResult {
+                ok: false,
+                services: BOOTSTRAP_RESTART_SERVICES
+                    .iter()
+                    .map(|service| service.to_string())
+                    .collect(),
+                detail: Some(format!(
+                    "{}\n\nBoth Compose recovery commands failed to execute. Restart error: {}",
+                    detail.unwrap_or_default(),
+                    err
+                )),
+                command: Some(combined_command_display),
+                stdout,
+                stderr,
+                exit_code,
+            };
+        }
+    }
+
+    BootstrapRestartResult {
+        ok,
+        services: BOOTSTRAP_RESTART_SERVICES
+            .iter()
+            .map(|service| service.to_string())
+            .collect(),
+        detail,
+        command: Some(combined_command_display),
+        stdout,
+        stderr,
+        exit_code,
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,9 +19,12 @@ pub fn run() {
             commands::desktop_set_api_key,
             commands::desktop_clear_api_key,
             commands::desktop_open_external,
+            commands::desktop_open_docker_desktop,
             commands::desktop_runtime_preflight_check,
             commands::desktop_run_setup_cli,
             commands::desktop_compose_up,
+            commands::desktop_get_bootstrap_logs,
+            commands::desktop_restart_runtime_services,
             commands::desktop_runtime_readiness_check,
             commands::desktop_runtime_health_check
         ])

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:449336b273b77338ae484406255a5ade1a80bf27a7863c93164dc4826e752fdc
-size 806
+oid sha256:04a68f92bc9ec517fc313f45ceee8584f347fd6a80aa0bc7fc864362fae233dd
+size 813


### PR DESCRIPTION
## Summary
- Rename runtime health check handling to readiness terminology across the frontend and Tauri command layer
- Poll `/ping`, `/health`, `/health/chat`, and `/health/llm` and surface more specific readiness state for backend, startup, Redis/chat, and model availability
- Refresh bootstrap copy and failure states to reflect the local beta readiness contract

## Testing
- Not run (not requested)