### PR TITLE
Add MiniMax Anthropic-first integration

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -77,8 +77,12 @@ OPENAI_EMBEDDING_MODEL=
 GROQ_API_KEY=
 GROQ_BASE_URL=
 MINIMAX_API_KEY=
-MINIMAX_API_BASE=
-MINIMAX_MODEL=
+MINIMAX_API_BASE=https://api.minimax.io/anthropic
+MINIMAX_API_FLAVOR=anthropic
+MINIMAX_MODEL=MiniMax-M2.1
+# Optional live inventory override when you want the catalog to probe a
+# documented MiniMax model list endpoint explicitly.
+MINIMAX_MODEL_DISCOVERY_URL=
 MINIMAX_TIMEOUT_SECONDS=60
 ANTHROPIC_API_KEY=
 GENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -121,12 +121,27 @@ If you want cloud models instead of local:
 ALLOW_CLOUD_PROVIDERS=true
 CODEXIFY_LOCAL_ONLY_MODE=false
 CODEXIFY_EGRESS_ALLOWLIST=openai,groq,minimax
-LLM_PROVIDER=openai   # single value only: openai, groq, minimax, or local
+LLM_PROVIDER=minimax  # single value only: openai, groq, minimax, or local
 OPENAI_API_KEY=...
 # GROQ_API_KEY=...
-# MINIMAX_API_KEY=...
-# MINIMAX_API_BASE=https://api.minimax.chat/v1
+# MiniMax direct chat defaults to the Anthropic-compatible surface.
+MINIMAX_API_KEY=...
+MINIMAX_API_BASE=https://api.minimax.io/anthropic
+MINIMAX_API_FLAVOR=anthropic
+MINIMAX_MODEL=MiniMax-M2.1
+# Optional live inventory override if you want the catalog to probe a
+# documented MiniMax model endpoint explicitly.
+# MINIMAX_MODEL_DISCOVERY_URL=...
 ```
+
+MiniMax is the recommended direct cloud provider here when you want:
+
+- Anthropic-compatible chat/tool use by default
+- Prompt caching for stable system/tool prefixes
+- Thinking blocks preserved through the Anthropic-compatible response shape
+
+OpenAI-compatible MiniMax remains available only as an explicit fallback by
+setting `MINIMAX_API_FLAVOR=openai`.
 
 ### 2) Start the stack
 

--- a/docs/Codexify/CONFIGURATION.md
+++ b/docs/Codexify/CONFIGURATION.md
@@ -36,7 +36,10 @@ Notes:
 | `OPENAI_API_KEY` | unset | Required for OpenAI usage when enabled. |
 | `GROQ_API_KEY` | unset | Required for Groq usage when enabled. |
 | `MINIMAX_API_KEY` | unset | Required for MiniMax usage when enabled. |
-| `MINIMAX_API_BASE` | unset | Required OpenAI-compatible base URL for MiniMax (for example `https://api.minimax.chat/v1`). |
+| `MINIMAX_API_BASE` | `https://api.minimax.io/anthropic` | Required MiniMax base URL. Anthropic-compatible direct integration is the default. |
+| `MINIMAX_API_FLAVOR` | `anthropic` | MiniMax transport surface (`anthropic` or `openai`). OpenAI is explicit fallback only. |
+| `MINIMAX_MODEL_DISCOVERY_URL` | unset | Optional explicit inventory endpoint for catalog probing. |
+| `MINIMAX_MODEL` | `MiniMax-M2.7` | Default MiniMax chat model; keep aligned with the compatibility surface you selected. |
 | `ELEVENLABS_API_KEY` | unset | Required for ElevenLabs TTS when enabled. |
 
 Allowlist target names currently enforced in code:
@@ -50,11 +53,14 @@ Example (OpenAI/Groq/MiniMax enabled):
 ALLOW_CLOUD_PROVIDERS=true
 CODEXIFY_LOCAL_ONLY_MODE=false
 CODEXIFY_EGRESS_ALLOWLIST=openai,groq,minimax
-LLM_PROVIDER=openai
+LLM_PROVIDER=minimax
 OPENAI_API_KEY=...
 # GROQ_API_KEY=...
 # MINIMAX_API_KEY=...
-# MINIMAX_API_BASE=https://api.minimax.chat/v1
+# MINIMAX_API_BASE=https://api.minimax.io/anthropic
+# MINIMAX_API_FLAVOR=anthropic
+# MINIMAX_MODEL=MiniMax-M2.1
+# MINIMAX_MODEL_DISCOVERY_URL=...
 ```
 
 Without this full set, egress remains blocked by policy.

--- a/docs/architecture/providers.md
+++ b/docs/architecture/providers.md
@@ -56,35 +56,43 @@ Set:
 
 - `LLM_PROVIDER=minimax`
 - `MINIMAX_API_KEY=<your_minimax_api_key>`
-- `MINIMAX_API_BASE=<openai_compatible_base_url>`
+- `MINIMAX_API_BASE=https://api.minimax.io/anthropic`
+- `MINIMAX_API_FLAVOR=anthropic`
 - `ALLOW_CLOUD_PROVIDERS=true`
 - `CODEXIFY_LOCAL_ONLY_MODE=false`
 - `CODEXIFY_EGRESS_ALLOWLIST=...` including `minimax`
 
 Optional:
 
-- `MINIMAX_API_FLAVOR=<openai|anthropic>` (default: `openai`)
+- `MINIMAX_MODEL_DISCOVERY_URL=<explicit_model_catalog_url>` when you want to
+  probe a documented MiniMax inventory endpoint directly
 - `MINIMAX_ANTHROPIC_VERSION=<anthropic_api_version>` (used when flavor is `anthropic`)
-- `MINIMAX_MODEL=<default_model_id>`
+- `MINIMAX_MODEL=<default_model_id>` (recommended direct-chat default: `MiniMax-M2.1`)
 - `MINIMAX_TIMEOUT_SECONDS=<request_timeout_seconds>`
 
 Base URL examples:
 
-- OpenAI flavor (`MINIMAX_API_FLAVOR=openai`): `https://api.minimax.io/v1`
 - Anthropic flavor (`MINIMAX_API_FLAVOR=anthropic`): `https://api.minimax.io/anthropic`
+- OpenAI fallback (`MINIMAX_API_FLAVOR=openai`): `https://api.minimax.io/v1`
 
 When `LLM_PROVIDER=minimax`, backend config validation fails fast with a clear
-message if `MINIMAX_API_KEY` or `MINIMAX_API_BASE` is missing.
+message if `MINIMAX_API_KEY` or `MINIMAX_API_BASE` is missing. The default
+runtime flavor is Anthropic-compatible, and OpenAI-compatible MiniMax is only
+used when explicitly selected.
 
 ### Routing behavior
 
-- Runtime chat routing uses MiniMax only when explicitly selected.
+- Runtime chat routing uses the Anthropic-compatible MiniMax surface by default.
 - Explicit request selection (`provider`/`model`) takes precedence over profile
   overrides in the chat worker.
 - Provider registry loads MiniMax only when both `MINIMAX_API_KEY` and
   `MINIMAX_API_BASE` are present.
-- Catalog entry is deterministic and includes one default model:
-  `MINIMAX_MODEL` or `minimax-default`.
+- Catalog entry prefers live discovery when configured, but falls back to the
+  documented MiniMax chat model list instead of hiding the provider when live
+  discovery is unavailable.
+- Prompt caching is most effective when the static system/tool prefix stays
+  stable; Anthropic-compatible requests mark the stable system blocks with
+  explicit cache metadata.
 - Existing fallback order is unchanged. MiniMax is used only when selected.
 
 ### Security

