### PR TITLE
Codex/fix appshell logo colors

### DIFF
--- a/frontend/src/components/persona/layout/AppShell.tsx
+++ b/frontend/src/components/persona/layout/AppShell.tsx
@@ -1825,6 +1825,7 @@ export default function AppShell({
           <button
             type="button"
             className="pill-tab brand-tab"
+            style={{ color: "var(--text)" }}
             title={
               layoutMode === "zen"
                 ? "Zen layout — click to switch to Focus"

--- a/frontend/src/components/persona/layout/__tests__/AppShell.test.tsx
+++ b/frontend/src/components/persona/layout/__tests__/AppShell.test.tsx
@@ -1,0 +1,213 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+import AppShell from "../AppShell";
+import {
+  LIVE_EVENT_CONNECTION_STATES,
+  RUNTIME_HEALTH_STATUSES,
+} from "@/contracts/runtimeTokens";
+
+const runtimeHealthState = {
+  status: RUNTIME_HEALTH_STATUSES.HEALTHY,
+  failureKind: null,
+  llmDetail: null,
+  lastSuccessAt: Date.parse("2026-03-20T12:00:00Z"),
+  backendReachable: true,
+  chatHealthy: true,
+  llmHealthy: true,
+  liveEventsStatus: LIVE_EVENT_CONNECTION_STATES.CONNECTED,
+  lastCheckedAt: Date.parse("2026-03-20T12:00:00Z"),
+  stale: false,
+};
+
+vi.mock("@/hooks/useRuntimeHealth", () => ({
+  default: () => runtimeHealthState,
+}));
+
+vi.mock("@/hooks/useLiveEvents", () => ({
+  useLiveEvents: () => ({
+    lastEvent: null,
+    subscribe: () => () => {},
+    connected: true,
+    connectionStatus: LIVE_EVENT_CONNECTION_STATES.CONNECTED,
+    statusUpdatedAt: Date.now(),
+  }),
+}));
+
+vi.mock("@/hooks/useWallpaperUrl", () => ({
+  useWallpaperUrl: () => ({ wallpaperUrl: null }),
+}));
+
+vi.mock("@/hooks/useUploader", () => ({
+  default: () => ({
+    uploadFiles: vi.fn(),
+    uploading: false,
+  }),
+}));
+
+vi.mock("@/hooks/useBreakpoint", () => ({
+  useBreakpoint: () => "lg",
+}));
+
+vi.mock("@/lib/authState", () => ({
+  useAuthState: () => ({
+    ready: true,
+    status: "authenticated",
+    token: "test-token",
+  }),
+  checkAuthGate: () => true,
+}));
+
+vi.mock("@/state/session/SessionSpine", () => ({
+  SessionSpine: class {
+    static getRegisteredSpine() {
+      return {
+        isComposerBlocked: () => false,
+        getActiveCompletion: () => null,
+        consumeAcceptedLiveEvent: vi.fn(),
+        findTabIdForThread: () => null,
+        getActiveTabId: () => null,
+        rememberSubmittedDraft: vi.fn(),
+        startCompletion: vi.fn(),
+        attachCompletionIdentity: vi.fn(),
+        failActiveCompletion: vi.fn(),
+        cancelActiveCompletion: vi.fn(),
+      };
+    }
+    static subscribeActiveSpine() {
+      return () => {};
+    }
+  },
+}));
+
+vi.mock("@/api/codex", () => ({
+  listCodexEntries: vi.fn(async () => []),
+}));
+
+vi.mock("@/lib/api", () => ({
+  default: {
+    get: vi.fn(async () => ({ data: {} })),
+    post: vi.fn(async () => ({ data: {} })),
+    delete: vi.fn(async () => ({ data: {} })),
+    interceptors: {
+      request: { use: vi.fn(() => 1), eject: vi.fn() },
+      response: { use: vi.fn(() => 2), eject: vi.fn() },
+    },
+  },
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children }: { children?: ReactNode }) => <button>{children}</button>,
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: () => <input data-testid="input-mock" />,
+}));
+
+vi.mock("@/components/ui/RefractiveGlassCard", () => ({
+  default: ({ children }: { children?: ReactNode }) => <>{children ?? null}</>,
+}));
+
+vi.mock("@/components/surface/FrameCard", () => ({
+  default: ({ children }: { children?: ReactNode }) => <>{children ?? null}</>,
+}));
+
+vi.mock("@/features/chat/GuardianChat", () => ({
+  default: () => <div data-testid="guardian-chat-mock" />,
+}));
+
+vi.mock("@/features/workspace/WorkspacePane", () => ({
+  default: () => <div data-testid="workspace-pane-mock" />,
+}));
+
+vi.mock("@/components/dashboard/DashboardView", () => ({
+  default: () => <div data-testid="dashboard-view-mock" />,
+}));
+
+vi.mock("@/features/settings/SettingsView", () => ({
+  default: () => <div data-testid="settings-view-mock" />,
+}));
+
+vi.mock("@/components/ErrorBoundary", () => ({
+  default: ({ children }: { children?: ReactNode }) => <>{children ?? null}</>,
+}));
+
+vi.mock("@/components/documents/DocumentsView", () => ({
+  default: () => <div data-testid="documents-view-mock" />,
+}));
+
+vi.mock("@/components/persona/layout/GuardianChatWithSidebar", () => ({
+  default: () => <div data-testid="guardian-chat-with-sidebar-mock" />,
+}));
+
+vi.mock("@/components/ui/ToastPortal", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/components/ui/ContextMenu", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/components/modals/ImageGenModal", () => ({
+  ImageGenModal: () => null,
+}));
+
+vi.mock("@/components/ShareButton", () => ({
+  ShareButton: () => <button type="button">Share</button>,
+}));
+
+vi.mock("@/theme", () => ({
+  injectCssVars: vi.fn(),
+}));
+
+function installMatchMedia(prefersDark = false) {
+  window.matchMedia = ((query: string) => ({
+    matches: query === "(prefers-color-scheme: dark)" ? prefersDark : false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+}
+
+function renderWordmark(themeMode: "light" | "dark") {
+  window.localStorage.setItem("cfy.themeMode", themeMode);
+  render(<AppShell />);
+  return screen.getByRole("button", { name: "Codexify" });
+}
+
+describe("AppShell logo wordmark color contract", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    installMatchMedia(false);
+    document.documentElement.classList.remove("dark");
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("binds the wordmark to the text token instead of a raw color literal across light and dark themes", () => {
+    const lightWordmark = renderWordmark("light");
+    expect(lightWordmark.style.color).toBe("var(--text)");
+    expect(lightWordmark.getAttribute("style")).not.toMatch(/#|rgb|hsl/i);
+
+    const lightShell = lightWordmark.closest("div[style*='--text:']");
+    expect(lightShell).not.toBeNull();
+    expect(lightShell?.getAttribute("style")).toContain("--text: #111827");
+
+    cleanup();
+
+    const darkWordmark = renderWordmark("dark");
+    expect(darkWordmark.style.color).toBe("var(--text)");
+    expect(darkWordmark.getAttribute("style")).not.toMatch(/#|rgb|hsl/i);
+
+    const darkShell = darkWordmark.closest("div[style*='--text:']");
+    expect(darkShell).not.toBeNull();
+    expect(darkShell?.getAttribute("style")).toContain("--text: #ffffff");
+  });
+});

--- a/frontend/src/features/chat/chatLane.ts
+++ b/frontend/src/features/chat/chatLane.ts
@@ -3,11 +3,11 @@ export const CHAT_LANE_MAX_WIDTH = 888;
 export const CHAT_LANE_MAX_WIDTH_CLASS = "md:max-w-[888px]";
 // Inline gutter applied around the lane when deriving shell widths. Mirrors
 // the default `--shell-gap` token to keep layout token-driven.
-export const CHAT_LANE_INLINE_GUTTER = 16;
+export const CHAT_LANE_INLINE_GUTTER = 20;
 export const CHAT_LANE_GUTTER_CLASS =
   "px-[max(var(--page-pad,0px),var(--shell-gap,16px))]";
 export const CHAT_LANE_STAGE_GUTTER_CLASS =
-  "mx-[max(var(--page-pad,0px),var(--shell-gap,16px))]";
+  "mx-[max(var(--page-pad,0px),var(--shell-gap,1px))]";
 
 // Shell boundary for the composer frame. Keep identical to lane width so the
 // composer edge aligns to the shared chat column contract.
@@ -28,13 +28,13 @@ export const CHAT_COMPOSER_SEND_PAD_CLASS = "pr-2";
 // Outer Guardian surface ceiling for fullscreen layouts. Keeps the shell large
 // enough for future workspace activation without letting the empty side bands
 // dominate the scene on very wide displays.
-export const GUARDIAN_SHELL_MAX_WIDTH = 1200;
+export const GUARDIAN_SHELL_MAX_WIDTH = 888;
 
 // Static class companion for shell consumers that need the canonical Tailwind
 // contract alongside the numeric token.
-export const GUARDIAN_SHELL_MAX_WIDTH_CLASS = "max-w-[1200px]";
+export const GUARDIAN_SHELL_MAX_WIDTH_CLASS = "max-w-[888px]";
 
 // Token-friendly padding expression reused by chat surfaces so portrait and
 // fullscreen share the same baseline inset without bespoke numbers.
 export const CHAT_LANE_INLINE_PADDING =
-  "max(var(--page-pad, 0px), var(--shell-gap, 16px))";
+  "max(var(--page-pad, 0px), var(--shell-gap, )10px)";


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
