### PR TITLE
fix(chat): disable rich code rendering for user messages

### DIFF
--- a/frontend/src/features/chat/components/ChatBubble.tsx
+++ b/frontend/src/features/chat/components/ChatBubble.tsx
@@ -82,9 +82,7 @@ const parseAttachments = (content: string) => {
     }
   }
 
-  const text = content
-    .replace(/<!--\s*(cfy-media(?:-src|-name)?):([^>]*?)\s*-->/gi, "")
-    .trim();
+  const text = content.replace(/<!--\s*(cfy-media(?:-src|-name)?):([^>]*?)\s*-->/gi, "");
   return { attachments, text };
 };
 
@@ -360,8 +358,9 @@ export function ChatBubble({
   const { attachments: contentAttachments, text } = parseAttachments(message.content || "");
   const attachments = mergeAttachments(message.attachments, contentAttachments);
   const cleanedContent = text;
+  const assistantContent = cleanedContent.trim();
   const hasAttachments = attachments.length > 0;
-  const hasText = Boolean(cleanedContent.trim());
+  const hasText = Boolean(assistantContent);
   const formattedTime = fmtTime(message.createdAt);
   const execution = message.execution;
   const executionBadgeLabel =
@@ -448,10 +447,33 @@ export function ChatBubble({
     ),
   };
 
-  const renderedMarkdown = hasText ? (
-    <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
-      {cleanedContent}
-    </ReactMarkdown>
+  const renderedContent = hasText ? (
+    isGuardian ? (
+      <div
+        className="text-sm leading-relaxed prose prose-sm max-w-none break-words dark:prose-invert"
+        style={{
+          color: "var(--text)",
+          overflowWrap: "break-word",
+          wordWrap: "break-word",
+        }}
+      >
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+          {assistantContent}
+        </ReactMarkdown>
+      </div>
+    ) : (
+      // User messages stay as plaintext so pasted code keeps raw line breaks and spacing.
+      <div
+        className="text-sm leading-relaxed whitespace-pre-wrap break-words"
+        style={{
+          color: "var(--pill-active-text)",
+          overflowWrap: "break-word",
+          wordWrap: "break-word",
+        }}
+      >
+        {cleanedContent}
+      </div>
+    )
   ) : null;
 
   if (isGuardian) {
@@ -471,18 +493,7 @@ export function ChatBubble({
         {hasAttachments ? (
           <AttachmentTiles attachments={attachments} align="left" />
         ) : null}
-        {hasText ? (
-          <div
-            className="text-sm leading-relaxed prose prose-sm max-w-none break-words dark:prose-invert"
-            style={{
-              color: "var(--text)",
-              overflowWrap: "break-word",
-              wordWrap: "break-word",
-            }}
-          >
-            {renderedMarkdown}
-          </div>
-        ) : null}
+        {renderedContent}
         <div className="mt-1.5 flex items-center gap-2">
           {executionBadgeLabel ? (
             <span
@@ -542,9 +553,7 @@ export function ChatBubble({
           className="max-w-full rounded-[var(--tile-radius)] p-3 shadow-sm"
           style={{ background: "var(--accent)", color: "var(--pill-active-text)" }}
         >
-          <div className="text-sm leading-relaxed prose prose-sm max-w-none break-words dark:prose-invert">
-            {renderedMarkdown}
-          </div>
+          {renderedContent}
           {formattedTime ? (
             <div className="mt-1.5 flex items-center justify-end gap-2">
               <span className="text-[10px] opacity-70">{formattedTime}</span>

--- a/frontend/src/features/chat/components/__tests__/ChatBubble.test.tsx
+++ b/frontend/src/features/chat/components/__tests__/ChatBubble.test.tsx
@@ -55,14 +55,14 @@ describe("ChatBubble", () => {
     );
   });
 
-  it("renders markdown images from relative /media sources", () => {
+  it("renders assistant markdown images from relative /media sources", () => {
     render(
       <ChatBubble
-        isGuardian={false}
+        isGuardian
         message={{
           id: "msg-3",
-          authorId: "me",
-          authorName: "You",
+          authorId: "bot",
+          authorName: "Guardian",
           content: "![Chat image](/media/images/chat-inline.jpg?sig=inline#viewer)",
           createdAt: Date.now(),
         }}
@@ -75,14 +75,14 @@ describe("ChatBubble", () => {
     );
   });
 
-  it("renders markdown images from relative media sources without a leading slash", () => {
+  it("renders assistant markdown images from relative media sources without a leading slash", () => {
     render(
       <ChatBubble
-        isGuardian={false}
+        isGuardian
         message={{
           id: "msg-4",
-          authorId: "me",
-          authorName: "You",
+          authorId: "bot",
+          authorName: "Guardian",
           content: "![Relative chat image](media/images/chat-inline-2.jpg?sig=inline2#viewer)",
           createdAt: Date.now(),
         }}
@@ -95,14 +95,14 @@ describe("ChatBubble", () => {
     );
   });
 
-  it("leaves external markdown image URLs untouched", () => {
+  it("leaves external assistant markdown image URLs untouched", () => {
     render(
       <ChatBubble
-        isGuardian={false}
+        isGuardian
         message={{
           id: "msg-5",
-          authorId: "me",
-          authorName: "You",
+          authorId: "bot",
+          authorName: "Guardian",
           content: "![External image](https://cdn.example.com/image.jpg?x=1#hero)",
           createdAt: Date.now(),
         }}
@@ -113,5 +113,47 @@ describe("ChatBubble", () => {
       "src",
       "https://cdn.example.com/image.jpg?x=1#hero"
     );
+  });
+
+  it("renders assistant fenced code blocks with rich code UI", () => {
+    render(
+      <ChatBubble
+        isGuardian
+        message={{
+          id: "msg-6",
+          authorId: "bot",
+          authorName: "Guardian",
+          content: "```ts\nconst total = 1;\n```",
+          createdAt: Date.now(),
+        }}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+    expect(screen.getByText("TS")).toBeInTheDocument();
+    expect(screen.getByText("const total = 1;")).toBeInTheDocument();
+  });
+
+  it("renders user multiline code as plaintext without copy affordances", () => {
+    const pastedCode = "function demo() {\n  const total = 1;\n  return total;\n}";
+
+    const { container } = render(
+      <ChatBubble
+        isGuardian={false}
+        message={{
+          id: "msg-7",
+          authorId: "me",
+          authorName: "You",
+          content: pastedCode,
+          createdAt: Date.now(),
+        }}
+      />
+    );
+
+    const plainText = container.querySelector(".whitespace-pre-wrap");
+    expect(plainText).not.toBeNull();
+    expect(plainText?.textContent).toBe(pastedCode);
+    expect(screen.queryByRole("button", { name: "Copy" })).not.toBeInTheDocument();
+    expect(container.querySelector(".codexifyCodeBlock")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
