### PR TITLE
Codex/add local embedder autodownload

### DIFF
--- a/backend/rag/embedder.py
+++ b/backend/rag/embedder.py
@@ -247,7 +247,7 @@ class LocalSemanticEmbedder:
             raise RuntimeError("sentence-transformers not installed.")
 
         try:
-            model = SentenceTransformer(
+            model = self._load_sentence_transformer(
                 self.model_name,
                 local_files_only=strict_local,
             )
@@ -265,12 +265,71 @@ class LocalSemanticEmbedder:
                 )
                 return self._init_mock_backend()
             if strict_local:
-                raise RuntimeError(
-                    "LOCAL_EMBED_MODEL could not be loaded from local cache."
-                ) from exc
+                return self._recover_local_model_once(exc)
             raise RuntimeError(
                 f"SentenceTransformer could not be initialized for model '{self.model_name}'."
             ) from exc
+
+    def _load_sentence_transformer(
+        self,
+        model_name: str,
+        *,
+        local_files_only: bool,
+    ):
+        assert SentenceTransformer is not None
+        return SentenceTransformer(
+            model_name,
+            local_files_only=local_files_only,
+        )
+
+    def _attempt_local_model_autodownload(self, model_name: str):
+        # Trigger SentenceTransformer/HF one-time fetch into local cache.
+        return self._load_sentence_transformer(
+            model_name,
+            local_files_only=False,
+        )
+
+    def _recover_local_model_once(self, initial_exc: Exception):
+        model_name = self.model_name or "UNKNOWN"
+        logger.info(
+            "[embedder] local model=%s missing from cache; attempting one-time auto-download",
+            model_name,
+        )
+        try:
+            self._attempt_local_model_autodownload(model_name)
+        except Exception as download_exc:
+            logger.error(
+                "[embedder] local model=%s auto-download failed: %s",
+                model_name,
+                str(download_exc),
+            )
+            raise RuntimeError(
+                f"LOCAL_EMBED_MODEL '{model_name}' could not be loaded from local cache. "
+                "Auto-download was attempted and failed: "
+                f"{download_exc}"
+            ) from initial_exc
+
+        try:
+            model = self._load_sentence_transformer(
+                model_name,
+                local_files_only=True,
+            )
+            logger.info(
+                "[embedder] local model=%s recovered after auto-download",
+                model_name,
+            )
+            return model
+        except Exception as retry_exc:
+            logger.error(
+                "[embedder] local model=%s still unavailable after auto-download: %s",
+                model_name,
+                str(retry_exc),
+            )
+            raise RuntimeError(
+                f"LOCAL_EMBED_MODEL '{model_name}' could not be loaded from local cache. "
+                "Auto-download was attempted, but initialization still failed: "
+                f"{retry_exc}"
+            ) from initial_exc
 
     def _embed_np(self, texts: list[str], batch_size: int = 64) -> np.ndarray:
         if not texts:

--- a/backend/rag/embedder.py
+++ b/backend/rag/embedder.py
@@ -79,6 +79,76 @@ _ALLOWED_BACKENDS = {
 }
 
 
