### PR TITLE
Align chat lane gutters across breakpoints

### DIFF
--- a/frontend/src/features/chat/ChatView.tsx
+++ b/frontend/src/features/chat/ChatView.tsx
@@ -24,7 +24,10 @@ import {
   isActiveInferencePhase,
   type InferenceRequestState,
 } from "@/types/inference";
-import { CHAT_LANE_MAX_WIDTH } from "@/features/chat/chatLane";
+import {
+  CHAT_LANE_INLINE_PADDING,
+  CHAT_LANE_MAX_WIDTH,
+} from "@/features/chat/chatLane";
 
 type DepthMode = "shallow" | "normal" | "deep" | "diagnostic";
 type BubblePlayState =
@@ -399,8 +402,11 @@ export function ChatView({
         }}
         data-testid="chat-container"
         data-debug-scroll
-        className="flex-1 min-h-0 flex flex-col overflow-y-auto overscroll-contain px-4"
-        style={scrollStyle}
+        className="flex-1 min-h-0 flex flex-col overflow-y-auto overscroll-contain"
+        style={{
+          ...scrollStyle,
+          paddingInline: CHAT_LANE_INLINE_PADDING,
+        }}
       >
         <div
           data-testid="chat-conversation-lane"

--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -52,7 +52,7 @@ import {
   type ComposerInferenceMode,
 } from "@/types/inference";
 import { setPreferredProviderSelection } from "@/lib/providerPref";
-import { CHAT_LANE_MAX_WIDTH } from "@/features/chat/chatLane";
+import { CHAT_LANE_MAX_WIDTH, CHAT_STAGE_MAX_WIDTH } from "@/features/chat/chatLane";
 
 
 const DRAFT_KEY_PREFIX = "gc-draft:";
@@ -2465,166 +2465,168 @@ export function GuardianChat({
         )}
       </div>
 
