### PR TITLE
Add read-only retrieval plan tracing to completion service

### DIFF
--- a/guardian/core/chat_completion_service.py
+++ b/guardian/core/chat_completion_service.py
@@ -19,6 +19,7 @@ from guardian.cognition.prompts import (
 )
 from guardian.cognition.prompts import build_context_system_message_with_meta
 from guardian.context.broker import ContextBroker
+from guardian.context.retrieval_router_policy import resolve_retrieval_plan
 from guardian.core import dependencies, event_bus
 from guardian.core.ai_router import (
     build_openai_vision_content,
@@ -38,6 +39,7 @@ from guardian.core.provider_registry import model_supports_capability
 from guardian.tasks.types import ChatCompletionTask
 
 logger = logging.getLogger(__name__)
+RETRIEVAL_PLAN_TRACE_KEY = "retrieval_plan"
 
 try:  # pragma: no cover - prompts are optional in some deployments
     from guardian.cognition.system_prompt_builder import (
@@ -507,6 +509,38 @@ def _build_document_context_message(
     return (message_prefix + "\n".join(lines), len(sources))
 
 
+def _active_persona_context_from_prompt_meta(
+    prompt_meta: dict[str, Any] | None,
+) -> str | None:
+    if not isinstance(prompt_meta, dict):
+        return None
+    resolved_persona_id = prompt_meta.get("resolved_persona_id")
+    if resolved_persona_id is None:
+        return None
+    text = str(resolved_persona_id).strip()
+    return text or None
+
+
+def _serialize_retrieval_plan_trace(
+    *,
+    plan: Any,
+    user_depth: str,
+) -> dict[str, Any]:
+    normalized_user_depth = str(user_depth or "").strip().lower() or "auto"
+    return {
+        "intent": plan.intent.value,
+        "user_depth": normalized_user_depth,
+        "resolved_depth": plan.effective_depth.value,
+        "primary_scope": plan.default_scope.value,
+        "time_mode": plan.time_mode.value,
+        "graph_allowance": plan.graph_allowance.value,
+        "retrieval_needed": bool(plan.retrieval_needed),
+        "allow_global_fallback": bool(plan.allow_global_fallback),
+        "escalation_order": [step.value for step in plan.escalation_order],
+        "reasons": [str(reason) for reason in plan.reasons],
+    }
+
+
 async def build_messages_for_llm(
     task: ChatCompletionTask,
 ) -> tuple[
@@ -696,6 +730,30 @@ async def build_messages_for_llm(
         bundle["_attachment_meta"] = {
             "latest_user": latest_user_meta,
         }
+
+    try:
+        retrieval_plan = resolve_retrieval_plan(
+            latest_message,
+            depth,
+            active_thread_id=thread_id,
+            active_project_id=project_id_for_prompt,
+            active_persona=_active_persona_context_from_prompt_meta(
+                prompt_meta
+            ),
+        )
+        if isinstance(trace, dict):
+            trace = dict(trace)
+            trace[RETRIEVAL_PLAN_TRACE_KEY] = _serialize_retrieval_plan_trace(
+                plan=retrieval_plan,
+                user_depth=depth,
+            )
+    except Exception as exc:
+        logger.warning(
+            "[chat-completion] retrieval plan resolution failed depth=%s err=%s",
+            depth,
+            exc,
+        )
+
     messages_for_llm.extend(context)
 
     model = task.model

--- a/tests/core/test_chat_completion_service_retrieval_plan.py
+++ b/tests/core/test_chat_completion_service_retrieval_plan.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from guardian.core import chat_completion_service
+from guardian.tasks.types import ChatCompletionTask
+
+
+def _seed_completion_service(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    user_content: str,
+    trace_payload: dict[str, object] | None,
+    prompt_meta: dict[str, object] | None = None,
+) -> dict[str, object]:
+    captured: dict[str, object] = {}
+    mock_chatlog_db = MagicMock()
+    mock_chatlog_db.get_chat_thread.return_value = {
+        "id": 1,
+        "user_id": "user-1",
+        "project_id": 42,
+    }
+    mock_chatlog_db.list_messages.return_value = [
+        {"id": 1, "role": "user", "content": user_content}
+    ]
+
+    class _FakeBroker:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def assemble(self, thread_id, query, depth_mode, user_id):
+            captured["thread_id"] = thread_id
+            captured["query"] = query
+            captured["depth_mode"] = depth_mode
+            captured["user_id"] = user_id
+            return {"semantic": []}, trace_payload
+
+    settings = SimpleNamespace(
+        LLM_PROVIDER="local",
+        LOCAL_LLM_MODEL="local-model",
+        DEFAULT_LOCAL_MODEL="local-model",
+        LLM_MODEL="local-model",
+    )
+
+    monkeypatch.setattr(
+        chat_completion_service, "get_settings", lambda: settings
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "validate_llm_config",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "build_guardian_system_prompt",
+        lambda **kwargs: (
+            "BASE SYSTEM",
+            dict(prompt_meta or {}),
+        ),
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "build_context_system_message_with_meta",
+        lambda *args, **kwargs: (None, {}),
+    )
+    monkeypatch.setattr(chat_completion_service, "ContextBroker", _FakeBroker)
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "chatlog_db",
+        mock_chatlog_db,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "CHAT_PROVIDER",
+        "local",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_vector_store",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_memory_store",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_sensors",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "DEFAULT_MODEL",
+        "local-model",
+        raising=False,
+    )
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_completion_assembly_emits_retrieval_plan_when_trace_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_completion_service(
+        monkeypatch,
+        user_content="What is the status?",
+        trace_payload={"documents": [], "graph": []},
+    )
+
+    task = ChatCompletionTask(thread_id=1, provider="local", model=None)
+    (
+        _messages,
+        _provider,
+        _model,
+        _bundle,
+        trace,
+    ) = await chat_completion_service.build_messages_for_llm(task)
+
+    assert isinstance(trace, dict)
+    assert trace["documents"] == []
+    assert trace["graph"] == []
+    assert chat_completion_service.RETRIEVAL_PLAN_TRACE_KEY in trace
+
+
+@pytest.mark.asyncio
+async def test_conversation_style_query_resolves_to_no_retrieval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_completion_service(
+        monkeypatch,
+        user_content="hello",
+        trace_payload={"documents": [], "graph": []},
+    )
+
+    task = ChatCompletionTask(thread_id=1, provider="local", model=None)
+    (
+        _messages,
+        _provider,
+        _model,
+        _bundle,
+        trace,
+    ) = await chat_completion_service.build_messages_for_llm(task)
+
+    assert isinstance(trace, dict)
+    plan = trace[chat_completion_service.RETRIEVAL_PLAN_TRACE_KEY]
+    assert plan["intent"] == "conversation_only"
+    assert plan["retrieval_needed"] is False
+
+
+@pytest.mark.asyncio
+async def test_timeline_style_query_resolves_to_chronological_time_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_completion_service(
+        monkeypatch,
+        user_content="What happened before this change?",
+        trace_payload={"documents": [], "graph": []},
+    )
+
+    task = ChatCompletionTask(thread_id=1, provider="local", model=None)
+    (
+        _messages,
+        _provider,
+        _model,
+        _bundle,
+        trace,
+    ) = await chat_completion_service.build_messages_for_llm(task)
+
+    assert isinstance(trace, dict)
+    plan = trace[chat_completion_service.RETRIEVAL_PLAN_TRACE_KEY]
+    assert plan["intent"] == "timeline_recall"
+    assert plan["time_mode"] == "chronological"
+
+
+@pytest.mark.asyncio
+async def test_provenance_style_query_resolves_to_graph_permissive_plan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_completion_service(
+        monkeypatch,
+        user_content="Where did this come from?",
+        trace_payload={"documents": [], "graph": []},
+    )
+
+    task = ChatCompletionTask(thread_id=1, provider="local", model=None)
+    (
+        _messages,
+        _provider,
+        _model,
+        _bundle,
+        trace,
+    ) = await chat_completion_service.build_messages_for_llm(task)
+
+    assert isinstance(trace, dict)
+    plan = trace[chat_completion_service.RETRIEVAL_PLAN_TRACE_KEY]
+    assert plan["intent"] == "provenance"
+    assert plan["graph_allowance"] == "prefer_enrichment"
+
+
+@pytest.mark.asyncio
+async def test_retrieval_plan_tracing_does_not_mutate_broker_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _seed_completion_service(
+        monkeypatch,
+        user_content="Please summarize this thread.",
+        trace_payload={"documents": [], "graph": []},
+        prompt_meta={"resolved_persona_id": 7},
+    )
+
+    task = ChatCompletionTask(
+        thread_id=1,
+        provider="local",
+        model=None,
+        depth_mode="deep",
+    )
+    await chat_completion_service.build_messages_for_llm(task)
+
+    assert captured == {
+        "thread_id": 1,
+        "query": "Please summarize this thread.",
+        "depth_mode": "deep",
+        "user_id": "user-1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_emitted_retrieval_plan_values_are_debug_safe_scalars_and_lists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_completion_service(
+        monkeypatch,
+        user_content="Search globally across all projects for related notes.",
+        trace_payload={"documents": [], "graph": []},
+    )
+
+    task = ChatCompletionTask(thread_id=1, provider="local", model=None)
+    (
+        _messages,
+        _provider,
+        _model,
+        _bundle,
+        trace,
+    ) = await chat_completion_service.build_messages_for_llm(task)
+
+    assert isinstance(trace, dict)
+    plan = trace[chat_completion_service.RETRIEVAL_PLAN_TRACE_KEY]
+    assert plan["intent"] == "explicit_global_search"
+    assert plan["user_depth"] == "normal"
+    assert plan["resolved_depth"] == "normal"
+    assert plan["primary_scope"] == "global"
+    assert plan["time_mode"] == "none"
+    assert plan["graph_allowance"] == "allow_enrichment"
+    assert isinstance(plan["retrieval_needed"], bool)
+    assert isinstance(plan["allow_global_fallback"], bool)
+    assert isinstance(plan["escalation_order"], list)
+    assert all(isinstance(item, str) for item in plan["escalation_order"])
+    assert isinstance(plan["reasons"], list)
+    assert all(isinstance(item, str) for item in plan["reasons"])


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