+def inspect_embedder_preflight(
+    backend: str | None = None,
+) -> dict[str, Any]:
+    """Return a lightweight embedder readiness snapshot.
+
+    This check is intentionally side-effect free:
+    - no vector store initialization
+    - no model download attempt
+    - no mutation of embedder runtime state
+    """
+
+    resolved_backend = (
+        backend
+        or os.getenv(_ENV_BACKEND)
+        or os.getenv("EMBEDDING_BACKEND")
+        or _BACKEND_SENTENCE_TRANSFORMER
+    )
+    backend_value = str(resolved_backend or "").strip().lower()
+    model_name = (os.getenv("LOCAL_EMBED_MODEL") or "").strip() or None
+
+    logger.info(
+        "[embedder] preflight backend=%s model=%s",
+        backend_value,
+        model_name or "<unset>",
+    )
+
+    if backend_value != _BACKEND_LOCAL:
+        reason = (
+            "local embedder preflight not applicable for stub backend"
+            if backend_value == "stub"
+            else (
+                f"local embedder preflight not applicable for {backend_value or 'unset'} backend"
+            )
+        )
+        return {
+            "backend": backend_value or "unset",
+            "model": model_name,
+            "ready": True,
+            "present": None,
+            "reason": reason,
+        }
+
+    try:
+        resolved_model = require_local_embed_model()
+    except Exception as exc:
+        logger.warning(
+            "[embedder] preflight local backend not ready model=%s reason=%s",
+            model_name or "<unset>",
+            str(exc),
+        )
+        return {
+            "backend": _BACKEND_LOCAL,
+            "model": model_name,
+            "ready": False,
+            "present": False,
+            "reason": (
+                "configured local embedder not found in cache or invalid: "
+                f"{exc}"
+            ),
+        }
+
+    return {
+        "backend": _BACKEND_LOCAL,
+        "model": resolved_model,
+        "ready": True,
+        "present": True,
+        "reason": "local embedder preflight passed",
+    }
+
+
 def _normalize_metadatas(
     metadatas: list[dict[str, Any]] | None, count: int
 ) -> list[dict[str, Any]]:

--- a/guardian/core/dependencies.py
+++ b/guardian/core/dependencies.py
@@ -510,6 +510,8 @@ def get_database_dsn() -> Optional[str]:
 # These will be initialized by guardian_api.py at startup
 _vector_store: Optional[VectorStore] = None
 _sensors: Optional[Sensors] = None
+_embedder_preflight_cache: Optional[dict[str, Any]] = None
+_embedder_preflight_cache_ts: float = 0.0
 
 
 def init_services(db: ChatDB) -> tuple[VectorStore, Sensors]:
@@ -521,6 +523,54 @@ def init_services(db: ChatDB) -> tuple[VectorStore, Sensors]:
     _vector_store = VectorStore()
     _sensors = Sensors(db)
     return _vector_store, _sensors
+
+
+def _embedder_preflight_cache_ttl_seconds() -> float:
+    raw = (os.getenv("EMBEDDER_PREFLIGHT_CACHE_TTL_SECONDS") or "5").strip()
+    try:
+        ttl = float(raw)
+    except ValueError:
+        ttl = 5.0
+    return max(0.0, ttl)
+
+
+def get_embedder_preflight_status(
+    *, force_refresh: bool = False
+) -> dict[str, Any]:
+    """Return cached embedder preflight status without constructing VectorStore."""
+
+    global _embedder_preflight_cache, _embedder_preflight_cache_ts
+
+    ttl = _embedder_preflight_cache_ttl_seconds()
+    now = time_module.monotonic()
+    if (
+        not force_refresh
+        and _embedder_preflight_cache is not None
+        and ttl > 0.0
+        and (now - _embedder_preflight_cache_ts) <= ttl
+    ):
+        return dict(_embedder_preflight_cache)
+
+    from backend.rag.embedder import inspect_embedder_preflight
+
+    try:
+        payload = inspect_embedder_preflight()
+    except Exception as exc:
+        logger.warning(
+            "[dependencies] embedder preflight failed: %s",
+            str(exc),
+        )
+        payload = {
+            "backend": "unknown",
+            "model": None,
+            "ready": False,
+            "present": None,
+            "reason": f"embedder preflight failed: {exc}",
+        }
+
+    _embedder_preflight_cache = dict(payload)
+    _embedder_preflight_cache_ts = now
+    return dict(payload)
 
 
 # =========================

