### PR TITLE
Codex/document redis chat completion state

### DIFF
--- a/docs/Future-Features/artifact_event_capture_and_task_graph.md
+++ b/docs/Future-Features/artifact_event_capture_and_task_graph.md
@@ -1,0 +1,333 @@
+Codexify: Artifact Event Capture, Thread Modes, and Task Graph
+
+Status: Draft v0.1
+Audience: Engineering, product, and system design contributors
+Scope: Repo-ready architecture + product specification
+
+⸻
+
+1. Purpose
+
+Codexify should automatically persist generated work artifacts and execution context so that tasks, notes, documents, and thread lineage become:
+ • recoverable
+ • reorderable
+ • traceable
+ • branch-aware where applicable
+ • usable without manual filing at creation time
+
+This feature addresses task loss, context fragmentation, and artifact scattering during active development.
+
+⸻
+
+1. Problem Statement
+
+Work artifacts are already being generated conversationally:
+ • “turn this into a task”
+ • “turn this into a note”
+ • “turn this into a document”
+
+However, these artifacts are not consistently persisted or structured as first-class system objects.
+
+Consequences:
+ • ideas are lost or buried in threads
+ • execution context and branch context drift apart
+ • follow-up work must be rediscovered manually
+ • lineage between artifacts is weak or implicit
+
+⸻
+
+1. Design Goals
+ • Zero-friction capture at point-of-thought
+ • Automatic persistence of generated artifacts
+ • Clear separation between capture and promotion
+ • Append-only event history as source of truth
+ • Task queue derived from artifact graph
+ • Minimal disruption to existing core loop
+
+⸻
+
+1. Non-Goals (V1)
+ • Full project management system
+ • Sprint planning or calendars
+ • Multi-user collaboration features
+ • Heavy UI systems (kanban boards, etc.)
+ • Mandatory forms at capture time
+
+⸻
+
+1. Core Concepts
+
+5.1 Thread Modes
+
+Execution Thread
+A thread capable of producing operational artifacts.
+
+Properties:
+ • may generate tasks
+ • may bind to branch/worktree
+ • records execution context
+ • allows planning and design discussion
+
+Non-Execution Thread
+A thread for ideation and reference.
+
+Properties:
+ • may generate notes/documents
+ • does not bind to execution context
+ • does not trigger execution flows
+
+Key distinction: permission and consequence, not topic.
+
+⸻
+
+5.2 Artifact Types
+
+First-class artifact categories:
+ • Task
+ • Note
+ • Document
+
+Future extensions may include prompts, summaries, and derived assets.
+
+⸻
+
+1. Capture Model
+
+6.1 Automatic Capture Triggers
+
+Artifacts are auto-created when:
+ • user invokes: “turn this into a task”
+ • user invokes: “turn this into a note”
+ • user invokes: “turn this into a document”
+ • structured artifact blocks are generated
+ • execution threads change branch binding
+
+6.2 Capture Philosophy
+ • Capture should be automatic
+ • Metadata should be inferred
+ • User action should be minimal
+
+Text storage cost is negligible compared to the cost of losing context.
+
+⸻
+
+6.3 Auto-Save vs Promotion
+
+Auto-Save:
+ • artifact is persisted
+
+Promotion:
+ • artifact becomes operational (task queue, priority, dependency)
+
+These must remain separate.
+
+⸻
+
+1. Event Graph Model
+
+The system is built on an append-only event log with graph relationships.
+
+7.1 Node Types
+ • thread
+ • message_span
+ • artifact
+ • task
+ • note
+ • document
+ • branch
+ • worktree
+ • commit
+
+7.2 Edge Types
+ • CREATED_IN
+ • DERIVED_FROM
+ • BOUND_TO_BRANCH
+ • PROMOTED_TO_TASK
+ • RELATED_TO
+ • DEPENDS_ON
+ • COMPLETED_BY
+ • ARCHIVED_AS
+
+⸻
+
+1. Task Queue (Derived View)
+
+Tasks are not the source of truth.
+
+They are derived from artifact records.
+
+8.1 Separation of Concerns
+ • Event time = historical truth
+ • Priority order = execution intent
+
+8.2 Supported Operations
+ • reorder
+ • status transitions
+ • filtering
+ • dependency relationships (future)
+
+⸻
+
+1. Data Model
+
+9.1 Thread Context
+
+type ThreadContext = {
+  threadId: string
+  mode: "execution" | "note" | "reference"
+  executionEnabled: boolean
+  boundBranch?: string
+  boundWorktree?: string
+  activeTaskId?: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+9.2 Artifact Record
+
+type ArtifactRecord = {
+  id: string
+  type: "task" | "note" | "document"
+  title: string
+  body: string
+
+  threadId?: string
+  sourceMessageId?: string
+
+  branch?: string | null
+  worktree?: string | null
+
+  status?: "inbox" | "shaped" | "ready" | "doing" | "done" | "dropped"
+  priority?: number | null
+
+  createdAt: string
+  updatedAt: string
+  archivedAt?: string | null
+}
+
+9.3 Event Record
+
+type ArtifactEvent = {
+  id: string
+  eventType: string
+  actor: "user" | "assistant" | "system"
+  threadId?: string
+  artifactId?: string
+  payload: Record<string, unknown>
+  createdAt: string
+}
+
+⸻
+
+1. Metadata Inference
+
+Automatically infer:
+ • timestamp
+ • thread id
+ • thread mode
+ • artifact type
+ • title
+
+Optional enrichment:
+ • branch/worktree
+ • related artifacts
+ • inferred tags
+
+⸻
+
+1. UI Surfaces (V1)
+
+11.1 Thread Mode Indicator
+
+Displays execution capability.
+
+11.2 Artifact Inbox
+ • recent tasks
+ • notes
+ • documents
+ • quick actions (delete, archive, promote)
+
+11.3 Task Queue
+ • reorderable
+ • status tracking
+ • linked to source artifacts
+
+11.4 Artifact Detail View
+ • source thread
+ • source message
+ • branch linkage
+ • related artifacts
+
+⸻
+
+1. Backend Surface (Illustrative)
+ • POST /api/artifacts
+ • GET /api/artifacts
+ • GET /api/artifacts/{id}
+ • POST /api/artifacts/{id}/promote
+ • POST /api/tasks/reorder
+ • POST /api/threads/{id}/mode
+ • POST /api/threads/{id}/bind-branch
+ • GET /api/events
+
+⸻
+
+1. Storage Strategy
+
+Recommended:
+ • Artifact table (primary records)
+ • Event log (append-only)
+ • Derived task queue
+
+Initial implementation should use existing Postgres infrastructure.
+
+⸻
+
+1. Architectural Guardrails
+ • Do not tightly couple to completion pipeline
+ • Avoid synchronous heavy processing at capture time
+ • Keep event history immutable
+ • Keep priority mutable
+ • Avoid frontend state fragmentation
+
+⸻
+
+1. Phased Rollout
+
+V1
+ • thread modes
+ • auto-save artifacts
+ • artifact inbox
+ • basic task queue
+ • lineage linking
+
+V2
+ • dependencies
+ • commit linkage
+ • clustering
+
+V3
+ • graph visualization
+ • task recommendations
+ • deduplication
+
+⸻
+
+1. Open Questions
+ • Branch binding: manual vs inferred?
+ • Auto-save scope: all generated blocks or explicit only?
+ • Single table vs polymorphic storage?
+ • Task ordering model?
+ • Service boundary for capture logic?
+
+⸻
+
+1. Summary
+
+Codexify should automatically persist generated work artifacts as graph-linked events, enabling:
+ • durable lineage
+ • recoverable context
+ • reorderable execution
+ • minimal capture friction
+
+This system transforms conversational output into structured, operational memory without interrupting developer flow.

--- a/docs/Plans/RedisChatReliabilitymd
+++ b/docs/Plans/RedisChatReliabilitymd
@@ -1,0 +1,168 @@
+# Redis / Chat Reliability Plan
+
+## Purpose
+This plan sequences the 2026-03-20 recon findings into small, repo-ready tasks that make the Redis-backed chat path more honest and more reliable without changing completion semantics in one edit. It assumes Redis remains the coordination substrate until a later architecture decision proves a safer split.
+
+## Inputs
+- Primary recon: `docs/audits/history/2026-03-20-redis-chat-completion-recon.md`
+- Implementation evidence: `guardian/routes/chat.py`, `guardian/core/chat_completion_service.py`, `guardian/workers/chat_worker.py`, `guardian/queue/redis_queue.py`, `guardian/queue/task_events.py`, `guardian/queue/turn_lock.py`, `guardian/routes/health.py`, `guardian/core/ai_router.py`
+- Related tests: `tests/routes/test_chat_routes.py`, `tests/core/test_turn_lock_recovery.py`, `tests/test_chat_worker_turn_integrity.py`, `guardian/tests/workers/test_chat_worker_completion_semantics.py`, `guardian/tests/workers/test_chat_worker_turn_metadata.py`, `guardian/tests/test_health_endpoints.py`, `tests/routes/test_metrics.py`, `tests/routes/test_event_graph_emission.py`
+- Context docs: `docs/architecture/completion_pipeline.md`, `docs/architecture/data-and-storage.md`, `docs/architecture/flows.md`, `docs/architecture/roadmap-signals.md`, `docs/architecture/tech-debt-and-risks.md`, `docs/architecture/00-current-state.md`, `docs/Codexify/RELEASE.md`
+- Assumption: claims below follow the recon artifact and code/tests above; anything not proven there is treated as unknown.
+
+## Current known issues
+- Redis is overloaded with chat-critical roles: queue transport, turn locks, task events, cancellation, worker heartbeat, turn-anchor cache, chat-embed queue, and the health-probe queue used by `/health/chat`.
+- API health can look good while chat completion is degraded. The current health surface proves Redis reachability and a bounded queue round-trip, not end-to-end completion or actual queue consumption.
+- Stale-lock recovery is not fully real. The recon found route-side helper stubs for terminal-event and worker-heartbeat checks, so the recovery branch can assert more certainty than it has.
+- Task-event visibility can fail without failing task execution. Publish is best-effort, so UI or operator visibility can degrade even when the worker completes work.
+- Queue-coupled chat creates silent-stall risk. A completion can be accepted, queued, and then never visibly finish if the worker is absent, wedged, or unable to advance.
+- Current docs have implementation drift. Several docs describe the system more optimistically or more generally than the current code proves.
+- Uncertainty: the recon did not prove a reliable, low-cost queue-consumption signal that is stronger than the current health round-trip. That gap must be labeled until a later task closes it.
+
+## Constraints and non-goals
+- No broad queue redesign in one edit.
+- No 10,000-line refactor plan packaged as one implementation step.
+- No simultaneous lock, queue, health, worker, and provider rewrites.
+- No fallback execution-mode implementation in this planning task.
+- Keep the main interaction loops usable and reliable; incremental safety matters more than theoretical cleanup.
+- Do not change chat completion semantics as part of the planning sequence itself.
+
+## Reliability objectives
+- No silent accepted-but-never-finished chat path without an observable failure signal.
+- No fake stale-lock intelligence.
+- No green health surface that masks a dead or wedged chat worker.
+- Clear operator truth for queue reachability, worker liveness, task-event flow, and completion progress.
+- Reduce Redis blast radius incrementally without destabilizing beta readiness.
+- Where the system cannot prove freshness, queue consumption, or terminality, surface `unknown` or degraded state explicitly instead of implying confidence.
+
+## Workstreams
+### Workstream A: truth and observability
+- Goal: make health and operator surfaces describe what the system can actually prove.
+- Why it matters: a healthy API that cannot finish chat is operationally worse than an explicitly degraded one.
+- What to defer: queue redesign, worker retries, provider routing changes, and any fallback execution mode.
+- Likely files involved: `guardian/routes/health.py`, `guardian/tests/test_health_endpoints.py`, `tests/routes/test_metrics.py`, `docs/Codexify/RELEASE.md`.
+
+### Workstream B: turn-lock correctness
+- Goal: make stale-lock recovery depend on real terminal-event and worker-freshness evidence, or fail closed when that evidence is absent.
+- Why it matters: stale-lock recovery is only useful if the signals behind it are real.
+- What to defer: broader turn-state redesign, provider changes, or coupling recovery to a new queue architecture.
+- Likely files involved: `guardian/routes/chat.py`, `guardian/queue/turn_lock.py`, `guardian/queue/task_events.py`, `tests/core/test_turn_lock_recovery.py`, `tests/routes/test_chat_routes.py`.
+
+### Workstream C: worker/readiness signaling
+- Goal: expose worker liveness and heartbeat freshness in a way operators can trust.
+- Why it matters: queue-coupled completion cannot be operationally safe if worker absence is invisible.
+- What to defer: changing the worker execution model, adding a second execution path, or changing task semantics.
+- Likely files involved: `guardian/workers/chat_worker.py`, `guardian/routes/health.py`, `guardian/tests/test_health_endpoints.py`, `tests/routes/test_metrics.py`.
+
+### Workstream D: task-event reliability
+- Goal: preserve lifecycle visibility when Redis stream publish or consumer behavior fails.
+- Why it matters: UI and ops should see visibility degradation instead of assuming task progress is healthy.
+- What to defer: replacing SSE with another bus, rewriting the event graph, or making publish failures fatal to task execution.
+- Likely files involved: `guardian/queue/task_events.py`, `guardian/workers/chat_worker.py`, `guardian/routes/chat.py`, `guardian/guardian_api.py`, `tests/routes/test_event_graph_emission.py`.
+
+### Workstream E: architecture follow-on decisions
+- Goal: decide, after the truth surfaces are honest, whether Redis should keep all coordination roles or be split further.
+- Why it matters: redistribution of responsibilities is only safe after the current failure modes are measurable.
+- What to defer: any structural decision before the system’s current health and lock truth are visible.
+- Likely files involved: `docs/architecture/completion_pipeline.md`, `docs/architecture/data-and-storage.md`, `docs/architecture/flows.md`, `docs/architecture/roadmap-signals.md`, `docs/architecture/tech-debt-and-risks.md`, `docs/architecture/00-current-state.md`, `docs/Codexify/RELEASE.md`.
+
+## Proposed sequence
+1. Phase 1: make the current failure surfaces honest.
+   - Start with health and readiness surfaces because they are the cheapest way to remove false confidence.
+   - This comes first because later lock or worker changes are hard to validate if the existing health view can still look green during a stall.
+
+2. Phase 2: fix the stale-lock recovery correctness holes.
+   - Once the failure surfaces are honest, wire recovery to real terminal-event and heartbeat evidence, or fail closed when that evidence is unavailable.
+   - This comes second because stale-lock recovery is correctness-sensitive and should not be evaluated against a misleading health surface.
+
+3. Phase 3: tighten worker readiness and health truth.
+   - Make worker freshness and queue-consumption truth explicit enough that an API-only success signal cannot masquerade as a live chat system.
+   - This comes after stale-lock truth because readiness semantics should match the actual worker state machine, not paper over it.
+
+4. Phase 4: improve task-event visibility and reliability.
+   - Make event publish and visibility failures observable enough that they can be distinguished from queue or lock failures.
+   - This comes after the state machine is honest because event issues are otherwise easy to confuse with worker or lock problems.
+
+5. Phase 5: only then evaluate larger Redis decoupling or fallback design.
+   - Structural redesign should follow measurement, not guesswork.
+   - This comes last because the current blast radius and failure signatures must be visible before any larger split is justified.
+
+## Atomic task candidates
+1. Make `/health/chat` report worker freshness honestly
+   - Target files: `guardian/routes/health.py`, `guardian/tests/test_health_endpoints.py`, `tests/routes/test_metrics.py`
+   - What changes: surface heartbeat age and explicit degraded/unknown states; distinguish Redis reachability from actual completion health.
+   - What it does not change: queue semantics, worker loop behavior, turn-lock behavior, or provider routing.
+   - Test scope: endpoint regression tests plus one compose-backed manual probe.
+   - Dependency notes: can be done first and does not require any larger queue rewrite.
+
+2. Replace the stale-lock evidence stubs with real checks or fail-closed behavior
+   - Target files: `guardian/routes/chat.py`, `guardian/queue/task_events.py`, `guardian/workers/chat_worker.py`, `tests/core/test_turn_lock_recovery.py`, `tests/routes/test_chat_routes.py`
+   - What changes: use actual terminal-event and heartbeat evidence for recovery decisions, or stop claiming recovery confidence when the evidence is absent.
+   - What it does not change: completion semantics, assistant persistence rules, or queue transport.
+   - Test scope: turn-lock recovery tests and chat-route contract tests.
+   - Dependency notes: should follow the health truth slice so the new behavior is visible.
+
+3. Add a queue-consumption readiness probe
+   - Target files: `guardian/routes/health.py`, `guardian/tests/test_health_endpoints.py`, `tests/routes/test_metrics.py`
+   - What changes: distinguish queue reachability from dequeue/consume health, or explicitly label the gap if a stronger probe cannot yet be proven.
+   - What it does not change: worker scheduling, job format, or lock model.
+   - Test scope: health endpoint tests and manual compose-backed checks.
+   - Dependency notes: likely depends on worker freshness being exposed in a stable way.
+
+4. Make task-event publish failures visible to operators
+   - Target files: `guardian/queue/task_events.py`, `guardian/workers/chat_worker.py`, `guardian/routes/chat.py`, `tests/routes/test_event_graph_emission.py`
+   - What changes: record or surface event publish failures so UI/ops can tell visibility is degraded even when the task itself succeeds.
+   - What it does not change: task success/failure semantics, the SSE protocol, or queue behavior.
+   - Test scope: happy-path emission tests and failure-path tests.
+   - Dependency notes: can be done after the core health surfaces are honest.
+
+5. Tighten completion-route failure signaling
+   - Target files: `guardian/routes/chat.py`, `guardian/core/chat_completion_service.py`, `tests/routes/test_chat_routes.py`
+   - What changes: ensure accepted completions always produce an observable task state or fail fast when lock/enqueue preconditions are not met.
+   - What it does not change: provider selection, assistant persistence logic, or queue architecture.
+   - Test scope: route contract tests and queue-unavailable tests.
+   - Dependency notes: should not be bundled with worker or provider rewrites.
+
+6. Align architecture docs with the observed Redis responsibilities
+   - Target files: `docs/architecture/completion_pipeline.md`, `docs/architecture/data-and-storage.md`, `docs/architecture/flows.md`, `docs/architecture/tech-debt-and-risks.md`, `docs/architecture/00-current-state.md`, `docs/Codexify/RELEASE.md`
+   - What changes: document the actual roles, caveats, and blind spots now observed in code and recon.
+   - What it does not change: runtime behavior.
+   - Test scope: doc review only.
+   - Dependency notes: should land after the code truth work so the docs track reality.
+
+7. Add explicit worker-heartbeat regression coverage
+   - Target files: `guardian/workers/chat_worker.py`, `guardian/tests/test_health_endpoints.py`, `tests/routes/test_metrics.py`
+   - What changes: verify heartbeat freshness and stale-heartbeat handling as part of readiness checks.
+   - What it does not change: task execution semantics or provider behavior.
+   - Test scope: heartbeat-focused unit and integration tests.
+   - Dependency notes: pairs naturally with candidate 1, but should remain a separate commit.
+
+8. Update the release runbook to match the new truth surfaces
+   - Target files: `docs/Codexify/RELEASE.md`
+   - What changes: explain what `/health`, `/health/chat`, `/api/health/llm`, logs, and task-event inspection do and do not prove.
+   - What it does not change: runtime behavior.
+   - Test scope: doc review only.
+   - Dependency notes: should follow the health and event truth work so the runbook does not lag behind code.
+
+## Validation strategy
+- Unit and integration coverage should stay targeted to the behavior under change, especially `tests/routes/test_chat_routes.py`, `tests/core/test_turn_lock_recovery.py`, `tests/test_chat_worker_turn_integrity.py`, `guardian/tests/workers/test_chat_worker_completion_semantics.py`, `guardian/tests/workers/test_chat_worker_turn_metadata.py`, `guardian/tests/test_health_endpoints.py`, `tests/routes/test_metrics.py`, and `tests/routes/test_event_graph_emission.py`.
+- Health checks should be validated directly with `/health`, `/health/chat`, and `/api/health/llm`, with the expected distinction between backend up, Redis reachable, worker fresh, and end-to-end completion healthy made explicit.
+- Task-event behavior should be inspected through the task-events endpoint and logs to confirm that visibility failures are observable instead of silently swallowed.
+- Worker heartbeat should be verified by confirming a fresh heartbeat during a compose-backed run and by confirming that stale or missing heartbeat state degrades the readiness surface instead of leaving it green.
+- Queue behavior should be verified with a manual completion probe that creates a thread, posts a user message, calls completion, and then checks for dequeue, completion, persistence, and event emission.
+- Compose-backed manual probes should use the existing stack commands (`docker compose ps`, `docker compose logs --tail=200 backend`, `docker compose logs --tail=200 worker-chat`, `docker compose logs --tail=200 redis`, and the relevant `curl` health checks) so the results reflect the real runtime, not only unit tests.
+- A probe that passes only the API health endpoints is not enough. The validation bar is that the completion path finishes, or fails with a visible signal, under both healthy-worker and missing-worker conditions.
+
+## Risks of overreach
+- Combining lock, queue, health, worker, and provider changes in one edit makes it hard to tell whether a regression came from the state machine, the readiness surface, or the event path.
+- Passing health tests after a large edit can create false confidence if the API still accepts work and then stalls it silently.
+- A partial test pass can hide the worst failure class here: accepted-but-never-finished chat.
+- The more subsystems change at once, the harder it becomes to isolate whether the regression is caused by stale-lock recovery, dequeue/heartbeat behavior, event publishing, or provider execution.
+- The main chat loop is the highest-risk path in the repo; overreach here risks degrading beta readiness while obscuring the root cause.
+
+## Recommended next atomic task
+Make `/health/chat` report worker freshness honestly.
+
+- Rationale: this is the smallest high-leverage slice. It immediately reduces false confidence, gives operators a trustworthy baseline, and makes later stale-lock and task-event work easier to validate.
+- Target files: `guardian/routes/health.py`, `guardian/tests/test_health_endpoints.py`, `tests/routes/test_metrics.py`
+- Why it should come before the others: as long as the health surface can still look green while chat is stalled, later fixes can be misread as successful even when the worker is absent or wedged. The truth surface has to come first.

--- a/docs/audits/history/2026-03-20-redis-chat-completion-recon.md
+++ b/docs/audits/history/2026-03-20-redis-chat-completion-recon.md
@@ -1,0 +1,111 @@
+# Redis / Chat Completion Recon
+
+## Scope
+
+- Inspected source: `guardian/routes/chat.py`, `guardian/core/chat_completion_service.py`, `guardian/workers/chat_worker.py`, `guardian/queue/redis_queue.py`, `guardian/queue/task_events.py`, `guardian/routes/health.py`, `guardian/core/ai_router.py`, `guardian/queue/turn_lock.py`, `docker-compose.yml`.
+- Inspected tests: `tests/routes/test_chat_routes.py`, `tests/core/test_turn_lock_recovery.py`, `tests/test_chat_worker_turn_integrity.py`, `guardian/tests/workers/test_chat_worker_completion_semantics.py`, `guardian/tests/workers/test_chat_worker_turn_metadata.py`, `guardian/tests/test_health_endpoints.py`, `tests/routes/test_metrics.py`, `tests/routes/test_event_graph_emission.py`.
+- Cross-checked docs for drift: `docs/architecture/completion_pipeline.md`, `docs/architecture/data-and-storage.md`, `docs/architecture/flows.md`, `docs/architecture/roadmap-signals.md`, `docs/architecture/tech-debt-and-risks.md`, `docs/architecture/00-current-state.md`.
+- Runtime verification was attempted, but live localhost access was blocked from this session, so no end-to-end completion probe could be completed.
+- No automated tests apply to this report. This was a report-only task, and no production source file was modified.
+
+## Repo state
+
+- Branch: `main`
+- HEAD: `9a8a0de1a3f011632ad5fb812a64941cb16ab8bd`
+- Worktree before this task: not clean; `git status --short` already showed the unrelated untracked file `docs/Future-Features/artifact_event_capture_and_task_graph.md`.
+- Recon timestamp: `2026-03-20 05:51:07 EDT`
+- Runtime verification commands and results:
+  - `timeout 15s docker compose ps` -> exit `124`; no compose status returned before timeout.
+  - `timeout 5s curl -sv http://127.0.0.1:8888/health` -> exit `7`; connect failed with `Operation not permitted`.
+  - `timeout 5s curl -sv http://127.0.0.1:8888/health/chat` -> exit `7`; same connect failure.
+  - `timeout 5s curl -sv -H "X-API-Key: $GUARDIAN_API_KEY" http://127.0.0.1:8888/api/health/llm` -> exit `7`; same connect failure.
+- No automated test suite was run.
+
+## Current implementation path
+
+1. User message persistence starts at `guardian/routes/chat.py::chat_post_message` and `chat_post_message_create_on_send`, both of which call `_persist_message_to_thread`.
+2. `_persist_message_to_thread` does a short Redis turn-lock probe with `acquire_turn_lock(thread_id, "api:chat.messages:user_probe")`, returns `429 turn_in_flight` if the assistant is active, and otherwise persists the message with `chatlog_db.create_message`, audit logging, `event_bus.emit_event("message.created", ...)`, `_emit_thread_update_event(...)`, and `_embed_message(...)`.
+3. The completion request enters `guardian/routes/chat.py::chat_complete`, which validates the thread exists, loads recent messages, filters unusable context, resolves depth, and builds a doc-context override before task creation.
+4. `chat_complete` creates a `ChatCompletionTask`, sets `turn_lock_owner = task.task_id`, carries `turn_id` in `origin`, acquires the per-thread lock with `guardian.queue.turn_lock.acquire_turn_lock`, and tries `_recover_orphaned_turn_lock` if the lock is stale.
+5. On successful lock acquisition, `chat_complete` enqueues the task to Redis with `guardian.queue.redis_queue.enqueue(task, "codexify:queue:chat")`, publishes `task.created` with `guardian.queue.task_events.publish`, and returns `task_id`, `turn_id`, and trace/message URLs.
+6. `guardian/workers/chat_worker.py::run_forever` dequeues from `codexify:queue:chat`, refreshes the worker heartbeat key, deserializes the task, applies `turn_id` and `turn_lock_owner` from payload if present, handles cancellation, and submits `_run_chat_task`.
+7. `_run_chat_task` publishes `task.running`, deduplicates on `turn_id`, calls `run_chat_completion_task`, caches the turn anchor, persists `turn_id` metadata, schedules assistant audio, publishes `task.completed` or `task.failed`, and releases the turn lock in `finally`.
+
+## Redis responsibilities actually in use today
+
+- Chat task queue: yes. `guardian/queue/redis_queue.py::enqueue/dequeue` operate on `codexify:queue:chat`, and `guardian/routes/chat.py::chat_complete` plus `guardian/workers/chat_worker.py::run_forever` are the primary producer/consumer pair.
+- Turn locks: yes. The primary chat path uses `guardian/queue/turn_lock.py` and the `turn_lock:{thread_id}` key; the route acquires the lock and the worker releases it. `guardian/queue/redis_queue.py` still contains legacy raw-string lock helpers, but the chat path does not use them.
+- Task event transport: yes. `guardian/queue/task_events.py` writes to `codexify:task:{task_id}:events`, and `guardian/guardian_api.py::stream_task_events` exposes the SSE consumer.
+- Cancellation: yes. `guardian/queue/redis_queue.py` stores cancellation in `codexify:queue:cancelled`, and the worker checks `is_cancelled()` before and during execution.
+- Worker heartbeat: yes. `guardian/workers/chat_worker.py::_publish_worker_heartbeat` writes `codexify:worker:chat:heartbeat`, and `/health/chat` reads it.
+- Completion turn-anchor cache: yes. The worker stores `codexify:chat:turn-anchor:{thread_id}:{turn_id}` in Redis so turn IDs can be resolved after persistence.
+- Chat embedding queue: yes. `enqueue_chat_embed()` pushes to `codexify:queue:chat-embed`.
+- Health probe queue: yes, transiently. `/health/chat` creates a throwaway `codexify:queue:healthcheck:{uuid}` list and round-trips it with `LPUSH`/`RPOP` to test Redis queue primitives.
+
+## Chat completion execution path
+
+1. The shared completion service, `guardian/core/chat_completion_service.py::build_messages_for_llm`, loads the thread, recent messages, and the latest user utterance, then calls `ContextBroker.assemble(...)`.
+2. That service builds the system prompt, thread-document context, and final provider-ready message list, then returns the bundle and trace payload alongside the resolved provider/model.
+3. `guardian/core/chat_completion_service.py::run_chat_completion_task` runs either `stream_local(...)` or `chat_with_ai(...)`, captures the assistant text, and preserves the trace/bundle for later use.
+4. When `persist_assistant_message=True`, `run_chat_completion_task` writes the assistant row with `chatlog_db.create_message`, appends audit state, emits `message.created`, and auto-embeds the response.
+5. `guardian/workers/chat_worker.py::_run_chat_completion_task_compat` is a compatibility wrapper around that shared service. It can rescue a non-explicit cloud failure to local execution if a local model exists, which is a real fallback branch, not a general retry loop.
+6. After persistence, `_run_chat_task` writes the turn ID into `chat_messages.extra_meta`, caches the turn anchor in Redis, and treats those failures as non-fatal unless the assistant message itself is missing.
+
+## Turn-lock and task-event contract
+
+- `turn_id` is normalized at route entry, threaded into the task origin, and copied into `task.turn_id`.
+- `turn_lock_owner` is set to the task ID before enqueue so the worker can release the same lock later.
+- The intended stale-lock recovery path is `_recover_orphaned_turn_lock(...)`, which checks `turn_lock_is_stale(...)`, `_task_terminal_event(...)`, and `_chat_worker_heartbeat_age_seconds()`.
+- In the current code, `_task_terminal_event` and `_chat_worker_heartbeat_age_seconds` are local stubs in `guardian/routes/chat.py` that return `None`, so recovery does not actually inspect Redis task events or worker heartbeat age.
+- That means stale-lock recovery is effectively driven by the Redis lease check alone, even though the code path reads as if it is heartbeat-aware.
+- On success, the worker publishes `task.running`, `task.progress`, `task.completed`, and on failure `task.failed`; on cancellation it publishes `task.cancelled`.
+- `task.completed` is the signal the debug trace path reads back through `guardian/routes/chat.py::_get_task_completed_payload(...)` and `GET /api/chat/debug/rag-trace/{thread_id}/latest`.
+- `guardian/guardian_api.py::stream_task_events` is the operator-facing SSE stream for a specific task ID.
+- Task-event publish failures are best-effort; `_safe_publish` logs and swallows Redis stream errors instead of turning them into route failures.
+
+## Health/readiness surfaces
+
+| Surface | What it proves | What it does not prove |
+|---|---|---|
+| `GET /health` | The backend app process is responding. | Redis reachability, worker presence, queue consumption, task-event flow, and provider health. |
+| `GET /health/chat` | Redis responds to `PING`, a throwaway queue can be `LPUSH`/`RPOP`'d, and the worker heartbeat key exists. | It does not prove that `codexify:queue:chat` is being consumed, that completions succeed, or that task events are flowing. It also ignores heartbeat age when setting `ok`. |
+| `GET /api/health/llm` | The active provider is configured, and for `local` it actively probes the local base URL; it also embeds the completion-service subcheck. | It does not prove chat worker consumption or end-to-end task completion. For cloud providers it returns `status=unknown`/`runtime_unprobed` rather than a live probe. |
+| `GET /api/tasks/{task_id}/events` | A specific task's Redis-backed event stream is readable. | It does not prove queue health for other tasks or the system as a whole. |
+| `docker compose ps` and `docker compose logs --tail=200 backend|worker-chat|redis` | Operator can inspect whether the relevant containers are present and what they logged. | These are inspection surfaces, not end-to-end proofs. |
+
+## Failure modes visible in code
+
+- `turn_lock_unavailable`: `guardian/routes/chat.py::chat_complete` catches lock acquisition exceptions and returns structured `503 completion_service_unavailable`. User impact: immediate HTTP error, no task ID.
+- `queue_unavailable`: the same route catches enqueue failures, releases the lock best-effort, and returns structured `503 completion_service_unavailable`. User impact: immediate HTTP error after lock acquisition.
+- `turn_in_flight`: if the lock already exists or recovery declines to clear it, the route returns `429`. User impact: immediate HTTP conflict and no enqueue.
+- `queued_but_never_completed`: the route can return `200` with a task ID even if `worker-chat` is absent or stuck. User impact: silent/stalled UX until task events or logs are inspected.
+- `provider_failure_after_dequeue`: provider exceptions inside `run_chat_completion_task` or `_run_chat_task` become `task.failed` and `completion.error` after the HTTP request has already succeeded. User impact: task failure event, not a route error.
+- `assistant_message_persist_failed`: a successful provider response can still fail when `chatlog_db.create_message(...)` raises `AssistantPersistenceError`. User impact: task failure after apparent generation success.
+- `task_event_visibility_failure`: Redis stream publish failures are swallowed by `_safe_publish`, so the worker may keep running while the UI loses progress/completion signals. User impact: missing progress, stalled spinner, or partial observability.
+- `stale_turn_lock_behavior`: because the route-level heartbeat and terminal-event hooks are stubs, stale-lock cleanup is not actually heartbeat-aware. If the lease expires while a worker is still running, the route can clear the lock and enqueue a second completion. User impact: duplicate work risk or false recovery.
+- `worker_absence_while_api_healthy`: `GET /health` can remain green while chat completion is unavailable. User impact: the API looks healthy even though the assistant path is degraded.
+
+## Drift between docs and implementation
+
+| Document | Status | Notes |
+|---|---|---|
+| `docs/architecture/completion_pipeline.md` | clearly stale | It says there is no retry in the worker path, but `_run_chat_completion_task_compat` now has a cloud-to-local rescue branch when the request was not explicitly pinned. The doc also does not capture the current best-effort event publishing and richer completion payloads. |
+| `docs/architecture/data-and-storage.md` | partially stale | The Redis role list is broadly right, but it omits the `chat-embed` queue, the transient health-probe queue, and the fact that the main chat path uses `guardian/queue/turn_lock.py` instead of the legacy raw-string helpers in `redis_queue.py`. |
+| `docs/architecture/flows.md` | partially stale | The coarse sequence still matches, but it does not mention route-side stale-lock recovery caveats, best-effort task-event emission, or the current provider rescue behavior. |
+| `docs/architecture/roadmap-signals.md` | still accurate | The statement that the primary chat loop is queue-coupled still matches the code. |
+| `docs/architecture/tech-debt-and-risks.md` | still accurate | The Redis/worker coupling risk and non-durable Compose Redis configuration still hold. |
+| `docs/architecture/00-current-state.md` | unresolved ambiguity | The release-state claim is directionally consistent with the code, but this session could not fresh-prove the "without stuck turns" outcome because live runtime access was blocked. |
+
+## Open questions / unknowns
+
+- The worker path does not show a general replay or retry mechanism after `task.failed`; I did not find a separate requeue path in this repo scan.
+- The route-level stale-lock recovery hooks are stubs today. It is unclear whether that is intentional placeholder code or an incomplete integration that should be wired to real Redis task-event and heartbeat reads.
+- `health/chat` reports heartbeat age, but `ok` ignores that age. It is unclear whether operators are expected to treat a stale heartbeat as unhealthy or merely informational.
+- I could not prove whether the live system currently consumes `/api/tasks/{task_id}/events` directly in the UI or primarily relies on the chat debug trace endpoint for progress visibility.
+- I could not prove whether any external supervisor watches worker failures and re-enqueues tasks after the worker itself publishes `task.failed`.
+
+## Decision-ready recommendations
+
+- Immediate next investigation: run a real compose-backed completion probe with a known thread, capture `/api/tasks/{task_id}/events`, and verify whether the worker heartbeat changes and the turn lock is released. If the runtime remains inaccessible, the next investigation is Docker daemon access, not code changes.
+- Likely robustness work: wire `_task_terminal_event` and `_chat_worker_heartbeat_age_seconds` to real data or remove the stale-lock recovery branch until it is real; consider making stale heartbeat age visible as an explicit readiness failure; surface task-event publish failures more loudly than a debug log.
+- Do not change yet: do not redesign the queue architecture, add a synchronous fallback execution mode, or alter completion semantics or health endpoint behavior in response to this recon alone.

--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -1583,19 +1583,21 @@ export function GuardianChat({
       const payload = (event.data as any)?.data ?? event.data;
       const tid = Number(payload?.thread_id ?? payload?.threadId);
       if (!Number.isFinite(tid)) return;
-      const eventTaskId = String(
-        payload?.task_id ??
-          payload?.taskId ??
-          completionState.activeTaskId ??
-          inferenceRequest.state.taskId ??
-          ""
-      ).trim();
-      const eventTurnId = String(
-        payload?.turn_id ?? payload?.turnId ?? ""
-      ).trim();
-      if (eventTaskId && eventTurnId) {
-        updateCompletionSessionTurnId(eventTaskId, eventTurnId);
+
+      // Issue 1: Only accept events with explicit task_id/turn_id, not by thread alone
+      const eventTaskId = String(payload?.task_id ?? payload?.taskId ?? "").trim();
+      const eventTurnId = String(payload?.turn_id ?? payload?.turnId ?? "").trim();
+
+      // Only proceed if both task_id and turn_id are present in the event payload
+      // This prevents accepting assistant completion events by thread alone
+      if (!eventTaskId || !eventTurnId) {
+        console.debug(`[guardian] Ignoring completion event without explicit task_id or turn_id for thread ${tid}`);
+        return;
       }
+
+      // Update the turn ID for the specific task
+      updateCompletionSessionTurnId(eventTaskId, eventTurnId);
+
       const terminalState =
         event.type === "task.completed"
           ? "completed"
@@ -1604,13 +1606,14 @@ export function GuardianChat({
             : event.type === "completion.error"
               ? "error"
               : "failed";
-      const finalized =
-        eventTaskId.length > 0
-          ? finalizeCompletionSession({
-              taskId: eventTaskId,
-              terminalState,
-            })
-          : false;
+
+      // Issue 2: Only finalize the session if the task ID matches the current session exactly
+      // This prevents rebinding new completions to stale responses
+      const finalized = finalizeCompletionSession({
+        taskId: eventTaskId,
+        terminalState,
+      });
+
       if (finalized) {
         clearInFlightCompletionTurnId(tid);
         setTurnLockForThread(tid, false);

--- a/frontend/src/features/chat/useChat.ts
+++ b/frontend/src/features/chat/useChat.ts
@@ -1218,10 +1218,22 @@ export function useChat(options: UseChatOptions = {}) {
       const normalizedTaskId = normalizeTaskId(taskId);
       if (!normalizedTaskId) return null;
 
+      // Check if there's an existing session for the same thread that hasn't completed yet
+      const existingSession = completionSessionRef.current;
+      if (existingSession &&
+          existingSession.threadId === threadId &&
+          existingSession.taskTerminalState === null) {
+        // If we're starting a new session for the same thread while another is active,
+        // we should finalize the existing one first to prevent conflicts
+        console.debug(`[useChat] Disposing active completion session for thread ${threadId} before starting new one`);
+        disposeCompletionSession();
+      }
+
       const sessionId = `${threadId}:${Date.now()}:${Math.random()
         .toString(36)
         .slice(2, 8)}`;
-      disposeCompletionSession();
+      // Only dispose if there was an active session for the same thread
+      // The general dispose is still needed to clean up any existing session
 
       const session: CompletionSession = {
         sessionId,
@@ -1347,16 +1359,12 @@ export function useChat(options: UseChatOptions = {}) {
         Boolean(messageTaskId) && current.taskIdAliases.has(messageTaskId as string);
       const matchedByTurn =
         Boolean(current.turnId) && message.turn_id === current.turnId;
-      const matchedByFallback =
-        !current.turnId &&
-        current.taskTerminalState != null &&
-        message.id >
-          Math.max(
-            current.baselineLastUserMessageId,
-            current.baselineLatestAssistantId
-          );
 
-      if (!(matchedByTask || matchedByTurn || matchedByFallback)) {
+      // Issue 1: Remove the fallback that matches only by position without task/turn verification
+      // This prevents accepting assistant completion events by thread alone
+      const matchedByFallback = false;
+
+      if (!(matchedByTask || matchedByTurn)) {
         return false;
       }
 

--- a/guardian/queue/task_events.py
+++ b/guardian/queue/task_events.py
@@ -12,6 +12,12 @@ from guardian.queue.redis_queue import _with_reconnect  # type: ignore
 logger = logging.getLogger(__name__)
 
 _STREAM_PREFIX = "codexify:task"
+_TERMINAL_EVENT_TYPES = {
+    "task.completed",
+    "task.failed",
+    "task.cancelled",
+}
+_TERMINAL_EVENT_SCAN_BATCH_SIZE = 100
 
 
 def _utc_now_iso() -> str:
@@ -75,3 +81,66 @@ def read_events(
         return events
 
     return _with_reconnect(_read)
+
+
+def describe_terminal_state(task_id: str) -> dict[str, Any]:
+    """Describe whether a task stream has reached a terminal state."""
+    try:
+        last_id = "0-0"
+        saw_events = False
+        while True:
+            events = read_events(
+                task_id,
+                last_id,
+                block_ms=1,
+                count=_TERMINAL_EVENT_SCAN_BATCH_SIZE,
+            )
+            if not events:
+                break
+            saw_events = True
+            for event_id, event in events:
+                last_id = event_id
+                event_type = str(event.get("type") or "").strip()
+                if event_type in _TERMINAL_EVENT_TYPES:
+                    return {
+                        "task_id": task_id,
+                        "state": "terminal",
+                        "event_id": event_id,
+                        "event": event,
+                        "event_type": event_type,
+                        "reason": "terminal_event_found",
+                    }
+            if len(events) < _TERMINAL_EVENT_SCAN_BATCH_SIZE:
+                break
+        if saw_events:
+            return {
+                "task_id": task_id,
+                "state": "nonterminal",
+                "event_id": None,
+                "event": None,
+                "event_type": None,
+                "reason": "terminal_event_not_found",
+            }
+        return {
+            "task_id": task_id,
+            "state": "unknown",
+            "event_id": None,
+            "event": None,
+            "event_type": None,
+            "reason": "task_events_missing",
+        }
+    except Exception as exc:
+        logger.debug(
+            "[task-events] terminal-state probe failed task_id=%s err=%s",
+            task_id,
+            exc,
+            exc_info=True,
+        )
+        return {
+            "task_id": task_id,
+            "state": "unknown",
+            "event_id": None,
+            "event": None,
+            "event_type": None,
+            "reason": f"{type(exc).__name__}: {exc}",
+        }

--- a/guardian/queue/task_events.py
+++ b/guardian/queue/task_events.py
@@ -44,6 +44,44 @@ def publish(
     return _with_reconnect(_add)
 
 
+def classify_event_visibility(event_type: str) -> str:
+    """Classify whether an event is terminal or progress-only visibility."""
+
+    normalized = str(event_type or "").strip()
+    if normalized in _TERMINAL_EVENT_TYPES:
+        return "terminal"
+    return "progress"
+
+
+def publish_with_visibility(
+    task_id: str, event_type: str, data: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Publish an event and return a machine-readable visibility result."""
+
+    visibility_scope = classify_event_visibility(event_type)
+    result: dict[str, Any] = {
+        "ok": False,
+        "task_id": task_id,
+        "event_type": event_type,
+        "visibility_scope": visibility_scope,
+        "terminal_visibility": visibility_scope == "terminal",
+        "execution_continued": True,
+        "event_id": None,
+        "failure_class": None,
+        "error": None,
+    }
+    try:
+        event_id = publish(task_id, event_type, data)
+    except Exception as exc:
+        result["failure_class"] = exc.__class__.__name__
+        result["error"] = str(exc)
+        return result
+
+    result["ok"] = True
+    result["event_id"] = event_id
+    return result
+
+
 def read_events(
     task_id: str,
     last_id: str,

--- a/guardian/routes/chat.py
+++ b/guardian/routes/chat.py
@@ -14,6 +14,8 @@ Frontend contract (primary calls today):
 import asyncio
 import json
 import logging
+import os
+import time
 import uuid
 from dataclasses import asdict
 from datetime import datetime, timezone
@@ -47,12 +49,16 @@ from guardian.queue.turn_lock import (
     release_turn_lock,
     turn_lock_is_stale,
 )
+from guardian.routes.health import _classify_chat_worker_heartbeat
 from guardian.tasks.types import ChatCompletionTask
 from guardian.voice.audio_assets import list_message_audio_assets
 
 logger = logging.getLogger(__name__)
 COMPLETION_SERVICE_UNAVAILABLE_MESSAGE = (
     "Completion service unavailable — check Docker/Redis."
+)
+CHAT_WORKER_HEARTBEAT_KEY = os.getenv(
+    "CHAT_WORKER_HEARTBEAT_KEY", "codexify:worker:chat:heartbeat"
 )
 
 
@@ -67,12 +73,64 @@ def _completion_service_unavailable(reason: str) -> HTTPException:
     )
 
 
-def _task_terminal_event(_task_id: str) -> dict[str, Any] | None:
-    return None
+def _task_terminal_event(task_id: str) -> dict[str, Any]:
+    """Return terminal-state evidence for a task event stream."""
+
+    return task_events.describe_terminal_state(task_id)
 
 
 def _chat_worker_heartbeat_age_seconds() -> float | None:
-    return None
+    evidence = _chat_worker_heartbeat_evidence()
+    age_seconds = evidence.get("age_seconds")
+    return float(age_seconds) if isinstance(age_seconds, (int, float)) else None
+
+
+def _chat_worker_heartbeat_evidence() -> dict[str, Any]:
+    """Inspect the chat worker heartbeat key and classify freshness."""
+
+    evidence: dict[str, Any] = {
+        "key": CHAT_WORKER_HEARTBEAT_KEY,
+        "state": "unknown",
+        "age_seconds": None,
+        "detected": False,
+        "reason": "unknown",
+        "error": None,
+    }
+    try:
+        from guardian.queue.redis_queue import get_redis_client
+
+        client = get_redis_client()
+        raw_heartbeat = client.get(CHAT_WORKER_HEARTBEAT_KEY)
+        if not raw_heartbeat:
+            evidence["state"] = "missing"
+            evidence["reason"] = "heartbeat_missing"
+            return evidence
+
+        evidence["detected"] = True
+        heartbeat_payload: dict[str, Any] = {}
+        try:
+            if isinstance(raw_heartbeat, (bytes, bytearray)):
+                heartbeat_payload = json.loads(raw_heartbeat.decode("utf-8"))
+            else:
+                heartbeat_payload = json.loads(str(raw_heartbeat))
+        except Exception:
+            evidence["reason"] = "heartbeat_parse_failed"
+            return evidence
+
+        ts = heartbeat_payload.get("ts")
+        if not isinstance(ts, (int, float)):
+            evidence["reason"] = "heartbeat_timestamp_missing"
+            return evidence
+
+        age_seconds = max(0.0, round(time.time() - float(ts), 3))
+        evidence["age_seconds"] = age_seconds
+        evidence["state"] = _classify_chat_worker_heartbeat(True, age_seconds)
+        evidence["reason"] = "ok"
+        return evidence
+    except Exception as exc:
+        evidence["reason"] = "heartbeat_probe_failed"
+        evidence["error"] = f"{type(exc).__name__}: {exc}"
+        return evidence
 
 
 def _turn_lock_payload(
@@ -98,13 +156,52 @@ def _recover_orphaned_turn_lock(thread_id: int) -> bool:
     stale_lock = get_turn_lock(thread_id)
     if stale_lock is None or not turn_lock_is_stale(stale_lock):
         return False
-    if _task_terminal_event(stale_lock.owner_task_id) is not None:
-        return False
 
-    heartbeat_age = _chat_worker_heartbeat_age_seconds()
-    if heartbeat_age is not None and heartbeat_age <= float(
-        stale_lock.lease_ttl_seconds
-    ):
+    terminal_evidence = _task_terminal_event(stale_lock.owner_task_id)
+    terminal_state = str(
+        terminal_evidence.get("state")
+        if isinstance(terminal_evidence, dict)
+        else "unknown"
+    )
+    heartbeat_evidence = _chat_worker_heartbeat_evidence()
+    heartbeat_state = str(
+        heartbeat_evidence.get("state")
+        if isinstance(heartbeat_evidence, dict)
+        else "unknown"
+    )
+
+    # Recovery rule:
+    # - terminal task evidence is enough to clear the stale lock.
+    # - otherwise, the task stream must be nonterminal and the worker heartbeat
+    #   must be stale/dead/missing. We do not recover when either evidence
+    #   source is unknown, and we never recover on lease age alone.
+    recoverable = False
+    recovery_reason = "unrecoverable_state"
+    if terminal_state == "terminal":
+        recoverable = True
+        recovery_reason = "terminal_task_event"
+    elif terminal_state == "nonterminal" and heartbeat_state in {
+        "stale",
+        "dead",
+        "missing",
+    }:
+        recoverable = True
+        recovery_reason = f"nonterminal_task_and_{heartbeat_state}_heartbeat"
+
+    if not recoverable:
+        logger.warning(
+            "[chat.complete] stale turn lock recovery denied thread_id=%s owner_task_id=%s terminal_state=%s terminal_reason=%s worker_state=%s worker_reason=%s",
+            thread_id,
+            stale_lock.owner_task_id,
+            terminal_state,
+            terminal_evidence.get("reason")
+            if isinstance(terminal_evidence, dict)
+            else "unknown",
+            heartbeat_state,
+            heartbeat_evidence.get("reason")
+            if isinstance(heartbeat_evidence, dict)
+            else "unknown",
+        )
         return False
 
     cleared = clear_turn_lock(thread_id, expected=stale_lock)
@@ -114,6 +211,14 @@ def _recover_orphaned_turn_lock(thread_id: int) -> bool:
             "chat_thread",
             str(thread_id),
             user_id="system",
+        )
+        logger.info(
+            "[chat.complete] stale turn lock recovered thread_id=%s owner_task_id=%s recovery_reason=%s terminal_state=%s worker_state=%s",
+            thread_id,
+            stale_lock.owner_task_id,
+            recovery_reason,
+            terminal_state,
+            heartbeat_state,
         )
     return cleared
 

--- a/guardian/routes/health.py
+++ b/guardian/routes/health.py
@@ -30,6 +30,10 @@ _LLM_HEALTH_PROBE_TS = 0.0
 _LLM_HEALTH_CACHE_LOCK = threading.Lock()
 _LLM_HEALTH_PROBE_INFLIGHT_LOCK = threading.Lock()
 
+# Chat worker heartbeat freshness thresholds.
+CHAT_WORKER_HEARTBEAT_FRESH_THRESHOLD_SECONDS = 10.0
+CHAT_WORKER_HEARTBEAT_DEAD_THRESHOLD_SECONDS = 60.0
+
 # Create unprefixed router to preserve /health/chat path
 router = APIRouter(tags=["Health"])
 
@@ -128,6 +132,24 @@ def _normalize_health_provider(raw_provider: str) -> str:
     return "local"
 
 
+def _classify_chat_worker_heartbeat(
+    heartbeat_detected: bool, heartbeat_age_seconds: object
+) -> str:
+    """Classify chat worker freshness from heartbeat presence and age."""
+    if not heartbeat_detected:
+        return "dead"
+
+    if not isinstance(heartbeat_age_seconds, (int, float)):
+        return "dead"
+
+    heartbeat_age = float(heartbeat_age_seconds)
+    if heartbeat_age <= CHAT_WORKER_HEARTBEAT_FRESH_THRESHOLD_SECONDS:
+        return "fresh"
+    if heartbeat_age <= CHAT_WORKER_HEARTBEAT_DEAD_THRESHOLD_SECONDS:
+        return "stale"
+    return "dead"
+
+
 def _collect_completion_service_health() -> dict[str, object]:
     from guardian.queue.redis_queue import get_redis_client
 
@@ -184,10 +206,17 @@ def _collect_completion_service_health() -> dict[str, object]:
                     0.0, round(time.time() - float(ts), 3)
                 )
 
+        completion_service[
+            "worker_heartbeat_status"
+        ] = _classify_chat_worker_heartbeat(
+            completion_service["worker_heartbeat_detected"],
+            completion_service["worker_heartbeat_age_seconds"],
+        )
+
         completion_service["ok"] = bool(
             completion_service["redis_reachable"]
             and completion_service["enqueue_test_ok"]
-            and completion_service["worker_heartbeat_detected"]
+            and completion_service["worker_heartbeat_status"] == "fresh"
         )
         if not completion_service["redis_reachable"]:
             completion_service["status_reason"] = "redis_unreachable"
@@ -195,6 +224,10 @@ def _collect_completion_service_health() -> dict[str, object]:
             completion_service["status_reason"] = "queue_enqueue_failed"
         elif not completion_service["worker_heartbeat_detected"]:
             completion_service["status_reason"] = "worker_heartbeat_missing"
+        elif completion_service["worker_heartbeat_status"] == "stale":
+            completion_service["status_reason"] = "worker_heartbeat_stale"
+        elif completion_service["worker_heartbeat_status"] == "dead":
+            completion_service["status_reason"] = "worker_heartbeat_dead"
         else:
             completion_service["status_reason"] = "ok"
     except Exception as exc:
@@ -348,9 +381,60 @@ def health_chat():
         threads = 0
         messages = 0
 
-    ok = bool(completion_service["ok"])
+    redis_reachable = bool(completion_service.get("redis_reachable"))
+    queue_ok = bool(completion_service.get("enqueue_test_ok"))
+    redis_ok = bool(redis_reachable and queue_ok)
+    worker_detected = bool(completion_service.get("worker_heartbeat_detected"))
+    worker_age_seconds = completion_service.get("worker_heartbeat_age_seconds")
+    worker_status = str(
+        completion_service.get("worker_heartbeat_status")
+        or _classify_chat_worker_heartbeat(worker_detected, worker_age_seconds)
+    )
+
+    if not redis_reachable:
+        status = "unhealthy"
+        notes = [
+            "redis unreachable; chat completion cannot be trusted",
+        ]
+    elif not queue_ok:
+        status = "unhealthy"
+        notes = [
+            "queue round-trip probe failed; chat completion cannot be trusted",
+        ]
+    elif worker_status == "fresh":
+        status = "healthy"
+        notes = []
+    elif worker_status == "stale":
+        status = "degraded"
+        notes = [
+            "worker heartbeat stale; chat completion may be degraded",
+        ]
+    else:
+        status = "unhealthy"
+        if not worker_detected:
+            notes = [
+                "worker heartbeat missing; chat completion cannot progress",
+            ]
+        elif worker_age_seconds is None:
+            notes = [
+                "worker heartbeat age unavailable; chat completion cannot be trusted",
+            ]
+        else:
+            notes = [
+                "worker heartbeat dead; chat completion cannot progress",
+            ]
+
     return {
-        "ok": ok,
+        "ok": status == "healthy",
+        "status": status,
+        "redis": "ok" if redis_ok else "unhealthy",
+        "worker": {
+            "status": worker_status,
+            "heartbeat_age_seconds": worker_age_seconds
+            if worker_detected
+            else None,
+        },
+        "notes": notes,
         "threads": threads,
         "messages": messages,
         "backend": DB_BACKEND,

--- a/guardian/routes/health.py
+++ b/guardian/routes/health.py
@@ -34,6 +34,14 @@ _LLM_HEALTH_PROBE_INFLIGHT_LOCK = threading.Lock()
 CHAT_WORKER_HEARTBEAT_FRESH_THRESHOLD_SECONDS = 10.0
 CHAT_WORKER_HEARTBEAT_DEAD_THRESHOLD_SECONDS = 60.0
 
+CHAT_QUEUE_NAME = "codexify:queue:chat"
+CHAT_QUEUE_HIGH_DEPTH_THRESHOLD = 25
+CHAT_QUEUE_PROGRESS_SAMPLE_STALE_SECONDS = 30.0
+
+_CHAT_QUEUE_PROGRESS_LOCK = threading.Lock()
+_CHAT_QUEUE_LAST_DEPTH: int | None = None
+_CHAT_QUEUE_LAST_CHECK_TS = 0.0
+
 # Create unprefixed router to preserve /health/chat path
 router = APIRouter(tags=["Health"])
 
@@ -148,6 +156,60 @@ def _classify_chat_worker_heartbeat(
     if heartbeat_age <= CHAT_WORKER_HEARTBEAT_DEAD_THRESHOLD_SECONDS:
         return "stale"
     return "dead"
+
+
+def _collect_chat_queue_health() -> dict[str, object]:
+    global _CHAT_QUEUE_LAST_DEPTH, _CHAT_QUEUE_LAST_CHECK_TS
+
+    from guardian.queue.redis_queue import get_redis_client
+
+    queue_health: dict[str, object] = {
+        "depth": None,
+        "status": "unknown",
+        "error": None,
+    }
+
+    try:
+        client = get_redis_client()
+        llen = getattr(client, "llen", None)
+        if not callable(llen):
+            queue_health["error"] = "queue_depth_unavailable"
+            return queue_health
+
+        depth = max(0, int(llen(CHAT_QUEUE_NAME)))
+        now = time.time()
+        with _CHAT_QUEUE_PROGRESS_LOCK:
+            previous_depth = _CHAT_QUEUE_LAST_DEPTH
+            previous_check_ts = _CHAT_QUEUE_LAST_CHECK_TS
+            _CHAT_QUEUE_LAST_DEPTH = depth
+            _CHAT_QUEUE_LAST_CHECK_TS = now
+
+        queue_health["depth"] = depth
+
+        if depth == 0:
+            queue_health["status"] = "progressing"
+            return queue_health
+
+        if previous_depth is None:
+            queue_health["status"] = "unknown"
+            return queue_health
+
+        if (
+            previous_check_ts
+            and now - previous_check_ts
+            > CHAT_QUEUE_PROGRESS_SAMPLE_STALE_SECONDS
+        ):
+            queue_health["status"] = "unknown"
+            return queue_health
+
+        if depth < previous_depth:
+            queue_health["status"] = "progressing"
+        else:
+            queue_health["status"] = "stalled"
+    except Exception as exc:
+        queue_health["error"] = f"{type(exc).__name__}: {exc}"
+
+    return queue_health
 
 
 def _collect_completion_service_health() -> dict[str, object]:
@@ -372,6 +434,7 @@ def health_chat():
     from guardian.core.dependencies import DB_BACKEND, chatlog_db
 
     completion_service = _collect_completion_service_health()
+    queue_health = _collect_chat_queue_health()
 
     try:
         threads = chatlog_db.count_chat_threads()
@@ -390,6 +453,9 @@ def health_chat():
         completion_service.get("worker_heartbeat_status")
         or _classify_chat_worker_heartbeat(worker_detected, worker_age_seconds)
     )
+    queue_depth = queue_health.get("depth")
+    queue_status = str(queue_health.get("status") or "unknown")
+    queue_error = queue_health.get("error")
 
     if not redis_reachable:
         status = "unhealthy"
@@ -402,8 +468,45 @@ def health_chat():
             "queue round-trip probe failed; chat completion cannot be trusted",
         ]
     elif worker_status == "fresh":
-        status = "healthy"
-        notes = []
+        if queue_error == "queue_depth_unavailable":
+            status = "degraded"
+            notes = [
+                "queue depth unavailable; forward progress cannot be assessed",
+            ]
+        elif queue_depth == 0 or queue_status == "progressing":
+            status = "healthy"
+            notes = (
+                ["queue empty"]
+                if queue_depth == 0
+                else ["queue backlog detected but progressing"]
+            )
+        elif queue_status == "unknown":
+            status = "degraded"
+            if (
+                isinstance(queue_depth, int)
+                and queue_depth >= CHAT_QUEUE_HIGH_DEPTH_THRESHOLD
+            ):
+                notes = [
+                    "queue backlog high; forward progress is not yet established",
+                ]
+            else:
+                notes = [
+                    "queue backlog observed; forward progress is not yet established",
+                ]
+        else:
+            if (
+                isinstance(queue_depth, int)
+                and queue_depth >= CHAT_QUEUE_HIGH_DEPTH_THRESHOLD
+            ):
+                status = "unhealthy"
+                notes = [
+                    "queue backlog high and not progressing; worker may be stuck",
+                ]
+            else:
+                status = "degraded"
+                notes = [
+                    "queue backlog not progressing; worker may be stuck",
+                ]
     elif worker_status == "stale":
         status = "degraded"
         notes = [
@@ -433,6 +536,10 @@ def health_chat():
             "heartbeat_age_seconds": worker_age_seconds
             if worker_detected
             else None,
+        },
+        "queue": {
+            "depth": queue_depth,
+            "status": queue_status,
         },
         "notes": notes,
         "threads": threads,

--- a/guardian/tests/test_health_endpoints.py
+++ b/guardian/tests/test_health_endpoints.py
@@ -1,7 +1,31 @@
+import json
+
+import pytest
 import requests
 from fastapi.testclient import TestClient
 
 from guardian.guardian_api import app
+from guardian.routes import health as health_routes
+
+
+class _FakeRedisClient:
+    def __init__(self, heartbeat_value):
+        self.heartbeat_value = heartbeat_value
+
+    def ping(self):
+        return True
+
+    def lpush(self, *args, **kwargs):
+        return 1
+
+    def rpop(self, *args, **kwargs):
+        return b"ok"
+
+    def delete(self, *args, **kwargs):
+        return 1
+
+    def get(self, key):
+        return self.heartbeat_value
 
 
 def test_health_endpoints_ok():
@@ -176,9 +200,198 @@ def test_health_and_catalog_share_dynamic_provider_model_index_state(
         assert (
             health_payload["provider_runtime"]["enabled"] == minimax["enabled"]
         )
-        assert minimax["models"] == []
         assert minimax["model_index"]["state"] == "degraded"
         assert "timed out" in minimax["model_index"]["reason"].lower()
     finally:
         for field, value in snapshot.items():
             setattr(settings, field, value)
+
+
+def test_completion_service_health_computes_heartbeat_age(monkeypatch):
+    fixed_now = 1_700_000_000.0
+    heartbeat_age = 27.5
+    heartbeat_payload = json.dumps({"ts": fixed_now - heartbeat_age}).encode(
+        "utf-8"
+    )
+
+    monkeypatch.setattr(
+        "guardian.queue.redis_queue.get_redis_client",
+        lambda: _FakeRedisClient(heartbeat_payload),
+    )
+    monkeypatch.setattr(health_routes.time, "time", lambda: fixed_now)
+
+    payload = health_routes._collect_completion_service_health()
+
+    assert payload["redis_reachable"] is True
+    assert payload["worker_heartbeat_detected"] is True
+    assert payload["worker_heartbeat_status"] == "stale"
+    assert payload["worker_heartbeat_age_seconds"] == pytest.approx(
+        heartbeat_age, abs=0.001
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "completion_service",
+        "expected_ok",
+        "expected_status",
+        "expected_worker_status",
+        "expected_note",
+    ),
+    [
+        (
+            {
+                "redis_reachable": True,
+                "enqueue_test_ok": False,
+                "worker_heartbeat_detected": True,
+                "worker_heartbeat_age_seconds": 0.5,
+                "status_reason": "queue_enqueue_failed",
+                "error": None,
+            },
+            False,
+            "unhealthy",
+            "fresh",
+            "queue round-trip probe failed",
+        ),
+        (
+            {
+                "redis_reachable": True,
+                "enqueue_test_ok": True,
+                "worker_heartbeat_detected": True,
+                "worker_heartbeat_age_seconds": 0.5,
+                "status_reason": "ok",
+                "error": None,
+            },
+            True,
+            "healthy",
+            "fresh",
+            None,
+        ),
+        (
+            {
+                "redis_reachable": True,
+                "enqueue_test_ok": True,
+                "worker_heartbeat_detected": True,
+                "worker_heartbeat_age_seconds": 10.0,
+                "status_reason": "ok",
+                "error": None,
+            },
+            True,
+            "healthy",
+            "fresh",
+            None,
+        ),
+        (
+            {
+                "redis_reachable": True,
+                "enqueue_test_ok": True,
+                "worker_heartbeat_detected": True,
+                "worker_heartbeat_age_seconds": 10.001,
+                "status_reason": "ok",
+                "error": None,
+            },
+            False,
+            "degraded",
+            "stale",
+            "worker heartbeat stale",
+        ),
+        (
+            {
+                "redis_reachable": True,
+                "enqueue_test_ok": True,
+                "worker_heartbeat_detected": True,
+                "worker_heartbeat_age_seconds": 60.0,
+                "status_reason": "ok",
+                "error": None,
+            },
+            False,
+            "degraded",
+            "stale",
+            "worker heartbeat stale",
+        ),
+        (
+            {
+                "redis_reachable": True,
+                "enqueue_test_ok": True,
+                "worker_heartbeat_detected": True,
+                "worker_heartbeat_age_seconds": 60.001,
+                "status_reason": "ok",
+                "error": None,
+            },
+            False,
+            "unhealthy",
+            "dead",
+            "worker heartbeat dead",
+        ),
+        (
+            {
+                "redis_reachable": True,
+                "enqueue_test_ok": True,
+                "worker_heartbeat_detected": False,
+                "worker_heartbeat_age_seconds": None,
+                "status_reason": "worker_heartbeat_missing",
+                "error": None,
+            },
+            False,
+            "unhealthy",
+            "dead",
+            "worker heartbeat missing",
+        ),
+        (
+            {
+                "redis_reachable": False,
+                "enqueue_test_ok": False,
+                "worker_heartbeat_detected": False,
+                "worker_heartbeat_age_seconds": None,
+                "status_reason": "redis_unreachable",
+                "error": None,
+            },
+            False,
+            "unhealthy",
+            "dead",
+            "redis unreachable",
+        ),
+    ],
+)
+def test_health_chat_classifies_worker_freshness(
+    monkeypatch,
+    completion_service,
+    expected_ok,
+    expected_status,
+    expected_worker_status,
+    expected_note,
+):
+    monkeypatch.setattr(
+        health_routes,
+        "_collect_completion_service_health",
+        lambda: completion_service,
+    )
+
+    client = TestClient(app)
+    resp = client.get("/health/chat")
+    assert resp.status_code == 200
+
+    payload = resp.json()
+    assert payload["ok"] is expected_ok
+    assert payload["status"] == expected_status
+    assert payload["redis"] == (
+        "ok"
+        if completion_service["redis_reachable"]
+        and completion_service["enqueue_test_ok"]
+        else "unhealthy"
+    )
+    assert payload["worker"]["status"] == expected_worker_status
+    if completion_service["worker_heartbeat_detected"]:
+        assert (
+            payload["worker"]["heartbeat_age_seconds"]
+            == completion_service["worker_heartbeat_age_seconds"]
+        )
+    else:
+        assert payload["worker"]["heartbeat_age_seconds"] is None
+
+    if expected_note is None:
+        assert payload["notes"] == []
+    else:
+        assert any(
+            expected_note in str(note).lower() for note in payload["notes"]
+        )

--- a/guardian/tests/test_health_endpoints.py
+++ b/guardian/tests/test_health_endpoints.py
@@ -9,8 +9,9 @@ from guardian.routes import health as health_routes
 
 
 class _FakeRedisClient:
-    def __init__(self, heartbeat_value):
+    def __init__(self, heartbeat_value=None, queue_depth=0):
         self.heartbeat_value = heartbeat_value
+        self.queue_depth = queue_depth
 
     def ping(self):
         return True
@@ -26,6 +27,31 @@ class _FakeRedisClient:
 
     def get(self, key):
         return self.heartbeat_value
+
+    def llen(self, key):
+        return self.queue_depth
+
+
+@pytest.fixture(autouse=True)
+def reset_chat_queue_progress_state():
+    health_routes._CHAT_QUEUE_LAST_DEPTH = None
+    health_routes._CHAT_QUEUE_LAST_CHECK_TS = 0.0
+    yield
+    health_routes._CHAT_QUEUE_LAST_DEPTH = None
+    health_routes._CHAT_QUEUE_LAST_CHECK_TS = 0.0
+
+
+def _fresh_completion_service() -> dict[str, object]:
+    return {
+        "ok": True,
+        "redis_reachable": True,
+        "enqueue_test_ok": True,
+        "worker_heartbeat_detected": True,
+        "worker_heartbeat_age_seconds": 0.5,
+        "worker_heartbeat_status": "fresh",
+        "status_reason": "ok",
+        "error": None,
+    }
 
 
 def test_health_endpoints_ok():
@@ -216,7 +242,7 @@ def test_completion_service_health_computes_heartbeat_age(monkeypatch):
 
     monkeypatch.setattr(
         "guardian.queue.redis_queue.get_redis_client",
-        lambda: _FakeRedisClient(heartbeat_payload),
+        lambda: _FakeRedisClient(heartbeat_payload, queue_depth=0),
     )
     monkeypatch.setattr(health_routes.time, "time", lambda: fixed_now)
 
@@ -265,7 +291,7 @@ def test_completion_service_health_computes_heartbeat_age(monkeypatch):
             True,
             "healthy",
             "fresh",
-            None,
+            "queue empty",
         ),
         (
             {
@@ -279,7 +305,7 @@ def test_completion_service_health_computes_heartbeat_age(monkeypatch):
             True,
             "healthy",
             "fresh",
-            None,
+            "queue empty",
         ),
         (
             {
@@ -366,6 +392,10 @@ def test_health_chat_classifies_worker_freshness(
         "_collect_completion_service_health",
         lambda: completion_service,
     )
+    monkeypatch.setattr(
+        "guardian.queue.redis_queue.get_redis_client",
+        lambda: _FakeRedisClient(queue_depth=0),
+    )
 
     client = TestClient(app)
     resp = client.get("/health/chat")
@@ -374,6 +404,8 @@ def test_health_chat_classifies_worker_freshness(
     payload = resp.json()
     assert payload["ok"] is expected_ok
     assert payload["status"] == expected_status
+    assert payload["queue"]["depth"] == 0
+    assert payload["queue"]["status"] == "progressing"
     assert payload["redis"] == (
         "ok"
         if completion_service["redis_reachable"]
@@ -395,3 +427,57 @@ def test_health_chat_classifies_worker_freshness(
         assert any(
             expected_note in str(note).lower() for note in payload["notes"]
         )
+
+
+def test_health_chat_reports_queue_progression(monkeypatch):
+    fake_redis = _FakeRedisClient(queue_depth=0)
+    monkeypatch.setattr(
+        health_routes,
+        "_collect_completion_service_health",
+        _fresh_completion_service,
+    )
+    monkeypatch.setattr(
+        "guardian.queue.redis_queue.get_redis_client",
+        lambda: fake_redis,
+    )
+
+    client = TestClient(app)
+
+    def read_health():
+        response = client.get("/health/chat")
+        assert response.status_code == 200
+        return response.json()
+
+    initial = read_health()
+    assert initial["queue"]["depth"] == 0
+    assert initial["queue"]["status"] == "progressing"
+    assert initial["status"] == "healthy"
+    assert any("queue empty" in note.lower() for note in initial["notes"])
+
+    fake_redis.queue_depth = 6
+    growing = read_health()
+    assert growing["queue"]["depth"] == 6
+    assert growing["queue"]["status"] == "stalled"
+    assert growing["status"] == "degraded"
+    assert any("not progressing" in note.lower() for note in growing["notes"])
+
+    fake_redis.queue_depth = 4
+    draining = read_health()
+    assert draining["queue"]["depth"] == 4
+    assert draining["queue"]["status"] == "progressing"
+    assert draining["status"] == "healthy"
+    assert any("progressing" in note.lower() for note in draining["notes"])
+
+    fake_redis.queue_depth = 4
+    stuck = read_health()
+    assert stuck["queue"]["depth"] == 4
+    assert stuck["queue"]["status"] == "stalled"
+    assert stuck["status"] == "degraded"
+    assert any("not progressing" in note.lower() for note in stuck["notes"])
+
+    fake_redis.queue_depth = 30
+    high = read_health()
+    assert high["queue"]["depth"] == 30
+    assert high["queue"]["status"] == "stalled"
+    assert high["status"] == "unhealthy"
+    assert any("high" in note.lower() for note in high["notes"])

--- a/guardian/workers/chat_worker.py
+++ b/guardian/workers/chat_worker.py
@@ -358,8 +358,8 @@ def _safe_emit_live_event(event_type: str, payload: dict[str, Any]) -> None:
         )
 
 
-def _safe_publish(task_id: str, event_type: str, data: dict) -> None:
-    """Best-effort event publishing.
+def _safe_publish(task_id: str, event_type: str, data: dict) -> dict[str, Any]:
+    """Best-effort event publishing with explicit visibility signaling.
 
     Never raise from the worker hot-path.
     """
@@ -370,19 +370,50 @@ def _safe_publish(task_id: str, event_type: str, data: dict) -> None:
         payload = {"data": str(data)}
 
     try:
-        task_events.publish(task_id, event_type, payload)
+        publish_result = task_events.publish_with_visibility(
+            task_id, event_type, payload
+        )
     except Exception as exc:
-        logger.warning(
-            "[chat-worker] failed to publish event type=%s task_id=%s err=%s",
-            event_type,
+        visibility_scope = task_events.classify_event_visibility(event_type)
+        publish_result = {
+            "ok": False,
+            "task_id": task_id,
+            "event_type": event_type,
+            "visibility_scope": visibility_scope,
+            "terminal_visibility": visibility_scope == "terminal",
+            "execution_continued": True,
+            "event_id": None,
+            "failure_class": exc.__class__.__name__,
+            "error": str(exc),
+        }
+
+    if not publish_result.get("ok"):
+        log_level = (
+            logging.ERROR
+            if publish_result.get("terminal_visibility")
+            else logging.WARNING
+        )
+        logger.log(
+            log_level,
+            (
+                "[chat-worker] task_event_visibility_degraded "
+                "task_id=%s event_type=%s visibility_scope=%s "
+                "failure_class=%s execution_continued=%s err=%s"
+            ),
             task_id,
-            exc,
+            event_type,
+            publish_result.get("visibility_scope"),
+            publish_result.get("failure_class"),
+            publish_result.get("execution_continued"),
+            publish_result.get("error"),
         )
 
     if event_type in _MIRRORED_LIVE_EVENT_TYPES:
         mirror_payload = dict(payload)
         mirror_payload.setdefault("task_id", task_id)
         _safe_emit_live_event(event_type, mirror_payload)
+
+    return publish_result
 
 
 def _describe_task_error(exc: Exception) -> str:

--- a/tests/core/test_turn_lock_recovery.py
+++ b/tests/core/test_turn_lock_recovery.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from guardian.queue import task_events
 from guardian.queue.turn_lock import TurnLockEnvelope, build_turn_lock_envelope
 
 os.environ.setdefault("CODEXIFY_EMBEDDINGS_BACKEND", "mock")
@@ -82,6 +83,110 @@ def _stale_lock(thread_id: int = 1) -> TurnLockEnvelope:
     )
 
 
+def _terminal_evidence(
+    state: str,
+    *,
+    event_type: str = "task.completed",
+    reason: str = "terminal_event_found",
+    task_id: str = "task-stale",
+) -> dict[str, object]:
+    if state == "terminal":
+        return {
+            "task_id": task_id,
+            "state": "terminal",
+            "event_id": "1-2",
+            "event": {"type": event_type, "data": {}},
+            "event_type": event_type,
+            "reason": reason,
+        }
+    if state == "nonterminal":
+        return {
+            "task_id": task_id,
+            "state": "nonterminal",
+            "event_id": None,
+            "event": None,
+            "event_type": None,
+            "reason": reason,
+        }
+    return {
+        "task_id": task_id,
+        "state": "unknown",
+        "event_id": None,
+        "event": None,
+        "event_type": None,
+        "reason": reason,
+    }
+
+
+def _heartbeat_evidence(
+    state: str,
+    *,
+    age_seconds: float | None = None,
+    reason: str = "ok",
+) -> dict[str, object]:
+    if state == "missing":
+        return {
+            "key": "codexify:worker:chat:heartbeat",
+            "state": "missing",
+            "age_seconds": None,
+            "detected": False,
+            "reason": "heartbeat_missing" if reason == "ok" else reason,
+            "error": None,
+        }
+    if state == "unknown":
+        return {
+            "key": "codexify:worker:chat:heartbeat",
+            "state": "unknown",
+            "age_seconds": None,
+            "detected": False,
+            "reason": reason,
+            "error": "probe_failed",
+        }
+    if age_seconds is None:
+        age_seconds = {
+            "fresh": 1.0,
+            "stale": 27.0,
+            "dead": 61.0,
+        }.get(state, 1.0)
+    return {
+        "key": "codexify:worker:chat:heartbeat",
+        "state": state,
+        "age_seconds": age_seconds,
+        "detected": True,
+        "reason": reason,
+        "error": None,
+    }
+
+
+def test_terminal_state_helper_detects_terminal_event(monkeypatch):
+    batches = [
+        [
+            ("1-1", {"type": "task.running", "data": {"step": 1}}),
+            ("1-2", {"type": "task.completed", "data": {"result": "ok"}}),
+        ]
+    ]
+
+    def fake_read_events(
+        _task_id: str,
+        _last_id: str,
+        *,
+        block_ms: int = 15000,
+        count: int = 100,
+    ) -> list[tuple[str, dict[str, object]]]:
+        _ = block_ms, count
+        if batches:
+            return batches.pop(0)
+        return []
+
+    monkeypatch.setattr(task_events, "read_events", fake_read_events)
+
+    evidence = task_events.describe_terminal_state("task-123")
+
+    assert evidence["state"] == "terminal"
+    assert evidence["event_type"] == "task.completed"
+    assert evidence["event"]["data"] == {"result": "ok"}
+
+
 def test_complete_recovers_orphaned_turn_lock(
     test_client, mock_db, monkeypatch
 ):
@@ -107,11 +212,12 @@ def test_complete_recovers_orphaned_turn_lock(
         "guardian.routes.chat.turn_lock_is_stale", lambda *_: True
     )
     monkeypatch.setattr(
-        "guardian.routes.chat._task_terminal_event", lambda *_: None
+        "guardian.routes.chat._task_terminal_event",
+        lambda *_: _terminal_evidence("terminal"),
     )
     monkeypatch.setattr(
-        "guardian.routes.chat._chat_worker_heartbeat_age_seconds",
-        lambda: None,
+        "guardian.routes.chat._chat_worker_heartbeat_evidence",
+        lambda: _heartbeat_evidence("fresh", age_seconds=1.0),
     )
     cleared: list[tuple[int, str]] = []
     monkeypatch.setattr(
@@ -143,6 +249,129 @@ def test_complete_recovers_orphaned_turn_lock(
     assert getattr(task, "turn_lock")["turn_id"]
 
 
+@pytest.mark.parametrize("worker_state", ["stale", "missing"])
+def test_complete_recovers_orphaned_turn_lock_when_worker_not_fresh(
+    test_client, mock_db, monkeypatch, worker_state
+):
+    captured: dict[str, object] = {}
+    acquire_calls = {"count": 0}
+
+    def _acquire(*args, **kwargs):
+        acquire_calls["count"] += 1
+        if acquire_calls["count"] == 1:
+            return None
+        return build_turn_lock_envelope(
+            args[0],
+            args[1],
+            turn_id=kwargs.get("turn_id"),
+            source=kwargs.get("source"),
+        )
+
+    monkeypatch.setattr("guardian.routes.chat.acquire_turn_lock", _acquire)
+    monkeypatch.setattr(
+        "guardian.routes.chat.get_turn_lock", lambda *_: _stale_lock()
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat.turn_lock_is_stale", lambda *_: True
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat._task_terminal_event",
+        lambda *_: _terminal_evidence("nonterminal"),
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat._chat_worker_heartbeat_evidence",
+        lambda: _heartbeat_evidence(worker_state),
+    )
+    cleared: list[tuple[int, str]] = []
+    monkeypatch.setattr(
+        "guardian.routes.chat.clear_turn_lock",
+        lambda thread_id, expected=None: cleared.append(
+            (thread_id, getattr(expected, "owner_task_id", ""))
+        )
+        or True,
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat.enqueue",
+        lambda task, queue_name: captured.update(
+            {"task": task, "queue_name": queue_name}
+        ),
+    )
+
+    response = test_client.post("/chat/1/complete", json={})
+
+    assert response.status_code == 200
+    assert acquire_calls["count"] == 2
+    assert cleared == [(1, "task-stale")]
+    assert captured["queue_name"] == "codexify:queue:chat"
+    assert getattr(captured["task"], "turn_lock_owner") == getattr(
+        captured["task"], "task_id"
+    )
+
+
+def test_complete_denies_recovery_when_worker_fresh(
+    test_client, mock_db, monkeypatch
+):
+    monkeypatch.setattr(
+        "guardian.routes.chat.acquire_turn_lock",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat.get_turn_lock", lambda *_: _stale_lock()
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat.turn_lock_is_stale", lambda *_: True
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat._task_terminal_event",
+        lambda *_: _terminal_evidence("nonterminal"),
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat._chat_worker_heartbeat_evidence",
+        lambda: _heartbeat_evidence("fresh", age_seconds=1.0),
+    )
+    clear_spy = MagicMock(return_value=False)
+    monkeypatch.setattr("guardian.routes.chat.clear_turn_lock", clear_spy)
+
+    response = test_client.post("/chat/1/complete", json={})
+
+    assert response.status_code == 429
+    assert response.json()["detail"] == "turn_in_flight"
+    clear_spy.assert_not_called()
+    mock_db.write_audit_log.assert_not_called()
+
+
+def test_complete_denies_recovery_on_unknown_terminal_state(
+    test_client, mock_db, monkeypatch
+):
+    monkeypatch.setattr(
+        "guardian.routes.chat.acquire_turn_lock",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat.get_turn_lock", lambda *_: _stale_lock()
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat.turn_lock_is_stale", lambda *_: True
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat._task_terminal_event",
+        lambda *_: _terminal_evidence("unknown", reason="event_probe_failed"),
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat._chat_worker_heartbeat_evidence",
+        lambda: _heartbeat_evidence("stale", age_seconds=27.0),
+    )
+    clear_spy = MagicMock(return_value=False)
+    monkeypatch.setattr("guardian.routes.chat.clear_turn_lock", clear_spy)
+
+    response = test_client.post("/chat/1/complete", json={})
+
+    assert response.status_code == 429
+    assert response.json()["detail"] == "turn_in_flight"
+    clear_spy.assert_not_called()
+    mock_db.write_audit_log.assert_not_called()
+
+
 def test_complete_keeps_active_turn_lock_in_place(
     test_client, mock_db, monkeypatch
 ):
@@ -155,13 +384,6 @@ def test_complete_keeps_active_turn_lock_in_place(
     )
     monkeypatch.setattr(
         "guardian.routes.chat.turn_lock_is_stale", lambda *_: False
-    )
-    monkeypatch.setattr(
-        "guardian.routes.chat._task_terminal_event", lambda *_: None
-    )
-    monkeypatch.setattr(
-        "guardian.routes.chat._chat_worker_heartbeat_age_seconds",
-        lambda: 1.0,
     )
     clear_spy = MagicMock(return_value=False)
     monkeypatch.setattr("guardian.routes.chat.clear_turn_lock", clear_spy)

--- a/tests/routes/test_chat_routes.py
+++ b/tests/routes/test_chat_routes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from contextlib import ExitStack
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -97,6 +98,88 @@ def _mock_redis_queue_for_chat_routes():
         for p in patches:
             stack.enter_context(p)
         yield
+
+
+def _stale_lock():
+    return SimpleNamespace(
+        owner_task_id="task-stale",
+        lease_ttl_seconds=30,
+        lease_expires_at="2026-03-13T12:00:30+00:00",
+    )
+
+
+def _terminal_evidence(
+    state: str,
+    *,
+    event_type: str = "task.completed",
+    reason: str = "terminal_event_found",
+) -> dict[str, object]:
+    if state == "terminal":
+        return {
+            "task_id": "task-stale",
+            "state": "terminal",
+            "event_id": "1-2",
+            "event": {"type": event_type, "data": {}},
+            "event_type": event_type,
+            "reason": reason,
+        }
+    if state == "nonterminal":
+        return {
+            "task_id": "task-stale",
+            "state": "nonterminal",
+            "event_id": None,
+            "event": None,
+            "event_type": None,
+            "reason": reason,
+        }
+    return {
+        "task_id": "task-stale",
+        "state": "unknown",
+        "event_id": None,
+        "event": None,
+        "event_type": None,
+        "reason": reason,
+    }
+
+
+def _heartbeat_evidence(
+    state: str,
+    *,
+    age_seconds: float | None = None,
+    reason: str = "ok",
+) -> dict[str, object]:
+    if state == "missing":
+        return {
+            "key": "codexify:worker:chat:heartbeat",
+            "state": "missing",
+            "age_seconds": None,
+            "detected": False,
+            "reason": "heartbeat_missing" if reason == "ok" else reason,
+            "error": None,
+        }
+    if state == "unknown":
+        return {
+            "key": "codexify:worker:chat:heartbeat",
+            "state": "unknown",
+            "age_seconds": None,
+            "detected": False,
+            "reason": reason,
+            "error": "probe_failed",
+        }
+    if age_seconds is None:
+        age_seconds = {
+            "fresh": 1.0,
+            "stale": 27.0,
+            "dead": 61.0,
+        }.get(state, 1.0)
+    return {
+        "key": "codexify:worker:chat:heartbeat",
+        "state": state,
+        "age_seconds": age_seconds,
+        "detected": True,
+        "reason": reason,
+        "error": None,
+    }
 
 
 class TestChatThreadsPost:
@@ -754,6 +837,132 @@ class TestChatCompletePost:
         assert getattr(task, "thread_id") == 1
         assert getattr(task, "turn_lock_owner") == data["task_id"]
         assert captured.get("queue_name") == "codexify:queue:chat"
+
+    def test_complete_recovers_orphaned_turn_lock_from_terminal_event(
+        self, test_client, mock_db, monkeypatch
+    ):
+        mock_db.list_messages.return_value = [
+            {"role": "user", "content": "Hello"}
+        ]
+
+        captured: dict[str, object] = {}
+        acquire_calls = {"count": 0}
+
+        def _acquire(*args, **kwargs):
+            acquire_calls["count"] += 1
+            return None if acquire_calls["count"] == 1 else True
+
+        monkeypatch.setattr("guardian.routes.chat.acquire_turn_lock", _acquire)
+        monkeypatch.setattr(
+            "guardian.routes.chat.get_turn_lock", lambda *_: _stale_lock()
+        )
+        monkeypatch.setattr(
+            "guardian.routes.chat.turn_lock_is_stale", lambda *_: True
+        )
+        monkeypatch.setattr(
+            "guardian.routes.chat._task_terminal_event",
+            lambda *_: _terminal_evidence("terminal"),
+        )
+        monkeypatch.setattr(
+            "guardian.routes.chat._chat_worker_heartbeat_evidence",
+            lambda: _heartbeat_evidence("fresh", age_seconds=1.0),
+        )
+        clear_spy = MagicMock(return_value=True)
+        monkeypatch.setattr("guardian.routes.chat.clear_turn_lock", clear_spy)
+        monkeypatch.setattr(
+            "guardian.routes.chat.enqueue",
+            lambda task, queue_name: captured.update(
+                {"task": task, "queue_name": queue_name}
+            ),
+        )
+
+        response = test_client.post("/chat/1/complete", json={})
+
+        assert response.status_code == 200
+        assert acquire_calls["count"] == 2
+        clear_spy.assert_called_once()
+        assert captured["queue_name"] == "codexify:queue:chat"
+        assert getattr(captured["task"], "turn_lock_owner") == getattr(
+            captured["task"], "task_id"
+        )
+
+    def test_complete_denies_recovery_when_worker_fresh(
+        self, test_client, mock_db, monkeypatch
+    ):
+        mock_db.list_messages.return_value = [
+            {"role": "user", "content": "Hello"}
+        ]
+
+        monkeypatch.setattr(
+            "guardian.routes.chat.acquire_turn_lock",
+            lambda *_a, **_k: None,
+        )
+        monkeypatch.setattr(
+            "guardian.routes.chat.get_turn_lock", lambda *_: _stale_lock()
+        )
+        monkeypatch.setattr(
+            "guardian.routes.chat.turn_lock_is_stale", lambda *_: True
+        )
+        monkeypatch.setattr(
+            "guardian.routes.chat._task_terminal_event",
+            lambda *_: _terminal_evidence("nonterminal"),
+        )
+        monkeypatch.setattr(
+            "guardian.routes.chat._chat_worker_heartbeat_evidence",
+            lambda: _heartbeat_evidence("fresh", age_seconds=1.0),
+        )
+        clear_spy = MagicMock(return_value=False)
+        monkeypatch.setattr("guardian.routes.chat.clear_turn_lock", clear_spy)
+        enqueue_spy = MagicMock()
+        monkeypatch.setattr("guardian.routes.chat.enqueue", enqueue_spy)
+
+        response = test_client.post("/chat/1/complete", json={})
+
+        assert response.status_code == 429
+        assert response.json()["detail"] == "turn_in_flight"
+        clear_spy.assert_not_called()
+        enqueue_spy.assert_not_called()
+        mock_db.write_audit_log.assert_not_called()
+
+    def test_complete_denies_recovery_on_unknown_terminal_state(
+        self, test_client, mock_db, monkeypatch
+    ):
+        mock_db.list_messages.return_value = [
+            {"role": "user", "content": "Hello"}
+        ]
+
+        monkeypatch.setattr(
+            "guardian.routes.chat.acquire_turn_lock",
+            lambda *_a, **_k: None,
+        )
+        monkeypatch.setattr(
+            "guardian.routes.chat.get_turn_lock", lambda *_: _stale_lock()
+        )
+        monkeypatch.setattr(
+            "guardian.routes.chat.turn_lock_is_stale", lambda *_: True
+        )
+        monkeypatch.setattr(
+            "guardian.routes.chat._task_terminal_event",
+            lambda *_: _terminal_evidence(
+                "unknown", reason="event_probe_failed"
+            ),
+        )
+        monkeypatch.setattr(
+            "guardian.routes.chat._chat_worker_heartbeat_evidence",
+            lambda: _heartbeat_evidence("stale", age_seconds=27.0),
+        )
+        clear_spy = MagicMock(return_value=False)
+        monkeypatch.setattr("guardian.routes.chat.clear_turn_lock", clear_spy)
+        enqueue_spy = MagicMock()
+        monkeypatch.setattr("guardian.routes.chat.enqueue", enqueue_spy)
+
+        response = test_client.post("/chat/1/complete", json={})
+
+        assert response.status_code == 429
+        assert response.json()["detail"] == "turn_in_flight"
+        clear_spy.assert_not_called()
+        enqueue_spy.assert_not_called()
+        mock_db.write_audit_log.assert_not_called()
 
     def test_complete_depth_contract_non_deep_request(
         self, test_client, mock_db, monkeypatch

--- a/tests/routes/test_event_graph_emission.py
+++ b/tests/routes/test_event_graph_emission.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -12,7 +13,9 @@ from guardian.core.event_graph import (
     reset_event_writer,
 )
 from guardian.db.models import Base, EventGraphEvent
+from guardian.queue import task_events
 from guardian.routes import chat
+from guardian.workers import chat_worker
 
 
 def _setup_event_graph_session():
@@ -58,3 +61,98 @@ def test_chat_post_message_emits_thread_update_event(monkeypatch):
     assert event.event_type == "thread.update"
     assert event.thread_id == 1
     assert event.payload_json.get("message_id") == 55
+
+
+def test_chat_worker_safe_publish_keeps_success_semantics(monkeypatch, caplog):
+    published: list[tuple[str, dict[str, object]]] = []
+
+    monkeypatch.setattr(task_events, "publish", lambda *_a, **_k: "1-0")
+    monkeypatch.setattr(
+        chat_worker,
+        "_safe_emit_live_event",
+        lambda event_type, payload: published.append(
+            (event_type, dict(payload))
+        ),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = chat_worker._safe_publish(
+            "task-1",
+            "task.running",
+            {"step": 1},
+        )
+
+    assert result["ok"] is True
+    assert result["visibility_scope"] == "progress"
+    assert result["terminal_visibility"] is False
+    assert result["execution_continued"] is True
+    assert result["event_id"] == "1-0"
+    assert published == [("task.running", {"step": 1, "task_id": "task-1"})]
+    assert not any(
+        record.levelno >= logging.WARNING for record in caplog.records
+    )
+
+
+def test_chat_worker_safe_publish_surfaces_progress_failure(
+    monkeypatch, caplog
+):
+    def _raise_publish(*_args, **_kwargs):
+        raise RuntimeError("redis down")
+
+    monkeypatch.setattr(task_events, "publish", _raise_publish)
+    monkeypatch.setattr(
+        chat_worker,
+        "_safe_emit_live_event",
+        lambda *_args, **_kwargs: None,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = chat_worker._safe_publish(
+            "task-2",
+            "task.progress",
+            {"token": "x"},
+        )
+
+    assert result["ok"] is False
+    assert result["visibility_scope"] == "progress"
+    assert result["terminal_visibility"] is False
+    assert result["execution_continued"] is True
+    assert result["failure_class"] == "RuntimeError"
+    assert any(
+        "task_event_visibility_degraded" in record.message
+        and "visibility_scope=progress" in record.message
+        for record in caplog.records
+    )
+
+
+def test_chat_worker_safe_publish_surfaces_terminal_failure(
+    monkeypatch, caplog
+):
+    def _raise_publish(*_args, **_kwargs):
+        raise RuntimeError("redis down")
+
+    monkeypatch.setattr(task_events, "publish", _raise_publish)
+    monkeypatch.setattr(
+        chat_worker,
+        "_safe_emit_live_event",
+        lambda *_args, **_kwargs: None,
+    )
+
+    with caplog.at_level(logging.ERROR):
+        result = chat_worker._safe_publish(
+            "task-3",
+            "task.completed",
+            {"message_id": 77},
+        )
+
+    assert result["ok"] is False
+    assert result["visibility_scope"] == "terminal"
+    assert result["terminal_visibility"] is True
+    assert result["execution_continued"] is True
+    assert result["failure_class"] == "RuntimeError"
+    assert any(
+        record.levelno >= logging.ERROR
+        and "task_event_visibility_degraded" in record.message
+        and "visibility_scope=terminal" in record.message
+        for record in caplog.records
+    )

--- a/tests/routes/test_metrics.py
+++ b/tests/routes/test_metrics.py
@@ -3,6 +3,17 @@
 import pytest
 from fastapi.testclient import TestClient
 
+from guardian.routes import health as health_routes
+
+
+@pytest.fixture(autouse=True)
+def reset_chat_queue_progress_state():
+    health_routes._CHAT_QUEUE_LAST_DEPTH = None
+    health_routes._CHAT_QUEUE_LAST_CHECK_TS = 0.0
+    yield
+    health_routes._CHAT_QUEUE_LAST_DEPTH = None
+    health_routes._CHAT_QUEUE_LAST_CHECK_TS = 0.0
+
 
 def test_metrics_endpoint_prometheus(test_client):
     """Test that /metrics endpoint returns Prometheus-compatible metrics."""
@@ -82,6 +93,7 @@ def test_health_chat_endpoint(test_client):
     assert "status" in data
     assert "redis" in data
     assert "worker" in data
+    assert "queue" in data
     assert "notes" in data
     assert "completion_service" in data
     completion = data["completion_service"]
@@ -94,6 +106,12 @@ def test_health_chat_endpoint(test_client):
     assert data["redis"] in {"ok", "unhealthy"}
     assert data["worker"]["status"] in {"fresh", "stale", "dead"}
     assert "heartbeat_age_seconds" in data["worker"]
+    assert "depth" in data["queue"]
+    assert data["queue"]["status"] in {
+        "progressing",
+        "stalled",
+        "unknown",
+    }
 
 
 def test_health_vector_endpoint(test_client):

--- a/tests/routes/test_metrics.py
+++ b/tests/routes/test_metrics.py
@@ -79,11 +79,21 @@ def test_health_chat_endpoint(test_client):
     assert res.status_code == 200
     data = res.json()
     assert "backend" in data
+    assert "status" in data
+    assert "redis" in data
+    assert "worker" in data
+    assert "notes" in data
     assert "completion_service" in data
     completion = data["completion_service"]
     assert "redis_reachable" in completion
     assert "enqueue_test_ok" in completion
     assert "worker_heartbeat_detected" in completion
+    assert "worker_heartbeat_age_seconds" in completion
+    assert "worker_heartbeat_status" in completion
+    assert data["status"] in {"healthy", "degraded", "unhealthy"}
+    assert data["redis"] in {"ok", "unhealthy"}
+    assert data["worker"]["status"] in {"fresh", "stale", "dead"}
+    assert "heartbeat_age_seconds" in data["worker"]
 
 
 def test_health_vector_endpoint(test_client):


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
