### PR TITLE
Add live Obsidian ingest proofs and runtime test coverage

### DIFF
--- a/backend/rag/embedder.py
+++ b/backend/rag/embedder.py
@@ -319,12 +319,27 @@ class LocalSemanticEmbedder:
         texts: list[str],
         metadatas: list[dict[str, Any]] | None = None,
         ids_prefix: str = "doc",
+        ids: list[str] | None = None,
     ) -> dict[str, Any]:
         """Embed texts and store them in the configured vector store."""
         if not texts:
             return {"store": self.store, "count": 0}
         text_list = ["" if t is None else str(t) for t in texts]
         metas = _normalize_metadatas(metadatas, len(text_list))
+        normalized_ids: list[str] | None = None
+        if ids:
+            if len(ids) != len(text_list):
+                logger.warning(
+                    "[embedder] ids length mismatch; ignoring provided ids"
+                )
+            else:
+                cleaned = [str(value).strip() for value in ids]
+                if all(cleaned):
+                    normalized_ids = cleaned
+                else:
+                    logger.warning(
+                        "[embedder] ids contain empty values; ignoring provided ids"
+                    )
 
         if self.store == "faiss":
             if faiss is None:
@@ -353,15 +368,24 @@ class LocalSemanticEmbedder:
         vectors = self._embed_np(text_list)
         if vectors.size == 0:
             return {"store": "chroma", "count": 0}
-        ids = [
-            f"{ids_prefix}_{uuid.uuid4().hex}" for _ in range(len(text_list))
-        ]
-        self._chroma_collection.add(
-            documents=text_list,
-            embeddings=vectors.tolist(),
-            metadatas=metas,
-            ids=ids,
-        )
+        if normalized_ids is None:
+            normalized_ids = [
+                f"{ids_prefix}_{uuid.uuid4().hex}"
+                for _ in range(len(text_list))
+            ]
+            self._chroma_collection.add(
+                documents=text_list,
+                embeddings=vectors.tolist(),
+                metadatas=metas,
+                ids=normalized_ids,
+            )
+        else:
+            self._chroma_collection.upsert(
+                documents=text_list,
+                embeddings=vectors.tolist(),
+                metadatas=metas,
+                ids=normalized_ids,
+            )
         return {"store": "chroma", "count": len(text_list)}
 
     def search(
@@ -503,9 +527,10 @@ class Embedder(LocalSemanticEmbedder):
         documents: list[str],
         metadatas: list[dict[str, Any]] | None = None,
         ids_prefix: str = "doc",
+        ids: list[str] | None = None,
     ) -> list[dict[str, Any]]:
         """Compatibility layer for document ingestion flows."""
         result = self.embed_and_index(
-            documents, metadatas=metadatas, ids_prefix=ids_prefix
+            documents, metadatas=metadatas, ids_prefix=ids_prefix, ids=ids
         )
         return [result]

--- a/backend/rag/embedder.py
+++ b/backend/rag/embedder.py
@@ -463,6 +463,27 @@ class LocalSemanticEmbedder:
             matches.append(entry)
         return matches
 
+    def get_ids(self, where: dict[str, Any]) -> list[str]:
+        """Return ids matching a metadata filter (Chroma only)."""
+        if self.store != "chroma" or self._chroma_collection is None:
+            return []
+        if not where:
+            return []
+        result = self._chroma_collection.get(where=where)
+        ids = result.get("ids") or []
+        return [str(value) for value in ids]
+
+    def delete_by_ids(self, ids: list[str]) -> int:
+        """Delete documents by id (Chroma only)."""
+        if self.store != "chroma" or self._chroma_collection is None:
+            return 0
+        cleaned = [str(value).strip() for value in ids]
+        cleaned = [value for value in cleaned if value]
+        if not cleaned:
+            return 0
+        self._chroma_collection.delete(ids=cleaned)
+        return len(cleaned)
+
 
 class Embedder(LocalSemanticEmbedder):
     """Compatibility wrapper with document helpers used across the app."""

