### PR TITLE
Add per-thread workspace posture presets

### DIFF
--- a/frontend/src/components/persona/layout/AppShell.tsx
+++ b/frontend/src/components/persona/layout/AppShell.tsx
@@ -1610,8 +1610,10 @@ export default function AppShell({
     layoutMode: workspaceLayoutMode,
     isWorkspaceDominant,
     ratioBucket: workspaceRatioBucket,
+    setLayoutMode: setWorkspaceLayoutMode,
   } = useWorkspaceLayoutMode({
     isOpen: workspaceDrawerOpen,
+    activeThreadId: activeRouteThreadId,
   });
   const handleWorkspaceDrawerTabChange = useCallback(
     (tab: WorkspaceDrawerTab) => {
@@ -1867,6 +1869,7 @@ export default function AppShell({
           closeWorkspaceDrawer();
         }}
         onActiveTabChange={handleWorkspaceDrawerTabChange}
+        onLayoutModeChange={setWorkspaceLayoutMode}
       />
     </div>
   ) : null;

--- a/frontend/src/components/persona/layout/__tests__/AppShell.test.tsx
+++ b/frontend/src/components/persona/layout/__tests__/AppShell.test.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
   act,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 
@@ -16,10 +17,10 @@ import {
   RUNTIME_HEALTH_STATUSES,
 } from "@/contracts/runtimeTokens";
 import {
-  DEFAULT_WORKSPACE_PANE_RATIO,
-  MAX_WORKSPACE_PANE_RATIO,
   MIN_WORKSPACE_PRIMARY_PANE_WIDTH,
-  WORKSPACE_LAYOUT_STORAGE_KEY,
+  getWorkspaceLayoutStorageKeyForThread,
+  getWorkspacePaneRatioForLayoutMode,
+  type WorkspaceLayoutMode,
 } from "@/features/workspace/state/useWorkspaceLayoutMode";
 
 const runtimeHealthState = {
@@ -250,10 +251,25 @@ function renderWordmark(themeMode: "light" | "dark") {
   return screen.findByRole("button", { name: "Codexify" });
 }
 
-function setWorkspaceLayoutState(paneRatio: number) {
+function setRoutePath(pathname: string) {
+  window.history.pushState({}, "", pathname);
+}
+
+function setRouteThread(threadId: number | null) {
+  setRoutePath(threadId == null ? "/dashboard" : `/chat/${threadId}`);
+}
+
+function notifyRouteChange() {
+  window.dispatchEvent(new PopStateEvent("popstate"));
+}
+
+function setWorkspaceThreadPosture(
+  threadId: number | string | null,
+  layoutMode: WorkspaceLayoutMode
+) {
   window.localStorage.setItem(
-    WORKSPACE_LAYOUT_STORAGE_KEY,
-    JSON.stringify({ paneRatio })
+    getWorkspaceLayoutStorageKeyForThread(threadId),
+    layoutMode
   );
 }
 
@@ -267,6 +283,7 @@ describe("AppShell logo wordmark color contract", () => {
     uploaderState.configs = [];
     installMatchMedia(false);
     document.documentElement.classList.remove("dark");
+    setRouteThread(null);
     routeCapabilityState.ready = true;
     routeCapabilityState.state = "available";
     listCodexEntriesSpy.mockClear();
@@ -333,6 +350,7 @@ describe("AppShell dashboard create project flow", () => {
     uploaderState.configs = [];
     installMatchMedia(false);
     document.documentElement.classList.remove("dark");
+    setRouteThread(null);
     localStorage.setItem("cfy.lastView", "dashboard");
     routeCapabilityState.ready = true;
     routeCapabilityState.state = "available";
@@ -383,6 +401,7 @@ describe("AppShell shared gallery persistence truth", () => {
     uploaderState.configs = [];
     installMatchMedia(false);
     document.documentElement.classList.remove("dark");
+    setRouteThread(null);
     routeCapabilityState.ready = true;
     routeCapabilityState.state = "available";
     listCodexEntriesSpy.mockClear();
@@ -483,6 +502,7 @@ describe("AppShell gallery demo content", () => {
     uploaderState.configs = [];
     installMatchMedia(false);
     document.documentElement.classList.remove("dark");
+    setRouteThread(null);
     routeCapabilityState.ready = true;
     routeCapabilityState.state = "available";
     listCodexEntriesSpy.mockClear();
@@ -553,6 +573,7 @@ describe("AppShell workspace drawer shell", () => {
     uploaderState.configs = [];
     installMatchMedia(false);
     document.documentElement.classList.remove("dark");
+    setRouteThread(null);
     routeCapabilityState.ready = true;
     routeCapabilityState.state = "available";
     listCodexEntriesSpy.mockClear();
@@ -567,7 +588,7 @@ describe("AppShell workspace drawer shell", () => {
   });
 
   it.each(["dashboard", "guardian", "documents"] as const)(
-    "renders the shared workspace drawer from the shell for %s",
+    "renders the shared workspace drawer from the shell for %s and keeps open/close behavior intact",
     async (initialView) => {
       localStorage.setItem("cfy.lastView", initialView);
 
@@ -579,12 +600,16 @@ describe("AppShell workspace drawer shell", () => {
       fireEvent.click(toggle);
 
       expect(await screen.findByTestId("workspace-drawer")).toBeInTheDocument();
+
+      fireEvent.click(toggle);
+      expect(screen.queryByTestId("workspace-drawer")).not.toBeInTheDocument();
     }
   );
 
   it("resolves supported views to chat_focus while the workspace is closed", () => {
     localStorage.setItem("cfy.lastView", "dashboard");
-    setWorkspaceLayoutState(MAX_WORKSPACE_PANE_RATIO);
+    setRouteThread(101);
+    setWorkspaceThreadPosture(101, "workspace_focus");
 
     render(<AppShell />);
 
@@ -595,62 +620,56 @@ describe("AppShell workspace drawer shell", () => {
     expect(screen.queryByTestId("workspace-drawer")).not.toBeInTheDocument();
   });
 
-  it("uses balanced_split for open workspace layouts at the default ratio", async () => {
+  it("defaults to Chat Focus and cycles the centered posture control through the preset states", async () => {
+    const user = userEvent.setup();
     localStorage.setItem("cfy.lastView", "guardian");
-    setWorkspaceLayoutState(DEFAULT_WORKSPACE_PANE_RATIO);
+    setRouteThread(101);
 
     render(<AppShell />);
 
     fireEvent.click(screen.getByTestId("workspace-drawer-toggle"));
 
     const drawer = await screen.findByTestId("workspace-drawer");
+    const posture = screen.getByTestId("workspace-drawer-posture");
+    const primaryPane = screen.getByTestId("workspace-primary-pane");
+    const drawerPane = screen.getByTestId("workspace-drawer-pane");
+    const chatPrimaryBasis = readPaneBasis(primaryPane);
+    const chatDrawerBasis = readPaneBasis(drawerPane);
+
+    expect(screen.getByTestId("workspace-layout-surface")).toHaveAttribute(
+      "data-workspace-layout-mode",
+      "chat_focus"
+    );
+    expect(drawer).toHaveAttribute("data-layout-mode", "chat_focus");
+    expect(drawer).toHaveAttribute("data-layout-label", "Chat Focus");
+    expect(posture).toHaveTextContent("Chat Focus");
+    expect(primaryPane).toHaveAttribute(
+      "data-pane-min-width",
+      MIN_WORKSPACE_PRIMARY_PANE_WIDTH
+    );
+
+    await user.click(posture);
+
+    expect(posture).toHaveTextContent("Balanced Split");
+    expect(drawer).toHaveAttribute("data-layout-mode", "balanced_split");
+    expect(drawer).toHaveAttribute("data-layout-label", "Balanced Split");
+    expect(drawer).toHaveAttribute(
+      "data-pane-ratio",
+      getWorkspacePaneRatioForLayoutMode("balanced_split").toFixed(2)
+    );
     expect(screen.getByTestId("workspace-layout-surface")).toHaveAttribute(
       "data-workspace-layout-mode",
       "balanced_split"
     );
-    expect(drawer).toHaveAttribute("data-layout-mode", "balanced_split");
-    expect(drawer).toHaveAttribute(
-      "data-pane-ratio",
-      DEFAULT_WORKSPACE_PANE_RATIO.toFixed(2)
-    );
     expect(screen.getByTestId("workspace-drawer-posture")).toHaveTextContent(
-      "Balanced split"
+      "Balanced Split"
     );
-  });
 
-  it("makes workspace_focus visibly more dominant than balanced_split", async () => {
-    localStorage.setItem("cfy.lastView", "guardian");
-    setWorkspaceLayoutState(DEFAULT_WORKSPACE_PANE_RATIO);
+    await user.click(posture);
 
-    const { unmount } = render(<AppShell />);
-
-    fireEvent.click(screen.getByTestId("workspace-drawer-toggle"));
-
-    const balancedPrimaryPane = await screen.findByTestId(
-      "workspace-primary-pane"
-    );
-    const balancedDrawerPane = screen.getByTestId("workspace-drawer-pane");
-    const balancedPrimaryBasis = readPaneBasis(balancedPrimaryPane);
-    const balancedDrawerBasis = readPaneBasis(balancedDrawerPane);
-
-    unmount();
-
-    localStorage.setItem("cfy.lastView", "documents");
-    localStorage.setItem(
-      "cfy.workspace.ui",
-      JSON.stringify({ isOpen: true, activeTab: "inspector" })
-    );
-    setWorkspaceLayoutState(0.95);
-
-    render(<AppShell />);
-
-    const focusPrimaryPane = screen.getByTestId("workspace-primary-pane");
-    const focusDrawerPane = screen.getByTestId("workspace-drawer-pane");
-    const drawer = screen.getByTestId("workspace-drawer");
-    expect(screen.getByTestId("workspace-layout-surface")).toHaveAttribute(
-      "data-workspace-layout-mode",
-      "workspace_focus"
-    );
+    expect(posture).toHaveTextContent("Workspace Focus");
+    expect(drawer).toHaveAttribute("data-layout-mode", "workspace_focus");
+    expect(drawer).toHaveAttribute("data-layout-label", "Workspace Focus");
     expect(screen.getByTestId("workspace-layout-surface")).toHaveAttribute(
       "data-workspace-dominant",
       "true"
@@ -659,40 +678,86 @@ describe("AppShell workspace drawer shell", () => {
       "data-workspace-ratio-bucket",
       "workspace_first"
     );
-    expect(drawer).toHaveAttribute("data-layout-mode", "workspace_focus");
     expect(drawer).toHaveAttribute(
       "data-pane-ratio",
-      MAX_WORKSPACE_PANE_RATIO.toFixed(2)
+      getWorkspacePaneRatioForLayoutMode("workspace_focus").toFixed(2)
     );
-    expect(screen.getByTestId("workspace-drawer-posture")).toHaveTextContent(
-      "Workspace focus"
-    );
-    expect(readPaneBasis(focusDrawerPane)).toBeGreaterThan(balancedDrawerBasis);
-    expect(readPaneBasis(focusPrimaryPane)).toBeLessThan(balancedPrimaryBasis);
-  });
-
-  it("keeps the chat lane at a readable minimum width in workspace_focus", () => {
-    localStorage.setItem("cfy.lastView", "guardian");
-    localStorage.setItem(
-      "cfy.workspace.ui",
-      JSON.stringify({ isOpen: true, activeTab: "scratchpad" })
-    );
-    setWorkspaceLayoutState(MAX_WORKSPACE_PANE_RATIO);
-
-    render(<AppShell />);
-
-    expect(screen.getByTestId("workspace-primary-pane")).toHaveAttribute(
+    expect(readPaneBasis(drawerPane)).toBeGreaterThan(chatDrawerBasis);
+    expect(readPaneBasis(primaryPane)).toBeLessThan(chatPrimaryBasis);
+    expect(primaryPane).toHaveAttribute(
       "data-pane-min-width",
       MIN_WORKSPACE_PRIMARY_PANE_WIDTH
     );
+
+    await user.dblClick(posture);
+
+    expect(posture).toHaveTextContent("Chat Focus");
+    expect(drawer).toHaveAttribute("data-layout-mode", "chat_focus");
+    expect(drawer).toHaveAttribute("data-layout-label", "Chat Focus");
+    expect(screen.getByTestId("workspace-layout-surface")).toHaveAttribute(
+      "data-workspace-layout-mode",
+      "chat_focus"
+    );
+  });
+
+  it("persists posture per thread and restores the saved posture when switching routes", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem("cfy.lastView", "guardian");
+    setRouteThread(101);
+
+    render(<AppShell />);
+
+    fireEvent.click(screen.getByTestId("workspace-drawer-toggle"));
+
+    const drawer = await screen.findByTestId("workspace-drawer");
+    const posture = screen.getByTestId("workspace-drawer-posture");
+
+    await user.click(posture);
+    await user.click(posture);
+
+    expect(
+      localStorage.getItem(getWorkspaceLayoutStorageKeyForThread(101))
+    ).toBe("workspace_focus");
+
+    act(() => {
+      setRouteThread(202);
+      notifyRouteChange();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workspace-drawer")).toHaveAttribute(
+        "data-layout-mode",
+        "chat_focus"
+      );
+      expect(screen.getByTestId("workspace-drawer-posture")).toHaveTextContent(
+        "Chat Focus"
+      );
+    });
+
+    await user.click(screen.getByTestId("workspace-drawer-posture"));
+    expect(
+      localStorage.getItem(getWorkspaceLayoutStorageKeyForThread(202))
+    ).toBe("balanced_split");
+
+    act(() => {
+      setRouteThread(101);
+      notifyRouteChange();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workspace-drawer")).toHaveAttribute(
+        "data-layout-mode",
+        "workspace_focus"
+      );
+      expect(screen.getByTestId("workspace-drawer-posture")).toHaveTextContent(
+        "Workspace Focus"
+      );
+    });
   });
 
   it("does not render the workspace drawer for unsupported views", () => {
     localStorage.setItem("cfy.lastView", "gallery");
-    localStorage.setItem(
-      "cfy.workspace.ui",
-      JSON.stringify({ isOpen: true, activeTab: "inspector" })
-    );
+    setRouteThread(null);
 
     render(<AppShell />);
 

--- a/frontend/src/features/workspace/__tests__/WorkspaceDrawer.test.tsx
+++ b/frontend/src/features/workspace/__tests__/WorkspaceDrawer.test.tsx
@@ -7,13 +7,15 @@ import WorkspaceDrawer from "../components/WorkspaceDrawer";
 import { useWorkspaceUiState } from "../state/useWorkspaceUiState";
 import {
   BALANCED_SPLIT_MIN_RATIO,
-  DEFAULT_WORKSPACE_PANE_RATIO,
+  BALANCED_SPLIT_WORKSPACE_PANE_RATIO,
   MAX_WORKSPACE_PANE_RATIO,
   MIN_WORKSPACE_PANE_RATIO,
   WORKSPACE_FOCUS_MIN_RATIO,
   clampWorkspacePaneRatio,
   deriveWorkspaceLayoutMode,
+  getNextWorkspaceLayoutMode,
   getWorkspaceLayoutRatioBucket,
+  getWorkspacePaneRatioForLayoutMode,
   type WorkspaceLayoutMode,
 } from "../state/useWorkspaceLayoutMode";
 
@@ -47,29 +49,37 @@ function WorkspaceDrawerHarness({
   routeContext,
   activeThreadId = null,
   onMoveScratchpadToComposer,
-  layoutMode = "balanced_split",
-  paneRatio = DEFAULT_WORKSPACE_PANE_RATIO,
+  initialLayoutMode = "chat_focus",
   minPaneRatio = MIN_WORKSPACE_PANE_RATIO,
   maxPaneRatio = MAX_WORKSPACE_PANE_RATIO,
 }: {
   routeContext: WorkspaceHarnessRoute;
   activeThreadId?: string | number | null;
   onMoveScratchpadToComposer?: (text: string) => void;
-  layoutMode?: WorkspaceLayoutMode;
-  paneRatio?: number;
+  initialLayoutMode?: WorkspaceLayoutMode;
   minPaneRatio?: number;
   maxPaneRatio?: number;
 }) {
   const { isOpen, activeTab, open, close, setActiveTab } = useWorkspaceUiState({
     routeContext,
   });
+  const [layoutMode, setLayoutMode] = React.useState<WorkspaceLayoutMode>(
+    initialLayoutMode
+  );
+  const paneRatio = getWorkspacePaneRatioForLayoutMode(layoutMode);
 
   return (
     <>
       <button
         type="button"
         data-testid="workspace-open-button"
-        onClick={() => open()}
+        onClick={() => {
+          if (isOpen) {
+            close();
+            return;
+          }
+          open();
+        }}
       >
         Open workspace
       </button>
@@ -83,6 +93,7 @@ function WorkspaceDrawerHarness({
         maxPaneRatio={maxPaneRatio}
         activeThreadId={activeThreadId}
         onMoveScratchpadToComposer={onMoveScratchpadToComposer}
+        onLayoutModeChange={setLayoutMode}
         onOpenChange={(nextOpen) => {
           if (nextOpen) {
             open();
@@ -113,6 +124,12 @@ describe("workspace layout mode contract", () => {
     expect(
       deriveWorkspaceLayoutMode({
         isOpen: true,
+        paneRatio: MIN_WORKSPACE_PANE_RATIO,
+      })
+    ).toBe("chat_focus");
+    expect(
+      deriveWorkspaceLayoutMode({
+        isOpen: true,
         paneRatio: BALANCED_SPLIT_MIN_RATIO,
       })
     ).toBe("balanced_split");
@@ -127,6 +144,20 @@ describe("workspace layout mode contract", () => {
     expect(getWorkspaceLayoutRatioBucket("workspace_focus")).toBe(
       "workspace_first"
     );
+    expect(getWorkspacePaneRatioForLayoutMode("chat_focus")).toBe(
+      MIN_WORKSPACE_PANE_RATIO
+    );
+    expect(getWorkspacePaneRatioForLayoutMode("balanced_split")).toBe(
+      BALANCED_SPLIT_WORKSPACE_PANE_RATIO
+    );
+    expect(getWorkspacePaneRatioForLayoutMode("workspace_focus")).toBe(
+      MAX_WORKSPACE_PANE_RATIO
+    );
+    expect(getNextWorkspaceLayoutMode("chat_focus")).toBe("balanced_split");
+    expect(getNextWorkspaceLayoutMode("balanced_split")).toBe(
+      "workspace_focus"
+    );
+    expect(getNextWorkspaceLayoutMode("workspace_focus")).toBe("chat_focus");
   });
 });
 
@@ -174,10 +205,6 @@ describe("WorkspaceDrawer shell", () => {
 
       await user.click(screen.getByTestId("workspace-open-button"));
 
-      expect(screen.getByTestId("workspace-tabs")).not.toHaveClass("glass-pill");
-      expect(screen.getByRole("tab", { name: expectedLabel })).toHaveClass(
-        "segment-tab"
-      );
       expect(screen.getByRole("tab", { name: expectedLabel })).toHaveAttribute(
         "aria-selected",
         "true"
@@ -190,6 +217,9 @@ describe("WorkspaceDrawer shell", () => {
           screen.getByTestId("workspace-scratchpad-textarea")
         ).toHaveAttribute("placeholder", expectedPlaceholder);
       }
+
+      await user.click(screen.getByTestId("workspace-open-button"));
+      expect(screen.queryByTestId("workspace-drawer")).not.toBeInTheDocument();
     }
   );
 
@@ -218,16 +248,10 @@ describe("WorkspaceDrawer shell", () => {
     expect(screen.getAllByRole("tab", { name: "Shelf" })).toHaveLength(1);
   });
 
-  it("renders posture as passive status text while tabs remain the interactive controls", async () => {
+  it("renders posture as a quiet button that cycles and resets the layout mode", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
 
-    render(
-      <WorkspaceDrawerHarness
-        routeContext="documents"
-        layoutMode="workspace_focus"
-        paneRatio={MAX_WORKSPACE_PANE_RATIO}
-      />
-    );
+    render(<WorkspaceDrawerHarness routeContext="documents" />);
 
     await user.click(screen.getByTestId("workspace-open-button"));
 
@@ -239,23 +263,56 @@ describe("WorkspaceDrawer shell", () => {
       "Workspace"
     );
     const posture = screen.getByTestId("workspace-drawer-posture");
-    expect(posture.tagName).toBe("P");
-    expect(posture).toHaveTextContent("Workspace focus");
+    expect(posture.tagName).toBe("BUTTON");
+    expect(posture).toHaveTextContent("Chat Focus");
+    expect(posture).toHaveClass("cursor-pointer");
+    expect(screen.getByTestId("workspace-drawer")).toHaveAttribute(
+      "data-layout-mode",
+      "chat_focus"
+    );
+    expect(screen.getByTestId("workspace-drawer")).toHaveAttribute(
+      "data-layout-label",
+      "Chat Focus"
+    );
+
+    await user.click(posture);
+    expect(posture).toHaveTextContent("Balanced Split");
+    expect(screen.getByTestId("workspace-drawer")).toHaveAttribute(
+      "data-layout-mode",
+      "balanced_split"
+    );
+
+    await user.click(posture);
+    expect(posture).toHaveTextContent("Workspace Focus");
+    expect(screen.getByTestId("workspace-drawer")).toHaveAttribute(
+      "data-layout-mode",
+      "workspace_focus"
+    );
+
+    await user.click(posture);
+    expect(posture).toHaveTextContent("Chat Focus");
+    expect(screen.getByTestId("workspace-drawer")).toHaveAttribute(
+      "data-layout-mode",
+      "chat_focus"
+    );
+
+    await user.dblClick(posture);
+    expect(posture).toHaveTextContent("Chat Focus");
+    expect(screen.getByTestId("workspace-drawer")).toHaveAttribute(
+      "data-layout-mode",
+      "chat_focus"
+    );
     expect(
       screen.queryByRole("button", { name: "Close workspace" })
     ).not.toBeInTheDocument();
     expect(screen.queryByTestId("workspace-drawer-close")).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Workspace focus" })
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("tab", { name: "Workspace focus" })
+      screen.queryByRole("button", { name: "Workspace Focus" })
     ).not.toBeInTheDocument();
 
     const tablist = screen.getByRole("tablist", { name: "Workspace panels" });
     expect(tablist).toBeInTheDocument();
     expect(screen.getByTestId("workspace-tabs")).toBeInTheDocument();
-    expect(screen.getByTestId("workspace-tabs")).not.toHaveClass("glass-pill");
     expect(screen.getAllByRole("tab")).toHaveLength(3);
   });
 
@@ -296,7 +353,7 @@ describe("WorkspaceDrawer shell", () => {
       "centered"
     );
     expect(screen.getByTestId("workspace-drawer-posture")).toHaveTextContent(
-      "Balanced split"
+      "Chat Focus"
     );
     expect(screen.queryByTestId("workspace-drawer-close")).not.toBeInTheDocument();
     expect(screen.queryByText(/Autosaves locally per thread/i)).not.toBeInTheDocument();
@@ -319,51 +376,13 @@ describe("WorkspaceDrawer shell", () => {
     );
   });
 
-  it("renders distinct visible posture labels for balanced and dominant layouts", async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-    const { rerender } = render(
-      <WorkspaceDrawerHarness
-        routeContext="documents"
-        layoutMode="balanced_split"
-        paneRatio={DEFAULT_WORKSPACE_PANE_RATIO}
-      />
-    );
-
-    await user.click(screen.getByTestId("workspace-open-button"));
-
-    expect(screen.getByTestId("workspace-drawer")).toHaveAttribute(
-      "data-layout-label",
-      "Balanced split"
-    );
-    expect(screen.getByTestId("workspace-drawer-posture")).toHaveTextContent(
-      "Balanced split"
-    );
-
-    rerender(
-      <WorkspaceDrawerHarness
-        routeContext="documents"
-        layoutMode="workspace_focus"
-        paneRatio={MAX_WORKSPACE_PANE_RATIO}
-      />
-    );
-
-    expect(screen.getByTestId("workspace-drawer")).toHaveAttribute(
-      "data-layout-label",
-      "Workspace focus"
-    );
-    expect(screen.getByTestId("workspace-drawer-posture")).toHaveTextContent(
-      "Workspace focus"
-    );
-  });
-
   it("keeps layout mode stable while active tabs change", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
 
     render(
       <WorkspaceDrawerHarness
         routeContext="dashboard"
-        layoutMode="workspace_focus"
-        paneRatio={MAX_WORKSPACE_PANE_RATIO}
+        initialLayoutMode="workspace_focus"
       />
     );
 
@@ -371,25 +390,25 @@ describe("WorkspaceDrawer shell", () => {
 
     const drawer = screen.getByTestId("workspace-drawer");
     expect(drawer).toHaveAttribute("data-layout-mode", "workspace_focus");
-    expect(drawer).toHaveAttribute("data-layout-label", "Workspace focus");
+    expect(drawer).toHaveAttribute("data-layout-label", "Workspace Focus");
     expect(drawer).toHaveAttribute(
       "data-pane-ratio",
       MAX_WORKSPACE_PANE_RATIO.toFixed(2)
     );
     expect(screen.getByTestId("workspace-drawer-posture")).toHaveTextContent(
-      "Workspace focus"
+      "Workspace Focus"
     );
 
     await user.click(screen.getByRole("tab", { name: "Scratchpad" }));
     expect(drawer).toHaveAttribute("data-layout-mode", "workspace_focus");
     expect(screen.getByTestId("workspace-drawer-posture")).toHaveTextContent(
-      "Workspace focus"
+      "Workspace Focus"
     );
 
     await user.click(screen.getByRole("tab", { name: "Inspector" }));
     expect(drawer).toHaveAttribute("data-layout-mode", "workspace_focus");
     expect(screen.getByTestId("workspace-drawer-posture")).toHaveTextContent(
-      "Workspace focus"
+      "Workspace Focus"
     );
   });
 

--- a/frontend/src/features/workspace/components/WorkspaceDrawer.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceDrawer.tsx
@@ -10,7 +10,12 @@ import type {
   WorkspaceDrawerTab,
   WorkspaceRouteContext,
 } from "../state/useWorkspaceUiState";
-import type { WorkspaceLayoutMode } from "../state/useWorkspaceLayoutMode";
+import {
+  getNextWorkspaceLayoutMode,
+  getWorkspaceLayoutModeLabel,
+  getWorkspacePaneRatioForLayoutMode,
+  type WorkspaceLayoutMode,
+} from "../state/useWorkspaceLayoutMode";
 
 type ShelfItem = { kind: "document"; item: { id: string; filename?: string; src_url: string; caption?: string; mime_type?: string; created_at?: string; project_id?: string | number; thread_id?: string | number } } | { kind: "image"; item: { id: string; src_url: string; filename?: string; caption?: string; created_at?: string; project_id?: string | number; thread_id?: string | number } };
 
@@ -24,6 +29,7 @@ type WorkspaceDrawerProps = {
   maxPaneRatio?: number;
   onOpenChange: (open: boolean) => void;
   onActiveTabChange: (tab: WorkspaceDrawerTab) => void;
+  onLayoutModeChange?: (layoutMode: WorkspaceLayoutMode) => void;
   activeThreadId?: string | number | null;
   onMoveScratchpadToComposer?: (text: string) => void;
 };
@@ -33,18 +39,6 @@ const WORKSPACE_PANEL_COPY: Record<WorkspaceDrawerTab, string> = {
   scratchpad: "Scratchpad editing lands in Phase 2 with text input and autosave.",
   inspector: "Inspector renderers will plug into this panel in a later phase.",
 };
-
-function formatLayoutModeLabel(layoutMode: WorkspaceLayoutMode): string {
-  switch (layoutMode) {
-    case "workspace_focus":
-      return "Workspace focus";
-    case "balanced_split":
-      return "Balanced split";
-    case "chat_focus":
-    default:
-      return "Chat focus";
-  }
-}
 
 function resolveRouteThreadIdentity(): string | null {
   if (typeof window === "undefined") return null;
@@ -56,11 +50,12 @@ export default function WorkspaceDrawer({
   routeContext,
   isOpen,
   activeTab,
-  layoutMode = "balanced_split",
-  paneRatio,
+  layoutMode = "chat_focus",
+  paneRatio = getWorkspacePaneRatioForLayoutMode(layoutMode),
   minPaneRatio,
   maxPaneRatio,
   onActiveTabChange,
+  onLayoutModeChange,
   activeThreadId,
   onMoveScratchpadToComposer,
 }: WorkspaceDrawerProps) {
@@ -77,7 +72,7 @@ export default function WorkspaceDrawer({
   );
 
   const panel = WORKSPACE_PANEL_COPY[activeTab];
-  const layoutModeLabel = formatLayoutModeLabel(layoutMode);
+  const layoutModeLabel = getWorkspaceLayoutModeLabel(layoutMode);
   const idBase = "workspace";
   const resolvedThreadIdentity =
     activeThreadId == null ? resolveRouteThreadIdentity() : activeThreadId;
@@ -96,6 +91,16 @@ export default function WorkspaceDrawer({
     },
     [onMoveScratchpadToComposer]
   );
+  const handlePostureClick = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      if (event.detail > 1) return;
+      onLayoutModeChange?.(getNextWorkspaceLayoutMode(layoutMode));
+    },
+    [layoutMode, onLayoutModeChange]
+  );
+  const handlePostureDoubleClick = React.useCallback(() => {
+    onLayoutModeChange?.("chat_focus");
+  }, [onLayoutModeChange]);
 
   if (!isOpen) return null;
 
@@ -128,13 +133,23 @@ export default function WorkspaceDrawer({
           >
             Workspace
           </div>
-          <p
+          <button
             data-testid="workspace-drawer-posture"
-            className="mt-1 text-[11px] font-medium tracking-[0.04em]"
+            className="group relative mt-1 inline-flex cursor-pointer items-center justify-center border-0 bg-transparent px-1 py-0 text-[11px] font-medium tracking-[0.04em] text-[var(--text-subtle)] transition-[color,filter,opacity] duration-200 hover:text-[var(--text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_oklab,var(--accent)_45%,transparent)] focus-visible:ring-offset-2"
             style={{ color: "var(--text-subtle)" }}
+            onClick={handlePostureClick}
+            onDoubleClick={handlePostureDoubleClick}
+            title="Click to cycle posture. Double-click to reset to Chat Focus."
+            type="button"
           >
-            {layoutModeLabel}
-          </p>
+            <span className="relative inline-flex items-center justify-center">
+              {layoutModeLabel}
+              <span
+                aria-hidden="true"
+                className="absolute inset-x-0 -bottom-0.5 h-px scale-x-0 bg-[color-mix(in_oklab,var(--accent)_55%,transparent)] opacity-0 shadow-[0_0_8px_color-mix(in_oklab,var(--accent)_45%,transparent)] transition-all duration-200 group-hover:scale-x-100 group-hover:opacity-100 group-focus-visible:scale-x-100 group-focus-visible:opacity-100"
+              />
+            </span>
+          </button>
         </div>
 
         <WorkspaceTabs

--- a/frontend/src/features/workspace/state/useWorkspaceLayoutMode.ts
+++ b/frontend/src/features/workspace/state/useWorkspaceLayoutMode.ts
@@ -3,11 +3,15 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 export const WORKSPACE_LAYOUT_STORAGE_KEY = "cfy.workspace.layout";
 export const MIN_WORKSPACE_PANE_RATIO = 0.28;
 export const MAX_WORKSPACE_PANE_RATIO = 0.62;
-export const DEFAULT_WORKSPACE_PANE_RATIO = 0.42;
+export const CHAT_FOCUS_WORKSPACE_PANE_RATIO = MIN_WORKSPACE_PANE_RATIO;
+export const DEFAULT_WORKSPACE_PANE_RATIO = CHAT_FOCUS_WORKSPACE_PANE_RATIO;
+export const BALANCED_SPLIT_WORKSPACE_PANE_RATIO = 0.42;
+export const WORKSPACE_FOCUS_WORKSPACE_PANE_RATIO = MAX_WORKSPACE_PANE_RATIO;
 export const BALANCED_SPLIT_MIN_RATIO = 0.36;
 export const WORKSPACE_FOCUS_MIN_RATIO = 0.52;
 export const MIN_WORKSPACE_PRIMARY_PANE_WIDTH = "24rem";
 export const MIN_WORKSPACE_DRAWER_PANE_WIDTH = "20rem";
+export const DEFAULT_WORKSPACE_LAYOUT_THREAD_KEY = "__workspace_default__";
 
 export type WorkspaceLayoutMode =
   | "chat_focus"
@@ -16,17 +20,39 @@ export type WorkspaceLayoutMode =
 export type WorkspaceLayoutRatioBucket = "chat_first" | "shared" | "workspace_first";
 
 type PersistedWorkspaceLayoutState = {
-  paneRatio?: number;
+  layoutMode?: WorkspaceLayoutMode;
 };
 
 type UseWorkspaceLayoutModeOptions = {
   isOpen: boolean;
-  initialPaneRatio?: number;
+  activeThreadId?: string | number | null;
   storageKey?: string;
 };
 
-function isFiniteNumber(value: unknown): value is number {
-  return typeof value === "number" && Number.isFinite(value);
+function isWorkspaceLayoutMode(value: unknown): value is WorkspaceLayoutMode {
+  return (
+    value === "chat_focus" ||
+    value === "balanced_split" ||
+    value === "workspace_focus"
+  );
+}
+
+function getWorkspaceLayoutThreadKey(
+  threadId: string | number | null | undefined
+): string {
+  if (threadId == null) {
+    return DEFAULT_WORKSPACE_LAYOUT_THREAD_KEY;
+  }
+
+  const normalized = String(threadId).trim();
+  return normalized || DEFAULT_WORKSPACE_LAYOUT_THREAD_KEY;
+}
+
+export function getWorkspaceLayoutStorageKeyForThread(
+  threadId: string | number | null | undefined,
+  storageKey = WORKSPACE_LAYOUT_STORAGE_KEY
+): string {
+  return `${storageKey}.${encodeURIComponent(getWorkspaceLayoutThreadKey(threadId))}`;
 }
 
 export function clampWorkspacePaneRatio(value: number): number {
@@ -57,6 +83,64 @@ export function deriveWorkspaceLayoutMode({
   return "balanced_split";
 }
 
+export function getWorkspacePaneRatioForLayoutMode(
+  layoutMode: WorkspaceLayoutMode
+): number {
+  switch (layoutMode) {
+    case "workspace_focus":
+      return WORKSPACE_FOCUS_WORKSPACE_PANE_RATIO;
+    case "balanced_split":
+      return BALANCED_SPLIT_WORKSPACE_PANE_RATIO;
+    case "chat_focus":
+    default:
+      return CHAT_FOCUS_WORKSPACE_PANE_RATIO;
+  }
+}
+
+export function getWorkspaceLayoutModeFromPaneRatio(
+  paneRatio: number
+): WorkspaceLayoutMode {
+  const clampedPaneRatio = clampWorkspacePaneRatio(paneRatio);
+
+  if (clampedPaneRatio < BALANCED_SPLIT_MIN_RATIO) {
+    return "chat_focus";
+  }
+
+  if (clampedPaneRatio >= WORKSPACE_FOCUS_MIN_RATIO) {
+    return "workspace_focus";
+  }
+
+  return "balanced_split";
+}
+
+export function getNextWorkspaceLayoutMode(
+  layoutMode: WorkspaceLayoutMode
+): WorkspaceLayoutMode {
+  switch (layoutMode) {
+    case "chat_focus":
+      return "balanced_split";
+    case "balanced_split":
+      return "workspace_focus";
+    case "workspace_focus":
+    default:
+      return "chat_focus";
+  }
+}
+
+export function getWorkspaceLayoutModeLabel(
+  layoutMode: WorkspaceLayoutMode
+): string {
+  switch (layoutMode) {
+    case "workspace_focus":
+      return "Workspace Focus";
+    case "balanced_split":
+      return "Balanced Split";
+    case "chat_focus":
+    default:
+      return "Chat Focus";
+  }
+}
+
 export function getWorkspaceLayoutRatioBucket(
   layoutMode: WorkspaceLayoutMode
 ): WorkspaceLayoutRatioBucket {
@@ -78,14 +162,9 @@ function readPersistedWorkspaceLayoutState(
 
   try {
     const raw = window.localStorage.getItem(storageKey);
-    if (!raw) return {};
+    if (!raw || !isWorkspaceLayoutMode(raw)) return {};
 
-    const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return {};
-    }
-
-    return parsed as PersistedWorkspaceLayoutState;
+    return { layoutMode: raw };
   } catch {
     return {};
   }
@@ -93,33 +172,31 @@ function readPersistedWorkspaceLayoutState(
 
 export function useWorkspaceLayoutMode({
   isOpen,
-  initialPaneRatio,
+  activeThreadId,
   storageKey = WORKSPACE_LAYOUT_STORAGE_KEY,
 }: UseWorkspaceLayoutModeOptions) {
+  const activeThreadStorageKey = useMemo(
+    () => getWorkspaceLayoutStorageKeyForThread(activeThreadId, storageKey),
+    [activeThreadId, storageKey]
+  );
+
   const [paneRatio, setPaneRatioState] = useState<number>(() => {
-    const persisted = readPersistedWorkspaceLayoutState(storageKey);
-
-    if (isFiniteNumber(persisted.paneRatio)) {
-      return clampWorkspacePaneRatio(persisted.paneRatio);
-    }
-
-    return clampWorkspacePaneRatio(
-      initialPaneRatio ?? DEFAULT_WORKSPACE_PANE_RATIO
+    const persisted = readPersistedWorkspaceLayoutState(activeThreadStorageKey);
+    return getWorkspacePaneRatioForLayoutMode(
+      persisted.layoutMode ?? "chat_focus"
     );
   });
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
+    const persisted = readPersistedWorkspaceLayoutState(activeThreadStorageKey);
+    const nextPaneRatio = getWorkspacePaneRatioForLayoutMode(
+      persisted.layoutMode ?? "chat_focus"
+    );
 
-    try {
-      window.localStorage.setItem(
-        storageKey,
-        JSON.stringify({ paneRatio })
-      );
-    } catch {
-      // Ignore local-only persistence failures.
-    }
-  }, [paneRatio, storageKey]);
+    setPaneRatioState((previousPaneRatio) =>
+      previousPaneRatio === nextPaneRatio ? previousPaneRatio : nextPaneRatio
+    );
+  }, [activeThreadStorageKey]);
 
   const setPaneRatio = useCallback(
     (nextPaneRatio: number | ((previousPaneRatio: number) => number)) => {
@@ -132,6 +209,22 @@ export function useWorkspaceLayoutMode({
       );
     },
     []
+  );
+
+  const setLayoutMode = useCallback(
+    (nextLayoutMode: WorkspaceLayoutMode) => {
+      const nextPaneRatio = getWorkspacePaneRatioForLayoutMode(nextLayoutMode);
+      setPaneRatioState(nextPaneRatio);
+
+      if (typeof window === "undefined") return;
+
+      try {
+        window.localStorage.setItem(activeThreadStorageKey, nextLayoutMode);
+      } catch {
+        // Ignore local-only persistence failures.
+      }
+    },
+    [activeThreadStorageKey]
   );
 
   const layoutMode = useMemo(
@@ -157,5 +250,6 @@ export function useWorkspaceLayoutMode({
     layoutMode,
     isWorkspaceDominant,
     ratioBucket,
+    setLayoutMode,
   };
 }


### PR DESCRIPTION
## Summary
- Made Chat Focus the default workspace posture and added preset helpers for Chat Focus, Balanced Split, and Workspace Focus.
- Wired the centered posture label into an accessible text-button that cycles posture on click and resets on double-click.
- Persisted posture per thread in localStorage and restored it when the active thread changes.
- Updated AppShell to pass the active thread into the layout hook and apply posture changes to the visible split.
- Tightened workspace and AppShell tests around cycling, reset behavior, persistence, and layout mirroring.

## Testing
- `pnpm --dir frontend/src exec vitest run features/workspace/__tests__/WorkspaceDrawer.test.tsx components/persona/layout/__tests__/AppShell.test.tsx`
- Result: pass