### PR TITLE
Align local execution model with health and catalog truth

### DIFF
--- a/guardian/core/ai_router.py
+++ b/guardian/core/ai_router.py
@@ -11,7 +11,10 @@ from requests import exceptions as req_exc
 from guardian.core.config import Settings, get_settings
 from guardian.core.egress import EgressDeniedError, assert_egress_allowed
 from guardian.core.event_contracts import _coerce_text
-from guardian.core.provider_registry import default_model_for_provider
+from guardian.core.provider_registry import (
+    default_model_for_provider,
+    normalize_model_id,
+)
 from guardian.core.provider_registry import (
     normalize_provider as normalize_registry_provider,
 )
@@ -28,6 +31,9 @@ _DEFAULT_MINIMAX_BASE = "https://api.minimax.io/v1"
 _DEFAULT_ALIBABA_BASE = "https://coding-intl.dashscope.aliyuncs.com/v1"
 _DEFAULT_LOCAL_DOCKER_FALLBACK_BASE = "http://host.docker.internal:11434"
 _LOCAL_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0"})
+LOCAL_MODEL_RESOLUTION_ERROR = "local_model_resolution_error"
+LOCAL_MODEL_MISSING_FAILURE_KIND = "local_model_missing"
+LOCAL_MODEL_UNAVAILABLE_FAILURE_KIND = "local_model_unavailable"
 
 
 @dataclass(frozen=True)
@@ -101,6 +107,71 @@ class LocalEndpointCandidate:
     base_url: str
     label: str
     source: str
+
+
+@dataclass(frozen=True)
+class LocalModelResolution:
+    model: str | None
+    source: str | None
+    strict: bool
+    requested_model: str | None = None
+    failure_kind: str | None = None
+    message: str | None = None
+    endpoint_resolution: dict[str, Any] | None = None
+
+    @property
+    def ok(self) -> bool:
+        return bool(self.model) and not self.failure_kind
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "strict": self.strict,
+            "source": self.source,
+            "model": self.model,
+        }
+        if self.requested_model:
+            payload["requested_model"] = self.requested_model
+        if self.failure_kind:
+            payload["failure_kind"] = self.failure_kind
+            payload["error"] = LOCAL_MODEL_RESOLUTION_ERROR
+        if self.message:
+            payload["message"] = self.message
+        if self.endpoint_resolution is not None:
+            payload["endpoint_resolution"] = dict(self.endpoint_resolution)
+        return payload
+
+    def error_detail(
+        self,
+        *,
+        attempted_endpoints: list[str] | None = None,
+        endpoint_resolution: dict[str, Any] | None = None,
+        failure_kind: str | None = None,
+        message: str | None = None,
+    ) -> dict[str, Any]:
+        detail: dict[str, Any] = {
+            "error": LOCAL_MODEL_RESOLUTION_ERROR,
+            "provider": "local",
+            "failure_kind": (
+                str(failure_kind or self.failure_kind or "").strip()
+                or LOCAL_MODEL_UNAVAILABLE_FAILURE_KIND
+            ),
+            "message": (
+                str(message or self.message or "").strip()
+                or "Local model resolution failed"
+            ),
+        }
+        if self.model:
+            detail["model"] = self.model
+        if self.source:
+            detail["configured_source"] = self.source
+        if self.requested_model:
+            detail["requested_model"] = self.requested_model
+        resolved_endpoint = endpoint_resolution or self.endpoint_resolution
+        if resolved_endpoint is not None:
+            detail["endpoint_resolution"] = dict(resolved_endpoint)
+        if attempted_endpoints:
+            detail["attempted_endpoints"] = list(attempted_endpoints)
+        return detail
 
 
 def _normalize_provider(provider: Optional[str]) -> str:
@@ -496,6 +567,121 @@ def _default_model_for_provider(provider: str, settings: Settings) -> str:
     return default_model_for_provider(provider, settings)
 
 
