### PR TITLE
fix(redis): use queue client + blocking read + backoff for task event…

### DIFF
--- a/guardian/queue/redis_queue.py
+++ b/guardian/queue/redis_queue.py
@@ -631,6 +631,13 @@ def get_request_redis_client() -> Any:
     return client
 
 
+def get_queue_redis_client() -> Any:
+    client = _get_queue_client()
+    if _running_under_pytest() and _is_mock_client(client):
+        client = _set_queue_client(_InMemoryRedis())
+    return client
+
+
 def get_redis_client() -> Any:
     # WARNING:
     # This client is NOT safe for blocking operations.

--- a/guardian/queue/task_events.py
+++ b/guardian/queue/task_events.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from guardian.protocol_tokens import ErrorCode, TaskEventType
 from guardian.queue.redis_queue import _with_reconnect  # type: ignore
+from guardian.queue.redis_queue import get_queue_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +23,10 @@ _TERMINAL_EVENT_TYPES = {
 _TERMINAL_EVENT_SCAN_BATCH_SIZE = 100
 _TASK_EVENT_FALLBACK_TYPE = TaskEventType.TASK_EVENT.value
 _TASK_EVENT_PUBLISH_ERROR_CODE = ErrorCode.TASK_EVENT_PUBLISH_FAILED.value
+_READ_EVENTS_BLOCK_MS = 5000
+_READ_EVENTS_BATCH_SIZE = 50
+_READ_EVENTS_INITIAL_BACKOFF_SECONDS = 0.5
+_READ_EVENTS_MAX_BACKOFF_SECONDS = 2.0
 
 
 class TaskEventPublishError(RuntimeError):
@@ -187,39 +193,52 @@ def read_events(
     task_id: str,
     last_id: str,
     *,
-    block_ms: int = 15000,
-    count: int = 100,
+    block_ms: int = _READ_EVENTS_BLOCK_MS,
+    count: int = _READ_EVENTS_BATCH_SIZE,
 ) -> list[tuple[str, dict[str, Any]]]:
     stream_key = _stream_key(task_id)
+    backoff = _READ_EVENTS_INITIAL_BACKOFF_SECONDS
 
-    def _read(client) -> list[tuple[str, dict[str, Any]]]:
-        result = client.xread(
-            {stream_key: last_id}, count=count, block=block_ms
-        )
-        if not result:
-            return []
-        _, entries = result[0]
-        events: list[tuple[str, dict[str, Any]]] = []
-        for event_id, fields in entries:
-            data_raw = fields.get("data", "{}")
-            try:
-                data = json.loads(data_raw)
-            except Exception:
-                data = {}
-            events.append(
-                (
-                    event_id,
-                    {
-                        "type": fields.get("type") or _TASK_EVENT_FALLBACK_TYPE,
-                        "task_id": fields.get("task_id") or task_id,
-                        "data": data,
-                        "created_at": fields.get("created_at"),
-                    },
-                )
+    while True:
+        try:
+            redis = get_queue_redis_client()
+            result = redis.xread(
+                streams={stream_key: last_id},
+                block=block_ms,
+                count=count,
             )
-        return events
+            backoff = _READ_EVENTS_INITIAL_BACKOFF_SECONDS
+            break
+        except Exception as exc:
+            logger.warning("[task-events] read failed: %s", str(exc))
+            time.sleep(backoff)
+            backoff = min(
+                backoff * 2,
+                _READ_EVENTS_MAX_BACKOFF_SECONDS,
+            )
 
-    return _with_reconnect(_read)
+    if not result:
+        return []
+    _, entries = result[0]
+    events: list[tuple[str, dict[str, Any]]] = []
+    for event_id, fields in entries:
+        data_raw = fields.get("data", "{}")
+        try:
+            data = json.loads(data_raw)
+        except Exception:
+            data = {}
+        events.append(
+            (
+                event_id,
+                {
+                    "type": fields.get("type") or _TASK_EVENT_FALLBACK_TYPE,
+                    "task_id": fields.get("task_id") or task_id,
+                    "data": data,
+                    "created_at": fields.get("created_at"),
+                },
+            )
+        )
+    return events
 
 
 def describe_terminal_state(task_id: str) -> dict[str, Any]:

--- a/guardian/tests/queue/test_task_events.py
+++ b/guardian/tests/queue/test_task_events.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from guardian.queue import task_events
+
+
+def test_read_events_uses_queue_client_defaults(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    class FakeRedis:
+        def xread(self, streams, block=None, count=None):
+            calls.append(
+                {
+                    "streams": streams,
+                    "block": block,
+                    "count": count,
+                }
+            )
+            return [
+                (
+                    "codexify:task:task-123:events",
+                    [
+                        (
+                            "1-0",
+                            {
+                                "type": "task.progress",
+                                "task_id": "task-123",
+                                "data": '{"ok": true}',
+                                "created_at": "2026-03-29T00:00:00+00:00",
+                            },
+                        )
+                    ],
+                )
+            ]
+
+    monkeypatch.setattr(
+        task_events,
+        "get_queue_redis_client",
+        lambda: FakeRedis(),
+    )
+
+    events = task_events.read_events("task-123", "0-0")
+
+    assert calls == [
+        {
+            "streams": {"codexify:task:task-123:events": "0-0"},
+            "block": 5000,
+            "count": 50,
+        }
+    ]
+    assert events == [
+        (
+            "1-0",
+            {
+                "type": "task.progress",
+                "task_id": "task-123",
+                "data": {"ok": True},
+                "created_at": "2026-03-29T00:00:00+00:00",
+            },
+        )
+    ]
+
+
+def test_read_events_retries_with_backoff(monkeypatch):
+    sleep_calls: list[float] = []
+
+    class FakeRedis:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def xread(self, streams, block=None, count=None):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("boom")
+            return []
+
+    fake_redis = FakeRedis()
+
+    monkeypatch.setattr(
+        task_events,
+        "get_queue_redis_client",
+        lambda: fake_redis,
+    )
+    monkeypatch.setattr(task_events.time, "sleep", sleep_calls.append)
+
+    events = task_events.read_events("task-123", "0-0")
+
+    assert events == []
+    assert fake_redis.calls == 2
+    assert sleep_calls == [0.5]


### PR DESCRIPTION
… streams

## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
