### PR TITLE
Add embedding lifecycle protocol tokens

### DIFF
--- a/docs/architecture/runtime-protocol-token-contract.md
+++ b/docs/architecture/runtime-protocol-token-contract.md
@@ -27,6 +27,7 @@ inline literals.
   `task.cancelled`, `task.event`.
 - Error codes: `QUEUE_ENQUEUE_FAILED`, `CHAT_COMPLETE_ENQUEUE_FAILED`,
   `TASK_EVENT_PUBLISH_FAILED`, `CHAT_COMPLETE_TASK_CREATED_EVENT_FAILED`.
+- Embedding lifecycle statuses: `pending`, `processing`, `ready`, `failed`.
 
 ## Change process
 - Add the new token to `guardian/protocol_tokens.py`.

--- a/guardian/db/models.py
+++ b/guardian/db/models.py
@@ -29,11 +29,21 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
+from guardian.protocol_tokens import EmbeddingLifecycleStatus
+
 
 class Base(DeclarativeBase):
     """Base class for all ORM models."""
 
     pass
+
+
+EMBEDDING_LIFECYCLE_VALUES_SQL = "','".join(
+    status.value for status in EmbeddingLifecycleStatus
+)
+UPLOADED_DOCUMENT_EMBEDDING_STATUS_CHECK = (
+    f"embedding_status IN ('{EMBEDDING_LIFECYCLE_VALUES_SQL}')"
+)
 
 
 # =========================
@@ -1171,7 +1181,9 @@ class UploadedDocument(Base):
         Text
     )  # Extracted text for FTS
     embedding_status: Mapped[str] = mapped_column(
-        String(32), nullable=False, server_default="pending"
+        String(32),
+        nullable=False,
+        server_default=EmbeddingLifecycleStatus.PENDING.value,
     )
     embedding_error: Mapped[str | None] = mapped_column(Text)
     embedding_started_at: Mapped[datetime | None] = mapped_column(
@@ -1199,7 +1211,7 @@ class UploadedDocument(Base):
 
     __table_args__ = (
         CheckConstraint(
-            "embedding_status IN ('pending','processing','ready','failed')",
+            UPLOADED_DOCUMENT_EMBEDDING_STATUS_CHECK,
             name="uploaded_documents_embedding_status_check",
         ),
     )

--- a/guardian/protocol_tokens.py
+++ b/guardian/protocol_tokens.py
@@ -28,6 +28,13 @@ class ErrorCode(str, Enum):
     )
 
 
+class EmbeddingLifecycleStatus(str, Enum):
+    PENDING = "pending"
+    PROCESSING = "processing"
+    READY = "ready"
+    FAILED = "failed"
+
+
 ACCEPTANCE_STATUSES: frozenset[str] = frozenset(
     {status.value for status in AcceptanceStatus}
 )
@@ -37,12 +44,17 @@ TASK_EVENT_TYPES: frozenset[str] = frozenset(
 ERROR_CODES: frozenset[str] = frozenset(
     {error_code.value for error_code in ErrorCode}
 )
+EMBEDDING_LIFECYCLE_STATUSES: frozenset[str] = frozenset(
+    {status.value for status in EmbeddingLifecycleStatus}
+)
 
 __all__ = [
     "AcceptanceStatus",
     "TaskEventType",
     "ErrorCode",
+    "EmbeddingLifecycleStatus",
     "ACCEPTANCE_STATUSES",
     "TASK_EVENT_TYPES",
     "ERROR_CODES",
+    "EMBEDDING_LIFECYCLE_STATUSES",
 ]

--- a/tests/contracts/test_protocol_tokens.py
+++ b/tests/contracts/test_protocol_tokens.py
@@ -1,8 +1,10 @@
 from guardian.protocol_tokens import (
     ACCEPTANCE_STATUSES,
+    EMBEDDING_LIFECYCLE_STATUSES,
     ERROR_CODES,
     TASK_EVENT_TYPES,
     AcceptanceStatus,
+    EmbeddingLifecycleStatus,
     ErrorCode,
     TaskEventType,
 )
@@ -37,4 +39,17 @@ def test_error_code_tokens() -> None:
         "CHAT_COMPLETE_ENQUEUE_FAILED",
         "TASK_EVENT_PUBLISH_FAILED",
         "CHAT_COMPLETE_TASK_CREATED_EVENT_FAILED",
+    }
+
+
+def test_embedding_lifecycle_tokens() -> None:
+    assert EmbeddingLifecycleStatus.PENDING.value == "pending"
+    assert EmbeddingLifecycleStatus.PROCESSING.value == "processing"
+    assert EmbeddingLifecycleStatus.READY.value == "ready"
+    assert EmbeddingLifecycleStatus.FAILED.value == "failed"
+    assert EMBEDDING_LIFECYCLE_STATUSES == {
+        "pending",
+        "processing",
+        "ready",
+        "failed",
     }


### PR DESCRIPTION
**Summary**
- Add canonical embedding lifecycle token domain to runtime protocol registry
- Wire uploaded document embedding status defaults/constraints to canonical tokens
- Extend token contract tests and doc coverage

**Testing**
- `pytest -v`