### PR TITLE
Introduce canonical LiveEvent normalization

### DIFF
--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -1621,28 +1621,18 @@ export function GuardianChat({
 
   useEffect(() => {
     const handleAgentRunEvent = (event: LiveEvent) => {
-      const payload = flattenChatEventPayload(event.data);
-      const nestedRun =
-        payload.run && typeof payload.run === "object" && !Array.isArray(payload.run)
-          ? (payload.run as Record<string, unknown>)
-          : null;
-      const threadId = Number(
-        payload.thread_id ??
-          payload.threadId ??
-          nestedRun?.thread_id ??
-          nestedRun?.threadId
-      );
-
-      if (!Number.isFinite(threadId)) {
+      if (event.entity !== "agent_run" || !event.thread_id) {
         return;
       }
 
+      const payload = flattenChatEventPayload(event.payload);
+
       console.debug("[agent-runs:event]", {
         type: event.type,
-        threadId,
+        threadId: event.thread_id,
       });
 
-      applyAgentRunEvent(String(threadId), {
+      applyAgentRunEvent(String(event.thread_id), {
         ...payload,
         event_type: event.type,
       });

--- a/frontend/src/hooks/useLiveEvents.ts
+++ b/frontend/src/hooks/useLiveEvents.ts
@@ -3,6 +3,7 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { buildAuthenticatedFetchInit } from "@/lib/api";
+import type { LiveEvent } from "@/lib/events/types";
 import { getRuntimeConfigSync, resolveSseEndpoint } from "@/lib/runtimeConfig";
 import {
   checkAuthGate,
@@ -23,11 +24,7 @@ import {
 const LAST_EVENT_DEBOUNCE_MS = 50;
 const CONNECTED_DEBOUNCE_MS = 200;
 
-export interface LiveEvent {
-  id: string | null;
-  type: string;
-  data: unknown;
-}
+export type { LiveEvent } from "@/lib/events/types";
 
 export type ConnectionStatus = LiveEventConnectionState;
 
@@ -127,31 +124,26 @@ export function useLiveEvents(options: { passive?: boolean } = {}): UseLiveEvent
 
   const handleHubEvent = useCallback(
     (event: LiveEventsHubEvent) => {
-      const payload: LiveEvent = {
-        id: event.id || null,
-        type: event.type || "message",
-        data: event.data,
-      };
       const activeSpine = SessionSpine.getRegisteredSpine();
-      if (activeSpine && !activeSpine.shouldAcceptLiveEvent(payload.type, payload.data)) {
+      if (activeSpine && !activeSpine.shouldAcceptLiveEvent(event.type, event.data)) {
         return;
       }
-      if (isSameEvent(lastEventRef.current, payload)) {
+      if (isSameEvent(lastEventRef.current, event)) {
         return;
       }
-      lastEventRef.current = payload;
+      lastEventRef.current = event;
       if (!passive) {
-        scheduleLastEventUpdate(payload);
+        scheduleLastEventUpdate(event);
       }
-      const listeners = listenersRef.current.get(payload.type);
+      const listeners = listenersRef.current.get(event.type);
       if (!listeners) {
         return;
       }
       listeners.forEach((listener) => {
         try {
-          listener(payload);
+          listener(event);
         } catch (error) {
-          console.error(`[useLiveEvents] listener for ${payload.type} failed`, error);
+          console.error(`[useLiveEvents] listener for ${event.type} failed`, error);
         }
       });
     },

--- a/frontend/src/lib/events/types.ts
+++ b/frontend/src/lib/events/types.ts
@@ -1,0 +1,22 @@
+export type LiveEventEntity =
+  | "task"
+  | "agent_run"
+  | "message"
+  | "approval"
+  | "command_run"
+  | "thread"
+  | "connector"
+  | "system";
+
+export type LiveEvent = {
+  id: string | null;
+  type: string;
+  entity: LiveEventEntity;
+  entity_id: string;
+  thread_id: string | null;
+  status?: string;
+  payload?: unknown;
+  data?: unknown;
+  raw?: unknown;
+  ts: number;
+};

--- a/frontend/src/lib/liveEventsHub.ts
+++ b/frontend/src/lib/liveEventsHub.ts
@@ -1,8 +1,14 @@
 import { GuardianEventSource } from "@/lib/guardianEventSource";
 import { getBackendOutageRemainingMs } from "@/lib/api";
+import type { LiveEvent, LiveEventEntity } from "@/lib/events/types";
 
 type HubEventListener = (event: LiveEventsHubEvent) => void;
 type HubStatusListener = (status: LiveEventsHubStatus) => void;
+type LiveEventsHubRawEvent = {
+  id: string | null;
+  type: string;
+  data: unknown;
+};
 
 type HubConnectionStatus =
   | "connecting"
@@ -17,11 +23,7 @@ export type LiveEventsHubConfig = {
   onUnauthorized?: () => void;
 };
 
-export type LiveEventsHubEvent = {
-  id: string | null;
-  type: string;
-  data: unknown;
-};
+export type LiveEventsHubEvent = LiveEvent;
 
 export type LiveEventsHubStatus = {
   readyState: 0 | 1 | 2;
@@ -55,6 +57,11 @@ const DEFAULT_EVENT_TYPES = [
   "task.failed",
   "task.cancelled",
   "completion.error",
+  "run.blocked",
+  "run.failed",
+  "run.completed",
+  "browser.approval.requested",
+  "browser.approval.decided",
   "connector.status",
   "connector.sync",
 ];
@@ -99,7 +106,7 @@ const seenFallbackHashQueue: string[] = [];
 const perTypeSequence = new Map<string, number>();
 
 const pressureTimestamps: number[] = [];
-const bufferedEvents: LiveEventsHubEvent[] = [];
+const bufferedEvents: LiveEventsHubRawEvent[] = [];
 let pressureFuseActive = false;
 let pressureLastHighAt = 0;
 
@@ -213,7 +220,312 @@ function extractSequence(data: unknown): number | null {
   return null;
 }
 
-function shouldDropEvent(event: LiveEventsHubEvent): boolean {
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function normalizeToken(value: unknown): string | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function collectEventRecords(payload: unknown, raw: unknown): Record<string, unknown>[] {
+  const records: Record<string, unknown>[] = [];
+
+  const pushRecord = (value: unknown) => {
+    const record = asRecord(value);
+    if (record) {
+      records.push(record);
+    }
+  };
+
+  const payloadRecord = asRecord(payload);
+  pushRecord(payloadRecord);
+  pushRecord(payloadRecord?.run);
+  pushRecord(payloadRecord?.message);
+  pushRecord(payloadRecord?.thread);
+  pushRecord(payloadRecord?.child);
+
+  const rawRecord = asRecord(raw);
+  if (rawRecord && rawRecord !== payloadRecord) {
+    pushRecord(rawRecord);
+  }
+  pushRecord(rawRecord?.run);
+  pushRecord(rawRecord?.message);
+  pushRecord(rawRecord?.thread);
+  pushRecord(rawRecord?.child);
+
+  return records;
+}
+
+function pickToken(
+  records: Record<string, unknown>[],
+  keys: string[]
+): string | null {
+  for (const record of records) {
+    for (const key of keys) {
+      const token = normalizeToken(record[key]);
+      if (token) {
+        return token;
+      }
+    }
+  }
+  return null;
+}
+
+function resolveThreadId(
+  eventType: string,
+  records: Record<string, unknown>[],
+  entityId: string | null
+): string | null {
+  const threadId = pickToken(records, ["thread_id", "threadId"]);
+  if (threadId) {
+    return threadId;
+  }
+  if (eventType.startsWith("thread.")) {
+    return entityId;
+  }
+  return null;
+}
+
+function resolveStatus(
+  eventType: string,
+  records: Record<string, unknown>[]
+): string | undefined {
+  const explicit = pickToken(records, ["status"]);
+  if (explicit) {
+    return explicit;
+  }
+
+  switch (eventType) {
+    case "task.created":
+    case "task.updated":
+    case "task.progress":
+    case "task.running":
+      return "running";
+    case "task.completed":
+      return "completed";
+    case "task.failed":
+    case "completion.error":
+      return "failed";
+    case "task.cancelled":
+      return "canceled";
+    case "run.blocked":
+      return "blocked";
+    case "run.failed":
+      return "failed";
+    case "run.completed":
+      return "completed";
+    default:
+      return undefined;
+  }
+}
+
+function hasAgentRunMarkers(records: Record<string, unknown>[]): boolean {
+  const runId = pickToken(records, ["run_id", "runId", "id"]);
+  const runtimeTarget = pickToken(records, ["runtime_target", "runtimeTarget"]);
+  const worktreeId = pickToken(records, ["worktree_id", "worktreeId"]);
+  const worktreePath = pickToken(records, ["worktree_path", "worktreePath"]);
+
+  return Boolean(
+    (runId && runId.startsWith("run_")) ||
+      runtimeTarget ||
+      worktreeId ||
+      worktreePath
+  );
+}
+
+function unwrapNormalizedPayload(raw: unknown): unknown {
+  const record = asRecord(raw);
+  const nested = asRecord(record?.data);
+  return nested ?? raw;
+}
+
+function buildLiveEventEnvelope(
+  rawEvent: LiveEventsHubRawEvent,
+  entity: LiveEventEntity,
+  entityId: string,
+  threadId: string | null,
+  status: string | undefined,
+  payload: unknown
+): LiveEvent {
+  const event: LiveEvent = {
+    id: rawEvent.id,
+    type: rawEvent.type || "message",
+    entity,
+    entity_id: entityId,
+    thread_id: threadId,
+    payload,
+    data: payload,
+    raw: rawEvent.data,
+    ts: Date.now(),
+  };
+
+  if (status) {
+    event.status = status;
+  }
+
+  return event;
+}
+
+export function normalizeLiveEvent(rawEvent: {
+  id: string | null;
+  type: string;
+  data: unknown;
+}): LiveEvent {
+  const normalizedType = rawEvent.type || "message";
+  const payload = unwrapNormalizedPayload(rawEvent.data);
+  const payloadRecord = asRecord(payload);
+  const rawRecord = asRecord(rawEvent.data);
+  const records = collectEventRecords(payload, rawEvent.data);
+  const status = resolveStatus(normalizedType, records);
+
+  if (normalizedType === "ping") {
+    return buildLiveEventEnvelope(
+      rawEvent,
+      "system",
+      rawEvent.id ?? "ping",
+      null,
+      status,
+      payload
+    );
+  }
+
+  if (normalizedType.startsWith("task.") || normalizedType === "completion.error") {
+    if (hasAgentRunMarkers(records)) {
+      const entityId =
+        pickToken(records, ["run_id", "runId", "id"]) ?? rawEvent.id ?? "unknown";
+      return buildLiveEventEnvelope(
+        rawEvent,
+        "agent_run",
+        entityId,
+        resolveThreadId(normalizedType, records, entityId),
+        status,
+        payload
+      );
+    }
+
+    const entityId =
+      pickToken(records, ["task_id", "taskId"]) ?? rawEvent.id ?? "unknown";
+    return buildLiveEventEnvelope(
+      rawEvent,
+      "task",
+      entityId,
+      resolveThreadId(normalizedType, records, entityId),
+      status,
+      payload
+    );
+  }
+
+  if (normalizedType.startsWith("run.")) {
+    const entityId =
+      pickToken(records, ["run_id", "runId"]) ?? rawEvent.id ?? "unknown";
+    return buildLiveEventEnvelope(
+      rawEvent,
+      "command_run",
+      entityId,
+      resolveThreadId(normalizedType, records, entityId),
+      status,
+      payload
+    );
+  }
+
+  if (normalizedType.startsWith("browser.approval.")) {
+    const entityId =
+      pickToken(records, ["approval_id", "approvalId"]) ?? rawEvent.id ?? "unknown";
+    return buildLiveEventEnvelope(
+      rawEvent,
+      "approval",
+      entityId,
+      resolveThreadId(normalizedType, records, null),
+      status,
+      payload
+    );
+  }
+
+  if (normalizedType === "message.created") {
+    const messageRecord =
+      asRecord(payloadRecord?.message) ?? asRecord(rawRecord?.message);
+    const entityId =
+      normalizeToken(
+        payloadRecord?.message_id ??
+          payloadRecord?.messageId ??
+          payloadRecord?.id ??
+          messageRecord?.id
+      ) ??
+      normalizeToken(
+        rawRecord?.message_id ?? rawRecord?.messageId ?? rawRecord?.id
+      ) ??
+      rawEvent.id ??
+      "unknown";
+    return buildLiveEventEnvelope(
+      rawEvent,
+      "message",
+      entityId,
+      resolveThreadId(normalizedType, records, null),
+      status,
+      payload
+    );
+  }
+
+  if (normalizedType.startsWith("thread.")) {
+    const childRecord =
+      asRecord(payloadRecord?.child) ?? asRecord(rawRecord?.child);
+    const threadRecord =
+      asRecord(payloadRecord?.thread) ?? asRecord(rawRecord?.thread);
+    const entityId =
+      normalizeToken(payloadRecord?.thread_id ?? payloadRecord?.threadId) ??
+      normalizeToken(rawRecord?.thread_id ?? rawRecord?.threadId) ??
+      normalizeToken(childRecord?.id) ??
+      normalizeToken(threadRecord?.id) ??
+      normalizeToken(payloadRecord?.id ?? rawRecord?.id) ??
+      rawEvent.id ??
+      "unknown";
+    return buildLiveEventEnvelope(
+      rawEvent,
+      "thread",
+      entityId,
+      resolveThreadId(normalizedType, records, entityId),
+      status,
+      payload
+    );
+  }
+
+  if (normalizedType.startsWith("connector.")) {
+    const entityId =
+      pickToken(records, ["connector_id", "connectorId", "connector"]) ??
+      rawEvent.id ??
+      "unknown";
+    return buildLiveEventEnvelope(
+      rawEvent,
+      "connector",
+      entityId,
+      resolveThreadId(normalizedType, records, null),
+      status,
+      payload
+    );
+  }
+
+  return buildLiveEventEnvelope(
+    rawEvent,
+    "system",
+    rawEvent.id ?? "unknown",
+    resolveThreadId(normalizedType, records, null),
+    status,
+    payload
+  );
+}
+
+function shouldDropEvent(event: LiveEventsHubRawEvent): boolean {
   const eventId = event.id ? String(event.id) : "";
   if (eventId) {
     if (seenEventIds.has(eventId)) return true;
@@ -289,10 +601,11 @@ function updatePressureFuse(now: number): void {
   }
 }
 
-function dispatchEvent(event: LiveEventsHubEvent): void {
+function dispatchEvent(event: LiveEventsHubRawEvent): void {
+  const normalizedEvent = normalizeLiveEvent(event);
   for (const listener of subscribers) {
     try {
-      listener(event);
+      listener(normalizedEvent);
     } catch (error) {
       console.error("[live-events-hub] subscriber failed", error);
     }
@@ -322,7 +635,7 @@ function scheduleBufferedFlush(): void {
   }, EVENT_PRESSURE_FLUSH_MS);
 }
 
-function publishEvent(event: LiveEventsHubEvent): void {
+function publishEvent(event: LiveEventsHubRawEvent): void {
   const now = Date.now();
   updatePressureFuse(now);
   if (pressureFuseActive) {
@@ -482,7 +795,7 @@ function connect(config: LiveEventsHubConfig, reconnecting: boolean): void {
 
   sourceMessageListener = (evt: MessageEvent) => {
     if (abortSignal.aborted) return;
-    const payload: LiveEventsHubEvent = {
+    const payload: LiveEventsHubRawEvent = {
       id: evt.lastEventId || null,
       type: evt.type || "message",
       data: parseEventData(evt.data as string),

--- a/frontend/src/test/live-events-singleton.test.tsx
+++ b/frontend/src/test/live-events-singleton.test.tsx
@@ -88,6 +88,7 @@ import {
 import {
   __resetLiveEventsHubForTests,
   getLiveEventsHubStatus,
+  normalizeLiveEvent,
 } from "@/lib/liveEventsHub";
 
 describe("live events singleton hub", () => {
@@ -189,7 +190,7 @@ describe("live events singleton hub", () => {
     unmount();
   });
 
-  it("binds task lifecycle SSE event types needed by the chat store bridge", async () => {
+  it("binds the active SSE event families consumed by the app", async () => {
     const { unmount } = renderHook(() => useLiveEvents({ passive: true }));
 
     await waitFor(() => {
@@ -201,10 +202,182 @@ describe("live events singleton hub", () => {
     );
 
     expect(registeredTypes).toEqual(
-      expect.arrayContaining(["task.created", "task.updated", "task.progress"])
+      expect.arrayContaining([
+        "task.created",
+        "task.updated",
+        "task.progress",
+        "run.blocked",
+        "run.failed",
+        "run.completed",
+        "browser.approval.requested",
+        "browser.approval.decided",
+      ])
     );
 
     unmount();
+  });
+
+  it("dispatches canonical task events without promoting incidental run_id payloads", async () => {
+    const { result, unmount } = renderHook(() => useLiveEvents({ passive: true }));
+
+    await waitFor(() => {
+      expect(mockState.createdSources).toHaveLength(1);
+    });
+
+    const listener = vi.fn();
+    const unsubscribe = result.current.subscribe("task.completed", listener);
+
+    act(() => {
+      mockState.createdSources[0].emitEvent(
+        "task.completed",
+        {
+          data: {
+            task_id: "task-1",
+            thread_id: 99,
+            run_id: "worker-local-run",
+            status: "completed",
+          },
+          seq: 1,
+        },
+        "evt-task-1"
+      );
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "evt-task-1",
+        type: "task.completed",
+        entity: "task",
+        entity_id: "task-1",
+        thread_id: "99",
+        status: "completed",
+        payload: {
+          task_id: "task-1",
+          thread_id: 99,
+          run_id: "worker-local-run",
+          status: "completed",
+        },
+        data: {
+          task_id: "task-1",
+          thread_id: 99,
+          run_id: "worker-local-run",
+          status: "completed",
+        },
+        raw: {
+          data: {
+            task_id: "task-1",
+            thread_id: 99,
+            run_id: "worker-local-run",
+            status: "completed",
+          },
+          seq: 1,
+        },
+      })
+    );
+    expect(typeof listener.mock.calls[0][0].ts).toBe("number");
+
+    unsubscribe();
+    unmount();
+  });
+
+  it("normalizes agent-run-shaped task events as canonical agent_run events", async () => {
+    const { result, unmount } = renderHook(() => useLiveEvents({ passive: true }));
+
+    await waitFor(() => {
+      expect(mockState.createdSources).toHaveLength(1);
+    });
+
+    const listener = vi.fn();
+    const unsubscribe = result.current.subscribe("task.created", listener);
+
+    act(() => {
+      mockState.createdSources[0].emitEvent(
+        "task.created",
+        {
+          thread_id: 701,
+          run_id: "run_live_1",
+          runtime_target: "terminal",
+          worktree_id: "wt-1",
+        },
+        "evt-run-1"
+      );
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "evt-run-1",
+        type: "task.created",
+        entity: "agent_run",
+        entity_id: "run_live_1",
+        thread_id: "701",
+        status: "running",
+      })
+    );
+
+    unsubscribe();
+    unmount();
+  });
+
+  it("keeps connector events in the connector family even when they carry run_id", async () => {
+    const { result, unmount } = renderHook(() => useLiveEvents({ passive: true }));
+
+    await waitFor(() => {
+      expect(mockState.createdSources).toHaveLength(1);
+    });
+
+    const listener = vi.fn();
+    const unsubscribe = result.current.subscribe("connector.sync", listener);
+
+    act(() => {
+      mockState.createdSources[0].emitEvent(
+        "connector.sync",
+        {
+          connector_id: 12,
+          connector: "github",
+          run_id: "abcd1234",
+          status: "running",
+        },
+        "evt-connector-1"
+      );
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "evt-connector-1",
+        type: "connector.sync",
+        entity: "connector",
+        entity_id: "12",
+        thread_id: null,
+        status: "running",
+      })
+    );
+
+    unsubscribe();
+    unmount();
+  });
+
+  it("normalizes unrecognized event families as system events", () => {
+    expect(
+      normalizeLiveEvent({
+        id: "evt-unknown-1",
+        type: "mystery.event",
+        data: { hello: "world" },
+      })
+    ).toEqual(
+      expect.objectContaining({
+        id: "evt-unknown-1",
+        type: "mystery.event",
+        entity: "system",
+        entity_id: "evt-unknown-1",
+        thread_id: null,
+        payload: { hello: "world" },
+        data: { hello: "world" },
+        raw: { hello: "world" },
+      })
+    );
   });
 
   it("activates pressure fuse under burst load and flushes buffered events", async () => {


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
