### PR TITLE
Add live-events runtime tokens

### DIFF
--- a/docs/architecture/runtime-protocol-token-contract.md
+++ b/docs/architecture/runtime-protocol-token-contract.md
@@ -27,6 +27,8 @@ inline literals.
   `task.cancelled`, `task.event`.
 - Error codes: `QUEUE_ENQUEUE_FAILED`, `CHAT_COMPLETE_ENQUEUE_FAILED`,
   `TASK_EVENT_PUBLISH_FAILED`, `CHAT_COMPLETE_TASK_CREATED_EVENT_FAILED`.
+- Frontend live-events connection states are governed by
+  `frontend/src/contracts/runtimeTokens.ts`.
 
 ## Change process
 - Add the new token to `guardian/protocol_tokens.py`.

--- a/frontend/src/components/persona/layout/AppShell.runtimeHealth.test.tsx
+++ b/frontend/src/components/persona/layout/AppShell.runtimeHealth.test.tsx
@@ -2,6 +2,10 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
 import AppShell from "@/components/persona/layout/AppShell";
+import {
+  LIVE_EVENT_CONNECTION_STATES,
+  LiveEventConnectionState,
+} from "@/contracts/runtimeTokens";
 
 type RuntimeHealthMock = {
   status: "healthy" | "degraded";
@@ -10,7 +14,7 @@ type RuntimeHealthMock = {
   backendReachable: boolean | null;
   chatHealthy: boolean | null;
   llmHealthy: boolean | null;
-  liveEventsStatus: "connecting" | "connected" | "reconnecting" | "disconnected";
+  liveEventsStatus: LiveEventConnectionState;
   lastCheckedAt: number | null;
   stale: boolean;
 };
@@ -22,7 +26,7 @@ const runtimeHealthState: RuntimeHealthMock = {
   backendReachable: true,
   chatHealthy: true,
   llmHealthy: true,
-  liveEventsStatus: "connected",
+  liveEventsStatus: LIVE_EVENT_CONNECTION_STATES.CONNECTED,
   lastCheckedAt: Date.parse("2026-03-20T12:00:00Z"),
   stale: false,
 };
@@ -36,7 +40,7 @@ vi.mock("@/hooks/useLiveEvents", () => ({
     lastEvent: null,
     subscribe: () => () => {},
     connected: true,
-    connectionStatus: "connected",
+    connectionStatus: LIVE_EVENT_CONNECTION_STATES.CONNECTED,
     statusUpdatedAt: Date.now(),
   }),
 }));

--- a/frontend/src/contracts/runtimeTokens.ts
+++ b/frontend/src/contracts/runtimeTokens.ts
@@ -1,0 +1,9 @@
+export const LIVE_EVENT_CONNECTION_STATES = {
+  CONNECTING: "connecting",
+  CONNECTED: "connected",
+  RECONNECTING: "reconnecting",
+  DISCONNECTED: "disconnected",
+} as const;
+
+export type LiveEventConnectionState =
+  (typeof LIVE_EVENT_CONNECTION_STATES)[keyof typeof LIVE_EVENT_CONNECTION_STATES];

--- a/frontend/src/hooks/useLiveEvents.ts
+++ b/frontend/src/hooks/useLiveEvents.ts
@@ -15,6 +15,10 @@ import {
   subscribeLiveEventsHub,
   subscribeLiveEventsHubStatus,
 } from "@/lib/liveEventsHub";
+import {
+  LIVE_EVENT_CONNECTION_STATES,
+  LiveEventConnectionState,
+} from "@/contracts/runtimeTokens";
 
 const LAST_EVENT_DEBOUNCE_MS = 50;
 const CONNECTED_DEBOUNCE_MS = 200;
@@ -25,11 +29,7 @@ export interface LiveEvent {
   data: unknown;
 }
 
-export type ConnectionStatus =
-  | "connecting"
-  | "connected"
-  | "reconnecting"
-  | "disconnected";
+export type ConnectionStatus = LiveEventConnectionState;
 
 export interface UseLiveEventsResult {
   connected: boolean;
@@ -43,8 +43,9 @@ export function useLiveEvents(options: { passive?: boolean } = {}): UseLiveEvent
   const { passive = false } = options;
   const auth = useAuthState();
   const [connected, setConnected] = useState(false);
-  const [connectionStatus, setConnectionStatus] =
-    useState<ConnectionStatus>("disconnected");
+  const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>(
+    LIVE_EVENT_CONNECTION_STATES.DISCONNECTED
+  );
   const [statusUpdatedAt, setStatusUpdatedAt] = useState<number>(() => Date.now());
   const [lastEvent, setLastEvent] = useState<LiveEvent | null>(null);
   const listenersRef = useRef<Map<string, Set<(event: LiveEvent) => void>>>(
@@ -188,7 +189,7 @@ export function useLiveEvents(options: { passive?: boolean } = {}): UseLiveEvent
       pendingConnectedRef.current = null;
       connectedRef.current = false;
       setConnected(false);
-      setConnectionStatus("disconnected");
+      setConnectionStatus(LIVE_EVENT_CONNECTION_STATES.DISCONNECTED);
       setStatusUpdatedAt(Date.now());
       return;
     }
@@ -213,7 +214,8 @@ export function useLiveEvents(options: { passive?: boolean } = {}): UseLiveEvent
         return status.connectionStatus;
       });
       updateConnected(
-        status.connectionStatus === "connected" && status.readyState === 1
+        status.connectionStatus === LIVE_EVENT_CONNECTION_STATES.CONNECTED &&
+          status.readyState === 1
       );
     });
 

