### PR TITLE
Fix content-only streaming and local model resolution fallback

### DIFF
--- a/frontend/src/features/chat/components/__tests__/Message.execution.test.tsx
+++ b/frontend/src/features/chat/components/__tests__/Message.execution.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import ChatBubble from "@/features/chat/components/ChatBubble";
+import { renderStreamChunk } from "@/features/chat/useChat";
 
 const baseMessage = {
   id: "msg-execution",
@@ -70,5 +71,17 @@ describe("ChatBubble execution badge", () => {
     );
 
     expect(screen.getByText("⚠ Executed on gpt-5.4-mini")).toBeInTheDocument();
+  });
+
+  it("does not render reasoning/thinking tokens", () => {
+    const chunk = {
+      content: "",
+      thinking: "internal reasoning",
+    };
+
+    const result = renderStreamChunk(chunk);
+
+    expect(result).not.toContain("internal reasoning");
+    expect(result).toBe("");
   });
 });

--- a/frontend/src/features/chat/useChat.ts
+++ b/frontend/src/features/chat/useChat.ts
@@ -12,7 +12,7 @@ import {
 
 import api from "@/lib/api";
 import { logOnce } from "@/lib/logging/logOnce";
-import type { ChatExecution } from "@/types/chat";
+import type { ChatExecution, StreamChunk } from "@/types/chat";
 
 export type ChatAttachment = {
   id: string;
@@ -159,6 +159,24 @@ export const parseMessagesResponse = (
   }
   return null;
 };
+
+export function renderStreamChunk(chunk: unknown): string {
+  // Only render the explicit public content channel.
+  if (!chunk || typeof chunk !== "object" || !("content" in chunk)) {
+    return "";
+  }
+
+  const content = (chunk as StreamChunk).content;
+  return typeof content === "string" ? content : "";
+}
+
+function normalizeMessageContent(raw: unknown): string {
+  if (typeof raw === "string") return raw;
+  if (raw && typeof raw === "object" && "content" in raw) {
+    return renderStreamChunk(raw);
+  }
+  return String(raw ?? "");
+}
 
 const normalizeSrcUrl = (src: any): string => {
   if (typeof src !== "string") return "";
@@ -340,8 +358,7 @@ const normalizeMessage = (
   const threadId = Number(base.thread_id ?? base.threadId ?? fallbackThreadId);
   const id = Number(base.id ?? base.message_id ?? base.messageId);
   const role = String(base.role ?? "").trim();
-  const content =
-    typeof base.content === "string" ? base.content : String(base.content ?? "");
+  const content = normalizeMessageContent(base.content);
   const createdAtRaw = base.created_at ?? base.createdAt;
   const createdAt = createdAtRaw ? String(createdAtRaw) : "";
   const attachments = normalizeAttachments(raw);

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -5,3 +5,8 @@ export type ChatExecution = {
   final_model: string;
   fallback_triggered: boolean;
 };
+
+export type StreamChunk = {
+  content?: string;
+  // Public contract is content-only. Do not add reasoning/thinking here.
+};

--- a/guardian/core/ai_router.py
+++ b/guardian/core/ai_router.py
@@ -1240,6 +1240,7 @@ def call_local(
             status_code=400,
             detail=local_model_resolution.error_detail(),
         )
+    model = local_model_resolution.model or model
     runtime_policy = resolve_local_runtime_policy(
         model, settings=settings, timeout=timeout
     )
@@ -1437,6 +1438,7 @@ def stream_local(
             status_code=400,
             detail=local_model_resolution.error_detail(),
         )
+    model = local_model_resolution.model or model
     runtime_policy = resolve_local_runtime_policy(model, settings=settings)
     adapted_messages, _ = apply_local_reasoning_directive(
         messages or [],

--- a/guardian/core/ai_router.py
+++ b/guardian/core/ai_router.py
@@ -582,31 +582,48 @@ def _local_chat_model_is_authoritative(settings: Settings) -> bool:
     )
 
 
-def _configured_local_model_resolution(
+def _local_execution_model_candidates(
     settings: Settings,
-) -> tuple[str, str | None, bool]:
+    *,
+    requested_model: str | None = None,
+) -> tuple[list[tuple[str, str]], bool]:
     strict = _local_chat_model_is_authoritative(settings)
-    candidates: tuple[tuple[str, Any], ...]
+    raw_candidates: tuple[tuple[str, Any], ...]
     if strict:
-        candidates = (
+        raw_candidates = (
             ("LOCAL_CHAT_MODEL", getattr(settings, "LOCAL_CHAT_MODEL", None)),
         )
     else:
-        candidates = (
-            ("LOCAL_CHAT_MODEL", getattr(settings, "LOCAL_CHAT_MODEL", None)),
+        raw_candidates = (
+            ("requested_model", requested_model),
             ("LOCAL_LLM_MODEL", getattr(settings, "LOCAL_LLM_MODEL", None)),
             (
                 "DEFAULT_LOCAL_MODEL",
                 getattr(settings, "DEFAULT_LOCAL_MODEL", None),
             ),
             ("LLM_MODEL", getattr(settings, "LLM_MODEL", None)),
+            ("LOCAL_CHAT_MODEL", getattr(settings, "LOCAL_CHAT_MODEL", None)),
         )
 
-    for source, candidate in candidates:
+    candidates: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for source, candidate in raw_candidates:
         normalized = normalize_model_id(candidate)
-        if normalized:
-            return normalized, source, strict
-    return "", candidates[0][0] if candidates else None, strict
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        candidates.append((normalized, source))
+    return candidates, strict
+
+
+def _configured_local_model_resolution(
+    settings: Settings,
+) -> tuple[str, str | None, bool]:
+    candidates, strict = _local_execution_model_candidates(settings)
+    if candidates:
+        model, source = candidates[0]
+        return model, source, strict
+    return "", "LOCAL_CHAT_MODEL" if strict else None, strict
 
 
 def resolve_local_execution_model(
@@ -621,11 +638,12 @@ def resolve_local_execution_model(
 ) -> LocalModelResolution:
     resolved = _resolve_settings(settings)
     requested = normalize_model_id(requested_model)
-    configured_model, source, strict = _configured_local_model_resolution(
-        resolved
+    candidates, strict = _local_execution_model_candidates(
+        resolved,
+        requested_model=requested_model,
     )
-    if not configured_model:
-        source_name = str(source or "LOCAL_CHAT_MODEL").strip()
+    if not candidates:
+        source_name = "LOCAL_CHAT_MODEL" if strict else "local_model"
         return LocalModelResolution(
             model=None,
             source=source_name,
@@ -637,6 +655,7 @@ def resolve_local_execution_model(
             ),
             endpoint_resolution=endpoint_resolution,
         )
+    configured_model, source = candidates[0]
 
     resolved_endpoint = endpoint_resolution
     names = list(discovered_model_names or [])
@@ -659,7 +678,7 @@ def resolve_local_execution_model(
             )
             if normalized
         }
-        if configured_model not in available_models:
+        if strict and configured_model not in available_models:
             return LocalModelResolution(
                 model=configured_model,
                 source=source,
@@ -669,6 +688,28 @@ def resolve_local_execution_model(
                 message=(
                     f"Configured local chat model '{configured_model}' from "
                     f"{source} is not advertised by the reachable local runtime"
+                ),
+                endpoint_resolution=resolved_endpoint,
+            )
+        if not strict:
+            for candidate_model, candidate_source in candidates:
+                if candidate_model in available_models:
+                    return LocalModelResolution(
+                        model=candidate_model,
+                        source=candidate_source,
+                        strict=strict,
+                        requested_model=requested or None,
+                        endpoint_resolution=resolved_endpoint,
+                    )
+            return LocalModelResolution(
+                model=configured_model,
+                source=source,
+                strict=strict,
+                requested_model=requested or None,
+                failure_kind=LOCAL_MODEL_UNAVAILABLE_FAILURE_KIND,
+                message=(
+                    "No runnable local model was found among the requested "
+                    "or configured local candidates"
                 ),
                 endpoint_resolution=resolved_endpoint,
             )
@@ -769,6 +810,7 @@ def chat_with_ai(
     local_model_resolution: LocalModelResolution | None = None
 
     if provider_name == "local":
+        strict_local_chat = _local_chat_model_is_authoritative(settings)
         authoritative_model = normalize_model_id(
             getattr(settings, "LOCAL_CHAT_MODEL", None)
         )
@@ -777,7 +819,9 @@ def chat_with_ai(
             settings=settings,
             requested_model=target_model,
             validate_availability=bool(
-                authoritative_model and authoritative_model != requested_model
+                strict_local_chat
+                and authoritative_model
+                and authoritative_model != requested_model
             ),
         )
         if not local_model_resolution.ok:

--- a/guardian/tests/workers/test_chat_worker_completion_semantics.py
+++ b/guardian/tests/workers/test_chat_worker_completion_semantics.py
@@ -630,6 +630,109 @@ def test_completion_persists_stripped_response_boundary(monkeypatch):
     assert mock_db.create_message.call_args[0][2] == "Hello!"
 
 
+def test_stream_completion_ignores_reasoning_chunks(monkeypatch):
+    async def _build_messages(_task):
+        return (
+            [{"role": "user", "content": "hello"}],
+            "local",
+            "qwen3.5:27b",
+            {},
+            None,
+            None,
+            {},
+        )
+
+    class _ChunkStream:
+        def __iter__(self):
+            return iter(
+                [
+                    {"delta": {"thinking": "private", "content": "Hello"}},
+                    {"delta": {"thinking": "hidden"}},
+                    {"delta": {"content": " world"}},
+                ]
+            )
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(chat_worker, "_build_messages_for_llm", _build_messages)
+    monkeypatch.setattr(
+        chat_worker, "stream_local", lambda *a, **k: _ChunkStream()
+    )
+
+    callback_tokens: list[str] = []
+    task = ChatCompletionTask(
+        thread_id=1,
+        provider="local",
+        model="qwen3.5:27b",
+        selection_source="explicit",
+    )
+
+    result = chat_worker._run_chat_completion_task_compat(
+        task,
+        token_callback=callback_tokens.append,
+        persist_assistant_message=False,
+    )
+
+    assert result["assistant_text"] == "Hello world"
+    assert callback_tokens == ["Hello", " world"]
+    assert "thinking" not in result
+    assert "reasoning" not in result
+
+
+def test_completion_fallback_response_ignores_reasoning_fields(monkeypatch):
+    async def _build_messages(_task):
+        return (
+            [{"role": "user", "content": "hello"}],
+            "local",
+            "qwen3.5:27b",
+            {},
+            None,
+            None,
+            {},
+        )
+
+    class _EmptyStream:
+        def __iter__(self):
+            return iter(())
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(chat_worker, "_build_messages_for_llm", _build_messages)
+    monkeypatch.setattr(
+        chat_worker, "stream_local", lambda *a, **k: _EmptyStream()
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "chat_with_ai",
+        lambda *_a, **_k: {
+            "content": "visible fallback",
+            "thinking": "private reasoning",
+            "reasoning": "internal only",
+        },
+    )
+
+    callback_tokens: list[str] = []
+    task = ChatCompletionTask(
+        thread_id=1,
+        provider="local",
+        model="qwen3.5:27b",
+        selection_source="explicit",
+    )
+
+    result = chat_worker._run_chat_completion_task_compat(
+        task,
+        token_callback=callback_tokens.append,
+        persist_assistant_message=False,
+    )
+
+    assert result["assistant_text"] == "visible fallback"
+    assert callback_tokens == ["visible fallback"]
+    assert "thinking" not in result
+    assert "reasoning" not in result
+
+
 def test_duplicate_turn_is_prevented_before_new_completion(monkeypatch):
     published: list[tuple[str, dict]] = []
 

--- a/guardian/workers/chat_worker.py
+++ b/guardian/workers/chat_worker.py
@@ -921,6 +921,54 @@ def extract_assistant_response(text: str) -> str:
     return text.strip()
 
 
+def _extract_visible_stream_text(chunk: Any) -> str:
+    """Enforce the public stream contract: content only, never reasoning."""
+
+    if isinstance(chunk, str):
+        return chunk
+
+    if not isinstance(chunk, dict):
+        return ""
+
+    delta = chunk.get("delta")
+    if isinstance(delta, dict):
+        content = delta.get("content")
+        if isinstance(content, str):
+            return content
+        if content is not None:
+            return str(content)
+        # Explicitly ignore reasoning/thinking deltas.
+        return ""
+
+    content = chunk.get("content")
+    if isinstance(content, str):
+        return content
+    if "content" in chunk and content is not None:
+        return str(content)
+
+    message = chunk.get("message")
+    if isinstance(message, dict):
+        nested_content = message.get("content")
+        if isinstance(nested_content, str):
+            return nested_content
+        if nested_content is not None:
+            return str(nested_content)
+
+    return ""
+
+
+def _sanitize_assistant_result_payload(result: dict[str, Any]) -> None:
+    """Strip provider-specific reasoning fields from the public assistant payload."""
+
+    result.pop("thinking", None)
+    result.pop("reasoning", None)
+
+    execution = result.get("execution")
+    if isinstance(execution, dict):
+        execution.pop("thinking", None)
+        execution.pop("reasoning", None)
+
+
 def _degraded_provider_model_fallback(
     *,
     provider: str,
@@ -1301,16 +1349,17 @@ def _run_chat_completion_task_compat(
                 for token in token_stream:
                     if cancel_check and cancel_check():
                         raise ChatTaskCancelled("task_cancelled")
-                    if token:
+                    visible_token = _extract_visible_stream_text(token)
+                    if visible_token:
                         streamed_any = True
-                        assistant_output += token
+                        assistant_output += visible_token
                         if token_callback:
-                            token_callback(token)
+                            token_callback(visible_token)
             finally:
                 token_stream.close()
 
             if not assistant_output.strip():
-                assistant_output = str(
+                assistant_output = _extract_visible_stream_text(
                     chat_with_ai(
                         messages_for_llm,
                         model=execution_model,
@@ -1329,7 +1378,7 @@ def _run_chat_completion_task_compat(
 
         if cancel_check and cancel_check():
             raise ChatTaskCancelled("task_cancelled")
-        assistant_output = str(
+        assistant_output = _extract_visible_stream_text(
             chat_with_ai(
                 messages_for_llm,
                 model=execution_model,
@@ -1505,6 +1554,7 @@ def _run_chat_completion_task_compat(
         "thread_id": task.thread_id,
         "payload_summary": payload_summary,
     }
+    _sanitize_assistant_result_payload(result)
 
     if not persist_assistant_message:
         return result

--- a/tests/core/test_ai_router.py
+++ b/tests/core/test_ai_router.py
@@ -250,6 +250,41 @@ def test_chat_with_ai_local_uses_configured_endpoint_chain_order(monkeypatch):
     )
 
 
+def test_chat_with_ai_non_strict_local_mode_ignores_stale_local_chat_model(
+    monkeypatch,
+):
+    captured: dict[str, object] = {}
+
+    def _mock_post(url: str, *, json, headers, timeout):
+        captured["url"] = url
+        captured["json"] = json
+        _ = (headers, timeout)
+        return _MockRawResponse({"message": {"content": "Non-strict reply"}})
+
+    monkeypatch.setattr("guardian.core.ai_router.requests.post", _mock_post)
+
+    settings = Settings(
+        LLM_PROVIDER="local",
+        CODEXIFY_LOCAL_ONLY_MODE=False,
+        ALLOW_CLOUD_PROVIDERS=False,
+        CODEXIFY_EGRESS_ALLOWLIST="",
+        LOCAL_BASE_URL="http://127.0.0.1:11434",
+        LOCAL_LLM_MODEL="llama3.2:3b",
+        LOCAL_CHAT_MODEL="qwen3.5:0.8b",
+        DEFAULT_LOCAL_MODEL="llama3.2:3b",
+        LLM_MODEL="llama3.2:3b",
+    )
+
+    result = chat_with_ai(
+        [{"role": "user", "content": "hello"}],
+        provider="local",
+        settings=settings,
+    )
+
+    assert result == "Non-strict reply"
+    assert captured["json"]["model"] == "llama3.2:3b"
+
+
 def test_chat_with_ai_local_only_uses_local_chat_model_for_execution(
     monkeypatch,
 ):

--- a/tests/core/test_ai_router.py
+++ b/tests/core/test_ai_router.py
@@ -11,8 +11,10 @@ from guardian.core.ai_router import (
     LOCAL_MODEL_RESOLUTION_ERROR,
     LOCAL_MODEL_UNAVAILABLE_FAILURE_KIND,
     call_alibaba,
+    call_local,
     call_minimax,
     chat_with_ai,
+    stream_local,
 )
 from guardian.core.config import Settings
 
@@ -33,6 +35,20 @@ class _MockRawResponse:
 
     def json(self) -> dict:
         return json.loads(self.content.decode("utf-8"))
+
+
+class _MockStreamingResponse:
+    def __init__(self, lines: list[bytes], status_code: int = 200) -> None:
+        self._lines = lines
+        self.status_code = status_code
+        self.closed = False
+
+    def iter_lines(self, decode_unicode: bool = False):
+        _ = decode_unicode
+        yield from self._lines
+
+    def close(self) -> None:
+        self.closed = True
 
 
 def _mock_local_inventory_request(
@@ -386,6 +402,82 @@ def test_chat_with_ai_local_only_invalid_local_chat_model_fails_clearly(
         exc.value.detail["failure_kind"] == LOCAL_MODEL_UNAVAILABLE_FAILURE_KIND
     )
     assert exc.value.detail["model"] == "qwen3.5:0.8b"
+
+
+def test_call_local_local_only_uses_resolved_model_for_execution(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def _mock_post(url: str, *, json, headers, timeout):
+        captured["url"] = url
+        captured["json"] = json
+        _ = (headers, timeout)
+        return _MockRawResponse({"message": {"content": "Local call reply"}})
+
+    monkeypatch.setattr("guardian.core.ai_router.requests.post", _mock_post)
+
+    settings = Settings(
+        LLM_PROVIDER="local",
+        CODEXIFY_LOCAL_ONLY_MODE=True,
+        ALLOW_CLOUD_PROVIDERS=False,
+        CODEXIFY_EGRESS_ALLOWLIST="",
+        LOCAL_BASE_URL="http://127.0.0.1:11434",
+        LOCAL_LLM_MODEL="library2/ministral-3:8b",
+        LOCAL_CHAT_MODEL="qwen3.5:0.8b",
+        DEFAULT_LOCAL_MODEL="library2/ministral-3:8b",
+        LLM_MODEL="library2/ministral-3:8b",
+    )
+
+    result = call_local(
+        [{"role": "user", "content": "hello"}],
+        "library2/ministral-3:8b",
+        settings=settings,
+    )
+
+    assert result == "Local call reply"
+    assert captured["json"]["model"] == "qwen3.5:0.8b"
+
+
+def test_stream_local_local_only_uses_resolved_model_for_execution(
+    monkeypatch,
+):
+    captured: dict[str, object] = {}
+
+    def _mock_post(url: str, *, json, headers, stream, timeout):
+        captured["url"] = url
+        captured["json"] = json
+        _ = (headers, stream, timeout)
+        return _MockStreamingResponse(
+            [
+                b'data: {"choices":[{"delta":{"content":"Local "}}]}',
+                b'data: {"choices":[{"delta":{"content":"stream"}}]}',
+                b"data: [DONE]",
+            ]
+        )
+
+    monkeypatch.setattr("guardian.core.ai_router.requests.post", _mock_post)
+
+    settings = Settings(
+        LLM_PROVIDER="local",
+        CODEXIFY_LOCAL_ONLY_MODE=True,
+        ALLOW_CLOUD_PROVIDERS=False,
+        CODEXIFY_EGRESS_ALLOWLIST="",
+        LOCAL_BASE_URL="http://127.0.0.1:11434/v1",
+        LOCAL_LLM_MODEL="library2/ministral-3:8b",
+        LOCAL_CHAT_MODEL="qwen3.5:0.8b",
+        DEFAULT_LOCAL_MODEL="library2/ministral-3:8b",
+        LLM_MODEL="library2/ministral-3:8b",
+    )
+
+    result = list(
+        stream_local(
+            [{"role": "user", "content": "hello"}],
+            "library2/ministral-3:8b",
+            settings=settings,
+        )
+    )
+
+    assert result == ["Local ", "stream"]
+    assert captured["json"]["model"] == "qwen3.5:0.8b"
 
 
 def test_call_alibaba_missing_key_surfaces_auth_config_failure():

--- a/tests/routes/test_health_endpoints.py
+++ b/tests/routes/test_health_endpoints.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from guardian.core.ai_router import LOCAL_MODEL_RESOLUTION_ERROR
+import json
+
+from guardian.core.ai_router import LOCAL_MODEL_RESOLUTION_ERROR, call_local
 from guardian.core.config import get_settings
 from guardian.routes import health as health_routes
 
@@ -12,6 +14,15 @@ class _MockResponse:
 
     def json(self) -> dict:
         return self._payload
+
+
+class _MockRawResponse:
+    def __init__(self, payload: dict, status_code: int = 200) -> None:
+        self.status_code = status_code
+        self.content = json.dumps(payload).encode("utf-8")
+
+    def json(self) -> dict:
+        return json.loads(self.content.decode("utf-8"))
 
 
 def _mock_local_runtime_request(
@@ -144,6 +155,69 @@ def test_health_chat_reports_effective_local_chat_model(
     finally:
         for field, value in snapshot.items():
             setattr(settings, field, value)
+
+
+def test_health_surfaces_match_executed_local_model(
+    test_client,
+    monkeypatch,
+):
+    captured: dict[str, object] = {}
+
+    def _mock_post(url: str, *, json, headers, timeout):
+        captured["url"] = url
+        captured["json"] = json
+        _ = (headers, timeout)
+        return _MockRawResponse({"message": {"content": "Strict reply"}})
+
+    monkeypatch.setattr(
+        "guardian.core.ai_router.requests.get",
+        _mock_local_runtime_request,
+    )
+    monkeypatch.setattr(
+        "guardian.routes.health.requests.get",
+        _mock_local_runtime_request,
+    )
+    monkeypatch.setattr("guardian.core.ai_router.requests.post", _mock_post)
+    monkeypatch.setattr(
+        health_routes,
+        "_collect_completion_service_health",
+        _healthy_completion_service,
+    )
+    monkeypatch.setattr(
+        health_routes, "_collect_chat_queue_health", _healthy_queue
+    )
+    health_routes._LLM_HEALTH_PROBE_CACHE = None
+    health_routes._LLM_HEALTH_PROBE_TS = 0.0
+
+    settings = get_settings()
+    snapshot = _snapshot_settings(settings)
+    try:
+        _apply_local_only_runtime(settings)
+        result = call_local(
+            [{"role": "user", "content": "hello"}],
+            "library2/ministral-3:8b",
+            settings=settings,
+        )
+        llm_payload = test_client.get("/health/llm").json()
+        chat_payload = test_client.get("/health/chat").json()
+
+        assert result == "Strict reply"
+        assert captured["json"]["model"] == "qwen3.5:0.8b"
+        assert llm_payload["model"] == captured["json"]["model"]
+        assert (
+            llm_payload["provider_runtime"]["default_model"]
+            == captured["json"]["model"]
+        )
+        assert chat_payload["model"] == captured["json"]["model"]
+        assert (
+            chat_payload["provider_runtime"]["default_model"]
+            == captured["json"]["model"]
+        )
+    finally:
+        for field, value in snapshot.items():
+            setattr(settings, field, value)
+        health_routes._LLM_HEALTH_PROBE_CACHE = None
+        health_routes._LLM_HEALTH_PROBE_TS = 0.0
 
 
 def test_health_llm_surfaces_local_model_resolution_error(

--- a/tests/routes/test_llm_catalog.py
+++ b/tests/routes/test_llm_catalog.py
@@ -143,6 +143,22 @@ def _mock_supported_local_catalog_request(
     return _MockResponse({"data": []}, status_code=404)
 
 
+def _mock_non_strict_local_catalog_request(
+    url: str, *args, **kwargs
+) -> _MockResponse:
+    _ = (args, kwargs)
+    if url.endswith("/api/tags"):
+        return _MockResponse(
+            {
+                "models": [
+                    {"name": "llama3.2:3b"},
+                    {"name": "qwen2.5:7b"},
+                ]
+            }
+        )
+    return _MockResponse({"data": []}, status_code=404)
+
+
 def _provider_by_id(payload: dict, provider_id: str) -> dict:
     return next(
         provider
@@ -292,6 +308,50 @@ def test_llm_catalog_local_only_exposes_effective_local_chat_model(
         assert local["enabled"] is True
         assert local["truth"]["selectable"] is True
         assert local["models"][0]["id"] == "qwen3.5:0.8b"
+    finally:
+        for field, value in snapshot.items():
+            setattr(settings, field, value)
+
+
+def test_llm_catalog_non_strict_mode_keeps_runnable_local_available(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "guardian.core.llm_catalog.requests.get",
+        _mock_non_strict_local_catalog_request,
+    )
+    _clear_extra_cloud_keys(monkeypatch)
+
+    settings = get_settings()
+    snapshot = {
+        "LOCAL_BASE_URL": settings.LOCAL_BASE_URL,
+        "ALLOW_CLOUD_PROVIDERS": settings.ALLOW_CLOUD_PROVIDERS,
+        "CODEXIFY_LOCAL_ONLY_MODE": settings.CODEXIFY_LOCAL_ONLY_MODE,
+        "CODEXIFY_EGRESS_ALLOWLIST": settings.CODEXIFY_EGRESS_ALLOWLIST,
+        "LOCAL_LLM_MODEL": settings.LOCAL_LLM_MODEL,
+        "LOCAL_CHAT_MODEL": settings.LOCAL_CHAT_MODEL,
+        "DEFAULT_LOCAL_MODEL": settings.DEFAULT_LOCAL_MODEL,
+        "LLM_MODEL": settings.LLM_MODEL,
+    }
+    try:
+        settings.LOCAL_BASE_URL = "http://host.docker.internal:11434/v1"
+        settings.ALLOW_CLOUD_PROVIDERS = False
+        settings.CODEXIFY_LOCAL_ONLY_MODE = False
+        settings.CODEXIFY_EGRESS_ALLOWLIST = ""
+        settings.LOCAL_LLM_MODEL = "llama3.2:3b"
+        settings.LOCAL_CHAT_MODEL = "qwen3.5:0.8b"
+        settings.DEFAULT_LOCAL_MODEL = "llama3.2:3b"
+        settings.LLM_MODEL = "llama3.2:3b"
+
+        client = TestClient(app)
+        payload = client.get("/api/llm/catalog").json()
+
+        local = _provider_by_id(payload, "local")
+        assert local["default_model"] == "llama3.2:3b"
+        assert local["enabled"] is True
+        assert local["truth"]["selectable"] is True
+        assert local["models"][0]["id"] == "llama3.2:3b"
+        assert "disabled_reason" not in local
     finally:
         for field, value in snapshot.items():
             setattr(settings, field, value)

--- a/tests/routes/test_llm_catalog.py
+++ b/tests/routes/test_llm_catalog.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import requests
 from fastapi.testclient import TestClient
 
+from guardian.core.ai_router import stream_local
 from guardian.core.config import get_settings
 from guardian.guardian_api import app
 
@@ -14,6 +15,20 @@ class _MockResponse:
 
     def json(self) -> dict:
         return self._payload
+
+
+class _MockStreamingResponse:
+    def __init__(self, lines: list[bytes], status_code: int = 200) -> None:
+        self._lines = lines
+        self.status_code = status_code
+        self.closed = False
+
+    def iter_lines(self, decode_unicode: bool = False):
+        _ = decode_unicode
+        yield from self._lines
+
+    def close(self) -> None:
+        self.closed = True
 
 
 def _mock_local_catalog_request(url: str, *args, **kwargs) -> _MockResponse:
@@ -352,6 +367,70 @@ def test_llm_catalog_non_strict_mode_keeps_runnable_local_available(
         assert local["truth"]["selectable"] is True
         assert local["models"][0]["id"] == "llama3.2:3b"
         assert "disabled_reason" not in local
+    finally:
+        for field, value in snapshot.items():
+            setattr(settings, field, value)
+
+
+def test_llm_catalog_matches_stream_local_executed_model(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def _mock_post(url: str, *, json, headers, stream, timeout):
+        captured["url"] = url
+        captured["json"] = json
+        _ = (headers, stream, timeout)
+        return _MockStreamingResponse(
+            [
+                b'data: {"choices":[{"delta":{"content":"Local "}}]}',
+                b'data: {"choices":[{"delta":{"content":"stream"}}]}',
+                b"data: [DONE]",
+            ]
+        )
+
+    monkeypatch.setattr(
+        "guardian.core.llm_catalog.requests.get",
+        _mock_supported_local_catalog_request,
+    )
+    monkeypatch.setattr("guardian.core.ai_router.requests.post", _mock_post)
+    _clear_extra_cloud_keys(monkeypatch)
+
+    settings = get_settings()
+    snapshot = {
+        "LOCAL_BASE_URL": settings.LOCAL_BASE_URL,
+        "ALLOW_CLOUD_PROVIDERS": settings.ALLOW_CLOUD_PROVIDERS,
+        "CODEXIFY_LOCAL_ONLY_MODE": settings.CODEXIFY_LOCAL_ONLY_MODE,
+        "CODEXIFY_EGRESS_ALLOWLIST": settings.CODEXIFY_EGRESS_ALLOWLIST,
+        "LOCAL_LLM_MODEL": settings.LOCAL_LLM_MODEL,
+        "LOCAL_CHAT_MODEL": settings.LOCAL_CHAT_MODEL,
+        "DEFAULT_LOCAL_MODEL": settings.DEFAULT_LOCAL_MODEL,
+        "LLM_MODEL": settings.LLM_MODEL,
+    }
+    try:
+        settings.LOCAL_BASE_URL = "http://host.docker.internal:11434/v1"
+        settings.ALLOW_CLOUD_PROVIDERS = False
+        settings.CODEXIFY_LOCAL_ONLY_MODE = True
+        settings.CODEXIFY_EGRESS_ALLOWLIST = ""
+        settings.LOCAL_LLM_MODEL = "library2/ministral-3:8b"
+        settings.LOCAL_CHAT_MODEL = "qwen3.5:0.8b"
+        settings.DEFAULT_LOCAL_MODEL = "library2/ministral-3:8b"
+        settings.LLM_MODEL = "library2/ministral-3:8b"
+
+        tokens = list(
+            stream_local(
+                [{"role": "user", "content": "hello"}],
+                "library2/ministral-3:8b",
+                settings=settings,
+            )
+        )
+
+        client = TestClient(app)
+        payload = client.get("/api/llm/catalog").json()
+
+        local = _provider_by_id(payload, "local")
+        assert tokens == ["Local ", "stream"]
+        assert captured["json"]["model"] == "qwen3.5:0.8b"
+        assert local["default_model"] == captured["json"]["model"]
+        assert local["model_resolution"]["source"] == "LOCAL_CHAT_MODEL"
     finally:
         for field, value in snapshot.items():
             setattr(settings, field, value)


### PR DESCRIPTION
## Summary
- enforce a content-only stream contract in the chat worker and frontend chunk handling so `thinking`/`reasoning` fields never reach the UI
- add a public `StreamChunk` type plus regression coverage for ignored reasoning tokens in chat rendering and worker completion semantics
- improve local model resolution to fall back to runnable configured candidates in non-strict mode while keeping strict local-only execution authoritative
- align local execution, health, and catalog tests with the resolved model actually used for `call_local` and `stream_local`

## Testing
- `pytest -v guardian/tests/workers/test_chat_worker_completion_semantics.py`
- `pnpm --dir frontend/src exec vitest run features/chat/components/__tests__/Message.execution.test.tsx features/chat/__tests__/useChat.test.ts`
- `pnpm test` failed due to unrelated existing frontend test failures