### PR TITLE
Fix model menu overflow and upward placement in chat composer

### DIFF
--- a/frontend/src/components/ui/__tests__/dropdown-menu.portal.test.tsx
+++ b/frontend/src/components/ui/__tests__/dropdown-menu.portal.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   DropdownMenu,
@@ -8,7 +8,50 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
+const originalGetBoundingClientRect = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  "getBoundingClientRect"
+);
+const originalInnerWidth = Object.getOwnPropertyDescriptor(window, "innerWidth");
+const originalInnerHeight = Object.getOwnPropertyDescriptor(window, "innerHeight");
+
+function rect(top: number, left: number, width: number, height: number): DOMRect {
+  return {
+    x: left,
+    y: top,
+    top,
+    left,
+    width,
+    height,
+    bottom: top + height,
+    right: left + width,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
 describe("DropdownMenu", () => {
+  afterEach(() => {
+    if (originalGetBoundingClientRect) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        "getBoundingClientRect",
+        originalGetBoundingClientRect
+      );
+    } else {
+      delete (HTMLElement.prototype as Record<string, unknown>).getBoundingClientRect;
+    }
+    if (originalInnerWidth) {
+      Object.defineProperty(window, "innerWidth", originalInnerWidth);
+    } else {
+      delete (window as Record<string, unknown>).innerWidth;
+    }
+    if (originalInnerHeight) {
+      Object.defineProperty(window, "innerHeight", originalInnerHeight);
+    } else {
+      delete (window as Record<string, unknown>).innerHeight;
+    }
+  });
+
   it("portals menu content outside overflow-clipped containers", () => {
     const { container } = render(
       <div data-testid="clipper" style={{ overflow: "hidden", width: 120, height: 40 }}>
@@ -32,5 +75,51 @@ describe("DropdownMenu", () => {
     expect(container.contains(menu)).toBe(false);
     expect(menu).toHaveStyle({ width: "max-content" });
     expect(menu.className).toContain("max-w-[min(32rem,calc(100vw-24px))]");
+  });
+
+  it("prefers top placement when the viewport is constrained below the trigger", () => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1280,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 720,
+    });
+    Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
+      configurable: true,
+      value: function getBoundingClientRect() {
+        if (this.getAttribute?.("role") === "menu") {
+          return rect(0, 0, 240, 480);
+        }
+        if (this.getAttribute?.("data-ddm-root") !== null) {
+          return rect(580, 40, 180, 32);
+        }
+        return rect(0, 0, 180, 32);
+      },
+    });
+
+    render(
+      <div data-testid="clipper" style={{ overflow: "hidden", width: 120, height: 40 }}>
+        <DropdownMenu>
+          <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+          <DropdownMenuContent side="top" collisionPadding={12} sideOffset={10}>
+            <DropdownMenuItem>Choice A</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+
+    const menu = screen.getByRole("menu");
+    const clipper = screen.getByTestId("clipper");
+
+    expect(menu).toHaveAttribute("data-side", "top");
+    expect(menu.style.getPropertyValue("--dropdown-menu-available-height")).toBe(
+      "558px"
+    );
+    expect(document.body.contains(menu)).toBe(true);
+    expect(clipper.contains(menu)).toBe(false);
   });
 });

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -127,6 +127,8 @@ type Placement = {
   left: number;
   top: number;
   triggerWidth: number;
+  side: "top" | "bottom";
+  availableHeight: number;
   visibility: React.CSSProperties["visibility"];
 };
 
