### PR TITLE
Fix Guardian shell width to match the chat lane

### DIFF
--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -52,7 +52,10 @@ import {
   type ComposerInferenceMode,
 } from "@/types/inference";
 import { setPreferredProviderSelection } from "@/lib/providerPref";
-import { CHAT_LANE_MAX_WIDTH, CHAT_STAGE_MAX_WIDTH } from "@/features/chat/chatLane";
+import {
+  CHAT_LANE_MAX_WIDTH,
+  CHAT_LANE_MAX_WIDTH_CLASS,
+} from "@/features/chat/chatLane";
 
 
 const DRAFT_KEY_PREFIX = "gc-draft:";
@@ -2468,9 +2471,9 @@ export function GuardianChat({
       <div className="shrink-0 z-20 mt-2 flex justify-center w-full">
         <div
           data-testid="composer-shell"
-          className="w-full rounded-[24px] border shadow-2xl backdrop-blur-xl flex flex-col overflow-hidden transition-all duration-200"
+          className={`mx-auto w-full max-w-full ${CHAT_LANE_MAX_WIDTH_CLASS} rounded-[24px] border shadow-2xl backdrop-blur-xl flex flex-col overflow-hidden transition-all duration-200`}
           style={{
-            maxWidth: CHAT_STAGE_MAX_WIDTH,
+            maxWidth: CHAT_LANE_MAX_WIDTH,
             borderColor: "var(--panel-border)",
             background: "color-mix(in oklab, var(--panel-bg) 95%, black)", // Deep opaque glass
             clipPath: "inset(0 round 24px)",
@@ -2482,7 +2485,7 @@ export function GuardianChat({
           <div className="flex flex-col p-4">
             <div
               data-testid="composer-conversation-lane"
-              className="mx-auto w-full max-w-full md:max-w-[880px]"
+              className={`mx-auto w-full max-w-full ${CHAT_LANE_MAX_WIDTH_CLASS}`}
               style={{ maxWidth: CHAT_LANE_MAX_WIDTH }}
             >
               <GuardianThreadApprovalRail

--- a/frontend/src/features/chat/__tests__/GuardianChat.session-tabs.test.tsx
+++ b/frontend/src/features/chat/__tests__/GuardianChat.session-tabs.test.tsx
@@ -4,7 +4,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import GuardianChat, {
   flattenChatEventPayload,
 } from "@/features/chat/GuardianChat";
-import { CHAT_LANE_MAX_WIDTH, CHAT_STAGE_MAX_WIDTH } from "@/features/chat/chatLane";
+import {
+  CHAT_LANE_MAX_WIDTH,
+  CHAT_LANE_MAX_WIDTH_CLASS,
+} from "@/features/chat/chatLane";
 
 const chatViewSpy = vi.hoisted(() => vi.fn());
 
@@ -195,10 +198,13 @@ describe("GuardianChat session-tab binding", () => {
 
     const lane = screen.getByTestId("composer-conversation-lane");
     expect(lane).toHaveStyle({ maxWidth: `${CHAT_LANE_MAX_WIDTH}px` });
-    expect(lane.className).toContain("md:max-w-[880px]");
+    expect(lane.className).toContain(CHAT_LANE_MAX_WIDTH_CLASS);
     expect(screen.getByTestId("composer-shell")).toHaveStyle({
-      maxWidth: `${CHAT_STAGE_MAX_WIDTH}px`,
+      maxWidth: `${CHAT_LANE_MAX_WIDTH}px`,
     });
+    expect(screen.getByTestId("composer-shell").className).toContain(
+      CHAT_LANE_MAX_WIDTH_CLASS
+    );
     expect(screen.getByTestId("composer-stub")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/chat/chatLane.ts
+++ b/frontend/src/features/chat/chatLane.ts
@@ -1,14 +1,8 @@
 // Canonical chat lane width used by message stack, approval rail, and composer.
 export const CHAT_LANE_MAX_WIDTH = 880;
 
-// Inline gutter applied around the lane when deriving shell widths. Mirrors
-// the default `--shell-gap` token to keep layout token-driven.
-export const CHAT_LANE_INLINE_GUTTER = 16;
-
-// Shell boundary that keeps the composer frame aligned with the lane while
-// leaving a consistent gutter on either side.
-export const CHAT_STAGE_MAX_WIDTH =
-  CHAT_LANE_MAX_WIDTH + CHAT_LANE_INLINE_GUTTER * 2;
+// Shared Tailwind class for lane-bound surfaces that match the canonical width.
+export const CHAT_LANE_MAX_WIDTH_CLASS = "md:max-w-[880px]";
 
 // Token-friendly padding expression reused by chat surfaces so portrait and
 // fullscreen share the same baseline inset without bespoke numbers.


### PR DESCRIPTION
## Summary
- remove the independent composer shell max-width and bind the shell to `CHAT_LANE_MAX_WIDTH`
- add a shared `CHAT_LANE_MAX_WIDTH_CLASS` token so the shell and inner conversation lane use the same width contract
- update the Guardian chat layout test to assert the unified width behavior

## Testing
- `pnpm test`