### PR TITLE
Add runtime health tokens

### DIFF
--- a/docs/architecture/runtime-protocol-token-contract.md
+++ b/docs/architecture/runtime-protocol-token-contract.md
@@ -29,6 +29,8 @@ inline literals.
   `TASK_EVENT_PUBLISH_FAILED`, `CHAT_COMPLETE_TASK_CREATED_EVENT_FAILED`.
 - Frontend live-events connection states are governed by
   `frontend/src/contracts/runtimeTokens.ts`.
+- Frontend runtime-health statuses and failure kinds are governed by
+  `frontend/src/contracts/runtimeTokens.ts`.
 
 ## Change process
 - Add the new token to `guardian/protocol_tokens.py`.

--- a/frontend/src/components/persona/layout/AppShell.runtimeHealth.test.tsx
+++ b/frontend/src/components/persona/layout/AppShell.runtimeHealth.test.tsx
@@ -5,11 +5,15 @@ import AppShell from "@/components/persona/layout/AppShell";
 import {
   LIVE_EVENT_CONNECTION_STATES,
   LiveEventConnectionState,
+  RUNTIME_HEALTH_FAILURE_KINDS,
+  RUNTIME_HEALTH_STATUSES,
+  RuntimeHealthFailureKindToken,
+  RuntimeHealthStatusToken,
 } from "@/contracts/runtimeTokens";
 
 type RuntimeHealthMock = {
-  status: "healthy" | "degraded";
-  failureKind: string | null;
+  status: RuntimeHealthStatusToken;
+  failureKind: RuntimeHealthFailureKindToken | "unknown" | null;
   lastSuccessAt: number | null;
   backendReachable: boolean | null;
   chatHealthy: boolean | null;
@@ -20,7 +24,7 @@ type RuntimeHealthMock = {
 };
 
 const runtimeHealthState: RuntimeHealthMock = {
-  status: "healthy",
+  status: RUNTIME_HEALTH_STATUSES.HEALTHY,
   failureKind: null,
   lastSuccessAt: Date.parse("2026-03-20T12:00:00Z"),
   backendReachable: true,
@@ -172,7 +176,7 @@ vi.mock("@/theme", () => ({
 
 describe("AppShell runtime health banner", () => {
   beforeEach(() => {
-    runtimeHealthState.status = "healthy";
+    runtimeHealthState.status = RUNTIME_HEALTH_STATUSES.HEALTHY;
     runtimeHealthState.failureKind = null;
     runtimeHealthState.lastSuccessAt = Date.parse("2026-03-20T12:00:00Z");
     if (!window.matchMedia) {
@@ -195,8 +199,9 @@ describe("AppShell runtime health banner", () => {
   });
 
   it("renders banner when runtime is degraded with failure kind and last healthy", () => {
-    runtimeHealthState.status = "degraded";
-    runtimeHealthState.failureKind = "backend_unreachable";
+    runtimeHealthState.status = RUNTIME_HEALTH_STATUSES.DEGRADED;
+    runtimeHealthState.failureKind =
+      RUNTIME_HEALTH_FAILURE_KINDS.BACKEND_UNREACHABLE;
     runtimeHealthState.lastSuccessAt = Date.parse("2026-03-20T11:55:00Z");
 
     render(<AppShell />);
@@ -209,8 +214,9 @@ describe("AppShell runtime health banner", () => {
   });
 
   it("does not render banner for missing health endpoint failure kind", () => {
-    runtimeHealthState.status = "degraded";
-    runtimeHealthState.failureKind = "health_endpoint_missing";
+    runtimeHealthState.status = RUNTIME_HEALTH_STATUSES.DEGRADED;
+    runtimeHealthState.failureKind =
+      RUNTIME_HEALTH_FAILURE_KINDS.HEALTH_ENDPOINT_MISSING;
     runtimeHealthState.lastSuccessAt = Date.parse("2026-03-20T11:55:00Z");
 
     render(<AppShell />);
@@ -219,8 +225,9 @@ describe("AppShell runtime health banner", () => {
   });
 
   it("renders banner for llm_unhealthy degradation", () => {
-    runtimeHealthState.status = "degraded";
-    runtimeHealthState.failureKind = "llm_unhealthy";
+    runtimeHealthState.status = RUNTIME_HEALTH_STATUSES.DEGRADED;
+    runtimeHealthState.failureKind =
+      RUNTIME_HEALTH_FAILURE_KINDS.LLM_UNHEALTHY;
     runtimeHealthState.lastSuccessAt = Date.parse("2026-03-20T11:55:00Z");
 
     render(<AppShell />);

--- a/frontend/src/components/persona/layout/AppShell.tsx
+++ b/frontend/src/components/persona/layout/AppShell.tsx
@@ -41,6 +41,10 @@ import { useBreakpoint } from "./useBreakpoint";
 import { useWallpaperUrl } from "@/hooks/useWallpaperUrl";
 import { useLiveEvents } from "@/hooks/useLiveEvents";
 import useRuntimeHealth from "@/hooks/useRuntimeHealth";
+import {
+  RUNTIME_HEALTH_FAILURE_KINDS,
+  RUNTIME_HEALTH_STATUSES,
+} from "@/contracts/runtimeTokens";
 import { checkAuthGate, useAuthState } from "@/lib/authState";
 import { ExtColors, GalleryItem, ThemeMode, Thread, Message } from "@/types/ui";
 import { DocumentLike } from "@/types/documents";
@@ -1613,10 +1617,12 @@ export default function AppShell({
     return { flex: "1 1 0%", maxWidth: "18rem" };
   }, [bp]);
 
-  const runtimeDegraded = runtimeHealth.status === "degraded";
+  const runtimeDegraded =
+    runtimeHealth.status === RUNTIME_HEALTH_STATUSES.DEGRADED;
   const runtimeFailureKind = runtimeHealth.failureKind ?? "unknown";
   const showRuntimeBanner =
-    runtimeDegraded && runtimeFailureKind !== "health_endpoint_missing";
+    runtimeDegraded &&
+    runtimeFailureKind !== RUNTIME_HEALTH_FAILURE_KINDS.HEALTH_ENDPOINT_MISSING;
   const runtimeLastHealthy = runtimeHealth.lastSuccessAt
     ? new Date(runtimeHealth.lastSuccessAt).toLocaleString()
     : "never";

--- a/frontend/src/contracts/runtimeTokens.ts
+++ b/frontend/src/contracts/runtimeTokens.ts
@@ -7,3 +7,23 @@ export const LIVE_EVENT_CONNECTION_STATES = {
 
 export type LiveEventConnectionState =
   (typeof LIVE_EVENT_CONNECTION_STATES)[keyof typeof LIVE_EVENT_CONNECTION_STATES];
+
+export const RUNTIME_HEALTH_STATUSES = {
+  HEALTHY: "healthy",
+  DEGRADED: "degraded",
+} as const;
+
+export type RuntimeHealthStatusToken =
+  (typeof RUNTIME_HEALTH_STATUSES)[keyof typeof RUNTIME_HEALTH_STATUSES];
+
+export const RUNTIME_HEALTH_FAILURE_KINDS = {
+  BACKEND_UNREACHABLE: "backend_unreachable",
+  HEALTH_ENDPOINT_MISSING: "health_endpoint_missing",
+  CHAT_UNHEALTHY: "chat_unhealthy",
+  LLM_UNHEALTHY: "llm_unhealthy",
+  LIVE_EVENTS_DISCONNECTED: "live_events_disconnected",
+  STALE: "stale",
+} as const;
+
+export type RuntimeHealthFailureKindToken =
+  (typeof RUNTIME_HEALTH_FAILURE_KINDS)[keyof typeof RUNTIME_HEALTH_FAILURE_KINDS];

--- a/frontend/src/hooks/useRuntimeHealth.test.ts
+++ b/frontend/src/hooks/useRuntimeHealth.test.ts
@@ -4,6 +4,8 @@ import { useRuntimeHealth } from "@/hooks/useRuntimeHealth";
 import {
   LIVE_EVENT_CONNECTION_STATES,
   LiveEventConnectionState,
+  RUNTIME_HEALTH_FAILURE_KINDS,
+  RUNTIME_HEALTH_STATUSES,
 } from "@/contracts/runtimeTokens";
 
 type LiveEventsStatus = {
@@ -110,7 +112,7 @@ describe("useRuntimeHealth", () => {
       await flushPromises();
     });
     await waitFor(() => {
-      expect(result.current.status).toBe("healthy");
+      expect(result.current.status).toBe(RUNTIME_HEALTH_STATUSES.HEALTHY);
     });
   });
 
@@ -121,8 +123,10 @@ describe("useRuntimeHealth", () => {
       await flushPromises();
     });
     await waitFor(() => {
-      expect(result.current.failureKind).toBe("backend_unreachable");
-      expect(result.current.status).toBe("degraded");
+      expect(result.current.failureKind).toBe(
+        RUNTIME_HEALTH_FAILURE_KINDS.BACKEND_UNREACHABLE
+      );
+      expect(result.current.status).toBe(RUNTIME_HEALTH_STATUSES.DEGRADED);
     });
   });
 
@@ -134,7 +138,9 @@ describe("useRuntimeHealth", () => {
     });
     await waitFor(() => {
       expect(result.current.backendReachable).toBe(true);
-      expect(result.current.failureKind).toBe("health_endpoint_missing");
+      expect(result.current.failureKind).toBe(
+        RUNTIME_HEALTH_FAILURE_KINDS.HEALTH_ENDPOINT_MISSING
+      );
     });
   });
 
@@ -146,7 +152,9 @@ describe("useRuntimeHealth", () => {
     });
     await waitFor(() => {
       expect(result.current.backendReachable).toBe(true);
-      expect(result.current.failureKind).toBe("health_endpoint_missing");
+      expect(result.current.failureKind).toBe(
+        RUNTIME_HEALTH_FAILURE_KINDS.HEALTH_ENDPOINT_MISSING
+      );
     });
   });
 
@@ -157,7 +165,9 @@ describe("useRuntimeHealth", () => {
       await flushPromises();
     });
     await waitFor(() => {
-      expect(result.current.failureKind).toBe("chat_unhealthy");
+      expect(result.current.failureKind).toBe(
+        RUNTIME_HEALTH_FAILURE_KINDS.CHAT_UNHEALTHY
+      );
     });
   });
 
@@ -168,7 +178,9 @@ describe("useRuntimeHealth", () => {
       await flushPromises();
     });
     await waitFor(() => {
-      expect(result.current.failureKind).toBe("llm_unhealthy");
+      expect(result.current.failureKind).toBe(
+        RUNTIME_HEALTH_FAILURE_KINDS.LLM_UNHEALTHY
+      );
     });
   });
 
@@ -179,15 +191,15 @@ describe("useRuntimeHealth", () => {
       await flushPromises();
     });
     await waitFor(() => {
-      expect(result.current.status).toBe("healthy");
+      expect(result.current.status).toBe(RUNTIME_HEALTH_STATUSES.HEALTHY);
     });
 
     act(() => {
       vi.setSystemTime(new Date("2026-03-20T12:01:00.000Z"));
     });
     rerender();
-    expect(result.current.failureKind).toBe("stale");
-    expect(result.current.status).toBe("degraded");
+    expect(result.current.failureKind).toBe(RUNTIME_HEALTH_FAILURE_KINDS.STALE);
+    expect(result.current.status).toBe(RUNTIME_HEALTH_STATUSES.DEGRADED);
   });
 
   it("flags live events disconnected after the threshold", async () => {
@@ -202,8 +214,10 @@ describe("useRuntimeHealth", () => {
       await flushPromises();
     });
     await waitFor(() => {
-      expect(result.current.failureKind).toBe("live_events_disconnected");
-      expect(result.current.status).toBe("degraded");
+      expect(result.current.failureKind).toBe(
+        RUNTIME_HEALTH_FAILURE_KINDS.LIVE_EVENTS_DISCONNECTED
+      );
+      expect(result.current.status).toBe(RUNTIME_HEALTH_STATUSES.DEGRADED);
     });
   });
 
@@ -212,5 +226,22 @@ describe("useRuntimeHealth", () => {
     expect(LIVE_EVENT_CONNECTION_STATES.CONNECTED).toBe("connected");
     expect(LIVE_EVENT_CONNECTION_STATES.RECONNECTING).toBe("reconnecting");
     expect(LIVE_EVENT_CONNECTION_STATES.DISCONNECTED).toBe("disconnected");
+  });
+
+  it("exposes canonical runtime health tokens", () => {
+    expect(RUNTIME_HEALTH_STATUSES.HEALTHY).toBe("healthy");
+    expect(RUNTIME_HEALTH_STATUSES.DEGRADED).toBe("degraded");
+    expect(RUNTIME_HEALTH_FAILURE_KINDS.BACKEND_UNREACHABLE).toBe(
+      "backend_unreachable"
+    );
+    expect(RUNTIME_HEALTH_FAILURE_KINDS.HEALTH_ENDPOINT_MISSING).toBe(
+      "health_endpoint_missing"
+    );
+    expect(RUNTIME_HEALTH_FAILURE_KINDS.CHAT_UNHEALTHY).toBe("chat_unhealthy");
+    expect(RUNTIME_HEALTH_FAILURE_KINDS.LLM_UNHEALTHY).toBe("llm_unhealthy");
+    expect(RUNTIME_HEALTH_FAILURE_KINDS.LIVE_EVENTS_DISCONNECTED).toBe(
+      "live_events_disconnected"
+    );
+    expect(RUNTIME_HEALTH_FAILURE_KINDS.STALE).toBe("stale");
   });
 });

--- a/frontend/src/hooks/useRuntimeHealth.ts
+++ b/frontend/src/hooks/useRuntimeHealth.ts
@@ -4,21 +4,19 @@ import { useLiveEvents } from "@/hooks/useLiveEvents";
 import {
   LIVE_EVENT_CONNECTION_STATES,
   LiveEventConnectionState,
+  RUNTIME_HEALTH_FAILURE_KINDS,
+  RUNTIME_HEALTH_STATUSES,
+  RuntimeHealthFailureKindToken,
+  RuntimeHealthStatusToken,
 } from "@/contracts/runtimeTokens";
 
 const POLL_INTERVAL_MS = 15000;
 const STALE_THRESHOLD_MS = 45000;
 
-export type RuntimeFailureKind =
-  | "backend_unreachable"
-  | "health_endpoint_missing"
-  | "chat_unhealthy"
-  | "llm_unhealthy"
-  | "live_events_disconnected"
-  | "stale";
+export type RuntimeFailureKind = RuntimeHealthFailureKindToken;
 
 export type RuntimeHealthStatus = {
-  status: "healthy" | "degraded";
+  status: RuntimeHealthStatusToken;
   failureKind: RuntimeFailureKind | null;
   backendReachable: boolean | null;
   chatHealthy: boolean | null;
@@ -161,21 +159,23 @@ export function useRuntimeHealth(): RuntimeHealthStatus {
 
   let failureKind: RuntimeFailureKind | null = null;
   if (hasChecked && snapshot.backendReachable === false) {
-    failureKind = "backend_unreachable";
+    failureKind = RUNTIME_HEALTH_FAILURE_KINDS.BACKEND_UNREACHABLE;
   } else if (hasChecked && snapshot.healthEndpointMissing) {
-    failureKind = "health_endpoint_missing";
+    failureKind = RUNTIME_HEALTH_FAILURE_KINDS.HEALTH_ENDPOINT_MISSING;
   } else if (hasChecked && snapshot.chatHealthy === false) {
-    failureKind = "chat_unhealthy";
+    failureKind = RUNTIME_HEALTH_FAILURE_KINDS.CHAT_UNHEALTHY;
   } else if (hasChecked && snapshot.llmHealthy === false) {
-    failureKind = "llm_unhealthy";
+    failureKind = RUNTIME_HEALTH_FAILURE_KINDS.LLM_UNHEALTHY;
   } else if (liveEventsDisconnected) {
-    failureKind = "live_events_disconnected";
+    failureKind = RUNTIME_HEALTH_FAILURE_KINDS.LIVE_EVENTS_DISCONNECTED;
   } else if (stale) {
-    failureKind = "stale";
+    failureKind = RUNTIME_HEALTH_FAILURE_KINDS.STALE;
   }
 
   return {
-    status: failureKind ? "degraded" : "healthy",
+    status: failureKind
+      ? RUNTIME_HEALTH_STATUSES.DEGRADED
+      : RUNTIME_HEALTH_STATUSES.HEALTHY,
     failureKind,
     backendReachable: snapshot.backendReachable,
     chatHealthy: snapshot.chatHealthy,


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
