### PR TITLE
fix(chat): enforce response boundary by stripping scratchpad output f…

### DIFF
--- a/guardian/tests/workers/test_chat_worker_completion_semantics.py
+++ b/guardian/tests/workers/test_chat_worker_completion_semantics.py
@@ -452,6 +452,97 @@ def test_generation_success_but_persistence_failure_is_non_authoritative(
         assert exc.metadata["completion_truth"]["completed"] is False
 
 
+def test_extract_assistant_response_strips_structured_scratchpad():
+    raw = (
+        "=== SCRATCHPAD ===\n"
+        "% System Note === internal\n"
+        "% User Note === internal\n"
+        "% System Response === Hello!\n"
+    )
+    assert chat_worker.extract_assistant_response(raw) == "Hello!"
+
+    raw_fallback = "header\n" "=== SCRATCHPAD ===\n" "Final visible reply"
+    assert (
+        chat_worker.extract_assistant_response(raw_fallback)
+        == "Final visible reply"
+    )
+
+
+def test_completion_persists_stripped_response_boundary(monkeypatch):
+    mock_db = MagicMock()
+    mock_db.create_message.return_value = 321
+    mock_db.write_audit_log = MagicMock()
+    monkeypatch.setattr(chat_worker.dependencies, "chatlog_db", mock_db)
+    monkeypatch.setattr(
+        chat_worker.event_bus, "emit_event", lambda *a, **k: None
+    )
+    monkeypatch.setattr(chat_worker, "_embed_message", lambda *a, **k: None)
+
+    async def _build_messages(_task):
+        return (
+            [{"role": "user", "content": "hello"}],
+            "local",
+            "qwen3.5:27b",
+            {},
+            None,
+            None,
+            {},
+        )
+
+    monkeypatch.setattr(chat_worker, "_build_messages_for_llm", _build_messages)
+    monkeypatch.setattr(
+        chat_worker,
+        "get_settings",
+        lambda: Settings(
+            LLM_PROVIDER="local",
+            ALLOW_CLOUD_PROVIDERS=True,
+            CODEXIFY_LOCAL_ONLY_MODE=False,
+            CODEXIFY_EGRESS_ALLOWLIST="groq,openai,minimax",
+            LOCAL_LLM_MODEL="qwen3.5:27b",
+            DEFAULT_LOCAL_MODEL="qwen3.5:27b",
+            LLM_MODEL="qwen3.5:27b",
+        ),
+    )
+
+    class _EmptyStream:
+        def __iter__(self):
+            return iter(())
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(
+        chat_worker, "stream_local", lambda *a, **k: _EmptyStream()
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "chat_with_ai",
+        lambda *_a, **_k: (
+            "=== SCRATCHPAD ===\n"
+            "% System Note === internal\n"
+            "% User Note === internal\n"
+            "% System Response === Hello!\n"
+        ),
+    )
+
+    callback_tokens: list[str] = []
+    task = ChatCompletionTask(
+        thread_id=1,
+        provider="local",
+        model="qwen3.5:27b",
+        selection_source="explicit",
+    )
+
+    result = chat_worker._run_chat_completion_task_compat(
+        task,
+        token_callback=callback_tokens.append,
+    )
+
+    assert result["assistant_text"] == "Hello!"
+    assert callback_tokens == ["Hello!"]
+    assert mock_db.create_message.call_args[0][2] == "Hello!"
+
+
 def test_duplicate_turn_is_prevented_before_new_completion(monkeypatch):
     published: list[tuple[str, dict]] = []
 

--- a/guardian/workers/chat_worker.py
+++ b/guardian/workers/chat_worker.py
@@ -906,6 +906,21 @@ def _normalize_model_override(value: Any) -> str | None:
     return normalized or None
 
 
+def extract_assistant_response(text: str) -> str:
+    """Normalize model output to the final assistant-visible response."""
+
+    if not text:
+        return text
+
+    if "System Response ===" in text:
+        return text.split("System Response ===")[-1].strip()
+
+    if "=== SCRATCHPAD ===" in text:
+        return text.split("=== SCRATCHPAD ===")[-1].strip()
+
+    return text.strip()
+
+
 def _degraded_provider_model_fallback(
     *,
     provider: str,
@@ -1309,7 +1324,7 @@ def _run_chat_completion_task_compat(
                     )
                 )
                 if token_callback and (not streamed_any) and assistant_output:
-                    token_callback(assistant_output)
+                    token_callback(extract_assistant_response(assistant_output))
             return assistant_output
 
         if cancel_check and cancel_check():
@@ -1328,7 +1343,7 @@ def _run_chat_completion_task_compat(
             )
         )
         if token_callback:
-            token_callback(assistant_output)
+            token_callback(extract_assistant_response(assistant_output))
         return assistant_output
 
     fallback_reason: str | None = None
@@ -1410,6 +1425,9 @@ def _run_chat_completion_task_compat(
             raise
         payload_summary["final_provider"] = final_provider
         payload_summary["final_model"] = final_model
+
+    logger.debug("[llm] raw_output=%s", assistant_text)
+    assistant_text = extract_assistant_response(assistant_text)
 
     if not assistant_text.strip():
         assistant_text = "No assistant response was generated."


### PR DESCRIPTION
…rom model responses

## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