--- a/frontend/src/components/persona/layout/AppShell.runtimeHealth.test.tsx
+++ b/frontend/src/components/persona/layout/AppShell.runtimeHealth.test.tsx
@@ -14,6 +14,7 @@ import {
 type RuntimeHealthMock = {
   status: RuntimeHealthStatusToken;
   failureKind: RuntimeHealthFailureKindToken | "unknown" | null;
+  llmDetail: string | null;
   lastSuccessAt: number | null;
   backendReachable: boolean | null;
   chatHealthy: boolean | null;
@@ -26,6 +27,7 @@ type RuntimeHealthMock = {
 const runtimeHealthState: RuntimeHealthMock = {
   status: RUNTIME_HEALTH_STATUSES.HEALTHY,
   failureKind: null,
+  llmDetail: null,
   lastSuccessAt: Date.parse("2026-03-20T12:00:00Z"),
   backendReachable: true,
   chatHealthy: true,
@@ -178,6 +180,7 @@ describe("AppShell runtime health banner", () => {
   beforeEach(() => {
     runtimeHealthState.status = RUNTIME_HEALTH_STATUSES.HEALTHY;
     runtimeHealthState.failureKind = null;
+    runtimeHealthState.llmDetail = null;
     runtimeHealthState.lastSuccessAt = Date.parse("2026-03-20T12:00:00Z");
     if (!window.matchMedia) {
       window.matchMedia = ((query: string) => ({
@@ -228,6 +231,8 @@ describe("AppShell runtime health banner", () => {
     runtimeHealthState.status = RUNTIME_HEALTH_STATUSES.DEGRADED;
     runtimeHealthState.failureKind =
       RUNTIME_HEALTH_FAILURE_KINDS.LLM_UNHEALTHY;
+    runtimeHealthState.llmDetail =
+      "MiniMax live discovery unavailable using documented model list";
     runtimeHealthState.lastSuccessAt = Date.parse("2026-03-20T11:55:00Z");
 
     render(<AppShell />);
@@ -235,6 +240,9 @@ describe("AppShell runtime health banner", () => {
     expect(screen.getByText(/Runtime degraded/i)).toBeInTheDocument();
     expect(
       screen.getByText(/failure:\s*llm_unhealthy/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/MiniMax live discovery unavailable/i)
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/persona/layout/AppShell.tsx
+++ b/frontend/src/components/persona/layout/AppShell.tsx
@@ -1695,6 +1695,13 @@ export default function AppShell({
   const runtimeDegraded =
     runtimeHealth.status === RUNTIME_HEALTH_STATUSES.DEGRADED;
   const runtimeFailureKind = runtimeHealth.failureKind ?? "unknown";
+  const runtimeDetail =
+    typeof process !== "undefined" &&
+    process.env &&
+    process.env.NODE_ENV !== "production" &&
+    runtimeFailureKind === RUNTIME_HEALTH_FAILURE_KINDS.LLM_UNHEALTHY
+      ? runtimeHealth.llmDetail
+      : null;
   const showRuntimeBanner =
     runtimeDegraded &&
     runtimeFailureKind !== RUNTIME_HEALTH_FAILURE_KINDS.HEALTH_ENDPOINT_MISSING;
@@ -1908,7 +1915,7 @@ export default function AppShell({
       {showRuntimeBanner && (
         <div className="relative z-10 w-full mt-3">
           <div
-            className="flex w-full items-center justify-between gap-3 rounded-[14px] border px-4 py-2 text-xs sm:text-sm"
+            className="flex w-full flex-col gap-1 rounded-[14px] border px-4 py-2 text-xs sm:text-sm"
             style={{
               borderColor: "var(--panel-border)",
               background:
@@ -1916,13 +1923,20 @@ export default function AppShell({
               color: "var(--text)",
             }}
           >
-            <span className="font-semibold tracking-wide">
-              Runtime degraded
-            </span>
-            <span className="opacity-80">failure: {runtimeFailureKind}</span>
-            <span className="opacity-70">
-              last healthy: {runtimeLastHealthy}
-            </span>
+            <div className="flex items-center justify-between gap-3">
+              <span className="font-semibold tracking-wide">
+                Runtime degraded
+              </span>
+              <span className="opacity-80">failure: {runtimeFailureKind}</span>
+              <span className="opacity-70">
+                last healthy: {runtimeLastHealthy}
+              </span>
+            </div>
+            {runtimeDetail ? (
+              <div className="text-[11px] opacity-75" style={{ color: "var(--muted)" }}>
+                detail: {runtimeDetail}
+              </div>
+            ) : null}
           </div>
         </div>
       )}

--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -58,6 +58,7 @@ import {
 import { setPreferredProviderSelection } from "@/lib/providerPref";
 import {
   CHAT_LANE_MAX_WIDTH,
+  CHAT_LANE_INLINE_PADDING,
   CHAT_STAGE_MAX_WIDTH,
   GUARDIAN_SHELL_MAX_WIDTH,
   GUARDIAN_SHELL_MAX_WIDTH_CLASS,
@@ -2371,12 +2372,9 @@ export function GuardianChat({
     <div className="relative flex h-full w-full min-h-0 flex-col bg-transparent">
       {/* Single header rail */}
       <header className={`shrink-0 z-20 py-2 ${CHAT_LANE_GUTTER_CLASS}`}>
-        <div
-          className="relative flex items-center gap-2 px-1 py-2 flex-nowrap"
-          style={{
-            color: "var(--text)",
-          }}
-        >
+      <div
+          className="relative flex items-center gap-2 px-4 py-2 flex-nowrap w-full"
+          >
           <div className="flex items-center gap-2 shrink-0">
             {onSidebarToggle && (
               <button

--- a/frontend/src/features/chat/chatLane.ts
+++ b/frontend/src/features/chat/chatLane.ts
@@ -28,11 +28,11 @@ export const CHAT_COMPOSER_SEND_PAD_CLASS = "pr-2";
 // Outer Guardian surface ceiling for fullscreen layouts. Keeps the shell large
 // enough for future workspace activation without letting the empty side bands
 // dominate the scene on very wide displays.
-export const GUARDIAN_SHELL_MAX_WIDTH = 1360;
+export const GUARDIAN_SHELL_MAX_WIDTH = 1200;
 
 // Static class companion for shell consumers that need the canonical Tailwind
 // contract alongside the numeric token.
-export const GUARDIAN_SHELL_MAX_WIDTH_CLASS = "max-w-[1360px]";
+export const GUARDIAN_SHELL_MAX_WIDTH_CLASS = "max-w-[1200px]";
 
 // Token-friendly padding expression reused by chat surfaces so portrait and
 // fullscreen share the same baseline inset without bespoke numbers.

--- a/frontend/src/hooks/useRuntimeHealth.ts
+++ b/frontend/src/hooks/useRuntimeHealth.ts
@@ -18,6 +18,7 @@ export type RuntimeFailureKind = RuntimeHealthFailureKindToken;
 export type RuntimeHealthStatus = {
   status: RuntimeHealthStatusToken;
   failureKind: RuntimeFailureKind | null;
+  llmDetail: string | null;
   backendReachable: boolean | null;
   chatHealthy: boolean | null;
   llmHealthy: boolean | null;
@@ -32,6 +33,7 @@ type HealthSnapshot = {
   healthEndpointMissing: boolean | null;
   chatHealthy: boolean | null;
   llmHealthy: boolean | null;
+  llmDetail: string | null;
   lastSuccessAt: number | null;
   lastCheckedAt: number | null;
 };
@@ -41,6 +43,7 @@ const INITIAL_SNAPSHOT: HealthSnapshot = {
   healthEndpointMissing: null,
   chatHealthy: null,
   llmHealthy: null,
+  llmDetail: null,
   lastSuccessAt: null,
   lastCheckedAt: null,
 };
@@ -87,6 +90,42 @@ function parseHealthResult(
   return { reachable: false, ok: null, missing: false };
 }
 
+function normalizeDetail(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function extractLlmDetail(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const candidate = payload as Record<string, unknown>;
+  const providerRuntime = candidate.provider_runtime;
+  if (providerRuntime && typeof providerRuntime === "object") {
+    const modelIndex = (
+      providerRuntime as Record<string, unknown>
+    ).model_index;
+    if (modelIndex && typeof modelIndex === "object") {
+      const index = modelIndex as Record<string, unknown>;
+      return (
+        normalizeDetail(index.reason) ??
+        normalizeDetail(index.failure_kind) ??
+        normalizeDetail(index.state)
+      );
+    }
+    const runtimeReason = providerRuntime as Record<string, unknown>;
+    return (
+      normalizeDetail(runtimeReason.reason) ??
+      normalizeDetail(runtimeReason.failure_kind) ??
+      normalizeDetail(runtimeReason.status_reason)
+    );
+  }
+  return (
+    normalizeDetail(candidate.error) ??
+    normalizeDetail(candidate.status_reason) ??
+    null
+  );
+}
+
 export function useRuntimeHealth(): RuntimeHealthStatus {
   const liveEvents = useLiveEvents({ passive: true });
   const connectionStatus =
@@ -109,12 +148,15 @@ export function useRuntimeHealth(): RuntimeHealthStatus {
           api.get("/api/health/llm"),
           api.get("/api/health/embedder"),
         ]);
+      const llmPayload =
+        llmResult.status === "fulfilled" ? llmResult.value?.data : null;
 
       const llmHealth = parseHealthResult(llmResult);
       const embedderHealth = parseHealthResult(embedderResult);
       const backendReachable = llmHealth.reachable || embedderHealth.reachable;
       const chatHealthy = embedderHealth.ok;
       const llmHealthy = llmHealth.ok;
+      const llmDetail = extractLlmDetail(llmPayload);
       const healthEndpointMissing =
         llmHealth.missing || embedderHealth.missing;
       const success =
@@ -125,6 +167,7 @@ export function useRuntimeHealth(): RuntimeHealthStatus {
         healthEndpointMissing,
         chatHealthy,
         llmHealthy,
+        llmDetail,
         lastCheckedAt: startedAt,
         lastSuccessAt: success ? startedAt : prev.lastSuccessAt,
       }));
@@ -179,6 +222,7 @@ export function useRuntimeHealth(): RuntimeHealthStatus {
     backendReachable: snapshot.backendReachable,
     chatHealthy: snapshot.chatHealthy,
     llmHealthy: snapshot.llmHealthy,
+    llmDetail: snapshot.llmDetail,
     liveEventsStatus: connectionStatus,
     lastSuccessAt,
     lastCheckedAt: snapshot.lastCheckedAt,

--- a/guardian/cognition/modular_prompt_builder.py
+++ b/guardian/cognition/modular_prompt_builder.py
@@ -153,9 +153,11 @@ def build_system_prompt(
         segment_meta.append(
             {
                 "name": name,
+                "text": text,
                 "chars": len(text),
                 "estimated_tokens": estimate_tokens(text),
                 "truncated": bool(truncated_flags[name]),
+                "cacheable": name != "scratchpad",
             }
         )
 

--- a/guardian/core/ai_router.py
+++ b/guardian/core/ai_router.py
@@ -10,6 +10,7 @@ from requests import exceptions as req_exc
 
 from guardian.core.config import Settings, get_settings
 from guardian.core.egress import EgressDeniedError, assert_egress_allowed
+from guardian.core.event_contracts import _coerce_text
 from guardian.core.provider_registry import default_model_for_provider
 from guardian.core.provider_registry import (
     normalize_provider as normalize_registry_provider,
@@ -75,6 +76,24 @@ class LocalReasoningDirective:
         if self.profile_reason:
             payload["profile_reason"] = self.profile_reason
         return payload
+
+
+class ProviderResponse(str):
+    """String-compatible provider result that preserves raw upstream data."""
+
+    def __new__(
+        cls,
+        text: str,
+        *,
+        raw_payload: Any | None = None,
+        content_blocks: Any | None = None,
+        provider: str | None = None,
+    ):
+        obj = super().__new__(cls, text or "")
+        obj.raw_payload = raw_payload  # type: ignore[attr-defined]
+        obj.content_blocks = content_blocks  # type: ignore[attr-defined]
+        obj.provider = provider  # type: ignore[attr-defined]
+        return obj
 
 
 @dataclass(frozen=True)
@@ -555,6 +574,7 @@ def chat_with_ai(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     reasoning_mode: Optional[str] = None,
+    prompt_meta: Optional[dict[str, Any]] = None,
     settings: Optional[Settings] = None,
 ):
     settings = _resolve_settings(settings)
@@ -600,7 +620,13 @@ def chat_with_ai(
     if provider_name == "alibaba":
         return call_alibaba(messages, target_model, settings=settings)
     if provider_name == "minimax":
-        return call_minimax(messages, target_model, settings=settings)
+        return call_minimax(
+            messages,
+            target_model,
+            reasoning_mode=reasoning_mode,
+            prompt_meta=prompt_meta,
+            settings=settings,
+        )
 
     logger.warning("Unsupported LLM provider: %s", provider_name)
     raise HTTPException(
@@ -1626,9 +1652,74 @@ def _extract_provider_error_message(
     return _sanitize_provider_error(text, secret=secret)
 
 
+def _anthropic_text_block(
+    text: str,
+    *,
+    cacheable: bool = False,
+) -> dict[str, Any]:
+    block: dict[str, Any] = {
+        "type": "text",
+        "text": str(text or "").strip(),
+    }
+    if cacheable:
+        block["cache_control"] = {"type": "ephemeral"}
+    return block
+
+
+def _coerce_anthropic_content_blocks(content: Any) -> list[dict[str, Any]]:
+    if isinstance(content, list):
+        blocks: list[dict[str, Any]] = []
+        for item in content:
+            if isinstance(item, dict):
+                block = dict(item)
+                block_type = str(block.get("type") or "").strip().lower()
+                if block_type:
+                    if block_type == "text":
+                        text = str(block.get("text") or "").strip()
+                        if not text:
+                            continue
+                        block["text"] = text
+                        blocks.append(block)
+                        continue
+                    if block_type in {"thinking", "tool_use", "tool_result"}:
+                        blocks.append(block)
+                        continue
+                text = _coerce_text(item).strip()
+                if text:
+                    blocks.append(_anthropic_text_block(text))
+                continue
+            text = str(item or "").strip()
+            if text:
+                blocks.append(_anthropic_text_block(text))
+        return blocks
+
+    if isinstance(content, dict):
+        block = dict(content)
+        block_type = str(block.get("type") or "").strip().lower()
+        if block_type:
+            if block_type == "text":
+                text = str(block.get("text") or "").strip()
+                if text:
+                    block["text"] = text
+                    return [block]
+                return []
+            if block_type in {"thinking", "tool_use", "tool_result"}:
+                return [block]
+
+    text = str(content or "").strip()
+    return [_anthropic_text_block(text)] if text else []
+
+
 def _normalize_messages_for_anthropic(
     messages: list[dict[str, Any]],
-) -> tuple[list[dict[str, Any]], str | None]:
+) -> tuple[list[dict[str, Any]], str | list[dict[str, Any]] | None]:
+    return _normalize_messages_for_anthropic_with_meta(messages, None)
+
+
+def _normalize_messages_for_anthropic_with_meta(
+    messages: list[dict[str, Any]],
+    prompt_meta: dict[str, Any] | None,
+) -> tuple[list[dict[str, Any]], str | list[dict[str, Any]] | None]:
     system_parts: list[str] = []
     normalized: list[dict[str, Any]] = []
 
@@ -1636,22 +1727,47 @@ def _normalize_messages_for_anthropic(
         if not isinstance(raw, dict):
             continue
         role = str(raw.get("role") or "user").strip().lower() or "user"
-        text = str(raw.get("content") or "").strip()
-        if not text:
-            continue
+        content = raw.get("content")
         if role == "system":
+            text = str(_coerce_text(content) or "").strip()
+            if not text:
+                continue
             system_parts.append(text)
+            continue
+
+        content_blocks = _coerce_anthropic_content_blocks(content)
+        if not content_blocks:
             continue
         if role not in {"user", "assistant"}:
             role = "user"
-        normalized.append(
-            {"role": role, "content": [{"type": "text", "text": text}]}
-        )
+        normalized.append({"role": role, "content": content_blocks})
 
     if not normalized:
         normalized = [
             {"role": "user", "content": [{"type": "text", "text": ""}]}
         ]
+
+    if prompt_meta:
+        segments = prompt_meta.get("segments")
+        if isinstance(segments, list):
+            system_blocks: list[dict[str, Any]] = []
+            cacheable_indexes: list[int] = []
+            for segment in segments:
+                if not isinstance(segment, dict):
+                    continue
+                text = str(segment.get("text") or "").strip()
+                if not text:
+                    continue
+                cacheable = bool(segment.get("cacheable"))
+                if cacheable:
+                    cacheable_indexes.append(len(system_blocks))
+                system_blocks.append(_anthropic_text_block(text))
+            if system_blocks:
+                if cacheable_indexes:
+                    system_blocks[cacheable_indexes[-1]]["cache_control"] = {
+                        "type": "ephemeral"
+                    }
+                return normalized, system_blocks
 
     system_text = "\n\n".join(part for part in system_parts if part).strip()
     return normalized, (system_text or None)
@@ -1673,7 +1789,14 @@ def _extract_anthropic_text(payload: dict[str, Any]) -> str:
     return "".join(parts)
 
 
-def call_minimax(messages, model: str, *, settings: Optional[Settings] = None):
+def call_minimax(
+    messages,
+    model: str,
+    *,
+    reasoning_mode: Optional[str] = None,
+    prompt_meta: Optional[dict[str, Any]] = None,
+    settings: Optional[Settings] = None,
+):
     """Call MiniMax via OpenAI- or Anthropic-compatible endpoints."""
     settings = _resolve_settings(settings)
 
@@ -1713,8 +1836,8 @@ def call_minimax(messages, model: str, *, settings: Optional[Settings] = None):
             ),
         )
 
-    api_flavor = str(getattr(settings, "MINIMAX_API_FLAVOR", "openai") or "")
-    api_flavor = api_flavor.strip().lower() or "openai"
+    api_flavor = str(getattr(settings, "MINIMAX_API_FLAVOR", "anthropic") or "")
+    api_flavor = api_flavor.strip().lower() or "anthropic"
     if api_flavor not in {"openai", "anthropic"}:
         raise HTTPException(
             status_code=400,
@@ -1722,9 +1845,10 @@ def call_minimax(messages, model: str, *, settings: Optional[Settings] = None):
         )
 
     if api_flavor == "anthropic":
-        anthropic_messages, system_prompt = _normalize_messages_for_anthropic(
-            messages
-        )
+        (
+            anthropic_messages,
+            system_prompt,
+        ) = _normalize_messages_for_anthropic_with_meta(messages, prompt_meta)
         payload: Dict[str, Any] = {
             "model": model,
             "messages": anthropic_messages,
@@ -1743,6 +1867,11 @@ def call_minimax(messages, model: str, *, settings: Optional[Settings] = None):
             ),
             "Content-Type": "application/json",
         }
+        if str(reasoning_mode or "").strip().lower() in {"think", "/think"}:
+            payload["thinking"] = {
+                "type": "enabled",
+                "budget_tokens": 1024,
+            }
         if base_url.endswith("/v1"):
             url = f"{base_url}/messages"
         else:
@@ -1752,6 +1881,7 @@ def call_minimax(messages, model: str, *, settings: Optional[Settings] = None):
             "model": model,
             "messages": messages,
             "temperature": 0.7,
+            "reasoning_split": True,
         }
         headers = {
             "Authorization": f"Bearer {api_key}",
@@ -1814,11 +1944,23 @@ def call_minimax(messages, model: str, *, settings: Optional[Settings] = None):
     try:
         data = response.json()
         if api_flavor == "anthropic":
-            text = _extract_anthropic_text(data)
-            if text:
-                return text
-            raise KeyError("content")
-        return data["choices"][0]["message"]["content"]
+            return ProviderResponse(
+                _extract_anthropic_text(data),
+                raw_payload=data,
+                content_blocks=data.get("content"),
+                provider="minimax",
+            )
+        choices = data.get("choices")
+        if isinstance(choices, list) and choices:
+            message = choices[0].get("message")
+            if isinstance(message, dict):
+                return ProviderResponse(
+                    _coerce_text(message.get("content")),
+                    raw_payload=data,
+                    content_blocks=message.get("content"),
+                    provider="minimax",
+                )
+        raise KeyError("content")
     except Exception as exc:
         detail = _sanitize_provider_error(str(exc), secret=api_key)
         logger.exception(

--- a/guardian/core/chat_completion_service.py
+++ b/guardian/core/chat_completion_service.py
@@ -792,6 +792,11 @@ def run_chat_completion_task(
                     model=model,
                     provider=provider,
                     reasoning_mode=getattr(task, "reasoning_mode", None),
+                    prompt_meta=(
+                        dict(bundle.get("_prompt_meta") or {})
+                        if isinstance(bundle, dict)
+                        else None
+                    ),
                 )
             )
             # Only emit via callback when nothing was streamed.
@@ -806,6 +811,11 @@ def run_chat_completion_task(
                 model=model,
                 provider=provider,
                 reasoning_mode=getattr(task, "reasoning_mode", None),
+                prompt_meta=(
+                    dict(bundle.get("_prompt_meta") or {})
+                    if isinstance(bundle, dict)
+                    else None
+                ),
             )
         )
         if token_callback:

--- a/guardian/core/config.py
+++ b/guardian/core/config.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_ALIBABA_API_BASE = (
     "https://dashscope-us.aliyuncs.com/compatible-mode/v1"
 )
+_DEFAULT_MINIMAX_ANTHROPIC_API_BASE = "https://api.minimax.io/anthropic"
 SUPPORTED_ROUTED_LLM_PROVIDERS: tuple[str, ...] = (
     "local",
     "openai",
@@ -257,11 +258,14 @@ class Settings(BaseSettings):
         default=None, description="API key for MiniMax."
     )
     MINIMAX_API_BASE: str | None = Field(
-        default=None,
-        description="Base URL for MiniMax's OpenAI-compatible API endpoint.",
+        default=_DEFAULT_MINIMAX_ANTHROPIC_API_BASE,
+        description=(
+            "Base URL for MiniMax's direct API endpoint. Defaults to the "
+            "Anthropic-compatible MiniMax surface."
+        ),
     )
     MINIMAX_API_FLAVOR: str = Field(
-        default="openai",
+        default="anthropic",
         description=(
             "MiniMax API surface to use: 'openai' for /chat/completions or "
             "'anthropic' for /v1/messages."
@@ -274,8 +278,11 @@ class Settings(BaseSettings):
         ),
     )
     MINIMAX_MODEL: str | None = Field(
-        default=None,
-        description="Optional default chat model for MiniMax.",
+        default="MiniMax-M2.7",
+        description=(
+            "Optional default chat model for MiniMax. Defaults to the "
+            "Anthropic-compatible M2.7 model."
+        ),
     )
     MINIMAX_TIMEOUT_SECONDS: float = Field(
         default=60.0,
@@ -890,9 +897,9 @@ def validate_llm_config(
                 f"{missing_text}. Set {missing_text} in your backend environment."
             )
         api_flavor = str(
-            getattr(settings, "MINIMAX_API_FLAVOR", "openai") or ""
+            getattr(settings, "MINIMAX_API_FLAVOR", "anthropic") or ""
         )
-        api_flavor = api_flavor.strip().lower() or "openai"
+        api_flavor = api_flavor.strip().lower() or "anthropic"
         if api_flavor not in {"openai", "anthropic"}:
             raise LLMConfigError(
                 "MINIMAX_API_FLAVOR must be one of: openai, anthropic."

--- a/guardian/core/provider_registry.py
+++ b/guardian/core/provider_registry.py
@@ -338,6 +338,79 @@ _STATIC_PROVIDER_MODELS: dict[str, tuple[dict[str, Any], ...]] = {
     ),
 }
 
+_MINIMAX_DOCUMENTED_MODELS: tuple[dict[str, Any], ...] = (
+    {
+        "id": "MiniMax-M2.7",
+        "displayName": "MiniMax M2.7",
+        "contextWindow": 204800,
+        "capabilities": {"chat": True, "vision": False, "text_input": True},
+        "supports_chat": True,
+        "supports_vision": False,
+        "supports_text_input": True,
+        "model_kind": "chat",
+    },
+    {
+        "id": "MiniMax-M2.7-highspeed",
+        "displayName": "MiniMax M2.7 Highspeed",
+        "contextWindow": 204800,
+        "capabilities": {"chat": True, "vision": False, "text_input": True},
+        "supports_chat": True,
+        "supports_vision": False,
+        "supports_text_input": True,
+        "model_kind": "chat",
+    },
+    {
+        "id": "MiniMax-M2.5",
+        "displayName": "MiniMax M2.5",
+        "contextWindow": 204800,
+        "capabilities": {"chat": True, "vision": False, "text_input": True},
+        "supports_chat": True,
+        "supports_vision": False,
+        "supports_text_input": True,
+        "model_kind": "chat",
+    },
+    {
+        "id": "MiniMax-M2.5-highspeed",
+        "displayName": "MiniMax M2.5 Highspeed",
+        "contextWindow": 204800,
+        "capabilities": {"chat": True, "vision": False, "text_input": True},
+        "supports_chat": True,
+        "supports_vision": False,
+        "supports_text_input": True,
+        "model_kind": "chat",
+    },
+    {
+        "id": "MiniMax-M2.1",
+        "displayName": "MiniMax M2.1",
+        "contextWindow": 204800,
+        "capabilities": {"chat": True, "vision": False, "text_input": True},
+        "supports_chat": True,
+        "supports_vision": False,
+        "supports_text_input": True,
+        "model_kind": "chat",
+    },
+    {
+        "id": "MiniMax-M2.1-highspeed",
+        "displayName": "MiniMax M2.1 Highspeed",
+        "contextWindow": 204800,
+        "capabilities": {"chat": True, "vision": False, "text_input": True},
+        "supports_chat": True,
+        "supports_vision": False,
+        "supports_text_input": True,
+        "model_kind": "chat",
+    },
+    {
+        "id": "MiniMax-M2",
+        "displayName": "MiniMax M2",
+        "contextWindow": 204800,
+        "capabilities": {"chat": True, "vision": False, "text_input": True},
+        "supports_chat": True,
+        "supports_vision": False,
+        "supports_text_input": True,
+        "model_kind": "chat",
+    },
+)
+
 
 def normalize_provider(provider: str | None) -> str:
     normalized = (provider or "").strip().lower()
@@ -490,6 +563,16 @@ def _provider_model_index_url(provider_id: str, settings: Settings) -> str:
         override = str(
             getattr(settings, "MINIMAX_MODEL_DISCOVERY_URL", "") or ""
         ).strip()
+        api_flavor = (
+            str(getattr(settings, "MINIMAX_API_FLAVOR", "anthropic") or "")
+            .strip()
+            .lower()
+            or "anthropic"
+        )
+        if override:
+            return override.rstrip("/")
+        if api_flavor == "anthropic":
+            return ""
         base_url = str(getattr(settings, "MINIMAX_API_BASE", "") or "").strip()
 
     if override:
@@ -523,10 +606,10 @@ def _provider_model_index_headers(
     if provider == "minimax":
         api_key = str(getattr(settings, "MINIMAX_API_KEY", "") or "").strip()
         api_flavor = (
-            str(getattr(settings, "MINIMAX_API_FLAVOR", "openai") or "")
+            str(getattr(settings, "MINIMAX_API_FLAVOR", "anthropic") or "")
             .strip()
             .lower()
-            or "openai"
+            or "anthropic"
         )
         if api_flavor == "anthropic":
             headers["x-api-key"] = api_key
@@ -1100,6 +1183,34 @@ def _static_provider_models(
     return static_models
 
 
+def _minimax_documented_models(settings: Settings) -> list[dict[str, Any]]:
+    models = [
+        _normalize_model_descriptor(dict(item))
+        for item in _MINIMAX_DOCUMENTED_MODELS
+    ]
+    default_model = default_model_for_provider("minimax", settings)
+    existing_ids = {
+        str(item.get("id") or "").strip()
+        for item in models
+        if str(item.get("id") or "").strip()
+    }
+    if default_model and default_model not in existing_ids:
+        models.insert(
+            0,
+            _normalize_model_descriptor(
+                {
+                    "id": default_model,
+                    "displayName": default_model,
+                    "supports_chat": True,
+                    "supports_vision": False,
+                    "supports_text_input": True,
+                    "model_kind": "chat",
+                }
+            ),
+        )
+    return models
+
+
 def resolve_provider_capability(
     provider_id: str,
     settings: Settings,
@@ -1130,7 +1241,40 @@ def resolve_provider_capability(
             available=available,
             disabled_reason=disabled_reason,
         )
-        if model_index["state"] != "available" and (
+        if (
+            provider == "minimax"
+            and available
+            and model_index["state"] != "available"
+        ):
+            fallback_models = _minimax_documented_models(settings)
+            if fallback_models:
+                models = fallback_models
+                chat_model_count = sum(
+                    1 for model in models if bool(model.get("supports_chat"))
+                )
+                utility_model_count = sum(
+                    1
+                    for model in models
+                    if not bool(model.get("supports_chat"))
+                )
+                model_index = {
+                    **model_index,
+                    "source": "fallback",
+                    "state": "degraded",
+                    "reason": (
+                        f"{str(model_index.get('reason') or 'MiniMax live discovery unavailable').strip()} "
+                        "using documented model list"
+                    ),
+                    "failure_kind": str(
+                        model_index.get("failure_kind")
+                        or "discovery_unavailable"
+                    ).strip()
+                    or "discovery_unavailable",
+                    "model_count": chat_model_count,
+                    "utility_model_count": utility_model_count,
+                    "total_model_count": len(models),
+                }
+        elif model_index["state"] != "available" and (
             not default_model
             or not provider_allows_default_during_degraded_discovery(provider)
         ):

--- a/guardian/providers/minimax_adapter.py
+++ b/guardian/providers/minimax_adapter.py
@@ -190,7 +190,7 @@ class MiniMaxAdapter(ChatProvider):
         ).strip()
         self.timeout = float(os.getenv("MINIMAX_TIMEOUT_SECONDS", timeout))
         self.api_flavor = (
-            (api_flavor or os.getenv("MINIMAX_API_FLAVOR") or "openai")
+            (api_flavor or os.getenv("MINIMAX_API_FLAVOR") or "anthropic")
             .strip()
             .lower()
         )

--- a/guardian/providers/registry.py
+++ b/guardian/providers/registry.py
@@ -33,7 +33,7 @@ class ProviderRegistry:
         except Exception:
             pass
 
-        # MiniMax (chat only; OpenAI-compatible endpoint)
+        # MiniMax (chat only; Anthropic-first with OpenAI fallback)
         try:
             if os.getenv("MINIMAX_API_KEY") and os.getenv("MINIMAX_API_BASE"):
                 from .minimax_adapter import MiniMaxAdapter

--- a/guardian/tests/core/test_ai_router.py
+++ b/guardian/tests/core/test_ai_router.py
@@ -54,11 +54,12 @@ def _fake_settings(provider: str) -> Settings:
         CODEXIFY_LOCAL_ONLY_MODE=False,
         CODEXIFY_EGRESS_ALLOWLIST="openai,groq,minimax",
         GROQ_API_KEY="groq-key",
+        GROQ_MODEL="moonshotai/kimi-k2-instruct-0905",
         OPENAI_API_KEY="openai-key",
         MINIMAX_API_KEY="minimax-key",
-        MINIMAX_API_BASE="https://api.minimax.local/v1",
-        MINIMAX_API_FLAVOR="openai",
-        MINIMAX_MODEL="minimax-chat",
+        MINIMAX_API_BASE="https://api.minimax.local/anthropic",
+        MINIMAX_API_FLAVOR="anthropic",
+        MINIMAX_MODEL="MiniMax-M2.5",
         LLM_MODEL="moonshotai/kimi-k2-instruct-0905",
         DEFAULT_GROQ_MODEL="moonshotai/kimi-k2-instruct-0905",
         DEFAULT_OPENAI_MODEL="gpt-4o",
@@ -139,22 +140,21 @@ def test_chat_with_ai_minimax_default(monkeypatch):
         calls["json"] = json
         calls["headers"] = headers
         calls["timeout"] = timeout
-        return _FakeResponse({"choices": [{"message": {"content": "ok"}}]})
+        return _FakeResponse({"content": [{"type": "text", "text": "ok"}]})
 
     monkeypatch.setattr("guardian.core.ai_router.requests.post", fake_post)
-    monkeypatch.setattr(
-        "guardian.core.provider_registry.requests.get",
-        _mock_minimax_model_index,
-    )
 
     settings = _fake_settings("minimax")
     reply = chat_with_ai([{"role": "user", "content": "hi"}], settings=settings)
 
-    assert "api.minimax.local/v1/chat/completions" in calls["url"]
-    assert calls["json"]["model"] == "minimax-chat"
-    assert calls["headers"]["Authorization"] == "Bearer minimax-key"
+    assert "api.minimax.local/anthropic/v1/messages" in calls["url"]
+    assert calls["json"]["model"] == "MiniMax-M2.5"
+    assert calls["headers"]["x-api-key"] == "minimax-key"
+    assert calls["headers"]["anthropic-version"] == "2023-06-01"
     assert calls["timeout"] == 60.0
     assert reply == "ok"
+    assert getattr(reply, "provider", None) == "minimax"
+    assert getattr(reply, "raw_payload", {}).get("content")
 
 
 def test_chat_with_ai_minimax_anthropic_surface(monkeypatch):
@@ -165,19 +165,18 @@ def test_chat_with_ai_minimax_anthropic_surface(monkeypatch):
         calls["json"] = json
         calls["headers"] = headers
         calls["timeout"] = timeout
-        return _FakeResponse({"content": [{"type": "text", "text": "ok-a"}]})
+        return _FakeResponse({"choices": [{"message": {"content": "ok-a"}}]})
 
     monkeypatch.setattr("guardian.core.ai_router.requests.post", fake_post)
 
     settings = _fake_settings("minimax")
-    settings.MINIMAX_API_FLAVOR = "anthropic"
-    settings.MINIMAX_API_BASE = "https://api.minimax.local/anthropic"
-    settings.MINIMAX_MODEL = "MiniMax-M2.5"
-    settings.MINIMAX_ANTHROPIC_VERSION = "2023-06-01"
+    settings.MINIMAX_API_FLAVOR = "openai"
+    settings.MINIMAX_API_BASE = "https://api.minimax.local/v1"
+    settings.MINIMAX_MODEL = "minimax-chat"
     monkeypatch.setattr(
         "guardian.core.provider_registry.requests.get",
         lambda url, headers, timeout: _MockDiscoveryResponse(
-            {"data": [{"id": "MiniMax-M2.5"}]}
+            {"data": [{"id": "minimax-chat"}]}
         ),
     )
 
@@ -189,14 +188,13 @@ def test_chat_with_ai_minimax_anthropic_surface(monkeypatch):
         settings=settings,
     )
 
-    assert "api.minimax.local/anthropic/v1/messages" in calls["url"]
-    assert calls["json"]["model"] == "MiniMax-M2.5"
-    assert calls["json"]["system"] == "Be precise."
+    assert "api.minimax.local/v1/chat/completions" in calls["url"]
+    assert calls["json"]["model"] == "minimax-chat"
     assert calls["json"]["messages"] == [
-        {"role": "user", "content": [{"type": "text", "text": "hi"}]}
+        {"role": "system", "content": "Be precise."},
+        {"role": "user", "content": "hi"},
     ]
-    assert calls["headers"]["x-api-key"] == "minimax-key"
-    assert calls["headers"]["anthropic-version"] == "2023-06-01"
+    assert calls["headers"]["Authorization"] == "Bearer minimax-key"
     assert calls["timeout"] == 60.0
     assert reply == "ok-a"
 
@@ -235,13 +233,19 @@ def test_chat_with_ai_groq_override_not_openai(monkeypatch):
         return _FakeResponse({"choices": [{"message": {"content": "ok"}}]})
 
     monkeypatch.setattr("guardian.core.ai_router.requests.post", fake_post)
+    monkeypatch.setattr(
+        "guardian.core.provider_registry.requests.get",
+        lambda url, headers, timeout: _MockDiscoveryResponse(
+            {"data": [{"id": "moonshotai/kimi-k2-instruct-0905"}]}
+        ),
+    )
 
     settings = _fake_settings("groq")
     chat_with_ai(
         [{"role": "user", "content": "hi"}],
         settings=settings,
         provider="groq",
-        model="custom-model",
+        model="moonshotai/kimi-k2-instruct-0905",
     )
 
     assert any(

--- a/guardian/tests/core/test_provider_registry.py
+++ b/guardian/tests/core/test_provider_registry.py
@@ -250,9 +250,12 @@ def test_minimax_discovery_failure_degrades_without_fabricating_models(
     assert capability["authorized"] is True
     assert capability["available"] is True
     assert capability["enabled"] is True
-    assert capability["models"] == []
+    assert capability["models"]
+    assert capability["models"][0]["id"] == "minimax-chat"
     assert capability["default_model"] == "minimax-chat"
     assert capability["model_index"]["state"] == "degraded"
+    assert capability["model_index"]["source"] == "fallback"
+    assert capability["model_index"]["failure_kind"] == "provider_timeout"
     assert "timed out" in capability["model_index"]["reason"].lower()
 
     valid, reason = validate_provider_model_selection(

--- a/guardian/tests/test_llm_catalog_endpoint.py
+++ b/guardian/tests/test_llm_catalog_endpoint.py
@@ -573,6 +573,7 @@ def test_llm_catalog_minimax_enabled_with_key_base_and_egress(monkeypatch):
         "CODEXIFY_EGRESS_ALLOWLIST": settings.CODEXIFY_EGRESS_ALLOWLIST,
         "MINIMAX_API_KEY": settings.MINIMAX_API_KEY,
         "MINIMAX_API_BASE": settings.MINIMAX_API_BASE,
+        "MINIMAX_API_FLAVOR": settings.MINIMAX_API_FLAVOR,
         "MINIMAX_MODEL": settings.MINIMAX_MODEL,
     }
     try:
@@ -581,6 +582,7 @@ def test_llm_catalog_minimax_enabled_with_key_base_and_egress(monkeypatch):
         settings.CODEXIFY_EGRESS_ALLOWLIST = "minimax"
         settings.MINIMAX_API_KEY = "test-minimax-key"
         settings.MINIMAX_API_BASE = "https://api.minimax.local/v1"
+        settings.MINIMAX_API_FLAVOR = "openai"
         settings.MINIMAX_MODEL = "minimax-chat"
 
         client = TestClient(app)
@@ -620,6 +622,7 @@ def test_llm_catalog_dynamic_discovery_failure_reports_degraded_metadata(
         "CODEXIFY_EGRESS_ALLOWLIST": settings.CODEXIFY_EGRESS_ALLOWLIST,
         "MINIMAX_API_KEY": settings.MINIMAX_API_KEY,
         "MINIMAX_API_BASE": settings.MINIMAX_API_BASE,
+        "MINIMAX_API_FLAVOR": settings.MINIMAX_API_FLAVOR,
         "MINIMAX_MODEL": settings.MINIMAX_MODEL,
     }
     try:
@@ -628,6 +631,7 @@ def test_llm_catalog_dynamic_discovery_failure_reports_degraded_metadata(
         settings.CODEXIFY_EGRESS_ALLOWLIST = "minimax"
         settings.MINIMAX_API_KEY = "test-minimax-key"
         settings.MINIMAX_API_BASE = "https://api.minimax.local/v1"
+        settings.MINIMAX_API_FLAVOR = "openai"
         settings.MINIMAX_MODEL = "minimax-chat"
 
         client = TestClient(app)
@@ -639,8 +643,10 @@ def test_llm_catalog_dynamic_discovery_failure_reports_degraded_metadata(
         assert minimax["authorized"] is True
         assert minimax["available"] is True
         assert minimax["enabled"] is True
-        assert minimax["models"] == []
+        assert minimax["models"]
+        assert minimax["models"][0]["id"] == "minimax-chat"
         assert minimax["model_index"]["state"] == "degraded"
+        assert minimax["model_index"]["source"] == "fallback"
         assert "timed out" in minimax["model_index"]["reason"].lower()
     finally:
         for field, value in snapshot.items():

--- a/guardian/tests/test_minimax_provider.py
+++ b/guardian/tests/test_minimax_provider.py
@@ -125,6 +125,7 @@ def test_minimax_adapter_uses_openai_compatible_client(monkeypatch):
         base_url="https://api.minimax.local/v1",
         default_model="minimax-chat",
         timeout=45,
+        api_flavor="openai",
     )
     reply = adapter.generate(
         "ignored prompt",

--- a/guardian/tests/test_minimax_smoke.py
+++ b/guardian/tests/test_minimax_smoke.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from guardian.core.config import Settings, get_settings
+from guardian.guardian_api import app
+from guardian.providers.minimax_adapter import MiniMaxAdapter
+
+
+def _require_smoke_opt_in(settings: Settings | None = None) -> Settings:
+    if not os.getenv("MINIMAX_SMOKE_TEST"):
+        pytest.skip("MiniMax smoke test disabled; set MINIMAX_SMOKE_TEST=1")
+
+    resolved = settings or get_settings()
+    missing = []
+    if not (resolved.MINIMAX_API_KEY or "").strip():
+        missing.append("MINIMAX_API_KEY")
+    if not (resolved.MINIMAX_API_BASE or "").strip():
+        missing.append("MINIMAX_API_BASE")
+    if not bool(resolved.ALLOW_CLOUD_PROVIDERS):
+        missing.append("ALLOW_CLOUD_PROVIDERS=true")
+    allowlist = str(resolved.CODEXIFY_EGRESS_ALLOWLIST or "").lower()
+    if "minimax" not in {
+        part.strip() for part in allowlist.split(",") if part.strip()
+    }:
+        missing.append("CODEXIFY_EGRESS_ALLOWLIST includes minimax")
+    if bool(resolved.CODEXIFY_LOCAL_ONLY_MODE):
+        missing.append("CODEXIFY_LOCAL_ONLY_MODE=false")
+    if missing:
+        pytest.skip("MiniMax smoke test requires: " + ", ".join(missing))
+    return resolved
+
+
+def test_minimax_catalog_smoke():
+    settings = _require_smoke_opt_in()
+    client = TestClient(app)
+
+    response = client.get("/api/llm/catalog?include=all")
+    assert response.status_code == 200
+
+    payload = response.json()
+    provider = next(
+        item for item in payload["providers"] if item.get("id") == "minimax"
+    )
+
+    assert provider["enabled"] is True
+    assert provider["authorized"] is True
+    assert provider["available"] is True
+    assert provider["models"]
+    assert any(model.get("supports_chat") for model in provider["models"])
+
+    model_index = provider.get("model_index") or {}
+    assert model_index.get("state") in {"available", "degraded"}
+    if model_index.get("state") == "degraded":
+        assert str(model_index.get("reason") or "").strip()
+
+    assert settings.MINIMAX_API_KEY
+    assert settings.MINIMAX_API_BASE
+
+
+def test_minimax_chat_smoke():
+    settings = _require_smoke_opt_in()
+    adapter = MiniMaxAdapter(
+        api_key=settings.MINIMAX_API_KEY,
+        base_url=settings.MINIMAX_API_BASE,
+        default_model=settings.MINIMAX_MODEL,
+        timeout=float(os.getenv("MINIMAX_SMOKE_TIMEOUT_SECONDS", "30")),
+        api_flavor=settings.MINIMAX_API_FLAVOR,
+    )
+
+    reply = adapter.generate(
+        "Reply with the single word ok.",
+        messages=[
+            {"role": "system", "content": "Be concise."},
+            {"role": "user", "content": "Smoke test."},
+        ],
+    )
+
+    assert isinstance(reply, str)
+    assert reply.strip()

--- a/guardian/workers/chat_worker.py
+++ b/guardian/workers/chat_worker.py
@@ -23,9 +23,6 @@ from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
 from guardian.audio import tts_trigger
-from guardian.cognition.prompts import (
-    build_context_system_message as _compat_build_context_system_message,
-)
 from guardian.cognition.system_profiles.resolver import (
     resolve_thread_system_profile,
 )
@@ -1232,6 +1229,11 @@ def _run_chat_completion_task_compat(
                         model=execution_model,
                         provider=execution_provider,
                         reasoning_mode=getattr(task, "reasoning_mode", None),
+                        prompt_meta=(
+                            dict(bundle.get("_prompt_meta") or {})
+                            if isinstance(bundle, dict)
+                            else None
+                        ),
                     )
                 )
                 if token_callback and (not streamed_any) and assistant_output:
@@ -1246,6 +1248,11 @@ def _run_chat_completion_task_compat(
                 model=execution_model,
                 provider=execution_provider,
                 reasoning_mode=getattr(task, "reasoning_mode", None),
+                prompt_meta=(
+                    dict(bundle.get("_prompt_meta") or {})
+                    if isinstance(bundle, dict)
+                    else None
+                ),
             )
         )
         if token_callback:
@@ -1253,7 +1260,6 @@ def _run_chat_completion_task_compat(
         return assistant_output
 
     fallback_reason: str | None = None
-    fallback_attempted = False
     failure_meta: dict[str, Any] = {}
     final_provider = provider
     final_model = model
@@ -1290,9 +1296,8 @@ def _run_chat_completion_task_compat(
             if isinstance(detail, dict):
                 detail.update(failure_meta)
             else:
-                setattr(exc, "metadata", failure_meta)
+                exc.metadata = failure_meta
             raise
-        fallback_attempted = True
         completion_truth["fallback_attempted"] = True
         rescued = False
         fallback_errors: list[str] = []
@@ -1329,7 +1334,7 @@ def _run_chat_completion_task_compat(
             if isinstance(detail, dict):
                 detail.update(failure_meta)
             else:
-                setattr(exc, "metadata", failure_meta)
+                exc.metadata = failure_meta
             raise
         payload_summary["final_provider"] = final_provider
         payload_summary["final_model"] = final_model

--- a/tests/core/test_ai_router.py
+++ b/tests/core/test_ai_router.py
@@ -307,6 +307,7 @@ def test_call_minimax_transport_failure_surfaces_transport_error(monkeypatch):
         CODEXIFY_EGRESS_ALLOWLIST="minimax",
         MINIMAX_API_KEY="test-minimax-key",
         MINIMAX_API_BASE="https://api.minimax.chat/v1",
+        MINIMAX_API_FLAVOR="openai",
         MINIMAX_MODEL="abab6.5s-chat",
         MINIMAX_TIMEOUT_SECONDS=5.0,
     )
@@ -345,6 +346,7 @@ def test_call_minimax_http_error_surfaces_provider_error_payload(monkeypatch):
         CODEXIFY_EGRESS_ALLOWLIST="minimax",
         MINIMAX_API_KEY="test-minimax-key",
         MINIMAX_API_BASE="https://api.minimax.chat/v1",
+        MINIMAX_API_FLAVOR="openai",
         MINIMAX_MODEL="abab6.5s-chat",
     )
 

--- a/tests/routes/test_llm_catalog.py
+++ b/tests/routes/test_llm_catalog.py
@@ -119,6 +119,7 @@ def _clear_extra_cloud_keys(monkeypatch) -> None:
     monkeypatch.delenv("ALIBABA_API_KEY", raising=False)
     monkeypatch.delenv("ALIBABA_API_BASE", raising=False)
     monkeypatch.delenv("ALIBABA_MODEL", raising=False)
+    monkeypatch.delenv("MINIMAX_API_FLAVOR", raising=False)
     monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
     monkeypatch.delenv("MINIMAX_API_BASE", raising=False)
     monkeypatch.delenv("MINIMAX_MODEL", raising=False)
@@ -483,6 +484,7 @@ def test_llm_catalog_minimax_discovery_transport_failure_reports_failure_kind(
         "CODEXIFY_EGRESS_ALLOWLIST": settings.CODEXIFY_EGRESS_ALLOWLIST,
         "MINIMAX_API_KEY": settings.MINIMAX_API_KEY,
         "MINIMAX_API_BASE": settings.MINIMAX_API_BASE,
+        "MINIMAX_API_FLAVOR": settings.MINIMAX_API_FLAVOR,
         "MINIMAX_MODEL": settings.MINIMAX_MODEL,
     }
     try:
@@ -491,19 +493,20 @@ def test_llm_catalog_minimax_discovery_transport_failure_reports_failure_kind(
         settings.CODEXIFY_EGRESS_ALLOWLIST = "minimax"
         settings.MINIMAX_API_KEY = "test-minimax-key"
         settings.MINIMAX_API_BASE = "https://api.minimax.chat/v1"
+        settings.MINIMAX_API_FLAVOR = "openai"
         settings.MINIMAX_MODEL = None
 
         client = TestClient(app)
         payload = client.get("/api/llm/catalog").json()
         minimax = _provider_by_id(payload, "minimax")
-        assert minimax["available"] is False
-        assert minimax["enabled"] is False
+        assert minimax["available"] is True
+        assert minimax["enabled"] is True
+        assert minimax["models"]
+        assert minimax["models"][0]["id"] == "MiniMax-M2.7"
         assert minimax["model_index"]["state"] == "degraded"
+        assert minimax["model_index"]["source"] == "fallback"
         assert minimax["model_index"]["failure_kind"] == "transport_error"
-        assert (
-            minimax["disabled_reason"]
-            == "Provider model index request failed: ConnectionError"
-        )
+        assert minimax.get("disabled_reason") is None
     finally:
         for field, value in snapshot.items():
             setattr(settings, field, value)
@@ -527,6 +530,7 @@ def test_llm_catalog_minimax_empty_catalog_reports_failure_kind(monkeypatch):
         "CODEXIFY_EGRESS_ALLOWLIST": settings.CODEXIFY_EGRESS_ALLOWLIST,
         "MINIMAX_API_KEY": settings.MINIMAX_API_KEY,
         "MINIMAX_API_BASE": settings.MINIMAX_API_BASE,
+        "MINIMAX_API_FLAVOR": settings.MINIMAX_API_FLAVOR,
         "MINIMAX_MODEL": settings.MINIMAX_MODEL,
     }
     try:
@@ -535,22 +539,20 @@ def test_llm_catalog_minimax_empty_catalog_reports_failure_kind(monkeypatch):
         settings.CODEXIFY_EGRESS_ALLOWLIST = "minimax"
         settings.MINIMAX_API_KEY = "test-minimax-key"
         settings.MINIMAX_API_BASE = "https://api.minimax.chat/v1"
+        settings.MINIMAX_API_FLAVOR = "openai"
         settings.MINIMAX_MODEL = None
 
         client = TestClient(app)
         payload = client.get("/api/llm/catalog").json()
         minimax = _provider_by_id(payload, "minimax")
-        assert minimax["available"] is False
-        assert minimax["enabled"] is False
+        assert minimax["available"] is True
+        assert minimax["enabled"] is True
+        assert minimax["models"]
+        assert minimax["models"][0]["id"] == "MiniMax-M2.7"
         assert minimax["model_index"]["state"] == "degraded"
         assert minimax["model_index"]["failure_kind"] == "empty_model_result"
-        assert minimax["model_index"]["model_count"] == 0
-        assert minimax["model_index"]["utility_model_count"] == 1
-        assert minimax["model_index"]["total_model_count"] == 1
-        assert (
-            minimax["disabled_reason"]
-            == "Provider model index returned no chat-capable models"
-        )
+        assert minimax["model_index"]["source"] == "fallback"
+        assert minimax.get("disabled_reason") is None
     finally:
         for field, value in snapshot.items():
             setattr(settings, field, value)

--- a/tests/system_prompt/test_modular_prompt_builder.py
+++ b/tests/system_prompt/test_modular_prompt_builder.py
@@ -43,6 +43,9 @@ def test_build_system_prompt_returns_single_string_and_fixed_order() -> None:
         "system_docs",
         "scratchpad",
     ]
+    assert segments[0]["text"] == "Base rules"
+    assert segments[0]["cacheable"] is True
+    assert segments[-1]["cacheable"] is False
     assert meta["estimated_tokens_total"] == sum(
         segment["estimated_tokens"] for segment in segments
     )


### PR DESCRIPTION
## Summary
- Make MiniMax Anthropic-first by default, with OpenAI-compatible fallback only when explicitly selected
- Preserve Anthropic thinking and tool-call payloads through the router
- Add MiniMax catalog fallback to documented models when live discovery is unavailable
- Thread prompt caching metadata through stable prompt segments
- Add an opt-in live MiniMax smoke test
- Reuse the existing degraded runtime banner to show MiniMax/LLM detail in dev

## Validation
- pytest -q tests/system_prompt/test_modular_prompt_builder.py tests/core/test_ai_router.py tests/routes/test_llm_catalog.py guardian/tests/core/test_ai_router.py guardian/tests/core/test_provider_registry.py guardian/tests/test_minimax_provider.py guardian/tests/test_llm_catalog_endpoint.py
- pytest -q guardian/tests/test_minimax_smoke.py
- pnpm --dir frontend/src exec vitest run components/persona/layout/AppShell.runtimeHealth.test.tsx