### PR TITLE
Codex/investigate image display bug

### DIFF
--- a/frontend/src/features/chat/components/ChatBubble.tsx
+++ b/frontend/src/features/chat/components/ChatBubble.tsx
@@ -8,6 +8,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import { Volume2 } from "lucide-react";
 import { Message, MessageAttachment } from "@/types/ui";
+import { resolveMediaSrc } from "@/lib/mediaUrl";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { cn } from "@/lib/utils";
@@ -32,12 +33,15 @@ const mergeAttachments = (
     return messageAttachments.map((att) => ({
       kind: att.kind,
       id: att.id,
-      src: att.src,
+      src: att.src ? resolveMediaSrc(att.src) : att.src,
       name: att.name,
     }));
   }
   // Otherwise fall back to parsed content attachments
-  return contentAttachments;
+  return contentAttachments.map((att) => ({
+    ...att,
+    src: att.src ? resolveMediaSrc(att.src) : att.src,
+  }));
 };
 
 const parseAttachments = (content: string) => {
@@ -274,10 +278,11 @@ const AttachmentTiles = ({
     <div className={`flex flex-col gap-2 ${alignClass}`}>
       {attachments.map((att, idx) => {
         const key = `${att.kind}-${att.id ?? idx}`;
+        const resolvedSrc = att.src ? resolveMediaSrc(att.src) : att.src;
         if (att.kind === "image") {
           return (
             <div key={key} className={`${tileFrame} ${tileSize}`}>
-              {att.src ? (
+              {resolvedSrc ? (
                 <button
                   type="button"
                   onClick={() => openInWorkspace(att, idx)}
@@ -285,7 +290,7 @@ const AttachmentTiles = ({
                   aria-label="Open image"
                 >
                   <img
-                    src={att.src}
+                    src={resolvedSrc}
                     alt="uploaded image"
                     loading="lazy"
                     className="block w-full h-auto"
@@ -303,7 +308,7 @@ const AttachmentTiles = ({
 
         return (
           <div key={key} className={`${tileFrame} ${tileSize} px-3 py-2`}>
-            {att.src ? (
+            {resolvedSrc ? (
               <button
                 type="button"
                 onClick={() => openInWorkspace(att, idx)}
@@ -429,7 +434,7 @@ export function ChatBubble({
     ),
     img: ({ src, alt }: any) => (
       <img
-        src={src}
+        src={resolveMediaSrc(String(src ?? ""))}
         alt={alt || "uploaded media"}
         loading="lazy"
         className="my-2 max-w-full rounded-xl border border-black/10 dark:border-white/10"

--- a/frontend/src/features/chat/components/__tests__/ChatBubble.test.tsx
+++ b/frontend/src/features/chat/components/__tests__/ChatBubble.test.tsx
@@ -1,5 +1,10 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/runtimeConfig", () => ({
+  resolveBackendUrl: (path: string) =>
+    `http://backend.test${path.startsWith("/") ? path : `/${path}`}`,
+}));
 
 import ChatBubble from "@/features/chat/components/ChatBubble";
 
@@ -20,5 +25,93 @@ describe("ChatBubble", () => {
 
     expect(screen.getByText("Hello world")).toBeInTheDocument();
     expect(screen.queryByText("Invalid Date")).not.toBeInTheDocument();
+  });
+
+  it("renders attachment tiles with normalized image URLs", () => {
+    render(
+      <ChatBubble
+        isGuardian
+        message={{
+          id: "msg-2",
+          authorId: "bot",
+          authorName: "Guardian",
+          content: "",
+          createdAt: Date.now(),
+          attachments: [
+            {
+              id: "img-1",
+              kind: "image",
+              src: "/media/images/chat-tile.jpg?sig=tile#preview",
+              name: "chat-tile.jpg",
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(screen.getByRole("img", { name: "uploaded image" })).toHaveAttribute(
+      "src",
+      "http://backend.test/media/images/chat-tile.jpg?sig=tile#preview"
+    );
+  });
+
+  it("renders markdown images from relative /media sources", () => {
+    render(
+      <ChatBubble
+        isGuardian={false}
+        message={{
+          id: "msg-3",
+          authorId: "me",
+          authorName: "You",
+          content: "![Chat image](/media/images/chat-inline.jpg?sig=inline#viewer)",
+          createdAt: Date.now(),
+        }}
+      />
+    );
+
+    expect(screen.getByRole("img", { name: "Chat image" })).toHaveAttribute(
+      "src",
+      "http://backend.test/media/images/chat-inline.jpg?sig=inline#viewer"
+    );
+  });
+
+  it("renders markdown images from relative media sources without a leading slash", () => {
+    render(
+      <ChatBubble
+        isGuardian={false}
+        message={{
+          id: "msg-4",
+          authorId: "me",
+          authorName: "You",
+          content: "![Relative chat image](media/images/chat-inline-2.jpg?sig=inline2#viewer)",
+          createdAt: Date.now(),
+        }}
+      />
+    );
+
+    expect(screen.getByRole("img", { name: "Relative chat image" })).toHaveAttribute(
+      "src",
+      "http://backend.test/media/images/chat-inline-2.jpg?sig=inline2#viewer"
+    );
+  });
+
+  it("leaves external markdown image URLs untouched", () => {
+    render(
+      <ChatBubble
+        isGuardian={false}
+        message={{
+          id: "msg-5",
+          authorId: "me",
+          authorName: "You",
+          content: "![External image](https://cdn.example.com/image.jpg?x=1#hero)",
+          createdAt: Date.now(),
+        }}
+      />
+    );
+
+    expect(screen.getByRole("img", { name: "External image" })).toHaveAttribute(
+      "src",
+      "https://cdn.example.com/image.jpg?x=1#hero"
+    );
   });
 });

--- a/frontend/src/features/workspace/WorkspacePane.spec.tsx
+++ b/frontend/src/features/workspace/WorkspacePane.spec.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/api/codex", () => ({
+  getCodexEntry: vi.fn(),
+  getCodexExportUrl: vi.fn(() => "/exports/codex.md"),
+}));
+
+vi.mock("@/lib/mediaUrl", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/mediaUrl")>(
+    "@/lib/mediaUrl"
+  );
+  return {
+    ...actual,
+    resolveMediaSrc: vi.fn(() => "http://backend.test/opaque-preview"),
+  };
+});
+
+import WorkspacePane from "./WorkspacePane";
+
+describe("WorkspacePane", () => {
+  it("classifies signed image URLs as images while ignoring query and hash", () => {
+    render(
+      <WorkspacePane
+        activeDoc={{
+          id: "img-1",
+          title: "Signed image",
+          ext: "jpg",
+          type: "file",
+          src_url: "/media/images/signed.jpg?sig=abc123&download=1#viewer",
+        }}
+      />
+    );
+
+    expect(screen.getByRole("img", { name: "Signed image" })).toHaveAttribute(
+      "src",
+      "http://backend.test/opaque-preview"
+    );
+  });
+
+  it("classifies signed PDF URLs as PDFs while ignoring query and hash", () => {
+    render(
+      <WorkspacePane
+        activeDoc={{
+          id: "pdf-1",
+          title: "Signed PDF",
+          ext: "pdf",
+          type: "file",
+          src_url: "http://assets.example.test/media/documents/guide.pdf?sig=pdf123#page=2",
+        }}
+      />
+    );
+
+    expect(screen.getByTitle("Signed PDF")).toHaveAttribute(
+      "src",
+      "http://backend.test/opaque-preview"
+    );
+  });
+});

--- a/frontend/src/features/workspace/WorkspacePane.tsx
+++ b/frontend/src/features/workspace/WorkspacePane.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { DocumentLike } from "@/types/documents";
 import { Button } from "@/components/ui/button";
 import { getCodexEntry, getCodexExportUrl, CodexEntry } from "@/api/codex";
+import { isImageMediaUrl, isPdfMediaUrl } from "@/lib/mediaUrl";
 import WorkspaceViewer from "./WorkspaceViewer";
 import "./workspace.css";
 
@@ -27,14 +28,11 @@ export default function WorkspacePane({ activeDoc, onOpenInThread }: WorkspacePa
   const previewUrl = resolvePreviewUrl();
 
   const isImage = useMemo(() => {
-    if (!previewUrl) return false;
-    const u = previewUrl.toLowerCase();
-    return u.endsWith(".png") || u.endsWith(".jpg") || u.endsWith(".jpeg") || u.endsWith(".webp") || u.startsWith("data:image/");
+    return previewUrl ? isImageMediaUrl(previewUrl) : false;
   }, [previewUrl]);
 
   const isPdf = useMemo(() => {
-    if (!previewUrl) return false;
-    return previewUrl.toLowerCase().includes(".pdf") || previewUrl.toLowerCase().startsWith("data:application/pdf");
+    return previewUrl ? isPdfMediaUrl(previewUrl) : false;
   }, [previewUrl]);
   const [codexEntry, setCodexEntry] = useState<CodexEntry | null>(null);
   const [loading, setLoading] = useState(false);

--- a/frontend/src/features/workspace/WorkspaceViewer.tsx
+++ b/frontend/src/features/workspace/WorkspaceViewer.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { CodexEntry } from "@/api/codex";
+import { resolveMediaSrc } from "@/lib/mediaUrl";
 import { DocumentLike } from "@/types/documents";
 
 type WorkspaceViewerProps = {
@@ -23,6 +24,8 @@ export default function WorkspaceViewer({
   loading,
   error,
 }: WorkspaceViewerProps) {
+  const resolvedPreviewUrl = previewUrl ? resolveMediaSrc(previewUrl) : null;
+
   if (!activeDoc) {
     return (
       <div className="codexifyWorkspaceViewer">
@@ -35,7 +38,7 @@ export default function WorkspaceViewer({
   }
 
   if (activeDoc.type !== "codex_entry") {
-    if (!previewUrl) {
+    if (!resolvedPreviewUrl) {
       return (
         <div className="codexifyWorkspaceViewer">
           <div className="codexifyWorkspaceHint">
@@ -49,7 +52,7 @@ export default function WorkspaceViewer({
     if (isPdf) {
       return (
         <div className="codexifyWorkspaceViewer codexifyWorkspaceViewer--embed">
-          <iframe title={activeDoc?.title || "PDF"} src={previewUrl} />
+          <iframe title={activeDoc?.title || "PDF"} src={resolvedPreviewUrl} />
         </div>
       );
     }
@@ -58,7 +61,7 @@ export default function WorkspaceViewer({
       return (
         <div className="codexifyWorkspaceViewer codexifyWorkspaceViewer--image">
           <img
-            src={previewUrl}
+            src={resolvedPreviewUrl}
             alt={activeDoc?.title || "Image"}
             className="codexifyWorkspaceImage"
             loading="lazy"
@@ -73,7 +76,7 @@ export default function WorkspaceViewer({
           This file type does not have an inline preview yet.
         </div>
         <a
-          href={previewUrl}
+          href={resolvedPreviewUrl}
           target="_blank"
           rel="noreferrer"
           className="codexifyWorkspaceLink"
@@ -114,7 +117,18 @@ export default function WorkspaceViewer({
 
       {!loading && !error && codexEntry && (
         <div className="prose prose-sm max-w-none dark:prose-invert codexifyWorkspaceMarkdown">
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            components={{
+              img: ({ src, alt }) => (
+                <img
+                  src={resolveMediaSrc(String(src ?? ""))}
+                  alt={alt || "Workspace media"}
+                  loading="lazy"
+                />
+              ),
+            }}
+          >
             {codexEntry?.body || "_No content available._"}
           </ReactMarkdown>
         </div>

--- a/frontend/src/lib/mediaUrl.ts
+++ b/frontend/src/lib/mediaUrl.ts
@@ -18,11 +18,85 @@ function isDirectlyRenderableUrl(value: string): boolean {
   return /^(?:https?:|data:|blob:)/i.test(value) || value.startsWith("//");
 }
 
+function splitPathAndSuffix(value: string): { path: string; suffix: string } {
+  const queryIndex = value.indexOf("?");
+  const hashIndex = value.indexOf("#");
+  const cutIndex =
+    queryIndex === -1 ? hashIndex :
+      hashIndex === -1 ? queryIndex :
+        Math.min(queryIndex, hashIndex);
+
+  if (cutIndex === -1) {
+    return { path: value, suffix: "" };
+  }
+
+  return {
+    path: value.slice(0, cutIndex),
+    suffix: value.slice(cutIndex),
+  };
+}
+
+function normalizeRelativeMediaPath(path: string): string | null {
+  if (!path) return null;
+  if (path === "/media" || path.startsWith("/media/")) return path;
+  if (path === "media" || path.startsWith("media/")) return `/${path}`;
+  return null;
+}
+
+function classifyPathname(value: string): string {
+  const trimmed = asNonEmptyString(value);
+  if (!trimmed) return "";
+  if (/^data:/i.test(trimmed)) return "";
+
+  if (/^(?:https?:)?\/\//i.test(trimmed)) {
+    try {
+      return new URL(trimmed, "http://placeholder").pathname || "";
+    } catch {
+      return splitPathAndSuffix(trimmed).path;
+    }
+  }
+
+  return splitPathAndSuffix(trimmed).path;
+}
+
+export function resolveMediaSrc(src: string): string {
+  const trimmed = asNonEmptyString(src);
+  if (!trimmed) return "";
+  if (isDirectlyRenderableUrl(trimmed)) return trimmed;
+
+  const { path, suffix } = splitPathAndSuffix(trimmed);
+  const normalizedMediaPath = normalizeRelativeMediaPath(path);
+  if (!normalizedMediaPath) return trimmed;
+
+  return `${resolveBackendUrl(normalizedMediaPath)}${suffix}`;
+}
+
 export function normalizeMediaUrl(srcUrl: string | null | undefined): string {
   const trimmed = asNonEmptyString(srcUrl);
   if (!trimmed) return "";
-  if (isDirectlyRenderableUrl(trimmed)) return trimmed;
-  return resolveBackendUrl(trimmed);
+  return resolveMediaSrc(trimmed);
+}
+
+export function isImageMediaUrl(src: string): boolean {
+  const trimmed = asNonEmptyString(src);
+  if (!trimmed) return false;
+  if (/^data:image\//i.test(trimmed)) return true;
+
+  const pathname = classifyPathname(trimmed).toLowerCase();
+  return (
+    pathname.endsWith(".png") ||
+    pathname.endsWith(".jpg") ||
+    pathname.endsWith(".jpeg") ||
+    pathname.endsWith(".webp")
+  );
+}
+
+export function isPdfMediaUrl(src: string): boolean {
+  const trimmed = asNonEmptyString(src);
+  if (!trimmed) return false;
+  if (/^data:application\/pdf(?:[;,]|$)/i.test(trimmed)) return true;
+
+  return classifyPathname(trimmed).toLowerCase().endsWith(".pdf");
 }
 
 export function resolveMediaAssetSrc(
@@ -33,7 +107,7 @@ export function resolveMediaAssetSrc(
   // Backend image payloads use `src_url` as the canonical asset field.
   for (const field of MEDIA_SOURCE_FIELDS) {
     const candidate = asNonEmptyString(media[field]);
-    if (candidate) return normalizeMediaUrl(candidate);
+    if (candidate) return resolveMediaSrc(candidate);
   }
 
   return "";

--- a/frontend/src/tests/media_rendering.spec.tsx
+++ b/frontend/src/tests/media_rendering.spec.tsx
@@ -24,16 +24,41 @@ vi.mock("@/components/modals/ImageGenModal", () => ({
 import DashboardView from "@/components/dashboard/DashboardView";
 import GalleryGrid from "@/components/gallery/GalleryGrid";
 import MediaTile from "@/components/media/MediaTile";
-import { resolveMediaAssetSrc } from "@/lib/mediaUrl";
+import {
+  normalizeMediaUrl,
+  resolveMediaAssetSrc,
+  resolveMediaSrc,
+} from "@/lib/mediaUrl";
 
 describe("media rendering", () => {
-  it("prefers src_url as the canonical image asset field", () => {
+  it("normalizes signed /media URLs while preserving query and hash", () => {
+    expect(resolveMediaSrc("/media/images/right.png?sig=abc123&download=1#viewer")).toBe(
+      "http://backend.test/media/images/right.png?sig=abc123&download=1#viewer"
+    );
+  });
+
+  it("normalizes relative media URLs without a leading slash", () => {
+    expect(resolveMediaSrc("media/images/right.png?sig=abc123#viewer")).toBe(
+      "http://backend.test/media/images/right.png?sig=abc123#viewer"
+    );
+  });
+
+  it("does not rewrite non-media absolute URLs", () => {
+    expect(resolveMediaSrc("https://cdn.example.com/image.png?sig=abc123#viewer")).toBe(
+      "https://cdn.example.com/image.png?sig=abc123#viewer"
+    );
+  });
+
+  it("keeps compatibility callers routed through the shared helper", () => {
+    expect(normalizeMediaUrl("media/images/compat.png?sig=keep#pane")).toBe(
+      "http://backend.test/media/images/compat.png?sig=keep#pane"
+    );
     expect(
       resolveMediaAssetSrc({
-        src_url: "/media/images/right.png",
+        src_url: "/media/images/right.png?sig=keep#pane",
         url: "/media/images/wrong.png",
       })
-    ).toBe("http://backend.test/media/images/right.png");
+    ).toBe("http://backend.test/media/images/right.png?sig=keep#pane");
   });
 
   it("renders gallery images through the shared normalized media path", () => {
@@ -42,7 +67,7 @@ describe("media rendering", () => {
         items={[
           {
             id: "gallery-1",
-            src: "/media/images/gallery.png",
+            src: "/media/images/gallery.png?sig=gallery#focus",
             prompt: "Gallery image",
           },
         ]}
@@ -52,7 +77,7 @@ describe("media rendering", () => {
 
     expect(screen.getByRole("img", { name: "Gallery image" })).toHaveAttribute(
       "src",
-      "http://backend.test/media/images/gallery.png"
+      "http://backend.test/media/images/gallery.png?sig=gallery#focus"
     );
     expect(container.querySelector(".codexifyMediaGrid--gallery")).toBeTruthy();
   });
@@ -73,7 +98,7 @@ describe("media rendering", () => {
         }}
         gallery={[
           {
-            src: "/media/images/dashboard.png",
+            src: "/media/images/dashboard.png?sig=dashboard#panel",
             prompt: "Dashboard image",
           },
         ]}
@@ -88,7 +113,10 @@ describe("media rendering", () => {
 
     expect(
       screen.getByRole("img", { name: "Dashboard image" })
-    ).toHaveAttribute("src", "http://backend.test/media/images/dashboard.png");
+    ).toHaveAttribute(
+      "src",
+      "http://backend.test/media/images/dashboard.png?sig=dashboard#panel"
+    );
   });
 
   it("renders every dashboard image without truncating the list", () => {

--- a/frontend/src/tests/vite.config.proxy.spec.ts
+++ b/frontend/src/tests/vite.config.proxy.spec.ts
@@ -1,0 +1,24 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("vite /media proxy", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("defines a /media proxy with the same target as /api", async () => {
+    vi.stubEnv("VITE_PROXY_TARGET", "http://proxy.test:9999");
+    vi.resetModules();
+
+    const viteConfigModule = await import("../vite.config");
+    const config = viteConfigModule.default as any;
+    const proxy = config.server?.proxy;
+
+    expect(proxy?.["/media"]).toBeDefined();
+    expect(proxy?.["/api"]).toBeDefined();
+    expect(proxy["/media"].target).toBe(proxy["/api"].target);
+    expect(proxy["/media"].target).toBe("http://proxy.test:9999");
+  });
+});

--- a/frontend/src/vite.config.ts
+++ b/frontend/src/vite.config.ts
@@ -184,6 +184,14 @@ export default defineConfig({
         },
       },
 
+      // Signed media assets are served from the backend at /media/*.
+      // Keep the path and query string intact so signature validation continues to work.
+      '/media': {
+        target: PROXY_TARGET,
+        changeOrigin: true,
+        secure: false,
+      },
+
       // Convenience routes so you can open docs directly via Vite dev server
       '/openapi.json': {
         target: process.env.VITE_PROXY_TARGET ?? 'http://localhost:8888',


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
