### PR TITLE
Fix Guardian shell width cap in fullscreen

### DIFF
--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -52,7 +52,12 @@ import {
   type ComposerInferenceMode,
 } from "@/types/inference";
 import { setPreferredProviderSelection } from "@/lib/providerPref";
-import { CHAT_LANE_MAX_WIDTH, CHAT_STAGE_MAX_WIDTH } from "@/features/chat/chatLane";
+import {
+  CHAT_LANE_MAX_WIDTH,
+  CHAT_STAGE_MAX_WIDTH,
+  GUARDIAN_SHELL_MAX_WIDTH,
+  GUARDIAN_SHELL_MAX_WIDTH_CLASS,
+} from "@/features/chat/chatLane";
 
 
 const DRAFT_KEY_PREFIX = "gc-draft:";
@@ -2637,7 +2642,13 @@ export function GuardianChat({
       <>
         {/* Messages scroll container - ChatView owns internal scroll, this provides outer constraint */}
         <div className="relative flex flex-col flex-1 min-h-0 overflow-y-auto">
-          {body}
+          <div
+            data-testid="guardian-shell"
+            className={`relative mx-auto flex h-full w-full min-h-0 flex-col ${GUARDIAN_SHELL_MAX_WIDTH_CLASS}`}
+            style={{ maxWidth: GUARDIAN_SHELL_MAX_WIDTH }}
+          >
+            {body}
+          </div>
         </div>
         <RAGTracePanel
           open={ragTraceOpen}
@@ -2651,7 +2662,9 @@ export function GuardianChat({
   return (
     <>
       <FrameCard
-        className="flex-1 min-h-0 min-w-0 flex flex-col h-full"
+        data-testid="guardian-shell"
+        className={`mx-auto flex h-full min-h-0 min-w-0 w-full flex-1 flex-col ${GUARDIAN_SHELL_MAX_WIDTH_CLASS}`}
+        style={{ maxWidth: GUARDIAN_SHELL_MAX_WIDTH }}
         hoverPop
       >
         <div className="relative flex flex-col w-full h-full">

--- a/frontend/src/features/chat/__tests__/GuardianChat.session-tabs.test.tsx
+++ b/frontend/src/features/chat/__tests__/GuardianChat.session-tabs.test.tsx
@@ -4,7 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import GuardianChat, {
   flattenChatEventPayload,
 } from "@/features/chat/GuardianChat";
-import { CHAT_LANE_MAX_WIDTH, CHAT_STAGE_MAX_WIDTH } from "@/features/chat/chatLane";
+import {
+  CHAT_LANE_MAX_WIDTH,
+  CHAT_STAGE_MAX_WIDTH,
+  GUARDIAN_SHELL_MAX_WIDTH,
+} from "@/features/chat/chatLane";
 
 const chatViewSpy = vi.hoisted(() => vi.fn());
 
@@ -52,7 +56,11 @@ vi.mock("@/features/chat/ChatView", () => ({
 }));
 
 vi.mock("@/components/surface/FrameCard", () => ({
-  default: ({ children }: any) => <div>{children}</div>,
+  default: ({ children, className, style, "data-testid": dataTestId }: any) => (
+    <div className={className} style={style} data-testid={dataTestId}>
+      {children}
+    </div>
+  ),
 }));
 
 vi.mock("@/features/chat/useChat", () => ({
@@ -192,6 +200,9 @@ describe("GuardianChat session-tab binding", () => {
         activeSessionTabId={"tab-2" as any}
       />
     );
+
+    const shell = screen.getByTestId("guardian-shell");
+    expect(shell).toHaveStyle({ maxWidth: `${GUARDIAN_SHELL_MAX_WIDTH}px` });
 
     const lane = screen.getByTestId("composer-conversation-lane");
     expect(lane).toHaveStyle({ maxWidth: `${CHAT_LANE_MAX_WIDTH}px` });

--- a/frontend/src/features/chat/chatLane.ts
+++ b/frontend/src/features/chat/chatLane.ts
@@ -10,6 +10,15 @@ export const CHAT_LANE_INLINE_GUTTER = 16;
 export const CHAT_STAGE_MAX_WIDTH =
   CHAT_LANE_MAX_WIDTH + CHAT_LANE_INLINE_GUTTER * 2;
 
+// Outer Guardian surface ceiling for fullscreen layouts. Keeps the shell large
+// enough for future workspace activation without letting the empty side bands
+// dominate the scene on very wide displays.
+export const GUARDIAN_SHELL_MAX_WIDTH = 1360;
+
+// Static class companion for shell consumers that need the canonical Tailwind
+// contract alongside the numeric token.
+export const GUARDIAN_SHELL_MAX_WIDTH_CLASS = "max-w-[1360px]";
+
 // Token-friendly padding expression reused by chat surfaces so portrait and
 // fullscreen share the same baseline inset without bespoke numbers.
 export const CHAT_LANE_INLINE_PADDING =


### PR DESCRIPTION
## Summary
- add a canonical Guardian shell max-width contract for the outer chat surface
- apply the cap to the Guardian shell while keeping the message lane and composer width contracts unchanged
- keep the shell centered in fullscreen and preserve room for future Workspace Pane use
- update Guardian chat layout coverage to assert the shell max-width contract

## Testing
- `pnpm test`