### PR TITLE
Fix composer send button clipping

### DIFF
--- a/frontend/src/features/chat/components/Composer.tsx
+++ b/frontend/src/features/chat/components/Composer.tsx
@@ -20,7 +20,10 @@ import {
   DEFAULT_COMPOSER_INFERENCE_MODE,
   type ComposerInferenceMode,
 } from "@/types/inference";
-import { CHAT_COMPOSER_CONTROLS_BOTTOM_GAP_CLASS } from "@/features/chat/chatLane";
+import {
+  CHAT_COMPOSER_CONTROLS_BOTTOM_GAP_CLASS,
+  CHAT_COMPOSER_SEND_PAD_CLASS,
+} from "@/features/chat/chatLane";
 const ACCEPTED_ATTACHMENTS =
   [
     "image/*",
@@ -733,10 +736,10 @@ export function Composer({
           data-testid="composer-control-row"
           className={cn(
             CHAT_COMPOSER_CONTROLS_BOTTOM_GAP_CLASS,
-            "mt-auto flex w-full items-center justify-between gap-3 pl-[8px] pr-[24px] pb-[6px]"
+            "mt-auto flex w-full items-center gap-3 pl-[8px] pb-[6px]"
           )}
         >
-          <div className="flex min-w-0 flex-nowrap items-center gap-3 overflow-x-auto pr-2">
+          <div className="flex min-w-0 flex-1 flex-nowrap items-center gap-3 overflow-x-auto pr-2">
             <ComposerActionMenu
               disabled={draftControlsDisabled}
               depthMode={depthMode}
@@ -794,7 +797,13 @@ export function Composer({
             />
           </div>
 
-          <div data-testid="composer-send-slot" className="shrink-0">
+          <div
+            data-testid="composer-send-slot"
+            className={cn(
+              CHAT_COMPOSER_SEND_PAD_CLASS,
+              "flex shrink-0 items-center justify-center"
+            )}
+          >
             <Button
               type="button"
               onClick={handleAttemptSend}
@@ -817,11 +826,6 @@ export function Composer({
                     : ""
               )}
               style={{
-                width: 32,
-                height: 32,
-                minWidth: 32,
-                minHeight: 32,
-                padding: 0,
                 background: "color-mix(in oklab, var(--accent-strong) 82%, white 18%)",
                 color: "var(--text-on-accent, #111827)",
                 boxShadow: "none",

--- a/frontend/src/features/chat/components/__tests__/Composer.draft-sync.test.tsx
+++ b/frontend/src/features/chat/components/__tests__/Composer.draft-sync.test.tsx
@@ -2,7 +2,10 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { Composer } from "@/features/chat/components/Composer";
-import { CHAT_COMPOSER_CONTROLS_BOTTOM_GAP_CLASS } from "@/features/chat/chatLane";
+import {
+  CHAT_COMPOSER_CONTROLS_BOTTOM_GAP_CLASS,
+  CHAT_COMPOSER_SEND_PAD_CLASS,
+} from "@/features/chat/chatLane";
 import api from "@/lib/api";
 import composerSource from "@/features/chat/components/Composer.tsx?raw";
 
@@ -118,15 +121,24 @@ describe("Composer draft sync", () => {
     expect(onDraftValueChange).toHaveBeenLastCalledWith("");
   });
 
-  it("assigns right-edge ownership to the control row and keeps the send button circular", () => {
+  it("gives the send slot its own fixed padded lane and keeps the send button circular", () => {
     render(<Composer onSend={vi.fn()} draftScopeKey="tab-1" draftValue="" />);
 
     const controlsRow = screen.getByTestId("composer-control-row");
-    expect(controlsRow).toHaveClass("pr-[24px]");
+    expect(controlsRow).not.toHaveClass("justify-between");
+    expect(controlsRow.className).not.toMatch(/\bpr-\[/);
+
+    const controlsStrip = controlsRow.firstElementChild as HTMLElement;
+    expect(controlsStrip).toHaveClass("flex-1", "min-w-0", "overflow-x-auto");
 
     const sendSlot = screen.getByTestId("composer-send-slot");
-    expect(sendSlot).toHaveClass("shrink-0");
-    expect(sendSlot.className).not.toMatch(/\bpr-/);
+    expect(sendSlot).toHaveClass(
+      "flex",
+      "shrink-0",
+      "items-center",
+      "justify-center"
+    );
+    expect(sendSlot.className).toContain(CHAT_COMPOSER_SEND_PAD_CLASS);
 
     const sendButton = screen.getByRole("button", { name: "Send" });
     expect(sendButton.parentElement).toBe(sendSlot);
@@ -138,6 +150,9 @@ describe("Composer draft sync", () => {
       "p-0"
     );
     expect(sendButton.className).not.toMatch(/\brounded-md\b/);
+    expect(sendButton.getAttribute("style") ?? "").not.toMatch(
+      /\b(?:width|min-width|height|min-height|padding)\s*:/
+    );
 
     const textarea = screen.getByPlaceholderText("Write a message…");
     expect(textarea.parentElement).toHaveAttribute("data-composer-root");


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