@@ -143,21 +145,36 @@ function resolvePlacement(
   const viewportWidth = window.innerWidth;
   const viewportHeight = window.innerHeight;
   const { side, align, sideOffset, collisionPadding } = options;
+  const availableHeightAbove = Math.max(
+    0,
+    rootRect.top - collisionPadding - sideOffset
+  );
+  const availableHeightBelow = Math.max(
+    0,
+    viewportHeight - rootRect.bottom - collisionPadding - sideOffset
+  );
 
-  const fitsBelow =
-    rootRect.bottom + sideOffset + contentRect.height <=
-    viewportHeight - collisionPadding;
-  const fitsAbove =
-    rootRect.top - sideOffset - contentRect.height >= collisionPadding;
+  const fitsBelow = contentRect.height <= availableHeightBelow;
+  const fitsAbove = contentRect.height <= availableHeightAbove;
 
   const resolvedSide =
     side === "top"
-      ? fitsAbove || !fitsBelow
+      ? fitsAbove
         ? "top"
-        : "bottom"
-      : fitsBelow || !fitsAbove
+        : fitsBelow
+          ? "bottom"
+          : availableHeightAbove >= availableHeightBelow
+            ? "top"
+            : "bottom"
+      : fitsBelow
         ? "bottom"
-        : "top";
+        : fitsAbove
+          ? "top"
+          : availableHeightBelow >= availableHeightAbove
+            ? "bottom"
+            : "top";
+  const availableHeight =
+    resolvedSide === "top" ? availableHeightAbove : availableHeightBelow;
 
   let left =
     align === "end"
@@ -177,7 +194,13 @@ function resolvePlacement(
     Math.max(collisionPadding, viewportHeight - contentRect.height - collisionPadding)
   );
 
-  return { left, top, visibility: "visible" };
+  return {
+    left,
+    top,
+    side: resolvedSide,
+    availableHeight,
+    visibility: "visible",
+  };
 }
 
 export const DropdownMenuContent = ({
@@ -196,6 +219,8 @@ export const DropdownMenuContent = ({
     left: 0,
     top: 0,
     triggerWidth: 0,
+    side,
+    availableHeight: 0,
     visibility: "hidden",
   });
 
@@ -212,8 +237,8 @@ export const DropdownMenuContent = ({
     if (!root || !content) return;
     const rootRect = root.getBoundingClientRect();
     const contentRect = content.getBoundingClientRect();
-    setPlacement(
-      {
+    setPlacement((previous) => {
+      const nextPlacement = {
         ...resolvePlacement(rootRect, contentRect, {
           side,
           align,
@@ -221,8 +246,16 @@ export const DropdownMenuContent = ({
           collisionPadding: resolvedCollisionPadding,
         }),
         triggerWidth: rootRect.width,
-      }
-    );
+      };
+      return previous.left === nextPlacement.left
+        && previous.top === nextPlacement.top
+        && previous.triggerWidth === nextPlacement.triggerWidth
+        && previous.side === nextPlacement.side
+        && previous.availableHeight === nextPlacement.availableHeight
+        && previous.visibility === nextPlacement.visibility
+        ? previous
+        : nextPlacement;
+    });
   }, [align, ctx.rootRef, resolvedCollisionPadding, resolvedOffset, side]);
 
   React.useLayoutEffect(() => {
@@ -231,11 +264,23 @@ export const DropdownMenuContent = ({
 
     const handleResize = () => updatePlacement();
     const handleScroll = () => updatePlacement();
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(() => updatePlacement())
+        : null;
+
+    if (ctx.rootRef.current) {
+      resizeObserver?.observe(ctx.rootRef.current);
+    }
+    if (contentRef.current) {
+      resizeObserver?.observe(contentRef.current);
+    }
 
     window.addEventListener("resize", handleResize);
     window.addEventListener("scroll", handleScroll, true);
 
     return () => {
+      resizeObserver?.disconnect();
       window.removeEventListener("resize", handleResize);
       window.removeEventListener("scroll", handleScroll, true);
     };
@@ -275,6 +320,7 @@ export const DropdownMenuContent = ({
     <div
       ref={contentRef}
       data-ddm-root
+      data-side={placement.side}
       role="menu"
       className={
         "inline-flex min-w-40 max-w-[min(32rem,calc(100vw-24px))] flex-col rounded-md border bg-[var(--panel-bg)] p-1 shadow-lg " +
@@ -287,6 +333,7 @@ export const DropdownMenuContent = ({
         top: placement.top,
         width: "max-content",
         ["--dropdown-menu-trigger-width" as string]: `${placement.triggerWidth}px`,
+        ["--dropdown-menu-available-height" as string]: `${placement.availableHeight}px`,
         visibility: placement.visibility,
         ...style,
       }}

--- a/frontend/src/features/chat/components/ComposerSelectMenu.tsx
+++ b/frontend/src/features/chat/components/ComposerSelectMenu.tsx
@@ -33,6 +33,11 @@ type ComposerSelectMenuProps = {
   onSelect: (value: string) => void;
 };
 
+const COMPOSER_SELECT_MENU_COLLISION_PADDING = 12;
+const COMPOSER_SELECT_MENU_SIDE_OFFSET = 10;
+const COMPOSER_SELECT_MENU_MAX_HEIGHT = "24rem";
+const COMPOSER_SELECT_MENU_VIEWPORT_MAX_HEIGHT = `min(${COMPOSER_SELECT_MENU_MAX_HEIGHT}, var(--dropdown-menu-available-height, calc(100vh - ${COMPOSER_SELECT_MENU_COLLISION_PADDING * 2}px)))`;
+
 export function ComposerSelectMenu({
   ariaLabel,
   menuLabel,
@@ -213,14 +218,15 @@ export function ComposerSelectMenu({
       <DropdownMenuContent
         side="top"
         align="start"
-        sideOffset={10}
-        collisionPadding={12}
+        sideOffset={COMPOSER_SELECT_MENU_SIDE_OFFSET}
+        collisionPadding={COMPOSER_SELECT_MENU_COLLISION_PADDING}
         aria-label={menuLabel}
-        className="overflow-hidden rounded-[var(--card-radius,19px)] border p-0 shadow-xl"
+        className="flex min-h-0 flex-col overflow-hidden rounded-[var(--card-radius,19px)] border p-0 shadow-xl"
         onKeyDown={handleMenuKeyDown}
         style={{
           minWidth: "max(var(--dropdown-menu-trigger-width, 0px), 11.5rem)",
           maxWidth: "min(20rem, calc(100vw - 24px))",
+          maxHeight: COMPOSER_SELECT_MENU_VIEWPORT_MAX_HEIGHT,
           borderColor: "color-mix(in oklab, var(--panel-border) 84%, var(--text) 16%)",
           background: menuSurface,
           boxShadow:
@@ -229,7 +235,7 @@ export function ComposerSelectMenu({
         }}
       >
         <div
-          className="w-full px-3 py-2 text-center text-[10px] font-medium uppercase tracking-[0.12em] leading-none"
+          className="w-full shrink-0 px-3 py-2 text-center text-[10px] font-medium uppercase tracking-[0.12em] leading-none"
           style={{ color: "var(--muted)" }}
         >
           {menuLabel}
@@ -238,7 +244,7 @@ export function ComposerSelectMenu({
           <div
             ref={scrollRegionRef}
             data-composer-select-scroll-region="true"
-            className="max-h-64 overflow-y-auto overscroll-contain pb-1"
+            className="min-h-0 flex-1 overflow-y-auto overscroll-contain pb-1"
           >
             {options.map((option, index) => {
               const selected = option.value === selectedValue;

--- a/frontend/src/features/chat/components/__tests__/ComposerSelectMenu.test.tsx
+++ b/frontend/src/features/chat/components/__tests__/ComposerSelectMenu.test.tsx
@@ -26,6 +26,12 @@ const originalScrollTo = Object.getOwnPropertyDescriptor(
   HTMLElement.prototype,
   "scrollTo"
 );
+const originalGetBoundingClientRect = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  "getBoundingClientRect"
+);
+const originalInnerWidth = Object.getOwnPropertyDescriptor(window, "innerWidth");
+const originalInnerHeight = Object.getOwnPropertyDescriptor(window, "innerHeight");
 
 function restoreDescriptor(
   key:
@@ -33,7 +39,8 @@ function restoreDescriptor(
     | "offsetHeight"
     | "clientHeight"
     | "scrollHeight"
-    | "scrollTo",
+    | "scrollTo"
+    | "getBoundingClientRect",
   descriptor?: PropertyDescriptor
 ) {
   if (descriptor) {
@@ -41,6 +48,20 @@ function restoreDescriptor(
     return;
   }
   delete (HTMLElement.prototype as Record<string, unknown>)[key];
+}
+
+function rect(top: number, left: number, width: number, height: number): DOMRect {
+  return {
+    x: left,
+    y: top,
+    top,
+    left,
+    width,
+    height,
+    bottom: top + height,
+    right: left + width,
+    toJSON: () => ({}),
+  } as DOMRect;
 }
 
 describe("ComposerSelectMenu", () => {
@@ -99,23 +120,34 @@ describe("ComposerSelectMenu", () => {
     restoreDescriptor("clientHeight", originalClientHeight);
     restoreDescriptor("scrollHeight", originalScrollHeight);
     restoreDescriptor("scrollTo", originalScrollTo);
+    restoreDescriptor("getBoundingClientRect", originalGetBoundingClientRect);
+    if (originalInnerWidth) {
+      Object.defineProperty(window, "innerWidth", originalInnerWidth);
+    } else {
+      delete (window as Record<string, unknown>).innerWidth;
+    }
+    if (originalInnerHeight) {
+      Object.defineProperty(window, "innerHeight", originalInnerHeight);
+    } else {
+      delete (window as Record<string, unknown>).innerHeight;
+    }
     scrollToMock.mockReset();
   });
 
   it("centers the selected option on open and keeps keyboard navigation in view", async () => {
     const onSelect = vi.fn();
-
-    render(
+    const options = Array.from({ length: 12 }, (_, index) => ({
+      value: `model-${index}`,
+      label: `Model ${index}`,
+      meta: `${index + 1}k`,
+    }));
+    const { rerender } = render(
       <ComposerSelectMenu
         ariaLabel="Select model"
         menuLabel="Model"
         valueLabel="Model 8"
         selectedValue="model-8"
-        options={Array.from({ length: 12 }, (_, index) => ({
-          value: `model-${index}`,
-          label: `Model ${index}`,
-          meta: `${index + 1}k`,
-        }))}
+        options={options}
         onSelect={onSelect}
       />
     );
@@ -141,5 +173,88 @@ describe("ComposerSelectMenu", () => {
 
     fireEvent.keyDown(menu, { key: "Enter" });
     expect(onSelect).toHaveBeenCalledWith("model-9");
+
+    rerender(
+      <ComposerSelectMenu
+        ariaLabel="Select model"
+        menuLabel="Model"
+        valueLabel="Model 9"
+        selectedValue="model-9"
+        options={options}
+        onSelect={onSelect}
+      />
+    );
+
+    scrollToMock.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: "Select model" }));
+
+    await screen.findByRole("menu", { name: "Model" });
+    await waitFor(() => {
+      expect(scrollToMock).toHaveBeenCalledWith({
+        behavior: "auto",
+        top: 240,
+      });
+    });
+    expect(screen.getByRole("menuitem", { name: /Model 9/i })).toHaveAttribute(
+      "data-selected",
+      "true"
+    );
+  });
+
+  it("keeps the menu bounded to the viewport and scrollable when opening upward", async () => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1280,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 720,
+    });
+    Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
+      configurable: true,
+      value: function getBoundingClientRect() {
+        if (this.getAttribute?.("role") === "menu") {
+          return rect(0, 0, 240, 640);
+        }
+        if (this.getAttribute?.("data-ddm-root") !== null) {
+          return rect(580, 32, 180, 32);
+        }
+        return rect(0, 0, 180, ITEM_HEIGHT);
+      },
+    });
+
+    render(
+      <ComposerSelectMenu
+        ariaLabel="Select model"
+        menuLabel="Model"
+        valueLabel="Model 2"
+        selectedValue="model-2"
+        options={Array.from({ length: 18 }, (_, index) => ({
+          value: `model-${index}`,
+          label: `Model ${index}`,
+          meta: `${index + 1}k`,
+        }))}
+        onSelect={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Select model" }));
+
+    const menu = await screen.findByRole("menu", { name: "Model" });
+    const scrollRegion = menu.querySelector(
+      '[data-composer-select-scroll-region="true"]'
+    );
+
+    expect(menu).toHaveAttribute("data-side", "top");
+    expect(menu.style.getPropertyValue("--dropdown-menu-available-height")).toBe(
+      "558px"
+    );
+    expect(menu.style.maxHeight).toBe(
+      "min(24rem, var(--dropdown-menu-available-height, calc(100vh - 24px)))"
+    );
+    expect(scrollRegion).not.toBeNull();
+    expect(scrollRegion).toHaveClass("min-h-0");
+    expect(scrollRegion).toHaveClass("flex-1");
+    expect(scrollRegion).toHaveClass("overflow-y-auto");
   });
 });


### PR DESCRIPTION
## Summary
- update the shared dropdown primitive to expose resolved side and available viewport height for collision-aware placement
- constrain the composer model menu to a bounded max height and keep the options list scrolling internally instead of expanding past the chat surface
- preserve reopening behavior by keeping the selected item focused and scrolled into view
- add regression tests for portal rendering outside clipped containers, top-side placement under constrained space, bounded height, and internal scroll behavior

## Testing
- `pnpm --dir frontend/src exec vitest run components/ui/__tests__/dropdown-menu.portal.test.tsx features/chat/components/__tests__/ComposerSelectMenu.test.tsx`
- `pnpm test`