--- a/frontend/src/hooks/useRuntimeHealth.test.ts
+++ b/frontend/src/hooks/useRuntimeHealth.test.ts
@@ -1,17 +1,21 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useRuntimeHealth } from "@/hooks/useRuntimeHealth";
+import {
+  LIVE_EVENT_CONNECTION_STATES,
+  LiveEventConnectionState,
+} from "@/contracts/runtimeTokens";
 
 type LiveEventsStatus = {
   connected: boolean;
-  connectionStatus: "connecting" | "connected" | "reconnecting" | "disconnected";
+  connectionStatus: LiveEventConnectionState;
   statusUpdatedAt: number | null;
 };
 
 const apiGet = vi.fn();
 let liveEventsStatus: LiveEventsStatus = {
   connected: true,
-  connectionStatus: "connected",
+  connectionStatus: LIVE_EVENT_CONNECTION_STATES.CONNECTED,
   statusUpdatedAt: Date.now(),
 };
 
@@ -90,7 +94,7 @@ describe("useRuntimeHealth", () => {
     apiGet.mockReset();
     liveEventsStatus = {
       connected: true,
-      connectionStatus: "connected",
+      connectionStatus: LIVE_EVENT_CONNECTION_STATES.CONNECTED,
       statusUpdatedAt: Date.now(),
     };
   });
@@ -190,7 +194,7 @@ describe("useRuntimeHealth", () => {
     mockHealthResponses();
     liveEventsStatus = {
       connected: false,
-      connectionStatus: "disconnected",
+      connectionStatus: LIVE_EVENT_CONNECTION_STATES.DISCONNECTED,
       statusUpdatedAt: Date.now() - 46_000,
     };
     const { result } = renderHook(() => useRuntimeHealth());
@@ -201,5 +205,12 @@ describe("useRuntimeHealth", () => {
       expect(result.current.failureKind).toBe("live_events_disconnected");
       expect(result.current.status).toBe("degraded");
     });
+  });
+
+  it("exposes canonical live event connection tokens", () => {
+    expect(LIVE_EVENT_CONNECTION_STATES.CONNECTING).toBe("connecting");
+    expect(LIVE_EVENT_CONNECTION_STATES.CONNECTED).toBe("connected");
+    expect(LIVE_EVENT_CONNECTION_STATES.RECONNECTING).toBe("reconnecting");
+    expect(LIVE_EVENT_CONNECTION_STATES.DISCONNECTED).toBe("disconnected");
   });
 });

--- a/frontend/src/hooks/useRuntimeHealth.ts
+++ b/frontend/src/hooks/useRuntimeHealth.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import api from "@/lib/api";
-import { ConnectionStatus, useLiveEvents } from "@/hooks/useLiveEvents";
+import { useLiveEvents } from "@/hooks/useLiveEvents";
+import {
+  LIVE_EVENT_CONNECTION_STATES,
+  LiveEventConnectionState,
+} from "@/contracts/runtimeTokens";
 
 const POLL_INTERVAL_MS = 15000;
 const STALE_THRESHOLD_MS = 45000;
@@ -19,7 +23,7 @@ export type RuntimeHealthStatus = {
   backendReachable: boolean | null;
   chatHealthy: boolean | null;
   llmHealthy: boolean | null;
-  liveEventsStatus: ConnectionStatus;
+  liveEventsStatus: LiveEventConnectionState;
   lastSuccessAt: number | null;
   lastCheckedAt: number | null;
   stale: boolean;
@@ -88,7 +92,7 @@ function parseHealthResult(
 export function useRuntimeHealth(): RuntimeHealthStatus {
   const liveEvents = useLiveEvents({ passive: true });
   const connectionStatus =
-    liveEvents.connectionStatus ?? "disconnected";
+    liveEvents.connectionStatus ?? LIVE_EVENT_CONNECTION_STATES.DISCONNECTED;
   const statusUpdatedAt = liveEvents.statusUpdatedAt ?? null;
   const [snapshot, setSnapshot] = useState<HealthSnapshot>(INITIAL_SNAPSHOT);
   const inFlightRef = useRef(false);
@@ -151,7 +155,7 @@ export function useRuntimeHealth(): RuntimeHealthStatus {
         ? now - firstCheckAt > STALE_THRESHOLD_MS
         : false;
   const liveEventsDisconnected =
-    connectionStatus === "disconnected" &&
+    connectionStatus === LIVE_EVENT_CONNECTION_STATES.DISCONNECTED &&
     typeof statusUpdatedAt === "number" &&
     now - statusUpdatedAt > STALE_THRESHOLD_MS;
 


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
