### PR TITLE
Fix background ChatGPT import acceptance for large exports

### DIFF
--- a/backend/rag/chatgpt_migration.py
+++ b/backend/rag/chatgpt_migration.py
@@ -1116,11 +1116,6 @@ def ingest_chatgpt_export(
     """
     Ingest a ChatGPT export (JSON bytes) into the database and vector store.
     """
-    # Defense-in-depth: enforce size limit at service entry
-    MAX_IMPORT_SIZE = 50 * 1024 * 1024  # 50MB
-    if len(content) > MAX_IMPORT_SIZE:
-        raise ValueError("Export file exceeds 50MB limit")
-
     if not user_id:
         raise ValueError(
             "ingest_chatgpt_export requires a valid user_id (got None or empty)"

--- a/frontend/src/components/modals/ChatGPTImportModal.tsx
+++ b/frontend/src/components/modals/ChatGPTImportModal.tsx
@@ -33,6 +33,15 @@ export interface MigrationStats {
   embedding_coverage_degraded: ChatGptImportStats["embedding_coverage_degraded"];
 }
 
+const LARGE_IMPORT_BYTES = 50 * 1024 * 1024;
+
+const formatFileSize = (size: number) => {
+  if (size >= 1024 * 1024) {
+    return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  return `${Math.ceil(size / 1024)} KB`;
+};
+
 export function ChatGPTImportModal({
   open,
   onOpenChange,
@@ -40,6 +49,7 @@ export function ChatGPTImportModal({
   onImported,
 }: ChatGPTImportModalProps) {
   const [file, setFile] = useState<File | null>(null);
+  const isLargeImport = Boolean(file && file.size >= LARGE_IMPORT_BYTES);
   const [isDragOver, setIsDragOver] = useState(false);
   const [status, setStatus] = useState<
     "idle" | "uploading" | "success" | "error"
@@ -220,9 +230,28 @@ export function ChatGPTImportModal({
               </Button>
             </div>
             <div className="mt-2 text-xs opacity-70 truncate">
-              {file ? `${file.name} (${Math.ceil(file.size / 1024)} KB)` : "No file selected"}
+              {file ? `${file.name} (${formatFileSize(file.size)})` : "No file selected"}
             </div>
           </div>
+
+          {isLargeImport && (
+            <div
+              className="rounded-xl border p-3 text-xs"
+              style={{
+                borderColor: "var(--panel-border)",
+                background:
+                  "color-mix(in oklab, var(--panel-sheet) 92%, transparent)",
+                color: "var(--text)",
+              }}
+            >
+              <div className="font-semibold">Large export detected</div>
+              <div className="mt-1 opacity-80">
+                Large ChatGPT exports are accepted. Processing may take longer,
+                runs in the background, and can resume across sessions or after
+                restarts.
+              </div>
+            </div>
+          )}
 
           {status === "uploading" && (
             <div className="text-sm text-center opacity-70 animate-pulse py-3">

--- a/frontend/src/tests/playwright/migration_e2e_import.spec.ts
+++ b/frontend/src/tests/playwright/migration_e2e_import.spec.ts
@@ -328,4 +328,150 @@ test.describe('ChatGPT migration import', () => {
     await expect.poll(() => completedThreadId).toBe(importedThread.id);
     await expect(page.getByText(recalledAnswer)).toBeVisible({ timeout: 20000 });
   });
+
+  test('accepts large exports without size gating', async ({ page, context }) => {
+    await context.addInitScript(() => {
+      localStorage.setItem('cfy.lastView', 'settings');
+    });
+
+    let uploadHits = 0;
+
+    await context.route('**/*', async (route) => {
+      const request = route.request();
+      const url = new URL(request.url());
+      const path = url.pathname;
+
+      if (!path.startsWith('/api/') && path !== '/upload-chatgpt-export') {
+        await route.continue();
+        return;
+      }
+      if (/\.(ts|tsx|js|jsx|css|map)$/.test(path)) {
+        await route.continue();
+        return;
+      }
+
+      if (path === '/upload-chatgpt-export') {
+        await route.fulfill({
+          status: 404,
+          contentType: 'application/json',
+          body: JSON.stringify({ detail: 'Use /api/upload-chatgpt-export' }),
+        });
+        return;
+      }
+
+      if (path === '/api/upload-chatgpt-export') {
+        uploadHits += 1;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ threads_imported: 0, messages_imported: 0 }),
+        });
+        return;
+      }
+
+      if (path === '/api/health/llm') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            ok: true,
+            status: 'online',
+            provider: 'local',
+            model: 'test-local-model',
+          }),
+        });
+        return;
+      }
+
+      if (path.startsWith('/api/chat/threads')) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ ok: true, threads: [] }),
+        });
+        return;
+      }
+
+      if (path.startsWith('/api/connectors')) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([]),
+        });
+        return;
+      }
+
+      if (path.startsWith('/api/projects')) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ projects: [] }),
+        });
+        return;
+      }
+
+      if (path.startsWith('/api/codex/entries')) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([]),
+        });
+        return;
+      }
+
+      if (path.startsWith('/api/events')) {
+        await route.fulfill({
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+          body: 'event: ping\\ndata: {}\\n\\n',
+        });
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      });
+    });
+
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    const settingsTab = page.getByRole('button', { name: 'Settings' }).first();
+    await expect(settingsTab).toBeVisible({ timeout: 20000 });
+    await settingsTab.click();
+    await expect(page.getByRole('button', { name: 'Appearance' })).toBeVisible();
+
+    const dataTab = page.getByRole('button', { name: 'Data' }).first();
+    await dataTab.click();
+    await expect(page.getByText('ChatGPT Migration')).toBeVisible();
+
+    const importButton = page.getByRole('button', { name: 'Import from ChatGPT' });
+    await expect(importButton).toBeVisible();
+    await importButton.click();
+
+    await expect(page.getByRole('heading', { name: 'Import from ChatGPT' })).toBeVisible();
+
+    const largePayload = Buffer.alloc(51 * 1024 * 1024, ' ');
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles({
+      name: 'chatgpt_export_large.json',
+      mimeType: 'application/json',
+      buffer: largePayload,
+    });
+
+    await expect(page.getByText('chatgpt_export_large.json')).toBeVisible();
+    await expect(
+      page.getByText('Large ChatGPT exports are accepted.')
+    ).toBeVisible();
+    await expect(
+      page.getByText('Export file exceeds 50MB limit.')
+    ).toHaveCount(0);
+
+    const uploadButton = page.getByRole('button', { name: 'Upload & Migrate' });
+    await expect(uploadButton).toBeEnabled();
+    await uploadButton.click();
+    await expect.poll(() => uploadHits).toBe(1);
+  });
 });

