### PR TITLE
fix(ui): stabilize app-shell fetch frequency and reduce request noise

### DIFF
--- a/frontend/src/components/ProviderSelect.tsx
+++ b/frontend/src/components/ProviderSelect.tsx
@@ -5,7 +5,7 @@
  */
 
 import { ChevronDown, ChevronLeft, Loader2 } from "lucide-react";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { usePreferredProvider } from "@/hooks/usePreferredProvider";
@@ -14,7 +14,6 @@ import {
   reconcilePreferredProviderSelection,
   setPreferredProviderSelection,
 } from "@/lib/providerPref";
-import { usePollWithBackoff } from "@/lib/polling/usePollWithBackoff";
 import { logOnce } from "@/lib/logging/logOnce";
 
 type ProviderSelectProps = {
@@ -87,7 +86,10 @@ export function ProviderSelect({
   const [activeProviderId, setActiveProviderId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
-  const CATALOG_POLL_MS = 15_000;
+  const hasFetchedRef = useRef(false);
+  const lastOpenSignalRef = useRef<number | null>(
+    typeof openSignal === "number" && openSignal > 0 ? openSignal : null
+  );
 
   const loadCatalog = useCallback(async (options: { throwOnError?: boolean; silent?: boolean } = {}) => {
     if (!options.silent) {
@@ -189,6 +191,8 @@ export function ProviderSelect({
   }, []);
 
   useEffect(() => {
+    if (hasFetchedRef.current) return;
+    hasFetchedRef.current = true;
     void loadCatalog();
   }, [loadCatalog]);
 
@@ -238,19 +242,10 @@ export function ProviderSelect({
         ? preferredProviderId || owningProviderId || null
         : null;
     setActiveProviderId(initialProvider);
+    if (lastOpenSignalRef.current === openSignal) return;
+    lastOpenSignalRef.current = openSignal;
     void loadCatalog();
   }, [openSignal, loadCatalog, displayMode, preferredProviderId, owningProviderId]);
-
-  usePollWithBackoff(
-    () => loadCatalog({ throwOnError: true, silent: true }),
-    {
-      intervalMs: CATALOG_POLL_MS,
-      maxBackoffMs: 60_000,
-      enabled: open,
-      onErrorKey: "poll:llm-catalog",
-      logTtlMs: 10_000,
-    }
-  );
 
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {

--- a/frontend/src/components/__tests__/ProviderSelect.catalog.test.tsx
+++ b/frontend/src/components/__tests__/ProviderSelect.catalog.test.tsx
@@ -97,8 +97,9 @@ describe("ProviderSelect catalog routing", () => {
     render(<ProviderSelect value="default" onChange={onChange} openSignal={1} />);
 
     await waitFor(() =>
-      expect(api.get).toHaveBeenCalledWith("/llm/catalog")
+      expect(api.get).toHaveBeenCalledTimes(1)
     );
+    expect(api.get).toHaveBeenCalledWith("/llm/catalog");
     expect(screen.getByText("Select Provider")).toBeInTheDocument();
     expect(screen.getByText("tailscale-server:11434")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Groq" })).toBeInTheDocument();
@@ -172,7 +173,7 @@ describe("ProviderSelect catalog routing", () => {
     rerender(<ProviderSelect value="default" onChange={vi.fn()} openSignal={2} />);
 
     await waitFor(() =>
-      expect((api.get as any).mock.calls.length).toBeGreaterThanOrEqual(2)
+      expect((api.get as any).mock.calls.length).toBe(2)
     );
     await waitFor(() => {
       expect(screen.queryByRole("button", { name: "Groq" })).not.toBeInTheDocument();

--- a/frontend/src/components/persona/layout/AppShell.tsx
+++ b/frontend/src/components/persona/layout/AppShell.tsx
@@ -604,6 +604,7 @@ export default function AppShell({
     const parsed = Number(raw);
     return Number.isFinite(parsed) ? parsed : null;
   });
+  const hasFetchedGeneralProjectRef = React.useRef(false);
   const [activeThreadProjectId, setActiveThreadProjectId] = useState<number | null>(null);
   const [projectScopeMode, setProjectScopeMode] = useState<"thread" | "project">(
     () => (readRouteThreadId() != null ? "thread" : "project")
@@ -654,11 +655,22 @@ export default function AppShell({
         cancelled = true;
       };
     }
+    if (generalProjectId != null) {
+      return () => {
+        cancelled = true;
+      };
+    }
+    if (hasFetchedGeneralProjectRef.current) {
+      return () => {
+        cancelled = true;
+      };
+    }
     if (!checkAuthGate(auth, "projects list load")) {
       return () => {
         cancelled = true;
       };
     }
+    hasFetchedGeneralProjectRef.current = true;
     (async () => {
       try {
         const response = await api.get("/api/projects");
@@ -681,7 +693,7 @@ export default function AppShell({
     return () => {
       cancelled = true;
     };
-  }, [auth, startupLocked]);
+  }, [auth, generalProjectId, startupLocked]);
   useEffect(() => {
     let cancelled = false;
     if (startupLocked) {

--- a/frontend/src/components/sidebar/__tests__/useProjectsCache.test.tsx
+++ b/frontend/src/components/sidebar/__tests__/useProjectsCache.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import api from "@/lib/api";
+import useProjectsCache from "../useProjectsCache";
+
+vi.mock("@/lib/api", () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/logging/logOnce", () => ({
+  logOnce: vi.fn(),
+}));
+
+function ProjectsHarness() {
+  const { projectList } = useProjectsCache();
+
+  return <div data-testid="project-count">{projectList.length}</div>;
+}
+
+describe("useProjectsCache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    (api.get as any).mockResolvedValue({
+      data: {
+        projects: [{ id: 1, name: "General", icon: "📁" }],
+      },
+    });
+  });
+
+  it("fetches projects once on mount and ignores focus churn", async () => {
+    render(<ProjectsHarness />);
+
+    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(1));
+    expect(api.get).toHaveBeenCalledWith("/api/projects");
+    expect(await screen.findByTestId("project-count")).toHaveTextContent("1");
+
+    window.dispatchEvent(new Event("focus"));
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(1));
+  });
+});

--- a/frontend/src/components/sidebar/useProjectsCache.ts
+++ b/frontend/src/components/sidebar/useProjectsCache.ts
@@ -1,11 +1,10 @@
 /**
  * useProjectsCache - maintains a stable project list cache and loose-thread count.
  */
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import api from "@/lib/api";
 import type { Project } from "@/types/common";
 import type { Thread } from "@/types/ui";
-import { usePollWithBackoff } from "@/lib/polling/usePollWithBackoff";
 import { logOnce } from "@/lib/logging/logOnce";
 
 type UseProjectsCacheOptions = {
@@ -21,8 +20,6 @@ type UseProjectsCacheResult = {
 };
 
 const STORAGE_KEY = "cfy.projectsCache";
-const PROJECTS_POLL_MS = 30_000;
-
 function normalizeProjectName(value: unknown): string {
   return String(value ?? "")
     .trim()
@@ -150,6 +147,7 @@ export function useProjectsCache({
     const cache = readProjectsCache();
     return cache.length ? cache : initialProjects;
   });
+  const hasFetchedRef = useRef(false);
 
   useEffect(() => {
     if (!initialProjects.length) return;
@@ -205,32 +203,10 @@ export function useProjectsCache({
     }
   }, []);
 
-  // Hydrate on mount
-  usePollWithBackoff(
-    () => refreshProjectsFromServer({ throwOnError: true }),
-    {
-      intervalMs: PROJECTS_POLL_MS,
-      maxBackoffMs: 120_000,
-      enabled: true,
-      onErrorKey: "poll:projects",
-      logTtlMs: 10_000,
-    }
-  );
-
-  // Refresh when focus or visibility regained
   useEffect(() => {
-    const onFocus = () => { void refreshProjectsFromServer(); };
-    const onVisible = () => {
-      if (document.visibilityState === "visible") {
-        void refreshProjectsFromServer();
-      }
-    };
-    window.addEventListener("focus", onFocus);
-    document.addEventListener("visibilitychange", onVisible);
-    return () => {
-      window.removeEventListener("focus", onFocus);
-      document.removeEventListener("visibilitychange", onVisible);
-    };
+    if (hasFetchedRef.current) return;
+    hasFetchedRef.current = true;
+    void refreshProjectsFromServer({ throwOnError: true });
   }, [refreshProjectsFromServer]);
 
   const looseCount = useMemo(

--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -41,7 +41,6 @@ import { getWrappedSessionTabId } from "@/state/session/hooks";
 import type { SessionTab, TabId } from "@/state/session/types";
 import type { RagTraceResponse } from "@/types/rag";
 import { fetchSystemPromptSummary, type PromptCostStatus, type SystemPromptSummary } from "@/imprint/api";
-import { usePollWithBackoff } from "@/lib/polling/usePollWithBackoff";
 import { logOnce } from "@/lib/logging/logOnce";
 import { useLlmCatalog } from "@/features/chat/hooks/useLlmCatalog";
 import { useInferenceRequestState } from "@/features/chat/hooks/useInferenceRequestState";
@@ -57,8 +56,7 @@ import { setPreferredProviderSelection } from "@/lib/providerPref";
 const DRAFT_KEY_PREFIX = "gc-draft:";
 const TURN_LOCK_TOAST =
   "Keep typing. Send unlocks when the current reply finishes.";
-const LLM_HEALTH_POLL_MS = 15000;
-const THREAD_PROFILE_POLL_MS = 15000;
+const LLM_HEALTH_POLL_MS = 5000;
 const NEW_THREAD_TITLE = "New Thread";
 
 /**
@@ -502,6 +500,7 @@ export function GuardianChat({
   const [promptCostPopoverOpen, setPromptCostPopoverOpen] = useState(false);
   const [providerMenuOpenSignal, setProviderMenuOpenSignal] = useState(0);
   const promptCostPopoverRef = useRef<HTMLDivElement | null>(null);
+  const profileThreadRef = useRef<number | null>(null);
   const showToast = useCallback((message: string) => {
     try {
       window.dispatchEvent(
@@ -762,13 +761,15 @@ export function GuardianChat({
       }
     }
   }, []);
-  usePollWithBackoff(() => refreshLlmHealth({ throwOnError: true }), {
-    intervalMs: LLM_HEALTH_POLL_MS,
-    maxBackoffMs: 60_000,
-    enabled: true,
-    onErrorKey: "poll:health-llm",
-    logTtlMs: 10_000,
-  });
+  useEffect(() => {
+    void refreshLlmHealth();
+    const timer = window.setInterval(() => {
+      void refreshLlmHealth();
+    }, LLM_HEALTH_POLL_MS);
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [refreshLlmHealth]);
   const llmBackendUnavailable =
     llmHealth.status === "offline" || llmHealth.status === "misconfigured";
   const cloudProvidersDisabled = /ALLOW_CLOUD_PROVIDERS\s*=\s*false/i.test(
@@ -1241,25 +1242,14 @@ export function GuardianChat({
 
   useEffect(() => {
     if (effectiveThreadId == null) {
+      profileThreadRef.current = null;
       applyProfileFallback();
       return;
     }
+    if (profileThreadRef.current === effectiveThreadId) return;
+    profileThreadRef.current = effectiveThreadId;
     void refreshThreadProfile(effectiveThreadId);
   }, [applyProfileFallback, effectiveThreadId, refreshThreadProfile]);
-
-  usePollWithBackoff(
-    async () => {
-      if (effectiveThreadId == null) return;
-      await refreshThreadProfile(effectiveThreadId, { throwOnError: true });
-    },
-    {
-      intervalMs: THREAD_PROFILE_POLL_MS,
-      maxBackoffMs: 60_000,
-      enabled: effectiveThreadId != null,
-      onErrorKey: "poll:chat-profile",
-      logTtlMs: 10_000,
-    }
-  );
 
   useEffect(() => {
     setPromptCostPopoverOpen(false);

--- a/frontend/src/features/chat/__tests__/GuardianChat.catalog-options.test.tsx
+++ b/frontend/src/features/chat/__tests__/GuardianChat.catalog-options.test.tsx
@@ -1,8 +1,12 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import GuardianChat from "@/features/chat/GuardianChat";
 import api from "@/lib/api";
+
+function countGetCalls(url: string): number {
+  return (api.get as any).mock.calls.filter((call: [string]) => call[0] === url).length;
+}
 
 vi.mock("@/lib/api", () => ({
   default: {
@@ -253,5 +257,88 @@ describe("GuardianChat catalog-backed model options", () => {
     expect(screen.getByText("Namespace archive")).toBeInTheDocument();
     expect(screen.queryByText("library2/qwen3:4b")).not.toBeInTheDocument();
     expect(screen.queryByText("archive/qwen3:4b")).not.toBeInTheDocument();
+  });
+
+  it("fetches catalog, health, and profile data once on mount", async () => {
+    (api.get as any).mockImplementation(async (url: string) => {
+      if (url === "/llm/catalog") {
+        return {
+          data: {
+            providers: [
+              {
+                id: "local",
+                displayName: "Local",
+                enabled: true,
+                authorized: true,
+                available: true,
+                source: {
+                  kind: "local",
+                  baseUrl: "http://127.0.0.1:11434/v1",
+                  label: "127.0.0.1:11434",
+                },
+                models: [{ id: "library2/qwen3:4b", displayName: "Qwen 3 4B · library2" }],
+              },
+            ],
+          },
+        };
+      }
+      if (url === "/health/llm") {
+        return {
+          data: {
+            ok: true,
+            status: "online",
+            provider: "local",
+            model: "library2/qwen3:4b",
+            error: null,
+          },
+        };
+      }
+      if (url === "/chat/123/profile") {
+        return {
+          data: {
+            profile: {
+              id: "default",
+              name: "Default",
+              mode: "cloud",
+            },
+            profiles: [
+              {
+                id: "default",
+                name: "Default",
+                mode: "cloud",
+              },
+            ],
+          },
+        };
+      }
+      return { data: {} };
+    });
+
+    render(
+      <GuardianChat
+        guardianName="Guardian"
+        userName="tester"
+        activeThread={{ id: "123", title: "Persisted" } as any}
+        onSendMessage={vi.fn().mockResolvedValue(undefined)}
+        onNewChat={vi.fn()}
+        sessionTabs={[
+          {
+            tabId: "tab-1",
+            title: "Tab 1",
+            providerId: "local",
+            modelId: "library2/qwen3:4b",
+            createdAt: "2026-03-06T00:00:00.000Z",
+            updatedAt: "2026-03-06T00:00:00.000Z",
+          } as any,
+        ]}
+        activeSessionTabId={"tab-1" as any}
+      />
+    );
+
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith("/chat/123/profile"));
+
+    expect(countGetCalls("/llm/catalog")).toBe(1);
+    expect(countGetCalls("/health/llm")).toBe(1);
+    expect(countGetCalls("/chat/123/profile")).toBe(1);
   });
 });

--- a/frontend/src/features/chat/hooks/useLlmCatalog.ts
+++ b/frontend/src/features/chat/hooks/useLlmCatalog.ts
@@ -1,8 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import api, { buildLlmCatalogPath } from "@/lib/api";
 import { logOnce } from "@/lib/logging/logOnce";
-import { usePollWithBackoff } from "@/lib/polling/usePollWithBackoff";
 import type { ComposerInferenceMode } from "@/types/inference";
 
 type CatalogReasoningRuntime = {
@@ -48,8 +47,6 @@ export type LlmCatalogProvider = {
   };
   models: LlmCatalogModel[];
 };
-
-const CATALOG_POLL_MS = 15_000;
 
 function normalizeString(value: unknown): string | null {
   if (typeof value !== "string") return null;
@@ -185,6 +182,7 @@ export function useLlmCatalog() {
   const [providers, setProviders] = useState<LlmCatalogProvider[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const hasFetchedRef = useRef(false);
 
   const loadCatalog = useCallback(
     async (options: { silent?: boolean; throwOnError?: boolean } = {}) => {
@@ -223,19 +221,10 @@ export function useLlmCatalog() {
   );
 
   useEffect(() => {
+    if (hasFetchedRef.current) return;
+    hasFetchedRef.current = true;
     void loadCatalog();
   }, [loadCatalog]);
-
-  usePollWithBackoff(
-    () => loadCatalog({ silent: true, throwOnError: true }),
-    {
-      intervalMs: CATALOG_POLL_MS,
-      maxBackoffMs: 60_000,
-      enabled: true,
-      onErrorKey: "poll:guardian-llm-catalog",
-      logTtlMs: 10_000,
-    }
-  );
 
   const models = useMemo(
     () => providers.flatMap((provider) => provider.models),

--- a/frontend/src/features/commandCenter/hooks/useHealthSummary.ts
+++ b/frontend/src/features/commandCenter/hooks/useHealthSummary.ts
@@ -14,7 +14,7 @@ import type {
   CommandCenterHealthStatus,
 } from "@/features/commandCenter/types";
 
-const POLL_INTERVAL_MS = 15_000;
+const POLL_INTERVAL_MS = 5_000;
 
 type UseHealthSummaryOptions = {
   enabled: boolean;


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
