### PR TITLE
fix(chat): restore completion compatibility after multimodal gating

### DIFF
--- a/guardian/core/chat_completion_service.py
+++ b/guardian/core/chat_completion_service.py
@@ -223,16 +223,45 @@ def _build_document_context_message(
     if not isinstance(docs, dict):
         return None, 0
 
-    sources = []
-    for scope in ("thread", "project"):
-        items = docs.get(scope)
-        if isinstance(items, list):
-            sources.extend(
-                [(scope, item) for item in items if isinstance(item, dict)]
-            )
+    thread_docs = docs.get("thread")
+    project_docs = docs.get("project")
+    thread_items = (
+        [item for item in thread_docs if isinstance(item, dict)]
+        if isinstance(thread_docs, list)
+        else []
+    )
+    project_items = (
+        [item for item in project_docs if isinstance(item, dict)]
+        if isinstance(project_docs, list)
+        else []
+    )
 
+    sources: list[tuple[str, dict[str, Any]]] = [
+        ("thread", item) for item in thread_items
+    ] + [("project", item) for item in project_items]
     if not sources:
         return None, 0
+
+    thread_only = bool(thread_items) and not project_items
+    project_only = bool(project_items) and not thread_items
+    if thread_only:
+        message_prefix = (
+            "Thread-linked document excerpts are available for this "
+            "conversation. Use them when they help answer the user's "
+            "request.\n\nThread documents:\n"
+        )
+    elif project_only:
+        message_prefix = (
+            "Project-linked document excerpts are available for this "
+            "conversation. Use them when they help answer the user's "
+            "request.\n\nProject documents:\n"
+        )
+    else:
+        message_prefix = (
+            "Linked document excerpts are available for this conversation. "
+            "Use them when they help answer the user's request.\n\n"
+            "Documents:\n"
+        )
 
     lines: list[str] = []
     for scope, item in sources:
@@ -243,8 +272,11 @@ def _build_document_context_message(
         if isinstance(provenance, dict):
             relation = str(provenance.get("relation") or "").strip().lower()
         relation_prefix = f"[{relation}] " if relation else ""
-        scope_prefix = "[thread] " if scope == "thread" else "[project] "
-        prefix = scope_prefix + relation_prefix
+        if thread_only or project_only:
+            prefix = relation_prefix
+        else:
+            scope_prefix = "[thread] " if scope == "thread" else "[project] "
+            prefix = scope_prefix + relation_prefix
         if excerpt:
             lines.append(f"- {prefix}{title}: {excerpt}")
         else:
@@ -253,12 +285,7 @@ def _build_document_context_message(
     if not lines:
         return None, 0
 
-    return (
-        "Linked document excerpts are available for this conversation. "
-        "Use them when they help answer the user's request.\n\n"
-        "Documents:\n" + "\n".join(lines),
-        len(sources),
-    )
+    return (message_prefix + "\n".join(lines), len(sources))
 
 
 async def build_messages_for_llm(

--- a/guardian/workers/chat_worker.py
+++ b/guardian/workers/chat_worker.py
@@ -75,6 +75,32 @@ _embed_message = _chat_completion_service._embed_message
 _ORIGINAL_BUILD_MESSAGES_FOR_LLM = (
     _chat_completion_service.build_messages_for_llm
 )
+_ORIGINAL_BUILD_CONTEXT_SYSTEM_MESSAGE_WITH_META = (
+    _chat_completion_service.build_context_system_message_with_meta
+)
+
+
+def build_context_system_message(bundle: dict[str, Any] | None) -> str | None:
+    """Compatibility seam for legacy tests/hooks that patch this symbol."""
+    message, _meta = _ORIGINAL_BUILD_CONTEXT_SYSTEM_MESSAGE_WITH_META(bundle)
+    return message
+
+
+def _build_context_system_message_with_meta_compat(
+    bundle: dict[str, Any] | None,
+) -> tuple[str | None, dict[str, Any]]:
+    message, meta = _ORIGINAL_BUILD_CONTEXT_SYSTEM_MESSAGE_WITH_META(bundle)
+    renderer = globals().get("build_context_system_message")
+    if callable(renderer):
+        try:
+            compat_message = renderer(bundle)
+        except Exception:
+            compat_message = None
+        if isinstance(compat_message, str):
+            cleaned = compat_message.strip()
+            if cleaned:
+                message = cleaned
+    return message, meta
 
 
 def _resolve_media_items(*_args: Any, **_kwargs: Any) -> list[Any]:
@@ -950,6 +976,9 @@ def _sync_build_messages_compat_seams() -> None:
     _chat_completion_service.ContextBroker = ContextBroker
     _chat_completion_service.build_guardian_system_prompt = (
         build_guardian_system_prompt
+    )
+    _chat_completion_service.build_context_system_message_with_meta = (
+        _build_context_system_message_with_meta_compat
     )
 
 

--- a/tests/test_chat_worker_turn_integrity.py
+++ b/tests/test_chat_worker_turn_integrity.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from typing import Any
 
 from guardian.tasks.types import ChatCompletionTask
@@ -26,16 +27,17 @@ def _isolate_turn_anchor(monkeypatch) -> None:
 def _build_task(
     *,
     task_id: str = "task-1",
-    turn_id: str = "11111111-1111-4111-8111-111111111111",
+    turn_id: str | None = None,
 ) -> ChatCompletionTask:
+    resolved_turn_id = turn_id or str(uuid.uuid4())
     task = ChatCompletionTask(
         task_id=task_id,
         thread_id=7,
         provider="local",
         model="test-model",
-        origin=f"api:chat.complete|turn_id={turn_id}",
+        origin=f"api:chat.complete|turn_id={resolved_turn_id}",
     )
-    task.turn_id = turn_id
+    task.turn_id = resolved_turn_id
     task.turn_lock_owner = task_id
     return task
 
@@ -48,6 +50,14 @@ def test_metadata_persistence_failure_is_non_fatal(monkeypatch):
     monkeypatch.setattr(chat_worker, "is_cancelled", lambda *_args: False)
     monkeypatch.setattr(chat_worker, "clear_cancelled", lambda *_args: None)
     monkeypatch.setattr(chat_worker, "release_turn_lock", lambda *_args: True)
+    monkeypatch.setattr(
+        chat_worker, "_find_assistant_message_for_turn", lambda **_kwargs: None
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_find_assistant_message_id_by_turn_id",
+        lambda **_kwargs: None,
+    )
     monkeypatch.setattr(
         chat_worker,
         "run_chat_completion_task",
@@ -230,6 +240,14 @@ def test_payload_summary_propagates_to_metadata_and_events(monkeypatch):
     monkeypatch.setattr(chat_worker, "is_cancelled", lambda *_args: False)
     monkeypatch.setattr(chat_worker, "clear_cancelled", lambda *_args: None)
     monkeypatch.setattr(chat_worker, "release_turn_lock", lambda *_args: True)
+    monkeypatch.setattr(
+        chat_worker, "_find_assistant_message_for_turn", lambda **_kwargs: None
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_find_assistant_message_id_by_turn_id",
+        lambda **_kwargs: None,
+    )
 
     def _fake_run_chat_completion(task, *_args, **_kwargs):
         persisted_meta.append({"payload_summary": sample_summary})


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
