### PR TITLE
Add packaged runtime home handling for macOS desktop bootstrap

### DIFF
--- a/docs/Codexify/macos-beta-packaging.md
+++ b/docs/Codexify/macos-beta-packaging.md
@@ -2,16 +2,106 @@
 
 ## Current contract
 
-Codexify currently produces a real macOS Tauri beta artifact, but the packaged desktop shell is still attached to the local Codexify repo/runtime model.
+Codexify now has a packaged-safe runtime attachment model for macOS.
 
-That means:
+The packaged desktop app does not depend on the repo checkout for startup. Instead, it resolves a user-scoped runtime home and materializes the minimum runtime payload there before setup or Compose starts.
 
-- the build emits a real `.app`
-- the build emits a real `.dmg`
-- the packaged app can only run bootstrap actions safely when it can resolve a local Codexify checkout
-- the workspace must remain locked whenever packaged bootstrap cannot safely continue
+Packaged runtime home on macOS:
 
-This is a beta packaging contract, not a signed/notarized public-distribution contract.
+- `~/Library/Application Support/Codexify`
+
+Implementation detail:
+
+- Tauri resolves the user data directory for the app
+- Codexify appends `Codexify`
+- that directory becomes the primary packaged runtime home
+
+If the runtime home cannot be resolved or created, packaged bootstrap fails with a classified error and the workspace stays locked.
+
+## Packaged runtime assets
+
+On packaged startup, Codexify expects the app bundle to contain the runtime payload needed for setup, Compose startup, logs, restart, and readiness checks.
+
+Bundled resources currently expected by the packaged app:
+
+- `backend`
+- `backend/requirements.txt`
+- `backend/requirements-tts.txt`
+- `docker`
+- `docker-compose.yml`
+- `guardian`
+- `plugins`
+- `pytest.ini`
+- `requirements`
+- `requirements.txt`
+- `scripts`
+- `tests`
+
+The packaged app copies those resources into the runtime home on startup.
+
+Runtime placeholders created under the runtime home:
+
+- `models`
+- `models/bge-large-en-v1.5`
+- `.chroma`
+
+The model-weight directory is only created as a placeholder here. It is not bundled by this slice.
+
+If the app bundle is missing any required packaged runtime resource, bootstrap fails with `packaged-runtime-assets-missing`.
+If copying or marker creation fails, bootstrap fails with `packaged-runtime-materialization-failed`.
+
+## Startup order
+
+The bootstrap sequence is unchanged:
+
+1. preflight
+2. setup
+3. compose up
+4. readiness wait
+5. welcome
+6. unlock
+
+This task only changed where packaged mode resolves runtime assets and paths from.
+
+## Packaged failure classification
+
+Packaged bootstrap now distinguishes these failure modes:
+
+- `runtime-home-unavailable`
+- `packaged-runtime-assets-missing`
+- `packaged-runtime-materialization-failed`
+- `docker-cli-unavailable`
+- `docker-daemon-unavailable`
+- `packaged-bootstrap-unsupported`
+- `unexpected-execution-error`
+
+The frontend copy now surfaces those cases separately instead of collapsing them into a generic startup failure.
+
+## Current limitations
+
+This packaged runtime model is still a beta attachment model, not a full public-distribution contract.
+
+Known limitations:
+
+- the packaged app still requires Docker Desktop and a reachable Docker daemon
+- the app bundle must contain the packaged runtime payload listed above
+- model weights are not bundled by this slice
+- signing and notarization automation are still not part of this task
+
+If packaged bootstrap cannot safely proceed, the workspace remains locked.
+
+## Validated current result
+
+On this machine, the packaged app now:
+
+- launches via Finder/open outside `cargo tauri dev`
+- resolves and creates the user-scoped runtime home at `~/Library/Application Support/Codexify`
+- materializes the packaged runtime payload into that directory
+- writes the packaged runtime marker at `.codexify-packaged-runtime`
+- reaches the bootstrap gate with a classified Docker preflight failure
+- keeps the workspace locked instead of unlocking prematurely
+
+The current validated packaged failure is Docker preflight, surfaced as "Docker Desktop is required" in the UI.
 
 ## Production build command
 
