### PR TITLE
fix(chat): replace weak local hit during widening

### DIFF
--- a/guardian/context/broker.py
+++ b/guardian/context/broker.py
@@ -762,7 +762,7 @@ class ContextBroker:
             and target_count > 0
             and len(limited_hits) >= target_count
         ):
-            preserve_count = max(target_count - 1, 1)
+            preserve_count = max(target_count - 1, 0)
             return limited_hits[:preserve_count]
         return limited_hits[:target_count]
 

--- a/tests/core/test_context_broker_source_mode.py
+++ b/tests/core/test_context_broker_source_mode.py
@@ -199,7 +199,7 @@ async def test_low_confidence_thread_hits_trigger_project_widening(
 
     mock_vector_store.search = MagicMock(side_effect=_search)
 
-    _context, trace = await context_broker.assemble(
+    context, trace = await context_broker.assemble(
         thread_id=1,
         query="status",
         depth_mode="normal",
@@ -207,6 +207,9 @@ async def test_low_confidence_thread_hits_trigger_project_widening(
         source_mode="project",
     )
 
+    assert [item["text"] for item in context["semantic"]] == [
+        "project sibling hit"
+    ]
     assert trace["source_mode"] == "project"
     assert trace["widen_reason"] == "low_confidence_thread_hits"
     assert _namespaces(mock_vector_store) == ["thread:1", "thread:2"]


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
