### PR TITLE
Fix Guardian Chat composer send button inset

### DIFF
--- a/frontend/src/features/chat/chatLane.ts
+++ b/frontend/src/features/chat/chatLane.ts
@@ -23,7 +23,7 @@ export const CHAT_COMPOSER_CONTROLS_PAD_CLASS = "px-3 pb-3 pt-2";
 export const CHAT_COMPOSER_INNER_PAD_CLASS = "px-3 pb-3 pt-3";
 export const CHAT_COMPOSER_TEXTAREA_PAD_CLASS = "px-3 pt-3";
 export const CHAT_COMPOSER_ATTACHMENTS_PAD_CLASS = "px-3 pt-2";
-export const CHAT_COMPOSER_SEND_PAD_CLASS = "pr-2";
+export const CHAT_COMPOSER_SEND_EDGE_INSET_CLASS = "pr-[32px]";
 
 // Outer Guardian surface ceiling for fullscreen layouts. Keeps the shell large
 // enough for future workspace activation without letting the empty side bands

--- a/frontend/src/features/chat/components/Composer.tsx
+++ b/frontend/src/features/chat/components/Composer.tsx
@@ -20,7 +20,10 @@ import {
   DEFAULT_COMPOSER_INFERENCE_MODE,
   type ComposerInferenceMode,
 } from "@/types/inference";
-import { CHAT_COMPOSER_CONTROLS_BOTTOM_GAP_CLASS } from "@/features/chat/chatLane";
+import {
+  CHAT_COMPOSER_CONTROLS_BOTTOM_GAP_CLASS,
+  CHAT_COMPOSER_SEND_EDGE_INSET_CLASS,
+} from "@/features/chat/chatLane";
 const ACCEPTED_ATTACHMENTS =
   [
     "image/*",
@@ -733,7 +736,8 @@ export function Composer({
           data-testid="composer-control-row"
           className={cn(
             CHAT_COMPOSER_CONTROLS_BOTTOM_GAP_CLASS,
-            "mt-auto flex w-full items-center justify-between gap-3 pl-[8px] pr-[24px] pb-[6px]"
+            CHAT_COMPOSER_SEND_EDGE_INSET_CLASS,
+            "mt-auto flex w-full items-center justify-between gap-3 pl-[8px] pb-[6px]"
           )}
         >
           <div className="flex min-w-0 flex-nowrap items-center gap-3 overflow-x-auto pr-2">

--- a/frontend/src/features/chat/components/__tests__/Composer.draft-sync.test.tsx
+++ b/frontend/src/features/chat/components/__tests__/Composer.draft-sync.test.tsx
@@ -2,7 +2,10 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { Composer } from "@/features/chat/components/Composer";
-import { CHAT_COMPOSER_CONTROLS_BOTTOM_GAP_CLASS } from "@/features/chat/chatLane";
+import {
+  CHAT_COMPOSER_CONTROLS_BOTTOM_GAP_CLASS,
+  CHAT_COMPOSER_SEND_EDGE_INSET_CLASS,
+} from "@/features/chat/chatLane";
 import api from "@/lib/api";
 import composerSource from "@/features/chat/components/Composer.tsx?raw";
 
@@ -122,7 +125,7 @@ describe("Composer draft sync", () => {
     render(<Composer onSend={vi.fn()} draftScopeKey="tab-1" draftValue="" />);
 
     const controlsRow = screen.getByTestId("composer-control-row");
-    expect(controlsRow).toHaveClass("pr-[24px]");
+    expect(controlsRow.className).toContain(CHAT_COMPOSER_SEND_EDGE_INSET_CLASS);
 
     const sendSlot = screen.getByTestId("composer-send-slot");
     expect(sendSlot).toHaveClass("shrink-0");
@@ -141,6 +144,8 @@ describe("Composer draft sync", () => {
 
     const textarea = screen.getByPlaceholderText("Write a message…");
     expect(textarea.parentElement).toHaveAttribute("data-composer-root");
+    expect(composerSource).toContain("CHAT_COMPOSER_SEND_EDGE_INSET_CLASS");
+    expect(composerSource).not.toContain('pr-[24px]');
   });
 
   it("stages attachments locally and uploads them only after send", async () => {


### PR DESCRIPTION
## Summary
- move the composer send-button right inset into a shared chat lane token
- increase the inset from 24px to 32px so the send button sits farther from the composer edge
- update the composer regression test to assert token usage instead of a hard-coded spacing class

## Testing
- `pnpm --dir /Users/resonant_jones/.codex/worktrees/db59/Codexify/frontend/src exec vitest run features/chat/components/__tests__/Composer.draft-sync.test.tsx`