### PR TITLE
Fix composer send button boundary and circle geometry

### DIFF
--- a/frontend/src/features/chat/components/Composer.tsx
+++ b/frontend/src/features/chat/components/Composer.tsx
@@ -730,10 +730,10 @@ export function Composer({
         />
 
         <div
-          data-testid="composer-controls-row"
+          data-testid="composer-control-row"
           className={cn(
-            "mt-auto flex w-full items-center justify-between gap-3",
-            CHAT_COMPOSER_CONTROLS_BOTTOM_GAP_CLASS
+            CHAT_COMPOSER_CONTROLS_BOTTOM_GAP_CLASS,
+            "mt-auto flex w-full items-center justify-between gap-3 pl-[8px] pr-[24px] pb-[6px]"
           )}
         >
           <div className="flex min-w-0 flex-nowrap items-center gap-3 overflow-x-auto pr-2">
@@ -794,7 +794,7 @@ export function Composer({
             />
           </div>
 
-          <div data-testid="composer-send-slot" className="flex shrink-0 items-center pr-[3px]">
+          <div data-testid="composer-send-slot" className="shrink-0">
             <Button
               type="button"
               onClick={handleAttemptSend}
@@ -809,7 +809,7 @@ export function Composer({
               }
               size="icon"
               className={cn(
-                "!h-8 !w-8 !min-w-0 !rounded-full !px-0 transition-opacity",
+                "h-8 w-8 min-w-0 rounded-full p-0 transition-opacity",
                 sendTransportDisabled
                   ? "cursor-not-allowed opacity-50"
                   : sendBlockedByTurnLock

--- a/frontend/src/features/chat/components/__tests__/Composer.draft-sync.test.tsx
+++ b/frontend/src/features/chat/components/__tests__/Composer.draft-sync.test.tsx
@@ -118,21 +118,26 @@ describe("Composer draft sync", () => {
     expect(onDraftValueChange).toHaveBeenLastCalledWith("");
   });
 
-  it("keeps the send control inset and the button circular", () => {
+  it("assigns right-edge ownership to the control row and keeps the send button circular", () => {
     render(<Composer onSend={vi.fn()} draftScopeKey="tab-1" draftValue="" />);
 
+    const controlsRow = screen.getByTestId("composer-control-row");
+    expect(controlsRow).toHaveClass("pr-[24px]");
+
     const sendSlot = screen.getByTestId("composer-send-slot");
-    expect(sendSlot).toHaveClass("flex", "shrink-0", "items-center", "pr-[3px]");
+    expect(sendSlot).toHaveClass("shrink-0");
+    expect(sendSlot.className).not.toMatch(/\bpr-/);
 
     const sendButton = screen.getByRole("button", { name: "Send" });
     expect(sendButton.parentElement).toBe(sendSlot);
     expect(sendButton).toHaveClass(
-      "!h-8",
-      "!w-8",
-      "!min-w-0",
-      "!rounded-full",
-      "!px-0"
+      "h-8",
+      "w-8",
+      "min-w-0",
+      "rounded-full",
+      "p-0"
     );
+    expect(sendButton.className).not.toMatch(/\brounded-md\b/);
 
     const textarea = screen.getByPlaceholderText("Write a message…");
     expect(textarea.parentElement).toHaveAttribute("data-composer-root");
@@ -412,7 +417,7 @@ describe("Composer draft sync", () => {
       />
     );
 
-    const controlsRow = screen.getByTestId("composer-controls-row");
+    const controlsRow = screen.getByTestId("composer-control-row");
     expect(controlsRow.className).toContain("mt-auto");
     expect(controlsRow.className).toContain(
       CHAT_COMPOSER_CONTROLS_BOTTOM_GAP_CLASS


### PR DESCRIPTION
## Summary
- move right-edge ownership to the composer control row with explicit `pl-[8px] pr-[24px] pb-[6px]`
- keep the send slot as a semantic/test boundary only with `data-testid="composer-send-slot"` and no right padding
- enforce local send button circle geometry with `size="icon"`, `h-8 w-8 min-w-0 rounded-full p-0`, and preserve existing send-state behavior
- update composer draft-sync tests to cover the new control-row anchor, boundary ownership, and circle class contract

## Testing
- `pnpm --dir frontend/src exec vitest run features/chat/components/__tests__/Composer.draft-sync.test.tsx features/chat/__tests__/GuardianChat.session-tabs.test.tsx`