### PR TITLE
fix(backend): enforce redis fail-fast and 503 degradation contract

### DIFF
--- a/guardian/queue/redis_queue.py
+++ b/guardian/queue/redis_queue.py
@@ -20,6 +20,9 @@ from guardian.protocol_tokens import ErrorCode
 logger = logging.getLogger(__name__)
 
 _DEFAULT_REDIS_URL = "redis://redis:6379/0"
+_DEFAULT_REDIS_OPERATION_TIMEOUT_SECONDS = float(
+    os.getenv("REDIS_OPERATION_TIMEOUT_SECONDS", "2")
+)
 _CANCEL_SET_KEY = "codexify:queue:cancelled"
 _TURN_LOCK_PREFIX = "turn_lock:"
 _DEFAULT_TURN_LOCK_TTL = int(os.getenv("CHAT_TURN_LOCK_TTL_SECONDS", "300"))
@@ -45,6 +48,24 @@ class QueueEnqueueError(RuntimeError):
         self.queue_name = queue_name
         self.error_code = error_code
         self.cause = cause
+
+
+class RedisOperationTimeout(RuntimeError):
+    """Raised when a Redis operation exceeds the backend fail-fast budget."""
+
+
+def run_with_redis_timeout(
+    fn: Callable[[], Any],
+    timeout_seconds: float = _DEFAULT_REDIS_OPERATION_TIMEOUT_SECONDS,
+) -> Any:
+    start = time.monotonic()
+    result = fn()
+    elapsed = time.monotonic() - start
+    if elapsed > timeout_seconds:
+        raise RedisOperationTimeout(
+            f"Redis operation exceeded {timeout_seconds}s"
+        )
+    return result
 
 
 class _InMemoryRedis:
@@ -249,9 +270,9 @@ def _connect() -> Any:
     client = redis.Redis.from_url(
         _redis_url(),
         decode_responses=True,
-        socket_connect_timeout=3,
-        socket_timeout=None,
-        retry_on_timeout=True,
+        socket_connect_timeout=2,
+        socket_timeout=2,
+        retry_on_timeout=False,
     )
     _patch_inmemory_redis(client)
     return client

--- a/guardian/routes/chat.py
+++ b/guardian/routes/chat.py
@@ -50,8 +50,10 @@ from guardian.protocol_tokens import AcceptanceStatus, ErrorCode, TaskEventType
 from guardian.queue import task_events
 from guardian.queue.redis_queue import (
     QueueEnqueueError,
+    RedisOperationTimeout,
     enqueue,
     enqueue_chat_embed,
+    run_with_redis_timeout,
 )
 from guardian.queue.turn_lock import (
     TurnLockEnvelope,
@@ -101,6 +103,28 @@ def _completion_service_unavailable(reason: str) -> HTTPException:
     )
 
 
+def _run_completion_redis_op(fn, *, reason: str, log_message: str):
+    try:
+        return run_with_redis_timeout(fn)
+    except (RedisOperationTimeout, Exception) as exc:
+        logger.warning(log_message, exc)
+        raise _completion_service_unavailable(reason)
+
+
+def _best_effort_release_turn_lock(
+    thread_id: int,
+    owner: str | TurnLockEnvelope,
+    *,
+    log_message: str,
+) -> None:
+    try:
+        run_with_redis_timeout(lambda: release_turn_lock(thread_id, owner))
+    except TypeError:
+        raise
+    except (RedisOperationTimeout, Exception):
+        logger.debug(log_message, exc_info=True)
+
+
 def _task_terminal_event(task_id: str) -> dict[str, Any]:
     """Return terminal-state evidence for a task event stream."""
 
@@ -127,8 +151,10 @@ def _chat_worker_heartbeat_evidence() -> dict[str, Any]:
     try:
         from guardian.queue.redis_queue import get_redis_client
 