+def _local_chat_model_is_authoritative(settings: Settings) -> bool:
+    if bool(getattr(settings, "CODEXIFY_LOCAL_ONLY_MODE", False)):
+        return True
+
+    from guardian.core.supported_profile import get_active_supported_profile
+
+    manifest = get_active_supported_profile()
+    if manifest is None:
+        return False
+    return (
+        _normalize_provider(manifest.provider_contract.get("LLM_PROVIDER"))
+        == "local"
+    )
+
+
+def _configured_local_model_resolution(
+    settings: Settings,
+) -> tuple[str, str | None, bool]:
+    strict = _local_chat_model_is_authoritative(settings)
+    candidates: tuple[tuple[str, Any], ...]
+    if strict:
+        candidates = (
+            ("LOCAL_CHAT_MODEL", getattr(settings, "LOCAL_CHAT_MODEL", None)),
+        )
+    else:
+        candidates = (
+            ("LOCAL_CHAT_MODEL", getattr(settings, "LOCAL_CHAT_MODEL", None)),
+            ("LOCAL_LLM_MODEL", getattr(settings, "LOCAL_LLM_MODEL", None)),
+            (
+                "DEFAULT_LOCAL_MODEL",
+                getattr(settings, "DEFAULT_LOCAL_MODEL", None),
+            ),
+            ("LLM_MODEL", getattr(settings, "LLM_MODEL", None)),
+        )
+
+    for source, candidate in candidates:
+        normalized = normalize_model_id(candidate)
+        if normalized:
+            return normalized, source, strict
+    return "", candidates[0][0] if candidates else None, strict
+
+
+def resolve_local_execution_model(
+    *,
+    settings: Optional[Settings] = None,
+    requested_model: str | None = None,
+    validate_availability: bool = False,
+    discovered_model_names: list[str] | None = None,
+    endpoint_resolution: dict[str, Any] | None = None,
+    timeout_seconds: float | None = None,
+    request_get: Any = None,
+) -> LocalModelResolution:
+    resolved = _resolve_settings(settings)
+    requested = normalize_model_id(requested_model)
+    configured_model, source, strict = _configured_local_model_resolution(
+        resolved
+    )
+    if not configured_model:
+        source_name = str(source or "LOCAL_CHAT_MODEL").strip()
+        return LocalModelResolution(
+            model=None,
+            source=source_name,
+            strict=strict,
+            requested_model=requested or None,
+            failure_kind=LOCAL_MODEL_MISSING_FAILURE_KIND,
+            message=(
+                f"{source_name} is not configured for local chat execution"
+            ),
+            endpoint_resolution=endpoint_resolution,
+        )
+
+    resolved_endpoint = endpoint_resolution
+    names = list(discovered_model_names or [])
+    if validate_availability and resolved_endpoint is None:
+        names, resolved_endpoint = discover_local_model_inventory(
+            resolved,
+            timeout_seconds=timeout_seconds or 1.5,
+            request_get=request_get,
+        )
+
+    if (
+        validate_availability
+        and resolved_endpoint is not None
+        and str(resolved_endpoint.get("state") or "").strip() == "available"
+    ):
+        available_models = {
+            normalized
+            for normalized in (
+                normalize_model_id(item) for item in (names or [])
+            )
+            if normalized
+        }
+        if configured_model not in available_models:
+            return LocalModelResolution(
+                model=configured_model,
+                source=source,
+                strict=strict,
+                requested_model=requested or None,
+                failure_kind=LOCAL_MODEL_UNAVAILABLE_FAILURE_KIND,
+                message=(
+                    f"Configured local chat model '{configured_model}' from "
+                    f"{source} is not advertised by the reachable local runtime"
+                ),
+                endpoint_resolution=resolved_endpoint,
+            )
+
+    return LocalModelResolution(
+        model=configured_model,
+        source=source,
+        strict=strict,
+        requested_model=requested or None,
+        endpoint_resolution=resolved_endpoint,
+    )
+
+
 def _provider_failure_detail(
     *,
     provider: str,
@@ -580,6 +766,27 @@ def chat_with_ai(
     settings = _resolve_settings(settings)
     provider_name = _normalize_provider(provider or settings.LLM_PROVIDER)
     target_model = model or _default_model_for_provider(provider_name, settings)
+    local_model_resolution: LocalModelResolution | None = None
+
+    if provider_name == "local":
+        authoritative_model = normalize_model_id(
+            getattr(settings, "LOCAL_CHAT_MODEL", None)
+        )
+        requested_model = normalize_model_id(target_model)
+        local_model_resolution = resolve_local_execution_model(
+            settings=settings,
+            requested_model=target_model,
+            validate_availability=bool(
+                authoritative_model and authoritative_model != requested_model
+            ),
+        )
+        if not local_model_resolution.ok:
+            raise HTTPException(
+                status_code=400,
+                detail=local_model_resolution.error_detail(),
+            )
+        if local_model_resolution.strict or not target_model:
+            target_model = local_model_resolution.model
 
     if not target_model:
         raise HTTPException(
@@ -841,6 +1048,12 @@ def _summarize_local_attempt_failures(failures: list[str]) -> str:
     return f"{head}; ... ({len(failures) - limit} more)"
 
 
+def _all_local_attempt_failures_are_404(failures: list[str]) -> bool:
+    return bool(failures) and all(
+        "(HTTP 404" in failure for failure in failures
+    )
+
+
 def _parse_local_catalog_payload(payload: Any) -> list[str]:
     names: list[str] = []
     if not isinstance(payload, dict):
@@ -934,10 +1147,8 @@ def discover_local_model_inventory(
         deduped.append(clean)
 
     if not deduped:
-        fallback = (
-            str(getattr(settings, "LOCAL_LLM_MODEL", "") or "").strip()
-            or str(getattr(settings, "DEFAULT_LOCAL_MODEL", "") or "").strip()
-            or str(getattr(settings, "LLM_MODEL", "") or "").strip()
+        fallback, _source, _strict = _configured_local_model_resolution(
+            settings
         )
         if fallback:
             deduped = [fallback]
@@ -976,6 +1187,15 @@ def call_local(
     log_exceptions: bool = True,
 ):
     settings = _resolve_settings(settings)
+    local_model_resolution = resolve_local_execution_model(
+        settings=settings,
+        requested_model=model,
+    )
+    if not local_model_resolution.ok:
+        raise HTTPException(
+            status_code=400,
+            detail=local_model_resolution.error_detail(),
+        )
     runtime_policy = resolve_local_runtime_policy(
         model, settings=settings, timeout=timeout
     )
@@ -1116,6 +1336,31 @@ def call_local(
             model=model,
             runtime_policy=runtime_policy,
         )
+    elif local_model_resolution.strict and _all_local_attempt_failures_are_404(
+        attempt_failures
+    ):
+        endpoint_resolution = describe_local_endpoint_resolution(
+            settings,
+            attempted_base_urls=base_urls,
+            state="degraded",
+            failure_kind=LOCAL_MODEL_UNAVAILABLE_FAILURE_KIND,
+            reason=_summarize_local_attempt_failures(attempt_failures),
+        )
+        detail_payload = local_model_resolution.error_detail(
+            attempted_endpoints=attempt_failures,
+            endpoint_resolution=endpoint_resolution,
+            failure_kind=LOCAL_MODEL_UNAVAILABLE_FAILURE_KIND,
+            message=(
+                f"Configured local chat model '{model}' from "
+                f"{local_model_resolution.source} could not be executed; "
+                "all supported local endpoints returned HTTP 404"
+            ),
+        )
+        if log_exceptions:
+            logger.error(detail_payload["message"])
+        else:
+            logger.warning(detail_payload["message"])
+        raise HTTPException(status_code=502, detail=detail_payload)
     else:
         detail = f"Local inference request failed for model '{model}'."
 
@@ -1139,6 +1384,15 @@ def stream_local(
     temperature: Optional[float] = None,
 ):
     settings = _resolve_settings(settings)
+    local_model_resolution = resolve_local_execution_model(
+        settings=settings,
+        requested_model=model,
+    )
+    if not local_model_resolution.ok:
+        raise HTTPException(
+            status_code=400,
+            detail=local_model_resolution.error_detail(),
+        )
     runtime_policy = resolve_local_runtime_policy(model, settings=settings)
     adapted_messages, _ = apply_local_reasoning_directive(
         messages or [],
@@ -1247,6 +1501,30 @@ def stream_local(
                     last_transport_error,
                     model=model,
                     runtime_policy=runtime_policy,
+                )
+            elif (
+                local_model_resolution.strict
+                and _all_local_attempt_failures_are_404(attempt_failures)
+            ):
+                endpoint_resolution = describe_local_endpoint_resolution(
+                    settings,
+                    attempted_base_urls=base_urls,
+                    state="degraded",
+                    failure_kind=LOCAL_MODEL_UNAVAILABLE_FAILURE_KIND,
+                    reason=_summarize_local_attempt_failures(attempt_failures),
+                )
+                raise HTTPException(
+                    status_code=502,
+                    detail=local_model_resolution.error_detail(
+                        attempted_endpoints=attempt_failures,
+                        endpoint_resolution=endpoint_resolution,
+                        failure_kind=LOCAL_MODEL_UNAVAILABLE_FAILURE_KIND,
+                        message=(
+                            f"Configured local chat model '{model}' from "
+                            f"{local_model_resolution.source} could not be executed; "
+                            "all supported local endpoints returned HTTP 404"
+                        ),
+                    ),
                 )
             else:
                 detail = f"Local inference request failed for model '{model}'."

--- a/guardian/core/llm_catalog.py
+++ b/guardian/core/llm_catalog.py
@@ -15,6 +15,7 @@ from guardian.core.ai_router import (
     _resolve_local_base,
     describe_local_runtime,
     discover_local_model_inventory,
+    resolve_local_execution_model,
 )
 from guardian.core.config import Settings, get_settings
 from guardian.core.provider_registry import CLOUD_PROVIDERS as _CLOUD_PROVIDERS
@@ -295,7 +296,7 @@ def _apply_local_display_disambiguation(
 
 def _fetch_local_models(
     settings: Settings,
-) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], dict[str, Any], Any]:
     timeout = _catalog_timeout_seconds()
     names, endpoint_resolution = discover_local_model_inventory(
         settings, timeout_seconds=timeout, request_get=requests.get
@@ -309,6 +310,28 @@ def _fetch_local_models(
             continue
         seen.add(key)
         deduped.append(key)
+    local_model_resolution = resolve_local_execution_model(
+        settings=settings,
+        validate_availability=True,
+        discovered_model_names=deduped,
+        endpoint_resolution=endpoint_resolution,
+    )
+    effective_model = normalize_model_id(local_model_resolution.model)
+    if effective_model:
+        normalized_names = {
+            normalize_model_id(name): name for name in deduped if name
+        }
+        if effective_model in normalized_names:
+            deduped = [
+                normalized_names[effective_model],
+                *[
+                    name
+                    for name in deduped
+                    if normalize_model_id(name) != effective_model
+                ],
+            ]
+        elif str(endpoint_resolution.get("state") or "").strip() != "available":
+            deduped = [effective_model, *deduped]
     source_base = str(
         (endpoint_resolution.get("selected_endpoint") or {}).get("base_url")
         or ""
@@ -364,7 +387,7 @@ def _fetch_local_models(
             "Local model discovery degraded; using configured/local fallback names. resolution=%s",
             endpoint_resolution,
         )
-    return entries, endpoint_resolution
+    return entries, endpoint_resolution, local_model_resolution
 
 
 def _cloud_models(
@@ -434,7 +457,9 @@ def _provider_models(
     settings: Settings,
 ) -> list[dict[str, Any]]:
     if provider_id == "local":
-        models, _resolution = _fetch_local_models(settings)
+        models, _resolution, _local_model_resolution = _fetch_local_models(
+            settings
+        )
         return models
     return _cloud_models(provider_id, settings)
 
@@ -485,8 +510,13 @@ def _provider_entry(
     disabled_reason = capability["disabled_reason"]
     enabled = bool(capability["enabled"])
     endpoint_resolution: dict[str, Any] | None = None
+    local_model_resolution = None
     if provider_id == "local":
-        models, endpoint_resolution = _fetch_local_models(settings)
+        (
+            models,
+            endpoint_resolution,
+            local_model_resolution,
+        ) = _fetch_local_models(settings)
         if (
             models
             and endpoint_resolution is not None
@@ -496,9 +526,25 @@ def _provider_entry(
             available = True
             enabled = True
             disabled_reason = None
+        if (
+            local_model_resolution is not None
+            and local_model_resolution.failure_kind
+        ):
+            enabled = False
+            disabled_reason = local_model_resolution.message
     else:
         models = _provider_models(provider_id, settings)
 
+    provider_capability = (
+        {
+            **capability,
+            "enabled": enabled,
+            "available": available,
+            "disabled_reason": disabled_reason,
+        }
+        if provider_id == "local"
+        else capability
+    )
     entry: dict[str, Any] = {
         "id": provider_id,
         "displayName": _PROVIDER_LABELS.get(provider_id, provider_id.title()),
@@ -512,7 +558,7 @@ def _provider_entry(
         "truth": build_provider_truth(
             provider_id,
             settings,
-            capability=capability,
+            capability=provider_capability,
             discoverable=(
                 str(endpoint_resolution.get("state") or "").strip()
                 == "available"
@@ -530,7 +576,10 @@ def _provider_entry(
         entry["source"] = source
     if endpoint_resolution is not None:
         entry["endpoint_resolution"] = endpoint_resolution
-    if not available and disabled_reason:
+    if local_model_resolution is not None:
+        entry["default_model"] = local_model_resolution.model
+        entry["model_resolution"] = local_model_resolution.as_dict()
+    if disabled_reason:
         entry["disabled_reason"] = disabled_reason
     return entry
 
@@ -555,7 +604,9 @@ def resolve_provider_for_model(
     settings: Settings | None = None,
 ) -> str | None:
     resolved = settings or get_settings()
-    local_models, _resolution = _fetch_local_models(resolved)
+    local_models, _resolution, _local_model_resolution = _fetch_local_models(
+        resolved
+    )
     local_model_ids = [model.get("id") for model in local_models]
     return resolve_provider_for_model_registry(
         model_id,

--- a/guardian/routes/health.py
+++ b/guardian/routes/health.py
@@ -390,6 +390,7 @@ def health_llm():
     from guardian.core.ai_router import (
         _resolve_local_base,
         describe_local_runtime,
+        resolve_local_execution_model,
     )
     from guardian.core.config import (
         LLMConfigError,
@@ -399,9 +400,24 @@ def health_llm():
 
     settings = get_settings()
     provider = _normalize_health_provider(settings.LLM_PROVIDER or "local")
-    provider_runtime = resolve_provider_capability(provider, settings)
+    provider_runtime = dict(resolve_provider_capability(provider, settings))
     model = str(provider_runtime.get("default_model") or "").strip()
     completion_service = _collect_completion_service_health()
+    local_model_resolution = None
+
+    if provider == "local":
+        local_model_resolution = resolve_local_execution_model(
+            settings=settings,
+            requested_model=model,
+            validate_availability=True,
+            request_get=requests.get,
+        )
+        if local_model_resolution.model:
+            model = local_model_resolution.model
+            provider_runtime["default_model"] = model
+        if local_model_resolution.failure_kind:
+            provider_runtime["enabled"] = False
+            provider_runtime["disabled_reason"] = local_model_resolution.message
 
     payload = {
         "provider": provider,
@@ -409,6 +425,8 @@ def health_llm():
         "provider_runtime": provider_runtime,
         "completion_service": completion_service,
     }
+    if local_model_resolution is not None:
+        payload["model_resolution"] = local_model_resolution.as_dict()
     if provider == "local" and model:
         payload["runtime"] = describe_local_runtime(model, settings=settings)
 
@@ -423,6 +441,35 @@ def health_llm():
             settings,
             capability=provider_runtime,
             discoverable=False,
+            selectable=False,
+        )
+        return payload
+
+    if (
+        local_model_resolution is not None
+        and local_model_resolution.failure_kind
+    ):
+        payload.update(
+            {
+                "ok": False,
+                "status": "misconfigured",
+                "error": payload["model_resolution"]["error"],
+                "failure_kind": local_model_resolution.failure_kind,
+                "message": local_model_resolution.message,
+            }
+        )
+        payload["provider_truth"] = build_provider_truth(
+            provider,
+            settings,
+            capability=provider_runtime,
+            discoverable=bool(
+                local_model_resolution.endpoint_resolution
+                and str(
+                    local_model_resolution.endpoint_resolution.get("state")
+                    or ""
+                ).strip()
+                == "available"
+            ),
             selectable=False,
         )
         return payload
@@ -549,7 +596,27 @@ def health_chat():
     queue_health = _collect_chat_queue_health()
     settings = get_settings()
     provider = _normalize_health_provider(settings.LLM_PROVIDER or "local")
-    provider_runtime = resolve_provider_capability(provider, settings)
+    provider_runtime = dict(resolve_provider_capability(provider, settings))
+    local_model_resolution = None
+    model = str(provider_runtime.get("default_model") or "").strip()
+    if provider == "local":
+        from guardian.core.ai_router import (
+            describe_local_runtime,
+            resolve_local_execution_model,
+        )
+
+        local_model_resolution = resolve_local_execution_model(
+            settings=settings,
+            requested_model=model,
+            validate_availability=True,
+            request_get=requests.get,
+        )
+        if local_model_resolution.model:
+            model = local_model_resolution.model
+            provider_runtime["default_model"] = model
+        if local_model_resolution.failure_kind:
+            provider_runtime["enabled"] = False
+            provider_runtime["disabled_reason"] = local_model_resolution.message
 
     try:
         threads = chatlog_db.count_chat_threads()
@@ -666,6 +733,7 @@ def health_chat():
         "backend": DB_BACKEND,
         "completion_service": completion_service,
         "provider": provider,
+        "model": model,
         "provider_runtime": provider_runtime,
         "provider_truth": build_provider_truth(
             provider,
@@ -680,6 +748,10 @@ def health_chat():
             selectable=bool(provider_runtime.get("enabled")),
         ),
     }
+    if local_model_resolution is not None:
+        payload["model_resolution"] = local_model_resolution.as_dict()
+    if provider == "local" and model:
+        payload["runtime"] = describe_local_runtime(model, settings=settings)
     if redis_dependency_unavailable:
         payload.update(
             {
@@ -694,6 +766,37 @@ def health_chat():
                 "redis unavailable; chat completion cannot be trusted"
             ] + list(notes)
         return _redis_dependency_unavailable_response(payload)
+    if (
+        local_model_resolution is not None
+        and local_model_resolution.failure_kind
+    ):
+        payload.update(
+            {
+                "ok": False,
+                "status": "unhealthy",
+                "error": payload["model_resolution"]["error"],
+                "failure_kind": local_model_resolution.failure_kind,
+                "message": local_model_resolution.message,
+            }
+        )
+        payload["notes"] = [
+            local_model_resolution.message
+            or "local chat model resolution failed"
+        ] + list(payload["notes"])
+        payload["provider_truth"] = build_provider_truth(
+            provider,
+            settings,
+            capability=provider_runtime,
+            discoverable=bool(
+                local_model_resolution.endpoint_resolution
+                and str(
+                    local_model_resolution.endpoint_resolution.get("state")
+                    or ""
+                ).strip()
+                == "available"
+            ),
+            selectable=False,
+        )
     return payload
 
 

--- a/tests/core/test_ai_router.py
+++ b/tests/core/test_ai_router.py
@@ -6,7 +6,14 @@ import pytest
 import requests
 from fastapi import HTTPException
 
-from guardian.core.ai_router import call_alibaba, call_minimax, chat_with_ai
+from guardian.core.ai_router import (
+    LOCAL_MODEL_MISSING_FAILURE_KIND,
+    LOCAL_MODEL_RESOLUTION_ERROR,
+    LOCAL_MODEL_UNAVAILABLE_FAILURE_KIND,
+    call_alibaba,
+    call_minimax,
+    chat_with_ai,
+)
 from guardian.core.config import Settings
 
 
@@ -26,6 +33,20 @@ class _MockRawResponse:
 
     def json(self) -> dict:
         return json.loads(self.content.decode("utf-8"))
+
+
+def _mock_local_inventory_request(
+    available_models: list[str],
+):
+    def _handler(url: str, *args, **kwargs) -> _MockResponse:
+        _ = (args, kwargs)
+        if url.endswith("/api/tags"):
+            return _MockResponse(
+                {"models": [{"name": name} for name in available_models]}
+            )
+        return _MockResponse({"data": []}, status_code=404)
+
+    return _handler
 
 
 def _mock_alibaba_model_index(url, headers, timeout):
@@ -227,6 +248,109 @@ def test_chat_with_ai_local_uses_configured_endpoint_chain_order(monkeypatch):
     assert any(
         "secondary.local:11434" in attempted_url for attempted_url in calls
     )
+
+
+def test_chat_with_ai_local_only_uses_local_chat_model_for_execution(
+    monkeypatch,
+):
+    captured: dict[str, object] = {}
+
+    def _mock_post(url: str, *, json, headers, timeout):
+        captured["url"] = url
+        captured["json"] = json
+        _ = (headers, timeout)
+        return _MockRawResponse({"message": {"content": "Local chat reply"}})
+
+    monkeypatch.setattr(
+        "guardian.core.ai_router.requests.get",
+        _mock_local_inventory_request(["qwen3.5:0.8b"]),
+    )
+    monkeypatch.setattr("guardian.core.ai_router.requests.post", _mock_post)
+
+    settings = Settings(
+        LLM_PROVIDER="local",
+        CODEXIFY_LOCAL_ONLY_MODE=True,
+        ALLOW_CLOUD_PROVIDERS=False,
+        CODEXIFY_EGRESS_ALLOWLIST="",
+        LOCAL_BASE_URL="http://127.0.0.1:11434",
+        LOCAL_LLM_MODEL="library2/ministral-3:8b",
+        LOCAL_CHAT_MODEL="qwen3.5:0.8b",
+        DEFAULT_LOCAL_MODEL="library2/ministral-3:8b",
+        LLM_MODEL="library2/ministral-3:8b",
+    )
+
+    result = chat_with_ai(
+        [{"role": "user", "content": "hello"}],
+        provider="local",
+        model="library2/ministral-3:8b",
+        settings=settings,
+    )
+
+    assert result == "Local chat reply"
+    assert captured["json"]["model"] == "qwen3.5:0.8b"
+
+
+def test_chat_with_ai_local_only_blank_local_chat_model_fails_clearly():
+    settings = Settings(
+        LLM_PROVIDER="local",
+        CODEXIFY_LOCAL_ONLY_MODE=True,
+        ALLOW_CLOUD_PROVIDERS=False,
+        CODEXIFY_EGRESS_ALLOWLIST="",
+        LOCAL_BASE_URL="http://127.0.0.1:11434",
+        LOCAL_LLM_MODEL="library2/ministral-3:8b",
+        LOCAL_CHAT_MODEL="",
+        DEFAULT_LOCAL_MODEL="library2/ministral-3:8b",
+        LLM_MODEL="library2/ministral-3:8b",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        chat_with_ai(
+            [{"role": "user", "content": "hello"}],
+            provider="local",
+            model="library2/ministral-3:8b",
+            settings=settings,
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail["error"] == LOCAL_MODEL_RESOLUTION_ERROR
+    assert exc.value.detail["failure_kind"] == LOCAL_MODEL_MISSING_FAILURE_KIND
+    assert exc.value.detail["configured_source"] == "LOCAL_CHAT_MODEL"
+
+
+def test_chat_with_ai_local_only_invalid_local_chat_model_fails_clearly(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "guardian.core.ai_router.requests.get",
+        _mock_local_inventory_request(["qwen2.5:7b"]),
+    )
+
+    settings = Settings(
+        LLM_PROVIDER="local",
+        CODEXIFY_LOCAL_ONLY_MODE=True,
+        ALLOW_CLOUD_PROVIDERS=False,
+        CODEXIFY_EGRESS_ALLOWLIST="",
+        LOCAL_BASE_URL="http://127.0.0.1:11434",
+        LOCAL_LLM_MODEL="library2/ministral-3:8b",
+        LOCAL_CHAT_MODEL="qwen3.5:0.8b",
+        DEFAULT_LOCAL_MODEL="library2/ministral-3:8b",
+        LLM_MODEL="library2/ministral-3:8b",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        chat_with_ai(
+            [{"role": "user", "content": "hello"}],
+            provider="local",
+            model="library2/ministral-3:8b",
+            settings=settings,
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail["error"] == LOCAL_MODEL_RESOLUTION_ERROR
+    assert (
+        exc.value.detail["failure_kind"] == LOCAL_MODEL_UNAVAILABLE_FAILURE_KIND
+    )
+    assert exc.value.detail["model"] == "qwen3.5:0.8b"
 
 
 def test_call_alibaba_missing_key_surfaces_auth_config_failure():

--- a/tests/routes/test_health_endpoints.py
+++ b/tests/routes/test_health_endpoints.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from guardian.core.ai_router import LOCAL_MODEL_RESOLUTION_ERROR
+from guardian.core.config import get_settings
+from guardian.routes import health as health_routes
+
+
+class _MockResponse:
+    def __init__(self, payload: dict, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def _mock_local_runtime_request(
+    url: str,
+    *args,
+    **kwargs,
+) -> _MockResponse:
+    _ = (args, kwargs)
+    if url.endswith("/api/tags"):
+        return _MockResponse({"models": [{"name": "qwen3.5:0.8b"}]})
+    return _MockResponse({"status": "ok"})
+
+
+def _healthy_completion_service() -> dict[str, object]:
+    return {
+        "ok": True,
+        "redis_reachable": True,
+        "enqueue_test_ok": True,
+        "worker_heartbeat_detected": True,
+        "worker_heartbeat_age_seconds": 0.5,
+        "worker_heartbeat_status": "fresh",
+        "heartbeat_key": "codexify:worker:chat:heartbeat",
+        "status_reason": "ok",
+        "error": None,
+        "dependency": None,
+        "dependency_unavailable": False,
+    }
+
+
+def _healthy_queue() -> dict[str, object]:
+    return {
+        "depth": 0,
+        "status": "progressing",
+        "error": None,
+        "dependency": None,
+        "dependency_unavailable": False,
+    }
+
+
+def _snapshot_settings(settings):
+    return {
+        "LLM_PROVIDER": settings.LLM_PROVIDER,
+        "ALLOW_CLOUD_PROVIDERS": settings.ALLOW_CLOUD_PROVIDERS,
+        "CODEXIFY_LOCAL_ONLY_MODE": settings.CODEXIFY_LOCAL_ONLY_MODE,
+        "CODEXIFY_EGRESS_ALLOWLIST": settings.CODEXIFY_EGRESS_ALLOWLIST,
+        "LOCAL_BASE_URL": settings.LOCAL_BASE_URL,
+        "LOCAL_API_KEY": settings.LOCAL_API_KEY,
+        "LOCAL_LLM_MODEL": settings.LOCAL_LLM_MODEL,
+        "LOCAL_CHAT_MODEL": settings.LOCAL_CHAT_MODEL,
+        "DEFAULT_LOCAL_MODEL": settings.DEFAULT_LOCAL_MODEL,
+        "LLM_MODEL": settings.LLM_MODEL,
+    }
+
+
+def _apply_local_only_runtime(settings) -> None:
+    settings.LLM_PROVIDER = "local"
+    settings.ALLOW_CLOUD_PROVIDERS = False
+    settings.CODEXIFY_LOCAL_ONLY_MODE = True
+    settings.CODEXIFY_EGRESS_ALLOWLIST = ""
+    settings.LOCAL_BASE_URL = "http://host.docker.internal:11434/v1"
+    settings.LOCAL_API_KEY = "local"
+    settings.LOCAL_LLM_MODEL = "library2/ministral-3:8b"
+    settings.LOCAL_CHAT_MODEL = "qwen3.5:0.8b"
+    settings.DEFAULT_LOCAL_MODEL = "library2/ministral-3:8b"
+    settings.LLM_MODEL = "library2/ministral-3:8b"
+
+
+def test_health_llm_reports_effective_local_chat_model(
+    test_client,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "guardian.core.ai_router.requests.get",
+        _mock_local_runtime_request,
+    )
+    monkeypatch.setattr(
+        "guardian.routes.health.requests.get",
+        _mock_local_runtime_request,
+    )
+    monkeypatch.setattr(
+        health_routes,
+        "_collect_completion_service_health",
+        _healthy_completion_service,
+    )
+    health_routes._LLM_HEALTH_PROBE_CACHE = None
+    health_routes._LLM_HEALTH_PROBE_TS = 0.0
+
+    settings = get_settings()
+    snapshot = _snapshot_settings(settings)
+    try:
+        _apply_local_only_runtime(settings)
+        payload = test_client.get("/health/llm").json()
+        assert payload["model"] == "qwen3.5:0.8b"
+        assert payload["provider_runtime"]["default_model"] == "qwen3.5:0.8b"
+        assert payload["model_resolution"]["source"] == "LOCAL_CHAT_MODEL"
+        assert payload["runtime"]["reasoning"]["mode"] == "no_think"
+    finally:
+        for field, value in snapshot.items():
+            setattr(settings, field, value)
+        health_routes._LLM_HEALTH_PROBE_CACHE = None
+        health_routes._LLM_HEALTH_PROBE_TS = 0.0
+
+
+def test_health_chat_reports_effective_local_chat_model(
+    test_client,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "guardian.core.ai_router.requests.get",
+        _mock_local_runtime_request,
+    )
+    monkeypatch.setattr(
+        health_routes,
+        "_collect_completion_service_health",
+        _healthy_completion_service,
+    )
+    monkeypatch.setattr(
+        health_routes, "_collect_chat_queue_health", _healthy_queue
+    )
+
+    settings = get_settings()
+    snapshot = _snapshot_settings(settings)
+    try:
+        _apply_local_only_runtime(settings)
+        payload = test_client.get("/health/chat").json()
+        assert payload["model"] == "qwen3.5:0.8b"
+        assert payload["provider_runtime"]["default_model"] == "qwen3.5:0.8b"
+        assert payload["model_resolution"]["source"] == "LOCAL_CHAT_MODEL"
+        assert payload["runtime"]["reasoning"]["mode"] == "no_think"
+    finally:
+        for field, value in snapshot.items():
+            setattr(settings, field, value)
+
+
+def test_health_llm_surfaces_local_model_resolution_error(
+    test_client,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "guardian.core.ai_router.requests.get",
+        _mock_local_runtime_request,
+    )
+    monkeypatch.setattr(
+        "guardian.routes.health.requests.get",
+        _mock_local_runtime_request,
+    )
+    monkeypatch.setattr(
+        health_routes,
+        "_collect_completion_service_health",
+        _healthy_completion_service,
+    )
+    health_routes._LLM_HEALTH_PROBE_CACHE = None
+    health_routes._LLM_HEALTH_PROBE_TS = 0.0
+
+    settings = get_settings()
+    snapshot = _snapshot_settings(settings)
+    try:
+        _apply_local_only_runtime(settings)
+        settings.LOCAL_CHAT_MODEL = ""
+        payload = test_client.get("/health/llm").json()
+        assert payload["status"] == "misconfigured"
+        assert payload["error"] == LOCAL_MODEL_RESOLUTION_ERROR
+        assert payload["failure_kind"] == "local_model_missing"
+    finally:
+        for field, value in snapshot.items():
+            setattr(settings, field, value)
+        health_routes._LLM_HEALTH_PROBE_CACHE = None
+        health_routes._LLM_HEALTH_PROBE_TS = 0.0

--- a/tests/routes/test_llm_catalog.py
+++ b/tests/routes/test_llm_catalog.py
@@ -127,6 +127,22 @@ def _mock_bridge_fallback_catalog_request(calls: list[str]):
     return _handler
 
 
+def _mock_supported_local_catalog_request(
+    url: str, *args, **kwargs
+) -> _MockResponse:
+    _ = (args, kwargs)
+    if url.endswith("/api/tags"):
+        return _MockResponse(
+            {
+                "models": [
+                    {"name": "qwen3.5:0.8b"},
+                    {"name": "qwen2.5:7b"},
+                ]
+            }
+        )
+    return _MockResponse({"data": []}, status_code=404)
+
+
 def _provider_by_id(payload: dict, provider_id: str) -> dict:
     return next(
         provider
@@ -232,6 +248,50 @@ def test_llm_catalog_uses_host_bridge_fallback_when_loopback_unreachable(
         assert local["models"][0]["source"] == "host.docker.internal:11434"
         assert any("127.0.0.1:11434" in url for url in calls)
         assert any("host.docker.internal:11434" in url for url in calls)
+    finally:
+        for field, value in snapshot.items():
+            setattr(settings, field, value)
+
+
+def test_llm_catalog_local_only_exposes_effective_local_chat_model(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "guardian.core.llm_catalog.requests.get",
+        _mock_supported_local_catalog_request,
+    )
+    _clear_extra_cloud_keys(monkeypatch)
+
+    settings = get_settings()
+    snapshot = {
+        "LOCAL_BASE_URL": settings.LOCAL_BASE_URL,
+        "ALLOW_CLOUD_PROVIDERS": settings.ALLOW_CLOUD_PROVIDERS,
+        "CODEXIFY_LOCAL_ONLY_MODE": settings.CODEXIFY_LOCAL_ONLY_MODE,
+        "CODEXIFY_EGRESS_ALLOWLIST": settings.CODEXIFY_EGRESS_ALLOWLIST,
+        "LOCAL_LLM_MODEL": settings.LOCAL_LLM_MODEL,
+        "LOCAL_CHAT_MODEL": settings.LOCAL_CHAT_MODEL,
+        "DEFAULT_LOCAL_MODEL": settings.DEFAULT_LOCAL_MODEL,
+        "LLM_MODEL": settings.LLM_MODEL,
+    }
+    try:
+        settings.LOCAL_BASE_URL = "http://host.docker.internal:11434/v1"
+        settings.ALLOW_CLOUD_PROVIDERS = False
+        settings.CODEXIFY_LOCAL_ONLY_MODE = True
+        settings.CODEXIFY_EGRESS_ALLOWLIST = ""
+        settings.LOCAL_LLM_MODEL = "library2/ministral-3:8b"
+        settings.LOCAL_CHAT_MODEL = "qwen3.5:0.8b"
+        settings.DEFAULT_LOCAL_MODEL = "library2/ministral-3:8b"
+        settings.LLM_MODEL = "library2/ministral-3:8b"
+
+        client = TestClient(app)
+        payload = client.get("/api/llm/catalog").json()
+
+        local = _provider_by_id(payload, "local")
+        assert local["default_model"] == "qwen3.5:0.8b"
+        assert local["model_resolution"]["source"] == "LOCAL_CHAT_MODEL"
+        assert local["enabled"] is True
+        assert local["truth"]["selectable"] is True
+        assert local["models"][0]["id"] == "qwen3.5:0.8b"
     finally:
         for field, value in snapshot.items():
             setattr(settings, field, value)


### PR DESCRIPTION
## Summary
- unify supported-path local model resolution so execution uses the same effective local chat model advertised by runtime surfaces
- add canonical machine-readable local model resolution failures for blank or unavailable supported-path configuration
- update `/health/llm`, `/health/chat`, and `/api/llm/catalog` to report the effective executable local model consistently
- add focused regressions for supported-path model parity and clear failure behavior while preserving local-only governance

## Testing
- `pytest -v tests/core/test_ai_router.py tests/routes/test_health_endpoints.py tests/routes/test_llm_catalog.py`
- `pytest -v tests/core tests/routes` failed in `tests/core/test_chat_completion_service_attachments.py` due to an existing assertion expecting `"Linked document excerpts are available"` while the current output starts with `"Thread-linked document excerpts are available..."`