### PR TITLE
Fix Guardian chat shell to use shared lane width class

### DIFF
--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -56,7 +56,11 @@ import {
   type ComposerInferenceMode,
 } from "@/types/inference";
 import { setPreferredProviderSelection } from "@/lib/providerPref";
-import { CHAT_LANE_MAX_WIDTH, CHAT_STAGE_MAX_WIDTH } from "@/features/chat/chatLane";
+import {
+  CHAT_LANE_MAX_WIDTH,
+  CHAT_LANE_MAX_WIDTH_CLASS,
+  CHAT_STAGE_MAX_WIDTH,
+} from "@/features/chat/chatLane";
 
 
 const DRAFT_KEY_PREFIX = "gc-draft:";
@@ -2509,7 +2513,7 @@ export function GuardianChat({
           <div className="flex flex-col p-4">
             <div
               data-testid="composer-conversation-lane"
-              className="mx-auto w-full max-w-full md:max-w-[880px]"
+              className={`mx-auto w-full max-w-full ${CHAT_LANE_MAX_WIDTH_CLASS}`}
               style={{ maxWidth: CHAT_LANE_MAX_WIDTH }}
             >
               <GuardianThreadApprovalRail

--- a/frontend/src/features/chat/chatLane.ts
+++ b/frontend/src/features/chat/chatLane.ts
@@ -1,5 +1,6 @@
 // Canonical chat lane width used by message stack, approval rail, and composer.
 export const CHAT_LANE_MAX_WIDTH = 880;
+export const CHAT_LANE_MAX_WIDTH_CLASS = "md:max-w-[880px]";
 
 // Inline gutter applied around the lane when deriving shell widths. Mirrors
 // the default `--shell-gap` token to keep layout token-driven.


### PR DESCRIPTION
## Summary
- extract the chat lane max-width utility class into `chatLane.ts`
- update `GuardianChat` to use the shared lane width class instead of an inline hardcoded value
- keep the composer lane aligned with the canonical chat lane width token

## Testing
- `pnpm test`