### PR TITLE
Add canonical retrieval router policy scaffold

### DIFF
--- a/docs/architecture/router-decision-table.md
+++ b/docs/architecture/router-decision-table.md
@@ -1,0 +1,115 @@
+Purpose: define the first canonical retrieval-router doctrine for Guardian so contributors can reason about retrieval posture without embedding ad hoc heuristics in chat, prompt, or provider code.
+Last updated: 2026-03-27
+Source anchors:
+- docs/architecture/README.md
+- docs/architecture/system-overview.md
+- docs/architecture/flows.md
+- guardian/context/broker.py
+- guardian/core/chat_completion_service.py
+- guardian/context/retrieval_router_policy.py
+
+# Retrieval Router Decision Table
+
+## Why This Exists
+
+Codexify's current runtime already separates completion routing, context
+assembly, and provider execution. The retrieval decision point belongs in the
+orchestration layer that sits before `ContextBroker` assembly, not in prompt
+text and not in UI controls.
+
+This document establishes the first canonical policy table for that seam.
+It is doctrine plus contract only. It does not claim that the live completion
+flow already consults this policy.
+
+## Reference Table vs Runtime Scaffold
+
+- `reference table`
+  - Human-readable guidance for contributors.
+  - Explains which query intents should stay conversation-only, which should
+    stay local, and which may justify broader retrieval or graph enrichment.
+- `runtime scaffold`
+  - Machine-readable policy contract exported from
+    `guardian/context/retrieval_router_policy.py`.
+  - Mirrors the same tokens and default rules so future orchestration can adopt
+    one canonical registry instead of re-inventing literals in routes,
+    prompts, or workers.
+
+The table is the doctrine. The scaffold is the backend contract. Neither one
+introduces live retrieval behavior changes in this task.
+
+## Intent Classes
+
+- `conversation_only`: answer from the active conversation without retrieval.
+- `direct_qa`: targeted question that may need ordinary local retrieval.
+- `memory_recall`: recall prior user/thread/project memory.
+- `timeline_recall`: reconstruct ordered events or state changes.
+- `provenance`: explain where a claim, document, or fact came from.
+- `exploratory`: broad inquiry where wider evidence gathering may help.
+- `explicit_global_search`: the user explicitly asks for a broadened search.
+- `scope_locked_local`: the user explicitly constrains the search to local scope.
+- `relationship_trace`: follow links or relationships between entities or facts.
+
+## Routing Dimensions
+
+- `default scope`
+  - Where retrieval begins.
+  - `conversation` means do not leave the active message history.
+  - `local` means start with thread/project-local evidence.
+  - `global` means the intent explicitly justifies broader search posture.
+- `time mode`
+  - Whether time should shape the retrieval partition.
+  - `none` means ordinary relevance rules are enough.
+  - `recent` means favor recency-bounded recall.
+  - `chronological` means preserve ordered history.
+- `graph allowance`
+  - Whether graph context is disallowed, merely allowed as enrichment, or
+    preferred as enrichment.
+  - Graph remains optional and feature-flagged in the current runtime.
+- `depth bias`
+  - The default retrieval budget when the caller asks for `auto`.
+  - This is a budget envelope, not an execution recipe.
+- `escalation order`
+  - The order in which broader evidence sources may be considered.
+- `stop condition`
+  - The point where the router should stop widening retrieval.
+
+## Canonical Decision Table
+
+| Intent | Retrieval Needed | Default Scope | Time Mode | Graph Allowance | Depth Bias | Escalation Order | Stop Condition |
+|---|---|---|---|---|---|---|---|
+| `conversation_only` | no | `conversation` | `none` | `disallow` | `shallow` | none | stop at the active conversation |
+| `direct_qa` | yes | `local` | `none` | `disallow` | `normal` | `thread_messages -> thread_semantic -> project_docs -> adjacent_local` | stop on first sufficient local evidence |
+| `memory_recall` | yes | `local` | `recent` | `disallow` | `deep` | `thread_messages -> memory -> thread_semantic -> project_docs` | stop once recall is supported |
+| `timeline_recall` | yes | `local` | `chronological` | `disallow` | `deep` | `thread_messages -> memory -> thread_semantic -> project_docs` | stop once a coherent ordered timeline exists |
+| `provenance` | yes | `local` | `none` | `prefer_enrichment` | `normal` | `thread_messages -> thread_semantic -> project_docs -> graph_enrichment -> adjacent_local` | stop once source or lineage can be explained |
+| `exploratory` | yes | `local` | `none` | `allow_enrichment` | `deep` | `thread_messages -> thread_semantic -> project_docs -> memory -> adjacent_local -> global_search` | stop when evidence budget is exhausted |
+| `explicit_global_search` | yes | `global` | `none` | `allow_enrichment` | `deep` | `thread_messages -> thread_semantic -> project_docs -> adjacent_local -> global_search` | stop after the explicit broadened pass |
+| `scope_locked_local` | yes | `local` | `none` | `disallow` | `normal` | `thread_messages -> thread_semantic -> project_docs` | stop without adjacent or global expansion |
+| `relationship_trace` | yes | `local` | `none` | `prefer_enrichment` | `deep` | `thread_messages -> thread_semantic -> graph_enrichment -> project_docs -> adjacent_local` | stop once the relationship path is explainable |
+
+## Design Rules
+
+- Retrieval is optional.
+  - Some turns should remain conversation-only.
+  - The router decides whether retrieval is needed instead of assuming it.
+- Scope starts narrow.
+  - Start from the active conversation and local evidence before widening.
+  - Broader search should be explicit or policy-driven, not accidental.
+- Time is a partition, not just ranking.
+  - Timeline queries are not ordinary QA with a recency boost.
+  - When time matters, retrieval should preserve the time posture directly.
+- Graph is enrichment, not default ceremony.
+  - Optional graph context may help provenance and relationship tracing.
+  - It should not be treated as a required first step for ordinary QA.
+- Depth is a budget envelope, not a fixed recipe.
+  - `shallow`, `normal`, and `deep` describe how much evidence the router may
+    spend, not a hard-coded execution trace.
+
+## Current Boundary
+
+- This policy does not modify `guardian/context/broker.py`.
+- This policy does not modify `guardian/core/chat_completion_service.py`.
+- This policy does not add UI controls.
+- This policy does not introduce graph execution behavior.
+- This policy exists so future runtime adoption can import one canonical
+  contract instead of growing inline heuristic tangles.