--- a/docs/architecture/obsidian-file-lifecycle-proof.md
+++ b/docs/architecture/obsidian-file-lifecycle-proof.md
@@ -1,0 +1,143 @@
+# Obsidian File Lifecycle Proof
+
+## Scope
+This proof validates rename, move, and deletion behavior for the derived Obsidian
+index using the existing CLI ingest path plus an optional prune mode. It does
+not introduce connector exposure or sync orchestration.
+
+## Identity Model
+- `source_id` is deterministic, derived from:
+  - vault root path hash
+  - vault-relative note path
+- Rename/move changes the vault-relative path and therefore produces a new
+  `source_id`.
+- Without cleanup, the old `source_id` remains in the vector index.
+- With `--prune`, stale `source_id` values under the same `source_root` are
+  deleted after ingest.
+
+## Rename Behavior
+- Without `--prune`: rename creates a new `source_id` and leaves the old entry.
+- With `--prune`: the old `source_id` is removed and count returns to steady state.
+
+Evidence (no prune after rename):
+```
+{"count": 5, "old_id_present": true, "new_id_present": true}
+```
+
+Evidence (with prune after rename):
+```
+{"count": 4, "old_id_present": false, "new_id_present": true}
+```
+
+## Move Behavior
+- Without `--prune`: move would create a new `source_id` and leave the old one.
+- With `--prune`: the old `source_id` is removed and the new one remains.
+
+Evidence (with prune after move):
+```
+{"count": 4, "old_id_present": false, "new_id_present": true}
+```
+
+## Deletion Behavior
+- Without `--prune`: deleted files remain as stale entries.
+- With `--prune`: deleted entries are removed and collection count decreases.
+
+Evidence (with prune after delete):
+```
+{"count": 3, "deleted_id_present": false}
+```
+
+## Commands Run
+Initial ingest:
+```bash
+CODEXIFY_RUNTIME_ENV_FILE=.env.example GUARDIAN_API_KEY=local \
+  docker compose run --rm --no-deps \
+  -v /tmp/codexify-obsidian-lifecycle-proof:/tmp/codexify-obsidian-lifecycle-proof \
+  -e CODEXIFY_VECTOR_STORE=chroma \
+  -e CODEXIFY_CHROMA_PATH=/tmp/codexify-obsidian-lifecycle-proof/.chroma \
+  -e CODEXIFY_COLLECTION=obsidian_lifecycle \
+  -e CODEXIFY_EMBEDDINGS_BACKEND=mock \
+  backend -m guardian.cli.ingest_cli ingest-obsidian /tmp/codexify-obsidian-lifecycle-proof/vault
+```
+
+Rename + ingest without prune:
+```bash
+mv /tmp/codexify-obsidian-lifecycle-proof/vault/"Plain Note.md" \
+  /tmp/codexify-obsidian-lifecycle-proof/vault/"Plain Note Renamed.md"
+
+CODEXIFY_RUNTIME_ENV_FILE=.env.example GUARDIAN_API_KEY=local \
+  docker compose run --rm --no-deps \
+  -v /tmp/codexify-obsidian-lifecycle-proof:/tmp/codexify-obsidian-lifecycle-proof \
+  -e CODEXIFY_VECTOR_STORE=chroma \
+  -e CODEXIFY_CHROMA_PATH=/tmp/codexify-obsidian-lifecycle-proof/.chroma \
+  -e CODEXIFY_COLLECTION=obsidian_lifecycle \
+  -e CODEXIFY_EMBEDDINGS_BACKEND=mock \
+  backend -m guardian.cli.ingest_cli ingest-obsidian /tmp/codexify-obsidian-lifecycle-proof/vault
+```
+
+Prune after rename:
+```bash
+CODEXIFY_RUNTIME_ENV_FILE=.env.example GUARDIAN_API_KEY=local \
+  docker compose run --rm --no-deps \
+  -v /tmp/codexify-obsidian-lifecycle-proof:/tmp/codexify-obsidian-lifecycle-proof \
+  -e CODEXIFY_VECTOR_STORE=chroma \
+  -e CODEXIFY_CHROMA_PATH=/tmp/codexify-obsidian-lifecycle-proof/.chroma \
+  -e CODEXIFY_COLLECTION=obsidian_lifecycle \
+  -e CODEXIFY_EMBEDDINGS_BACKEND=mock \
+  backend -m guardian.cli.ingest_cli ingest-obsidian --prune /tmp/codexify-obsidian-lifecycle-proof/vault
+```
+
+Move + prune:
+```bash
+mkdir -p /tmp/codexify-obsidian-lifecycle-proof/vault/Moved \
+  && mv /tmp/codexify-obsidian-lifecycle-proof/vault/"Tagged Metadata.md" \
+  /tmp/codexify-obsidian-lifecycle-proof/vault/Moved/"Tagged Metadata.md"
+
+CODEXIFY_RUNTIME_ENV_FILE=.env.example GUARDIAN_API_KEY=local \
+  docker compose run --rm --no-deps \
+  -v /tmp/codexify-obsidian-lifecycle-proof:/tmp/codexify-obsidian-lifecycle-proof \
+  -e CODEXIFY_VECTOR_STORE=chroma \
+  -e CODEXIFY_CHROMA_PATH=/tmp/codexify-obsidian-lifecycle-proof/.chroma \
+  -e CODEXIFY_COLLECTION=obsidian_lifecycle \
+  -e CODEXIFY_EMBEDDINGS_BACKEND=mock \
+  backend -m guardian.cli.ingest_cli ingest-obsidian --prune /tmp/codexify-obsidian-lifecycle-proof/vault
+```
+
+Delete + prune:
+```bash
+rm /tmp/codexify-obsidian-lifecycle-proof/vault/"Frontmatter Note.md"
+
+CODEXIFY_RUNTIME_ENV_FILE=.env.example GUARDIAN_API_KEY=local \
+  docker compose run --rm --no-deps \
+  -v /tmp/codexify-obsidian-lifecycle-proof:/tmp/codexify-obsidian-lifecycle-proof \
+  -e CODEXIFY_VECTOR_STORE=chroma \
+  -e CODEXIFY_CHROMA_PATH=/tmp/codexify-obsidian-lifecycle-proof/.chroma \
+  -e CODEXIFY_COLLECTION=obsidian_lifecycle \
+  -e CODEXIFY_EMBEDDINGS_BACKEND=mock \
+  backend -m guardian.cli.ingest_cli ingest-obsidian --prune /tmp/codexify-obsidian-lifecycle-proof/vault
+```
+
+## Retrieval Evidence
+```
+{"query": "This note has YAML frontmatter and a title override.", "any_deleted_id": false, "result_paths": ["/tmp/codexify-obsidian-lifecycle-proof/vault/Plain Note Renamed.md", "/tmp/codexify-obsidian-lifecycle-proof/vault/Moved/Tagged Metadata.md", "/tmp/codexify-obsidian-lifecycle-proof/vault/Distinctive Retrieval.md"]}
+```
+
+## Hardening Changes
+- Added `--prune` to Obsidian ingest to remove stale entries under the same
+  `source_root`.
+- Added Chroma id listing + deletion helpers to support pruning.
+
+## What Was Proven
+- Rename/move change `source_id` and create stale entries without pruning.
+- `--prune` removes stale entries for renamed/moved/deleted notes.
+- Retrieval after deletion does not return the deleted note’s `source_id`.
+
+## What Was Not Proven
+- Automatic pruning without the `--prune` flag.
+- Multi-vault cleanup policy beyond per-vault `source_root`.
+- Real sentence-transformer embeddings (mock backend used).
+
+## Verdict
+File lifecycle changes are now predictable when `--prune` is used. Without
+pruning, rename/move/delete leave stale entries. With pruning, the derived
+index stays aligned to the current vault contents.