-      {/* Composer rail - Footer workspace island */}
-      <div
-        className="shrink-0 z-20 mx-[6px] mt-2 rounded-[24px] border shadow-2xl backdrop-blur-xl flex flex-col overflow-hidden transition-all duration-200"
-        style={{
-          borderColor: "var(--panel-border)",
-          background: "color-mix(in oklab, var(--panel-bg) 95%, black)", // Deep opaque glass
-          clipPath: "inset(0 round 24px)",
-          isolation: "isolate",
-          minHeight: "140px",
-          maxHeight: "60vh",
-        }}
-      >
-        <div className="flex flex-col p-4">
-<div
-  data-testid="composer-conversation-lane"
-  className="mx-auto w-full max-w-full md:max-w-[880px]"
-  style={{ maxWidth: CHAT_LANE_MAX_WIDTH }}
->
-  <GuardianThreadApprovalRail
-    className="mb-3"
-    onTellGuardianWhatToDoInstead={handleTellGuardianWhatToDoInstead}
-    reloadSignal={chatReloadVersion}
-    threadId={effectiveThreadId ?? undefined}
-  />
+      <div className="shrink-0 z-20 mt-2 flex justify-center w-full">
+        <div
+          data-testid="composer-shell"
+          className="w-full rounded-[24px] border shadow-2xl backdrop-blur-xl flex flex-col overflow-hidden transition-all duration-200"
+          style={{
+            maxWidth: CHAT_STAGE_MAX_WIDTH,
+            borderColor: "var(--panel-border)",
+            background: "color-mix(in oklab, var(--panel-bg) 95%, black)", // Deep opaque glass
+            clipPath: "inset(0 round 24px)",
+            isolation: "isolate",
+            minHeight: "140px",
+            maxHeight: "60vh",
+          }}
+        >
+          <div className="flex flex-col p-4">
+            <div
+              data-testid="composer-conversation-lane"
+              className="mx-auto w-full max-w-full md:max-w-[880px]"
+              style={{ maxWidth: CHAT_LANE_MAX_WIDTH }}
+            >
+              <GuardianThreadApprovalRail
+                className="mb-3"
+                onTellGuardianWhatToDoInstead={handleTellGuardianWhatToDoInstead}
+                reloadSignal={chatReloadVersion}
+                threadId={effectiveThreadId ?? undefined}
+              />
+              <Composer
+                onSend={handleSendMessage}
+                ensureThreadIdForAttachments={ensureThreadIdForAttachments}
+                prefill={externalPrefill ?? prefill}
+                onPrefillConsumed={() => {
+                  setExternalPrefill(undefined);
+                  onPrefillConsumed?.();
+                }}
+                threadId={effectiveThreadId ?? undefined}
+                isTurnInFlight={isTurnLocked(effectiveThreadId)}
+                draftValue={activeDraft}
+                draftScopeKey={activeSessionTabId ?? "global"}
+                onDraftValueChange={onSessionDraftChange}
+                activeProviderId={selectedProvider?.id ?? activeProviderId}
+                providerOptions={providerOptions}
+                providerOpenSignal={providerMenuOpenSignal}
+                onProviderChange={(providerId) => {
+                  const activeRequestThreadId =
+                    completionState.activeThreadId ??
+                    inferenceRequest.state.threadId ??
+                    effectiveThreadId;
 
-  <Composer
-    onSend={handleSendMessage}
-    ensureThreadIdForAttachments={ensureThreadIdForAttachments}
-    prefill={externalPrefill ?? prefill}
-    onPrefillConsumed={() => {
-      setExternalPrefill(undefined);
-      onPrefillConsumed?.();
-    }}
-    threadId={effectiveThreadId ?? undefined}
-    isTurnInFlight={isTurnLocked(effectiveThreadId)}
-    draftValue={activeDraft}
-    draftScopeKey={activeSessionTabId ?? "global"}
-    onDraftValueChange={onSessionDraftChange}
-    activeProviderId={selectedProvider?.id ?? activeProviderId}
-    providerOptions={providerOptions}
-    providerOpenSignal={providerMenuOpenSignal}
-    onProviderChange={(providerId) => {
-      const activeRequestThreadId =
-        completionState.activeThreadId ??
-        inferenceRequest.state.threadId ??
-        effectiveThreadId;
+                  const currentProviderId =
+                    selectedProvider?.id ?? activeProviderId ?? null;
 
-      const currentProviderId =
-        selectedProvider?.id ?? activeProviderId ?? null;
+                  const providerChanged = providerId !== currentProviderId;
 
-      const providerChanged = providerId !== currentProviderId;
+                  if (
+                    providerChanged &&
+                    activeRequestThreadId != null &&
+                    isTurnLocked(activeRequestThreadId)
+                  ) {
+                    void inferenceRequest.requestCancel();
+                    releaseTurnLease(activeRequestThreadId, {
+                      clearCompletion: true,
+                      clearInference: true,
+                    });
+                  }
 
-      if (
-        providerChanged &&
-        activeRequestThreadId != null &&
-        isTurnLocked(activeRequestThreadId)
-      ) {
-        void inferenceRequest.requestCancel();
-        releaseTurnLease(activeRequestThreadId, {
-          clearCompletion: true,
-          clearInference: true,
-        });
-      }
+                  const nextProvider =
+                    catalogProviders.find((p) => p.id === providerId) ?? null;
 
-      const nextProvider =
-        catalogProviders.find((p) => p.id === providerId) ?? null;
+                  onSessionProviderChange?.(providerId);
 
-      onSessionProviderChange?.(providerId);
+                  const nextModelId = nextProvider?.models?.[0]?.id ?? null;
 
-      const nextModelId = nextProvider?.models?.[0]?.id ?? null;
-
-      if (
-        nextProvider &&
-        (!selectedModel ||
-          !nextProvider.models.some((m) => m.id === selectedModel.id)) &&
-        nextModelId
-      ) {
-        onSessionModelChange?.(nextModelId);
-      }
-    }}
-    activeModelId={selectedModel?.id ?? activeModelId}
-    modelOptions={modelOptions}
-    onModelChange={(modelId) => onSessionModelChange?.(modelId)}
-    activeInferenceMode={effectiveInferenceMode}
-    inferenceModeOptions={inferenceModeOptions}
-    onInferenceModeChange={(mode) =>
-      onSessionInferenceModeChange?.(mode)
-    }
-    depthMode={depth}
-    depthOptions={depthOptions}
-    onDepthModeChange={setDepth}
-    onVoiceTurn={
-      voiceTurnBasedEnabled
-        ? () => {
-            if (effectiveThreadId == null) {
-              alert("Create or open a thread before starting a voice turn.");
-              return;
-            }
-            voiceFileInputRef.current?.click();
-          }
-        : undefined
-    }
-    voiceTurnLabel={
-      voiceUploading ? "Processing voice…" : "Upload voice turn"
-    }
-  />
-</div>
-          {voiceTurnBasedEnabled ? (
-            <input
-              ref={voiceFileInputRef}
-              type="file"
-              accept={voiceUploadAccept}
-              className="hidden"
-              onChange={async (event) => {
-                const file = event.target.files?.[0];
-                event.currentTarget.value = "";
-                if (!file) return;
-                if (effectiveThreadId == null) {
-                  alert("Create or open a thread before starting a voice turn.");
-                  return;
+                  if (
+                    nextProvider &&
+                    (!selectedModel ||
+                      !nextProvider.models.some((m) => m.id === selectedModel.id)) &&
+                    nextModelId
+                  ) {
+                    onSessionModelChange?.(nextModelId);
+                  }
+                }}
+                activeModelId={selectedModel?.id ?? activeModelId}
+                modelOptions={modelOptions}
+                onModelChange={(modelId) => onSessionModelChange?.(modelId)}
+                activeInferenceMode={effectiveInferenceMode}
+                inferenceModeOptions={inferenceModeOptions}
+                onInferenceModeChange={(mode) =>
+                  onSessionInferenceModeChange?.(mode)
                 }
-                const normalizedMime = String(file.type || "")
-                  .trim()
-                  .toLowerCase();
-                if (
-                  normalizedMime &&
-                  supportedVoiceInputMime.length > 0 &&
-                  !supportedVoiceInputMime.includes(normalizedMime)
-                ) {
-                  alert(`Unsupported audio type: ${normalizedMime}`);
-                  return;
+                depthMode={depth}
+                depthOptions={depthOptions}
+                onDepthModeChange={setDepth}
+                onVoiceTurn={
+                  voiceTurnBasedEnabled
+                    ? () => {
+                        if (effectiveThreadId == null) {
+                          alert(
+                            "Create or open a thread before starting a voice turn."
+                          );
+                          return;
+                        }
+                        voiceFileInputRef.current?.click();
+                      }
+                    : undefined
                 }
-                if (
-                  voiceUploadLimitBytes != null &&
-                  file.size > voiceUploadLimitBytes
-                ) {
-                  const limitMb = (voiceUploadLimitBytes / (1024 * 1024)).toFixed(1);
-                  alert(`Audio file too large. Max ${limitMb} MB.`);
-                  return;
-                }
-                setVoiceUploading(true);
-                try {
-                  const form = new FormData();
-                  form.append("thread_id", String(effectiveThreadId));
-                  form.append("audio_file", file);
-                  form.append("tts_enabled", "true");
-                  await api.post("/voice/turn", form, {
-                    headers: { "Content-Type": "multipart/form-data" },
-                    timeout: 180000,
-                  });
-                  triggerReload();
-                } catch (error) {
-                  console.warn("[guardian] voice turn failed", error);
-                  alert("Voice turn failed. Check backend voice configuration.");
-                } finally {
-                  setVoiceUploading(false);
-                }
-              }}
-            />
-          ) : null}
+                voiceTurnLabel={voiceUploading ? "Processing voice…" : "Upload voice turn"}
+              />
+              {voiceTurnBasedEnabled ? (
+                <input
+                  ref={voiceFileInputRef}
+                  type="file"
+                  accept={voiceUploadAccept}
+                  className="hidden"
+                  onChange={async (event) => {
+                    const file = event.target.files?.[0];
+                    event.currentTarget.value = "";
+                    if (!file) return;
+                    if (effectiveThreadId == null) {
+                      alert("Create or open a thread before starting a voice turn.");
+                      return;
+                    }
+                    const normalizedMime = String(file.type || "")
+                      .trim()
+                      .toLowerCase();
+                    if (
+                      normalizedMime &&
+                      supportedVoiceInputMime.length > 0 &&
+                      !supportedVoiceInputMime.includes(normalizedMime)
+                    ) {
+                      alert(`Unsupported audio type: ${normalizedMime}`);
+                      return;
+                    }
+                    if (
+                      voiceUploadLimitBytes != null &&
+                      file.size > voiceUploadLimitBytes
+                    ) {
+                      const limitMb = (voiceUploadLimitBytes / (1024 * 1024)).toFixed(1);
+                      alert(`Audio file too large. Max ${limitMb} MB.`);
+                      return;
+                    }
+                    setVoiceUploading(true);
+                    try {
+                      const form = new FormData();
+                      form.append("thread_id", String(effectiveThreadId));
+                      form.append("audio_file", file);
+                      form.append("tts_enabled", "true");
+                      await api.post("/voice/turn", form, {
+                        headers: { "Content-Type": "multipart/form-data" },
+                        timeout: 180000,
+                      });
+                      triggerReload();
+                    } catch (error) {
+                      console.warn("[guardian] voice turn failed", error);
+                      alert("Voice turn failed. Check backend voice configuration.");
+                    } finally {
+                      setVoiceUploading(false);
+                    }
+                  }}
+                />
+              ) : null}
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/features/chat/__tests__/GuardianChat.session-tabs.test.tsx
+++ b/frontend/src/features/chat/__tests__/GuardianChat.session-tabs.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import GuardianChat, {
   flattenChatEventPayload,
 } from "@/features/chat/GuardianChat";
-import { CHAT_LANE_MAX_WIDTH } from "@/features/chat/chatLane";
+import { CHAT_LANE_MAX_WIDTH, CHAT_STAGE_MAX_WIDTH } from "@/features/chat/chatLane";
 
 const chatViewSpy = vi.hoisted(() => vi.fn());
 
@@ -196,6 +196,9 @@ describe("GuardianChat session-tab binding", () => {
     const lane = screen.getByTestId("composer-conversation-lane");
     expect(lane).toHaveStyle({ maxWidth: `${CHAT_LANE_MAX_WIDTH}px` });
     expect(lane.className).toContain("md:max-w-[880px]");
+    expect(screen.getByTestId("composer-shell")).toHaveStyle({
+      maxWidth: `${CHAT_STAGE_MAX_WIDTH}px`,
+    });
     expect(screen.getByTestId("composer-stub")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/chat/chatLane.ts
+++ b/frontend/src/features/chat/chatLane.ts
@@ -1,1 +1,16 @@
+// Canonical chat lane width used by message stack, approval rail, and composer.
 export const CHAT_LANE_MAX_WIDTH = 880;
+
+// Inline gutter applied around the lane when deriving shell widths. Mirrors
+// the default `--shell-gap` token to keep layout token-driven.
+export const CHAT_LANE_INLINE_GUTTER = 16;
+
+// Shell boundary that keeps the composer frame aligned with the lane while
+// leaving a consistent gutter on either side.
+export const CHAT_STAGE_MAX_WIDTH =
+  CHAT_LANE_MAX_WIDTH + CHAT_LANE_INLINE_GUTTER * 2;
+
+// Token-friendly padding expression reused by chat surfaces so portrait and
+// fullscreen share the same baseline inset without bespoke numbers.
+export const CHAT_LANE_INLINE_PADDING =
+  "max(var(--page-pad, 0px), var(--shell-gap, 16px))";


### PR DESCRIPTION
## Summary
- Define shared chat lane padding, gutter, and stage width constants to keep messages, approval rail, and composer aligned
- Apply token-driven inline padding to the chat scroll container so portrait gutters stay intact while scaling on wide viewports
- Center the composer shell to the shared stage width and assert alignment in session-tab tests

## Testing
- pnpm test