### PR TITLE
fix(chat): rate-limit refreshSnapshot to prevent UI polling loop

### DIFF
--- a/frontend/src/features/chat/useChat.ts
+++ b/frontend/src/features/chat/useChat.ts
@@ -491,11 +491,16 @@ export function useChat(options: UseChatOptions = {}) {
   const paginationMessagesRef = useRef<ChatMessage[]>([]);
   const totalRef = useRef(0);
   const messagesRef = useRef<ChatMessage[]>([]);
-  const lastRefreshRef = useRef<{ threadId: number; messageCount: number; timestamp: number }>({
+  const lastRefreshGuardRef = useRef<{
+    threadId: number;
+    messageCount: number;
+    timestamp: number;
+  }>({
     threadId: 0,
     messageCount: 0,
     timestamp: 0,
   });
+  const lastRefreshRef = useRef<Record<number, number>>({});
   const snapshotLaneRef = useRef<RequestLaneState>({
     controller: null,
     promise: null,
@@ -883,7 +888,30 @@ export function useChat(options: UseChatOptions = {}) {
 
   const refreshSnapshot = useCallback(
     async (threadId: number, reason = "manual") => {
-      return runSnapshotRefresh(threadId, reason);
+      if (!Number.isFinite(threadId)) return;
+      const now = Date.now();
+      const last = lastRefreshRef.current[threadId] ?? 0;
+      if (now - last < 500) {
+        if (process.env.NODE_ENV === "development") {
+          console.debug(`[useChat] refreshSnapshot skipped (rate-limited)`, {
+            threadId,
+            reason,
+          });
+        }
+        return;
+      }
+      lastRefreshRef.current[threadId] = now;
+      try {
+        await runSnapshotRefresh(threadId, reason);
+        if (process.env.NODE_ENV === "development") {
+          console.debug(`[useChat] refreshSnapshot executed`, {
+            threadId,
+            reason,
+          });
+        }
+      } catch (err) {
+        console.warn("[useChat] refreshSnapshot failed", err);
+      }
     },
     [runSnapshotRefresh]
   );
@@ -1415,7 +1443,7 @@ export function useChat(options: UseChatOptions = {}) {
 
   const shouldRefresh = useCallback(
     (threadId: number, currentMessageCount: number) => {
-      const last = lastRefreshRef.current;
+      const last = lastRefreshGuardRef.current;
       const now = Date.now();
       if (last.threadId !== threadId) return true;
       if (last.messageCount !== currentMessageCount) return true;
@@ -1426,7 +1454,7 @@ export function useChat(options: UseChatOptions = {}) {
   );
 
   const markRefreshed = useCallback((threadId: number, messageCount: number) => {
-    lastRefreshRef.current = {
+    lastRefreshGuardRef.current = {
       threadId,
       messageCount,
       timestamp: Date.now(),


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