--- a/guardian/context/retrieval_router_policy.py
+++ b/guardian/context/retrieval_router_policy.py
@@ -1,0 +1,510 @@
+"""Canonical retrieval-router policy contract for Guardian orchestration.
+
+This module defines stable tokens and a pure policy resolver for future runtime
+use. It does not execute retrieval and does not change live broker or
+completion behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class QueryIntent(str, Enum):
+    CONVERSATION_ONLY = "conversation_only"
+    DIRECT_QA = "direct_qa"
+    MEMORY_RECALL = "memory_recall"
+    TIMELINE_RECALL = "timeline_recall"
+    PROVENANCE = "provenance"
+    EXPLORATORY = "exploratory"
+    EXPLICIT_GLOBAL_SEARCH = "explicit_global_search"
+    SCOPE_LOCKED_LOCAL = "scope_locked_local"
+    RELATIONSHIP_TRACE = "relationship_trace"
+
+
+class RetrievalDepth(str, Enum):
+    AUTO = "auto"
+    SHALLOW = "shallow"
+    NORMAL = "normal"
+    DEEP = "deep"
+    DIAGNOSTIC = "diagnostic"
+
+
+class ScopeMode(str, Enum):
+    CONVERSATION = "conversation"
+    LOCAL = "local"
+    GLOBAL = "global"
+
+
+class TimeMode(str, Enum):
+    NONE = "none"
+    RECENT = "recent"
+    CHRONOLOGICAL = "chronological"
+
+
+class GraphAllowance(str, Enum):
+    DISALLOW = "disallow"
+    ALLOW_ENRICHMENT = "allow_enrichment"
+    PREFER_ENRICHMENT = "prefer_enrichment"
+
+
+class EscalationStep(str, Enum):
+    THREAD_MESSAGES = "thread_messages"
+    THREAD_SEMANTIC = "thread_semantic"
+    PROJECT_DOCS = "project_docs"
+    MEMORY = "memory"
+    ADJACENT_LOCAL = "adjacent_local"
+    GRAPH_ENRICHMENT = "graph_enrichment"
+    GLOBAL_SEARCH = "global_search"
+
+
+@dataclass(frozen=True)
+class PolicyRule:
+    intent: QueryIntent
+    summary: str
+    retrieval_needed: bool
+    default_scope: ScopeMode
+    time_mode: TimeMode
+    graph_allowance: GraphAllowance
+    depth_bias: RetrievalDepth
+    escalation_order: tuple[EscalationStep, ...]
+    allow_global_fallback: bool
+    stop_condition: str
+
+
+@dataclass(frozen=True)
+class RetrievalPlan:
+    query: str
+    intent: QueryIntent
+    effective_depth: RetrievalDepth
+    default_scope: ScopeMode
+    time_mode: TimeMode
+    graph_allowance: GraphAllowance
+    escalation_order: tuple[EscalationStep, ...]
+    retrieval_needed: bool
+    allow_global_fallback: bool
+    reasons: tuple[str, ...]
+    active_thread_id: int | None = None
+    active_project_id: int | None = None
+    active_persona: str | None = None
+
+
+QUERY_INTENTS: frozenset[str] = frozenset(
+    intent.value for intent in QueryIntent
+)
+RETRIEVAL_DEPTHS: frozenset[str] = frozenset(
+    depth.value for depth in RetrievalDepth
+)
+SCOPE_MODES: frozenset[str] = frozenset(scope.value for scope in ScopeMode)
+TIME_MODES: frozenset[str] = frozenset(mode.value for mode in TimeMode)
+GRAPH_ALLOWANCES: frozenset[str] = frozenset(
+    allowance.value for allowance in GraphAllowance
+)
+ESCALATION_STEPS: frozenset[str] = frozenset(
+    step.value for step in EscalationStep
+)
+
+_EMPTY_ESCALATION: tuple[EscalationStep, ...] = ()
+
+ROUTER_POLICY: dict[QueryIntent, PolicyRule] = {
+    QueryIntent.CONVERSATION_ONLY: PolicyRule(
+        intent=QueryIntent.CONVERSATION_ONLY,
+        summary="Answer from the active conversation without retrieval.",
+        retrieval_needed=False,
+        default_scope=ScopeMode.CONVERSATION,
+        time_mode=TimeMode.NONE,
+        graph_allowance=GraphAllowance.DISALLOW,
+        depth_bias=RetrievalDepth.SHALLOW,
+        escalation_order=_EMPTY_ESCALATION,
+        allow_global_fallback=False,
+        stop_condition="Stop at the active conversation.",
+    ),
+    QueryIntent.DIRECT_QA: PolicyRule(
+        intent=QueryIntent.DIRECT_QA,
+        summary="Use ordinary local retrieval for targeted questions.",
+        retrieval_needed=True,
+        default_scope=ScopeMode.LOCAL,
+        time_mode=TimeMode.NONE,
+        graph_allowance=GraphAllowance.DISALLOW,
+        depth_bias=RetrievalDepth.NORMAL,
+        escalation_order=(
+            EscalationStep.THREAD_MESSAGES,
+            EscalationStep.THREAD_SEMANTIC,
+            EscalationStep.PROJECT_DOCS,
+            EscalationStep.ADJACENT_LOCAL,
+        ),
+        allow_global_fallback=False,
+        stop_condition="Stop on first sufficient local evidence set.",
+    ),
+    QueryIntent.MEMORY_RECALL: PolicyRule(
+        intent=QueryIntent.MEMORY_RECALL,
+        summary="Favor memory-backed local recall.",
+        retrieval_needed=True,
+        default_scope=ScopeMode.LOCAL,
+        time_mode=TimeMode.RECENT,
+        graph_allowance=GraphAllowance.DISALLOW,
+        depth_bias=RetrievalDepth.DEEP,
+        escalation_order=(
+            EscalationStep.THREAD_MESSAGES,
+            EscalationStep.MEMORY,
+            EscalationStep.THREAD_SEMANTIC,
+            EscalationStep.PROJECT_DOCS,
+        ),
+        allow_global_fallback=False,
+        stop_condition="Stop once memory-backed recall is sufficient.",
+    ),
+    QueryIntent.TIMELINE_RECALL: PolicyRule(
+        intent=QueryIntent.TIMELINE_RECALL,
+        summary="Preserve chronological ordering for timeline reconstruction.",
+        retrieval_needed=True,
+        default_scope=ScopeMode.LOCAL,
+        time_mode=TimeMode.CHRONOLOGICAL,
+        graph_allowance=GraphAllowance.DISALLOW,
+        depth_bias=RetrievalDepth.DEEP,
+        escalation_order=(
+            EscalationStep.THREAD_MESSAGES,
+            EscalationStep.MEMORY,
+            EscalationStep.THREAD_SEMANTIC,
+            EscalationStep.PROJECT_DOCS,
+        ),
+        allow_global_fallback=False,
+        stop_condition="Stop once a coherent ordered timeline exists.",
+    ),
+    QueryIntent.PROVENANCE: PolicyRule(
+        intent=QueryIntent.PROVENANCE,
+        summary="Explain source and lineage with graph as optional enrichment.",
+        retrieval_needed=True,
+        default_scope=ScopeMode.LOCAL,
+        time_mode=TimeMode.NONE,
+        graph_allowance=GraphAllowance.PREFER_ENRICHMENT,
+        depth_bias=RetrievalDepth.NORMAL,
+        escalation_order=(
+            EscalationStep.THREAD_MESSAGES,
+            EscalationStep.THREAD_SEMANTIC,
+            EscalationStep.PROJECT_DOCS,
+            EscalationStep.GRAPH_ENRICHMENT,
+            EscalationStep.ADJACENT_LOCAL,
+        ),
+        allow_global_fallback=False,
+        stop_condition="Stop once source or lineage can be explained.",
+    ),
+    QueryIntent.EXPLORATORY: PolicyRule(
+        intent=QueryIntent.EXPLORATORY,
+        summary="Spend a larger evidence budget for broad exploration.",
+        retrieval_needed=True,
+        default_scope=ScopeMode.LOCAL,
+        time_mode=TimeMode.NONE,
+        graph_allowance=GraphAllowance.ALLOW_ENRICHMENT,
+        depth_bias=RetrievalDepth.DEEP,
+        escalation_order=(
+            EscalationStep.THREAD_MESSAGES,
+            EscalationStep.THREAD_SEMANTIC,
+            EscalationStep.PROJECT_DOCS,
+            EscalationStep.MEMORY,
+            EscalationStep.ADJACENT_LOCAL,
+            EscalationStep.GLOBAL_SEARCH,
+        ),
+        allow_global_fallback=True,
+        stop_condition="Stop when the configured evidence budget is exhausted.",
+    ),
+    QueryIntent.EXPLICIT_GLOBAL_SEARCH: PolicyRule(
+        intent=QueryIntent.EXPLICIT_GLOBAL_SEARCH,
+        summary="Broaden search posture because the user asked explicitly.",
+        retrieval_needed=True,
+        default_scope=ScopeMode.GLOBAL,
+        time_mode=TimeMode.NONE,
+        graph_allowance=GraphAllowance.ALLOW_ENRICHMENT,
+        depth_bias=RetrievalDepth.DEEP,
+        escalation_order=(
+            EscalationStep.THREAD_MESSAGES,
+            EscalationStep.THREAD_SEMANTIC,
+            EscalationStep.PROJECT_DOCS,
+            EscalationStep.ADJACENT_LOCAL,
+            EscalationStep.GLOBAL_SEARCH,
+        ),
+        allow_global_fallback=True,
+        stop_condition="Stop after the explicit broadened search pass.",
+    ),
+    QueryIntent.SCOPE_LOCKED_LOCAL: PolicyRule(
+        intent=QueryIntent.SCOPE_LOCKED_LOCAL,
+        summary="Keep retrieval strictly local and do not widen scope.",
+        retrieval_needed=True,
+        default_scope=ScopeMode.LOCAL,
+        time_mode=TimeMode.NONE,
+        graph_allowance=GraphAllowance.DISALLOW,
+        depth_bias=RetrievalDepth.NORMAL,
+        escalation_order=(
+            EscalationStep.THREAD_MESSAGES,
+            EscalationStep.THREAD_SEMANTIC,
+            EscalationStep.PROJECT_DOCS,
+        ),
+        allow_global_fallback=False,
+        stop_condition="Stop without adjacent or global expansion.",
+    ),
+    QueryIntent.RELATIONSHIP_TRACE: PolicyRule(
+        intent=QueryIntent.RELATIONSHIP_TRACE,
+        summary="Trace relationships with graph as preferred enrichment.",
+        retrieval_needed=True,
+        default_scope=ScopeMode.LOCAL,
+        time_mode=TimeMode.NONE,
+        graph_allowance=GraphAllowance.PREFER_ENRICHMENT,
+        depth_bias=RetrievalDepth.DEEP,
+        escalation_order=(
+            EscalationStep.THREAD_MESSAGES,
+            EscalationStep.THREAD_SEMANTIC,
+            EscalationStep.GRAPH_ENRICHMENT,
+            EscalationStep.PROJECT_DOCS,
+            EscalationStep.ADJACENT_LOCAL,
+        ),
+        allow_global_fallback=False,
+        stop_condition="Stop once the relationship path is explainable.",
+    ),
+}
+
+_EXPLICIT_GLOBAL_SEARCH_HINTS = (
+    "search everywhere",
+    "search globally",
+    "global search",
+    "across all projects",
+    "across everything",
+    "search across all",
+    "look everywhere",
+)
+_SCOPE_LOCKED_LOCAL_HINTS = (
+    "only in this thread",
+    "only in this project",
+    "stay local",
+    "keep it local",
+    "local only",
+    "no global search",
+    "do not expand",
+    "don't expand",
+)
+_RELATIONSHIP_TRACE_HINTS = (
+    "relationship between",
+    "relation between",
+    "linked to",
+    "connected to",
+    "trace relationship",
+    "how does ",
+)
+_PROVENANCE_HINTS = (
+    "provenance",
+    "where did",
+    "source of",
+    "cite",
+    "citation",
+    "came from",
+)
+_TIMELINE_RECALL_HINTS = (
+    "timeline",
+    "chronological",
+    "when did",
+    "what happened first",
+    "what happened before",
+    "sequence of events",
+    "over time",
+)
+_MEMORY_RECALL_HINTS = (
+    "remember",
+    "recall",
+    "what do you know about",
+    "what did i say",
+    "previously",
+    "last time we",
+)
+_EXPLORATORY_HINTS = (
+    "explore",
+    "brainstorm",
+    "survey",
+    "map out",
+    "look around",
+    "broad search",
+    "compare options",
+)
+_CONVERSATION_ONLY_EXACT = frozenset(
+    {
+        "",
+        "hi",
+        "hello",
+        "hey",
+        "thanks",
+        "thank you",
+        "ok",
+        "okay",
+        "cool",
+        "sounds good",
+        "how are you",
+    }
+)
+_CONVERSATION_ONLY_PREFIXES = ("hi ", "hello ", "hey ", "thanks ", "thank ")
+
+
+def _contains_any(text: str, hints: tuple[str, ...]) -> bool:
+    return any(hint in text for hint in hints)
+
+
+def _coerce_query_intent(value: QueryIntent | str) -> QueryIntent:
+    if isinstance(value, QueryIntent):
+        return value
+    normalized = str(value or "").strip().lower()
+    try:
+        return QueryIntent(normalized)
+    except ValueError as exc:
+        raise ValueError(f"Unsupported query intent: {value!r}") from exc
+
+
+def _coerce_retrieval_depth(
+    value: RetrievalDepth | str | None,
+) -> RetrievalDepth:
+    if value is None:
+        return RetrievalDepth.AUTO
+    if isinstance(value, RetrievalDepth):
+        return value
+    normalized = str(value or "").strip().lower()
+    if not normalized:
+        return RetrievalDepth.AUTO
+    try:
+        return RetrievalDepth(normalized)
+    except ValueError as exc:
+        raise ValueError(f"Unsupported retrieval depth: {value!r}") from exc
+
+
+def classify_query_intent(query: str) -> QueryIntent:
+    """Deterministic placeholder intent classifier for policy scaffolding."""
+    normalized = " ".join(str(query or "").strip().lower().split())
+
+    if _contains_any(normalized, _EXPLICIT_GLOBAL_SEARCH_HINTS):
+        return QueryIntent.EXPLICIT_GLOBAL_SEARCH
+    if _contains_any(normalized, _SCOPE_LOCKED_LOCAL_HINTS):
+        return QueryIntent.SCOPE_LOCKED_LOCAL
+    if _contains_any(normalized, _RELATIONSHIP_TRACE_HINTS):
+        return QueryIntent.RELATIONSHIP_TRACE
+    if _contains_any(normalized, _PROVENANCE_HINTS):
+        return QueryIntent.PROVENANCE
+    if _contains_any(normalized, _TIMELINE_RECALL_HINTS):
+        return QueryIntent.TIMELINE_RECALL
+    if _contains_any(normalized, _MEMORY_RECALL_HINTS):
+        return QueryIntent.MEMORY_RECALL
+    if _contains_any(normalized, _EXPLORATORY_HINTS):
+        return QueryIntent.EXPLORATORY
+    if normalized in _CONVERSATION_ONLY_EXACT or normalized.startswith(
+        _CONVERSATION_ONLY_PREFIXES
+    ):
+        return QueryIntent.CONVERSATION_ONLY
+    return QueryIntent.DIRECT_QA
+
+
+def resolve_retrieval_plan(
+    query: str,
+    user_depth: RetrievalDepth | str | None,
+    *,
+    intent: QueryIntent | str | None = None,
+    active_thread_id: int | None = None,
+    active_project_id: int | None = None,
+    active_persona: str | None = None,
+) -> RetrievalPlan:
+    """Resolve a pure retrieval plan from canonical policy tokens."""
+    reasons: list[str] = []
+
+    if intent is None:
+        resolved_intent = classify_query_intent(query)
+        reasons.append(
+            f"intent classified from deterministic scaffold: {resolved_intent.value}"
+        )
+    else:
+        resolved_intent = _coerce_query_intent(intent)
+        reasons.append(
+            f"intent accepted from explicit token: {resolved_intent.value}"
+        )
+
+    rule = ROUTER_POLICY[resolved_intent]
+    requested_depth = _coerce_retrieval_depth(user_depth)
+
+    if active_thread_id is not None:
+        reasons.append(f"active thread context available: {active_thread_id}")
+    if active_project_id is not None:
+        reasons.append(f"active project context available: {active_project_id}")
+    if active_persona:
+        reasons.append(f"active persona context available: {active_persona}")
+
+    if not rule.retrieval_needed:
+        effective_depth = RetrievalDepth.SHALLOW
+        reasons.append("policy marks retrieval as unnecessary for this intent.")
+        if requested_depth != RetrievalDepth.AUTO:
+            reasons.append(
+                "conversation-only intent collapses explicit depth to shallow."
+            )
+        return RetrievalPlan(
+            query=str(query or ""),
+            intent=resolved_intent,
+            effective_depth=effective_depth,
+            default_scope=rule.default_scope,
+            time_mode=rule.time_mode,
+            graph_allowance=rule.graph_allowance,
+            escalation_order=_EMPTY_ESCALATION,
+            retrieval_needed=False,
+            allow_global_fallback=False,
+            reasons=tuple(reasons),
+            active_thread_id=active_thread_id,
+            active_project_id=active_project_id,
+            active_persona=active_persona,
+        )
+
+    if requested_depth == RetrievalDepth.AUTO:
+        effective_depth = rule.depth_bias
+        reasons.append(
+            "depth resolved from auto to policy bias: "
+            f"{effective_depth.value}"
+        )
+    else:
+        effective_depth = requested_depth
+        reasons.append(
+            f"explicit depth preserved from caller: {effective_depth.value}"
+        )
+
+    reasons.append(
+        f"default scope resolved from policy: {rule.default_scope.value}"
+    )
+    reasons.append(f"time mode resolved from policy: {rule.time_mode.value}")
+    reasons.append(
+        "graph allowance resolved from policy: " f"{rule.graph_allowance.value}"
+    )
+
+    return RetrievalPlan(
+        query=str(query or ""),
+        intent=resolved_intent,
+        effective_depth=effective_depth,
+        default_scope=rule.default_scope,
+        time_mode=rule.time_mode,
+        graph_allowance=rule.graph_allowance,
+        escalation_order=rule.escalation_order,
+        retrieval_needed=rule.retrieval_needed,
+        allow_global_fallback=rule.allow_global_fallback,
+        reasons=tuple(reasons),
+        active_thread_id=active_thread_id,
+        active_project_id=active_project_id,
+        active_persona=active_persona,
+    )
+
+
+__all__ = [
+    "ESCALATION_STEPS",
+    "GRAPH_ALLOWANCES",
+    "QUERY_INTENTS",
+    "RETRIEVAL_DEPTHS",
+    "SCOPE_MODES",
+    "TIME_MODES",
+    "EscalationStep",
+    "GraphAllowance",
+    "PolicyRule",
+    "QueryIntent",
+    "ROUTER_POLICY",
+    "RetrievalDepth",
+    "RetrievalPlan",
+    "ScopeMode",
+    "TimeMode",
+    "classify_query_intent",
+    "resolve_retrieval_plan",
+]

--- a/tests/context/test_retrieval_router_policy.py
+++ b/tests/context/test_retrieval_router_policy.py
@@ -1,0 +1,91 @@
+from guardian.context.retrieval_router_policy import (
+    ROUTER_POLICY,
+    EscalationStep,
+    GraphAllowance,
+    PolicyRule,
+    QueryIntent,
+    RetrievalDepth,
+    TimeMode,
+    resolve_retrieval_plan,
+)
+
+
+def test_conversation_only_disables_retrieval_and_global_fallback() -> None:
+    plan = resolve_retrieval_plan(
+        "hello",
+        RetrievalDepth.AUTO,
+        intent=QueryIntent.CONVERSATION_ONLY,
+    )
+
+    assert plan.retrieval_needed is False
+    assert plan.effective_depth == RetrievalDepth.SHALLOW
+    assert plan.escalation_order == ()
+    assert plan.allow_global_fallback is False
+
+
+def test_timeline_recall_uses_chronological_time_mode() -> None:
+    plan = resolve_retrieval_plan(
+        "when did that happen?",
+        RetrievalDepth.AUTO,
+        intent=QueryIntent.TIMELINE_RECALL,
+    )
+
+    assert plan.time_mode == TimeMode.CHRONOLOGICAL
+
+
+def test_provenance_prefers_graph_more_than_direct_qa() -> None:
+    qa_plan = resolve_retrieval_plan(
+        "answer this question",
+        RetrievalDepth.AUTO,
+        intent=QueryIntent.DIRECT_QA,
+    )
+    provenance_plan = resolve_retrieval_plan(
+        "where did this come from?",
+        RetrievalDepth.AUTO,
+        intent=QueryIntent.PROVENANCE,
+    )
+
+    assert qa_plan.graph_allowance == GraphAllowance.DISALLOW
+    assert provenance_plan.graph_allowance == GraphAllowance.PREFER_ENRICHMENT
+
+
+def test_scope_locked_local_disables_adjacent_and_global_expansion() -> None:
+    plan = resolve_retrieval_plan(
+        "only in this thread",
+        RetrievalDepth.AUTO,
+        intent=QueryIntent.SCOPE_LOCKED_LOCAL,
+    )
+
+    assert EscalationStep.ADJACENT_LOCAL not in plan.escalation_order
+    assert EscalationStep.GLOBAL_SEARCH not in plan.escalation_order
+    assert plan.allow_global_fallback is False
+
+
+def test_auto_depth_resolves_per_intent_instead_of_always_deep() -> None:
+    direct_plan = resolve_retrieval_plan(
+        "what is the status?",
+        RetrievalDepth.AUTO,
+        intent=QueryIntent.DIRECT_QA,
+    )
+    memory_plan = resolve_retrieval_plan(
+        "what do you remember about this?",
+        RetrievalDepth.AUTO,
+        intent=QueryIntent.MEMORY_RECALL,
+    )
+    conversation_plan = resolve_retrieval_plan(
+        "thanks",
+        RetrievalDepth.AUTO,
+        intent=QueryIntent.CONVERSATION_ONLY,
+    )
+
+    assert direct_plan.effective_depth == RetrievalDepth.NORMAL
+    assert memory_plan.effective_depth == RetrievalDepth.DEEP
+    assert conversation_plan.effective_depth == RetrievalDepth.SHALLOW
+
+
+def test_policy_registry_is_stable_and_complete() -> None:
+    assert set(ROUTER_POLICY) == set(QueryIntent)
+
+    for intent, rule in ROUTER_POLICY.items():
+        assert isinstance(rule, PolicyRule)
+        assert rule.intent is intent


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