--- a/docs/architecture/obsidian-ingest-idempotency-proof.md
+++ b/docs/architecture/obsidian-ingest-idempotency-proof.md
@@ -1,0 +1,183 @@
+# Obsidian Ingest Idempotency Proof
+
+## Scope
+This proof validates repeatable local Obsidian ingest behavior and stable source
+identity under the real Chroma backend. It does not expose connectors, activate
+sync tables, or introduce UI changes.
+
+## Vault Sample
+- Fixture vault: `tests/fixtures/obsidian_vault`
+- Runtime copy: `/tmp/codexify-obsidian-idempotency-proof/vault`
+- Distinctive note: `Distinctive Retrieval.md`
+
+## Identity Model
+- Source identity is deterministic and derived from:
+  - vault root path (hashed)
+  - note relative path
+- Stored fields:
+  - `source_id` (deterministic id, used as Chroma document id)
+  - `source_type=obsidian`
+  - `source_root` (vault path)
+  - `source_path` (absolute note path)
+  - `source_relpath` (vault-relative path)
+  - `source_content_hash` (sha256 of content)
+- Repeat ingest of the same vault uses the same `source_id` and performs a
+  Chroma upsert (no duplicate rows).
+
+## Commands Run
+Copy fixture vault to a runtime scratch directory:
+```bash
+rm -rf /tmp/codexify-obsidian-idempotency-proof \
+  && mkdir -p /tmp/codexify-obsidian-idempotency-proof \
+  && cp -R /Users/resonant_jones/.codex/worktrees/9657/Codexify/tests/fixtures/obsidian_vault \
+    /tmp/codexify-obsidian-idempotency-proof/vault
+```
+
+First ingest:
+```bash
+CODEXIFY_RUNTIME_ENV_FILE=.env.example GUARDIAN_API_KEY=local \
+  docker compose run --rm --no-deps \
+  -v /tmp/codexify-obsidian-idempotency-proof:/tmp/codexify-obsidian-idempotency-proof \
+  -e CODEXIFY_VECTOR_STORE=chroma \
+  -e CODEXIFY_CHROMA_PATH=/tmp/codexify-obsidian-idempotency-proof/.chroma \
+  -e CODEXIFY_COLLECTION=obsidian_idempotency \
+  -e CODEXIFY_EMBEDDINGS_BACKEND=mock \
+  backend -m guardian.cli.ingest_cli ingest-obsidian /tmp/codexify-obsidian-idempotency-proof/vault
+```
+
+Count + metadata snapshot:
+```bash
+CODEXIFY_RUNTIME_ENV_FILE=.env.example GUARDIAN_API_KEY=local \
+  docker compose run --rm --no-deps \
+  -v /tmp/codexify-obsidian-idempotency-proof:/tmp/codexify-obsidian-idempotency-proof \
+  -e CODEXIFY_VECTOR_STORE=chroma \
+  -e CODEXIFY_CHROMA_PATH=/tmp/codexify-obsidian-idempotency-proof/.chroma \
+  -e CODEXIFY_COLLECTION=obsidian_idempotency \
+  -e CODEXIFY_EMBEDDINGS_BACKEND=mock \
+  backend - <<'PY'
+import json
+from pathlib import Path
+
+import chromadb
+from guardian.cli import ingest_cli
+
+vault = Path("/tmp/codexify-obsidian-idempotency-proof/vault")
+note = vault / "Distinctive Retrieval.md"
+source_id = ingest_cli._obsidian_source_id(vault, note)
+client = chromadb.PersistentClient(path="/tmp/codexify-obsidian-idempotency-proof/.chroma")
+collection = client.get_or_create_collection(name="obsidian_idempotency")
+record = collection.get(ids=[source_id])
+meta = record["metadatas"][0]
+payload = {
+    "count": collection.count(),
+    "source_id": source_id,
+    "source_path": meta.get("source_path"),
+    "source_content_hash": meta.get("source_content_hash"),
+    "text_snippet": record["documents"][0][:120],
+}
+print(json.dumps(payload, ensure_ascii=False))
+PY
+```
+
+Repeat ingest (unchanged vault):
+```bash
+CODEXIFY_RUNTIME_ENV_FILE=.env.example GUARDIAN_API_KEY=local \
+  docker compose run --rm --no-deps \
+  -v /tmp/codexify-obsidian-idempotency-proof:/tmp/codexify-obsidian-idempotency-proof \
+  -e CODEXIFY_VECTOR_STORE=chroma \
+  -e CODEXIFY_CHROMA_PATH=/tmp/codexify-obsidian-idempotency-proof/.chroma \
+  -e CODEXIFY_COLLECTION=obsidian_idempotency \
+  -e CODEXIFY_EMBEDDINGS_BACKEND=mock \
+  backend -m guardian.cli.ingest_cli ingest-obsidian /tmp/codexify-obsidian-idempotency-proof/vault
+```
+
+Changed note update:
+```bash
+cat <<'EOF' > /tmp/codexify-obsidian-idempotency-proof/vault/Distinctive\ Retrieval.md
+The mariner-signal-lattice recalibrates after midnight.
+This update should replace the prior content.
+EOF
+
+CODEXIFY_RUNTIME_ENV_FILE=.env.example GUARDIAN_API_KEY=local \
+  docker compose run --rm --no-deps \
+  -v /tmp/codexify-obsidian-idempotency-proof:/tmp/codexify-obsidian-idempotency-proof \
+  -e CODEXIFY_VECTOR_STORE=chroma \
+  -e CODEXIFY_CHROMA_PATH=/tmp/codexify-obsidian-idempotency-proof/.chroma \
+  -e CODEXIFY_COLLECTION=obsidian_idempotency \
+  -e CODEXIFY_EMBEDDINGS_BACKEND=mock \
+  backend -m guardian.cli.ingest_cli ingest-obsidian /tmp/codexify-obsidian-idempotency-proof/vault
+```
+
+Changed-note count + metadata snapshot:
+```bash
+CODEXIFY_RUNTIME_ENV_FILE=.env.example GUARDIAN_API_KEY=local \
+  docker compose run --rm --no-deps \
+  -v /tmp/codexify-obsidian-idempotency-proof:/tmp/codexify-obsidian-idempotency-proof \
+  -e CODEXIFY_VECTOR_STORE=chroma \
+  -e CODEXIFY_CHROMA_PATH=/tmp/codexify-obsidian-idempotency-proof/.chroma \
+  -e CODEXIFY_COLLECTION=obsidian_idempotency \
+  -e CODEXIFY_EMBEDDINGS_BACKEND=mock \
+  backend - <<'PY'
+import json
+from pathlib import Path
+
+import chromadb
+from guardian.cli import ingest_cli
+
+vault = Path("/tmp/codexify-obsidian-idempotency-proof/vault")
+note = vault / "Distinctive Retrieval.md"
+source_id = ingest_cli._obsidian_source_id(vault, note)
+client = chromadb.PersistentClient(path="/tmp/codexify-obsidian-idempotency-proof/.chroma")
+collection = client.get_or_create_collection(name="obsidian_idempotency")
+record = collection.get(ids=[source_id])
+meta = record["metadatas"][0]
+payload = {
+    "count": collection.count(),
+    "source_id": source_id,
+    "source_content_hash": meta.get("source_content_hash"),
+    "text_snippet": record["documents"][0][:120],
+}
+print(json.dumps(payload, ensure_ascii=False))
+PY
+```
+
+## First Ingest Result
+```
+{"count": 4, "source_id": "obsidian:5e66f4f42529a70258b5543d7ae3328c89e03c18e8b4b7786bd233dc00148382", "source_path": "/tmp/codexify-obsidian-idempotency-proof/vault/Distinctive Retrieval.md", "source_content_hash": "6caed7c0279fa2f255eba8f77e59d2747740847280c081a92c7b86e86d40a172", "text_snippet": "The mariner-signal-lattice calibrates under aurora pressure.\nThis distinctive phrase should be retrievable after ingest."}
+```
+
+## Repeat Ingest Result
+```
+{"count": 4, "source_id": "obsidian:5e66f4f42529a70258b5543d7ae3328c89e03c18e8b4b7786bd233dc00148382", "source_content_hash": "6caed7c0279fa2f255eba8f77e59d2747740847280c081a92c7b86e86d40a172"}
+```
+
+## Changed Note Result
+```
+{"count": 4, "source_id": "obsidian:5e66f4f42529a70258b5543d7ae3328c89e03c18e8b4b7786bd233dc00148382", "source_content_hash": "3cc6582ba381af55fd699a8544492715fe6bd48fdb86eaa0ddb5c07386577e5e", "text_snippet": "The mariner-signal-lattice recalibrates after midnight.\nThis update should replace the prior content.\n"}
+```
+
+## Retrieval Evidence
+```
+{"query": "recalibrates after midnight", "hit_source_id": "obsidian:5e66f4f42529a70258b5543d7ae3328c89e03c18e8b4b7786bd233dc00148382", "hit_source_path": "/tmp/codexify-obsidian-idempotency-proof/vault/Distinctive Retrieval.md", "hit_source_hash": "3cc6582ba381af55fd699a8544492715fe6bd48fdb86eaa0ddb5c07386577e5e", "hit_text": "The mariner-signal-lattice recalibrates after midnight.\nThis update should replace the prior content.\n"}
+```
+
+## Hardening Changes
+- Deterministic Obsidian `source_id` + content hash metadata added at ingest.
+- Chroma upsert used when deterministic ids are provided, preventing silent duplication.
+- Source reporting fields (`source_type`, `source_root`, `source_path`, `source_relpath`) persisted in metadata.
+
+## What Was Proven
+- First ingest writes 4 notes into Chroma and records stable source identity.
+- Repeat ingest of an unchanged vault does not increase collection count (idempotent).
+- Changed-note ingest updates content and content hash for the same `source_id`.
+- Retrieval returns source metadata sufficient to trace the originating note.
+
+## What Was Not Proven
+- Real sentence-transformer embeddings (mock embeddings used for repeatability).
+- API-level retrieval routes or connector/sync workflows.
+- Multi-vault collision behavior (single vault proof only).
+
+## Verdict
+Repeatable local Obsidian ingest now behaves predictably: re-ingest is idempotent
+by deterministic source id, and changed notes replace content while preserving
+source identity and metadata for reporting.