--- a/guardian/routes/migration.py
+++ b/guardian/routes/migration.py
@@ -55,32 +55,15 @@ async def upload_chatgpt_export(
     Legacy alias: /upload-chatgpt-export
     """
     try:
-        # Enforce size limit using bounded chunked reads to prevent memory exhaustion
-        MAX_IMPORT_SIZE = 50 * 1024 * 1024  # 50MB
-
-        # Fast path: check Content-Length header if available
-        if file.size is not None and file.size > MAX_IMPORT_SIZE:
-            raise HTTPException(
-                status_code=413,
-                detail="Export file exceeds 50MB limit. Please upload a smaller export.",
-            )
-
-        # Bounded chunked read with hard stop at size limit
-        chunks = []
-        total = 0
+        # Read the upload in bounded chunks to avoid a single large read.
+        chunks = bytearray()
         while True:
             chunk = await file.read(1024 * 1024)  # 1MB chunks
             if not chunk:
                 break
-            total += len(chunk)
-            if total > MAX_IMPORT_SIZE:
-                raise HTTPException(
-                    status_code=413,
-                    detail="Export file exceeds 50MB limit. Please upload a smaller export.",
-                )
-            chunks.append(chunk)
+            chunks.extend(chunk)
 
-        content = b"".join(chunks)
+        content = bytes(chunks)
         stats = ingest_chatgpt_export(content, user_id=user_id)
         return MigrationStats(
             threads_imported=stats["threads_imported"],
@@ -96,7 +79,7 @@ async def upload_chatgpt_export(
             ),
         )
     except HTTPException:
-        # Re-raise HTTPExceptions (e.g., 413 from size limit) without catching them
+        # Re-raise HTTPExceptions without catching them
         raise
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/tests/routes/test_migration_routes.py
+++ b/tests/routes/test_migration_routes.py
@@ -9,6 +9,7 @@ import pytest
 
 from backend.rag import chatgpt_migration
 from guardian.core import dependencies
+from guardian.routes import migration as migration_routes
 
 SERVER_USER_ID = "local_user"
 
@@ -62,6 +63,14 @@ def _build_mainline_export() -> bytes:
         }
     ]
     return json.dumps(payload).encode("utf-8")
+
+
+def _build_large_export(min_size: int) -> bytes:
+    payload = _build_mainline_export()
+    if len(payload) >= min_size:
+        return payload
+    padding = b" " * (min_size - len(payload))
+    return payload + padding
 
 
 def _post_export(test_client, path: str):
@@ -526,10 +535,27 @@ def test_migration_route_reports_embedding_degradation_on_exit_139(
     assert data["embedding_coverage_degraded"] is True
 
 
-def test_migration_rejects_oversized_file(test_client):
-    """Oversized file should return 413 instead of loading into memory."""
-    # Create payload larger than 50MB limit
-    oversized_content = b"x" * (51 * 1024 * 1024)
+def test_migration_accepts_large_export(test_client, monkeypatch):
+    """Large but valid exports should be accepted and processed."""
+    oversized_content = _build_large_export(51 * 1024 * 1024)
+    captured: dict[str, object] = {}
+
+    def fake_ingest(content: bytes, user_id: str | None = None):
+        captured["size"] = len(content)
+        captured["user_id"] = user_id
+        parsed = json.loads(content)
+        chatgpt_migration._validate_chatgpt_export_payload(parsed)
+        return {
+            "threads_imported": 0,
+            "messages_imported": 0,
+            "embedding_candidates": 0,
+            "embeddings_persisted": 0,
+            "embeddings_failed": 0,
+            "embedding_coverage_degraded": False,
+        }
+
+    monkeypatch.setattr(migration_routes, "ingest_chatgpt_export", fake_ingest)
+
     files = {
         "file": (
             "huge_export.json",
@@ -544,8 +570,10 @@ def test_migration_rejects_oversized_file(test_client):
         headers={"X-User-Id": "spoofed_user"},
     )
 
-    assert response.status_code == 413
-    assert "50MB" in response.json()["detail"]
+    assert response.status_code == 200
+    assert captured["size"] >= 51 * 1024 * 1024
+    assert captured["user_id"] == SERVER_USER_ID
+    assert response.json()["threads_imported"] == 0
 
 
 def test_migration_rejects_malformed_json(test_client):


### PR DESCRIPTION
**Summary**
- Accept large ChatGPT exports without size-based rejection in migration flow
- Update import UI to keep large files visible and show background processing guidance
- Add backend and frontend coverage for large export acceptance

**Testing**
- Not run (not requested)