### PR TITLE
Fix chat model selection by capability

### DIFF
--- a/frontend/src/components/ProviderSelect.tsx
+++ b/frontend/src/components/ProviderSelect.tsx
@@ -11,6 +11,10 @@ import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuIte
 import { usePreferredProvider } from "@/hooks/usePreferredProvider";
 import api, { buildLlmCatalogPath } from "@/lib/api";
 import {
+  describeModelCapability,
+  isChatSelectableModel,
+} from "@/features/chat/hooks/useLlmCatalog";
+import {
   reconcilePreferredProviderSelection,
   setPreferredProviderSelection,
 } from "@/lib/providerPref";
@@ -32,8 +36,14 @@ type CatalogModel = {
   id: string;
   displayName: string;
   contextWindow?: number;
+  supportsChat?: boolean;
+  supportsVision?: boolean;
+  supportsTextInput?: boolean;
+  modelKind?: "chat" | "vision_chat" | "utility";
   capabilities?: {
+    chat?: boolean;
     vision?: boolean;
+    textInput?: boolean;
     tools?: boolean;
     streaming?: boolean;
   };
@@ -149,11 +159,49 @@ export function ProviderSelect({
                     typeof (model as any).contextWindow === "number"
                       ? (model as any).contextWindow
                       : undefined,
+                  supportsChat:
+                    typeof (model as any).supports_chat === "boolean"
+                      ? (model as any).supports_chat
+                      : typeof (model as any).supportsChat === "boolean"
+                        ? (model as any).supportsChat
+                        : typeof (model as any).capabilities?.chat === "boolean"
+                          ? (model as any).capabilities.chat
+                          : undefined,
+                  supportsVision:
+                    typeof (model as any).supports_vision === "boolean"
+                      ? (model as any).supports_vision
+                      : typeof (model as any).supportsVision === "boolean"
+                        ? (model as any).supportsVision
+                        : typeof (model as any).capabilities?.vision === "boolean"
+                          ? (model as any).capabilities.vision
+                          : undefined,
+                  supportsTextInput:
+                    typeof (model as any).supports_text_input === "boolean"
+                      ? (model as any).supports_text_input
+                      : typeof (model as any).supportsTextInput === "boolean"
+                        ? (model as any).supportsTextInput
+                        : typeof (model as any).capabilities?.textInput === "boolean"
+                          ? (model as any).capabilities.textInput
+                          : undefined,
+                  modelKind:
+                    typeof (model as any).model_kind === "string"
+                      ? (model as any).model_kind
+                      : typeof (model as any).modelKind === "string"
+                        ? (model as any).modelKind
+                        : undefined,
                   capabilities:
                     typeof (model as any).capabilities === "object"
                     && (model as any).capabilities
                       ? {
+                          chat:
+                            typeof (model as any).capabilities.chat === "boolean"
+                              ? (model as any).capabilities.chat
+                              : undefined,
                           vision: Boolean((model as any).capabilities.vision),
+                          textInput:
+                            typeof (model as any).capabilities.textInput === "boolean"
+                              ? (model as any).capabilities.textInput
+                              : undefined,
                           tools: Boolean((model as any).capabilities.tools),
                           streaming: Boolean((model as any).capabilities.streaming),
                         }
@@ -162,7 +210,7 @@ export function ProviderSelect({
                 .filter((model) => model.id.length > 0)
             : [],
         }))
-        .filter((entry) => entry.id.length > 0 && entry.enabled);
+      .filter((entry) => entry.id.length > 0 && entry.enabled);
 
       setProviders(normalizedProviders);
       reconcilePreferredProviderSelection(normalizedProviders);
@@ -201,7 +249,7 @@ export function ProviderSelect({
   const selectedProvider = useMemo(() => {
     if (selectedRaw === "default") return null;
     const byModel = providers.find((entry) =>
-      entry.models.some((model) => model.id === selectedRaw)
+      entry.models.some((model) => isChatSelectableModel(model) && model.id === selectedRaw)
     );
     if (byModel) return byModel;
     return providers.find((entry) => entry.id === selectedRaw) ?? null;
@@ -209,7 +257,8 @@ export function ProviderSelect({
 
   const selectedModel = useMemo(() => {
     if (!selectedProvider) return null;
-    return selectedProvider.models.find((m) => m.id === selectedRaw) ?? null;
+    const chatModels = selectedProvider.models.filter(isChatSelectableModel);
+    return chatModels.find((m) => m.id === selectedRaw) ?? chatModels[0] ?? null;
   }, [selectedProvider, selectedRaw]);
 
   const owningProviderId = useMemo(() => {
@@ -280,7 +329,9 @@ export function ProviderSelect({
           setPreferredProviderSelection(null);
         } else {
           const providerFromModel = providers.find((entry) =>
-            entry.models.some((model) => model.id === normalizedModel)
+            entry.models.some(
+              (model) => isChatSelectableModel(model) && model.id === normalizedModel
+            )
           );
           const providerValue = providerFromModel?.id || null;
           if (providerValue) setProvider(providerValue);
@@ -309,7 +360,9 @@ export function ProviderSelect({
       }
 
       const providerFromModel = providers.find((entry) =>
-        entry.models.some((model) => model.id === normalizedModel)
+        entry.models.some(
+          (model) => isChatSelectableModel(model) && model.id === normalizedModel
+        )
       );
       const providerValue = providerFromModel?.id || null;
       if (providerValue) {
@@ -384,7 +437,9 @@ export function ProviderSelect({
                 Source: {describeProviderSource(activeProvider.source)}
               </div>
             ) : null}
-            {activeProvider.models.map((model) => (
+            {activeProvider.models
+              .filter(isChatSelectableModel)
+              .map((model) => (
               <DropdownMenuItem
                 key={model.id}
                 disabled={!activeProvider.available}
@@ -401,7 +456,12 @@ export function ProviderSelect({
                 }}
               >
                 <span className="flex items-center justify-between w-full gap-2">
-                  <span className="truncate">{model.displayName}</span>
+                  <span className="min-w-0">
+                    <span className="block truncate">{model.displayName}</span>
+                    <span className="block truncate text-[10px] opacity-65">
+                      {describeModelCapability(model)}
+                    </span>
+                  </span>
                   <span className="inline-flex items-center gap-1">
                     {typeof model.contextWindow === "number" ? (
                       <span
@@ -418,8 +478,10 @@ export function ProviderSelect({
                 </span>
               </DropdownMenuItem>
             ))}
-            {activeProvider.models.length === 0 ? (
-              <div className="px-3 py-2 text-xs opacity-75">No models available.</div>
+            {activeProvider.models.filter(isChatSelectableModel).length === 0 ? (
+              <div className="px-3 py-2 text-xs opacity-75">
+                No chat-capable models available.
+              </div>
             ) : null}
             {!activeProvider.available && activeProvider.disabled_reason ? (
               <div
@@ -432,13 +494,19 @@ export function ProviderSelect({
           </div>
         ) : (
           <div className="transition-all duration-150 ease-out">
-            {providers.map((entry) => (
+            {providers.map((entry) => {
+              const chatModels = entry.models.filter(isChatSelectableModel);
+              return (
               <DropdownMenuItem
                 key={entry.id}
+                aria-label={entry.displayName}
                 onClick={(event) => {
                   event.preventDefault();
-                  setActiveProviderId(entry.id);
+                  if (chatModels.length > 0) {
+                    setActiveProviderId(entry.id);
+                  }
                 }}
+                disabled={chatModels.length === 0}
                 style={{ color: "var(--text)" }}
               >
                 <span className="flex items-center justify-between w-full gap-2">
@@ -450,12 +518,20 @@ export function ProviderSelect({
                       </span>
                     ) : null}
                   </span>
+                  {chatModels.length > 0 ? (
+                    <span className="text-[10px] opacity-70">
+                      {chatModels.length} chat model{chatModels.length === 1 ? "" : "s"}
+                    </span>
+                  ) : (
+                    <span className="text-[10px] opacity-70">No chat models</span>
+                  )}
                   {!entry.available ? (
                     <span className="text-[10px] opacity-70">Unavailable</span>
                   ) : null}
                 </span>
               </DropdownMenuItem>
-            ))}
+              );
+            })}
             {providers.length === 0 ? (
               <div className="px-3 py-2 text-xs opacity-75">No providers available.</div>
             ) : null}

--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -43,7 +43,11 @@ import type { SessionTab, TabId } from "@/state/session/types";
 import type { RagTraceResponse } from "@/types/rag";
 import { fetchSystemPromptSummary, type PromptCostStatus, type SystemPromptSummary } from "@/imprint/api";
 import { logOnce } from "@/lib/logging/logOnce";
-import { useLlmCatalog } from "@/features/chat/hooks/useLlmCatalog";
+import {
+  describeModelCapability,
+  isChatSelectableModel,
+  useLlmCatalog,
+} from "@/features/chat/hooks/useLlmCatalog";
 import { useInferenceRequestState } from "@/features/chat/hooks/useInferenceRequestState";
 import {
   createIdleInferenceRequestState,
@@ -567,10 +571,14 @@ export function GuardianChat({
 
   const selectedProvider = useMemo(() => {
     const explicitProvider = getProviderById(activeProviderId);
-    if (explicitProvider) return explicitProvider;
+    if (explicitProvider && explicitProvider.models.some(isChatSelectableModel)) {
+      return explicitProvider;
+    }
     const providerFromModel = findProviderForModel(activeModelId);
     if (providerFromModel) return providerFromModel;
-    return catalogProviders[0] ?? null;
+    return catalogProviders.find((provider) =>
+      provider.models.some(isChatSelectableModel)
+    ) ?? null;
   }, [
     activeModelId,
     activeProviderId,
@@ -580,14 +588,16 @@ export function GuardianChat({
   ]);
 
   const selectedModel = useMemo(() => {
-    if (selectedProvider?.models?.length) {
+    const chatModels = selectedProvider?.models.filter(isChatSelectableModel) ?? [];
+    if (chatModels.length > 0) {
       return (
-        selectedProvider.models.find((model) => model.id === activeModelId) ??
-        selectedProvider.models[0] ??
+        chatModels.find((model) => model.id === activeModelId) ??
+        chatModels[0] ??
         null
       );
     }
-    return getModelById(activeModelId);
+    const catalogModel = getModelById(activeModelId);
+    return isChatSelectableModel(catalogModel) ? catalogModel : null;
   }, [activeModelId, getModelById, selectedProvider]);
 
   const providerOptions = useMemo(
@@ -595,24 +605,31 @@ export function GuardianChat({
       catalogProviders.map((provider) => ({
         value: provider.id,
         label: provider.displayName,
-        description: provider.available
-          ? [
-              `${provider.models.length} models`,
-              describeProviderSource(provider.source)
-                ? `Source ${describeProviderSource(provider.source)}`
-                : null,
-            ]
-              .filter(Boolean)
-              .join(" · ")
-          : provider.disabledReason || "Unavailable",
-        disabled: !provider.available,
+        description: (() => {
+          const chatModels = provider.models.filter(isChatSelectableModel);
+          if (!provider.available) {
+            return provider.disabledReason || "Unavailable";
+          }
+          if (chatModels.length === 0) {
+            return "No chat-capable models";
+          }
+          return [
+            `${chatModels.length} chat model${chatModels.length === 1 ? "" : "s"}`,
+            describeProviderSource(provider.source)
+              ? `Source ${describeProviderSource(provider.source)}`
+              : null,
+          ]
+            .filter(Boolean)
+            .join(" · ");
+        })(),
+        disabled: !provider.available || !provider.models.some(isChatSelectableModel),
       })),
     [catalogProviders]
   );
 
   const modelOptions = useMemo(
     () => {
-      const models = selectedProvider?.models ?? [];
+      const models = selectedProvider?.models.filter(isChatSelectableModel) ?? [];
       const providerSourceLabel = describeProviderSource(selectedProvider?.source);
       const modelsByLabel = new Map<string, typeof models>();
 
@@ -629,10 +646,16 @@ export function GuardianChat({
       return models.map((model) => {
         const label = getModelMenuLabel(model);
         const siblingModels = modelsByLabel.get(getModelLabelKey(model)) ?? [model];
+        const capabilityLabel = describeModelCapability(model);
         const description =
           siblingModels.length > 1
-            ? getModelDifferentiator(model, siblingModels, providerSourceLabel)
-            : undefined;
+            ? [
+                getModelDifferentiator(model, siblingModels, providerSourceLabel),
+                capabilityLabel,
+              ]
+                .filter(Boolean)
+                .join(" · ")
+            : capabilityLabel;
 
         return {
           value: model.id,
@@ -642,6 +665,10 @@ export function GuardianChat({
             typeof model.contextWindow === "number"
               ? `${Math.round(model.contextWindow / 1000)}k`
               : null,
+          supportsChat: model.supportsChat,
+          supportsVision: model.supportsVision,
+          supportsTextInput: model.supportsTextInput,
+          modelKind: model.modelKind,
         };
       });
     },
@@ -2535,12 +2562,15 @@ export function GuardianChat({
 
                   onSessionProviderChange?.(providerId);
 
-                  const nextModelId = nextProvider?.models?.[0]?.id ?? null;
+                  const nextModelId =
+                    nextProvider?.models.find(isChatSelectableModel)?.id ?? null;
 
                   if (
                     nextProvider &&
                     (!selectedModel ||
-                      !nextProvider.models.some((m) => m.id === selectedModel.id)) &&
+                      !nextProvider.models.some(
+                        (m) => isChatSelectableModel(m) && m.id === selectedModel.id
+                      )) &&
                     nextModelId
                   ) {
                     onSessionModelChange?.(nextModelId);

--- a/frontend/src/features/chat/__tests__/GuardianChat.catalog-options.test.tsx
+++ b/frontend/src/features/chat/__tests__/GuardianChat.catalog-options.test.tsx
@@ -41,14 +41,31 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
 }));
 
 vi.mock("@/features/chat/components", () => ({
-  Composer: ({ modelOptions }: { modelOptions?: Array<{ label: string; description?: string }> }) => (
+  Composer: ({
+    providerOptions,
+    modelOptions,
+  }: {
+    providerOptions?: Array<{ label: string; description?: string; disabled?: boolean }>;
+    modelOptions?: Array<{ label: string; description?: string }>;
+  }) => (
     <div data-testid="composer-stub">
+      <div data-testid="provider-options">
+        {(providerOptions ?? []).map((option, index) => (
+          <div key={`${option.label}-${option.description ?? "none"}-${index}`}>
+            <span>{option.label}</span>
+            {option.description ? <span>{option.description}</span> : null}
+            {option.disabled ? <span>disabled</span> : null}
+          </div>
+        ))}
+      </div>
+      <div data-testid="model-options">
       {(modelOptions ?? []).map((option, index) => (
         <div key={`${option.label}-${option.description ?? "none"}-${index}`}>
           <span>{option.label}</span>
           {option.description ? <span>{option.description}</span> : null}
         </div>
       ))}
+      </div>
     </div>
   ),
 }));
@@ -271,10 +288,107 @@ describe("GuardianChat catalog-backed model options", () => {
     );
 
     expect((await screen.findAllByText("Qwen 3 4B")).length).toBeGreaterThanOrEqual(2);
-    expect(screen.getByText("Namespace library2")).toBeInTheDocument();
-    expect(screen.getByText("Namespace archive")).toBeInTheDocument();
+    expect(
+      screen.getByText("Namespace library2 · Text-only chat")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Namespace archive · Text-only chat")
+    ).toBeInTheDocument();
     expect(screen.queryByText("library2/qwen3:4b")).not.toBeInTheDocument();
     expect(screen.queryByText("archive/qwen3:4b")).not.toBeInTheDocument();
+  });
+
+  it("filters utility models while labeling vision-capable and text-only chat models", async () => {
+    (api.get as any).mockImplementation(async (url: string) => {
+      if (url === "/llm/catalog") {
+        return {
+          data: {
+            providers: [
+              {
+                id: "local",
+                displayName: "Local",
+                enabled: true,
+                authorized: true,
+                available: true,
+                source: {
+                  kind: "local",
+                  baseUrl: "http://127.0.0.1:11434/v1",
+                  label: "127.0.0.1:11434",
+                },
+                models: [
+                  {
+                    id: "text-chat",
+                    canonical_id: "text-chat",
+                    display_label: "Text Chat",
+                    supports_chat: true,
+                    supports_vision: false,
+                    supports_text_input: true,
+                    model_kind: "chat",
+                  },
+                  {
+                    id: "vision-chat",
+                    canonical_id: "vision-chat",
+                    display_label: "Vision Chat",
+                    supports_chat: true,
+                    supports_vision: true,
+                    supports_text_input: true,
+                    model_kind: "vision_chat",
+                  },
+                  {
+                    id: "text-embedding-3-small",
+                    canonical_id: "text-embedding-3-small",
+                    display_label: "Embedding",
+                    supports_chat: false,
+                    supports_vision: false,
+                    supports_text_input: true,
+                    model_kind: "utility",
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      }
+      if (url === "/health/llm") {
+        return {
+          data: {
+            ok: true,
+            status: "online",
+            provider: "local",
+            model: "text-chat",
+            error: null,
+          },
+        };
+      }
+      return { data: {} };
+    });
+
+    render(
+      <GuardianChat
+        guardianName="Guardian"
+        userName="tester"
+        activeThread={{ id: "draft", title: "Draft" } as any}
+        onSendMessage={vi.fn().mockResolvedValue(undefined)}
+        onNewChat={vi.fn()}
+        sessionTabs={[
+          {
+            tabId: "tab-1",
+            title: "Tab 1",
+            providerId: "local",
+            modelId: "text-chat",
+            createdAt: "2026-03-06T00:00:00.000Z",
+            updatedAt: "2026-03-06T00:00:00.000Z",
+          } as any,
+        ]}
+        activeSessionTabId={"tab-1" as any}
+      />
+    );
+
+    expect(await screen.findByText("Text Chat")).toBeInTheDocument();
+    expect(screen.getByText("Text-only chat")).toBeInTheDocument();
+    expect(screen.getByText("Vision-capable chat")).toBeInTheDocument();
+    expect(screen.queryByText("Embedding")).not.toBeInTheDocument();
+    expect(screen.getByText("2 chat models · Source 127.0.0.1:11434")).toBeInTheDocument();
   });
 
   it("fetches catalog, health, and profile data once on mount", async () => {

--- a/frontend/src/features/chat/__tests__/GuardianChat.turn-lock-lifecycle.test.tsx
+++ b/frontend/src/features/chat/__tests__/GuardianChat.turn-lock-lifecycle.test.tsx
@@ -318,6 +318,20 @@ vi.mock("@/features/chat/hooks/useInferenceRequestState", () => ({
 }));
 
 vi.mock("@/features/chat/hooks/useLlmCatalog", () => ({
+  isChatSelectableModel: (model: {
+    supportsChat?: boolean;
+    modelKind?: string;
+  } | null | undefined) => Boolean(model && model.supportsChat !== false && model.modelKind !== "utility"),
+  describeModelCapability: (model: {
+    supportsVision?: boolean;
+    supportsChat?: boolean;
+    modelKind?: string;
+  } | null | undefined) =>
+    !model || model.supportsChat === false || model.modelKind === "utility"
+      ? "Utility model"
+      : model.supportsVision
+        ? "Vision-capable chat"
+        : "Text-only chat",
   useLlmCatalog: () => {
     const providers = [
       {
@@ -346,7 +360,9 @@ vi.mock("@/features/chat/hooks/useLlmCatalog", () => ({
         null,
       findProviderForModel: (modelId: string | null | undefined) =>
         providers.find((provider) =>
-          provider.models.some((model) => model.id === modelId)
+          provider.models.some(
+            (model) => model.id === modelId && model.modelKind !== "utility"
+          )
         ) ?? null,
     };
   },

--- a/frontend/src/features/chat/components/Composer.tsx
+++ b/frontend/src/features/chat/components/Composer.tsx
@@ -590,6 +590,18 @@ export function Composer({
     modelOptions.find((option) => option.value === activeModelId)?.label ??
     modelOptions[0]?.label ??
     "Model";
+  const hasImageAttachments = draftAttachments.some((att) => att.kind === "image");
+  const hasVisionCapableModel = modelOptions.some((option) => {
+    if (option.supportsChat === false || option.modelKind === "utility") {
+      return false;
+    }
+    return option.supportsVision === true;
+  });
+  const imageCapabilityMessage = hasImageAttachments
+    ? hasVisionCapableModel
+      ? "Image attached. Vision-capable chat models can inspect it; text-only chat models will not see it natively."
+      : "Image attached, but no vision-capable chat models are available for this provider."
+    : null;
   const inferenceModeLabel =
     inferenceModeOptions.find((option) => option.value === activeInferenceMode)
       ?.label ??
@@ -770,6 +782,11 @@ export function Composer({
               </Button>
             </div>
           </div>
+          {imageCapabilityMessage ? (
+            <div className="px-[12px] pb-[6px] text-[11px] leading-snug" style={{ color: "var(--muted)" }}>
+              {imageCapabilityMessage}
+            </div>
+          ) : null}
         </div>
       </div>
       <ImageGenModal

--- a/frontend/src/features/chat/components/ComposerSelectMenu.tsx
+++ b/frontend/src/features/chat/components/ComposerSelectMenu.tsx
@@ -15,6 +15,10 @@ export type ComposerSelectOption = {
   description?: string;
   meta?: string | null;
   disabled?: boolean;
+  supportsChat?: boolean;
+  supportsVision?: boolean;
+  supportsTextInput?: boolean;
+  modelKind?: "chat" | "vision_chat" | "utility";
 };
 
 type ComposerSelectMenuProps = {

--- a/frontend/src/features/chat/components/__tests__/Composer.draft-sync.test.tsx
+++ b/frontend/src/features/chat/components/__tests__/Composer.draft-sync.test.tsx
@@ -151,6 +151,68 @@ describe("Composer draft sync", () => {
     expect(onSend.mock.calls[0][1]).toEqual({ threadIdOverride: 123 });
   });
 
+  it("shows a vision capability notice when image attachments are staged", async () => {
+    const createObjectURLMock = vi.fn(() => "blob:preview");
+    const revokeObjectURLMock = vi.fn();
+    if (typeof window.URL.createObjectURL !== "function") {
+      Object.defineProperty(window.URL, "createObjectURL", {
+        configurable: true,
+        value: createObjectURLMock,
+      });
+    } else {
+      vi.spyOn(window.URL, "createObjectURL").mockImplementation(createObjectURLMock);
+    }
+    if (typeof window.URL.revokeObjectURL !== "function") {
+      Object.defineProperty(window.URL, "revokeObjectURL", {
+        configurable: true,
+        value: revokeObjectURLMock,
+      });
+    } else {
+      vi.spyOn(window.URL, "revokeObjectURL").mockImplementation(revokeObjectURLMock);
+    }
+
+    const { container } = render(
+      <Composer
+        onSend={vi.fn()}
+        draftScopeKey="tab-1"
+        draftValue=""
+        activeModelId="vision-chat"
+        modelOptions={[
+          {
+            value: "text-chat",
+            label: "Text Chat",
+            supportsChat: true,
+            supportsVision: false,
+            modelKind: "chat",
+          },
+          {
+            value: "vision-chat",
+            label: "Vision Chat",
+            supportsChat: true,
+            supportsVision: true,
+            modelKind: "vision_chat",
+          },
+        ]}
+      />
+    );
+
+    const fileInput = container.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+    const file = new File(["image"], "photo.png", {
+      type: "image/png",
+    });
+
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    expect(
+      screen.getByText(
+        "Image attached. Vision-capable chat models can inspect it; text-only chat models will not see it natively."
+      )
+    ).toBeInTheDocument();
+    expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+  });
+
   it("flushes previous tab draft and loads next tab initial draft on scope switch", () => {
     vi.useFakeTimers();
     const onDraftValueChange = vi.fn();

--- a/frontend/src/features/chat/hooks/useLlmCatalog.ts
+++ b/frontend/src/features/chat/hooks/useLlmCatalog.ts
@@ -21,8 +21,14 @@ export type LlmCatalogModel = {
   namespace?: string;
   source?: string;
   contextWindow?: number;
+  supportsChat?: boolean;
+  supportsVision?: boolean;
+  supportsTextInput?: boolean;
+  modelKind?: "chat" | "vision_chat" | "utility";
   capabilities?: {
+    chat?: boolean;
     vision?: boolean;
+    textInput?: boolean;
     tools?: boolean;
     streaming?: boolean;
   };
@@ -62,6 +68,42 @@ function normalizeReasoningMode(value: unknown): ComposerInferenceMode | null {
   return null;
 }
 
+function normalizeBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function normalizeModelKind(value: unknown): "chat" | "vision_chat" | "utility" | undefined {
+  const normalized = normalizeString(value);
+  if (
+    normalized === "chat" ||
+    normalized === "vision_chat" ||
+    normalized === "utility"
+  ) {
+    return normalized;
+  }
+  return undefined;
+}
+
+export function isChatSelectableModel(model: {
+  supportsChat?: boolean;
+  modelKind?: "chat" | "vision_chat" | "utility";
+} | null | undefined): boolean {
+  if (!model) return false;
+  if (model.supportsChat === false) return false;
+  return model.modelKind !== "utility";
+}
+
+export function describeModelCapability(model: {
+  supportsVision?: boolean;
+  supportsChat?: boolean;
+  modelKind?: "chat" | "vision_chat" | "utility";
+} | null | undefined): string {
+  if (!model || model.supportsChat === false || model.modelKind === "utility") {
+    return "Utility model";
+  }
+  return model.supportsVision ? "Vision-capable chat" : "Text-only chat";
+}
+
 function normalizeModel(
   providerId: string,
   raw: unknown
@@ -89,6 +131,29 @@ function normalizeModel(
     runtime && typeof runtime === "object"
       ? (runtime as Record<string, unknown>).reasoning
       : null;
+  const capabilities =
+    model.capabilities && typeof model.capabilities === "object"
+      ? (model.capabilities as Record<string, unknown>)
+      : null;
+  const supportsChat =
+    normalizeBoolean(model.supports_chat) ??
+    normalizeBoolean(model.supportsChat) ??
+    normalizeBoolean(capabilities?.chat) ??
+    (normalizeModelKind(model.model_kind ?? model.modelKind) !== "utility");
+  const supportsVision =
+    normalizeBoolean(model.supports_vision) ??
+    normalizeBoolean(model.supportsVision) ??
+    normalizeBoolean(capabilities?.vision) ??
+    false;
+  const supportsTextInput =
+    normalizeBoolean(model.supports_text_input) ??
+    normalizeBoolean(model.supportsTextInput) ??
+    normalizeBoolean(capabilities?.textInput) ??
+    normalizeBoolean(capabilities?.text_input) ??
+    supportsChat;
+  const modelKind =
+    normalizeModelKind(model.model_kind ?? model.modelKind) ??
+    (supportsChat ? (supportsVision ? "vision_chat" : "chat") : "utility");
 
   return {
     id: canonicalId,
@@ -104,14 +169,18 @@ function normalizeModel(
       typeof model.contextWindow === "number" && Number.isFinite(model.contextWindow)
         ? model.contextWindow
         : undefined,
+    supportsChat,
+    supportsVision,
+    supportsTextInput,
+    modelKind,
     capabilities:
-      model.capabilities && typeof model.capabilities === "object"
+      capabilities
         ? {
-            vision: Boolean((model.capabilities as Record<string, unknown>).vision),
-            tools: Boolean((model.capabilities as Record<string, unknown>).tools),
-            streaming: Boolean(
-              (model.capabilities as Record<string, unknown>).streaming
-            ),
+            chat: supportsChat,
+            vision: supportsVision,
+            textInput: supportsTextInput,
+            tools: Boolean(capabilities.tools),
+            streaming: Boolean(capabilities.streaming),
           }
         : undefined,
     runtime:
@@ -252,7 +321,9 @@ export function useLlmCatalog() {
       if (!modelId) return null;
       return (
         providers.find((provider) =>
-          provider.models.some((model) => model.id === modelId)
+          provider.models.some(
+            (model) => isChatSelectableModel(model) && model.id === modelId
+          )
         ) ?? null
       );
     },

--- a/guardian/core/llm_catalog.py
+++ b/guardian/core/llm_catalog.py
@@ -51,6 +51,13 @@ _MEANINGFUL_VARIANT_LABELS = {
     "thinking": "Thinking",
     "vl": "VL",
 }
+_LOCAL_VISION_HINTS = (
+    "image",
+    "vision",
+    "llava",
+    "vl",
+    "multimodal",
+)
 _QUANTIZATION_MARKER_RE = re.compile(
     r"^(?:q\d+(?:_[a-z0-9]+)*|bf16|f16|fp16|fp32|fp8|int4|int8)$",
     re.IGNORECASE,
@@ -82,6 +89,11 @@ def _base_model_entry(
     display_name: str | None = None,
     context_window: int | None = None,
     capabilities: dict[str, bool] | None = None,
+    *,
+    supports_chat: bool | None = None,
+    supports_vision: bool | None = None,
+    supports_text_input: bool | None = None,
+    model_kind: str | None = None,
 ) -> dict[str, Any]:
     clean_id = str(model_id or "").strip()
     clean_name = str(display_name or clean_id).strip() or clean_id
@@ -102,7 +114,29 @@ def _base_model_entry(
             for key, value in capabilities.items()
             if isinstance(value, bool)
         }
+    if isinstance(supports_chat, bool):
+        entry["supports_chat"] = supports_chat
+    if isinstance(supports_vision, bool):
+        entry["supports_vision"] = supports_vision
+    if isinstance(supports_text_input, bool):
+        entry["supports_text_input"] = supports_text_input
+    normalized_kind = str(model_kind or "").strip().lower()
+    if normalized_kind in {"chat", "vision_chat", "utility"}:
+        entry["model_kind"] = normalized_kind
     return entry
+
+
+def _local_model_capabilities(
+    model_id: str, display_name: str
+) -> dict[str, Any]:
+    haystack = f"{model_id} {display_name}".lower()
+    supports_vision = any(hint in haystack for hint in _LOCAL_VISION_HINTS)
+    return {
+        "supports_chat": True,
+        "supports_vision": supports_vision,
+        "supports_text_input": True,
+        "model_kind": "vision_chat" if supports_vision else "chat",
+    }
 
 
 def _split_local_model_id(model_id: str) -> tuple[str | None, str, str | None]:
@@ -381,7 +415,20 @@ def _fetch_local_models(settings: Settings) -> list[dict[str, Any]]:
         display_label = str(
             identity.get("alias") or identity.get("display_label") or name
         ).strip()
-        entry = _base_model_entry(name, display_name=display_label)
+        local_capabilities = _local_model_capabilities(name, display_label)
+        entry = _base_model_entry(
+            name,
+            display_name=display_label,
+            supports_chat=bool(local_capabilities["supports_chat"]),
+            supports_vision=bool(local_capabilities["supports_vision"]),
+            supports_text_input=bool(local_capabilities["supports_text_input"]),
+            model_kind=str(local_capabilities["model_kind"]),
+        )
+        entry["capabilities"] = {
+            "chat": bool(local_capabilities["supports_chat"]),
+            "vision": bool(local_capabilities["supports_vision"]),
+            "text_input": bool(local_capabilities["supports_text_input"]),
+        }
         entry["canonical_id"] = str(
             identity.get("canonical_id") or name
         ).strip()
@@ -409,6 +456,35 @@ def _cloud_models(
         model_id = str(item.get("id") or "").strip()
         if not model_id:
             continue
+        capabilities = (
+            item.get("capabilities")
+            if isinstance(item.get("capabilities"), dict)
+            else {}
+        )
+        supports_chat = (
+            item.get("supports_chat")
+            if isinstance(item.get("supports_chat"), bool)
+            else bool(capabilities.get("chat"))
+        )
+        supports_vision = (
+            item.get("supports_vision")
+            if isinstance(item.get("supports_vision"), bool)
+            else bool(capabilities.get("vision"))
+        )
+        supports_text_input = (
+            item.get("supports_text_input")
+            if isinstance(item.get("supports_text_input"), bool)
+            else bool(capabilities.get("text_input"))
+        )
+        model_kind = str(item.get("model_kind") or "").strip().lower()
+        if not model_kind:
+            model_kind = (
+                "vision_chat"
+                if supports_chat and supports_vision
+                else "chat"
+                if supports_chat
+                else "utility"
+            )
         entries.append(
             _base_model_entry(
                 model_id=model_id,
@@ -418,11 +494,11 @@ def _cloud_models(
                     if isinstance(item.get("contextWindow"), int)
                     else None
                 ),
-                capabilities=(
-                    item.get("capabilities")
-                    if isinstance(item.get("capabilities"), dict)
-                    else None
-                ),
+                capabilities=capabilities if capabilities else None,
+                supports_chat=bool(supports_chat),
+                supports_vision=bool(supports_vision),
+                supports_text_input=bool(supports_text_input),
+                model_kind=model_kind,
             )
         )
     return entries

--- a/guardian/core/provider_registry.py
+++ b/guardian/core/provider_registry.py
@@ -201,6 +201,19 @@ _MODEL_INDEX_NON_CHAT_HINTS = (
     "tts",
     "video",
 )
+_MODEL_INDEX_VISION_HINTS = (
+    "image",
+    "vision",
+    "vl",
+    "multimodal",
+)
+_MODEL_INDEX_TEXT_INPUT_HINTS = (
+    "embedding",
+    "embeddings",
+    "moderation",
+    "rerank",
+    "tts",
+)
 _DEFAULT_GROQ_MODEL_INDEX_BASE = "https://api.groq.com/openai/v1"
 
 _STATIC_PROVIDER_MODELS: dict[str, tuple[dict[str, Any], ...]] = {
@@ -210,12 +223,20 @@ _STATIC_PROVIDER_MODELS: dict[str, tuple[dict[str, Any], ...]] = {
             "displayName": "GPT-4o",
             "contextWindow": 128000,
             "capabilities": {"vision": True, "tools": True, "streaming": True},
+            "supports_chat": True,
+            "supports_vision": True,
+            "supports_text_input": True,
+            "model_kind": "vision_chat",
         },
         {
             "id": "gpt-4.1-mini",
             "displayName": "GPT-4.1 Mini",
             "contextWindow": 128000,
             "capabilities": {"vision": True, "tools": True, "streaming": True},
+            "supports_chat": True,
+            "supports_vision": True,
+            "supports_text_input": True,
+            "model_kind": "vision_chat",
         },
     ),
     "anthropic": (
@@ -224,12 +245,20 @@ _STATIC_PROVIDER_MODELS: dict[str, tuple[dict[str, Any], ...]] = {
             "displayName": "Claude 3.5 Sonnet",
             "contextWindow": 200000,
             "capabilities": {"vision": True, "tools": True, "streaming": True},
+            "supports_chat": True,
+            "supports_vision": True,
+            "supports_text_input": True,
+            "model_kind": "vision_chat",
         },
         {
             "id": "claude-3-5-haiku-latest",
             "displayName": "Claude 3.5 Haiku",
             "contextWindow": 200000,
             "capabilities": {"vision": True, "tools": True, "streaming": True},
+            "supports_chat": True,
+            "supports_vision": True,
+            "supports_text_input": True,
+            "model_kind": "vision_chat",
         },
     ),
     "gemini": (
@@ -238,12 +267,20 @@ _STATIC_PROVIDER_MODELS: dict[str, tuple[dict[str, Any], ...]] = {
             "displayName": "Gemini 1.5 Pro",
             "contextWindow": 1048576,
             "capabilities": {"vision": True, "tools": True, "streaming": True},
+            "supports_chat": True,
+            "supports_vision": True,
+            "supports_text_input": True,
+            "model_kind": "vision_chat",
         },
         {
             "id": "gemini-1.5-flash",
             "displayName": "Gemini 1.5 Flash",
             "contextWindow": 1048576,
             "capabilities": {"vision": True, "tools": True, "streaming": True},
+            "supports_chat": True,
+            "supports_vision": True,
+            "supports_text_input": True,
+            "model_kind": "vision_chat",
         },
     ),
     "groq": (
@@ -256,6 +293,10 @@ _STATIC_PROVIDER_MODELS: dict[str, tuple[dict[str, Any], ...]] = {
                 "tools": False,
                 "streaming": True,
             },
+            "supports_chat": True,
+            "supports_vision": False,
+            "supports_text_input": True,
+            "model_kind": "chat",
         },
         {
             "id": "llama-3.1-70b-versatile",
@@ -266,6 +307,10 @@ _STATIC_PROVIDER_MODELS: dict[str, tuple[dict[str, Any], ...]] = {
                 "tools": False,
                 "streaming": True,
             },
+            "supports_chat": True,
+            "supports_vision": False,
+            "supports_text_input": True,
+            "model_kind": "chat",
         },
     ),
 }
@@ -480,6 +525,8 @@ def _model_index_metadata(
     endpoint: str | None = None,
     reason: str | None = None,
     model_count: int | None = None,
+    utility_model_count: int | None = None,
+    total_model_count: int | None = None,
     failure_kind: str | None = None,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
@@ -492,6 +539,10 @@ def _model_index_metadata(
         payload["reason"] = reason
     if model_count is not None:
         payload["model_count"] = int(model_count)
+    if utility_model_count is not None:
+        payload["utility_model_count"] = int(utility_model_count)
+    if total_model_count is not None:
+        payload["total_model_count"] = int(total_model_count)
     if failure_kind:
         payload["failure_kind"] = failure_kind
     return payload
@@ -594,10 +645,103 @@ def _model_index_hint_text(item: dict[str, Any]) -> str:
 
 
 def _is_chat_model_index_item(item: dict[str, Any]) -> bool:
+    raw_chat = item.get("supports_chat")
+    if isinstance(raw_chat, bool):
+        return raw_chat
+    raw_chat = item.get("supportsChat")
+    if isinstance(raw_chat, bool):
+        return raw_chat
     hint_text = _model_index_hint_text(item)
     if not hint_text:
         return True
     return not any(hint in hint_text for hint in _MODEL_INDEX_NON_CHAT_HINTS)
+
+
+def _is_vision_model_index_item(item: dict[str, Any]) -> bool:
+    raw_vision = item.get("supports_vision")
+    if isinstance(raw_vision, bool):
+        return raw_vision
+    raw_vision = item.get("supportsVision")
+    if isinstance(raw_vision, bool):
+        return raw_vision
+    raw_caps = item.get("capabilities")
+    if isinstance(raw_caps, dict):
+        for key in ("vision", "supports_vision", "supportsVision"):
+            value = raw_caps.get(key)
+            if isinstance(value, bool):
+                return value
+    hint_text = _model_index_hint_text(item)
+    return any(hint in hint_text for hint in _MODEL_INDEX_VISION_HINTS)
+
+
+def _supports_text_input_model(
+    item: dict[str, Any],
+    *,
+    supports_chat: bool,
+) -> bool:
+    raw_text_input = item.get("supports_text_input")
+    if isinstance(raw_text_input, bool):
+        return raw_text_input
+    raw_text_input = item.get("supportsTextInput")
+    if isinstance(raw_text_input, bool):
+        return raw_text_input
+    raw_caps = item.get("capabilities")
+    if isinstance(raw_caps, dict):
+        for key in ("text_input", "supports_text_input", "supportsTextInput"):
+            value = raw_caps.get(key)
+            if isinstance(value, bool):
+                return value
+    if supports_chat:
+        return True
+    hint_text = _model_index_hint_text(item)
+    return any(hint in hint_text for hint in _MODEL_INDEX_TEXT_INPUT_HINTS)
+
+
+def _normalize_model_kind(
+    item: dict[str, Any],
+    *,
+    supports_chat: bool,
+    supports_vision: bool,
+) -> str:
+    raw_kind = (
+        str(item.get("model_kind") or item.get("modelKind") or "")
+        .strip()
+        .lower()
+    )
+    if raw_kind in {"chat", "vision_chat", "utility"}:
+        return raw_kind
+    if not supports_chat:
+        return "utility"
+    if supports_vision:
+        return "vision_chat"
+    return "chat"
+
+
+def _normalize_model_descriptor(item: dict[str, Any]) -> dict[str, Any]:
+    descriptor = dict(item)
+    supports_chat = _is_chat_model_index_item(descriptor)
+    supports_vision = _is_vision_model_index_item(descriptor)
+    supports_text_input = _supports_text_input_model(
+        descriptor,
+        supports_chat=supports_chat,
+    )
+    model_kind = _normalize_model_kind(
+        descriptor,
+        supports_chat=supports_chat,
+        supports_vision=supports_vision,
+    )
+
+    descriptor["supports_chat"] = supports_chat
+    descriptor["supports_vision"] = supports_vision
+    descriptor["supports_text_input"] = supports_text_input
+    descriptor["model_kind"] = model_kind
+
+    capabilities = dict(descriptor.get("capabilities") or {})
+    capabilities["chat"] = supports_chat
+    capabilities["vision"] = supports_vision
+    capabilities["text_input"] = supports_text_input
+    descriptor["capabilities"] = capabilities
+    return descriptor
 
 
 def _extract_context_window(item: dict[str, Any]) -> int | None:
@@ -639,44 +783,47 @@ def _extract_capabilities(item: dict[str, Any]) -> dict[str, bool] | None:
 
 def _parse_dynamic_model_descriptors(
     payload: Any,
-) -> tuple[list[dict[str, Any]], bool]:
+) -> tuple[list[dict[str, Any]], bool, int, int]:
     collections = _extract_model_index_collections(payload)
     if not collections:
-        return [], False
+        return [], False, 0, 0
 
     models: list[dict[str, Any]] = []
     seen: set[str] = set()
+    chat_model_count = 0
+    utility_model_count = 0
 
     for collection in collections:
         for item in collection:
             model_id = _model_id_from_index_item(item)
             if not model_id or model_id in seen:
                 continue
-            if isinstance(item, dict) and not _is_chat_model_index_item(item):
-                continue
 
-            descriptor: dict[str, Any] = {
-                "id": model_id,
-                "displayName": (
-                    str(
-                        item.get("displayName") or item.get("name") or model_id
-                    ).strip()
-                    if isinstance(item, dict)
-                    else model_id
-                ),
-            }
             if isinstance(item, dict):
+                descriptor = dict(item)
+                descriptor["id"] = model_id
+                descriptor["displayName"] = str(
+                    item.get("displayName") or item.get("name") or model_id
+                ).strip()
                 context_window = _extract_context_window(item)
                 if context_window is not None:
                     descriptor["contextWindow"] = context_window
                 capabilities = _extract_capabilities(item)
                 if capabilities:
                     descriptor["capabilities"] = capabilities
+            else:
+                descriptor = {"id": model_id, "displayName": model_id}
+            descriptor = _normalize_model_descriptor(descriptor)
+
+            if bool(descriptor.get("supports_chat")):
+                chat_model_count += 1
+            else:
+                utility_model_count += 1
 
             seen.add(model_id)
             models.append(descriptor)
 
-    return models, True
+    return models, True, chat_model_count, utility_model_count
 
 
 def _discover_dynamic_provider_models(
@@ -748,7 +895,12 @@ def _discover_dynamic_provider_models(
             failure_kind="provider_payload_error",
         )
 
-    models, recognized_payload = _parse_dynamic_model_descriptors(payload)
+    (
+        models,
+        recognized_payload,
+        chat_model_count,
+        utility_model_count,
+    ) = _parse_dynamic_model_descriptors(payload)
     if not recognized_payload:
         return [], _model_index_metadata(
             "degraded",
@@ -756,18 +908,22 @@ def _discover_dynamic_provider_models(
             reason="Provider model index payload was invalid",
             failure_kind="provider_payload_error",
         )
-    if not models:
+    if chat_model_count <= 0:
         return [], _model_index_metadata(
             "degraded",
             endpoint=endpoint,
             reason="Provider model index returned no chat-capable models",
             model_count=0,
+            utility_model_count=utility_model_count,
+            total_model_count=len(models),
             failure_kind="empty_model_result",
         )
     return models, _model_index_metadata(
         "available",
         endpoint=endpoint,
-        model_count=len(models),
+        model_count=chat_model_count,
+        utility_model_count=utility_model_count,
+        total_model_count=len(models),
     )
 
 
@@ -872,7 +1028,8 @@ def _static_provider_models(
 ) -> list[dict[str, Any]]:
     provider = normalize_provider(provider_id)
     static_models = [
-        dict(item) for item in _STATIC_PROVIDER_MODELS.get(provider, ())
+        _normalize_model_descriptor(dict(item))
+        for item in _STATIC_PROVIDER_MODELS.get(provider, ())
     ]
     default_model = default_model_for_provider(provider, settings)
     existing_ids = {
@@ -883,7 +1040,16 @@ def _static_provider_models(
     if default_model and default_model not in existing_ids:
         static_models.insert(
             0,
-            {"id": default_model, "displayName": default_model},
+            _normalize_model_descriptor(
+                {
+                    "id": default_model,
+                    "displayName": default_model,
+                    "supports_chat": True,
+                    "supports_vision": False,
+                    "supports_text_input": True,
+                    "model_kind": "chat",
+                }
+            ),
         )
     return static_models
 
@@ -907,6 +1073,9 @@ def resolve_provider_capability(
         model_index = {
             "source": "local",
             "state": "available",
+            "model_count": 0,
+            "utility_model_count": 0,
+            "total_model_count": 0,
         }
     elif governance and governance.live_discovery_expected:
         models, model_index = _discover_dynamic_provider_models(
@@ -933,8 +1102,32 @@ def resolve_provider_capability(
         model_index = {
             "source": "static",
             "state": "available",
-            "model_count": len(models),
+            "model_count": sum(
+                1 for model in models if bool(model.get("supports_chat"))
+            ),
+            "utility_model_count": sum(
+                1 for model in models if not bool(model.get("supports_chat"))
+            ),
+            "total_model_count": len(models),
         }
+
+    chat_model_count = sum(
+        1 for model in models if bool(model.get("supports_chat"))
+    )
+    if chat_model_count <= 0 and model_index.get("state") == "available":
+        model_index = {
+            **model_index,
+            "state": "degraded",
+            "model_count": 0,
+            "utility_model_count": sum(
+                1 for model in models if not bool(model.get("supports_chat"))
+            ),
+            "total_model_count": len(models),
+            "failure_kind": "empty_model_result",
+            "reason": "Provider model index returned no chat-capable models",
+        }
+        available = False
+        disabled_reason = "Provider model index returned no chat-capable models"
 
     enabled = bool(available) and (
         bool(governance and governance.local_only) or bool(authorized)
@@ -974,7 +1167,18 @@ def get_provider_model_descriptors(
         and default_model
         and model_index_state != "available"
     ):
-        return [{"id": default_model, "displayName": default_model}]
+        return [
+            _normalize_model_descriptor(
+                {
+                    "id": default_model,
+                    "displayName": default_model,
+                    "supports_chat": True,
+                    "supports_vision": False,
+                    "supports_text_input": True,
+                    "model_kind": "chat",
+                }
+            )
+        ]
     return []
 
 
@@ -1004,6 +1208,8 @@ def resolve_provider_for_model(
         if enabled_only and not capability["enabled"]:
             continue
         for model in get_provider_model_descriptors(provider_id, settings):
+            if not bool(model.get("supports_chat")):
+                continue
             if normalize_model_id(model.get("id")) == candidate:
                 return provider_id
     return None
@@ -1038,7 +1244,9 @@ def validate_provider_model_selection(
         return True, None
 
     provider_model_ids = {
-        normalize_model_id(item.get("id")) for item in capability["models"]
+        normalize_model_id(item.get("id"))
+        for item in capability["models"]
+        if bool(item.get("supports_chat"))
     }
     if model not in provider_model_ids:
         model_index = capability["model_index"]

--- a/guardian/tests/core/test_provider_registry.py
+++ b/guardian/tests/core/test_provider_registry.py
@@ -11,6 +11,7 @@ from guardian.core.provider_registry import (
     STATIC_AUTHORIZED_PROVIDERS,
     get_provider_model_descriptors,
     provider_allows_default_during_degraded_discovery,
+    provider_availability,
     provider_governance,
     provider_governance_contract,
     provider_routing_requires_discovered_inventory,
@@ -35,7 +36,8 @@ def _settings(**overrides) -> Settings:
 
 def test_every_known_provider_is_classified_exactly_once():
     known_providers = set(PROVIDER_ORDER)
-    assert set(PROVIDER_GOVERNANCE) == known_providers
+    contract = provider_governance_contract()
+    assert set(contract) == known_providers
 
     categories = (
         DISCOVERY_BACKED_PROVIDERS,
@@ -53,21 +55,24 @@ def test_every_known_provider_is_classified_exactly_once():
 
 def test_provider_governance_audit_matches_current_contract():
     assert DISCOVERY_BACKED_PROVIDERS == frozenset(
-        {"openai", "groq", "alibaba", "minimax"}
+        {"groq", "alibaba", "minimax"}
     )
-    assert STATIC_AUTHORIZED_PROVIDERS == frozenset()
+    assert STATIC_AUTHORIZED_PROVIDERS == frozenset({"openai"})
     assert LOCAL_ONLY_PROVIDERS == frozenset({"local"})
     assert DISABLED_PROVIDERS == frozenset({"anthropic", "gemini"})
 
 
 def test_local_only_provider_is_marked_explicitly():
-    contract = get_provider_governance("local")
+    contract = provider_governance("local")
     assert contract is not None
-    assert contract["classification"] == "local_only"
+    assert contract["governance_classification"] == "local_only"
     assert contract["local_only"] is True
-    assert contract["live_discovery_expected"] is True
-    assert contract["routing_requires_discovered_inventory"] is True
-    assert contract["configured_defaults_allowed_on_discovery_failure"] is True
+    assert contract["live_discovery_expected"] is False
+    assert contract["routing_validate_discovered_inventory"] is False
+    assert (
+        contract["configured_defaults_allowed_during_degraded_discovery"]
+        is False
+    )
 
 
 def test_static_authorized_providers_are_distinct_from_discovery_backed():
@@ -204,16 +209,22 @@ def test_resolve_provider_capability_discovers_alibaba_models_live(
     assert capability["authorized"] is True
     assert capability["available"] is True
     assert capability["enabled"] is True
-    assert capability["models"] == [
-        {
-            "id": "qwen-max",
-            "displayName": "qwen-max",
-            "contextWindow": 32768,
-            "capabilities": {"tools": True},
-        }
+    assert [model["id"] for model in capability["models"]] == [
+        "qwen-max",
+        "text-embedding-v3",
     ]
+    assert capability["models"][0]["supports_chat"] is True
+    assert capability["models"][0]["supports_vision"] is False
+    assert capability["models"][0]["supports_text_input"] is True
+    assert capability["models"][0]["model_kind"] == "chat"
+    assert capability["models"][1]["supports_chat"] is False
+    assert capability["models"][1]["supports_vision"] is False
+    assert capability["models"][1]["supports_text_input"] is True
+    assert capability["models"][1]["model_kind"] == "utility"
     assert capability["model_index"]["state"] == "available"
     assert capability["model_index"]["model_count"] == 1
+    assert capability["model_index"]["utility_model_count"] == 1
+    assert capability["model_index"]["total_model_count"] == 2
 
 
 def test_minimax_discovery_failure_degrades_without_fabricating_models(
@@ -298,14 +309,66 @@ def test_resolve_provider_for_model_only_matches_discovered_dynamic_models(
     )
 
     assert get_provider_model_descriptors("minimax", settings) == [
-        {"id": "minimax-chat", "displayName": "minimax-chat"},
-        {"id": "abab7.5-chat", "displayName": "abab7.5-chat"},
+        {
+            "id": "minimax-chat",
+            "displayName": "minimax-chat",
+            "supports_chat": True,
+            "supports_vision": False,
+            "supports_text_input": True,
+            "model_kind": "chat",
+            "capabilities": {
+                "chat": True,
+                "vision": False,
+                "text_input": True,
+            },
+        },
+        {
+            "id": "abab7.5-chat",
+            "displayName": "abab7.5-chat",
+            "supports_chat": True,
+            "supports_vision": False,
+            "supports_text_input": True,
+            "model_kind": "chat",
+            "capabilities": {
+                "chat": True,
+                "vision": False,
+                "text_input": True,
+            },
+        },
     ]
     assert (
         resolve_provider_for_model("minimax-chat", settings=settings)
         == "minimax"
     )
     assert resolve_provider_for_model("not-real", settings=settings) is None
+
+
+def test_validate_provider_model_selection_rejects_non_chat_models(monkeypatch):
+    monkeypatch.setattr(
+        "guardian.core.provider_registry.requests.get",
+        lambda *args, **kwargs: _MockResponse(
+            {
+                "data": [
+                    {"id": "qwen-max", "capabilities": {"tools": True}},
+                    {"id": "text-embedding-v3", "task": "embedding"},
+                ]
+            }
+        ),
+    )
+
+    settings = _provider_settings()
+
+    valid, reason = validate_provider_model_selection(
+        provider_id="alibaba",
+        model_id="text-embedding-v3",
+        settings=settings,
+    )
+    assert valid is False
+    assert "not available" in str(reason)
+    assert (
+        resolve_provider_for_model("text-embedding-v3", settings=settings)
+        is None
+    )
 
 
 def test_provider_governance_contract_classifies_every_known_provider_once():
@@ -350,19 +413,9 @@ def test_provider_governance_contract_classifies_every_known_provider_once():
     assert (
         discovery_backed
         == DISCOVERY_BACKED_PROVIDERS
-        == {
-            "alibaba",
-            "minimax",
-        }
+        == {"groq", "alibaba", "minimax"}
     )
-    assert (
-        static_authorized
-        == STATIC_AUTHORIZED_PROVIDERS
-        == {
-            "openai",
-            "groq",
-        }
-    )
+    assert static_authorized == STATIC_AUTHORIZED_PROVIDERS == {"openai"}
     assert local_only == LOCAL_ONLY_PROVIDERS == {"local"}
     assert disabled == DISABLED_PROVIDERS == {"anthropic", "gemini"}
     assert discovery_backed.isdisjoint(static_authorized)

--- a/tests/routes/test_llm_catalog.py
+++ b/tests/routes/test_llm_catalog.py
@@ -250,6 +250,10 @@ def test_llm_catalog_provider_appears_when_key_exists(monkeypatch):
         assert openai["enabled"] is True
         assert openai["available"] is True
         assert openai["authorized"] is True
+        assert openai["models"][0]["supports_chat"] is True
+        assert openai["models"][0]["supports_vision"] is True
+        assert openai["models"][0]["supports_text_input"] is True
+        assert openai["models"][0]["model_kind"] == "vision_chat"
     finally:
         for field, value in snapshot.items():
             setattr(settings, field, value)
@@ -349,14 +353,24 @@ def test_llm_catalog_groq_discovery_surfaces_multiple_models(monkeypatch):
         assert groq["authorized"] is True
         assert groq["model_index"]["state"] == "available"
         assert groq["model_index"]["model_count"] == 2
+        assert groq["model_index"]["utility_model_count"] == 1
+        assert groq["model_index"]["total_model_count"] == 3
         assert [model["id"] for model in groq["models"]] == [
             "llama-3.3-70b-versatile",
             "moonshotai/kimi-k2-instruct-0905",
+            "text-embedding-3-small",
         ]
         assert [model["displayName"] for model in groq["models"]] == [
             "Llama 3.3 70B",
             "Kimi K2 Instruct",
+            "Embeddings",
         ]
+        assert groq["models"][0]["supports_chat"] is True
+        assert groq["models"][0]["supports_vision"] is False
+        assert groq["models"][0]["supports_text_input"] is True
+        assert groq["models"][0]["model_kind"] == "chat"
+        assert groq["models"][2]["supports_chat"] is False
+        assert groq["models"][2]["model_kind"] == "utility"
     finally:
         for field, value in snapshot.items():
             setattr(settings, field, value)
@@ -535,6 +549,8 @@ def test_llm_catalog_minimax_empty_catalog_reports_failure_kind(monkeypatch):
         assert minimax["model_index"]["state"] == "degraded"
         assert minimax["model_index"]["failure_kind"] == "empty_model_result"
         assert minimax["model_index"]["model_count"] == 0
+        assert minimax["model_index"]["utility_model_count"] == 1
+        assert minimax["model_index"]["total_model_count"] == 1
         assert (
             minimax["disabled_reason"]
             == "Provider model index returned no chat-capable models"


### PR DESCRIPTION
## Summary
- Normalize catalog metadata so chat-visible models carry authoritative capability flags for chat, vision, and text input
- Gate the chat model picker to hide non-chat utility models and clearly distinguish vision-capable chat models from text-only models
- Add image-aware guidance in the composer so attachments do not imply native vision support where it does not exist
- Update backend and frontend tests to cover catalog shaping, provider selection, and attachment-aware UI behavior

## Testing
- `pytest -v tests/routes/test_llm_catalog.py guardian/tests/core/test_provider_registry.py`
- `pnpm --dir frontend/src exec vitest run features/chat/__tests__/GuardianChat.catalog-options.test.tsx features/chat/components/__tests__/Composer.draft-sync.test.tsx features/chat/components/__tests__/ComposerSelectMenu.test.tsx`
- `pnpm test`
- `pytest -v` (passed with unrelated pre-existing failures in chat worker and obsidian tests)