-        client = get_redis_client()
-        raw_heartbeat = client.get(CHAT_WORKER_HEARTBEAT_KEY)
+        client = run_with_redis_timeout(get_redis_client)
+        raw_heartbeat = run_with_redis_timeout(
+            lambda: client.get(CHAT_WORKER_HEARTBEAT_KEY)
+        )
         if not raw_heartbeat:
             evidence["state"] = "missing"
             evidence["reason"] = "heartbeat_missing"
@@ -155,8 +181,8 @@ def _chat_worker_heartbeat_evidence() -> dict[str, Any]:
         evidence["state"] = _classify_chat_worker_heartbeat(True, age_seconds)
         evidence["reason"] = "ok"
         return evidence
-    except Exception as exc:
-        evidence["reason"] = "heartbeat_probe_failed"
+    except (RedisOperationTimeout, Exception) as exc:
+        evidence["reason"] = "redis_unavailable"
         evidence["error"] = f"{type(exc).__name__}: {exc}"
         return evidence
 
@@ -289,7 +315,11 @@ def _completion_acceptance_outcome(
 
 
 def _recover_orphaned_turn_lock(thread_id: int) -> bool:
-    stale_lock = get_turn_lock(thread_id)
+    stale_lock = _run_completion_redis_op(
+        lambda: get_turn_lock(thread_id),
+        reason="turn_lock_unavailable",
+        log_message="[chat.complete] stale turn lock probe unavailable: %s",
+    )
     if stale_lock is None or not turn_lock_is_stale(stale_lock):
         return False
 
@@ -340,7 +370,11 @@ def _recover_orphaned_turn_lock(thread_id: int) -> bool:
         )
         return False
 
