### PR TITLE
Add source selector retrieval boundary controls and harden fallback behavior

### DIFF
--- a/frontend/src/features/chat/components/Composer.tsx
+++ b/frontend/src/features/chat/components/Composer.tsx
@@ -817,7 +817,7 @@ export function Composer({
               <ComposerSelectMenu
                 ariaLabel="Select retrieval source"
                 menuLabel="Source"
-                valueLabel={`Source: ${sourceLabel}`}
+                valueLabel={`${sourceLabel}`}
                 options={sourceOptions}
                 selectedValue={sourceMode}
                 disabled={draftControlsDisabled || sourceOptions.length === 0}

--- a/frontend/src/features/chat/components/__tests__/Composer.source-selector.test.tsx
+++ b/frontend/src/features/chat/components/__tests__/Composer.source-selector.test.tsx
@@ -61,7 +61,7 @@ describe("Composer source selector", () => {
 
     expect(
       screen.getByRole("button", { name: "Select retrieval source" })
-    ).toHaveTextContent("Source: Project");
+    ).toHaveTextContent("Project");
   });
 
   it("shows only Project and Personal Knowledge with the exact descriptions", async () => {
@@ -82,8 +82,8 @@ describe("Composer source selector", () => {
 
     const options = await screen.findAllByRole("menuitem");
     expect(options).toHaveLength(2);
-    expect(screen.getByText("Project")).toBeInTheDocument();
-    expect(screen.getByText("Personal Knowledge")).toBeInTheDocument();
+    expect(options[0]).toHaveTextContent("Project");
+    expect(options[1]).toHaveTextContent("Personal Knowledge");
     expect(
       screen.getByText(
         "Current thread first, then this project if more context is needed."
@@ -125,7 +125,7 @@ describe("Composer source selector", () => {
 
     expect(
       screen.getByRole("button", { name: "Select retrieval source" })
-    ).toHaveTextContent("Source: Personal Knowledge");
+    ).toHaveTextContent("Personal Knowledge");
 
     fireEvent.change(screen.getByPlaceholderText("Write a message…"), {
       target: { value: "Test retrieval source" },
@@ -139,6 +139,6 @@ describe("Composer source selector", () => {
     });
     expect(
       screen.getByRole("button", { name: "Select retrieval source" })
-    ).toHaveTextContent("Source: Personal Knowledge");
+    ).toHaveTextContent("Personal Knowledge");
   });
 });


### PR DESCRIPTION
## Summary
- add a persistent `Source` selector in chat with `Project` and `Personal Knowledge` options
- pass `source_mode` through the chat completion path and expose it in the completion response
- enforce source-aware broker widening with same-user-only boundaries and stable `widen_reason` diagnostics
- harden the temporary `origin` bridge with focused fallback coverage and document the supported proof scope

## Testing
- `pytest -v tests/routes/test_chat_source_mode.py tests/core/test_chat_completion_service_source_mode_fallback.py tests/core/test_context_broker_source_mode.py`
- `pnpm --dir frontend/src exec vitest run features/chat/components/__tests__/Composer.source-selector.test.tsx`