### PR TITLE
Align chat lane and composer width and anchor controls at bottom

### DIFF
--- a/frontend/src/features/chat/ChatView.tsx
+++ b/frontend/src/features/chat/ChatView.tsx
@@ -410,7 +410,7 @@ export function ChatView({
       >
         <div
           data-testid="chat-conversation-lane"
-          className="mx-auto w-full max-w-full md:max-w-[880px] space-y-4"
+          className="mx-auto w-full max-w-full md:max-w-[888px] space-y-4"
           style={{ maxWidth: CHAT_LANE_MAX_WIDTH }}
         >
           {messages.map((message, index) => {

--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -2468,7 +2468,7 @@ export function GuardianChat({
       <div className="shrink-0 z-20 mt-2 flex justify-center w-full">
         <div
           data-testid="composer-shell"
-          className="w-full rounded-[24px] border shadow-2xl backdrop-blur-xl flex flex-col overflow-hidden transition-all duration-200"
+          className="w-full rounded-[24px] border shadow-2xl backdrop-blur-xl flex min-h-0 flex-col overflow-hidden transition-all duration-200"
           style={{
             maxWidth: CHAT_STAGE_MAX_WIDTH,
             borderColor: "var(--panel-border)",
@@ -2479,10 +2479,10 @@ export function GuardianChat({
             maxHeight: "60vh",
           }}
         >
-          <div className="flex flex-col p-4">
+          <div className="flex h-full min-h-0 flex-col">
             <div
               data-testid="composer-conversation-lane"
-              className="mx-auto w-full max-w-full md:max-w-[880px]"
+              className="mx-auto flex h-full min-h-0 w-full max-w-full flex-col md:max-w-[888px]"
               style={{ maxWidth: CHAT_LANE_MAX_WIDTH }}
             >
               <GuardianThreadApprovalRail

--- a/frontend/src/features/chat/__tests__/ChatView.loop-guards.test.tsx
+++ b/frontend/src/features/chat/__tests__/ChatView.loop-guards.test.tsx
@@ -274,6 +274,6 @@ describe("ChatView loop guards", () => {
 
     const lane = screen.getByTestId("chat-conversation-lane");
     expect(lane).toHaveStyle({ maxWidth: `${CHAT_LANE_MAX_WIDTH}px` });
-    expect(lane.className).toContain("md:max-w-[880px]");
+    expect(lane.className).toContain("md:max-w-[888px]");
   });
 });

--- a/frontend/src/features/chat/__tests__/GuardianChat.session-tabs.test.tsx
+++ b/frontend/src/features/chat/__tests__/GuardianChat.session-tabs.test.tsx
@@ -195,7 +195,7 @@ describe("GuardianChat session-tab binding", () => {
 
     const lane = screen.getByTestId("composer-conversation-lane");
     expect(lane).toHaveStyle({ maxWidth: `${CHAT_LANE_MAX_WIDTH}px` });
-    expect(lane.className).toContain("md:max-w-[880px]");
+    expect(lane.className).toContain("md:max-w-[888px]");
     expect(screen.getByTestId("composer-shell")).toHaveStyle({
       maxWidth: `${CHAT_STAGE_MAX_WIDTH}px`,
     });

--- a/frontend/src/features/chat/chatLane.ts
+++ b/frontend/src/features/chat/chatLane.ts
@@ -1,14 +1,16 @@
 // Canonical chat lane width used by message stack, approval rail, and composer.
-export const CHAT_LANE_MAX_WIDTH = 880;
+export const CHAT_LANE_MAX_WIDTH = 888;
 
 // Inline gutter applied around the lane when deriving shell widths. Mirrors
 // the default `--shell-gap` token to keep layout token-driven.
 export const CHAT_LANE_INLINE_GUTTER = 16;
 
-// Shell boundary that keeps the composer frame aligned with the lane while
-// leaving a consistent gutter on either side.
-export const CHAT_STAGE_MAX_WIDTH =
-  CHAT_LANE_MAX_WIDTH + CHAT_LANE_INLINE_GUTTER * 2;
+// Shell boundary for the composer frame. Keep identical to lane width so the
+// composer edge aligns to the shared chat column contract.
+export const CHAT_STAGE_MAX_WIDTH = CHAT_LANE_MAX_WIDTH;
+
+// Shared class contract for control-row bottom seating in the composer.
+export const CHAT_COMPOSER_CONTROLS_BOTTOM_GAP_CLASS = "pb-[2px]";
 
 // Token-friendly padding expression reused by chat surfaces so portrait and
 // fullscreen share the same baseline inset without bespoke numbers.

--- a/frontend/src/features/chat/components/Composer.tsx
+++ b/frontend/src/features/chat/components/Composer.tsx
@@ -20,6 +20,7 @@ import {
   DEFAULT_COMPOSER_INFERENCE_MODE,
   type ComposerInferenceMode,
 } from "@/types/inference";
+import { CHAT_COMPOSER_CONTROLS_BOTTOM_GAP_CLASS } from "@/features/chat/chatLane";
 
 const ACCEPTED_ATTACHMENTS =
   [
@@ -679,8 +680,14 @@ export function Composer({
             }}
           />
 
-          <div className="flex flex-wrap items-center justify-between gap-3 px-[8px] pb-[4px]">
-            <div className="flex min-w-0 flex-wrap items-center gap-3">
+          <div
+            data-testid="composer-controls-row"
+            className={cn(
+              "mt-auto flex items-center justify-between gap-3 px-[8px]",
+              CHAT_COMPOSER_CONTROLS_BOTTOM_GAP_CLASS
+            )}
+          >
+            <div className="flex min-w-0 flex-nowrap items-center gap-3 overflow-x-auto pr-2">
               <ComposerActionMenu
                 disabled={draftControlsDisabled}
                 depthMode={depthMode}

--- a/frontend/src/features/chat/components/__tests__/Composer.draft-sync.test.tsx
+++ b/frontend/src/features/chat/components/__tests__/Composer.draft-sync.test.tsx
@@ -2,7 +2,9 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { Composer } from "@/features/chat/components/Composer";
+import { CHAT_COMPOSER_CONTROLS_BOTTOM_GAP_CLASS } from "@/features/chat/chatLane";
 import api from "@/lib/api";
+import composerSource from "@/features/chat/components/Composer.tsx?raw";
 
 vi.mock("@/lib/api", () => ({
   default: {
@@ -268,5 +270,23 @@ describe("Composer draft sync", () => {
 
     fireEvent.click(voiceTurnButton);
     expect(onVoiceTurn).not.toHaveBeenCalled();
+  });
+
+  it("pins controls row using the shared bottom-gap contract", () => {
+    render(
+      <Composer
+        onSend={vi.fn()}
+        draftScopeKey="tab-1"
+        draftValue=""
+      />
+    );
+
+    const controlsRow = screen.getByTestId("composer-controls-row");
+    expect(controlsRow.className).toContain("mt-auto");
+    expect(controlsRow.className).toContain(
+      CHAT_COMPOSER_CONTROLS_BOTTOM_GAP_CLASS
+    );
+
+    expect(composerSource).not.toContain('pb-[2px]');
   });
 });


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