-    cleared = clear_turn_lock(thread_id, expected=stale_lock)
+    cleared = _run_completion_redis_op(
+        lambda: clear_turn_lock(thread_id, expected=stale_lock),
+        reason="turn_lock_unavailable",
+        log_message="[chat.complete] stale turn lock clear unavailable: %s",
+    )
     if cleared and hasattr(chatlog_db, "write_audit_log"):
         chatlog_db.write_audit_log(
             "recover_orphaned_turn_lock",
@@ -506,13 +540,15 @@ def _embed_message(thread_id: int, role: str, content: str, message_id: int):
     if not _vector_store:
         return
     try:
-        enqueue_chat_embed(
-            {
-                "thread_id": thread_id,
-                "role": role,
-                "content": content,
-                "message_id": message_id,
-            }
+        run_with_redis_timeout(
+            lambda: enqueue_chat_embed(
+                {
+                    "thread_id": thread_id,
+                    "role": role,
+                    "content": content,
+                    "message_id": message_id,
+                }
+            )
         )
     except NameError:
         logger.exception(
@@ -781,7 +817,9 @@ def _persist_message_to_thread(
     lock_probe_owner = "api:chat.messages:user_probe"
     lock_probe_acquired = False
     try:
-        lock_probe_acquired = acquire_turn_lock(thread_id, lock_probe_owner)
+        lock_probe_acquired = run_with_redis_timeout(
+            lambda: acquire_turn_lock(thread_id, lock_probe_owner)
+        )
         if not lock_probe_acquired:
             raise HTTPException(
                 status_code=429,
@@ -805,10 +843,12 @@ def _persist_message_to_thread(
     finally:
         if lock_probe_acquired:
             try:
-                release_turn_lock(thread_id, lock_probe_owner)
+                run_with_redis_timeout(
+                    lambda: release_turn_lock(thread_id, lock_probe_owner)
+                )
             except TypeError:
                 raise
-            except Exception:
+            except (RedisOperationTimeout, Exception):
                 logger.debug(
                     "[chat.messages] turn lock probe release failed thread_id=%s",
                     thread_id,
@@ -1848,21 +1888,18 @@ async def chat_complete(
     task.task_id = task_identity
     task.turn_lock_owner = task_identity
 
-    try:
-        locked = acquire_turn_lock(thread_id, task.turn_lock_owner)
-    except Exception as exc:
-        logger.warning("[chat.complete] turn lock unavailable: %s", exc)
-        raise _completion_service_unavailable("turn_lock_unavailable")
+    locked = _run_completion_redis_op(
+        lambda: acquire_turn_lock(thread_id, task.turn_lock_owner),
+        reason="turn_lock_unavailable",
+        log_message="[chat.complete] turn lock unavailable: %s",
+    )
     if not locked:
         if _recover_orphaned_turn_lock(thread_id):
-            try:
-                locked = acquire_turn_lock(thread_id, task.turn_lock_owner)
-            except Exception as exc:
-                logger.warning(
-                    "[chat.complete] turn lock unavailable after recovery: %s",
-                    exc,
-                )
-                raise _completion_service_unavailable("turn_lock_unavailable")
+            locked = _run_completion_redis_op(
+                lambda: acquire_turn_lock(thread_id, task.turn_lock_owner),
+                reason="turn_lock_unavailable",
+                log_message="[chat.complete] turn lock unavailable after recovery: %s",
+            )
         if not locked:
             raise HTTPException(status_code=429, detail="turn_in_flight")
 
@@ -1876,15 +1913,13 @@ async def chat_complete(
     queue_name = "codexify:queue:chat"
 
     try:
-        enqueue(task, queue_name)
+        run_with_redis_timeout(lambda: enqueue(task, queue_name))
     except QueueEnqueueError as exc:
-        try:
-            release_turn_lock(thread_id, task.turn_lock_owner)
-        except Exception:
-            logger.debug(
-                "[chat.complete] failed to release lock after enqueue error",
-                exc_info=True,
-            )
+        _best_effort_release_turn_lock(
+            thread_id,
+            task.turn_lock_owner,
+            log_message="[chat.complete] failed to release lock after enqueue error",
+        )
         logger.error(
             "[chat.complete] enqueue failed",
             extra={
@@ -1905,14 +1940,12 @@ async def chat_complete(
         if isinstance(detail, dict):
             detail = {**detail, "error_code": "CHAT_COMPLETE_ENQUEUE_FAILED"}
         raise HTTPException(status_code=503, detail=detail)
-    except Exception as exc:
-        try:
-            release_turn_lock(thread_id, task.turn_lock_owner)
-        except Exception:
-            logger.debug(
-                "[chat.complete] failed to release lock after enqueue error",
-                exc_info=True,
-            )
+    except (RedisOperationTimeout, Exception) as exc:
+        _best_effort_release_turn_lock(
+            thread_id,
+            task.turn_lock_owner,
+            log_message="[chat.complete] failed to release lock after enqueue error",
+        )
         logger.warning(
             "[chat.complete] queue unavailable error_code=%s: %s",
             CHAT_COMPLETE_ENQUEUE_ERROR_CODE,

--- a/guardian/routes/health.py
+++ b/guardian/routes/health.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 
 import requests
 from fastapi import APIRouter, Depends, Query, Request, Response
+from fastapi.responses import JSONResponse
 
 from guardian.core import metrics
 from guardian.core.dependencies import DB_BACKEND, get_database_dsn
@@ -44,6 +45,12 @@ _CHAT_QUEUE_LAST_CHECK_TS = 0.0
 
 # Create unprefixed router to preserve /health/chat path
 router = APIRouter(tags=["Health"])
+
+
+def _redis_dependency_unavailable_response(
+    payload: dict[str, object]
+) -> JSONResponse:
+    return JSONResponse(status_code=503, content=payload)
 
 
 def _resolve_llm_health_endpoints() -> list[str]:
@@ -161,22 +168,31 @@ def _classify_chat_worker_heartbeat(
 def _collect_chat_queue_health() -> dict[str, object]:
     global _CHAT_QUEUE_LAST_DEPTH, _CHAT_QUEUE_LAST_CHECK_TS
 
-    from guardian.queue.redis_queue import get_redis_client
+    from guardian.queue.redis_queue import (
+        RedisOperationTimeout,
+        get_redis_client,
+        run_with_redis_timeout,
+    )
 
     queue_health: dict[str, object] = {
         "depth": None,
         "status": "unknown",
         "error": None,
+        "dependency": None,
+        "dependency_unavailable": False,
     }
 
     try:
-        client = get_redis_client()
+        client = run_with_redis_timeout(get_redis_client)
         llen = getattr(client, "llen", None)
         if not callable(llen):
             queue_health["error"] = "queue_depth_unavailable"
             return queue_health
 
-        depth = max(0, int(llen(CHAT_QUEUE_NAME)))
+        depth = max(
+            0,
+            int(run_with_redis_timeout(lambda: llen(CHAT_QUEUE_NAME))),
+        )
         now = time.time()
         with _CHAT_QUEUE_PROGRESS_LOCK:
             previous_depth = _CHAT_QUEUE_LAST_DEPTH
@@ -206,14 +222,20 @@ def _collect_chat_queue_health() -> dict[str, object]:
             queue_health["status"] = "progressing"
         else:
             queue_health["status"] = "stalled"
-    except Exception as exc:
+    except (RedisOperationTimeout, Exception) as exc:
         queue_health["error"] = f"{type(exc).__name__}: {exc}"
+        queue_health["dependency"] = "redis"
+        queue_health["dependency_unavailable"] = True
 
     return queue_health
 
 
 def _collect_completion_service_health() -> dict[str, object]:
-    from guardian.queue.redis_queue import get_redis_client
+    from guardian.queue.redis_queue import (
+        RedisOperationTimeout,
+        get_redis_client,
+        run_with_redis_timeout,
+    )
 
     heartbeat_key = os.getenv(
         "CHAT_WORKER_HEARTBEAT_KEY", "codexify:worker:chat:heartbeat"
@@ -227,11 +249,15 @@ def _collect_completion_service_health() -> dict[str, object]:
         "heartbeat_key": heartbeat_key,
         "status_reason": "unknown",
         "error": None,
+        "dependency": None,
+        "dependency_unavailable": False,
     }
 
     try:
-        client = get_redis_client()
-        completion_service["redis_reachable"] = bool(client.ping())
+        client = run_with_redis_timeout(get_redis_client)
+        completion_service["redis_reachable"] = bool(
+            run_with_redis_timeout(client.ping)
+        )
 
         probe_queue = f"codexify:queue:healthcheck:{uuid4().hex}"
         probe_payload = {
@@ -239,17 +265,21 @@ def _collect_completion_service_health() -> dict[str, object]:
             "probe_id": uuid4().hex,
             "ts": int(time.time()),
         }
-        client.lpush(probe_queue, json.dumps(probe_payload))
-        popped = client.rpop(probe_queue)
+        run_with_redis_timeout(
+            lambda: client.lpush(probe_queue, json.dumps(probe_payload))
+        )
+        popped = run_with_redis_timeout(lambda: client.rpop(probe_queue))
         completion_service["enqueue_test_ok"] = bool(popped)
         try:
-            client.delete(probe_queue)
-        except Exception:
+            run_with_redis_timeout(lambda: client.delete(probe_queue))
+        except (RedisOperationTimeout, Exception):
             logger.debug(
                 "[health/chat] probe queue cleanup failed", exc_info=True
             )
 
-        raw_heartbeat = client.get(heartbeat_key)
+        raw_heartbeat = run_with_redis_timeout(
+            lambda: client.get(heartbeat_key)
+        )
         completion_service["worker_heartbeat_detected"] = bool(raw_heartbeat)
         if raw_heartbeat:
             heartbeat_payload = {}
@@ -292,9 +322,11 @@ def _collect_completion_service_health() -> dict[str, object]:
             completion_service["status_reason"] = "worker_heartbeat_dead"
         else:
             completion_service["status_reason"] = "ok"
-    except Exception as exc:
+    except (RedisOperationTimeout, Exception) as exc:
         completion_service["error"] = f"{type(exc).__name__}: {exc}"
-        completion_service["status_reason"] = "probe_failed"
+        completion_service["status_reason"] = "dependency_unavailable"
+        completion_service["dependency"] = "redis"
+        completion_service["dependency_unavailable"] = True
         logger.warning("[health/chat] completion service check failed: %s", exc)
 
     return completion_service
@@ -353,6 +385,17 @@ def health_llm():
             {"ok": False, "status": "misconfigured", "error": str(exc)}
         )
         return payload
+
+    if completion_service.get("dependency_unavailable"):
+        payload.update(
+            {
+                "ok": False,
+                "status": "dependency_unavailable",
+                "error": "dependency_unavailable",
+                "dependency": "redis",
+            }
+        )
+        return _redis_dependency_unavailable_response(payload)
 
     if provider == "local":
         timeout = float(os.getenv("HEALTH_LLM_REQUEST_TIMEOUT_SECONDS", "1.0"))
@@ -456,6 +499,10 @@ def health_chat():
     queue_depth = queue_health.get("depth")
     queue_status = str(queue_health.get("status") or "unknown")
     queue_error = queue_health.get("error")
+    redis_dependency_unavailable = bool(
+        completion_service.get("dependency_unavailable")
+        or queue_health.get("dependency_unavailable")
+    )
 
     if not redis_reachable:
         status = "unhealthy"
@@ -527,7 +574,7 @@ def health_chat():
                 "worker heartbeat dead; chat completion cannot progress",
             ]
 
-    return {
+    payload = {
         "ok": status == "healthy",
         "status": status,
         "redis": "ok" if redis_ok else "unhealthy",
@@ -547,6 +594,21 @@ def health_chat():
         "backend": DB_BACKEND,
         "completion_service": completion_service,
     }
+    if redis_dependency_unavailable:
+        payload.update(
+            {
+                "ok": False,
+                "status": "unhealthy",
+                "error": "dependency_unavailable",
+                "dependency": "redis",
+            }
+        )
+        if not any("redis unavailable" in str(note).lower() for note in notes):
+            payload["notes"] = [
+                "redis unavailable; chat completion cannot be trusted"
+            ] + list(notes)
+        return _redis_dependency_unavailable_response(payload)
+    return payload
 
 
 @router.get("/health/memory")

--- a/guardian/routes/ui_session.py
+++ b/guardian/routes/ui_session.py
@@ -3,15 +3,21 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import quote
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
-from guardian.queue.redis_queue import get_redis_client
+from guardian.queue.redis_queue import (
+    RedisOperationTimeout,
+    get_redis_client,
+    run_with_redis_timeout,
+)
 
 try:
     from guardian.core.dependencies import require_api_key
@@ -22,6 +28,7 @@ except Exception:  # pragma: no cover - test/import fallback
 
 
 router = APIRouter(tags=["UI Session"])
+logger = logging.getLogger(__name__)
 
 SESSION_NAMESPACE = "ui:v1"
 SESSION_STATE_KEY = "session"
@@ -74,6 +81,28 @@ def _now_iso() -> str:
 def _session_cache_client() -> Any:
     """Always resolve cache client via the shared redis_queue factory."""
     return get_redis_client()
+
+
+def _redis_dependency_unavailable_response() -> JSONResponse:
+    return JSONResponse(
+        status_code=503,
+        content={
+            "error": "dependency_unavailable",
+            "dependency": "redis",
+        },
+    )
+
+
+def _best_effort_delete_session_key(key: str) -> None:
+    try:
+        client = _session_cache_client()
+        run_with_redis_timeout(lambda: client.delete(key))
+    except Exception:
+        logger.debug(
+            "[ui_session] best-effort delete failed key=%s",
+            key,
+            exc_info=True,
+        )
 
 
 def _decode_cached_json(raw: Any) -> Any | None:
@@ -235,24 +264,18 @@ def get_ui_session(
 ) -> dict[str, Any]:
     _ = api_key
     key = make_session_key(user_id, device_id)
-    client = _session_cache_client()
     try:
-        raw = client.get(key)
-    except Exception as exc:  # pragma: no cover - network/runtime failure path
-        raise HTTPException(status_code=503, detail=f"redis_unavailable: {exc}")
+        raw = run_with_redis_timeout(lambda: _session_cache_client().get(key))
+    except (RedisOperationTimeout, Exception) as exc:
+        logger.warning("[ui_session] redis unavailable during get: %s", exc)
+        return _redis_dependency_unavailable_response()
     decoded = _decode_cached_json(raw)
     if decoded is None:
-        try:
-            client.delete(key)
-        except Exception:
-            pass
+        _best_effort_delete_session_key(key)
         return {"ok": True, "state": None}
     state = _coerce_state(decoded, user_id=user_id, device_id=device_id)
     if not state:
-        try:
-            client.delete(key)
-        except Exception:
-            pass
+        _best_effort_delete_session_key(key)
         return {"ok": True, "state": None}
     return {"ok": True, "state": state}
 
@@ -275,11 +298,13 @@ def set_ui_session(
     ttl_seconds = _resolve_ttl(body.ttl_seconds)
     payload = json.dumps(state, separators=(",", ":"), default=str)
 
-    client = _session_cache_client()
     try:
-        client.setex(key, ttl_seconds, payload)
-    except Exception as exc:  # pragma: no cover - network/runtime failure path
-        raise HTTPException(status_code=503, detail=f"redis_unavailable: {exc}")
+        run_with_redis_timeout(
+            lambda: _session_cache_client().setex(key, ttl_seconds, payload)
+        )
+    except (RedisOperationTimeout, Exception) as exc:
+        logger.warning("[ui_session] redis unavailable during set: %s", exc)
+        return _redis_dependency_unavailable_response()
     return {"ok": True}
 
 
@@ -290,18 +315,17 @@ def patch_ui_session(
 ) -> dict[str, Any]:
     _ = api_key
     key = make_session_key(body.user_id, body.device_id)
-    client = _session_cache_client()
     try:
-        raw = client.get(key)
-    except Exception as exc:  # pragma: no cover - network/runtime failure path
-        raise HTTPException(status_code=503, detail=f"redis_unavailable: {exc}")
+        raw = run_with_redis_timeout(lambda: _session_cache_client().get(key))
+    except (RedisOperationTimeout, Exception) as exc:
+        logger.warning(
+            "[ui_session] redis unavailable during patch get: %s", exc
+        )
+        return _redis_dependency_unavailable_response()
 
     decoded = _decode_cached_json(raw)
     if decoded is None:
-        try:
-            client.delete(key)
-        except Exception:
-            pass
+        _best_effort_delete_session_key(key)
         return {"ok": True, "state": None}
 
     current = decoded if isinstance(decoded, dict) else {}
@@ -317,9 +341,14 @@ def patch_ui_session(
     ttl_seconds = _resolve_ttl(body.ttl_seconds)
     payload = json.dumps(coerced, separators=(",", ":"), default=str)
     try:
-        client.setex(key, ttl_seconds, payload)
-    except Exception as exc:  # pragma: no cover - network/runtime failure path
-        raise HTTPException(status_code=503, detail=f"redis_unavailable: {exc}")
+        run_with_redis_timeout(
+            lambda: _session_cache_client().setex(key, ttl_seconds, payload)
+        )
+    except (RedisOperationTimeout, Exception) as exc:
+        logger.warning(
+            "[ui_session] redis unavailable during patch set: %s", exc
+        )
+        return _redis_dependency_unavailable_response()
     return {"ok": True, "state": coerced}
 
 
@@ -331,9 +360,9 @@ def delete_ui_session(
 ) -> dict[str, Any]:
     _ = api_key
     key = make_session_key(user_id, device_id)
-    client = _session_cache_client()
     try:
-        client.delete(key)
-    except Exception as exc:  # pragma: no cover - network/runtime failure path
-        raise HTTPException(status_code=503, detail=f"redis_unavailable: {exc}")
+        run_with_redis_timeout(lambda: _session_cache_client().delete(key))
+    except (RedisOperationTimeout, Exception) as exc:
+        logger.warning("[ui_session] redis unavailable during delete: %s", exc)
+        return _redis_dependency_unavailable_response()
     return {"ok": True}


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