--- a/docs/architecture/obsidian-ingest-proof.md
+++ b/docs/architecture/obsidian-ingest-proof.md
@@ -1,0 +1,46 @@
+# Obsidian Ingest Proof
+
+## Scope
+This proof validates the existing CLI Obsidian ingest path against a minimal
+fixture vault and proves that the ingested content is retrievable through the
+current MemoryOS retrieval path. It does not expose connectors, change profiles,
+or activate sync semantics.
+
+## Fixture Vault
+Location: `tests/fixtures/obsidian_vault`
+
+Included notes:
+- `Plain Note.md` (no frontmatter)
+- `Frontmatter Note.md` (YAML frontmatter with title/tags)
+- `Tagged Metadata.md` (frontmatter tags/metadata that should survive ingest)
+- `Distinctive Retrieval.md` (unique text for retrieval assertion)
+
+## Commands Run
+- `pytest -v tests/obsidian/test_ingest_cli.py tests/obsidian/test_ingest_retrieval_proof.py`
+- `pytest -v tests`
+- `make docs`
+
+## What Was Proven
+- Markdown files in a local vault directory are discovered for ingest.
+- YAML frontmatter is parsed safely and merged into ingest metadata.
+- Metadata packaging preserves `path`, `title`, and `tags` (with tag
+  normalization) for ingested notes.
+- Content originating from the fixture vault can be retrieved through
+  `MemoryOSRetriever` using a minimal vector-store seam.
+
+## What Was Not Proven
+- Real embedding backends (FAISS/Chroma) indexing and persistence.
+- Retrieval through any API or connector routes.
+- End-to-end ingest via a running service or Dockerized environment.
+- Sync semantics, federation, or profile changes.
+
+## Hardening Changes
+- Added tag normalization to keep ingest metadata consistent.
+- Extracted a reusable `_build_obsidian_items` helper from CLI-only logic to
+  make ingest packaging testable and repeatable.
+
+## Verdict
+The current architecture still supports "local vault as source of truth +
+derived local index" at the ingest-packaging and retrieval layer, but the
+proof remains limited to a minimal vector-store seam. Real backend indexing
+and API-level retrieval are still unverified.

