### PR TITLE
Fix sidebar search sizing and normalize icon scale

### DIFF
--- a/frontend/src/components/sidebar/SidebarRoot.tsx
+++ b/frontend/src/components/sidebar/SidebarRoot.tsx
@@ -347,17 +347,20 @@ export default function SidebarRoot({
         </div>
 
         <div className={clsx(columnClass, tab === "projects" && "mb-[5px]")}>
-          <div className="relative">
+          <div
+            className="flex items-center gap-[calc(var(--radius-micro)/2)] rounded-[var(--tile-radius)] border bg-[var(--chip-bg)] px-[var(--radius-micro)] focus-within:ring-2 focus-within:ring-[var(--accent)]"
+            style={{ borderColor: "var(--panel-border)" }}
+          >
             <div
               data-testid="sidebar-search-icon"
-              className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 opacity-60"
+              className="flex shrink-0 items-center justify-center text-[color:var(--muted)]"
               aria-hidden="true"
             >
-              <Search className="h-4 w-4" />
+              <Search size={16} strokeWidth={2} />
             </div>
             <Input
               data-testid="sidebar-search-input"
-              className="h-10 w-full rounded-xl pl-10 pr-3 bg-[var(--chip-bg)] border border-white/10"
+              className="h-[calc(var(--radius-micro)*3)] min-w-0 flex-1 border-0 bg-transparent px-0 py-0 shadow-none focus:ring-0 focus:outline-none"
               placeholder={tab === "projects" ? "Search projects…" : "Search threads…"}
               value={q}
               onChange={(e) => setQ(e.target.value)}


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