@@ -21,7 +111,7 @@ Run from the repo root:
 cd src-tauri && cargo tauri build
 ```
 
-## Current output artifacts
+## Output artifacts
 
 On the validated Apple Silicon build path, the production artifacts are:
 
@@ -32,18 +122,9 @@ The plain release executable is also produced at:
 
 - `src-tauri/target/release/app`
 
-## Artifact identity
-
-- Product name: `Codexify`
-- Bundle identifier: `com.codexify.desktop`
-- App bundle name: `Codexify.app`
-- DMG name on the validated Apple Silicon build: `Codexify_0.1.0_aarch64.dmg`
-
-The DMG suffix is architecture-specific. On this machine the validated output is `aarch64`.
-
 ## Signing and notarization status
 
-Current beta artifacts are not developer-signed or notarized.
+Current artifacts are not developer-signed or notarized.
 
 Observed local status:
 
@@ -53,69 +134,27 @@ Observed local status:
 
 This task does not add signing or notarization automation.
 
-## Packaged bootstrap behavior
+## Release posture
 
-The packaged macOS beta build now resolves runtime context explicitly instead of assuming the repo root from the shell working directory.
+The DMG is a technical preview artifact, not public-beta ready yet.
 
-Supported packaged bootstrap context today:
+Reason:
 
-- run `Codexify.app` from inside a Codexify checkout, including the default `src-tauri/target/release/bundle/macos/` build output
-- or launch with `CODEXIFY_DESKTOP_REPO_ROOT` pointing at a local Codexify checkout
+- it is not signed or notarized
+- packaged startup still depends on local Docker Desktop availability
+- the runtime payload is local-materialized, not fully self-contained
 
-Classified packaged failure modes:
+## Packaged startup expectations
 
-- `runtime-path-unavailable`
-- `repo-runtime-missing`
-- `packaged-bootstrap-unsupported`
-- `unexpected-execution-error`
+For a packaged Finder launch to succeed end-to-end, the app should:
 
-The bootstrap overlay now distinguishes:
+1. resolve `~/Library/Application Support/Codexify`
+2. materialize the packaged runtime payload into that directory
+3. run preflight
+4. run setup
+5. start Docker Compose from the runtime home
+6. wait for readiness
+7. show the welcome screen
+8. unlock the workspace
 
-- Docker missing
-- Docker daemon unavailable
-- packaged app cannot locate local runtime assets/config
-- packaged app launched outside a supported local runtime context
-- generic packaged startup failure
-
-## Current known limitations
-
-The packaged beta artifact is not self-contained yet.
-
-Known limitations in the current state:
-
-- setup, Compose startup, log retrieval, and restart actions still depend on the real local Codexify repo/runtime directory
-- launching the packaged app outside a Codexify checkout is unsupported unless `CODEXIFY_DESKTOP_REPO_ROOT` is provided
-- the validated Finder-launched packaged app still reproduced a Docker CLI execution failure even while Docker Desktop and the Compose stack were healthy; the app stayed locked and surfaced packaged startup support copy instead of unlocking the workspace
-- this means packaged bootstrap is supportable and classified, but not yet fully end-to-end reliable outside the development shell
-
-## Manual validation checklist
-
-Use this checklist for packaged beta validation:
-
-1. Run `cd src-tauri && cargo tauri build`.
-2. Confirm `Codexify.app` exists under `src-tauri/target/release/bundle/macos/`.
-3. Confirm the DMG exists under `src-tauri/target/release/bundle/dmg/`.
-4. Launch `Codexify.app` outside `cargo tauri dev`.
-5. Confirm the bootstrap overlay appears instead of unlocking the workspace prematurely.
-6. If the packaged app resolves the local runtime cleanly, confirm setup, Compose startup, readiness, welcome, and unlock complete in order.
-7. If packaged bootstrap does not complete, confirm the failure is classified, the workspace remains locked, and the recovery/support copy matches the real failure mode.
-8. Confirm logs/restart actions never pretend the packaged app can operate against a repo/runtime path it has not safely resolved.
-
-## Validated current result
-
-The current validated result on this machine is:
-
-- `cargo tauri build` completed successfully and emitted both `Codexify.app` and `Codexify_0.1.0_aarch64.dmg`
-- the packaged app launched outside `cargo tauri dev`
-- packaged bootstrap did not proceed end-to-end to welcome/unlock in Finder-launched validation
-- the window remained locked on the bootstrap gate, which is the required safety behavior
-
-## Beta download target
-
-The `codexify.space` beta download button should ultimately point at the uploaded DMG artifact for the current beta release lineage, not the raw `.app` bundle.
-
-For the currently validated local artifact shape, that means the hosted equivalent of:
-
-- `Codexify_0.1.0_aarch64.dmg`
-
-If universal or signed/notarized artifacts are introduced later, the download target should move to that release asset without changing the in-app bootstrap contract described here.
+If any packaged runtime step cannot proceed safely, the workspace must stay locked and the failure must be classified.

--- a/frontend/src/components/bootstrap/BootstrapGate.tsx
+++ b/frontend/src/components/bootstrap/BootstrapGate.tsx
@@ -52,6 +52,22 @@ const PHASE_STEP_MAP: Record<
   readiness: "waiting-for-ready",
 };
 
+const PREFLIGHT_FAILURE_KINDS = new Set([
+  "runtime-home-unavailable",
+  "packaged-runtime-assets-missing",
+  "packaged-runtime-materialization-failed",
+  "packaged-bootstrap-unsupported",
+  "runtime-path-unavailable",
+  "repo-runtime-missing",
+  "docker-cli-unavailable",
+  "docker-compose-unavailable",
+  "docker-daemon-unavailable",
+  "docker-missing",
+  "compose-missing",
+  "docker-not-running",
+  "unexpected-execution-error",
+]);
+
 function PhaseCard({ label, state, description }: PhaseCardProps) {
   const palette =
     state === "done"
@@ -129,12 +145,21 @@ function phaseStateFor(
   state: RuntimeBootstrapState,
   step: "preflight" | "setup" | "compose-up" | "readiness"
 ): PhaseCardState {
+  const failureKind = state.failureKind ?? state.preflight?.failureKind;
+
   if (step === "preflight") {
     if (state.status === "checking-requirements") return "running";
     if (
       state.status === "docker-missing" ||
       state.status === "compose-missing" ||
       state.status === "docker-not-running"
+    ) {
+      return "failed";
+    }
+    if (
+      state.status === "failed" &&
+      failureKind &&
+      PREFLIGHT_FAILURE_KINDS.has(failureKind)
     ) {
       return "failed";
     }
@@ -216,13 +241,13 @@ export default function BootstrapGate({
       id: PHASE_STEP_MAP.setup,
       label: "Preparing local config",
       description:
-        "Run the repo-defined setup source so .env/bootstrap state comes from Codexify itself, not from duplicate Tauri logic.",
+        "Run the packaged-safe setup source so .env/bootstrap state comes from the resolved runtime home, not duplicate Tauri logic.",
     },
     {
       id: PHASE_STEP_MAP["compose-up"],
       label: "Starting local services",
       description:
-        "Bring the existing Docker Compose stack up from the real repo runtime directory.",
+        "Bring the existing Docker Compose stack up from the packaged-safe runtime home.",
     },
     {
       id: PHASE_STEP_MAP.readiness,

--- a/frontend/src/lib/runtimeBootstrap.ts
+++ b/frontend/src/lib/runtimeBootstrap.ts
@@ -13,6 +13,7 @@ export type RuntimePreflight = {
   detail?: string;
   runtimeContext?: "development" | "packaged";
   repoRoot?: string;
+  runtimeHome?: string;
   packaged?: boolean;
 };
 
@@ -45,6 +46,7 @@ export type BootstrapStepResult = {
   failureKind?: string;
   runtimeContext?: "development" | "packaged";
   repoRoot?: string;
+  runtimeHome?: string;
   packaged?: boolean;
   command?: string;
   stdout?: string;
@@ -88,6 +90,7 @@ export type BootstrapLogResult = {
   failureKind?: string;
   runtimeContext?: "development" | "packaged";
   repoRoot?: string;
+  runtimeHome?: string;
   packaged?: boolean;
   logs?: string;
   command?: string;
@@ -100,6 +103,7 @@ export type BootstrapRestartResult = {
   failureKind?: string;
   runtimeContext?: "development" | "packaged";
   repoRoot?: string;
+  runtimeHome?: string;
   packaged?: boolean;
   command?: string;
   stdout?: string;
@@ -167,7 +171,24 @@ function normalizeText(value: unknown): string | undefined {
 }
 
 function normalizeFailureKind(value: unknown): string | undefined {
-  return normalizeText(value)?.toLowerCase();
+  const normalized = normalizeText(value)?.toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+
+  switch (normalized) {
+    case "runtime-path-unavailable":
+      return "runtime-home-unavailable";
+    case "repo-runtime-missing":
+      return "packaged-runtime-assets-missing";
+    case "docker-binary-not-found":
+    case "docker-cli-invocation-failed":
+      return "docker-cli-unavailable";
+    case "docker-daemon-unreachable":
+      return "docker-daemon-unavailable";
+    default:
+      return normalized;
+  }
 }
 
 function normalizeRuntimeContext(
@@ -234,6 +255,7 @@ function normalizeStepResult(
     failureKind: normalizeFailureKind(source.failureKind),
     runtimeContext: normalizeRuntimeContext(source.runtimeContext),
     repoRoot: normalizeText(source.repoRoot),
+    runtimeHome: normalizeText(source.runtimeHome),
     packaged: normalizeOptionalBoolean(source.packaged),
     command: normalizeText(source.command),
     stdout: normalizeText(source.stdout),
@@ -273,6 +295,7 @@ function normalizeBootstrapLogResult(
     failureKind: normalizeFailureKind(source.failureKind),
     runtimeContext: normalizeRuntimeContext(source.runtimeContext),
     repoRoot: normalizeText(source.repoRoot),
+    runtimeHome: normalizeText(source.runtimeHome),
     packaged: normalizeOptionalBoolean(source.packaged),
     logs: normalizeText(source.logs),
     command: normalizeText(source.command),
@@ -300,6 +323,7 @@ function normalizeBootstrapRestartResult(
     failureKind: normalizeFailureKind(source.failureKind),
     runtimeContext: normalizeRuntimeContext(source.runtimeContext),
     repoRoot: normalizeText(source.repoRoot),
+    runtimeHome: normalizeText(source.runtimeHome),
     packaged: normalizeOptionalBoolean(source.packaged),
     command: normalizeText(source.command),
     stdout: normalizeText(source.stdout),
@@ -324,6 +348,7 @@ export function normalizeRuntimePreflight(payload: unknown): RuntimePreflight {
     detail: normalizeText(source.detail),
     runtimeContext: normalizeRuntimeContext(source.runtimeContext),
     repoRoot: normalizeText(source.repoRoot),
+    runtimeHome: normalizeText(source.runtimeHome),
     packaged: normalizeOptionalBoolean(source.packaged),
   };
 
@@ -410,6 +435,9 @@ function formatPreflightDetail(preflight: RuntimePreflight): string | undefined 
   }
   if (preflight.repoRoot) {
     lines.push(`repoRoot=${preflight.repoRoot}`);
+  }
+  if (preflight.runtimeHome) {
+    lines.push(`runtimeHome=${preflight.runtimeHome}`);
   }
   if (preflight.failureKind) {
     lines.push(`failureKind=${preflight.failureKind}`);
@@ -542,11 +570,11 @@ export function mapRuntimePreflightFailureToState(
     preflight.detail
   );
 
-  if (preflight.failureKind === "docker-binary-not-found") {
+  if (preflight.failureKind === "runtime-home-unavailable") {
     return buildRuntimeBootstrapState(
-      "docker-missing",
-      "Docker Desktop is required",
-      "Codexify could not find a usable Docker installation on this machine. Install Docker Desktop, then retry the bootstrap check.",
+      "failed",
+      "Packaged runtime home is unavailable",
+      "Codexify could not resolve or create its user-scoped runtime home under the current macOS profile, so the packaged bootstrap stayed locked.",
       {
         detail,
         failureKind: preflight.failureKind,
@@ -556,11 +584,53 @@ export function mapRuntimePreflightFailureToState(
     );
   }
 
-  if (preflight.packaged && preflight.failureKind === "docker-cli-invocation-failed") {
+  if (preflight.failureKind === "packaged-runtime-assets-missing") {
     return buildRuntimeBootstrapState(
       "failed",
-      "Packaged startup could not execute the Docker CLI",
-      "Docker Desktop appears to be installed, but this packaged beta build could not execute the Docker CLI cleanly from the desktop shell. Retry once, then relaunch from the repo build output and review the technical details before assuming Docker is missing.",
+      "Packaged runtime assets are missing",
+      "This packaged build could not find the bundled runtime source it needs to materialize setup, Compose, and recovery assets into the user profile runtime home.",
+      {
+        detail,
+        failureKind: preflight.failureKind,
+        preflight,
+        stepResults,
+      }
+    );
+  }
+
+  if (preflight.failureKind === "packaged-runtime-materialization-failed") {
+    return buildRuntimeBootstrapState(
+      "failed",
+      "Packaged runtime materialization failed",
+      "Codexify found the packaged runtime payload, but it could not finish copying the required bootstrap assets into the runtime home safely.",
+      {
+        detail,
+        failureKind: preflight.failureKind,
+        preflight,
+        stepResults,
+      }
+    );
+  }
+
+  if (preflight.failureKind === "packaged-bootstrap-unsupported") {
+    return buildRuntimeBootstrapState(
+      "failed",
+      "Packaged bootstrap is not yet supported",
+      "This macOS artifact launched without a packaged runtime payload it can safely attach to, so the workspace stayed locked instead of falling back to a development checkout.",
+      {
+        detail,
+        failureKind: preflight.failureKind,
+        preflight,
+        stepResults,
+      }
+    );
+  }
+
+  if (!preflight.dockerCliInstalled || preflight.failureKind === "docker-cli-unavailable") {
+    return buildRuntimeBootstrapState(
+      "docker-missing",
+      "Docker Desktop is required",
+      "Codexify could not find a usable Docker installation on this machine. Install Docker Desktop, then retry the bootstrap check.",
       {
         detail,
         failureKind: preflight.failureKind,
@@ -588,55 +658,13 @@ export function mapRuntimePreflightFailureToState(
   }
 
   if (
-    preflight.failureKind === "docker-daemon-unreachable" ||
+    preflight.failureKind === "docker-daemon-unavailable" ||
     !preflight.dockerDaemonReachable
   ) {
     return buildRuntimeBootstrapState(
       "docker-not-running",
       "Docker Desktop is not responding yet",
       "Codexify found Docker on this machine, but the local daemon is not reachable. Start Docker Desktop, wait for it to finish initializing, then retry.",
-      {
-        detail,
-        failureKind: preflight.failureKind,
-        preflight,
-        stepResults,
-      }
-    );
-  }
-
-  if (preflight.failureKind === "repo-runtime-missing") {
-    return buildRuntimeBootstrapState(
-      "failed",
-      "Packaged startup could not find local runtime assets",
-      "Docker is reachable, but this build could not locate the repo-backed Codexify runtime files it needs to run setup and Compose. Keep the app inside a Codexify checkout or point it at a local checkout with CODEXIFY_DESKTOP_REPO_ROOT, then retry.",
-      {
-        detail,
-        failureKind: preflight.failureKind,
-        preflight,
-        stepResults,
-      }
-    );
-  }
-
-  if (preflight.failureKind === "packaged-bootstrap-unsupported") {
-    return buildRuntimeBootstrapState(
-      "failed",
-      "Packaged beta app needs a local Codexify checkout",
-      "This packaged beta build was launched outside a supported local runtime context. The current macOS artifact is still repo-attached for setup, Compose, and recovery commands, so the workspace stays locked until the app is run from a Codexify checkout or an explicit local repo root is provided.",
-      {
-        detail,
-        failureKind: preflight.failureKind,
-        preflight,
-        stepResults,
-      }
-    );
-  }
-
-  if (preflight.failureKind === "runtime-path-unavailable") {
-    return buildRuntimeBootstrapState(
-      "failed",
-      "Codexify could not inspect the packaged startup path",
-      "The desktop bootstrap could not determine where this packaged app is running from, so it cannot safely resolve the local runtime directory. Retry once, then relaunch from the produced Codexify.app inside the repo build output if the path stays unavailable.",
       {
         detail,
         failureKind: preflight.failureKind,
@@ -681,7 +709,7 @@ export function createPreparingLocalConfigState(
   return buildRuntimeBootstrapState(
     "preparing-local-config",
     "Preparing local config",
-    "Codexify is running the existing setup source of truth so local configuration stays aligned with the repo-defined bootstrap path.",
+    "Codexify is running the setup source of truth so local configuration stays aligned with the resolved runtime home.",
     { detail, preflight, stepResults }
   );
 }
@@ -694,7 +722,7 @@ export function createStartingLocalServicesState(
   return buildRuntimeBootstrapState(
     "starting-local-services",
     "Starting local services",
-    "Codexify is bringing the local Docker Compose stack up from the repo runtime directory.",
+    "Codexify is bringing the local Docker Compose stack up from the packaged-safe runtime home.",
     { detail, preflight, stepResults }
   );
 }
@@ -801,19 +829,51 @@ export function getBootstrapDisplayCopy(state: RuntimeBootstrapState): {
   const failureKind = stateFailureKind(state);
   const packaged = isPackagedBootstrapState(state);
 
-  if (failureKind === "repo-runtime-missing") {
+  if (failureKind === "runtime-home-unavailable") {
     return {
-      title: "Packaged startup could not find local runtime assets",
+      title: "Packaged runtime home is unavailable",
       message:
-        "The desktop shell can see Docker, but it cannot find the Codexify repo runtime files it needs for setup and Compose. Run this build from a Codexify checkout or set CODEXIFY_DESKTOP_REPO_ROOT to a local checkout before retrying.",
+        "The packaged app could not resolve or create its user-scoped runtime home under the current macOS profile, so startup stayed locked.",
+    };
+  }
+
+  if (failureKind === "packaged-runtime-assets-missing") {
+    return {
+      title: "Packaged runtime assets are missing",
+      message:
+        "This packaged build could not find the bundled runtime source it needs to materialize setup, Compose, and recovery assets into the runtime home.",
+    };
+  }
+
+  if (failureKind === "packaged-runtime-materialization-failed") {
+    return {
+      title: "Packaged runtime materialization failed",
+      message:
+        "Codexify found the packaged runtime payload, but it could not safely copy the required bootstrap assets into the runtime home.",
     };
   }
 
   if (failureKind === "packaged-bootstrap-unsupported") {
     return {
-      title: "Packaged beta app needs a local Codexify checkout",
+      title: "Packaged bootstrap is not yet supported",
       message:
-        "This macOS beta artifact is not self-contained yet. Launch the built Codexify.app from inside a Codexify checkout, or provide an explicit local repo root, so bootstrap can reach the real setup and Docker Compose runtime.",
+        "This macOS artifact launched without a packaged runtime payload it can safely attach to yet, so the workspace stayed locked instead of falling back to a development checkout.",
+    };
+  }
+
+  if (failureKind === "docker-cli-unavailable") {
+    return {
+      title: "Docker is unavailable",
+      message:
+        "Codexify could not find a usable Docker CLI or Compose entrypoint on this machine. Install or repair Docker Desktop, then retry.",
+    };
+  }
+
+  if (failureKind === "docker-daemon-unavailable") {
+    return {
+      title: "Docker Desktop is not responding yet",
+      message:
+        "Docker is installed, but the local daemon is not reachable yet. Open Docker Desktop, wait for it to finish starting, then retry.",
     };
   }
 
@@ -821,15 +881,7 @@ export function getBootstrapDisplayCopy(state: RuntimeBootstrapState): {
     return {
       title: "Codexify could not inspect the packaged startup path",
       message:
-        "The packaged desktop shell could not determine its runtime path safely, so it kept the workspace locked. Retry once, then relaunch the produced Codexify.app from the repo build output if this keeps happening.",
-    };
-  }
-
-  if (packaged && failureKind === "docker-cli-invocation-failed") {
-    return {
-      title: "Packaged startup could not execute the Docker CLI",
-      message:
-        "Docker Desktop looks installed, but this packaged beta build could not execute the Docker CLI from the desktop shell cleanly. Retry once, then use the technical details below to confirm whether this is a packaged-shell limitation before reinstalling Docker.",
+        "The packaged desktop shell could not determine a safe runtime path, so it kept the workspace locked instead of guessing at local state. Retry once, then relaunch the produced Codexify.app if this keeps happening.",
     };
   }
 
@@ -837,7 +889,7 @@ export function getBootstrapDisplayCopy(state: RuntimeBootstrapState): {
     return {
       title: "Packaged startup failed unexpectedly",
       message:
-        "The macOS beta artifact reached the repo-backed bootstrap path but hit an unexpected execution error. Retry first, then review the technical details below before trying broader recovery.",
+        "The macOS beta artifact reached the packaged bootstrap path but hit an unexpected execution error. Retry first, then review the technical details below before trying broader recovery.",
     };
   }
 
@@ -940,16 +992,52 @@ export function createBootstrapSupportNoticeFromLogResult(
 ): BootstrapRecoveryNotice | null {
   if (result.ok) return null;
 
-  if (
-    result.failureKind === "repo-runtime-missing" ||
-    result.failureKind === "packaged-bootstrap-unsupported" ||
-    result.failureKind === "runtime-path-unavailable"
-  ) {
+  if (result.failureKind === "runtime-home-unavailable") {
     return {
       kind: "logs-unavailable",
-      title: "Runtime logs are unavailable from this packaged context",
+      title: "Runtime home is unavailable",
       message:
-        "Codexify could not read Compose logs because this packaged build does not currently have a safe local runtime path. Reopen the app from a Codexify checkout or provide CODEXIFY_DESKTOP_REPO_ROOT, then retry logs.",
+        "Codexify could not resolve or create its user-scoped runtime home, so it did not attempt to read Compose logs.",
+      detail: result.detail,
+    };
+  }
+
+  if (result.failureKind === "packaged-runtime-assets-missing") {
+    return {
+      kind: "logs-unavailable",
+      title: "Packaged runtime assets are missing",
+      message:
+        "Codexify could not find the bundled runtime payload it needs to attach Compose logs from the packaged app.",
+      detail: result.detail,
+    };
+  }
+
+  if (result.failureKind === "packaged-runtime-materialization-failed") {
+    return {
+      kind: "logs-unavailable",
+      title: "Packaged runtime materialization failed",
+      message:
+        "Codexify found the packaged runtime payload, but it could not finish copying it into the runtime home, so logs are unavailable.",
+      detail: result.detail,
+    };
+  }
+
+  if (result.failureKind === "packaged-bootstrap-unsupported") {
+    return {
+      kind: "logs-unavailable",
+      title: "Packaged bootstrap is not yet supported",
+      message:
+        "This packaged build does not yet include a runtime payload it can safely attach to, so log access stayed locked.",
+      detail: result.detail,
+    };
+  }
+
+  if (result.failureKind === "runtime-path-unavailable") {
+    return {
+      kind: "logs-unavailable",
+      title: "Runtime path is unavailable",
+      message:
+        "Codexify could not determine a safe local runtime path, so it did not attempt to read Compose logs.",
       detail: result.detail,
     };
   }
@@ -981,16 +1069,52 @@ export function createBootstrapSupportNoticeFromRestartResult(
 ): BootstrapRecoveryNotice | null {
   if (result.ok) return null;
 
-  if (
-    result.failureKind === "repo-runtime-missing" ||
-    result.failureKind === "packaged-bootstrap-unsupported" ||
-    result.failureKind === "runtime-path-unavailable"
-  ) {
+  if (result.failureKind === "runtime-home-unavailable") {
     return {
       kind: "restart-services-failed",
-      title: "Service restart is unavailable from this packaged context",
+      title: "Runtime home is unavailable",
       message:
-        "The packaged app could not reach the real repo-backed Compose runtime safely, so it did not attempt a service restart. Reopen the beta artifact from a Codexify checkout or configure CODEXIFY_DESKTOP_REPO_ROOT first.",
+        "Codexify could not resolve or create its user-scoped runtime home, so it did not attempt a service restart.",
+      detail: result.detail,
+    };
+  }
+
+  if (result.failureKind === "packaged-runtime-assets-missing") {
+    return {
+      kind: "restart-services-failed",
+      title: "Packaged runtime assets are missing",
+      message:
+        "Codexify could not find the bundled runtime payload it needs to restart services from the packaged app.",
+      detail: result.detail,
+    };
+  }
+
+  if (result.failureKind === "packaged-runtime-materialization-failed") {
+    return {
+      kind: "restart-services-failed",
+      title: "Packaged runtime materialization failed",
+      message:
+        "Codexify found the packaged runtime payload, but it could not finish copying it into the runtime home, so service restart is unavailable.",
+      detail: result.detail,
+    };
+  }
+
+  if (result.failureKind === "packaged-bootstrap-unsupported") {
+    return {
+      kind: "restart-services-failed",
+      title: "Packaged bootstrap is not yet supported",
+      message:
+        "This packaged build does not yet include a runtime payload it can safely attach to, so service restart stayed locked.",
+      detail: result.detail,
+    };
+  }
+
+  if (result.failureKind === "runtime-path-unavailable") {
+    return {
+      kind: "restart-services-failed",
+      title: "Runtime path is unavailable",
+      message:
+        "Codexify could not determine a safe local runtime path, so it did not attempt a service restart.",
       detail: result.detail,
     };
   }
@@ -1051,6 +1175,9 @@ export function formatBootstrapStepResult(result: BootstrapStepResult): string {
   }
   if (result.repoRoot) {
     lines.push(`repoRoot=${result.repoRoot}`);
+  }
+  if (result.runtimeHome) {
+    lines.push(`runtimeHome=${result.runtimeHome}`);
   }
   if (result.failureKind) {
     lines.push(`failureKind=${result.failureKind}`);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -9,6 +9,7 @@ use std::net::{TcpStream, ToSocketAddrs};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
+use tauri::Manager;
 
 const DESKTOP_KEYCHAIN_SERVICE: &str = "com.codexify.desktop";
 const DESKTOP_KEYCHAIN_ACCOUNT: &str = "guardian_api_key";
@@ -16,12 +17,39 @@ const NORMALIZED_DOCKER_PATH: &str = "/opt/homebrew/bin:/usr/local/bin:/Applicat
 const BOOTSTRAP_LOG_TAIL_LINES: &str = "200";
 const BOOTSTRAP_LOG_SERVICES: [&str; 5] = ["backend", "worker-chat", "db", "redis", "migrator"];
 const BOOTSTRAP_RESTART_SERVICES: [&str; 5] = ["db", "redis", "migrator", "backend", "worker-chat"];
+const FAILURE_KIND_RUNTIME_HOME_UNAVAILABLE: &str = "runtime-home-unavailable";
+const FAILURE_KIND_PACKAGED_RUNTIME_ASSETS_MISSING: &str = "packaged-runtime-assets-missing";
+const FAILURE_KIND_PACKAGED_RUNTIME_MATERIALIZATION_FAILED: &str =
+    "packaged-runtime-materialization-failed";
+const FAILURE_KIND_DOCKER_CLI_UNAVAILABLE: &str = "docker-cli-unavailable";
+const FAILURE_KIND_DOCKER_DAEMON_UNAVAILABLE: &str = "docker-daemon-unavailable";
 const FAILURE_KIND_RUNTIME_PATH_UNAVAILABLE: &str = "runtime-path-unavailable";
 const FAILURE_KIND_REPO_RUNTIME_MISSING: &str = "repo-runtime-missing";
 const FAILURE_KIND_PACKAGED_BOOTSTRAP_UNSUPPORTED: &str = "packaged-bootstrap-unsupported";
 const FAILURE_KIND_UNEXPECTED_EXECUTION_ERROR: &str = "unexpected-execution-error";
 const RUNTIME_CONTEXT_DEVELOPMENT: &str = "development";
 const RUNTIME_CONTEXT_PACKAGED: &str = "packaged";
+const PACKAGED_RUNTIME_HOME_DIRNAME: &str = "Codexify";
+const PACKAGED_RUNTIME_MARKER_FILENAME: &str = ".codexify-packaged-runtime";
+const PACKAGED_RUNTIME_REQUIRED_ASSETS: [&str; 12] = [
+    "backend",
+    "backend/requirements.txt",
+    "backend/requirements-tts.txt",
+    "docker",
+    "docker-compose.yml",
+    "guardian",
+    "plugins",
+    "pytest.ini",
+    "requirements",
+    "requirements.txt",
+    "scripts",
+    "tests",
+];
+const PACKAGED_RUNTIME_PLACEHOLDER_DIRS: [&str; 3] = [
+    "models",
+    "models/bge-large-en-v1.5",
+    ".chroma",
+];
 
 #[cfg(target_os = "macos")]
 const MACOS_DOCKER_APP_BUNDLE: &str = "/Applications/Docker.app";
@@ -59,6 +87,8 @@ pub struct RuntimePreflight {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repo_root: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_home: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub packaged: Option<bool>,
 }
 
@@ -74,6 +104,8 @@ pub struct BootstrapStepResult {
     pub runtime_context: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repo_root: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_home: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub packaged: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -145,6 +177,8 @@ pub struct BootstrapLogResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repo_root: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_home: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub packaged: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub logs: Option<String>,
@@ -167,6 +201,8 @@ pub struct BootstrapRestartResult {
     pub runtime_context: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repo_root: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_home: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub packaged: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -191,20 +227,20 @@ enum FailureKind {
 impl FailureKind {
     fn as_str(self) -> &'static str {
         match self {
-            Self::DockerBinaryNotFound => "docker-binary-not-found",
-            Self::DockerCliInvocationFailed => "docker-cli-invocation-failed",
+            Self::DockerBinaryNotFound => FAILURE_KIND_DOCKER_CLI_UNAVAILABLE,
+            Self::DockerCliInvocationFailed => FAILURE_KIND_DOCKER_CLI_UNAVAILABLE,
             Self::DockerComposeUnavailable => "docker-compose-unavailable",
-            Self::DockerDaemonUnreachable => "docker-daemon-unreachable",
-            Self::UnexpectedCommandExecutionError => "unexpected-command-execution-error",
+            Self::DockerDaemonUnreachable => FAILURE_KIND_DOCKER_DAEMON_UNAVAILABLE,
+            Self::UnexpectedCommandExecutionError => FAILURE_KIND_UNEXPECTED_EXECUTION_ERROR,
         }
     }
 
     fn summary(self) -> &'static str {
         match self {
-            Self::DockerBinaryNotFound => "Docker binary not found",
-            Self::DockerCliInvocationFailed => "Docker CLI invocation failed",
+            Self::DockerBinaryNotFound => "Docker CLI unavailable",
+            Self::DockerCliInvocationFailed => "Docker CLI unavailable",
             Self::DockerComposeUnavailable => "Docker Compose unavailable",
-            Self::DockerDaemonUnreachable => "Docker daemon unreachable",
+            Self::DockerDaemonUnreachable => "Docker daemon unavailable",
             Self::UnexpectedCommandExecutionError => "Unexpected command execution error",
         }
     }
@@ -258,19 +294,270 @@ struct ParsedHttpUrl {
 }
 
 #[derive(Debug)]
-struct ResolvedRuntimeRepo {
-    repo_root: PathBuf,
-    runtime_context: &'static str,
+pub struct BootstrapRuntime {
+    runtime_context: String,
     packaged: bool,
-    resolution_detail: String,
+    runtime_root: Option<PathBuf>,
+    repo_root: Option<PathBuf>,
+    runtime_home: Option<PathBuf>,
+    resource_root: Option<PathBuf>,
+    resolution_detail: Option<String>,
+    failure_kind: Option<String>,
+}
+
+impl BootstrapRuntime {
+    fn success(
+        runtime_context: &'static str,
+        packaged: bool,
+        runtime_root: PathBuf,
+        repo_root: Option<PathBuf>,
+        runtime_home: Option<PathBuf>,
+        resource_root: Option<PathBuf>,
+        resolution_detail: String,
+    ) -> Self {
+        Self {
+            runtime_context: runtime_context.to_string(),
+            packaged,
+            runtime_root: Some(runtime_root),
+            repo_root,
+            runtime_home,
+            resource_root,
+            resolution_detail: Some(resolution_detail),
+            failure_kind: None,
+        }
+    }
+
+    fn failure(
+        runtime_context: &'static str,
+        packaged: bool,
+        runtime_root: Option<PathBuf>,
+        repo_root: Option<PathBuf>,
+        runtime_home: Option<PathBuf>,
+        resource_root: Option<PathBuf>,
+        failure_kind: &'static str,
+        detail: String,
+    ) -> Self {
+        Self {
+            runtime_context: runtime_context.to_string(),
+            packaged,
+            runtime_root,
+            repo_root,
+            runtime_home,
+            resource_root,
+            resolution_detail: Some(detail),
+            failure_kind: Some(failure_kind.to_string()),
+        }
+    }
+
+    fn runtime_root_path(&self) -> Option<&Path> {
+        self.runtime_root.as_deref()
+    }
+
+    fn runtime_home_display(&self) -> Option<String> {
+        self.runtime_home
+            .as_ref()
+            .map(|path| path.display().to_string())
+    }
+
+    fn repo_root_display(&self) -> Option<String> {
+        self.repo_root
+            .as_ref()
+            .map(|path| path.display().to_string())
+    }
 }
 
 #[derive(Debug)]
-struct RuntimeRepoResolutionError {
+struct BootstrapRuntimeMaterializationError {
     failure_kind: &'static str,
-    runtime_context: &'static str,
-    packaged: bool,
     detail: String,
+}
+
+fn path_exists(path: &Path) -> bool {
+    path.exists()
+}
+
+fn copy_file_to_runtime(source: &Path, destination: &Path) -> Result<(), String> {
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|err| format!("Failed to create runtime parent {}: {err}", parent.display()))?;
+    }
+
+    fs::copy(source, destination).map_err(|err| {
+        format!(
+            "Failed to copy resource {} -> {}: {err}",
+            source.display(),
+            destination.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+fn copy_dir_all(source: &Path, destination: &Path) -> Result<(), String> {
+    if !source.is_dir() {
+        return Err(format!("Resource directory missing: {}", source.display()));
+    }
+
+    fs::create_dir_all(destination).map_err(|err| {
+        format!(
+            "Failed to create runtime directory {}: {err}",
+            destination.display()
+        )
+    })?;
+
+    for entry in fs::read_dir(source).map_err(|err| {
+        format!("Failed to read resource directory {}: {err}", source.display())
+    })? {
+        let entry = entry.map_err(|err| {
+            format!(
+                "Failed to inspect resource entry under {}: {err}",
+                source.display()
+            )
+        })?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let file_type = entry.file_type().map_err(|err| {
+            format!(
+                "Failed to inspect resource type {}: {err}",
+                source_path.display()
+            )
+        })?;
+
+        if file_type.is_dir() {
+            copy_dir_all(&source_path, &destination_path)?;
+        } else if file_type.is_file() {
+            copy_file_to_runtime(&source_path, &destination_path)?;
+        } else if file_type.is_symlink() {
+            let metadata = fs::metadata(&source_path).map_err(|err| {
+                format!(
+                    "Failed to resolve symbolic resource {}: {err}",
+                    source_path.display()
+                )
+            })?;
+            if metadata.is_dir() {
+                copy_dir_all(&source_path, &destination_path)?;
+            } else if metadata.is_file() {
+                copy_file_to_runtime(&source_path, &destination_path)?;
+            } else {
+                return Err(format!(
+                    "Unsupported packaged resource type at {}",
+                    source_path.display()
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn materialize_packaged_runtime_assets(
+    resource_root: &Path,
+    runtime_root: &Path,
+) -> Result<Vec<String>, BootstrapRuntimeMaterializationError> {
+    let mut detail_lines = vec![
+        format!("resourceRoot={}", resource_root.display()),
+        format!("runtimeHome={}", runtime_root.display()),
+    ];
+
+    fs::create_dir_all(runtime_root).map_err(|err| BootstrapRuntimeMaterializationError {
+        failure_kind: FAILURE_KIND_RUNTIME_HOME_UNAVAILABLE,
+        detail: join_lines(vec![
+            "Packaged runtime home is unavailable.".to_string(),
+            format!("runtimeHome={}", runtime_root.display()),
+            format!("error={err}"),
+        ]),
+    })?;
+
+    for placeholder in PACKAGED_RUNTIME_PLACEHOLDER_DIRS {
+        let placeholder_path = runtime_root.join(placeholder);
+        fs::create_dir_all(&placeholder_path).map_err(|err| BootstrapRuntimeMaterializationError {
+            failure_kind: FAILURE_KIND_PACKAGED_RUNTIME_MATERIALIZATION_FAILED,
+            detail: join_lines(vec![
+                "Packaged runtime materialization failed while creating placeholder directories."
+                    .to_string(),
+                format!("runtimeHome={}", runtime_root.display()),
+                format!("placeholder={}", placeholder_path.display()),
+                format!("error={err}"),
+            ]),
+        })?;
+    }
+
+    let mut missing_assets = Vec::new();
+    for relative_path in PACKAGED_RUNTIME_REQUIRED_ASSETS {
+        let source_path = resource_root.join(relative_path);
+        let destination_path = runtime_root.join(relative_path);
+        if !path_exists(&source_path) {
+            missing_assets.push(relative_path.to_string());
+            continue;
+        }
+
+        let metadata = fs::metadata(&source_path).map_err(|err| BootstrapRuntimeMaterializationError {
+            failure_kind: FAILURE_KIND_PACKAGED_RUNTIME_MATERIALIZATION_FAILED,
+            detail: join_lines(vec![
+                "Packaged runtime materialization failed while inspecting a resource.".to_string(),
+                format!("resource={}", source_path.display()),
+                format!("error={err}"),
+            ]),
+        })?;
+
+        if metadata.is_dir() {
+            copy_dir_all(&source_path, &destination_path).map_err(|detail| {
+                BootstrapRuntimeMaterializationError {
+                    failure_kind: FAILURE_KIND_PACKAGED_RUNTIME_MATERIALIZATION_FAILED,
+                    detail: join_lines(vec![
+                        "Packaged runtime materialization failed while copying a resource directory."
+                            .to_string(),
+                        detail,
+                    ]),
+                }
+            })?;
+        } else if metadata.is_file() {
+            copy_file_to_runtime(&source_path, &destination_path).map_err(|detail| {
+                BootstrapRuntimeMaterializationError {
+                    failure_kind: FAILURE_KIND_PACKAGED_RUNTIME_MATERIALIZATION_FAILED,
+                    detail: join_lines(vec![
+                        "Packaged runtime materialization failed while copying a resource file."
+                            .to_string(),
+                        detail,
+                    ]),
+                }
+            })?;
+        } else {
+            missing_assets.push(relative_path.to_string());
+        }
+    }
+
+    if !missing_assets.is_empty() {
+        detail_lines.push(format!("missingAssets={}", missing_assets.join(",")));
+        detail_lines.push(
+            "The packaged app bundle is missing the runtime source payload needed to bootstrap safely."
+                .to_string(),
+        );
+        return Err(BootstrapRuntimeMaterializationError {
+            failure_kind: FAILURE_KIND_PACKAGED_RUNTIME_ASSETS_MISSING,
+            detail: join_lines(detail_lines),
+        });
+    }
+
+    let marker_path = runtime_root.join(PACKAGED_RUNTIME_MARKER_FILENAME);
+    let marker_contents = join_lines(vec![
+        format!("version={}", env!("CARGO_PKG_VERSION")),
+        format!("resourceRoot={}", resource_root.display()),
+        format!("runtimeHome={}", runtime_root.display()),
+    ]);
+    fs::write(&marker_path, marker_contents).map_err(|err| BootstrapRuntimeMaterializationError {
+        failure_kind: FAILURE_KIND_PACKAGED_RUNTIME_MATERIALIZATION_FAILED,
+        detail: join_lines(vec![
+            "Packaged runtime materialization failed while writing the runtime marker."
+                .to_string(),
+            format!("runtimeHome={}", runtime_root.display()),
+            format!("marker={}", marker_path.display()),
+            format!("error={err}"),
+        ]),
+    })?;
+
+    detail_lines.push("materialization=complete".to_string());
+    Ok(detail_lines)
 }
 
 fn env_first(keys: &[&str], fallback: &str) -> String {
@@ -381,6 +668,248 @@ fn normalize_bootstrap_service(service: &str) -> Result<&'static str, String> {
                 BOOTSTRAP_LOG_SERVICES.join(", ")
             )
         })
+}
+
+fn resolve_development_bootstrap_runtime() -> BootstrapRuntime {
+    let current_exe = match env::current_exe() {
+        Ok(path) => path,
+        Err(err) => {
+            return BootstrapRuntime::failure(
+                RUNTIME_CONTEXT_DEVELOPMENT,
+                false,
+                None,
+                None,
+                None,
+                None,
+                FAILURE_KIND_RUNTIME_PATH_UNAVAILABLE,
+                join_lines(vec![
+                    "runtime repo resolution: failed".to_string(),
+                    format!("currentExeError={err}"),
+                ]),
+            );
+        }
+    };
+
+    let mut detail_lines = vec![
+        "runtime repo resolution:".to_string(),
+        format!("runtimeContext={RUNTIME_CONTEXT_DEVELOPMENT}"),
+        "packaged=false".to_string(),
+        format!("currentExe={}", current_exe.display()),
+    ];
+
+    if let Ok(current_dir) = env::current_dir() {
+        detail_lines.push(format!("currentDir={}", current_dir.display()));
+    }
+
+    if let Some(override_root) = env::var_os("CODEXIFY_DESKTOP_REPO_ROOT") {
+        let override_path = PathBuf::from(override_root);
+        detail_lines.push(format!(
+            "repoRootOverride={}",
+            override_path.display()
+        ));
+
+        if is_repo_runtime_root(&override_path) {
+            detail_lines.push("repo root resolved from CODEXIFY_DESKTOP_REPO_ROOT.".to_string());
+            return BootstrapRuntime::success(
+                RUNTIME_CONTEXT_DEVELOPMENT,
+                false,
+                override_path.clone(),
+                Some(override_path),
+                None,
+                None,
+                join_lines(detail_lines),
+            );
+        }
+
+        detail_lines.push(
+            "The explicit CODEXIFY_DESKTOP_REPO_ROOT override did not contain the required Codexify runtime files."
+                .to_string(),
+        );
+        return BootstrapRuntime::failure(
+            RUNTIME_CONTEXT_DEVELOPMENT,
+            false,
+            None,
+            None,
+            None,
+            None,
+            FAILURE_KIND_REPO_RUNTIME_MISSING,
+            join_lines(detail_lines),
+        );
+    }
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_candidate = manifest_dir
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| manifest_dir.clone());
+
+    detail_lines.push(format!(
+        "manifestCandidate={}",
+        manifest_candidate.display()
+    ));
+    if let Some(repo_root) = find_repo_root_from_ancestors(&manifest_candidate) {
+        detail_lines.push(format!(
+            "repo root resolved from cargo manifest ancestors: {}",
+            repo_root.display()
+        ));
+        return BootstrapRuntime::success(
+            RUNTIME_CONTEXT_DEVELOPMENT,
+            false,
+            repo_root.clone(),
+            Some(repo_root),
+            None,
+            None,
+            join_lines(detail_lines),
+        );
+    }
+
+    if let Ok(current_dir) = env::current_dir() {
+        if let Some(repo_root) = find_repo_root_from_ancestors(&current_dir) {
+            detail_lines.push(format!(
+                "repo root resolved from working directory ancestors: {}",
+                repo_root.display()
+            ));
+            return BootstrapRuntime::success(
+                RUNTIME_CONTEXT_DEVELOPMENT,
+                false,
+                repo_root.clone(),
+                Some(repo_root),
+                None,
+                None,
+                join_lines(detail_lines),
+            );
+        }
+    }
+
+    detail_lines.push(
+        "Unable to resolve the Codexify repo root from the active development runtime."
+            .to_string(),
+    );
+    BootstrapRuntime::failure(
+        RUNTIME_CONTEXT_DEVELOPMENT,
+        false,
+        None,
+        None,
+        None,
+        None,
+        FAILURE_KIND_REPO_RUNTIME_MISSING,
+        join_lines(detail_lines),
+    )
+}
+
+fn resolve_packaged_bootstrap_runtime(
+    app: &tauri::AppHandle,
+    current_exe: &Path,
+    packaged_bundle: &Path,
+) -> BootstrapRuntime {
+    let mut detail_lines = vec![
+        "runtime repo resolution:".to_string(),
+        format!("runtimeContext={RUNTIME_CONTEXT_PACKAGED}"),
+        "packaged=true".to_string(),
+        format!("currentExe={}", current_exe.display()),
+        format!("appBundle={}", packaged_bundle.display()),
+    ];
+
+    if let Ok(current_dir) = env::current_dir() {
+        detail_lines.push(format!("currentDir={}", current_dir.display()));
+    }
+
+    let runtime_home = match app.path().data_dir() {
+        Ok(data_dir) => data_dir.join(PACKAGED_RUNTIME_HOME_DIRNAME),
+        Err(err) => {
+            detail_lines.push(
+                "The packaged app could not resolve a user-scoped runtime home."
+                    .to_string(),
+            );
+            detail_lines.push(format!("runtimeHomeError={err}"));
+            return BootstrapRuntime::failure(
+                RUNTIME_CONTEXT_PACKAGED,
+                true,
+                None,
+                None,
+                None,
+                None,
+                FAILURE_KIND_RUNTIME_HOME_UNAVAILABLE,
+                join_lines(detail_lines),
+            );
+        }
+    };
+    detail_lines.push(format!("runtimeHome={}", runtime_home.display()));
+
+    let resource_root = match app.path().resource_dir() {
+        Ok(path) => path,
+        Err(err) => {
+            detail_lines.push(
+                "The packaged app could not resolve its bundled resource directory."
+                    .to_string(),
+            );
+            detail_lines.push(format!("resourceRootError={err}"));
+            return BootstrapRuntime::failure(
+                RUNTIME_CONTEXT_PACKAGED,
+                true,
+                Some(runtime_home.clone()),
+                None,
+                Some(runtime_home),
+                None,
+                FAILURE_KIND_PACKAGED_BOOTSTRAP_UNSUPPORTED,
+                join_lines(detail_lines),
+            );
+        }
+    };
+    detail_lines.push(format!("resourceRoot={}", resource_root.display()));
+
+    match materialize_packaged_runtime_assets(&resource_root, &runtime_home) {
+        Ok(materialization_detail) => {
+            detail_lines.extend(materialization_detail);
+            BootstrapRuntime::success(
+                RUNTIME_CONTEXT_PACKAGED,
+                true,
+                runtime_home.clone(),
+                None,
+                Some(runtime_home),
+                Some(resource_root),
+                join_lines(detail_lines),
+            )
+        }
+        Err(err) => BootstrapRuntime::failure(
+            RUNTIME_CONTEXT_PACKAGED,
+            true,
+            Some(runtime_home.clone()),
+            None,
+            Some(runtime_home),
+            Some(resource_root),
+            err.failure_kind,
+            join_lines(vec![join_lines(detail_lines), err.detail]),
+        ),
+    }
+}
+
+pub fn resolve_bootstrap_runtime(app: &tauri::AppHandle) -> BootstrapRuntime {
+    let current_exe = match env::current_exe() {
+        Ok(path) => path,
+        Err(err) => {
+            return BootstrapRuntime::failure(
+                RUNTIME_CONTEXT_DEVELOPMENT,
+                false,
+                None,
+                None,
+                None,
+                None,
+                FAILURE_KIND_RUNTIME_PATH_UNAVAILABLE,
+                join_lines(vec![
+                    "runtime repo resolution: failed".to_string(),
+                    format!("currentExeError={err}"),
+                ]),
+            );
+        }
+    };
+
+    let packaged_bundle = find_macos_app_bundle(&current_exe);
+    if let Some(bundle) = packaged_bundle {
+        return resolve_packaged_bootstrap_runtime(app, &current_exe, &bundle);
+    }
+
+    resolve_development_bootstrap_runtime()
 }
 
 fn build_context_lines(label: &str, binary: &ResolvedDockerBinary) -> Vec<String> {
@@ -607,25 +1136,10 @@ fn is_repo_runtime_root(candidate: &Path) -> bool {
         && candidate.join("src-tauri").is_dir()
 }
 
-fn has_repo_runtime_hints(candidate: &Path) -> bool {
-    candidate.join(".git").exists()
-        || candidate.join("docker-compose.yml").exists()
-        || candidate.join("guardian").exists()
-        || candidate.join("frontend").exists()
-        || candidate.join("src-tauri").exists()
-}
-
 fn find_repo_root_from_ancestors(start: &Path) -> Option<PathBuf> {
     start
         .ancestors()
         .find(|candidate| is_repo_runtime_root(candidate))
-        .map(Path::to_path_buf)
-}
-
-fn find_repo_hint_from_ancestors(start: &Path) -> Option<PathBuf> {
-    start
-        .ancestors()
-        .find(|candidate| has_repo_runtime_hints(candidate))
         .map(Path::to_path_buf)
 }
 
@@ -636,185 +1150,6 @@ fn find_macos_app_bundle(path: &Path) -> Option<PathBuf> {
         } else {
             None
         }
-    })
-}
-
-fn build_runtime_resolution_detail(lines: Vec<String>) -> String {
-    join_lines(lines)
-}
-
-fn resolve_repo_root() -> Result<ResolvedRuntimeRepo, RuntimeRepoResolutionError> {
-    let current_exe = env::current_exe().map_err(|err| RuntimeRepoResolutionError {
-        failure_kind: FAILURE_KIND_RUNTIME_PATH_UNAVAILABLE,
-        runtime_context: RUNTIME_CONTEXT_DEVELOPMENT,
-        packaged: false,
-        detail: build_runtime_resolution_detail(vec![
-            "runtime repo resolution: failed".to_string(),
-            format!("currentExeError={err}"),
-        ]),
-    })?;
-
-    let packaged_bundle = find_macos_app_bundle(&current_exe);
-    let packaged = packaged_bundle.is_some();
-    let runtime_context = if packaged {
-        RUNTIME_CONTEXT_PACKAGED
-    } else {
-        RUNTIME_CONTEXT_DEVELOPMENT
-    };
-
-    let mut detail_lines = vec![
-        "runtime repo resolution:".to_string(),
-        format!("runtimeContext={runtime_context}"),
-        format!("packaged={packaged}"),
-        format!("currentExe={}", current_exe.display()),
-    ];
-
-    if let Some(bundle) = &packaged_bundle {
-        detail_lines.push(format!("appBundle={}", bundle.display()));
-    }
-
-    if let Ok(current_dir) = env::current_dir() {
-        detail_lines.push(format!("currentDir={}", current_dir.display()));
-    }
-
-    if let Some(override_root) = env::var_os("CODEXIFY_DESKTOP_REPO_ROOT") {
-        let override_path = PathBuf::from(override_root);
-        detail_lines.push(format!(
-            "repoRootOverride={}",
-            override_path.display()
-        ));
-
-        if is_repo_runtime_root(&override_path) {
-            detail_lines.push("repo root resolved from CODEXIFY_DESKTOP_REPO_ROOT.".to_string());
-            return Ok(ResolvedRuntimeRepo {
-                repo_root: override_path,
-                runtime_context,
-                packaged,
-                resolution_detail: build_runtime_resolution_detail(detail_lines),
-            });
-        }
-
-        detail_lines.push(
-            "The explicit CODEXIFY_DESKTOP_REPO_ROOT override did not contain the required Codexify runtime files."
-                .to_string(),
-        );
-        return Err(RuntimeRepoResolutionError {
-            failure_kind: FAILURE_KIND_REPO_RUNTIME_MISSING,
-            runtime_context,
-            packaged,
-            detail: build_runtime_resolution_detail(detail_lines),
-        });
-    }
-
-    if packaged {
-        if let Some(repo_root) = find_repo_root_from_ancestors(&current_exe) {
-            detail_lines.push(format!(
-                "repo root resolved from packaged executable ancestors: {}",
-                repo_root.display()
-            ));
-            return Ok(ResolvedRuntimeRepo {
-                repo_root,
-                runtime_context,
-                packaged,
-                resolution_detail: build_runtime_resolution_detail(detail_lines),
-            });
-        }
-
-        if let Some(bundle) = &packaged_bundle {
-            if let Some(repo_root) = find_repo_root_from_ancestors(bundle) {
-                detail_lines.push(format!(
-                    "repo root resolved from packaged app bundle ancestors: {}",
-                    repo_root.display()
-                ));
-                return Ok(ResolvedRuntimeRepo {
-                    repo_root,
-                    runtime_context,
-                    packaged,
-                    resolution_detail: build_runtime_resolution_detail(detail_lines),
-                });
-            }
-        }
-
-        if let Some(hint_root) = find_repo_hint_from_ancestors(&current_exe) {
-            detail_lines.push(format!(
-                "Found a partial repo-like ancestor, but the required runtime files were missing: {}",
-                hint_root.display()
-            ));
-            detail_lines.push(
-                "Required files: docker-compose.yml, guardian/, frontend/, and src-tauri/."
-                    .to_string(),
-            );
-            return Err(RuntimeRepoResolutionError {
-                failure_kind: FAILURE_KIND_REPO_RUNTIME_MISSING,
-                runtime_context,
-                packaged,
-                detail: build_runtime_resolution_detail(detail_lines),
-            });
-        }
-
-        detail_lines.push(
-            "The packaged app is not running inside a supported local Codexify repo context."
-                .to_string(),
-        );
-        detail_lines.push(
-            "Supported packaged beta context: run the built .app from a Codexify checkout or set CODEXIFY_DESKTOP_REPO_ROOT explicitly."
-                .to_string(),
-        );
-        return Err(RuntimeRepoResolutionError {
-            failure_kind: FAILURE_KIND_PACKAGED_BOOTSTRAP_UNSUPPORTED,
-            runtime_context,
-            packaged,
-            detail: build_runtime_resolution_detail(detail_lines),
-        });
-    }
-
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let manifest_candidate = manifest_dir
-        .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| manifest_dir.clone());
-
-    detail_lines.push(format!(
-        "manifestCandidate={}",
-        manifest_candidate.display()
-    ));
-    if let Some(repo_root) = find_repo_root_from_ancestors(&manifest_candidate) {
-        detail_lines.push(format!(
-            "repo root resolved from cargo manifest ancestors: {}",
-            repo_root.display()
-        ));
-        return Ok(ResolvedRuntimeRepo {
-            repo_root,
-            runtime_context,
-            packaged,
-            resolution_detail: build_runtime_resolution_detail(detail_lines),
-        });
-    }
-
-    if let Ok(current_dir) = env::current_dir() {
-        if let Some(repo_root) = find_repo_root_from_ancestors(&current_dir) {
-            detail_lines.push(format!(
-                "repo root resolved from working directory ancestors: {}",
-                repo_root.display()
-            ));
-            return Ok(ResolvedRuntimeRepo {
-                repo_root,
-                runtime_context,
-                packaged,
-                resolution_detail: build_runtime_resolution_detail(detail_lines),
-            });
-        }
-    }
-
-    detail_lines.push(
-        "Unable to resolve the Codexify repo root from the active development runtime."
-            .to_string(),
-    );
-    Err(RuntimeRepoResolutionError {
-        failure_kind: FAILURE_KIND_REPO_RUNTIME_MISSING,
-        runtime_context,
-        packaged,
-        detail: build_runtime_resolution_detail(detail_lines),
     })
 }
 
@@ -843,7 +1178,7 @@ fn build_step_result(
     stdout: Option<String>,
     stderr: Option<String>,
     exit_code: Option<i32>,
-    context: Option<&ResolvedRuntimeRepo>,
+    context: Option<&BootstrapRuntime>,
     failure_kind: Option<&str>,
 ) -> BootstrapStepResult {
     BootstrapStepResult {
@@ -851,8 +1186,9 @@ fn build_step_result(
         step: step.to_string(),
         detail,
         failure_kind: failure_kind.map(str::to_string),
-        runtime_context: context.map(|resolved| resolved.runtime_context.to_string()),
-        repo_root: context.map(|resolved| resolved.repo_root.display().to_string()),
+        runtime_context: context.map(|resolved| resolved.runtime_context.clone()),
+        repo_root: context.and_then(|resolved| resolved.repo_root_display()),
+        runtime_home: context.and_then(|resolved| resolved.runtime_home_display()),
         packaged: context.map(|resolved| resolved.packaged),
         command,
         stdout,
@@ -885,16 +1221,31 @@ fn render_step_detail(
     }
 }
 
-fn build_compose_runtime_lines(context: &ResolvedRuntimeRepo) -> Vec<String> {
-    vec![
+fn build_compose_runtime_lines(context: &BootstrapRuntime) -> Vec<String> {
+    let runtime_root = context.runtime_root_path();
+    let mut lines = vec![
         format!("runtimeContext={}", context.runtime_context),
         format!("packaged={}", context.packaged),
-        format!("repoRoot={}", context.repo_root.display()),
-        format!(
+    ];
+
+    if let Some(repo_root) = &context.repo_root {
+        lines.push(format!("repoRoot={}", repo_root.display()));
+    }
+    if let Some(runtime_home) = &context.runtime_home {
+        lines.push(format!("runtimeHome={}", runtime_home.display()));
+    }
+    if let Some(resource_root) = &context.resource_root {
+        lines.push(format!("resourceRoot={}", resource_root.display()));
+    }
+    if let Some(runtime_root) = runtime_root {
+        lines.push(format!("runtimeRoot={}", runtime_root.display()));
+        lines.push(format!(
             "composeFile={}",
-            context.repo_root.join("docker-compose.yml").display()
-        ),
-    ]
+            runtime_root.join("docker-compose.yml").display()
+        ));
+    }
+
+    lines
 }
 
 fn parse_http_url(url: &str) -> Result<ParsedHttpUrl, String> {
@@ -1305,28 +1656,33 @@ pub fn desktop_open_external(url: String) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub fn desktop_runtime_preflight_check() -> RuntimePreflight {
-    let runtime_repo = resolve_repo_root();
-    let (runtime_context, packaged, repo_root, runtime_probe, runtime_failure_kind) =
-        match &runtime_repo {
-            Ok(resolved) => (
-                Some(resolved.runtime_context.to_string()),
-                Some(resolved.packaged),
-                Some(resolved.repo_root.display().to_string()),
-                CommandProbe::success(resolved.resolution_detail.clone()),
-                None,
-            ),
-            Err(err) => (
-                Some(err.runtime_context.to_string()),
-                Some(err.packaged),
-                None,
-                CommandProbe::failure(
-                    FailureKind::UnexpectedCommandExecutionError,
-                    err.detail.clone(),
-                ),
-                Some(err.failure_kind.to_string()),
-            ),
+pub fn desktop_runtime_preflight_check(
+    runtime: tauri::State<'_, BootstrapRuntime>,
+) -> RuntimePreflight {
+    let runtime_probe = if let Some(detail) = &runtime.resolution_detail {
+        CommandProbe::success(detail.clone())
+    } else {
+        CommandProbe::success("runtime resolution detail unavailable.".to_string())
+    };
+    let runtime_context = Some(runtime.runtime_context.clone());
+    let repo_root = runtime.repo_root_display();
+    let runtime_home = runtime.runtime_home_display();
+    let packaged = Some(runtime.packaged);
+
+    if runtime.failure_kind.is_some() || runtime.runtime_root_path().is_none() {
+        return RuntimePreflight {
+            docker_cli_installed: false,
+            docker_compose_available: false,
+            docker_daemon_reachable: false,
+            ready: false,
+            detail: build_preflight_detail(&[runtime_probe]),
+            failure_kind: runtime.failure_kind.clone(),
+            runtime_context,
+            repo_root,
+            runtime_home,
+            packaged,
         };
+    }
 
     match resolve_docker_binary() {
         Ok(binary) => {
@@ -1393,7 +1749,7 @@ pub fn desktop_runtime_preflight_check() -> RuntimePreflight {
             let ready = cli_probe.ok
                 && docker_compose_available
                 && docker_daemon_reachable
-                && runtime_repo.is_ok();
+                && runtime.runtime_root_path().is_some();
             let detail = build_preflight_detail(&[
                 runtime_probe,
                 resolution_probe,
@@ -1401,7 +1757,6 @@ pub fn desktop_runtime_preflight_check() -> RuntimePreflight {
                 compose_probe,
                 daemon_probe,
             ]);
-            let failure_kind = failure_kind.or(runtime_failure_kind);
 
             RuntimePreflight {
                 docker_cli_installed: true,
@@ -1412,14 +1767,12 @@ pub fn desktop_runtime_preflight_check() -> RuntimePreflight {
                 failure_kind,
                 runtime_context,
                 repo_root,
+                runtime_home,
                 packaged,
             }
         }
         Err(resolution_probe) => {
-            let failure_kind = resolution_probe
-                .failure_kind
-                .map(|kind| kind.as_str().to_string())
-                .or(runtime_failure_kind);
+            let failure_kind = resolution_probe.failure_kind.map(|kind| kind.as_str().to_string());
             RuntimePreflight {
                 docker_cli_installed: false,
                 docker_compose_available: false,
@@ -1429,6 +1782,7 @@ pub fn desktop_runtime_preflight_check() -> RuntimePreflight {
                 failure_kind,
                 runtime_context,
                 repo_root,
+                runtime_home,
                 packaged,
             }
         }
@@ -1436,18 +1790,21 @@ pub fn desktop_runtime_preflight_check() -> RuntimePreflight {
 }
 
 #[tauri::command]
-pub fn desktop_run_setup_cli() -> BootstrapStepResult {
-    let repo_root = match resolve_repo_root() {
-        Ok(path) => path,
-        Err(err) => {
+pub fn desktop_run_setup_cli(
+    runtime: tauri::State<'_, BootstrapRuntime>,
+) -> BootstrapStepResult {
+    let repo_root = match runtime.runtime_root_path() {
+        Some(path) => path.to_path_buf(),
+        None => {
             return BootstrapStepResult {
                 ok: false,
                 step: "setup".to_string(),
-                detail: Some(err.detail),
-                failure_kind: Some(err.failure_kind.to_string()),
-                runtime_context: Some(err.runtime_context.to_string()),
-                repo_root: None,
-                packaged: Some(err.packaged),
+                detail: runtime.resolution_detail.clone(),
+                failure_kind: runtime.failure_kind.clone(),
+                runtime_context: Some(runtime.runtime_context.clone()),
+                repo_root: runtime.repo_root_display(),
+                runtime_home: runtime.runtime_home_display(),
+                packaged: Some(runtime.packaged),
                 command: None,
                 stdout: None,
                 stderr: None,
@@ -1455,7 +1812,7 @@ pub fn desktop_run_setup_cli() -> BootstrapStepResult {
             }
         }
     };
-    let python = resolve_python_binary(&repo_root.repo_root);
+    let python = resolve_python_binary(&repo_root);
     let command_display = format!(
         "{} -c <guardian.tui.setup_wizard_app.write_wizard_env>",
         python.display()
@@ -1492,12 +1849,12 @@ payload = {{
 print(json.dumps(payload, indent=2))
 raise SystemExit(code)
 "#,
-        repo_root = repo_root.repo_root.display().to_string()
+        repo_root = repo_root.display().to_string()
     );
 
     match Command::new(&python)
         .args(["-c", &script])
-        .current_dir(&repo_root.repo_root)
+        .current_dir(&repo_root)
         .output()
     {
         Ok(output) => {
@@ -1505,9 +1862,14 @@ raise SystemExit(code)
             let stderr = normalize_output(&output.stderr);
             let detail = render_step_detail(
                 vec![
-                    format!("runtimeContext={}", repo_root.runtime_context),
-                    format!("packaged={}", repo_root.packaged),
-                    format!("repoRoot={}", repo_root.repo_root.display()),
+                    format!("runtimeContext={}", runtime.runtime_context),
+                    format!("packaged={}", runtime.packaged),
+                    format!("repoRoot={}", repo_root.display()),
+                    runtime
+                        .runtime_home
+                        .as_ref()
+                        .map(|path| format!("runtimeHome={}", path.display()))
+                        .unwrap_or_default(),
                     "setupSource=guardian.cli.memoryos_cli setup".to_string(),
                     "automationPath=guardian.tui.setup_wizard_app.write_wizard_env".to_string(),
                     format!("status={}", output.status),
@@ -1523,7 +1885,7 @@ raise SystemExit(code)
                 stdout,
                 stderr,
                 output.status.code(),
-                Some(&repo_root),
+                Some(&*runtime),
                 None,
             )
         }
@@ -1538,25 +1900,28 @@ raise SystemExit(code)
             None,
             None,
             None,
-            Some(&repo_root),
+            Some(&*runtime),
             Some(FAILURE_KIND_UNEXPECTED_EXECUTION_ERROR),
         ),
     }
 }
 
 #[tauri::command]
-pub fn desktop_compose_up() -> BootstrapStepResult {
-    let repo_root = match resolve_repo_root() {
-        Ok(path) => path,
-        Err(err) => {
+pub fn desktop_compose_up(
+    runtime: tauri::State<'_, BootstrapRuntime>,
+) -> BootstrapStepResult {
+    let repo_root = match runtime.runtime_root_path() {
+        Some(path) => path.to_path_buf(),
+        None => {
             return BootstrapStepResult {
                 ok: false,
                 step: "compose-up".to_string(),
-                detail: Some(err.detail),
-                failure_kind: Some(err.failure_kind.to_string()),
-                runtime_context: Some(err.runtime_context.to_string()),
-                repo_root: None,
-                packaged: Some(err.packaged),
+                detail: runtime.resolution_detail.clone(),
+                failure_kind: runtime.failure_kind.clone(),
+                runtime_context: Some(runtime.runtime_context.clone()),
+                repo_root: runtime.repo_root_display(),
+                runtime_home: runtime.runtime_home_display(),
+                packaged: Some(runtime.packaged),
                 command: None,
                 stdout: None,
                 stderr: None,
@@ -1575,7 +1940,7 @@ pub fn desktop_compose_up() -> BootstrapStepResult {
                 None,
                 None,
                 None,
-                Some(&repo_root),
+                Some(&*runtime),
                 probe.failure_kind.map(FailureKind::as_str),
             )
         }
@@ -1583,7 +1948,7 @@ pub fn desktop_compose_up() -> BootstrapStepResult {
     let command_display = format!("{} compose up -d", docker.display);
 
     match spawn_docker_command(&docker, &["compose", "up", "-d"])
-        .current_dir(&repo_root.repo_root)
+        .current_dir(&repo_root)
         .output()
     {
         Ok(output) => {
@@ -1591,7 +1956,7 @@ pub fn desktop_compose_up() -> BootstrapStepResult {
             let stderr = normalize_output(&output.stderr);
             let detail = render_step_detail(
                 {
-                    let mut lines = build_compose_runtime_lines(&repo_root);
+                    let mut lines = build_compose_runtime_lines(&runtime);
                     lines.push(format!("status={}", output.status));
                     lines
                 },
@@ -1606,7 +1971,7 @@ pub fn desktop_compose_up() -> BootstrapStepResult {
                 stdout,
                 stderr,
                 output.status.code(),
-                Some(&repo_root),
+                Some(&*runtime),
                 None,
             )
         }
@@ -1618,7 +1983,7 @@ pub fn desktop_compose_up() -> BootstrapStepResult {
             None,
             None,
             None,
-            Some(&repo_root),
+            Some(&*runtime),
             Some(FAILURE_KIND_UNEXPECTED_EXECUTION_ERROR),
         ),
     }
@@ -1713,7 +2078,10 @@ pub fn desktop_open_docker_desktop() -> BootstrapDockerOpenResult {
 }
 
 #[tauri::command]
-pub fn desktop_get_bootstrap_logs(service: String) -> BootstrapLogResult {
+pub fn desktop_get_bootstrap_logs(
+    runtime: tauri::State<'_, BootstrapRuntime>,
+    service: String,
+) -> BootstrapLogResult {
     let requested_service = service.trim().to_string();
     let service = match normalize_bootstrap_service(&requested_service) {
         Ok(service) => service,
@@ -1723,9 +2091,10 @@ pub fn desktop_get_bootstrap_logs(service: String) -> BootstrapLogResult {
                 service: requested_service,
                 detail: Some(detail),
                 failure_kind: None,
-                runtime_context: None,
-                repo_root: None,
-                packaged: None,
+                runtime_context: Some(runtime.runtime_context.clone()),
+                repo_root: runtime.repo_root_display(),
+                runtime_home: runtime.runtime_home_display(),
+                packaged: Some(runtime.packaged),
                 logs: None,
                 command: None,
                 exit_code: None,
@@ -1733,17 +2102,18 @@ pub fn desktop_get_bootstrap_logs(service: String) -> BootstrapLogResult {
         }
     };
 
-    let repo_root = match resolve_repo_root() {
-        Ok(path) => path,
-        Err(err) => {
+    let repo_root = match runtime.runtime_root_path() {
+        Some(path) => path.to_path_buf(),
+        None => {
             return BootstrapLogResult {
                 ok: false,
                 service: service.to_string(),
-                detail: Some(err.detail),
-                failure_kind: Some(err.failure_kind.to_string()),
-                runtime_context: Some(err.runtime_context.to_string()),
-                repo_root: None,
-                packaged: Some(err.packaged),
+                detail: runtime.resolution_detail.clone(),
+                failure_kind: runtime.failure_kind.clone(),
+                runtime_context: Some(runtime.runtime_context.clone()),
+                repo_root: runtime.repo_root_display(),
+                runtime_home: runtime.runtime_home_display(),
+                packaged: Some(runtime.packaged),
                 logs: None,
                 command: None,
                 exit_code: None,
@@ -1758,9 +2128,10 @@ pub fn desktop_get_bootstrap_logs(service: String) -> BootstrapLogResult {
                 service: service.to_string(),
                 detail: Some(probe.detail),
                 failure_kind: probe.failure_kind.map(|kind| kind.as_str().to_string()),
-                runtime_context: Some(repo_root.runtime_context.to_string()),
-                repo_root: Some(repo_root.repo_root.display().to_string()),
-                packaged: Some(repo_root.packaged),
+                runtime_context: Some(runtime.runtime_context.clone()),
+                repo_root: runtime.repo_root_display(),
+                runtime_home: runtime.runtime_home_display(),
+                packaged: Some(runtime.packaged),
                 logs: None,
                 command: Some(format!("docker compose logs --tail {BOOTSTRAP_LOG_TAIL_LINES} --no-color {service}")),
                 exit_code: None,
@@ -1784,13 +2155,13 @@ pub fn desktop_get_bootstrap_logs(service: String) -> BootstrapLogResult {
             service,
         ],
     )
-    .current_dir(&repo_root.repo_root)
+    .current_dir(&repo_root)
     .output()
     {
         Ok(output) => {
             let logs = normalize_output(&output.stdout);
             let stderr = normalize_output(&output.stderr);
-            let mut detail_lines = build_compose_runtime_lines(&repo_root);
+            let mut detail_lines = build_compose_runtime_lines(&runtime);
             detail_lines.push(format!("service={service}"));
             detail_lines.push(format!("status={}", output.status));
             if let Some(stderr) = &stderr {
@@ -1804,9 +2175,10 @@ pub fn desktop_get_bootstrap_logs(service: String) -> BootstrapLogResult {
                 service: service.to_string(),
                 detail: Some(join_lines(detail_lines)),
                 failure_kind: None,
-                runtime_context: Some(repo_root.runtime_context.to_string()),
-                repo_root: Some(repo_root.repo_root.display().to_string()),
-                packaged: Some(repo_root.packaged),
+                runtime_context: Some(runtime.runtime_context.clone()),
+                repo_root: runtime.repo_root_display(),
+                runtime_home: runtime.runtime_home_display(),
+                packaged: Some(runtime.packaged),
                 logs,
                 command: Some(command_display),
                 exit_code: output.status.code(),
@@ -1817,9 +2189,10 @@ pub fn desktop_get_bootstrap_logs(service: String) -> BootstrapLogResult {
             service: service.to_string(),
             detail: Some(format!("Failed to execute `{command_display}`: {err}")),
             failure_kind: Some(FAILURE_KIND_UNEXPECTED_EXECUTION_ERROR.to_string()),
-            runtime_context: Some(repo_root.runtime_context.to_string()),
-            repo_root: Some(repo_root.repo_root.display().to_string()),
-            packaged: Some(repo_root.packaged),
+            runtime_context: Some(runtime.runtime_context.clone()),
+            repo_root: runtime.repo_root_display(),
+            runtime_home: runtime.runtime_home_display(),
+            packaged: Some(runtime.packaged),
             logs: None,
             command: Some(command_display),
             exit_code: None,
@@ -1828,21 +2201,24 @@ pub fn desktop_get_bootstrap_logs(service: String) -> BootstrapLogResult {
 }
 
 #[tauri::command]
-pub fn desktop_restart_runtime_services() -> BootstrapRestartResult {
-    let repo_root = match resolve_repo_root() {
-        Ok(path) => path,
-        Err(err) => {
+pub fn desktop_restart_runtime_services(
+    runtime: tauri::State<'_, BootstrapRuntime>,
+) -> BootstrapRestartResult {
+    let repo_root = match runtime.runtime_root_path() {
+        Some(path) => path.to_path_buf(),
+        None => {
             return BootstrapRestartResult {
                 ok: false,
                 services: BOOTSTRAP_RESTART_SERVICES
                     .iter()
                     .map(|service| service.to_string())
                     .collect(),
-                detail: Some(err.detail),
-                failure_kind: Some(err.failure_kind.to_string()),
-                runtime_context: Some(err.runtime_context.to_string()),
-                repo_root: None,
-                packaged: Some(err.packaged),
+                detail: runtime.resolution_detail.clone(),
+                failure_kind: runtime.failure_kind.clone(),
+                runtime_context: Some(runtime.runtime_context.clone()),
+                repo_root: runtime.repo_root_display(),
+                runtime_home: runtime.runtime_home_display(),
+                packaged: Some(runtime.packaged),
                 command: None,
                 stdout: None,
                 stderr: None,
@@ -1861,9 +2237,10 @@ pub fn desktop_restart_runtime_services() -> BootstrapRestartResult {
                     .collect(),
                 detail: Some(probe.detail),
                 failure_kind: probe.failure_kind.map(|kind| kind.as_str().to_string()),
-                runtime_context: Some(repo_root.runtime_context.to_string()),
-                repo_root: Some(repo_root.repo_root.display().to_string()),
-                packaged: Some(repo_root.packaged),
+                runtime_context: Some(runtime.runtime_context.clone()),
+                repo_root: runtime.repo_root_display(),
+                runtime_home: runtime.runtime_home_display(),
+                packaged: Some(runtime.packaged),
                 command: Some(format!(
                     "docker compose restart {} && docker compose up -d {}",
                     ["db", "redis", "backend", "worker-chat"].join(" "),
@@ -1901,7 +2278,7 @@ pub fn desktop_restart_runtime_services() -> BootstrapRestartResult {
             "worker-chat",
         ],
     )
-    .current_dir(&repo_root.repo_root)
+    .current_dir(&repo_root)
     .output();
 
     let up_output = spawn_docker_command(
@@ -1917,10 +2294,10 @@ pub fn desktop_restart_runtime_services() -> BootstrapRestartResult {
             "worker-chat",
         ],
     )
-    .current_dir(&repo_root.repo_root)
+    .current_dir(&repo_root)
     .output();
 
-    let mut detail_lines = build_compose_runtime_lines(&repo_root);
+    let mut detail_lines = build_compose_runtime_lines(&runtime);
     detail_lines.push(format!(
         "services={}",
         BOOTSTRAP_RESTART_SERVICES.join(",")
@@ -1997,9 +2374,10 @@ pub fn desktop_restart_runtime_services() -> BootstrapRestartResult {
                     err
                 )),
                 failure_kind: Some(FAILURE_KIND_UNEXPECTED_EXECUTION_ERROR.to_string()),
-                runtime_context: Some(repo_root.runtime_context.to_string()),
-                repo_root: Some(repo_root.repo_root.display().to_string()),
-                packaged: Some(repo_root.packaged),
+                runtime_context: Some(runtime.runtime_context.clone()),
+                repo_root: runtime.repo_root_display(),
+                runtime_home: runtime.runtime_home_display(),
+                packaged: Some(runtime.packaged),
                 command: Some(combined_command_display),
                 stdout,
                 stderr,
@@ -2016,9 +2394,10 @@ pub fn desktop_restart_runtime_services() -> BootstrapRestartResult {
             .collect(),
         detail,
         failure_kind: None,
-        runtime_context: Some(repo_root.runtime_context.to_string()),
-        repo_root: Some(repo_root.repo_root.display().to_string()),
-        packaged: Some(repo_root.packaged),
+        runtime_context: Some(runtime.runtime_context.clone()),
+        repo_root: runtime.repo_root_display(),
+        runtime_home: runtime.runtime_home_display(),
+        packaged: Some(runtime.packaged),
         command: Some(combined_command_display),
         stdout,
         stderr,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,7 @@
 mod commands;
 
+use tauri::Manager;
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -11,6 +13,9 @@ pub fn run() {
                         .build(),
                 )?;
             }
+            let handle = app.handle().clone();
+            let bootstrap_runtime = commands::resolve_bootstrap_runtime(&handle);
+            app.manage(bootstrap_runtime);
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:04a68f92bc9ec517fc313f45ceee8584f347fd6a80aa0bc7fc864362fae233dd
-size 813
+oid sha256:1e286cf9142cd987dd8031263fb3320abd7655890f83c4461f9dc9e360a39071
+size 7565


### PR DESCRIPTION
## Summary
- resolve a user-scoped packaged runtime home for the macOS app and materialize required bootstrap assets there instead of depending on a repo checkout
- expand Tauri bootstrap commands to support packaged runtime resolution, richer readiness checks, Docker Desktop launch, log retrieval, and targeted service restart recovery
- update the frontend bootstrap gate to classify packaged startup failures, expose recovery actions, and reflect the stricter local readiness contract
- document the current macOS beta packaging model, runtime asset contract, failure classes, and release limitations

## Testing
- Not run (not requested)