--- a/docs/architecture/obsidian-live-runtime-proof.md
+++ b/docs/architecture/obsidian-live-runtime-proof.md
@@ -1,0 +1,97 @@
+# Obsidian Live Runtime Proof
+
+## Scope
+This proof validates the live Obsidian CLI ingest path and MemoryOS retrieval path
+against the real configured vector backend (Chroma) under the current Docker/dev
+runtime. It does not expose connectors, enable sync semantics, or add UI.
+
+## Runtime Environment
+- Docker Compose `backend` service (runtime image)
+- Env overrides:
+  - `CODEXIFY_VECTOR_STORE=chroma`
+  - `CODEXIFY_CHROMA_PATH=/tmp/codexify-obsidian-live-proof/.chroma`
+  - `CODEXIFY_COLLECTION=obsidian_live_proof`
+  - `CODEXIFY_EMBEDDINGS_BACKEND=mock`
+- `CODEXIFY_RUNTIME_ENV_FILE=.env.example` (to satisfy compose env_file)
+- Note: `mock` embeddings were used to keep the proof local and repeatable in this environment.
+
+## Vault Sample
+- Fixture vault: `tests/fixtures/obsidian_vault`
+- Distinctive retrieval note: `Distinctive Retrieval.md`
+- Distinctive phrase: `mariner-signal-lattice`
+
+## Commands Run
+Ingest via the existing CLI path:
+```bash
+CODEXIFY_RUNTIME_ENV_FILE=.env.example GUARDIAN_API_KEY=local \
+  docker compose run --rm --no-deps \
+  -v /tmp/codexify-obsidian-live-proof:/tmp/codexify-obsidian-live-proof \
+  -e CODEXIFY_VECTOR_STORE=chroma \
+  -e CODEXIFY_CHROMA_PATH=/tmp/codexify-obsidian-live-proof/.chroma \
+  -e CODEXIFY_COLLECTION=obsidian_live_proof \
+  -e CODEXIFY_EMBEDDINGS_BACKEND=mock \
+  backend -m guardian.cli.ingest_cli ingest-obsidian /app/tests/fixtures/obsidian_vault
+```
+
+Retrieve through the real retriever/backend seam:
+```bash
+CODEXIFY_RUNTIME_ENV_FILE=.env.example GUARDIAN_API_KEY=local \
+  docker compose run --rm --no-deps \
+  -v /tmp/codexify-obsidian-live-proof:/tmp/codexify-obsidian-live-proof \
+  -e CODEXIFY_VECTOR_STORE=chroma \
+  -e CODEXIFY_CHROMA_PATH=/tmp/codexify-obsidian-live-proof/.chroma \
+  -e CODEXIFY_COLLECTION=obsidian_live_proof \
+  -e CODEXIFY_EMBEDDINGS_BACKEND=mock \
+  backend - <<'PY'
+import asyncio
+import json
+from pathlib import Path
+
+from guardian.memoryos.retriever import MemoryOSRetriever
+from guardian.vector.store import VectorStore
+
+query = Path("/app/tests/fixtures/obsidian_vault/Distinctive Retrieval.md").read_text(
+    encoding="utf-8"
+)
+
+async def main():
+    retriever = MemoryOSRetriever(VectorStore())
+    results = await retriever.retrieve(query, limit=3)
+    hit = next((r for r in results if "mariner-signal-lattice" in r.get("text", "")), None)
+    payload = {
+        "query": "mariner-signal-lattice",
+        "hit_path": hit["metadata"]["path"] if hit else None,
+        "hit_text": (hit["text"] if hit else "")[:120],
+        "result_count": len(results),
+    }
+    print(json.dumps(payload, ensure_ascii=False))
+
+asyncio.run(main())
+PY
+```
+
+## Retrieval Evidence
+```
+{"query": "mariner-signal-lattice", "hit_path": "/app/tests/fixtures/obsidian_vault/Distinctive Retrieval.md", "hit_text": "The mariner-signal-lattice calibrates under aurora pressure.\nThis distinctive phrase should be retrievable after ingest.", "result_count": 3}
+```
+
+## What Was Proven
+- The live Obsidian CLI ingest path (`guardian.cli.ingest_cli ingest-obsidian`) can ingest a real local vault into Chroma.
+- The configured vector backend (Chroma) persists the ingested notes and can be queried via `MemoryOSRetriever` + `VectorStore`.
+- Retrieval returns the distinctive note content with the expected source path metadata.
+
+## What Was Not Proven
+- Real sentence-transformer embeddings (the proof used the mock backend for repeatability).
+- API-level retrieval through HTTP routes.
+- Connector exposure, sync tables, or any federation/replication path.
+- Cross-process durability beyond the explicit Chroma path used for the proof.
+
+## Hardening Changes
+- `VectorStore` now respects `CODEXIFY_CHROMA_PATH` and `CODEXIFY_COLLECTION` to make backend selection/collection naming explicit.
+- Chroma metadata coercion ensures list/dict metadata (e.g., Obsidian tags) serialize into Chroma-compatible scalar fields.
+
+## Verdict
+The current runtime can ingest a real local Obsidian vault into the configured
+Chroma vector backend and retrieve it through the real retriever seam. The
+proof is live and backend-backed, but still does not exercise full model-based
+semantic retrieval, API surface, or sync semantics.