--- a/guardian/guardian_api.py
+++ b/guardian/guardian_api.py
@@ -1289,6 +1289,16 @@ def serve_signed_media(
     return FileResponse(candidate)
 
 
+@app.get("/api/health/embedder", tags=["Health"])
+def health_embedder():
+    """Expose lightweight embedder preflight status."""
+    embedder_status = dependencies.get_embedder_preflight_status()
+    return {
+        "status": "ok",
+        "embedder": embedder_status,
+    }
+
+
 # =========================
 # Root Endpoint
 # =========================

--- a/tests/backend/rag/test_embedder.py
+++ b/tests/backend/rag/test_embedder.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from backend.rag import embedder as embedder_module
+
+
+def _patch_faiss_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(embedder_module, "faiss", object())
+
+
+def test_local_model_present_skips_autodownload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_faiss_available(monkeypatch)
+
+    calls: list[tuple[str, bool]] = []
+    model_obj = object()
+
+    def fake_sentence_transformer(
+        model_name: str,
+        local_files_only: bool,
+    ):
+        calls.append((model_name, local_files_only))
+        return model_obj
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("auto-download should not be attempted")
+
+    monkeypatch.setattr(
+        embedder_module,
+        "SentenceTransformer",
+        fake_sentence_transformer,
+    )
+    monkeypatch.setattr(
+        embedder_module.LocalSemanticEmbedder,
+        "_attempt_local_model_autodownload",
+        fail_if_called,
+    )
+
+    embedder = embedder_module.LocalSemanticEmbedder(
+        model="/models/default-local-embedder",
+        backend="local",
+    )
+
+    assert embedder._model is model_obj
+    assert calls == [("/models/default-local-embedder", True)]
+
+
+def test_local_model_missing_autodownload_then_retry_success(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _patch_faiss_available(monkeypatch)
+    caplog.set_level(logging.INFO)
+
+    calls: list[tuple[str, bool]] = []
+    recovered_model = object()
+
+    def fake_sentence_transformer(
+        model_name: str,
+        local_files_only: bool,
+    ):
+        calls.append((model_name, local_files_only))
+        if len(calls) == 1:
+            raise RuntimeError("not in cache")
+        if len(calls) == 2:
+            assert local_files_only is False
+            return object()  # download/installation path
+        if len(calls) == 3:
+            assert local_files_only is True
+            return recovered_model
+        raise AssertionError("unexpected extra retry")
+
+    monkeypatch.setattr(
+        embedder_module,
+        "SentenceTransformer",
+        fake_sentence_transformer,
+    )
+
+    embedder = embedder_module.LocalSemanticEmbedder(
+        model="/models/default-local-embedder",
+        backend="local",
+    )
+
+    assert embedder._model is recovered_model
+    assert calls == [
+        ("/models/default-local-embedder", True),
+        ("/models/default-local-embedder", False),
+        ("/models/default-local-embedder", True),
+    ]
+    assert "attempting one-time auto-download" in caplog.text
+    assert "recovered after auto-download" in caplog.text
+
+
+def test_local_model_missing_autodownload_fails_raises_clear_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _patch_faiss_available(monkeypatch)
+    caplog.set_level(logging.INFO)
+
+    calls: list[tuple[str, bool]] = []
+
+    def fake_sentence_transformer(
+        model_name: str,
+        local_files_only: bool,
+    ):
+        calls.append((model_name, local_files_only))
+        if len(calls) == 1:
+            raise RuntimeError("not in cache")
+        if len(calls) == 2:
+            raise RuntimeError("download unavailable")
+        raise AssertionError("unexpected retry")
+
+    monkeypatch.setattr(
+        embedder_module,
+        "SentenceTransformer",
+        fake_sentence_transformer,
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        embedder_module.LocalSemanticEmbedder(
+            model="/models/default-local-embedder",
+            backend="local",
+        )
+
+    message = str(exc_info.value)
+    assert "/models/default-local-embedder" in message
+    assert "Auto-download was attempted" in message
+    assert "download unavailable" in message
+    assert calls == [
+        ("/models/default-local-embedder", True),
+        ("/models/default-local-embedder", False),
+    ]
+    assert "auto-download failed" in caplog.text
+
+
+def test_local_model_missing_download_succeeds_retry_still_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _patch_faiss_available(monkeypatch)
+    caplog.set_level(logging.INFO)
+
+    calls: list[tuple[str, bool]] = []
+
+    def fake_sentence_transformer(
+        model_name: str,
+        local_files_only: bool,
+    ):
+        calls.append((model_name, local_files_only))
+        if len(calls) == 1:
+            raise RuntimeError("not in cache")
+        if len(calls) == 2:
+            assert local_files_only is False
+            return object()
+        if len(calls) == 3:
+            assert local_files_only is True
+            raise RuntimeError("still unavailable")
+        raise AssertionError("unexpected extra retry")
+
+    monkeypatch.setattr(
+        embedder_module,
+        "SentenceTransformer",
+        fake_sentence_transformer,
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        embedder_module.LocalSemanticEmbedder(
+            model="/models/default-local-embedder",
+            backend="local",
+        )
+
+    message = str(exc_info.value)
+    assert "/models/default-local-embedder" in message
+    assert "Auto-download was attempted" in message
+    assert "still unavailable" in message
+    assert calls == [
+        ("/models/default-local-embedder", True),
+        ("/models/default-local-embedder", False),
+        ("/models/default-local-embedder", True),
+    ]
+    assert "still unavailable after auto-download" in caplog.text

--- a/tests/backend/rag/test_embedder.py
+++ b/tests/backend/rag/test_embedder.py
@@ -184,3 +184,70 @@ def test_local_model_missing_download_succeeds_retry_still_fails(
         ("/models/default-local-embedder", True),
     ]
     assert "still unavailable after auto-download" in caplog.text
+
+
+def test_preflight_stub_backend_reports_not_applicable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CODEXIFY_EMBEDDINGS_BACKEND", raising=False)
+    monkeypatch.setenv("EMBEDDING_BACKEND", "stub")
+    monkeypatch.delenv("LOCAL_EMBED_MODEL", raising=False)
+
+    result = embedder_module.inspect_embedder_preflight()
+
+    assert result["backend"] == "stub"
+    assert result["model"] is None
+    assert result["present"] is None
+    assert result["ready"] is True
+    assert "not applicable for stub backend" in str(result["reason"])
+
+
+def test_preflight_local_model_present_ready_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CODEXIFY_EMBEDDINGS_BACKEND", "local")
+    monkeypatch.setenv("LOCAL_EMBED_MODEL", "/models/default-local-embedder")
+    monkeypatch.setattr(
+        embedder_module,
+        "require_local_embed_model",
+        lambda: "/models/default-local-embedder",
+    )
+
+    result = embedder_module.inspect_embedder_preflight()
+
+    assert result == {
+        "backend": "local",
+        "model": "/models/default-local-embedder",
+        "ready": True,
+        "present": True,
+        "reason": "local embedder preflight passed",
+    }
+
+
+def test_preflight_local_model_missing_no_download_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CODEXIFY_EMBEDDINGS_BACKEND", "local")
+    monkeypatch.setenv("LOCAL_EMBED_MODEL", "/models/default-local-embedder")
+    monkeypatch.setattr(
+        embedder_module,
+        "require_local_embed_model",
+        lambda: (_ for _ in ()).throw(RuntimeError("missing local model")),
+    )
+    monkeypatch.setattr(
+        embedder_module.LocalSemanticEmbedder,
+        "_attempt_local_model_autodownload",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("preflight must not trigger auto-download")
+        ),
+    )
+
+    result = embedder_module.inspect_embedder_preflight()
+
+    assert result["backend"] == "local"
+    assert result["model"] == "/models/default-local-embedder"
+    assert result["ready"] is False
+    assert result["present"] is False
+    assert "configured local embedder not found in cache or invalid" in str(
+        result["reason"]
+    )

--- a/tests/core/test_embedder_preflight_dependencies.py
+++ b/tests/core/test_embedder_preflight_dependencies.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from guardian.core import dependencies
+
+
+def test_embedder_preflight_dependency_accessor_is_lightweight(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("EMBEDDER_PREFLIGHT_CACHE_TTL_SECONDS", "0")
+    monkeypatch.setattr(dependencies, "_vector_store", None)
+    monkeypatch.setattr(
+        dependencies,
+        "VectorStore",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("VectorStore must not be constructed")
+        ),
+    )
+
+    monkeypatch.setattr(
+        "backend.rag.embedder.inspect_embedder_preflight",
+        lambda: {
+            "backend": "local",
+            "model": "/models/default-local-embedder",
+            "ready": True,
+            "present": True,
+            "reason": "local embedder preflight passed",
+        },
+    )
+
+    payload = dependencies.get_embedder_preflight_status(force_refresh=True)
+
+    assert payload["backend"] == "local"
+    assert payload["ready"] is True
+    assert payload["present"] is True
+
+
+def test_embedder_preflight_dependency_accessor_uses_cache(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("EMBEDDER_PREFLIGHT_CACHE_TTL_SECONDS", "60")
+    monkeypatch.setattr(dependencies, "_embedder_preflight_cache", None)
+    monkeypatch.setattr(dependencies, "_embedder_preflight_cache_ts", 0.0)
+
+    calls = {"count": 0}
+
+    def _fake_preflight() -> dict[str, object]:
+        calls["count"] += 1
+        return {
+            "backend": "stub",
+            "model": None,
+            "ready": True,
+            "present": None,
+            "reason": "local embedder preflight not applicable for stub backend",
+        }
+
+    monkeypatch.setattr(
+        "backend.rag.embedder.inspect_embedder_preflight",
+        _fake_preflight,
+    )
+
+    first = dependencies.get_embedder_preflight_status(force_refresh=False)
+    second = dependencies.get_embedder_preflight_status(force_refresh=False)
+
+    assert first == second
+    assert calls["count"] == 1

--- a/tests/routes/test_metrics.py
+++ b/tests/routes/test_metrics.py
@@ -125,3 +125,74 @@ def test_health_vector_endpoint(test_client):
     assert data.get("source") in ("shared", "local", "probe")
     assert data.get("added") == 1
     assert data.get("matches", 0) >= 1
+
+
+def test_health_embedder_endpoint_stub_backend(test_client, monkeypatch):
+    monkeypatch.setattr(
+        "guardian.core.dependencies.get_embedder_preflight_status",
+        lambda: {
+            "backend": "stub",
+            "model": None,
+            "ready": True,
+            "present": None,
+            "reason": "local embedder preflight not applicable for stub backend",
+        },
+    )
+
+    res = test_client.get("/api/health/embedder")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["status"] == "ok"
+    assert data["embedder"]["backend"] == "stub"
+    assert data["embedder"]["ready"] is True
+    assert data["embedder"]["present"] is None
+
+
+def test_health_embedder_endpoint_local_present(test_client, monkeypatch):
+    monkeypatch.setattr(
+        "guardian.core.dependencies.get_embedder_preflight_status",
+        lambda: {
+            "backend": "local",
+            "model": "/models/default-local-embedder",
+            "ready": True,
+            "present": True,
+            "reason": "local embedder preflight passed",
+        },
+    )
+
+    res = test_client.get("/api/health/embedder")
+    assert res.status_code == 200
+    data = res.json()
+    assert data == {
+        "status": "ok",
+        "embedder": {
+            "backend": "local",
+            "model": "/models/default-local-embedder",
+            "ready": True,
+            "present": True,
+            "reason": "local embedder preflight passed",
+        },
+    }
+
+
+def test_health_embedder_endpoint_local_missing(test_client, monkeypatch):
+    monkeypatch.setattr(
+        "guardian.core.dependencies.get_embedder_preflight_status",
+        lambda: {
+            "backend": "local",
+            "model": "/models/default-local-embedder",
+            "ready": False,
+            "present": False,
+            "reason": "configured local embedder not found in cache",
+        },
+    )
+
+    res = test_client.get("/api/health/embedder")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["status"] == "ok"
+    assert data["embedder"]["backend"] == "local"
+    assert data["embedder"]["model"] == "/models/default-local-embedder"
+    assert data["embedder"]["ready"] is False
+    assert data["embedder"]["present"] is False
+    assert "not found in cache" in data["embedder"]["reason"]


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