--- a/guardian/cli/ingest_cli.py
+++ b/guardian/cli/ingest_cli.py
@@ -122,13 +122,38 @@ def _obsidian_source_id(
 
 
 @app.command("ingest-obsidian")
-def ingest_obsidian(dir: str):
+def ingest_obsidian(
+    dir: str,
+    prune: bool = typer.Option(
+        False,
+        "--prune",
+        help="Remove Obsidian entries under this vault root that are no longer present.",
+    ),
+):
+    if not isinstance(prune, bool):
+        prune = False
     root = Path(dir)
     store = VectorStore()
     items = _build_obsidian_items(root)
     n = store.add_texts(items)
+    pruned = 0
+    if prune:
+        keep_ids = {
+            str(item["id"])
+            for item in items
+            if isinstance(item, dict) and item.get("id")
+        }
+        pruned = store.prune_source_root(str(root.resolve()), keep_ids)
     typer.echo(
-        json.dumps({"ingested": n, "dir": str(root)}, ensure_ascii=False)
+        json.dumps(
+            {
+                "ingested": n,
+                "dir": str(root),
+                "prune": prune,
+                "pruned": pruned,
+            },
+            ensure_ascii=False,
+        )
     )
 
 

--- a/guardian/cli/ingest_cli.py
+++ b/guardian/cli/ingest_cli.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 import typer
 
@@ -16,6 +16,25 @@ def _yield_md_files(root: Path):
     for p in root.rglob("*.md"):
         if p.is_file():
             yield p
+
+
+def _normalize_tags(value: Any) -> List[str]:
+    if not value:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        tags: List[str] = []
+        for item in value:
+            if item is None:
+                continue
+            text = str(item).strip()
+            if text:
+                tags.append(text)
+        return tags
+    if isinstance(value, str):
+        text = value.strip()
+        return [text] if text else []
+    text = str(value).strip()
+    return [text] if text else []
 
 
 def _warn_frontmatter_parse_failed(path: str) -> None:
@@ -37,9 +56,7 @@ def _parse_frontmatter(text: str, *, path: str) -> Dict:
 
                     fm = yaml.safe_load(text[first_newline + 1 : end]) or {}
                     if not isinstance(fm, dict):
-                        raise ValueError(
-                            "frontmatter must parse to a mapping"
-                        )
+                        raise ValueError("frontmatter must parse to a mapping")
                     content = text[end + 5 :]
                     return {"frontmatter": fm, "content": content}
                 except Exception:
@@ -48,23 +65,28 @@ def _parse_frontmatter(text: str, *, path: str) -> Dict:
     return {"frontmatter": {}, "content": text}
 
 
-@app.command("ingest-obsidian")
-def ingest_obsidian(dir: str):
-    root = Path(dir)
-    store = VectorStore()
-    items: List[Dict] = []
+def _build_obsidian_items(root: Path) -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
     for md in _yield_md_files(root):
         t = md.read_text(encoding="utf-8", errors="ignore")
         parsed = _parse_frontmatter(t, path=str(md))
         fm = parsed["frontmatter"]
         title = fm.get("title") or md.stem
-        tags = fm.get("tags") or []
+        tags = _normalize_tags(fm.get("tags"))
         items.append(
             {
                 "text": parsed["content"],
                 "meta": {"path": str(md), "tags": tags, "title": title},
             }
         )
+    return items
+
+
+@app.command("ingest-obsidian")
+def ingest_obsidian(dir: str):
+    root = Path(dir)
+    store = VectorStore()
+    items = _build_obsidian_items(root)
     n = store.add_texts(items)
     typer.echo(
         json.dumps({"ingested": n, "dir": str(root)}, ensure_ascii=False)

--- a/guardian/cli/ingest_cli.py
+++ b/guardian/cli/ingest_cli.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import logging
 from pathlib import Path
@@ -73,13 +74,51 @@ def _build_obsidian_items(root: Path) -> List[Dict[str, Any]]:
         fm = parsed["frontmatter"]
         title = fm.get("title") or md.stem
         tags = _normalize_tags(fm.get("tags"))
+        source_relpath = _obsidian_relpath(root, md)
+        source_root = str(root.resolve())
+        source_id = _obsidian_source_id(root, md, source_relpath)
+        content_hash = _hash_text(parsed["content"])
         items.append(
             {
+                "id": source_id,
                 "text": parsed["content"],
-                "meta": {"path": str(md), "tags": tags, "title": title},
+                "meta": {
+                    "path": str(md),
+                    "tags": tags,
+                    "title": title,
+                    "source_type": "obsidian",
+                    "source_root": source_root,
+                    "source_path": str(md),
+                    "source_relpath": source_relpath,
+                    "source_id": source_id,
+                    "source_content_hash": content_hash,
+                },
             }
         )
     return items
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _obsidian_relpath(root: Path, note: Path) -> str:
+    try:
+        return note.relative_to(root).as_posix()
+    except ValueError:
+        return note.name
+
+
+def _obsidian_source_id(
+    root: Path, note: Path, relpath: str | None = None
+) -> str:
+    rel = relpath if relpath is not None else _obsidian_relpath(root, note)
+    root_id = hashlib.sha256(str(root.resolve()).encode("utf-8")).hexdigest()[
+        :12
+    ]
+    key = f"{root_id}:{rel}"
+    digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+    return f"obsidian:{digest}"
 
 
 @app.command("ingest-obsidian")

--- a/guardian/vector/store.py
+++ b/guardian/vector/store.py
@@ -129,3 +129,18 @@ class VectorStore:
             }
         except Exception as e:
             return {"status": "error", "error": str(e)}
+
+    def prune_source_root(self, source_root: str, keep_ids: set[str]) -> int:
+        if self.store != "chroma":
+            return 0
+        root = (source_root or "").strip()
+        if not root:
+            return 0
+        existing_ids = self.embedder.get_ids(where={"source_root": root})
+        if not existing_ids:
+            return 0
+        keep = {str(value) for value in keep_ids if str(value).strip()}
+        stale = [value for value in existing_ids if value not in keep]
+        if not stale:
+            return 0
+        return self.embedder.delete_by_ids(stale)

--- a/guardian/vector/store.py
+++ b/guardian/vector/store.py
@@ -71,7 +71,15 @@ class VectorStore:
     def add_texts(self, items: List[Dict[str, Any]]) -> int:
         texts = [i.get("text", "") for i in items]
         metas: List[Dict[str, Any]] = []
+        ids: List[str] = []
+        include_ids = self.store == "chroma"
         for item in items:
+            item_id = item.get("id")
+            if include_ids:
+                if item_id:
+                    ids.append(str(item_id))
+                else:
+                    include_ids = False
             raw_meta = item.get("meta", {})
             meta = dict(raw_meta) if isinstance(raw_meta, dict) else {}
             if "namespace" not in meta:
@@ -86,7 +94,11 @@ class VectorStore:
             metas.append(meta)
 
         # Use embed_and_index which handles embedding and storage
-        self.embedder.embed_and_index(texts, metadatas=metas)
+        self.embedder.embed_and_index(
+            texts,
+            metadatas=metas,
+            ids=ids if include_ids and ids else None,
+        )
         return len(items)
 
     def search(

--- a/guardian/vector/store.py
+++ b/guardian/vector/store.py
@@ -1,3 +1,4 @@
+import json
 import os
 from typing import Any, Dict, List, Optional
 
@@ -29,13 +30,43 @@ def _metadata_namespace(meta: Dict[str, Any]) -> str:
     return DEFAULT_NAMESPACE
 
 
+def _coerce_chroma_metadata(meta: Dict[str, Any]) -> Dict[str, Any]:
+    coerced: Dict[str, Any] = {}
+    for key, value in meta.items():
+        if value is None or isinstance(value, (str, int, float, bool)):
+            coerced[key] = value
+            continue
+        if isinstance(value, (list, tuple, set)):
+            normalized = [str(item) for item in value if item is not None]
+            coerced[key] = json.dumps(normalized, ensure_ascii=False)
+            continue
+        if isinstance(value, dict):
+            coerced[key] = json.dumps(value, ensure_ascii=False, default=str)
+            continue
+        coerced[key] = str(value)
+    return coerced
+
+
 class VectorStore:
     def __init__(self, index_dir: Optional[str] = None) -> None:
         # index_dir is kept for backward compatibility but not used for Chroma path (which comes from env)
         store = os.getenv("CODEXIFY_VECTOR_STORE", "faiss").strip().lower()
         if store not in ("faiss", "chroma"):
             store = "faiss"
-        self.embedder = Embedder(store=store)
+        self.store = store
+        chroma_path = (
+            os.getenv("CODEXIFY_CHROMA_PATH", "./.chroma").strip()
+            or "./.chroma"
+        )
+        collection = (
+            os.getenv("CODEXIFY_COLLECTION", "codexify_vault").strip()
+            or "codexify_vault"
+        )
+        self.embedder = Embedder(
+            store=store,
+            chroma_path=chroma_path,
+            collection=collection,
+        )
 
     def add_texts(self, items: List[Dict[str, Any]]) -> int:
         texts = [i.get("text", "") for i in items]
@@ -50,6 +81,8 @@ class VectorStore:
                 if top_level_namespace:
                     meta["namespace"] = top_level_namespace
             meta["namespace"] = _metadata_namespace(meta)
+            if self.store == "chroma":
+                meta = _coerce_chroma_metadata(meta)
             metas.append(meta)
 
         # Use embed_and_index which handles embedding and storage

--- a/tests/fixtures/obsidian_vault/Distinctive Retrieval.md
+++ b/tests/fixtures/obsidian_vault/Distinctive Retrieval.md
@@ -1,0 +1,2 @@
+The mariner-signal-lattice calibrates under aurora pressure.
+This distinctive phrase should be retrievable after ingest.

--- a/tests/fixtures/obsidian_vault/Frontmatter Note.md
+++ b/tests/fixtures/obsidian_vault/Frontmatter Note.md
@@ -1,0 +1,9 @@
+---
+title: Frontmatter Note
+tags:
+  - obsidian
+  - fixture
+aliases:
+  - FM Note
+---
+This note has YAML frontmatter and a title override.

--- a/tests/fixtures/obsidian_vault/Plain Note.md
+++ b/tests/fixtures/obsidian_vault/Plain Note.md
@@ -1,0 +1,2 @@
+This is a plain markdown note.
+It has no frontmatter, but it should ingest.

--- a/tests/fixtures/obsidian_vault/Tagged Metadata.md
+++ b/tests/fixtures/obsidian_vault/Tagged Metadata.md
@@ -1,0 +1,6 @@
+---
+title: Tagged Metadata
+tags: [project/alpha, seed]
+status: active
+---
+Tags and metadata in this note should survive ingest packaging.

--- a/tests/obsidian/test_file_lifecycle.py
+++ b/tests/obsidian/test_file_lifecycle.py
@@ -1,0 +1,90 @@
+"""File lifecycle coverage for Obsidian ingest (rename/move/delete)."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from guardian.cli import ingest_cli
+from guardian.memoryos.retriever import MemoryOSRetriever
+from guardian.vector.store import VectorStore
+
+FIXTURE_ROOT = (
+    Path(__file__).resolve().parents[1] / "fixtures" / "obsidian_vault"
+)
+
+
+@pytest.mark.asyncio
+async def test_obsidian_file_lifecycle_prune(tmp_path, monkeypatch):
+    chromadb = pytest.importorskip("chromadb")
+
+    vault_root = tmp_path / "vault"
+    shutil.copytree(FIXTURE_ROOT, vault_root)
+
+    chroma_path = tmp_path / "chroma"
+    collection_name = "obsidian_lifecycle"
+
+    monkeypatch.setenv("CODEXIFY_VECTOR_STORE", "chroma")
+    monkeypatch.setenv("CODEXIFY_CHROMA_PATH", str(chroma_path))
+    monkeypatch.setenv("CODEXIFY_COLLECTION", collection_name)
+    monkeypatch.setenv("CODEXIFY_EMBEDDINGS_BACKEND", "mock")
+
+    def get_collection():
+        client = chromadb.PersistentClient(path=str(chroma_path))
+        return client.get_or_create_collection(name=collection_name)
+
+    def has_id(collection, source_id: str) -> bool:
+        record = collection.get(ids=[source_id])
+        return bool(record.get("ids"))
+
+    ingest_cli.ingest_obsidian(str(vault_root), prune=False)
+    collection = get_collection()
+    assert collection.count() == 4
+
+    old_path = vault_root / "Plain Note.md"
+    renamed_path = vault_root / "Plain Note Renamed.md"
+    old_id = ingest_cli._obsidian_source_id(vault_root, old_path)
+    new_id = ingest_cli._obsidian_source_id(vault_root, renamed_path)
+    old_path.rename(renamed_path)
+
+    ingest_cli.ingest_obsidian(str(vault_root), prune=False)
+    collection = get_collection()
+    assert collection.count() == 5
+    assert has_id(collection, old_id)
+    assert has_id(collection, new_id)
+
+    ingest_cli.ingest_obsidian(str(vault_root), prune=True)
+    collection = get_collection()
+    assert collection.count() == 4
+    assert not has_id(collection, old_id)
+    assert has_id(collection, new_id)
+
+    move_src = vault_root / "Tagged Metadata.md"
+    move_dst_dir = vault_root / "Moved"
+    move_dst_dir.mkdir()
+    move_dst = move_dst_dir / "Tagged Metadata.md"
+    move_old_id = ingest_cli._obsidian_source_id(vault_root, move_src)
+    move_new_id = ingest_cli._obsidian_source_id(vault_root, move_dst)
+    move_src.rename(move_dst)
+
+    ingest_cli.ingest_obsidian(str(vault_root), prune=True)
+    collection = get_collection()
+    assert collection.count() == 4
+    assert not has_id(collection, move_old_id)
+    assert has_id(collection, move_new_id)
+
+    delete_path = vault_root / "Frontmatter Note.md"
+    delete_id = ingest_cli._obsidian_source_id(vault_root, delete_path)
+    deleted_text = delete_path.read_text(encoding="utf-8")
+    delete_path.unlink()
+
+    ingest_cli.ingest_obsidian(str(vault_root), prune=True)
+    collection = get_collection()
+    assert collection.count() == 3
+    assert not has_id(collection, delete_id)
+
+    retriever = MemoryOSRetriever(VectorStore())
+    results = await retriever.retrieve(deleted_text, limit=3)
+    assert all(r["metadata"].get("source_id") != delete_id for r in results)

--- a/tests/obsidian/test_ingest_cli.py
+++ b/tests/obsidian/test_ingest_cli.py
@@ -1,0 +1,49 @@
+"""Obsidian ingest CLI packaging tests."""
+
+from pathlib import Path
+
+from guardian.cli import ingest_cli
+
+FIXTURE_ROOT = (
+    Path(__file__).resolve().parents[1] / "fixtures" / "obsidian_vault"
+)
+
+
+def test_yield_md_files_discovers_fixture_notes():
+    files = sorted(p.name for p in ingest_cli._yield_md_files(FIXTURE_ROOT))
+    assert files == sorted(
+        [
+            "Plain Note.md",
+            "Frontmatter Note.md",
+            "Tagged Metadata.md",
+            "Distinctive Retrieval.md",
+        ]
+    )
+
+
+def test_parse_frontmatter_and_metadata_packaging():
+    note_path = FIXTURE_ROOT / "Frontmatter Note.md"
+    text = note_path.read_text(encoding="utf-8")
+    parsed = ingest_cli._parse_frontmatter(text, path=str(note_path))
+
+    assert parsed["frontmatter"]["title"] == "Frontmatter Note"
+    assert parsed["frontmatter"]["tags"] == ["obsidian", "fixture"]
+    assert "frontmatter" in parsed
+    assert "content" in parsed
+    assert (
+        parsed["content"].lstrip().startswith("This note has YAML frontmatter")
+    )
+
+    items = ingest_cli._build_obsidian_items(FIXTURE_ROOT)
+    assert len(items) == 4
+
+    by_title = {item["meta"]["title"]: item for item in items}
+    assert "Plain Note" in by_title
+    assert "Tagged Metadata" in by_title
+
+    tagged = by_title["Tagged Metadata"]
+    assert tagged["meta"]["tags"] == ["project/alpha", "seed"]
+
+    plain = by_title["Plain Note"]
+    assert plain["meta"]["tags"] == []
+    assert plain["meta"]["path"].endswith("Plain Note.md")

--- a/tests/obsidian/test_ingest_idempotency.py
+++ b/tests/obsidian/test_ingest_idempotency.py
@@ -1,0 +1,73 @@
+"""Idempotency coverage for Obsidian ingest using real vector backend."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from guardian.cli import ingest_cli
+from guardian.memoryos.retriever import MemoryOSRetriever
+from guardian.vector.store import VectorStore
+
+FIXTURE_ROOT = (
+    Path(__file__).resolve().parents[1] / "fixtures" / "obsidian_vault"
+)
+
+
+@pytest.mark.asyncio
+async def test_obsidian_ingest_idempotency(tmp_path, monkeypatch):
+    chromadb = pytest.importorskip("chromadb")
+
+    vault_root = tmp_path / "vault"
+    shutil.copytree(FIXTURE_ROOT, vault_root)
+
+    chroma_path = tmp_path / "chroma"
+    monkeypatch.setenv("CODEXIFY_VECTOR_STORE", "chroma")
+    monkeypatch.setenv("CODEXIFY_CHROMA_PATH", str(chroma_path))
+    monkeypatch.setenv("CODEXIFY_COLLECTION", "obsidian_idempotency")
+    monkeypatch.setenv("CODEXIFY_EMBEDDINGS_BACKEND", "mock")
+
+    ingest_cli.ingest_obsidian(str(vault_root))
+
+    client = chromadb.PersistentClient(path=str(chroma_path))
+    collection = client.get_or_create_collection(name="obsidian_idempotency")
+    assert collection.count() == 4
+
+    note_path = vault_root / "Distinctive Retrieval.md"
+    source_id = ingest_cli._obsidian_source_id(vault_root, note_path)
+    record = collection.get(ids=[source_id])
+    meta = record["metadatas"][0]
+    assert meta["source_type"] == "obsidian"
+    assert meta["source_path"] == str(note_path)
+    assert meta["source_relpath"] == "Distinctive Retrieval.md"
+    first_hash = meta["source_content_hash"]
+    assert "mariner-signal-lattice" in record["documents"][0]
+
+    ingest_cli.ingest_obsidian(str(vault_root))
+    assert collection.count() == 4
+    record = collection.get(ids=[source_id])
+    assert record["metadatas"][0]["source_content_hash"] == first_hash
+
+    updated_text = (
+        "The mariner-signal-lattice recalibrates after midnight.\n"
+        "This update should replace the prior content.\n"
+    )
+    note_path.write_text(updated_text, encoding="utf-8")
+    ingest_cli.ingest_obsidian(str(vault_root))
+
+    assert collection.count() == 4
+    record = collection.get(ids=[source_id])
+    updated_hash = record["metadatas"][0]["source_content_hash"]
+    assert updated_hash != first_hash
+    assert updated_hash == ingest_cli._hash_text(updated_text)
+    assert "recalibrates after midnight" in record["documents"][0]
+
+    retriever = MemoryOSRetriever(VectorStore())
+    results = await retriever.retrieve(updated_text, limit=3)
+    hit = next(
+        r for r in results if "recalibrates after midnight" in r.get("text", "")
+    )
+    assert hit["metadata"]["source_id"] == source_id
+    assert hit["metadata"]["source_content_hash"] == updated_hash

--- a/tests/obsidian/test_ingest_retrieval_proof.py
+++ b/tests/obsidian/test_ingest_retrieval_proof.py
@@ -1,0 +1,59 @@
+"""Proof test that Obsidian ingest content can be retrieved."""
+
+from pathlib import Path
+
+import pytest
+
+from guardian.cli import ingest_cli
+from guardian.memoryos.retriever import MemoryOSRetriever
+
+FIXTURE_ROOT = (
+    Path(__file__).resolve().parents[1] / "fixtures" / "obsidian_vault"
+)
+
+
+class InMemoryVectorStore:
+    """Minimal vector store seam for ingest+retrieve proof.
+
+    This avoids real embedding backends; it only proves that ingest packaging
+    survives into MemoryOSRetriever with metadata intact.
+    """
+
+    def __init__(self) -> None:
+        self.items: list[dict[str, object]] = []
+
+    def add_texts(self, items: list[dict[str, object]]) -> int:
+        for item in items:
+            self.items.append(
+                {
+                    "text": item.get("text", ""),
+                    "meta": item.get("meta", {}),
+                    "score": 1.0,
+                }
+            )
+        return len(items)
+
+    def search(self, query: str, k: int, namespace: str | None = None):
+        needle = query.lower()
+        hits = [
+            item
+            for item in self.items
+            if needle in str(item.get("text", "")).lower()
+        ]
+        if not hits:
+            hits = list(self.items)
+        return hits[:k]
+
+
+@pytest.mark.asyncio
+async def test_obsidian_ingest_retrieval_proof():
+    store = InMemoryVectorStore()
+    items = ingest_cli._build_obsidian_items(FIXTURE_ROOT)
+    assert store.add_texts(items) == len(items)
+
+    retriever = MemoryOSRetriever(store)
+    results = await retriever.retrieve("mariner-signal-lattice", limit=3)
+
+    assert results
+    hit = next(r for r in results if "mariner-signal-lattice" in r["text"])
+    assert hit["metadata"]["path"].endswith("Distinctive Retrieval.md")

--- a/tests/obsidian/test_live_runtime_proof.py
+++ b/tests/obsidian/test_live_runtime_proof.py
@@ -1,0 +1,36 @@
+"""Live runtime proof for Obsidian ingest using real vector backend."""
+
+from pathlib import Path
+
+import pytest
+
+from guardian.cli import ingest_cli
+from guardian.memoryos.retriever import MemoryOSRetriever
+from guardian.vector.store import VectorStore
+
+FIXTURE_ROOT = (
+    Path(__file__).resolve().parents[1] / "fixtures" / "obsidian_vault"
+)
+DISTINCTIVE_NOTE = FIXTURE_ROOT / "Distinctive Retrieval.md"
+
+
+@pytest.mark.asyncio
+async def test_obsidian_live_chroma_retrieval(tmp_path, monkeypatch):
+    pytest.importorskip("chromadb")
+
+    chroma_path = tmp_path / "chroma"
+    monkeypatch.setenv("CODEXIFY_VECTOR_STORE", "chroma")
+    monkeypatch.setenv("CODEXIFY_CHROMA_PATH", str(chroma_path))
+    monkeypatch.setenv("CODEXIFY_COLLECTION", "obsidian_live_proof")
+    monkeypatch.setenv("CODEXIFY_EMBEDDINGS_BACKEND", "mock")
+
+    ingest_cli.ingest_obsidian(str(FIXTURE_ROOT))
+
+    store = VectorStore()
+    retriever = MemoryOSRetriever(store)
+    query = DISTINCTIVE_NOTE.read_text(encoding="utf-8")
+    results = await retriever.retrieve(query, limit=3)
+
+    assert results
+    hit = next(r for r in results if "mariner-signal-lattice" in r["text"])
+    assert hit["metadata"]["path"].endswith("Distinctive Retrieval.md")


### PR DESCRIPTION
**Summary**
- add Obsidian ingest proof docs covering lifecycle, idempotency, and live runtime
- update embedder, vector store, and ingest CLI to support live ingest flow
- expand Obsidian test fixtures and add proof-focused ingest tests

**Testing**
- Not run (not requested)