### PR TITLE
Codex/add chatgpt fact import refactor

### DIFF
--- a/backend/rag/chatgpt_migration.py
+++ b/backend/rag/chatgpt_migration.py
@@ -4,7 +4,6 @@ import json
 import logging
 import multiprocessing as mp
 import os
-import re
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -250,6 +249,13 @@ def _fetch_retryable_chatgpt_embedding_items(
                         "source_thread_id": existing_meta.get(
                             "source_thread_id"
                         ),
+                        "source_conversation_template_id": existing_meta.get(
+                            "source_conversation_template_id"
+                        ),
+                        "source_gizmo_id": existing_meta.get("source_gizmo_id"),
+                        "source_gizmo_type": existing_meta.get(
+                            "source_gizmo_type"
+                        ),
                         "source_message_id": existing_meta.get(
                             "source_message_id"
                         ),
@@ -383,17 +389,34 @@ def _resolve_imports_project_id(chatlog_db) -> int:
         imports_ids = [int(p["id"]) for p in imports if p.get("id") is not None]
         if imports_ids:
             return min(imports_ids)
-
-        legacy = [p for p in projects if p.get("name") == "Loose Threads"]
-        legacy_ids = [int(p["id"]) for p in legacy if p.get("id") is not None]
-        if legacy_ids:
-            return min(legacy_ids)
     except Exception as e:
         logger.warning(
-            "Failed to resolve Imports/Loose Threads project ID via list_projects: %s",
+            "Failed to resolve Imports project ID via list_projects: %s",
             e,
         )
-    raise RuntimeError("Unable to resolve Loose Threads project ID")
+    raise RuntimeError("Unable to resolve Imports project ID")
+
+
+def _build_import_grouping_metadata(
+    conversation: Dict[str, Any],
+) -> Dict[str, Any]:
+    metadata: Dict[str, Any] = {}
+
+    template_id = _normalize_template_id(
+        conversation.get("conversation_template_id")
+    )
+    if template_id:
+        metadata["source_conversation_template_id"] = template_id
+
+    gizmo_id = conversation.get("gizmo_id")
+    if isinstance(gizmo_id, str) and gizmo_id.strip():
+        metadata["source_gizmo_id"] = gizmo_id.strip()
+
+    gizmo_type = conversation.get("gizmo_type")
+    if isinstance(gizmo_type, str) and gizmo_type.strip():
+        metadata["source_gizmo_type"] = gizmo_type.strip()
+
+    return metadata
 
 
 def _parse_export_timestamp(value: Any) -> Optional[datetime]:
@@ -650,122 +673,6 @@ def _normalize_template_id(value: Any) -> Optional[str]:
     if not candidate.startswith("g-p-"):
         return None
     return candidate
-
-
-def _slugify_title_for_project(title: Any) -> str:
-    text = str(title or "").strip()
-    if not text:
-        return "Project"
-    words = re.findall(r"[A-Za-z0-9]+", text)
-    if not words:
-        return "Project"
-    friendly = " ".join(words[:6]).strip()
-    if len(friendly) > 42:
-        friendly = friendly[:42].rstrip()
-    return friendly or "Project"
-
-
-def _build_template_project_name(template_id: str, title: Any) -> str:
-    suffix = template_id[-8:]
-    friendly = _slugify_title_for_project(title)
-    return f"ChatGPT {friendly} [{suffix}]"
-
-
-def _find_project_id_by_name(chatlog_db, project_name: str) -> Optional[int]:
-    try:
-        projects = chatlog_db.list_projects()
-    except Exception:
-        return None
-
-    for project in projects:
-        if str(project.get("name") or "") != project_name:
-            continue
-        project_id = project.get("id")
-        if project_id is None:
-            continue
-        try:
-            return int(project_id)
-        except (TypeError, ValueError):
-            continue
-    return None
-
-
-def _find_existing_project_for_template(
-    chatlog_db,
-    *,
-    user_id: str,
-    template_id: str,
-) -> Optional[int]:
-    if not template_id or not hasattr(chatlog_db, "_connect"):
-        return None
-    try:
-        with chatlog_db._connect() as conn, conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT project_id
-                FROM chat_threads
-                WHERE user_id = %s
-                  AND project_id IS NOT NULL
-                  AND metadata->>'import_source' = 'chatgpt'
-                  AND metadata->>'source_conversation_template_id' = %s
-                ORDER BY id ASC
-                LIMIT 1
-                """,
-                (user_id, template_id),
-            )
-            row = cur.fetchone()
-            if not row:
-                return None
-            project_id = row.get("project_id")
-            return int(project_id) if project_id is not None else None
-    except Exception:
-        return None
-
-
-def _ensure_template_project_id(
-    chatlog_db,
-    *,
-    template_id: str,
-    title: Any,
-) -> Tuple[int, bool]:
-    project_name = _build_template_project_name(template_id, title)
-    existing_by_name = _find_project_id_by_name(chatlog_db, project_name)
-    if existing_by_name is not None:
-        return existing_by_name, False
-
-    project_id = chatlog_db.ensure_project(
-        project_name,
-        f"Imported ChatGPT conversations for template {template_id}",
-    )
-    return int(project_id), True
-
-
-def _resolve_target_project(
-    chatlog_db,
-    *,
-    user_id: str,
-    conversation: Dict[str, Any],
-) -> Tuple[int, Optional[str], str]:
-    template_id = _normalize_template_id(
-        conversation.get("conversation_template_id")
-    )
-    if not template_id:
-        return _resolve_imports_project_id(chatlog_db), None, "imports"
-
-    existing_project_id = _find_existing_project_for_template(
-        chatlog_db,
-        user_id=user_id,
-        template_id=template_id,
-    )
-    if existing_project_id is not None:
-        return existing_project_id, template_id, "reused"
-
-    project_id, created = _ensure_template_project_id(
-        chatlog_db,
-        template_id=template_id,
-        title=conversation.get("title"),
-    )
-    return project_id, template_id, "created" if created else "reused"
 
 
 def _map_role(raw_role: Any) -> Tuple[str, Optional[str]]:
@@ -1189,9 +1096,7 @@ def ingest_chatgpt_export(
                 conv.get("create_time")
             ) or _parse_export_timestamp(conv.get("update_time"))
             imported_at = datetime.now(timezone.utc)
-            template_id = _normalize_template_id(
-                conv.get("conversation_template_id")
-            )
+            import_grouping_metadata = _build_import_grouping_metadata(conv)
 
             # Linearize canonical mainline (root -> active leaf).
             mainline_nodes = _linearize_mainline(
@@ -1219,21 +1124,9 @@ def ingest_chatgpt_export(
                 chatlog_db, user_id=user_id, source_thread_id=source_thread_id
             )
             if thread_id is None:
+                # Keep the surface flat: imported threads land in Imports, and
+                # any inferred grouping survives only in metadata.
                 project_id = imports_project_id
-                if template_id:
-                    (
-                        project_id,
-                        template_id,
-                        project_resolution,
-                    ) = _resolve_target_project(
-                        chatlog_db,
-                        user_id=user_id,
-                        conversation=conv,
-                    )
-                    if project_resolution == "created":
-                        projects_created += 1
-                    elif project_resolution == "reused":
-                        projects_reused += 1
 
                 thread_metadata: Dict[str, Any] = {
                     "import_source": "chatgpt",
@@ -1244,25 +1137,8 @@ def ingest_chatgpt_export(
                         "messages_filtered": conv_filtered_count,
                         "filtered_reasons": filtered_reasons,
                     },
+                    **import_grouping_metadata,
                 }
-                if template_id:
-                    thread_metadata[
-                        "source_conversation_template_id"
-                    ] = template_id
-                if (
-                    isinstance(conv.get("gizmo_id"), str)
-                    and str(conv.get("gizmo_id")).strip()
-                ):
-                    thread_metadata["source_gizmo_id"] = str(
-                        conv.get("gizmo_id")
-                    ).strip()
-                if (
-                    isinstance(conv.get("gizmo_type"), str)
-                    and str(conv.get("gizmo_type")).strip()
-                ):
-                    thread_metadata["source_gizmo_type"] = str(
-                        conv.get("gizmo_type")
-                    ).strip()
 
                 try:
                     thread_record = chatlog_db.create_chat_thread(
@@ -1300,12 +1176,12 @@ def ingest_chatgpt_export(
                         "import_source": "chatgpt",
                         "import_profile": _CHATGPT_IMPORT_PROFILE,
                         "source_thread_id": source_thread_id,
-                        "source_conversation_template_id": template_id,
                         "import_summary": {
                             "messages_kept": len(messages),
                             "messages_filtered": conv_filtered_count,
                             "filtered_reasons": filtered_reasons,
                         },
+                        **import_grouping_metadata,
                     },
                 )
 
@@ -1329,6 +1205,7 @@ def ingest_chatgpt_export(
                     "origin": msg.get("origin"),
                     "era": msg.get("era"),
                     "canonical_filter_profile": _CHATGPT_IMPORT_PROFILE,
+                    **import_grouping_metadata,
                 }
 
                 if existing:
@@ -1395,6 +1272,7 @@ def ingest_chatgpt_export(
                             "era": msg["era"],
                             "source": "chatgpt_import",
                             "canonical_filter_profile": _CHATGPT_IMPORT_PROFILE,
+                            **import_grouping_metadata,
                         }
                         pending_embed_items.append(
                             {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -773,6 +773,9 @@ services:
     command: ["/app/guardian/scripts/ensure_embed_model.py"]
 
   tts:
+    # Optional voice service: only start when explicitly requested via --profile voice.
+    profiles:
+      - voice
     build:
       context: .
       dockerfile: backend/Dockerfile

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,5 +1,5 @@
 Purpose: Provide a KB-first entry point into Codexify's current architecture so humans and AI can orient quickly, find the right source files, and plan changes with an accurate map.
-Last updated: 2026-03-29
+Last updated: 2026-04-01
 Source anchors:
 - docs/architecture/
 - guardian/guardian_api.py
@@ -10,6 +10,7 @@ Source anchors:
 - guardian/core/dependencies.py
 - frontend/src/App.tsx
 - frontend/src/components/persona/layout/AppShell.tsx
+- frontend/src/features/personaStudio/
 - docker-compose.yml
 
 # Codexify Architecture KB
@@ -36,6 +37,7 @@ Before generating architecture diagrams, read the [`KB Validity Matrix`](./kb-va
 - [`00-current-state.md`](./00-current-state.md): live operational truth, current release/readiness interpretation, and short-horizon priorities.
 - [Architecture Atlas](./architecture-atlas.md): peer-facing reading guide for the validated architecture corpus, runtime diagrams, and UI diagrams.
 - [Workspace Surface Spec v1](./codexify_workspace_surface_spec_v_1.md): UI/design-canon contract for Workspace as Shelf + Scratchpad + Inspector across Dashboard, Guardian, and Documents; not first-pass runtime topology truth.
+- [Persona Studio Architecture](./persona-studio.md): shell-integrated persona/profile configuration surface, local draft state, diagnostics preview, and boundary rules; complements the broader product spec.
 - [System Overview](./system-overview.md): current runtime components, topology, and critical paths.
 - [Critical Flows](./flows.md): current trigger-to-output runtime flows with failure modes.
 - [Data and Storage](./data-and-storage.md): storage systems, key tables, invariants, and data risk hotspots.

--- a/docs/architecture/persona-studio.md
+++ b/docs/architecture/persona-studio.md
@@ -1,0 +1,301 @@
+Purpose: Document Persona Studio as it exists in the shell today so readers can understand the page structure, local state flow, and boundary limits without reading implementation code first.
+Last updated: 2026-04-01
+Source anchors:
+- frontend/src/components/persona/layout/AppShell.tsx
+- frontend/src/features/personaStudio/PersonaStudioPage.tsx
+- frontend/src/features/personaStudio/personaStudioStore.ts
+- frontend/src/features/personaStudio/__tests__/PersonaStudioShell.test.tsx
+- frontend/src/features/personaStudio/__tests__/PersonaStudioPage.persistence.test.tsx
+- docs/architecture/persona-studio-spec.md
+
+# Persona Studio Architecture
+
+## Purpose and Scope
+
+Persona Studio is a non-conversational configuration surface for persona and profile settings.
+
+It exists to define persona/profile settings before runtime selection, not inside a chat turn. In this note, "mocked" means seeded or locally synthesized in the browser, not fetched from or enforced by backend runtime.
+
+Persona Studio is:
+
+- not a chat surface
+- not a memory-writing surface
+- not a thread/history surface
+- not a runtime assistant session
+
+## Current Implementation Status
+
+| Surface | Status now | Meaning |
+|---|---|---|
+| AppShell navigation entry and route | runtime-active | `AppShell` exposes `/persona-studio` as a first-class shell view and renders the page inside a `FrameCard`. |
+| Three-panel layout | runtime-active | The page renders left Profiles, center Editor, and right Diagnostics panels. |
+| Seeded profile list | mocked / seeded | The profile list comes from built-in seed drafts in `personaStudioStore.ts`, not from a backend profile API. |
+| Editor draft state | frontend-local | The selected profile draft is mutated in browser state and persisted to localStorage. |
+| Diagnostics panel | frontend-local preview | The panel renders a JSON config preview plus a synthetic debug log derived from the current draft. |
+| Save / Reset / Save As New | frontend-local only | These actions update local snapshots or restore seed/saved drafts; they do not mutate backend runtime. |
+| Runtime profile application | not wired | The selected profile is not yet applied to live chat, memory, tool execution, or voice runtime. |
+
+### Presentational, Frontend-Local, Runtime-Bound
+
+| Category | Current contents |
+|---|---|
+| Presentational | Shell nav entry, route switch, frame wrapper, three panels, tabs, form controls, badges, diagnostics card |
+| Frontend-local state | Seed profiles, selected profile, active tab, editable draft fields, saved snapshots, debug log, localStorage persistence |
+| Runtime-bound behavior | None yet for profile CRUD, live assistant session binding, memory writes, or runtime enforcement |
+
+### What Is Not Yet Wired
+
+- No backend persistence contract for profiles
+- No live application of persona settings to chat, voice, retrieval, or tools runtime
+- No import/export/delete flow in the current page
+- No server-driven diagnostics feed or validation loop
+
+### Do Not Assume
+
+- Do not assume Save writes to a backend service
+- Do not assume Reset changes live assistant behavior
+- Do not assume selecting a profile changes an active thread or session
+- Do not assume Generation Top K and Retrieval Top K are interchangeable
+- Do not assume any profile control is enforced outside this page yet
+
+## Where It Lives in the Shell
+
+Persona Studio is a top-level AppShell view alongside Guardian, Dashboard, Documents, Gallery, and Settings.
+
+- Route mapping: `/persona-studio`
+- Shell entry: the navigation pill in `frontend/src/components/persona/layout/AppShell.tsx`
+- Mounted content: `PersonaStudioPage` rendered inside a `FrameCard`
+
+This matters because the page is not nested inside chat or settings as a subpanel. It is a sibling shell surface.
+
+## UI Structure
+
+The page uses a simple three-panel layout:
+
+- Left panel: Profiles
+- Center panel: Editor
+- Right panel: Diagnostics
+
+The center panel contains six tabs:
+
+- Identity
+- Model
+- Voice
+- Prompt
+- Tools
+- Retrieval
+
+The Model tab contains generation controls, including `Generation Top K`.
+
+The Retrieval tab contains retrieval controls, including `Retrieval Top K`.
+
+These are separate concepts and must remain separate.
+
+## Data Model
+
+The current screen uses a narrower frontend-facing shape than the broader product spec. The effective profile draft shape is:
+
+```ts
+type PersonaStudioLocalState = {
+  profiles: PersonaProfileDraft[];
+  selectedProfileId: string;
+  activeTab: "identity" | "model" | "voice" | "prompt" | "tools" | "retrieval";
+  lastSavedProfiles: Record<string, PersonaProfileDraft>;
+};
+
+type PersonaProfileDraft = {
+  id: string;
+  name: string;
+  description: string;
+  isDefault?: boolean;
+  config: {
+    identity: {
+      name: string;
+      description: string;
+    };
+    model: {
+      provider: string;
+      model: string;
+      temperature: number;
+      topK: number;
+      topP: number;
+      maxTokens: number;
+    };
+    voice: {
+      enabled: boolean;
+      provider: string;
+      voicePreset: string;
+      speed: number;
+      wakeWord: string;
+      interruptible: boolean;
+    };
+    prompt: {
+      systemPrompt: string;
+      styleNotes: string;
+      directives: string;
+    };
+    tools: {
+      pinnedTools: string[];
+      allowedTools: string[];
+      skills: string[];
+      permissions: {
+        web: boolean;
+        email: boolean;
+        calendar: boolean;
+        cli: boolean;
+        filesystem: boolean;
+      };
+    };
+    retrieval: {
+      enabled: boolean;
+      mode: string;
+      topK: number;
+      rerank: boolean;
+    };
+  };
+};
+```
+
+Diagnostics-facing derived state is not a separate persisted contract. It is computed from the selected draft and the local save snapshot:
+
+- `selectedProfile`
+- `currentConfig`
+- `selectedSavedProfile`
+- `seedProfile`
+- `isDirty`
+- `hasSavedVersion`
+- `debugLog`
+
+## State Flow
+
+1. `readPersonaStudioLocalState()` loads local state from localStorage, or falls back to built-in seed profiles if nothing valid exists.
+2. `selectedProfileId` chooses the current draft; `activeTab` chooses the visible editor subpanel.
+3. `selectedProfile` and `currentConfig` are derived from the selected draft, not stored as separate backend truth.
+4. `updateSelectedProfile()` mutates the selected draft inside the `profiles` array.
+5. A `useEffect` persists the full local state back to localStorage after each state change.
+6. `isDirty` is computed by comparing the selected draft to the selected saved snapshot, or to the built-in seed fallback if no snapshot exists.
+7. `hasSavedVersion` is true when a local saved snapshot exists for the selected profile.
+8. `DiagnosticsPanel` builds a local `debugLog` from the selected profile and config, then renders the effective config JSON preview plus save status.
+9. `saveSelectedProfile()` clones the current draft into `lastSavedProfiles`.
+10. `saveSelectedProfileAsNew()` clones the current draft, assigns a new profile ID, selects the new copy, and stores it locally.
+11. `resetSelectedProfile()` restores the selected draft from the last saved snapshot or the seed profile for that ID.
+12. `resetAllLocalPersonaStudioData()` restores the entire seeded browser state.
+
+The practical relationship is:
+
+- selected profile state is the source for the editor
+- active tab state controls which editor section is visible
+- draft field edits update the selected profile
+- diagnostics state is derived from the selected profile and save snapshot
+- save/reset actions only reshuffle local browser state
+
+## Diagrams
+
+### A. Component Hierarchy
+
+```mermaid
+flowchart TD
+    A["AppShell"] --> B["Persona Studio nav pill"]
+    B --> C["Persona Studio route<br/>/persona-studio"]
+    C --> D["FrameCard shell"]
+    D --> E["PersonaStudioPage"]
+    E --> F["Profiles panel"]
+    E --> G["Editor panel"]
+    E --> H["Diagnostics panel"]
+    G --> I["Identity tab"]
+    G --> J["Model tab"]
+    G --> K["Voice tab"]
+    G --> L["Prompt tab"]
+    G --> M["Tools tab"]
+    G --> N["Retrieval tab"]
+    J --> O["Generation Top K field"]
+    N --> P["Retrieval Top K field"]
+```
+
+### B. Data Flow
+
+```mermaid
+flowchart LR
+    A["Seeded mock profiles<br/>PERSONA_STUDIO_SEED_PROFILES"] --> B["readPersonaStudioLocalState()"]
+    C["localStorage<br/>cfy.personaStudio.localState.v1"] <--> B
+    B --> D["Local page state<br/>profiles, selectedProfileId, activeTab, lastSavedProfiles"]
+    D --> E["selectedProfileId"]
+    D --> F["activeTab"]
+    D --> G["profiles[] draft list"]
+    D --> H["lastSavedProfiles map"]
+    E --> I["selectedProfile"]
+    E --> J["seedProfile fallback"]
+    I --> K["currentConfig"]
+    I --> L["updateSelectedProfile()"]
+    K --> M["Editor tabs"]
+    K --> N["Diagnostics panel"]
+    H --> O["selectedSavedProfile"]
+    O --> P["hasSavedVersion"]
+    I --> Q["isDirty"]
+    J --> Q
+    O --> Q
+    Q --> N
+    P --> N
+    N --> R["debugLog and effective config JSON"]
+    L --> G
+    L --> C
+    S["saveSelectedProfile()"] --> H
+    S --> C
+    T["saveSelectedProfileAsNew()"] --> G
+    T --> C
+    U["resetSelectedProfile()"] --> G
+    U --> C
+    V["resetAllLocalPersonaStudioData()"] --> W["createPersonaStudioSeedState()"]
+    W --> D
+    W --> C
+```
+
+### C. User Interaction Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant S as AppShell
+    participant P as PersonaStudioPage
+    participant T as Local store
+    participant L as localStorage
+    participant D as DiagnosticsPanel
+
+    U->>S: Click Persona Studio nav pill
+    S->>P: Mount /persona-studio inside FrameCard
+    U->>P: Select a profile
+    P->>T: setSelectedProfileId()
+    T-->>P: selectedProfile and currentConfig update
+    U->>P: Edit tab fields
+    P->>T: updateSelectedProfile()
+    T->>L: persist full local state
+    T-->>D: recompute isDirty / hasSavedVersion / debugLog
+    D-->>U: effective config preview and save status refresh
+    U->>P: Save or Reset
+    P->>T: saveSelectedProfile() / saveSelectedProfileAsNew() / resetSelectedProfile() / resetAllLocalPersonaStudioData()
+    T->>L: write updated local snapshot or seed state
+```
+
+## Boundary Rules
+
+Persona Studio does not:
+
+- create chat messages
+- create thread history
+- write long-term memory
+- act as a runtime assistant session
+- apply profile settings to live runtime yet
+
+Unless a later architecture note says otherwise, this page should be treated as a browser-local configuration surface only.
+
+## Next-Step Recommendations
+
+Likely next phases, if the surface is promoted beyond local preview, are:
+
+- local draft persistence beyond the current browser state model
+- backend persistence contract for profile CRUD and snapshots
+- runtime profile application to chat, voice, retrieval, and tool binding
+- permissions and capability enforcement for selected profiles
+- voice and runtime validation against live execution instead of local preview
+
+None of those phases are implemented by this note; they are forward-looking only.

--- a/docs/audits/investigations/2026-04-01-account-export-status.md
+++ b/docs/audits/investigations/2026-04-01-account-export-status.md
@@ -1,0 +1,142 @@
+# Account Export / Export Codexify History Status Investigation
+
+Date: 2026-04-01
+Scope: investigation-only (no runtime code changes)
+
+## Summary
+The live DATA tab does **not** implement a full account export. The current surface is a narrow download path for imported ChatGPT conversations, plus a separate thread-row NDJSON export and an unrelated single-entry Codex markdown export.
+
+The exact label `Export Codexify History` does not appear in the active source. The live DATA tab renders `Import ChatGPT history` and `Download Codexify ZIP export`.
+
+## Frontend surface
+
+### Active settings surface
+- The settings UI mounted by the app shell is `frontend/src/features/settings/SettingsView.tsx`, not the older `frontend/src/components/settings/SettingsView.tsx`.
+- Anchor: `frontend/src/components/persona/layout/AppShell.tsx:35,2488-2490`
+
+### DATA tab buttons
+- The DATA tab renders the import and export buttons in `frontend/src/features/settings/SettingsView.tsx:1250-1268`.
+- The import button only toggles local UI state:
+  - `setImportPanelHidden(false)`
+  - `setChatGPTModalOpen(true)`
+- That means the import button does **not** itself trigger a backend call or route change. It opens the modal.
+
+### Import wiring
+- The modal submit path is `frontend/src/components/modals/ChatGPTImportModal.tsx:89-121`.
+- It posts `POST /api/upload-chatgpt-export` via the shared API client.
+
+### Export wiring
+- The export button is wired to `handleDownloadExport` in `frontend/src/features/settings/SettingsView.tsx:942-949`.
+- That function resolves `"/exports/chatgpt.zip"` and then:
+  - in desktop mode, calls `openExternalUrl(exportUrl)` (`frontend/src/lib/runtimeConfig.ts:341-353`)
+  - otherwise sets `window.location.href = exportUrl`
+- Classification: browser navigation / download, not a frontend route change and not an XHR/fetch API call.
+- The browser-side download path is not an app-authenticated fetch; it depends on whatever auth state the browser already has.
+
+### Legacy adjacency
+- The older `frontend/src/components/settings/SettingsView.tsx` contains ChatGPT import controls, but it is not the active settings surface mounted by `AppShell`.
+
+## Backend / export surface
+
+### Export router
+- The export router is mounted under the `/exports` prefix.
+- Anchor: `guardian/routes/api_exports.py:19-22`
+
+### `GET /exports/threads.ndjson`
+- Handler: `export_threads`
+- Anchor: `guardian/routes/api_exports.py:243-295`
+- Auth: `require_user`
+- Response type: `StreamingResponse`
+- Artifact format: `application/x-ndjson`, filename `threads.ndjson`
+- Included entity family: `chat_threads` rows for the current authenticated user
+- Excluded by design: message bodies, uploaded documents, generated documents, uploaded images, generated images
+
+### `GET /exports/chatgpt.zip`
+- Handler: `export_chatgpt_zip`
+- Anchor: `guardian/routes/api_exports.py:298-425`
+- Auth: `require_user`
+- Response type: `Response`
+- Artifact format: `application/zip`, filename `chatgpt_export_<timestamp>.zip`
+- Included entity family: imported ChatGPT conversations only
+- Internal payload contents:
+  - `manifest.json`
+  - per-thread `.json` export when `format=both` or `json`
+  - per-thread `.md` export when `format=both` or `markdown`
+- Data source helpers:
+  - `fetch_imported_chatgpt_threads_for_user`
+  - `fetch_imported_chatgpt_messages_for_thread`
+- Anchor for those helpers: `guardian/core/pgdb.py:2225-2405`
+
+### Import-adjacent surface
+- Import route: `guardian/routes/migration.py:44-55`
+- Canonical path: `POST /api/upload-chatgpt-export`
+- Legacy alias: `POST /upload-chatgpt-export`
+- Auth: `get_request_user_id` and `require_api_key`
+- Response model: `MigrationStats`
+
+### Nearest adjacent export-related surface
+- Single-entry Codex markdown export:
+  - `guardian/routes/codex.py:191-208`
+  - legacy redirect alias in `guardian/guardian_api.py:1063-1068`
+- This is not account export. It exports one Codex entry as markdown.
+
+### Authentication note
+- `require_user` accepts API key, bearer token, or `gc_session` cookie.
+- Anchors:
+  - `guardian/core/auth.py:124-140`
+  - `guardian/routes/admin.py:270-307`
+- The DATA-tab export click path does not use the authenticated fetch helper that the rest of the frontend uses for normal API calls, so the button is only safe if browser auth state already exists in the current runtime.
+
+## Coverage against the expected account export scope
+
+| Data family | Status | Repo anchor(s) | Why |
+|---|---|---|---|
+| Chats / thread history | Partially implemented | `guardian/routes/api_exports.py:243-295`, `guardian/routes/api_exports.py:298-425`, `guardian/core/pgdb.py:2108-2184`, `guardian/core/pgdb.py:2225-2405` | There is a thread-row NDJSON export and a ChatGPT-conversation ZIP export, but no single full conversation-history export for all chat messages across the product. |
+| Uploaded documents | Partially implemented | `guardian/routes/media.py:1011-1029`, `guardian/routes/media.py:1981-2000`, `guardian/routes/documents.py:457-500`, `guardian/routes/share.py:69-183`, `guardian/routes/share.py:196-320` | Documents can be uploaded, listed, linked to threads, and shared individually, but there is no bulk account export path. |
+| Generated documents | Partially implemented | `guardian/routes/documents.py:307-322`, `guardian/routes/documents.py:457-500`, `guardian/routes/share.py:116-137`, `guardian/routes/share.py:296-320` | Generated docs can be created, linked to threads, and shared individually, but there is no bulk export bundle for them. |
+| Uploaded images | Partially implemented | `guardian/routes/media.py:629-647`, `guardian/routes/media.py:959-983`, `guardian/routes/media.py:1887-1908` | Images can be uploaded, retrieved, and listed, but there is no account export route that packages all user-owned images. |
+| Generated images | Partially implemented | `guardian/routes/media.py:1499-1510`, `guardian/routes/media.py:1887-1908` | Generated images are tracked and listable via `GET /images?tag=generated`, but there is no bulk export route. |
+| Thread-linked artifacts / related media | Partially implemented | `guardian/routes/documents.py:457-500`, `guardian/routes/share.py:243-320` | Thread-document links and shareable thread/document payloads exist, but there is no unified export envelope for all linked artifacts. |
+
+## Bug diagnosis for the reported `GET /codex` 404
+
+- `GET /codex` is **not** the direct cause of the DATA-tab export button.
+- The active export button resolves to `GET /exports/chatgpt.zip`, not `/codex`.
+- The `GET /codex` 404 is therefore unrelated noise for the DATA-tab export path.
+- If a separate legacy codex link is being exercised, the failure mode is route drift:
+  - canonical codex routes are `/api/codex/entries`, `/api/codex/entries/{entry_id}`, and `/api/codex/entries/{entry_id}/export`
+  - the compatibility aliases under `/codex/...` are gated by `CODEXIFY_ENABLE_CODEX_ROUTES`
+  - anchors: `guardian/routes/codex.py:191-208`, `guardian/guardian_api.py:1047-1068`
+- So the concrete issue is not "account export is broken because `/codex` 404s"; the concrete issue is that the DATA-tab export surface is only wired to a narrow export bundle and does not cover the full account scope.
+
+## Truthful conclusion
+
+Account Export currently is:
+- a narrow authenticated download of imported ChatGPT conversations (`/exports/chatgpt.zip`)
+- a separate NDJSON export of thread rows (`/exports/threads.ndjson`)
+- a separate single-entry Codex markdown export
+
+Account Export currently is not:
+- a complete "extract everything I put into Codexify" feature
+- a bulk export for uploaded documents, generated documents, uploaded images, generated images, or all thread-linked artifacts
+
+Production-safety verdict for the DATA-tab export button:
+- **Not production-safe as a full account-export control.**
+- It only covers a subset of user-owned data and it relies on browser navigation/open-external behavior rather than a guaranteed authenticated fetch flow.
+
+Minimum next engineering task:
+- define and implement a real account-export contract that enumerates all user-owned data families, serializes them into one authenticated export artifact or job result, and includes explicit handling for thread history, docs, images, generated artifacts, and thread links.
+
+## Search strings used
+- `Import ChatGPT History`
+- `Export Codexify History`
+- `Import ChatGPT history`
+- `Download Codexify ZIP export`
+- `/exports/chatgpt.zip`
+- `/api/upload-chatgpt-export`
+- `/codex/entries/{entry_id}/export`
+- `CODEXIFY_ENABLE_CODEX_ROUTES`
+
+## Verification
+- No automated tests apply for this investigation-only documentation task.
+- Code inspection only; no runtime behavior was changed.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -99,6 +99,11 @@ function isCommandCenterRoute() {
   return window.location.pathname.startsWith("/command-center");
 }
 
+function isPersonaStudioRoute() {
+  if (typeof window === "undefined") return false;
+  return window.location.pathname.startsWith("/persona-studio");
+}
+
 function isShareRoute() {
   if (typeof window === "undefined") return false;
   return window.location.pathname.startsWith("/share/");
@@ -380,6 +385,7 @@ export default function App() {
   const tuneRoute = TUNE_ENABLED && isTuneRoute();
   const eventsRoute = isEventsRoute();
   const commandCenterRoute = isCommandCenterRoute();
+  const personaStudioRoute = isPersonaStudioRoute();
   const shareRoute = isShareRoute();
   const shareToken = shareRoute ? getShareToken() : null;
   const bootstrapEnabled =
@@ -387,6 +393,7 @@ export default function App() {
     !tuneRoute &&
     !eventsRoute &&
     !commandCenterRoute &&
+    !personaStudioRoute &&
     !(shareRoute && !!shareToken);
   const [docGenOpen, setDocGenOpen] = React.useState(false);
   const [docGenDraft, setDocGenDraft] = React.useState<DocumentGenInput | null>(
@@ -1050,7 +1057,10 @@ export default function App() {
     );
   }
   if (commandCenterRoute) {
-    return <CommandCenterPage enabled={COMMAND_CENTER_ENABLED} />;
+    return <CommandCenterPage enabled={COMMAND_CENTER_ENABLED || commandCenterRoute} />;
+  }
+  if (personaStudioRoute) {
+    return <AppShell />;
   }
   if (shareRoute) {
     if (shareToken) {

--- a/frontend/src/components/persona/layout/AppShell.tsx
+++ b/frontend/src/components/persona/layout/AppShell.tsx
@@ -33,6 +33,7 @@ import RefractiveGlassCard from "@/components/ui/RefractiveGlassCard";
 import GuardianChat from "@/features/chat/GuardianChat";
 import DashboardView from "@/components/dashboard/DashboardView";
 import SettingsView from "@/features/settings/SettingsView";
+import PersonaStudioPage from "@/features/personaStudio/PersonaStudioPage";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import DocumentsView from "@/components/documents/DocumentsView";
 import GuardianChatWithSidebar from "@/components/persona/layout/GuardianChatWithSidebar";
@@ -102,7 +103,8 @@ type AppShellView =
   | "documents"
   | "gallery"
   | "guardian"
-  | "settings";
+  | "settings"
+  | "personaStudio";
 type WorkspaceShellView = "dashboard" | "documents" | "guardian";
 type DocItem = DocumentLike & { ext: keyof ExtColors };
 type AppShellProps = PropsWithChildren<{
@@ -2078,6 +2080,13 @@ export default function AppShell({
           >
             Settings
           </button>
+          <button
+            className="pill-tab"
+            data-state={view === "personaStudio" ? "active" : "inactive"}
+            onClick={() => setView("personaStudio")}
+          >
+            Persona Studio
+          </button>
         </div>
         {(workspaceShellEnabled || activeRouteThreadId != null) && (
           <div className="flex items-center justify-end gap-2">
@@ -2432,6 +2441,16 @@ export default function AppShell({
                   />
                 </ErrorBoundary>
               </div>
+            </FrameCard>
+          )}
+          {!startupLocked && view === "personaStudio" && (
+            <FrameCard
+              refractiveFallback
+              shimmerMode="subtle"
+              className="flex h-full w-full min-h-0 flex-col overflow-hidden"
+              data-testid="persona-studio-framecard"
+            >
+              <PersonaStudioPage />
             </FrameCard>
           )}
         </div>

--- a/frontend/src/components/persona/layout/AppShell.tsx
+++ b/frontend/src/components/persona/layout/AppShell.tsx
@@ -112,6 +112,49 @@ type AppShellProps = PropsWithChildren<{
   startupOverlay?: React.ReactNode;
 }>;
 
+const APP_SHELL_VIEWS = [
+  "dashboard",
+  "documents",
+  "gallery",
+  "guardian",
+  "settings",
+  "personaStudio",
+] as const satisfies readonly AppShellView[];
+
+const APP_SHELL_VIEW_SET = new Set<AppShellView>(APP_SHELL_VIEWS);
+
+function isAppShellView(value: string | null): value is AppShellView {
+  return value != null && APP_SHELL_VIEW_SET.has(value as AppShellView);
+}
+
+function resolveViewFromPathname(pathname: string): AppShellView | null {
+  if (pathname.startsWith("/persona-studio")) return "personaStudio";
+  if (pathname.startsWith("/settings")) return "settings";
+  if (pathname.startsWith("/gallery")) return "gallery";
+  if (pathname.startsWith("/documents")) return "documents";
+  if (pathname.startsWith("/dashboard")) return "dashboard";
+  if (pathname.startsWith("/chat")) return "guardian";
+  return null;
+}
+
+function resolvePathForView(view: AppShellView, threadId: number | null): string {
+  switch (view) {
+    case "guardian":
+      return threadId != null ? `/chat/${threadId}` : "/chat";
+    case "documents":
+      return "/documents";
+    case "gallery":
+      return "/gallery";
+    case "settings":
+      return "/settings";
+    case "personaStudio":
+      return "/persona-studio";
+    case "dashboard":
+    default:
+      return "/dashboard";
+  }
+}
+
 function isWorkspaceShellView(view: AppShellView): view is WorkspaceShellView {
   return view === "dashboard" || view === "documents" || view === "guardian";
 }
@@ -782,9 +825,19 @@ export default function AppShell({
      - `wallpaper`: Optional image for the background.
      - We persist the last view and wallpaper for a seamless return experience.
      ───────────────────────────────────────────────────────────────────────────── */
-  const [view, setView] = useState<AppShellView>(() =>
-    (typeof window === "undefined" ? "dashboard" : ((localStorage.getItem("cfy.lastView") as any) || "dashboard"))
-  );
+  const [view, setView] = useState<AppShellView>(() => {
+    if (typeof window !== "undefined") {
+      const routeView = resolveViewFromPathname(window.location.pathname);
+      if (routeView) return routeView;
+
+      const storedView = window.localStorage.getItem("cfy.lastView");
+      if (isAppShellView(storedView)) {
+        return storedView;
+      }
+    }
+
+    return "dashboard";
+  });
   const workspaceShellEnabled = isWorkspaceShellView(view);
   const workspaceRouteContext: WorkspaceShellView = workspaceShellEnabled
     ? view
@@ -865,13 +918,26 @@ export default function AppShell({
     [projectModalIcon, projectModalName]
   );
   useEffect(() => { if (typeof window !== "undefined") localStorage.setItem("cfy.lastView", view); }, [view]);
-  // Sync the main view with URL when landing directly on /chat/:id
+  // Sync the main view with the browser URL so direct links and back/forward
+  // navigation keep the shell view in lockstep with the pathname.
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      if (window.location.pathname.startsWith("/chat/")) {
-        setView("guardian");
+    if (typeof window === "undefined") return;
+
+    const syncRouteState = () => {
+      setActiveRouteThreadId(readRouteThreadId());
+      const routeView = resolveViewFromPathname(window.location.pathname);
+      if (routeView) {
+        setView(routeView);
       }
-    }
+    };
+
+    syncRouteState();
+    window.addEventListener("popstate", syncRouteState);
+    window.addEventListener("cfy:threads:refresh", syncRouteState as EventListener);
+    return () => {
+      window.removeEventListener("popstate", syncRouteState);
+      window.removeEventListener("cfy:threads:refresh", syncRouteState as EventListener);
+    };
   }, []);
   const [wallpaper, setWallpaper] = useState<string | null>(() => (typeof window === "undefined" ? "https://images.unsplash.com/photo-1579546929518-9e396f3cc809?q=80&w=600&auto=format&fit=crop" : localStorage.getItem("cfy.wallpaper")));
 
@@ -938,6 +1004,19 @@ export default function AppShell({
   useEffect(() => {
     setProjectScopeMode(activeRouteThreadId != null ? "thread" : "project");
   }, [activeRouteThreadId]);
+  const navigateToView = useCallback(
+    (nextView: AppShellView) => {
+      setView(nextView);
+      if (typeof window === "undefined") return;
+
+      const nextPath = resolvePathForView(nextView, activeRouteThreadId);
+      if (window.location.pathname !== nextPath) {
+        window.history.pushState({}, "", nextPath);
+      }
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    },
+    [activeRouteThreadId]
+  );
   const [documentsSource, setDocumentsSource] = useState<"default" | "cache" | "backend">(() => {
     if (typeof window === "undefined") return "default";
     return readCachedDocuments() ? "cache" : "default";
@@ -1628,10 +1707,10 @@ export default function AppShell({
       const doc = normalizeDoc(request.doc);
       setDocumentsSource((prev) => (prev === "default" ? "cache" : prev));
       setDocuments((prev) => dedupeDocItems([doc, ...prev]));
-      setView(request.targetView === "guardian" ? "guardian" : "documents");
+      navigateToView(request.targetView === "guardian" ? "guardian" : "documents");
       openWorkspaceDrawer("inspector");
     },
-    [openWorkspaceDrawer]
+    [navigateToView, openWorkspaceDrawer]
   );
   const {
     openWorkspaceDocument,
@@ -1728,7 +1807,7 @@ export default function AppShell({
     }
     // Prefill Guardian chat with image-derived tag
     setPrefill(`[image-derived][${mode}] ${prompt}`);
-    setView("guardian");
+    navigateToView("guardian");
     try { window.dispatchEvent(new CustomEvent("cfy:toast", { detail: { message: "Image prompt generated" } })); } catch {}
     setVisionBusySrc(null);
   }
@@ -1750,7 +1829,7 @@ export default function AppShell({
     }
     setPrefill(undefined);
     closeWorkspaceDrawer();
-    setView("guardian");
+    navigateToView("guardian");
     if (typeof window !== "undefined") {
       try {
         window.dispatchEvent(
@@ -1761,10 +1840,8 @@ export default function AppShell({
       } catch (eventErr) {
         console.warn("[dashboard] draft-thread event failed", eventErr);
       }
-      window.history.pushState({}, "", "/chat");
-      window.dispatchEvent(new PopStateEvent("popstate"));
     }
-  }, [auth, closeWorkspaceDrawer]);
+  }, [auth, closeWorkspaceDrawer, navigateToView]);
   // Use an active wallpaper for refractive glass; fall back to first gallery image if none chosen yet
   const activeWallpaper = useMemo(() => {
     return wallpaper ?? (gallery && gallery.length > 0 ? gallery[0].src : "https://images.unsplash.com/photo-1579546929518-9e396f3cc809?q=80&w=600&auto=format&fit=crop");
@@ -1773,7 +1850,7 @@ export default function AppShell({
   const bp = useBreakpoint();
 
   // Helper to jump to Guardian chat with a prefilled prompt
-  function openChatWithPrompt(p: string) { setPrefill(p); setView("guardian"); }
+  function openChatWithPrompt(p: string) { setPrefill(p); navigateToView("guardian"); }
 
   // Responsive layout helper for Settings view
   const settingsLayout = useMemo(() => {
@@ -2048,42 +2125,42 @@ export default function AppShell({
           <button
             className="pill-tab"
             data-state={view === "guardian" ? "active" : "inactive"}
-            onClick={() => setView("guardian")}
+            onClick={() => navigateToView("guardian")}
           >
             Guardian
           </button>
           <button
             className="pill-tab"
             data-state={view === "dashboard" ? "active" : "inactive"}
-            onClick={() => setView("dashboard")}
+            onClick={() => navigateToView("dashboard")}
           >
             Dashboard
           </button>
           <button
             className="pill-tab"
             data-state={view === "documents" ? "active" : "inactive"}
-            onClick={() => setView("documents")}
+            onClick={() => navigateToView("documents")}
           >
             Documents
           </button>
           <button
             className="pill-tab"
             data-state={view === "gallery" ? "active" : "inactive"}
-            onClick={() => setView("gallery")}
+            onClick={() => navigateToView("gallery")}
           >
             Gallery
           </button>
           <button
             className="pill-tab"
             data-state={view === "settings" ? "active" : "inactive"}
-            onClick={() => setView("settings")}
+            onClick={() => navigateToView("settings")}
           >
             Settings
           </button>
           <button
             className="pill-tab"
             data-state={view === "personaStudio" ? "active" : "inactive"}
-            onClick={() => setView("personaStudio")}
+            onClick={() => navigateToView("personaStudio")}
           >
             Persona Studio
           </button>
@@ -2392,8 +2469,8 @@ export default function AppShell({
                     onImagePrompt={openChatWithPrompt}
                     onRequestNewProject={openCreateProjectModal}
                     onRequestNewThread={createThreadFromDashboard}
-                    onNavigateDocuments={() => setView("documents")}
-                    onNavigateGallery={() => setView("gallery")}
+                    onNavigateDocuments={() => navigateToView("documents")}
+                    onNavigateGallery={() => navigateToView("gallery")}
                     threadGridRows={dashboardThreadRows}
                   />
                 </div>

--- a/frontend/src/components/persona/layout/__tests__/AppShell.test.tsx
+++ b/frontend/src/components/persona/layout/__tests__/AppShell.test.tsx
@@ -256,7 +256,7 @@ function setRoutePath(pathname: string) {
 }
 
 function setRouteThread(threadId: number | null) {
-  setRoutePath(threadId == null ? "/dashboard" : `/chat/${threadId}`);
+  setRoutePath(threadId == null ? "/" : `/chat/${threadId}`);
 }
 
 function notifyRouteChange() {
@@ -341,6 +341,16 @@ describe("AppShell logo wordmark color contract", () => {
     render(<AppShell />);
 
     expect(listCodexEntriesSpy).not.toHaveBeenCalled();
+  });
+
+  it("honors the /persona-studio route on initial render", async () => {
+    setRoutePath("/persona-studio");
+
+    render(<AppShell />);
+
+    expect(
+      await screen.findByText(/configure runtime persona profiles/i)
+    ).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/features/personaStudio/PersonaStudioPage.tsx
+++ b/frontend/src/features/personaStudio/PersonaStudioPage.tsx
@@ -4,229 +4,12 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-
-type PersonaProfile = {
-  id: string;
-  name: string;
-  description: string;
-  isDefault?: boolean;
-};
-
-type ModelSettings = {
-  provider: string;
-  model: string;
-  temperature: number;
-  topK: number;
-  topP: number;
-  maxTokens: number;
-};
-
-type VoiceSettings = {
-  enabled: boolean;
-  provider: string;
-  voicePreset: string;
-  speed: number;
-  wakeWord: string;
-  interruptible: boolean;
-};
-
-type PromptSettings = {
-  systemPrompt: string;
-  styleNotes: string;
-  directives: string;
-};
-
-type ToolsSettings = {
-  pinnedTools: string[];
-  allowedTools: string[];
-  skills: string[];
-  permissions: {
-    web: boolean;
-    email: boolean;
-    calendar: boolean;
-    cli: boolean;
-    filesystem: boolean;
-  };
-};
-
-type RetrievalSettings = {
-  enabled: boolean;
-  mode: string;
-  topK: number;
-  rerank: boolean;
-};
-
-type PersonaConfig = {
-  identity: {
-    name: string;
-    description: string;
-  };
-  model: ModelSettings;
-  voice: VoiceSettings;
-  prompt: PromptSettings;
-  tools: ToolsSettings;
-  permissions: ToolsSettings;
-  retrieval: RetrievalSettings;
-};
-
-const MOCK_PROFILES: PersonaProfile[] = [
-  {
-    id: "profile-1",
-    name: "Guardian Default",
-    description: "Default guardian persona for general assistance",
-    isDefault: true,
-  },
-  {
-    id: "profile-2",
-    name: "Code Assistant",
-    description: "Specialized for code review and programming tasks",
-  },
-  {
-    id: "profile-3",
-    name: "Research Partner",
-    description: "Focused on research and information synthesis",
-  },
-];
-
-const MOCK_CONFIG: Record<string, PersonaConfig> = {
-  "profile-1": {
-    identity: {
-      name: "Guardian Default",
-      description: "Default guardian persona for general assistance",
-    },
-    model: {
-      provider: "openai",
-      model: "gpt-4o",
-      temperature: 0.7,
-      topK: 40,
-      topP: 0.95,
-      maxTokens: 4096,
-    },
-    voice: {
-      enabled: true,
-      provider: "elevenlabs",
-      voicePreset: "rachel",
-      speed: 1.0,
-      wakeWord: "Hey Guardian",
-      interruptible: true,
-    },
-    prompt: {
-      systemPrompt: "You are a Guardian, a partner in thought. Your primary goal is to foster the user's autonomy and creativity.",
-      styleNotes: "Use a warm, encouraging tone. Favor questions over statements when appropriate.",
-      directives: "Always prioritize user privacy. Never share sensitive information without explicit permission.",
-    },
-    tools: {
-      pinnedTools: ["web-search", "calculator", "code-interpreter"],
-      allowedTools: ["web-search", "calculator", "code-interpreter", "file-reader"],
-      skills: ["critical-thinking", "creative-brainstorming"],
-      permissions: {
-        web: true,
-        email: false,
-        calendar: false,
-        cli: false,
-        filesystem: true,
-      },
-    },
-    retrieval: {
-      enabled: true,
-      mode: "hybrid",
-      topK: 10,
-      rerank: true,
-    },
-  },
-  "profile-2": {
-    identity: {
-      name: "Code Assistant",
-      description: "Specialized for code review and programming tasks",
-    },
-    model: {
-      provider: "anthropic",
-      model: "claude-sonnet-4-20250514",
-      temperature: 0.3,
-      topK: 20,
-      topP: 0.9,
-      maxTokens: 8192,
-    },
-    voice: {
-      enabled: false,
-      provider: "elevenlabs",
-      voicePreset: "matt",
-      speed: 1.0,
-      wakeWord: "",
-      interruptible: true,
-    },
-    prompt: {
-      systemPrompt: "You are an expert code assistant. Provide clear, concise, and accurate code solutions with explanation.",
-      styleNotes: "Be precise and technical. Include code examples where helpful.",
-      directives: "Always verify code syntax before presenting. Flag potential security issues.",
-    },
-    tools: {
-      pinnedTools: ["code-interpreter", "git", "terminal"],
-      allowedTools: ["code-interpreter", "git", "terminal", "web-search", "file-reader"],
-      skills: ["code-review", "debugging", "architecture-design"],
-      permissions: {
-        web: true,
-        email: false,
-        calendar: false,
-        cli: true,
-        filesystem: true,
-      },
-    },
-    retrieval: {
-      enabled: true,
-      mode: "semantic",
-      topK: 5,
-      rerank: false,
-    },
-  },
-  "profile-3": {
-    identity: {
-      name: "Research Partner",
-      description: "Focused on research and information synthesis",
-    },
-    model: {
-      provider: "openai",
-      model: "gpt-4-turbo",
-      temperature: 0.5,
-      topK: 60,
-      topP: 0.97,
-      maxTokens: 16384,
-    },
-    voice: {
-      enabled: true,
-      provider: "elevenlabs",
-      voicePreset: "aria",
-      speed: 0.9,
-      wakeWord: "Hey Research",
-      interruptible: true,
-    },
-    prompt: {
-      systemPrompt: "You are a research partner specializing in information synthesis and critical analysis.",
-      styleNotes: "Present information in organized, cited format. Distinguish between facts and interpretations.",
-      directives: "Cite sources when available. Clearly state uncertainty when information is incomplete.",
-    },
-    tools: {
-      pinnedTools: ["web-search", "academic-search", "note-taking"],
-      allowedTools: ["web-search", "academic-search", "note-taking", "calculator"],
-      skills: ["literature-review", "meta-analysis", "synthesis"],
-      permissions: {
-        web: true,
-        email: false,
-        calendar: false,
-        cli: false,
-        filesystem: true,
-      },
-    },
-    retrieval: {
-      enabled: true,
-      mode: "hybrid",
-      topK: 20,
-      rerank: true,
-    },
-  },
-};
-
-type EditorTab = "identity" | "model" | "voice" | "prompt" | "tools" | "retrieval";
+import {
+  type PersonaConfig,
+  type PersonaProfileDraft,
+  type ToolsSettings,
+  usePersonaStudioLocalDraftState,
+} from "./personaStudioStore";
 
 function TabButton({
   active,
@@ -922,36 +705,55 @@ function RetrievalEditor({
   );
 }
 
+function buildDebugLog(
+  profile: PersonaProfileDraft | null,
+  config: PersonaConfig | null
+): string[] {
+  if (!profile || !config) {
+    return [
+      "[PersonaStudio] Initialized local draft store",
+      "[PersonaStudio] Waiting for profile selection",
+      "[Config] No profile selected",
+    ];
+  }
+
+  return [
+    "[PersonaStudio] Initialized local draft store",
+    `[PersonaStudio] Selected profile: ${profile.id}`,
+    `[PersonaStudio] Profile loaded: ${profile.name}`,
+    `[Config] Model: ${config.model.provider}/${config.model.model}`,
+    `[Config] Temperature: ${config.model.temperature}`,
+    `[Config] Voice: ${config.voice.enabled ? config.voice.provider : "disabled"}`,
+    `[Config] Retrieval: ${config.retrieval.enabled ? config.retrieval.mode : "disabled"}`,
+  ];
+}
+
 function DiagnosticsPanel({
   profile,
   config,
   isDirty,
-  saveStatus,
+  hasSavedVersion,
 }: {
-  profile: PersonaProfile | null;
+  profile: PersonaProfileDraft | null;
   config: PersonaConfig | null;
   isDirty: boolean;
-  saveStatus: "idle" | "saving" | "saved" | "error";
+  hasSavedVersion: boolean;
 }) {
-  const [debugLog, setDebugLog] = React.useState<string[]>([
-    "[PersonaStudio] Initialized mock persona engine",
-    "[PersonaStudio] Loaded profile list: 3 profiles",
-    "[PersonaStudio] Selected profile: guardian-default",
-    "[Config] Model provider: openai",
-    "[Config] Temperature: 0.7",
-  ]);
+  const [debugLog, setDebugLog] = React.useState<string[]>(() =>
+    buildDebugLog(profile, config)
+  );
 
   React.useEffect(() => {
-    if (!profile || !config) return;
-    const logs = [
-      `[PersonaStudio] Profile loaded: ${profile.name}`,
-      `[Config] Model: ${config.model.provider}/${config.model.model}`,
-      `[Config] Temperature: ${config.model.temperature}`,
-      `[Config] Voice: ${config.voice.enabled ? config.voice.provider : "disabled"}`,
-      `[Config] Retrieval: ${config.retrieval.enabled ? config.retrieval.mode : "disabled"}`,
-    ];
-    setDebugLog(logs);
+    setDebugLog(buildDebugLog(profile, config));
   }, [profile, config]);
+
+  const saveStatusLabel = isDirty
+    ? "Unsaved Draft"
+    : hasSavedVersion
+      ? "Saved Locally"
+      : "Seed Draft";
+
+  const saveStatusTone = isDirty ? "warning" : hasSavedVersion ? "saved" : "seed";
 
   return (
     <div className="space-y-4 h-full flex flex-col">
@@ -966,19 +768,19 @@ function DiagnosticsPanel({
               className="text-xs"
               style={{
                 borderColor:
-                  saveStatus === "saved"
+                  saveStatusTone === "saved"
                     ? "rgba(34, 197, 94, 0.35)"
-                    : saveStatus === "error"
-                      ? "rgba(239, 68, 68, 0.35)"
+                    : saveStatusTone === "warning"
+                      ? "rgba(234, 179, 8, 0.35)"
                       : "var(--panel-border)",
-                background: saveStatus === "saved"
+                background: saveStatusTone === "saved"
                   ? "rgba(34, 197, 94, 0.12)"
-                  : saveStatus === "error"
-                    ? "rgba(239, 68, 68, 0.12)"
+                  : saveStatusTone === "warning"
+                    ? "rgba(234, 179, 8, 0.12)"
                     : "transparent",
               }}
             >
-              {saveStatus === "idle" ? "No changes" : saveStatus === "saving" ? "Saving..." : saveStatus === "saved" ? "Saved" : "Error"}
+              {saveStatusLabel}
             </Badge>
           </div>
 
@@ -1033,63 +835,49 @@ function DiagnosticsPanel({
           ))}
         </div>
       </div>
+
     </div>
   );
 }
 
 export default function PersonaStudioPage() {
-  const [selectedProfileId, setSelectedProfileId] = React.useState<string>(
-    MOCK_PROFILES[0].id
-  );
-  const [activeTab, setActiveTab] = React.useState<EditorTab>("identity");
-  const [configs, setConfigs] = React.useState<Record<string, PersonaConfig>>(MOCK_CONFIG);
-  const [isDirty, setIsDirty] = React.useState(false);
-  const [saveStatus, setSaveStatus] = React.useState<"idle" | "saving" | "saved" | "error">("idle");
+  const {
+    profiles,
+    selectedProfileId,
+    activeTab,
+    selectedProfile,
+    isDirty,
+    hasSavedVersion,
+    setSelectedProfileId,
+    setActiveTab,
+    updateSelectedProfile,
+    saveSelectedProfile,
+    saveSelectedProfileAsNew,
+    resetSelectedProfile,
+    resetAllLocalPersonaStudioData,
+  } = usePersonaStudioLocalDraftState();
 
-  const selectedProfile = MOCK_PROFILES.find((p) => p.id === selectedProfileId) || null;
-  const currentConfig = configs[selectedProfileId] || null;
+  const currentConfig = selectedProfile?.config || null;
 
   const handleConfigChange = (newConfig: PersonaConfig) => {
-    setConfigs((prev) => ({
-      ...prev,
-      [selectedProfileId]: newConfig,
+    updateSelectedProfile((currentProfile) => ({
+      ...currentProfile,
+      name: newConfig.identity.name,
+      description: newConfig.identity.description,
+      config: newConfig,
     }));
-    setIsDirty(true);
-    setSaveStatus("idle");
   };
 
   const handleSave = () => {
-    setSaveStatus("saving");
-    setTimeout(() => {
-      setSaveStatus("saved");
-      setIsDirty(false);
-    }, 500);
+    saveSelectedProfile();
   };
 
   const handleSaveAsNew = () => {
-    const newId = `profile-${Date.now()}`;
-    const newProfile: PersonaProfile = {
-      id: newId,
-      name: `${currentConfig?.identity.name || "Persona"} (Copy)`,
-      description: currentConfig?.identity.description || "",
-    };
-    MOCK_PROFILES.push(newProfile);
-    setConfigs((prev) => ({
-      ...prev,
-      [newId]: JSON.parse(JSON.stringify(currentConfig)),
-    }));
-    setSelectedProfileId(newId);
-    setSaveStatus("saved");
-    setIsDirty(false);
+    saveSelectedProfileAsNew();
   };
 
   const handleReset = () => {
-    setConfigs((prev) => ({
-      ...prev,
-      [selectedProfileId]: JSON.parse(JSON.stringify(MOCK_CONFIG[selectedProfileId])),
-    }));
-    setIsDirty(false);
-    setSaveStatus("idle");
+    resetSelectedProfile();
   };
 
   return (
@@ -1114,16 +902,12 @@ export default function PersonaStudioPage() {
               <CardTitle className="text-base">Profiles</CardTitle>
             </CardHeader>
             <CardContent className="space-y-2">
-              {MOCK_PROFILES.map((profile) => (
+              {profiles.map((profile) => (
                 <button
                   key={profile.id}
                   type="button"
                   onClick={() => {
-                    if (profile.id !== selectedProfileId) {
-                      setSelectedProfileId(profile.id);
-                      setIsDirty(false);
-                      setSaveStatus("idle");
-                    }
+                    setSelectedProfileId(profile.id);
                   }}
                   className={`w-full text-left p-3 rounded-xl transition-colors ${
                     profile.id === selectedProfileId
@@ -1247,9 +1031,9 @@ export default function PersonaStudioPage() {
                 <Button
                   type="button"
                   onClick={handleSave}
-                  disabled={!isDirty || saveStatus === "saving"}
+                  disabled={!isDirty}
                 >
-                  {saveStatus === "saving" ? "Saving..." : "Save"}
+                  Save
                 </Button>
                 <Button
                   type="button"
@@ -1267,6 +1051,17 @@ export default function PersonaStudioPage() {
                 >
                   Reset
                 </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={resetAllLocalPersonaStudioData}
+                  className="whitespace-nowrap"
+                  aria-label="Reset All Local Persona Studio Data"
+                  title="Reset All Local Persona Studio Data"
+                >
+                  Reset All Data
+                </Button>
               </div>
             </CardContent>
           </Card>
@@ -1283,7 +1078,7 @@ export default function PersonaStudioPage() {
                 profile={selectedProfile}
                 config={currentConfig}
                 isDirty={isDirty}
-                saveStatus={saveStatus}
+                hasSavedVersion={hasSavedVersion}
               />
             </CardContent>
           </Card>

--- a/frontend/src/features/personaStudio/PersonaStudioPage.tsx
+++ b/frontend/src/features/personaStudio/PersonaStudioPage.tsx
@@ -1,0 +1,1294 @@
+import * as React from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+type PersonaProfile = {
+  id: string;
+  name: string;
+  description: string;
+  isDefault?: boolean;
+};
+
+type ModelSettings = {
+  provider: string;
+  model: string;
+  temperature: number;
+  topK: number;
+  topP: number;
+  maxTokens: number;
+};
+
+type VoiceSettings = {
+  enabled: boolean;
+  provider: string;
+  voicePreset: string;
+  speed: number;
+  wakeWord: string;
+  interruptible: boolean;
+};
+
+type PromptSettings = {
+  systemPrompt: string;
+  styleNotes: string;
+  directives: string;
+};
+
+type ToolsSettings = {
+  pinnedTools: string[];
+  allowedTools: string[];
+  skills: string[];
+  permissions: {
+    web: boolean;
+    email: boolean;
+    calendar: boolean;
+    cli: boolean;
+    filesystem: boolean;
+  };
+};
+
+type RetrievalSettings = {
+  enabled: boolean;
+  mode: string;
+  topK: number;
+  rerank: boolean;
+};
+
+type PersonaConfig = {
+  identity: {
+    name: string;
+    description: string;
+  };
+  model: ModelSettings;
+  voice: VoiceSettings;
+  prompt: PromptSettings;
+  tools: ToolsSettings;
+  permissions: ToolsSettings;
+  retrieval: RetrievalSettings;
+};
+
+const MOCK_PROFILES: PersonaProfile[] = [
+  {
+    id: "profile-1",
+    name: "Guardian Default",
+    description: "Default guardian persona for general assistance",
+    isDefault: true,
+  },
+  {
+    id: "profile-2",
+    name: "Code Assistant",
+    description: "Specialized for code review and programming tasks",
+  },
+  {
+    id: "profile-3",
+    name: "Research Partner",
+    description: "Focused on research and information synthesis",
+  },
+];
+
+const MOCK_CONFIG: Record<string, PersonaConfig> = {
+  "profile-1": {
+    identity: {
+      name: "Guardian Default",
+      description: "Default guardian persona for general assistance",
+    },
+    model: {
+      provider: "openai",
+      model: "gpt-4o",
+      temperature: 0.7,
+      topK: 40,
+      topP: 0.95,
+      maxTokens: 4096,
+    },
+    voice: {
+      enabled: true,
+      provider: "elevenlabs",
+      voicePreset: "rachel",
+      speed: 1.0,
+      wakeWord: "Hey Guardian",
+      interruptible: true,
+    },
+    prompt: {
+      systemPrompt: "You are a Guardian, a partner in thought. Your primary goal is to foster the user's autonomy and creativity.",
+      styleNotes: "Use a warm, encouraging tone. Favor questions over statements when appropriate.",
+      directives: "Always prioritize user privacy. Never share sensitive information without explicit permission.",
+    },
+    tools: {
+      pinnedTools: ["web-search", "calculator", "code-interpreter"],
+      allowedTools: ["web-search", "calculator", "code-interpreter", "file-reader"],
+      skills: ["critical-thinking", "creative-brainstorming"],
+      permissions: {
+        web: true,
+        email: false,
+        calendar: false,
+        cli: false,
+        filesystem: true,
+      },
+    },
+    retrieval: {
+      enabled: true,
+      mode: "hybrid",
+      topK: 10,
+      rerank: true,
+    },
+  },
+  "profile-2": {
+    identity: {
+      name: "Code Assistant",
+      description: "Specialized for code review and programming tasks",
+    },
+    model: {
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      temperature: 0.3,
+      topK: 20,
+      topP: 0.9,
+      maxTokens: 8192,
+    },
+    voice: {
+      enabled: false,
+      provider: "elevenlabs",
+      voicePreset: "matt",
+      speed: 1.0,
+      wakeWord: "",
+      interruptible: true,
+    },
+    prompt: {
+      systemPrompt: "You are an expert code assistant. Provide clear, concise, and accurate code solutions with explanation.",
+      styleNotes: "Be precise and technical. Include code examples where helpful.",
+      directives: "Always verify code syntax before presenting. Flag potential security issues.",
+    },
+    tools: {
+      pinnedTools: ["code-interpreter", "git", "terminal"],
+      allowedTools: ["code-interpreter", "git", "terminal", "web-search", "file-reader"],
+      skills: ["code-review", "debugging", "architecture-design"],
+      permissions: {
+        web: true,
+        email: false,
+        calendar: false,
+        cli: true,
+        filesystem: true,
+      },
+    },
+    retrieval: {
+      enabled: true,
+      mode: "semantic",
+      topK: 5,
+      rerank: false,
+    },
+  },
+  "profile-3": {
+    identity: {
+      name: "Research Partner",
+      description: "Focused on research and information synthesis",
+    },
+    model: {
+      provider: "openai",
+      model: "gpt-4-turbo",
+      temperature: 0.5,
+      topK: 60,
+      topP: 0.97,
+      maxTokens: 16384,
+    },
+    voice: {
+      enabled: true,
+      provider: "elevenlabs",
+      voicePreset: "aria",
+      speed: 0.9,
+      wakeWord: "Hey Research",
+      interruptible: true,
+    },
+    prompt: {
+      systemPrompt: "You are a research partner specializing in information synthesis and critical analysis.",
+      styleNotes: "Present information in organized, cited format. Distinguish between facts and interpretations.",
+      directives: "Cite sources when available. Clearly state uncertainty when information is incomplete.",
+    },
+    tools: {
+      pinnedTools: ["web-search", "academic-search", "note-taking"],
+      allowedTools: ["web-search", "academic-search", "note-taking", "calculator"],
+      skills: ["literature-review", "meta-analysis", "synthesis"],
+      permissions: {
+        web: true,
+        email: false,
+        calendar: false,
+        cli: false,
+        filesystem: true,
+      },
+    },
+    retrieval: {
+      enabled: true,
+      mode: "hybrid",
+      topK: 20,
+      rerank: true,
+    },
+  },
+};
+
+type EditorTab = "identity" | "model" | "voice" | "prompt" | "tools" | "retrieval";
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+        active
+          ? "bg-[var(--accent)] text-[var(--text-on-accent)]"
+          : "text-[var(--muted)] hover:text-[var(--text)] hover:bg-[var(--panel-hover)]"
+      }`}
+      style={{
+        background: active ? "var(--accent)" : undefined,
+        color: active ? "var(--text-on-accent)" : undefined,
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function IdentityEditor({
+  config,
+  onChange,
+}: {
+  config: PersonaConfig;
+  onChange: (config: PersonaConfig) => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Persona Name</label>
+        <Input
+          value={config.identity.name}
+          onChange={(e) =>
+            onChange({
+              ...config,
+              identity: { ...config.identity, name: e.target.value },
+            })
+          }
+          placeholder="Enter persona name"
+        />
+      </div>
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Description</label>
+        <Textarea
+          value={config.identity.description}
+          onChange={(e) =>
+            onChange({
+              ...config,
+              identity: { ...config.identity, description: e.target.value },
+            })
+          }
+          rows={3}
+          placeholder="Describe this persona"
+        />
+      </div>
+    </div>
+  );
+}
+
+function ModelEditor({
+  config,
+  onChange,
+}: {
+  config: PersonaConfig;
+  onChange: (config: PersonaConfig) => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Provider</label>
+          <select
+            className="w-full h-9 px-3 rounded-md border text-sm"
+            style={{
+              background: "transparent",
+              borderColor: "var(--panel-border)",
+              color: "var(--text)",
+            }}
+            value={config.model.provider}
+            onChange={(e) =>
+              onChange({
+                ...config,
+                model: { ...config.model, provider: e.target.value },
+              })
+            }
+          >
+            <option value="openai">OpenAI</option>
+            <option value="anthropic">Anthropic</option>
+            <option value="google">Google</option>
+            <option value="local">Local</option>
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Model</label>
+          <Input
+            value={config.model.model}
+            onChange={(e) =>
+              onChange({
+                ...config,
+                model: { ...config.model, model: e.target.value },
+              })
+            }
+            placeholder="e.g., gpt-4o"
+          />
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Temperature</label>
+          <div className="flex items-center gap-2">
+            <input
+              type="range"
+              min="0"
+              max="2"
+              step="0.1"
+              value={config.model.temperature}
+              onChange={(e) =>
+                onChange({
+                  ...config,
+                  model: { ...config.model, temperature: parseFloat(e.target.value) },
+                })
+              }
+              className="flex-1"
+            />
+            <span className="text-sm w-12 text-right">{config.model.temperature}</span>
+          </div>
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Max Tokens</label>
+          <Input
+            type="number"
+            value={config.model.maxTokens}
+            onChange={(e) =>
+              onChange({
+                ...config,
+                model: { ...config.model, maxTokens: parseInt(e.target.value) || 0 },
+              })
+            }
+          />
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Generation Top K</label>
+          <Input
+            type="number"
+            value={config.model.topK}
+            onChange={(e) =>
+              onChange({
+                ...config,
+                model: { ...config.model, topK: parseInt(e.target.value) || 0 },
+              })
+            }
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Top P</label>
+          <div className="flex items-center gap-2">
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.05"
+              value={config.model.topP}
+              onChange={(e) =>
+                onChange({
+                  ...config,
+                  model: { ...config.model, topP: parseFloat(e.target.value) },
+                })
+              }
+              className="flex-1"
+            />
+            <span className="text-sm w-12 text-right">{config.model.topP}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function VoiceEditor({
+  config,
+  onChange,
+}: {
+  config: PersonaConfig;
+  onChange: (config: PersonaConfig) => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <label className="relative inline-flex items-center cursor-pointer">
+          <input
+            type="checkbox"
+            checked={config.voice.enabled}
+            onChange={(e) =>
+              onChange({
+                ...config,
+                voice: { ...config.voice, enabled: e.target.checked },
+              })
+            }
+            className="sr-only peer"
+          />
+          <div className="w-9 h-5 bg-[var(--panel-border)] peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-[var(--accent)]"></div>
+        </label>
+        <span className="text-sm font-medium">Voice Enabled</span>
+      </div>
+
+      {config.voice.enabled && (
+        <>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Provider</label>
+              <select
+                className="w-full h-9 px-3 rounded-md border text-sm"
+                style={{
+                  background: "transparent",
+                  borderColor: "var(--panel-border)",
+                  color: "var(--text)",
+                }}
+                value={config.voice.provider}
+                onChange={(e) =>
+                  onChange({
+                    ...config,
+                    voice: { ...config.voice, provider: e.target.value },
+                  })
+                }
+              >
+                <option value="elevenlabs">ElevenLabs</option>
+                <option value="aws">AWS Polly</option>
+                <option value="google">Google TTS</option>
+                <option value="azure">Azure Speech</option>
+              </select>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Voice Preset / Voice ID</label>
+              <Input
+                value={config.voice.voicePreset}
+                onChange={(e) =>
+                  onChange({
+                    ...config,
+                    voice: { ...config.voice, voicePreset: e.target.value },
+                  })
+                }
+                placeholder="e.g., rachel"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Speed</label>
+              <div className="flex items-center gap-2">
+                <input
+                  type="range"
+                  min="0.5"
+                  max="2"
+                  step="0.1"
+                  value={config.voice.speed}
+                  onChange={(e) =>
+                    onChange({
+                      ...config,
+                      voice: { ...config.voice, speed: parseFloat(e.target.value) },
+                    })
+                  }
+                  className="flex-1"
+                />
+                <span className="text-sm w-12 text-right">{config.voice.speed}x</span>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Wake Word</label>
+              <Input
+                value={config.voice.wakeWord}
+                onChange={(e) =>
+                  onChange({
+                    ...config,
+                    voice: { ...config.voice, wakeWord: e.target.value },
+                  })
+                }
+                placeholder="e.g., Hey Guardian"
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <label className="relative inline-flex items-center cursor-pointer">
+              <input
+                type="checkbox"
+                checked={config.voice.interruptible}
+                onChange={(e) =>
+                  onChange({
+                    ...config,
+                    voice: { ...config.voice, interruptible: e.target.checked },
+                  })
+                }
+                className="sr-only peer"
+              />
+              <div className="w-9 h-5 bg-[var(--panel-border)] peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-[var(--accent)]"></div>
+            </label>
+            <span className="text-sm font-medium">Interruptible</span>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function PromptEditor({
+  config,
+  onChange,
+}: {
+  config: PersonaConfig;
+  onChange: (config: PersonaConfig) => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <label className="text-sm font-medium">System Prompt</label>
+        <Textarea
+          value={config.prompt.systemPrompt}
+          onChange={(e) =>
+            onChange({
+              ...config,
+              prompt: { ...config.prompt, systemPrompt: e.target.value },
+            })
+          }
+          rows={6}
+          placeholder="Enter the system prompt that defines this persona's behavior"
+        />
+      </div>
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Style Notes</label>
+        <Textarea
+          value={config.prompt.styleNotes}
+          onChange={(e) =>
+            onChange({
+              ...config,
+              prompt: { ...config.prompt, styleNotes: e.target.value },
+            })
+          }
+          rows={3}
+          placeholder="Notes about tone, manner, and communication style"
+        />
+      </div>
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Directives</label>
+        <Textarea
+          value={config.prompt.directives}
+          onChange={(e) =>
+            onChange({
+              ...config,
+              prompt: { ...config.prompt, directives: e.target.value },
+            })
+          }
+          rows={3}
+          placeholder="Operational directives and constraints"
+        />
+      </div>
+    </div>
+  );
+}
+
+function ToolsEditor({
+  config,
+  onChange,
+}: {
+  config: PersonaConfig;
+  onChange: (config: PersonaConfig) => void;
+}) {
+  const [newPinnedTool, setNewPinnedTool] = React.useState("");
+  const [newAllowedTool, setNewAllowedTool] = React.useState("");
+  const [newSkill, setNewSkill] = React.useState("");
+
+  const addPinnedTool = () => {
+    if (newPinnedTool.trim() && !config.tools.pinnedTools.includes(newPinnedTool.trim())) {
+      onChange({
+        ...config,
+        tools: {
+          ...config.tools,
+          pinnedTools: [...config.tools.pinnedTools, newPinnedTool.trim()],
+        },
+      });
+      setNewPinnedTool("");
+    }
+  };
+
+  const removePinnedTool = (tool: string) => {
+    onChange({
+      ...config,
+      tools: {
+        ...config.tools,
+        pinnedTools: config.tools.pinnedTools.filter((t) => t !== tool),
+      },
+    });
+  };
+
+  const addAllowedTool = () => {
+    if (newAllowedTool.trim() && !config.tools.allowedTools.includes(newAllowedTool.trim())) {
+      onChange({
+        ...config,
+        tools: {
+          ...config.tools,
+          allowedTools: [...config.tools.allowedTools, newAllowedTool.trim()],
+        },
+      });
+      setNewAllowedTool("");
+    }
+  };
+
+  const removeAllowedTool = (tool: string) => {
+    onChange({
+      ...config,
+      tools: {
+        ...config.tools,
+        allowedTools: config.tools.allowedTools.filter((t) => t !== tool),
+      },
+    });
+  };
+
+  const addSkill = () => {
+    if (newSkill.trim() && !config.tools.skills.includes(newSkill.trim())) {
+      onChange({
+        ...config,
+        tools: {
+          ...config.tools,
+          skills: [...config.tools.skills, newSkill.trim()],
+        },
+      });
+      setNewSkill("");
+    }
+  };
+
+  const removeSkill = (skill: string) => {
+    onChange({
+      ...config,
+      tools: {
+        ...config.tools,
+        skills: config.tools.skills.filter((s) => s !== skill),
+      },
+    });
+  };
+
+  const togglePermission = (key: keyof ToolsSettings["permissions"]) => {
+    onChange({
+      ...config,
+      tools: {
+        ...config.tools,
+        permissions: {
+          ...config.tools.permissions,
+          [key]: !config.tools.permissions[key],
+        },
+      },
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <label className="text-sm font-medium">Pinned Tools</label>
+        <div className="flex flex-wrap gap-2">
+          {config.tools.pinnedTools.map((tool) => (
+            <Badge
+              key={tool}
+              variant="outline"
+              className="px-2 py-1 text-xs"
+              style={{ borderColor: "var(--panel-border)" }}
+            >
+              {tool}
+              <button
+                type="button"
+                onClick={() => removePinnedTool(tool)}
+                className="ml-1.5 text-[var(--muted)] hover:text-[var(--text)]"
+              >
+                ×
+              </button>
+            </Badge>
+          ))}
+        </div>
+        <div className="flex gap-2">
+          <Input
+            value={newPinnedTool}
+            onChange={(e) => setNewPinnedTool(e.target.value)}
+            placeholder="Add pinned tool"
+            className="flex-1"
+            onKeyDown={(e) => e.key === "Enter" && addPinnedTool()}
+          />
+          <Button type="button" size="sm" variant="ghost" onClick={addPinnedTool}>
+            Add
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <label className="text-sm font-medium">Allowed Tools</label>
+        <div className="flex flex-wrap gap-2">
+          {config.tools.allowedTools.map((tool) => (
+            <Badge
+              key={tool}
+              variant="outline"
+              className="px-2 py-1 text-xs"
+              style={{ borderColor: "var(--panel-border)" }}
+            >
+              {tool}
+              <button
+                type="button"
+                onClick={() => removeAllowedTool(tool)}
+                className="ml-1.5 text-[var(--muted)] hover:text-[var(--text)]"
+              >
+                ×
+              </button>
+            </Badge>
+          ))}
+        </div>
+        <div className="flex gap-2">
+          <Input
+            value={newAllowedTool}
+            onChange={(e) => setNewAllowedTool(e.target.value)}
+            placeholder="Add allowed tool"
+            className="flex-1"
+            onKeyDown={(e) => e.key === "Enter" && addAllowedTool()}
+          />
+          <Button type="button" size="sm" variant="ghost" onClick={addAllowedTool}>
+            Add
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <label className="text-sm font-medium">Skills</label>
+        <div className="flex flex-wrap gap-2">
+          {config.tools.skills.map((skill) => (
+            <Badge
+              key={skill}
+              variant="outline"
+              className="px-2 py-1 text-xs"
+              style={{ borderColor: "var(--panel-border)" }}
+            >
+              {skill}
+              <button
+                type="button"
+                onClick={() => removeSkill(skill)}
+                className="ml-1.5 text-[var(--muted)] hover:text-[var(--text)]"
+              >
+                ×
+              </button>
+            </Badge>
+          ))}
+        </div>
+        <div className="flex gap-2">
+          <Input
+            value={newSkill}
+            onChange={(e) => setNewSkill(e.target.value)}
+            placeholder="Add skill"
+            className="flex-1"
+            onKeyDown={(e) => e.key === "Enter" && addSkill()}
+          />
+          <Button type="button" size="sm" variant="ghost" onClick={addSkill}>
+            Add
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <label className="text-sm font-medium">Permissions</label>
+        <div className="grid grid-cols-2 gap-3">
+          {(
+            [
+              ["web", "Web Access"],
+              ["email", "Email"],
+              ["calendar", "Calendar"],
+              ["cli", "CLI"],
+              ["filesystem", "Filesystem"],
+            ] as const
+          ).map(([key, label]) => (
+            <div key={key} className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id={`perm-${key}`}
+                checked={config.tools.permissions[key]}
+                onChange={() => togglePermission(key)}
+                className="rounded"
+              />
+              <label htmlFor={`perm-${key}`} className="text-sm">
+                {label}
+              </label>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RetrievalEditor({
+  config,
+  onChange,
+}: {
+  config: PersonaConfig;
+  onChange: (config: PersonaConfig) => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <label className="relative inline-flex items-center cursor-pointer">
+          <input
+            type="checkbox"
+            checked={config.retrieval.enabled}
+            onChange={(e) =>
+              onChange({
+                ...config,
+                retrieval: { ...config.retrieval, enabled: e.target.checked },
+              })
+            }
+            className="sr-only peer"
+          />
+          <div className="w-9 h-5 bg-[var(--panel-border)] peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-[var(--accent)]"></div>
+        </label>
+        <span className="text-sm font-medium">Retrieval Enabled</span>
+      </div>
+
+      {config.retrieval.enabled && (
+        <>
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Retrieval Mode</label>
+            <select
+              className="w-full h-9 px-3 rounded-md border text-sm"
+              style={{
+                background: "transparent",
+                borderColor: "var(--panel-border)",
+                color: "var(--text)",
+              }}
+              value={config.retrieval.mode}
+              onChange={(e) =>
+                onChange({
+                  ...config,
+                  retrieval: { ...config.retrieval, mode: e.target.value },
+                })
+              }
+            >
+              <option value="semantic">Semantic</option>
+              <option value="hybrid">Hybrid</option>
+              <option value="keyword">Keyword</option>
+            </select>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Retrieval Top K</label>
+            <Input
+              type="number"
+              value={config.retrieval.topK}
+              onChange={(e) =>
+                onChange({
+                  ...config,
+                  retrieval: { ...config.retrieval, topK: parseInt(e.target.value) || 0 },
+                })
+              }
+            />
+            <p className="text-xs text-[var(--muted)]">
+              Number of documents to retrieve (distinct from Generation Top K)
+            </p>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <label className="relative inline-flex items-center cursor-pointer">
+              <input
+                type="checkbox"
+                checked={config.retrieval.rerank}
+                onChange={(e) =>
+                  onChange({
+                    ...config,
+                    retrieval: { ...config.retrieval, rerank: e.target.checked },
+                  })
+                }
+                className="sr-only peer"
+              />
+              <div className="w-9 h-5 bg-[var(--panel-border)] peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-[var(--accent)]"></div>
+            </label>
+            <span className="text-sm font-medium">Rerank Results</span>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function DiagnosticsPanel({
+  profile,
+  config,
+  isDirty,
+  saveStatus,
+}: {
+  profile: PersonaProfile | null;
+  config: PersonaConfig | null;
+  isDirty: boolean;
+  saveStatus: "idle" | "saving" | "saved" | "error";
+}) {
+  const [debugLog, setDebugLog] = React.useState<string[]>([
+    "[PersonaStudio] Initialized mock persona engine",
+    "[PersonaStudio] Loaded profile list: 3 profiles",
+    "[PersonaStudio] Selected profile: guardian-default",
+    "[Config] Model provider: openai",
+    "[Config] Temperature: 0.7",
+  ]);
+
+  React.useEffect(() => {
+    if (!profile || !config) return;
+    const logs = [
+      `[PersonaStudio] Profile loaded: ${profile.name}`,
+      `[Config] Model: ${config.model.provider}/${config.model.model}`,
+      `[Config] Temperature: ${config.model.temperature}`,
+      `[Config] Voice: ${config.voice.enabled ? config.voice.provider : "disabled"}`,
+      `[Config] Retrieval: ${config.retrieval.enabled ? config.retrieval.mode : "disabled"}`,
+    ];
+    setDebugLog(logs);
+  }, [profile, config]);
+
+  return (
+    <div className="space-y-4 h-full flex flex-col">
+      <div className="space-y-3">
+        <h3 className="text-sm font-semibold">Diagnostics</h3>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between text-xs">
+            <span style={{ color: "var(--muted)" }}>Save Status</span>
+            <Badge
+              variant="outline"
+              className="text-xs"
+              style={{
+                borderColor:
+                  saveStatus === "saved"
+                    ? "rgba(34, 197, 94, 0.35)"
+                    : saveStatus === "error"
+                      ? "rgba(239, 68, 68, 0.35)"
+                      : "var(--panel-border)",
+                background: saveStatus === "saved"
+                  ? "rgba(34, 197, 94, 0.12)"
+                  : saveStatus === "error"
+                    ? "rgba(239, 68, 68, 0.12)"
+                    : "transparent",
+              }}
+            >
+              {saveStatus === "idle" ? "No changes" : saveStatus === "saving" ? "Saving..." : saveStatus === "saved" ? "Saved" : "Error"}
+            </Badge>
+          </div>
+
+          <div className="flex items-center justify-between text-xs">
+            <span style={{ color: "var(--muted)" }}>Unsaved Changes</span>
+            <span
+              className={`font-medium ${isDirty ? "text-[var(--warning)]" : ""}`}
+              style={{ color: isDirty ? "rgb(234, 179, 8)" : "var(--muted)" }}
+            >
+              {isDirty ? "Yes" : "No"}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2 flex-1 min-h-0">
+        <h4 className="text-xs font-semibold" style={{ color: "var(--muted)" }}>
+          Effective Config
+        </h4>
+        <div
+          className="rounded-lg border p-3 text-xs font-mono overflow-auto"
+          style={{
+            background: "rgba(0,0,0,0.12)",
+            borderColor: "var(--panel-border)",
+            color: "var(--text)",
+            maxHeight: "200px",
+          }}
+        >
+          {config ? (
+            <pre className="whitespace-pre-wrap">{JSON.stringify(config, null, 2)}</pre>
+          ) : (
+            <span style={{ color: "var(--muted)" }}>No profile selected</span>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <h4 className="text-xs font-semibold" style={{ color: "var(--muted)" }}>
+          Debug Log
+        </h4>
+        <div
+          className="rounded-lg border p-3 text-xs font-mono overflow-auto"
+          style={{
+            background: "rgba(0,0,0,0.12)",
+            borderColor: "var(--panel-border)",
+            color: "var(--text)",
+            maxHeight: "150px",
+          }}
+        >
+          {debugLog.map((log, i) => (
+            <div key={i}>{log}</div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function PersonaStudioPage() {
+  const [selectedProfileId, setSelectedProfileId] = React.useState<string>(
+    MOCK_PROFILES[0].id
+  );
+  const [activeTab, setActiveTab] = React.useState<EditorTab>("identity");
+  const [configs, setConfigs] = React.useState<Record<string, PersonaConfig>>(MOCK_CONFIG);
+  const [isDirty, setIsDirty] = React.useState(false);
+  const [saveStatus, setSaveStatus] = React.useState<"idle" | "saving" | "saved" | "error">("idle");
+
+  const selectedProfile = MOCK_PROFILES.find((p) => p.id === selectedProfileId) || null;
+  const currentConfig = configs[selectedProfileId] || null;
+
+  const handleConfigChange = (newConfig: PersonaConfig) => {
+    setConfigs((prev) => ({
+      ...prev,
+      [selectedProfileId]: newConfig,
+    }));
+    setIsDirty(true);
+    setSaveStatus("idle");
+  };
+
+  const handleSave = () => {
+    setSaveStatus("saving");
+    setTimeout(() => {
+      setSaveStatus("saved");
+      setIsDirty(false);
+    }, 500);
+  };
+
+  const handleSaveAsNew = () => {
+    const newId = `profile-${Date.now()}`;
+    const newProfile: PersonaProfile = {
+      id: newId,
+      name: `${currentConfig?.identity.name || "Persona"} (Copy)`,
+      description: currentConfig?.identity.description || "",
+    };
+    MOCK_PROFILES.push(newProfile);
+    setConfigs((prev) => ({
+      ...prev,
+      [newId]: JSON.parse(JSON.stringify(currentConfig)),
+    }));
+    setSelectedProfileId(newId);
+    setSaveStatus("saved");
+    setIsDirty(false);
+  };
+
+  const handleReset = () => {
+    setConfigs((prev) => ({
+      ...prev,
+      [selectedProfileId]: JSON.parse(JSON.stringify(MOCK_CONFIG[selectedProfileId])),
+    }));
+    setIsDirty(false);
+    setSaveStatus("idle");
+  };
+
+  return (
+    <div className="h-full w-full overflow-auto p-[var(--card-pad)]">
+      <div className="h-full flex flex-col">
+        <div className="mb-4">
+          <h1 className="text-xl font-semibold">Persona Studio</h1>
+          <p className="text-sm mt-0.5" style={{ color: "var(--muted)" }}>
+            Configure runtime persona profiles. This is for configuration only — no chat history or memory records are created.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-[280px_1fr_320px] gap-4 flex-1 min-h-0">
+          <Card
+            className="bezel-none rounded-2xl border"
+            style={{
+              background: "color-mix(in srgb, var(--panel-bg) 96%, transparent)",
+              borderColor: "var(--panel-border)",
+            }}
+          >
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Profiles</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {MOCK_PROFILES.map((profile) => (
+                <button
+                  key={profile.id}
+                  type="button"
+                  onClick={() => {
+                    if (profile.id !== selectedProfileId) {
+                      setSelectedProfileId(profile.id);
+                      setIsDirty(false);
+                      setSaveStatus("idle");
+                    }
+                  }}
+                  className={`w-full text-left p-3 rounded-xl transition-colors ${
+                    profile.id === selectedProfileId
+                      ? "border-2"
+                      : "border border-transparent hover:border-[var(--panel-border)]"
+                  }`}
+                  style={{
+                    background:
+                      profile.id === selectedProfileId
+                        ? "rgba(255,255,255,0.08)"
+                        : "transparent",
+                    borderColor:
+                      profile.id === selectedProfileId
+                        ? "var(--accent)"
+                        : "transparent",
+                  }}
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-sm">{profile.name}</span>
+                    {profile.isDefault && (
+                      <Badge
+                        variant="outline"
+                        className="text-[10px] px-1.5 py-0.5"
+                        style={{ borderColor: "var(--panel-border)" }}
+                      >
+                        Default
+                      </Badge>
+                    )}
+                  </div>
+                  <p
+                    className="text-xs mt-1 line-clamp-2"
+                    style={{ color: "var(--muted)" }}
+                  >
+                    {profile.description}
+                  </p>
+                </button>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card
+            className="bezel-none rounded-2xl border"
+            style={{
+              background: "color-mix(in srgb, var(--panel-bg) 96%, transparent)",
+              borderColor: "var(--panel-border)",
+            }}
+          >
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <CardTitle className="text-base">
+                  {selectedProfile?.name || "Editor"}
+                </CardTitle>
+                <div className="flex gap-1">
+                  <TabButton
+                    active={activeTab === "identity"}
+                    onClick={() => setActiveTab("identity")}
+                  >
+                    Identity
+                  </TabButton>
+                  <TabButton
+                    active={activeTab === "model"}
+                    onClick={() => setActiveTab("model")}
+                  >
+                    Model
+                  </TabButton>
+                  <TabButton
+                    active={activeTab === "voice"}
+                    onClick={() => setActiveTab("voice")}
+                  >
+                    Voice
+                  </TabButton>
+                  <TabButton
+                    active={activeTab === "prompt"}
+                    onClick={() => setActiveTab("prompt")}
+                  >
+                    Prompt
+                  </TabButton>
+                  <TabButton
+                    active={activeTab === "tools"}
+                    onClick={() => setActiveTab("tools")}
+                  >
+                    Tools
+                  </TabButton>
+                  <TabButton
+                    active={activeTab === "retrieval"}
+                    onClick={() => setActiveTab("retrieval")}
+                  >
+                    Retrieval
+                  </TabButton>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {currentConfig && (
+                <>
+                  {activeTab === "identity" && (
+                    <IdentityEditor config={currentConfig} onChange={handleConfigChange} />
+                  )}
+                  {activeTab === "model" && (
+                    <ModelEditor config={currentConfig} onChange={handleConfigChange} />
+                  )}
+                  {activeTab === "voice" && (
+                    <VoiceEditor config={currentConfig} onChange={handleConfigChange} />
+                  )}
+                  {activeTab === "prompt" && (
+                    <PromptEditor config={currentConfig} onChange={handleConfigChange} />
+                  )}
+                  {activeTab === "tools" && (
+                    <ToolsEditor config={currentConfig} onChange={handleConfigChange} />
+                  )}
+                  {activeTab === "retrieval" && (
+                    <RetrievalEditor config={currentConfig} onChange={handleConfigChange} />
+                  )}
+                </>
+              )}
+
+              <div
+                className="flex items-center gap-3 pt-4 border-t"
+                style={{ borderColor: "var(--panel-border)" }}
+              >
+                <Button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={!isDirty || saveStatus === "saving"}
+                >
+                  {saveStatus === "saving" ? "Saving..." : "Save"}
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={handleSaveAsNew}
+                  disabled={!currentConfig}
+                >
+                  Save As New
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={handleReset}
+                  disabled={!isDirty}
+                >
+                  Reset
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card
+            className="bezel-none rounded-2xl border"
+            style={{
+              background: "color-mix(in srgb, var(--panel-bg) 96%, transparent)",
+              borderColor: "var(--panel-border)",
+            }}
+          >
+            <CardContent className="pt-4">
+              <DiagnosticsPanel
+                profile={selectedProfile}
+                config={currentConfig}
+                isDirty={isDirty}
+                saveStatus={saveStatus}
+              />
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/personaStudio/__tests__/PersonaStudioPage.persistence.test.tsx
+++ b/frontend/src/features/personaStudio/__tests__/PersonaStudioPage.persistence.test.tsx
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import PersonaStudioPage from "../PersonaStudioPage";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("Persona Studio persistence", () => {
+  it("persists the selected profile, active tab, and draft edits across remounts", async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<PersonaStudioPage />);
+
+    await user.click(screen.getByRole("button", { name: /code assistant/i }));
+
+    const nameInput = screen.getByPlaceholderText(/enter persona name/i);
+    await user.clear(nameInput);
+    await user.type(nameInput, "Code Assistant Draft");
+
+    const descriptionInput = screen.getByPlaceholderText(/describe this persona/i);
+    await user.clear(descriptionInput);
+    await user.type(descriptionInput, "Persisted draft description");
+
+    await user.click(screen.getByRole("button", { name: /model/i }));
+
+    unmount();
+    render(<PersonaStudioPage />);
+
+    expect(
+      screen.getByRole("heading", { name: "Code Assistant Draft" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Provider")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/enter persona name/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /identity/i }));
+
+    expect(screen.getByDisplayValue("Code Assistant Draft")).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue("Persisted draft description")
+    ).toBeInTheDocument();
+  });
+
+  it("resets to the built-in seed before the first save and to the last saved local snapshot after save", async () => {
+    const user = userEvent.setup();
+    render(<PersonaStudioPage />);
+
+    await user.click(screen.getByRole("button", { name: /code assistant/i }));
+
+    const nameInput = screen.getByPlaceholderText(/enter persona name/i);
+    await user.clear(nameInput);
+    await user.type(nameInput, "Transient Draft");
+
+    await user.click(screen.getByRole("button", { name: /^reset$/i }));
+
+    expect(screen.getByRole("heading", { name: "Code Assistant" })).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Code Assistant")).toBeInTheDocument();
+
+    const savedNameInput = screen.getByPlaceholderText(/enter persona name/i);
+    await user.clear(savedNameInput);
+    await user.type(savedNameInput, "Saved Draft");
+
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    const editedNameInput = screen.getByPlaceholderText(/enter persona name/i);
+    await user.clear(editedNameInput);
+    await user.type(editedNameInput, "Unsaved Draft");
+
+    await user.click(screen.getByRole("button", { name: /^reset$/i }));
+
+    expect(screen.getByDisplayValue("Saved Draft")).toBeInTheDocument();
+  });
+
+  it("restores the local seed workspace when resetting all persona studio data", async () => {
+    const user = userEvent.setup();
+    render(<PersonaStudioPage />);
+
+    await user.click(screen.getByRole("button", { name: /code assistant/i }));
+
+    const nameInput = screen.getByPlaceholderText(/enter persona name/i);
+    await user.clear(nameInput);
+    await user.type(nameInput, "Reset All Draft");
+
+    await user.click(screen.getByRole("button", { name: /model/i }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /reset all local persona studio data/i,
+      })
+    );
+
+    expect(screen.getByRole("heading", { name: "Guardian Default" })).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Guardian Default")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /identity/i })).toBeInTheDocument();
+    expect(screen.queryByText("Provider")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/personaStudio/__tests__/PersonaStudioShell.test.tsx
+++ b/frontend/src/features/personaStudio/__tests__/PersonaStudioShell.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
@@ -33,6 +33,11 @@ vi.mock("@/state/session/SessionSpine", () => ({
     subscribeActiveSpine: () => () => {},
   },
 }));
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.history.pushState({}, "", "/");
+});
 
 function renderAppShell() {
   return render(
@@ -139,6 +144,6 @@ describe("Persona Studio Shell Integration", () => {
     await user.click(screen.getByRole("button", { name: /persona studio/i }));
 
     expect(screen.getByRole("button", { name: /save as new/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /reset/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^reset$/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/personaStudio/__tests__/PersonaStudioShell.test.tsx
+++ b/frontend/src/features/personaStudio/__tests__/PersonaStudioShell.test.tsx
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import AppShell from "@/components/persona/layout/AppShell";
+
+vi.mock("@/lib/authState", () => ({
+  checkAuthGate: () => true,
+  useAuthState: () => ({ user: null, token: null, loading: false }),
+}));
+
+vi.mock("@/hooks/useLiveEvents", () => ({
+  useLiveEvents: () => ({ connected: false, lastEvent: null }),
+}));
+
+vi.mock("@/hooks/useRuntimeHealth", () => ({
+  default: () => ({ healthy: false, checkedAt: null }),
+}));
+
+vi.mock("@/hooks/useWallpaperUrl", () => ({
+  useWallpaperUrl: () => null,
+}));
+
+vi.mock("@/lib/runtimeRouteCapabilities", () => ({
+  useRuntimeRouteCapability: () => ({ ready: true, state: "available" }),
+  SUPPORTED_PROFILE_ROUTE_LABELS: { CODEX: "codex", IMPRINT: "imprint", CONNECTORS: "connectors" },
+}));
+
+vi.mock("@/state/session/SessionSpine", () => ({
+  SessionSpine: {
+    getRegisteredSpine: () => null,
+    subscribeActiveSpine: () => () => {},
+  },
+}));
+
+function renderAppShell() {
+  return render(
+    <AppShell startupLocked={false} startupOverlay={null} />
+  );
+}
+
+describe("Persona Studio Shell Integration", () => {
+  it("renders Persona Studio navigation pill in the app shell", async () => {
+    renderAppShell();
+
+    const personaStudioPill = screen.getByRole("button", { name: /persona studio/i });
+    expect(personaStudioPill).toBeInTheDocument();
+  });
+
+  it("renders Persona Studio page content when navigating to it", async () => {
+    const user = userEvent.setup();
+    renderAppShell();
+
+    const personaStudioPill = screen.getByRole("button", { name: /persona studio/i });
+    await user.click(personaStudioPill);
+
+    expect(screen.getByText(/configure runtime persona profiles/i)).toBeInTheDocument();
+  });
+
+  it("renders the profile list panel when Persona Studio is active", async () => {
+    const user = userEvent.setup();
+    renderAppShell();
+
+    await user.click(screen.getByRole("button", { name: /persona studio/i }));
+
+    expect(screen.getByText("Profiles")).toBeInTheDocument();
+  });
+
+  it("renders the editor tabs when Persona Studio is active", async () => {
+    const user = userEvent.setup();
+    renderAppShell();
+
+    await user.click(screen.getByRole("button", { name: /persona studio/i }));
+
+    expect(screen.getByRole("button", { name: /identity/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /model/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /voice/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /prompt/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /tools/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retrieval/i })).toBeInTheDocument();
+  });
+
+  it("renders diagnostics panel when Persona Studio is active", async () => {
+    const user = userEvent.setup();
+    renderAppShell();
+
+    await user.click(screen.getByRole("button", { name: /persona studio/i }));
+
+    expect(screen.getByText("Diagnostics")).toBeInTheDocument();
+    expect(screen.getByText("Save Status")).toBeInTheDocument();
+    expect(screen.getByText("Unsaved Changes")).toBeInTheDocument();
+    expect(screen.getByText("Effective Config")).toBeInTheDocument();
+    expect(screen.getByText("Debug Log")).toBeInTheDocument();
+  });
+
+  it("does not render chat composer elements in Persona Studio", async () => {
+    const user = userEvent.setup();
+    renderAppShell();
+
+    await user.click(screen.getByRole("button", { name: /persona studio/i }));
+
+    expect(screen.getByTestId("persona-studio-framecard")).toBeInTheDocument();
+    expect(screen.queryByTestId("composer-input")).not.toBeInTheDocument();
+  });
+
+  it("renders Generation Top K and Retrieval Top K as separate fields", async () => {
+    const user = userEvent.setup();
+    renderAppShell();
+
+    await user.click(screen.getByRole("button", { name: /persona studio/i }));
+    await user.click(screen.getByRole("button", { name: /model/i }));
+
+    expect(screen.getByText("Generation Top K")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /retrieval/i }));
+
+    expect(screen.getByText("Retrieval Top K")).toBeInTheDocument();
+    expect(screen.getByText(/distinct from generation top k/i)).toBeInTheDocument();
+  });
+
+  it("can switch between profile tabs", async () => {
+    const user = userEvent.setup();
+    renderAppShell();
+
+    await user.click(screen.getByRole("button", { name: /persona studio/i }));
+
+    const codeAssistantCard = screen.getAllByText("Code Assistant")[0]?.closest("button");
+    if (codeAssistantCard) {
+      await user.click(codeAssistantCard);
+    }
+    expect(screen.getByTestId("persona-studio-framecard")).toBeInTheDocument();
+  });
+
+  it("renders Save, Save As New, and Reset controls", async () => {
+    const user = userEvent.setup();
+    renderAppShell();
+
+    await user.click(screen.getByRole("button", { name: /persona studio/i }));
+
+    expect(screen.getByRole("button", { name: /save as new/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /reset/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/personaStudio/personaStudioStore.ts
+++ b/frontend/src/features/personaStudio/personaStudioStore.ts
@@ -1,0 +1,767 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+export type PersonaCapabilityPermissions = {
+  web: boolean;
+  email: boolean;
+  calendar: boolean;
+  cli: boolean;
+  filesystem: boolean;
+};
+
+export type ModelSettings = {
+  provider: string;
+  model: string;
+  temperature: number;
+  topK: number;
+  topP: number;
+  maxTokens: number;
+};
+
+export type VoiceSettings = {
+  enabled: boolean;
+  provider: string;
+  voicePreset: string;
+  speed: number;
+  wakeWord: string;
+  interruptible: boolean;
+};
+
+export type PromptSettings = {
+  systemPrompt: string;
+  styleNotes: string;
+  directives: string;
+};
+
+export type ToolsSettings = {
+  pinnedTools: string[];
+  allowedTools: string[];
+  skills: string[];
+  permissions: PersonaCapabilityPermissions;
+};
+
+export type RetrievalSettings = {
+  enabled: boolean;
+  mode: string;
+  topK: number;
+  rerank: boolean;
+};
+
+export type PersonaConfig = {
+  identity: {
+    name: string;
+    description: string;
+  };
+  model: ModelSettings;
+  voice: VoiceSettings;
+  prompt: PromptSettings;
+  tools: ToolsSettings;
+  retrieval: RetrievalSettings;
+};
+
+export type PersonaProfile = {
+  id: string;
+  name: string;
+  description: string;
+  isDefault?: boolean;
+};
+
+export type PersonaProfileDraft = PersonaProfile & {
+  config: PersonaConfig;
+};
+
+export type EditorTab =
+  | "identity"
+  | "model"
+  | "voice"
+  | "prompt"
+  | "tools"
+  | "retrieval";
+
+export type PersonaStudioLocalState = {
+  profiles: PersonaProfileDraft[];
+  selectedProfileId: string;
+  activeTab: EditorTab;
+  lastSavedProfiles: Record<string, PersonaProfileDraft>;
+};
+
+export const PERSONA_STUDIO_STORAGE_KEY = "cfy.personaStudio.localState.v1";
+
+const EDITOR_TABS: EditorTab[] = [
+  "identity",
+  "model",
+  "voice",
+  "prompt",
+  "tools",
+  "retrieval",
+];
+
+const PERSONA_STUDIO_SEED_PROFILES: PersonaProfileDraft[] = [
+  {
+    id: "profile-1",
+    name: "Guardian Default",
+    description: "Default guardian persona for general assistance",
+    isDefault: true,
+    config: {
+      identity: {
+        name: "Guardian Default",
+        description: "Default guardian persona for general assistance",
+      },
+      model: {
+        provider: "openai",
+        model: "gpt-4o",
+        temperature: 0.7,
+        topK: 40,
+        topP: 0.95,
+        maxTokens: 4096,
+      },
+      voice: {
+        enabled: true,
+        provider: "elevenlabs",
+        voicePreset: "rachel",
+        speed: 1.0,
+        wakeWord: "Hey Guardian",
+        interruptible: true,
+      },
+      prompt: {
+        systemPrompt:
+          "You are a Guardian, a partner in thought. Your primary goal is to foster the user's autonomy and creativity.",
+        styleNotes:
+          "Use a warm, encouraging tone. Favor questions over statements when appropriate.",
+        directives:
+          "Always prioritize user privacy. Never share sensitive information without explicit permission.",
+      },
+      tools: {
+        pinnedTools: ["web-search", "calculator", "code-interpreter"],
+        allowedTools: [
+          "web-search",
+          "calculator",
+          "code-interpreter",
+          "file-reader",
+        ],
+        skills: ["critical-thinking", "creative-brainstorming"],
+        permissions: {
+          web: true,
+          email: false,
+          calendar: false,
+          cli: false,
+          filesystem: true,
+        },
+      },
+      retrieval: {
+        enabled: true,
+        mode: "hybrid",
+        topK: 10,
+        rerank: true,
+      },
+    },
+  },
+  {
+    id: "profile-2",
+    name: "Code Assistant",
+    description: "Specialized for code review and programming tasks",
+    config: {
+      identity: {
+        name: "Code Assistant",
+        description: "Specialized for code review and programming tasks",
+      },
+      model: {
+        provider: "anthropic",
+        model: "claude-sonnet-4-20250514",
+        temperature: 0.3,
+        topK: 20,
+        topP: 0.9,
+        maxTokens: 8192,
+      },
+      voice: {
+        enabled: false,
+        provider: "elevenlabs",
+        voicePreset: "matt",
+        speed: 1.0,
+        wakeWord: "",
+        interruptible: true,
+      },
+      prompt: {
+        systemPrompt:
+          "You are an expert code assistant. Provide clear, concise, and accurate code solutions with explanation.",
+        styleNotes: "Be precise and technical. Include code examples where helpful.",
+        directives:
+          "Always verify code syntax before presenting. Flag potential security issues.",
+      },
+      tools: {
+        pinnedTools: ["code-interpreter", "git", "terminal"],
+        allowedTools: ["code-interpreter", "git", "terminal", "web-search", "file-reader"],
+        skills: ["code-review", "debugging", "architecture-design"],
+        permissions: {
+          web: true,
+          email: false,
+          calendar: false,
+          cli: true,
+          filesystem: true,
+        },
+      },
+      retrieval: {
+        enabled: true,
+        mode: "semantic",
+        topK: 5,
+        rerank: false,
+      },
+    },
+  },
+  {
+    id: "profile-3",
+    name: "Research Partner",
+    description: "Focused on research and information synthesis",
+    config: {
+      identity: {
+        name: "Research Partner",
+        description: "Focused on research and information synthesis",
+      },
+      model: {
+        provider: "openai",
+        model: "gpt-4-turbo",
+        temperature: 0.5,
+        topK: 60,
+        topP: 0.97,
+        maxTokens: 16384,
+      },
+      voice: {
+        enabled: true,
+        provider: "elevenlabs",
+        voicePreset: "aria",
+        speed: 0.9,
+        wakeWord: "Hey Research",
+        interruptible: true,
+      },
+      prompt: {
+        systemPrompt:
+          "You are a research partner specializing in information synthesis and critical analysis.",
+        styleNotes:
+          "Present information in organized, cited format. Distinguish between facts and interpretations.",
+        directives:
+          "Cite sources when available. Clearly state uncertainty when information is incomplete.",
+      },
+      tools: {
+        pinnedTools: ["web-search", "academic-search", "note-taking"],
+        allowedTools: ["web-search", "academic-search", "note-taking", "calculator"],
+        skills: ["literature-review", "meta-analysis", "synthesis"],
+        permissions: {
+          web: true,
+          email: false,
+          calendar: false,
+          cli: false,
+          filesystem: true,
+        },
+      },
+      retrieval: {
+        enabled: true,
+        mode: "hybrid",
+        topK: 20,
+        rerank: true,
+      },
+    },
+  },
+];
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isEditorTab(value: unknown): value is EditorTab {
+  return typeof value === "string" && EDITOR_TABS.includes(value as EditorTab);
+}
+
+function normalizeStringArray(value: unknown, fallback: string[]): string[] {
+  if (!Array.isArray(value)) return clone(fallback);
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function normalizePersonaCapabilityPermissions(
+  value: unknown,
+  fallback: PersonaCapabilityPermissions
+): PersonaCapabilityPermissions {
+  if (!isRecord(value)) return clone(fallback);
+
+  return {
+    web: typeof value.web === "boolean" ? value.web : fallback.web,
+    email: typeof value.email === "boolean" ? value.email : fallback.email,
+    calendar:
+      typeof value.calendar === "boolean" ? value.calendar : fallback.calendar,
+    cli: typeof value.cli === "boolean" ? value.cli : fallback.cli,
+    filesystem:
+      typeof value.filesystem === "boolean" ? value.filesystem : fallback.filesystem,
+  };
+}
+
+function normalizePersonaConfig(
+  value: unknown,
+  fallback: PersonaConfig
+): PersonaConfig {
+  if (!isRecord(value)) return clone(fallback);
+
+  const model = isRecord(value.model) ? value.model : null;
+  const voice = isRecord(value.voice) ? value.voice : null;
+  const prompt = isRecord(value.prompt) ? value.prompt : null;
+  const tools = isRecord(value.tools) ? value.tools : null;
+  const retrieval = isRecord(value.retrieval) ? value.retrieval : null;
+
+  return {
+    identity: {
+      name: typeof value.identity === "object" && value.identity !== null && !Array.isArray(value.identity) && typeof (value.identity as Record<string, unknown>).name === "string"
+        ? String((value.identity as Record<string, unknown>).name)
+        : fallback.identity.name,
+      description:
+        typeof value.identity === "object" &&
+        value.identity !== null &&
+        !Array.isArray(value.identity) &&
+        typeof (value.identity as Record<string, unknown>).description === "string"
+          ? String((value.identity as Record<string, unknown>).description)
+          : fallback.identity.description,
+    },
+    model: {
+      provider: typeof model?.provider === "string" ? model.provider : fallback.model.provider,
+      model: typeof model?.model === "string" ? model.model : fallback.model.model,
+      temperature:
+        typeof model?.temperature === "number"
+          ? model.temperature
+          : fallback.model.temperature,
+      topK: typeof model?.topK === "number" ? model.topK : fallback.model.topK,
+      topP: typeof model?.topP === "number" ? model.topP : fallback.model.topP,
+      maxTokens:
+        typeof model?.maxTokens === "number"
+          ? model.maxTokens
+          : fallback.model.maxTokens,
+    },
+    voice: {
+      enabled:
+        typeof voice?.enabled === "boolean" ? voice.enabled : fallback.voice.enabled,
+      provider:
+        typeof voice?.provider === "string" ? voice.provider : fallback.voice.provider,
+      voicePreset:
+        typeof voice?.voicePreset === "string"
+          ? voice.voicePreset
+          : fallback.voice.voicePreset,
+      speed: typeof voice?.speed === "number" ? voice.speed : fallback.voice.speed,
+      wakeWord:
+        typeof voice?.wakeWord === "string" ? voice.wakeWord : fallback.voice.wakeWord,
+      interruptible:
+        typeof voice?.interruptible === "boolean"
+          ? voice.interruptible
+          : fallback.voice.interruptible,
+    },
+    prompt: {
+      systemPrompt:
+        typeof prompt?.systemPrompt === "string"
+          ? prompt.systemPrompt
+          : fallback.prompt.systemPrompt,
+      styleNotes:
+        typeof prompt?.styleNotes === "string"
+          ? prompt.styleNotes
+          : fallback.prompt.styleNotes,
+      directives:
+        typeof prompt?.directives === "string"
+          ? prompt.directives
+          : fallback.prompt.directives,
+    },
+    tools: {
+      pinnedTools: normalizeStringArray(tools?.pinnedTools, fallback.tools.pinnedTools),
+      allowedTools: normalizeStringArray(
+        tools?.allowedTools,
+        fallback.tools.allowedTools
+      ),
+      skills: normalizeStringArray(tools?.skills, fallback.tools.skills),
+      permissions: normalizePersonaCapabilityPermissions(
+        tools?.permissions,
+        fallback.tools.permissions
+      ),
+    },
+    retrieval: {
+      enabled:
+        typeof retrieval?.enabled === "boolean"
+          ? retrieval.enabled
+          : fallback.retrieval.enabled,
+      mode: typeof retrieval?.mode === "string" ? retrieval.mode : fallback.retrieval.mode,
+      topK: typeof retrieval?.topK === "number" ? retrieval.topK : fallback.retrieval.topK,
+      rerank:
+        typeof retrieval?.rerank === "boolean"
+          ? retrieval.rerank
+          : fallback.retrieval.rerank,
+    },
+  };
+}
+
+function normalizePersonaProfileDraft(
+  value: unknown,
+  fallback: PersonaProfileDraft
+): PersonaProfileDraft {
+  if (!isRecord(value)) return clone(fallback);
+
+  const profileId = typeof value.id === "string" ? value.id : fallback.id;
+  const normalizedFallback = fallback.id === profileId ? fallback : getPersonaStudioSeedProfile(profileId);
+
+  return {
+    id: profileId,
+    name: typeof value.name === "string" ? value.name : normalizedFallback.name,
+    description:
+      typeof value.description === "string"
+        ? value.description
+        : normalizedFallback.description,
+    ...(typeof value.isDefault === "boolean"
+      ? { isDefault: value.isDefault }
+      : normalizedFallback.isDefault != null
+        ? { isDefault: normalizedFallback.isDefault }
+        : {}),
+    config: normalizePersonaConfig(value.config, normalizedFallback.config),
+  };
+}
+
+function getSeedProfileReference(profileId?: string | null): PersonaProfileDraft {
+  return (
+    PERSONA_STUDIO_SEED_PROFILES.find((profile) => profile.id === profileId) ??
+    PERSONA_STUDIO_SEED_PROFILES[0] ??
+    clone({
+      id: "profile-1",
+      name: "Persona",
+      description: "",
+      config: {
+        identity: {
+          name: "Persona",
+          description: "",
+        },
+        model: {
+          provider: "openai",
+          model: "gpt-4o",
+          temperature: 0,
+          topK: 0,
+          topP: 1,
+          maxTokens: 1024,
+        },
+        voice: {
+          enabled: false,
+          provider: "elevenlabs",
+          voicePreset: "",
+          speed: 1,
+          wakeWord: "",
+          interruptible: true,
+        },
+        prompt: {
+          systemPrompt: "",
+          styleNotes: "",
+          directives: "",
+        },
+        tools: {
+          pinnedTools: [],
+          allowedTools: [],
+          skills: [],
+          permissions: {
+            web: false,
+            email: false,
+            calendar: false,
+            cli: false,
+            filesystem: false,
+          },
+        },
+        retrieval: {
+          enabled: false,
+          mode: "semantic",
+          topK: 5,
+          rerank: false,
+        },
+      },
+    })
+  );
+}
+
+function normalizePersonaStudioLocalState(
+  value: unknown
+): PersonaStudioLocalState {
+  if (!isRecord(value)) return createPersonaStudioSeedState();
+
+  const rawProfiles = Array.isArray(value.profiles) ? value.profiles : [];
+  const nextProfiles: PersonaProfileDraft[] = [];
+  const seenProfileIds = new Set<string>();
+
+  for (const profileValue of rawProfiles) {
+    const fallbackId =
+      isRecord(profileValue) && typeof profileValue.id === "string"
+        ? profileValue.id
+        : PERSONA_STUDIO_SEED_PROFILES[0]?.id ?? "";
+    const normalized = normalizePersonaProfileDraft(
+      profileValue,
+      getSeedProfileReference(fallbackId)
+    );
+
+    if (seenProfileIds.has(normalized.id)) continue;
+    seenProfileIds.add(normalized.id);
+    nextProfiles.push(normalized);
+  }
+
+  const profiles =
+    nextProfiles.length > 0 ? nextProfiles : clone(PERSONA_STUDIO_SEED_PROFILES);
+  const profilesById = new Map(profiles.map((profile) => [profile.id, profile]));
+
+  const selectedProfileId =
+    typeof value.selectedProfileId === "string" && profilesById.has(value.selectedProfileId)
+      ? value.selectedProfileId
+      : profiles[0]?.id ?? PERSONA_STUDIO_SEED_PROFILES[0]?.id ?? "";
+
+  const lastSavedProfiles: Record<string, PersonaProfileDraft> = {};
+  if (isRecord(value.lastSavedProfiles)) {
+    for (const [profileId, savedValue] of Object.entries(value.lastSavedProfiles)) {
+      const fallback = profilesById.get(profileId) ?? getSeedProfileReference(profileId);
+      lastSavedProfiles[profileId] = normalizePersonaProfileDraft(savedValue, fallback);
+    }
+  }
+
+  return {
+    profiles,
+    selectedProfileId,
+    activeTab: isEditorTab(value.activeTab) ? value.activeTab : "identity",
+    lastSavedProfiles,
+  };
+}
+
+function cloneProfile(profile: PersonaProfileDraft): PersonaProfileDraft {
+  return clone(profile);
+}
+
+export function getPersonaStudioSeedProfile(
+  profileId?: string | null
+): PersonaProfileDraft {
+  return cloneProfile(getSeedProfileReference(profileId));
+}
+
+export function createPersonaStudioSeedState(): PersonaStudioLocalState {
+  return {
+    profiles: clone(PERSONA_STUDIO_SEED_PROFILES),
+    selectedProfileId: PERSONA_STUDIO_SEED_PROFILES[0]?.id ?? "",
+    activeTab: "identity",
+    lastSavedProfiles: {},
+  };
+}
+
+export function readPersonaStudioLocalState(): PersonaStudioLocalState {
+  if (typeof window === "undefined") {
+    return createPersonaStudioSeedState();
+  }
+
+  try {
+    const raw = window.localStorage.getItem(PERSONA_STUDIO_STORAGE_KEY);
+    if (!raw) return createPersonaStudioSeedState();
+    return normalizePersonaStudioLocalState(JSON.parse(raw));
+  } catch {
+    return createPersonaStudioSeedState();
+  }
+}
+
+export function persistPersonaStudioLocalState(state: PersonaStudioLocalState): void {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.setItem(PERSONA_STUDIO_STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Ignore local-only storage failures.
+  }
+}
+
+export function clearPersonaStudioLocalState(): void {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.removeItem(PERSONA_STUDIO_STORAGE_KEY);
+  } catch {
+    // Ignore local-only storage failures.
+  }
+}
+
+function createNextProfileId(profiles: PersonaProfileDraft[]): string {
+  const existingIds = new Set(profiles.map((profile) => profile.id));
+  let nextIndex = profiles.length + 1;
+  let nextId = `profile-${nextIndex}`;
+
+  while (existingIds.has(nextId)) {
+    nextIndex += 1;
+    nextId = `profile-${nextIndex}`;
+  }
+
+  return nextId;
+}
+
+function sameProfileDraft(
+  left: PersonaProfileDraft | null | undefined,
+  right: PersonaProfileDraft | null | undefined
+): boolean {
+  return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+}
+
+export function usePersonaStudioLocalDraftState() {
+  const [state, setState] = useState<PersonaStudioLocalState>(() =>
+    readPersonaStudioLocalState()
+  );
+
+  useEffect(() => {
+    persistPersonaStudioLocalState(state);
+  }, [state]);
+
+  const selectedProfile = useMemo(
+    () => state.profiles.find((profile) => profile.id === state.selectedProfileId) ?? null,
+    [state.profiles, state.selectedProfileId]
+  );
+
+  const selectedSavedProfile = useMemo(
+    () => state.lastSavedProfiles[state.selectedProfileId] ?? null,
+    [state.lastSavedProfiles, state.selectedProfileId]
+  );
+
+  const seedProfile = useMemo(
+    () => getPersonaStudioSeedProfile(state.selectedProfileId),
+    [state.selectedProfileId]
+  );
+
+  const isDirty = selectedProfile
+    ? !sameProfileDraft(selectedProfile, selectedSavedProfile ?? seedProfile)
+    : false;
+
+  const hasSavedVersion = Boolean(selectedSavedProfile);
+
+  const setSelectedProfileId = useCallback((profileId: string) => {
+    setState((previous) => {
+      if (!previous.profiles.some((profile) => profile.id === profileId)) {
+        return previous;
+      }
+
+      if (previous.selectedProfileId === profileId) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        selectedProfileId: profileId,
+      };
+    });
+  }, []);
+
+  const setActiveTab = useCallback((activeTab: EditorTab) => {
+    setState((previous) =>
+      previous.activeTab === activeTab
+        ? previous
+        : {
+            ...previous,
+            activeTab,
+          }
+    );
+  }, []);
+
+  const updateSelectedProfile = useCallback(
+    (updater: (currentProfile: PersonaProfileDraft) => PersonaProfileDraft) => {
+      setState((previous) => {
+        const currentProfile = previous.profiles.find(
+          (profile) => profile.id === previous.selectedProfileId
+        );
+
+        if (!currentProfile) return previous;
+
+        const nextProfile = updater(currentProfile);
+        if (sameProfileDraft(nextProfile, currentProfile)) return previous;
+
+        return {
+          ...previous,
+          profiles: previous.profiles.map((profile) =>
+            profile.id === currentProfile.id ? nextProfile : profile
+          ),
+        };
+      });
+    },
+    []
+  );
+
+  const saveSelectedProfile = useCallback(() => {
+    setState((previous) => {
+      const currentProfile = previous.profiles.find(
+        (profile) => profile.id === previous.selectedProfileId
+      );
+
+      if (!currentProfile) return previous;
+
+      return {
+        ...previous,
+        lastSavedProfiles: {
+          ...previous.lastSavedProfiles,
+          [currentProfile.id]: cloneProfile(currentProfile),
+        },
+      };
+    });
+  }, []);
+
+  const saveSelectedProfileAsNew = useCallback(() => {
+    setState((previous) => {
+      const currentProfile = previous.profiles.find(
+        (profile) => profile.id === previous.selectedProfileId
+      );
+
+      if (!currentProfile) return previous;
+
+      const nextId = createNextProfileId(previous.profiles);
+      const nextProfile = cloneProfile(currentProfile);
+      nextProfile.id = nextId;
+      nextProfile.name = `${currentProfile.name} (Copy)`;
+      nextProfile.isDefault = false;
+
+      return {
+        ...previous,
+        profiles: [...previous.profiles, nextProfile],
+        selectedProfileId: nextId,
+        lastSavedProfiles: {
+          ...previous.lastSavedProfiles,
+          [nextId]: cloneProfile(nextProfile),
+        },
+      };
+    });
+  }, []);
+
+  const resetSelectedProfile = useCallback(() => {
+    setState((previous) => {
+      const currentProfile = previous.profiles.find(
+        (profile) => profile.id === previous.selectedProfileId
+      );
+
+      if (!currentProfile) return previous;
+
+      const fallbackProfile =
+        previous.lastSavedProfiles[currentProfile.id] ??
+        getPersonaStudioSeedProfile(currentProfile.id);
+
+      const nextProfile = cloneProfile(fallbackProfile);
+
+      return {
+        ...previous,
+        profiles: previous.profiles.map((profile) =>
+          profile.id === currentProfile.id ? nextProfile : profile
+        ),
+      };
+    });
+  }, []);
+
+  const resetAllLocalPersonaStudioData = useCallback(() => {
+    setState(createPersonaStudioSeedState());
+  }, []);
+
+  return {
+    ...state,
+    selectedProfile,
+    selectedSavedProfile,
+    seedProfile,
+    isDirty,
+    hasSavedVersion,
+    setSelectedProfileId,
+    setActiveTab,
+    updateSelectedProfile,
+    saveSelectedProfile,
+    saveSelectedProfileAsNew,
+    resetSelectedProfile,
+    resetAllLocalPersonaStudioData,
+  };
+}

--- a/frontend/src/features/workspace/WorkspaceViewer.tsx
+++ b/frontend/src/features/workspace/WorkspaceViewer.tsx
@@ -370,6 +370,7 @@ function resolveDocumentMimeType(
       "contentType",
     ])?.toLowerCase() ?? ""
   );
+}
 
 function resolveInlinePreviewText(
   doc: DocumentLike | null | undefined

--- a/guardian/tests/migration/test_chatgpt_import_flat_structure.py
+++ b/guardian/tests/migration/test_chatgpt_import_flat_structure.py
@@ -1,0 +1,228 @@
+"""Regression tests for flat ChatGPT imports with hidden grouping metadata."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from backend.rag import chatgpt_migration
+from backend.rag.chatgpt_migration import ingest_chatgpt_export
+from guardian.core import dependencies
+
+
+def _build_mainline_export(
+    turns: list[tuple[str, str, float]],
+    *,
+    thread_id: str = "t1",
+    title: str = "Test Conversation",
+) -> list[dict[str, Any]]:
+    mapping: dict[str, dict[str, Any]] = {}
+    parent: str | None = None
+    for idx, (role, text, create_time) in enumerate(turns, start=1):
+        node_id = f"m{idx}"
+        mapping[node_id] = {
+            "id": node_id,
+            "parent": parent,
+            "children": [],
+            "message": {
+                "author": {"role": role},
+                "content": {"parts": [text]},
+                "create_time": create_time,
+            },
+        }
+        if parent:
+            mapping[parent]["children"].append(node_id)
+        parent = node_id
+    return [
+        {
+            "id": thread_id,
+            "title": title,
+            "current_node": parent,
+            "mapping": mapping,
+        }
+    ]
+
+
+class InMemoryFlatImportStore:
+    def __init__(self) -> None:
+        self._next_thread_id = 1
+        self._next_message_id = 1
+        self.threads: dict[int, dict[str, Any]] = {}
+        self.messages: list[dict[str, Any]] = []
+        self.ensure_project_calls: list[tuple[str, str]] = []
+
+    def ensure_project(self, name: str, description: str) -> int:
+        self.ensure_project_calls.append((name, description))
+        return 1 if name == "Imports" else 99
+
+    def list_projects(self) -> list[dict[str, Any]]:
+        return [{"id": 1, "name": "Imports"}]
+
+    def create_chat_thread(
+        self,
+        *,
+        user_id: str,
+        title: str,
+        summary: str = "",
+        project_id: int | None = None,
+        metadata: dict[str, Any] | None = None,
+        parent_id: int | None = None,
+    ) -> dict[str, Any]:
+        thread_id = self._next_thread_id
+        self._next_thread_id += 1
+        thread = {
+            "id": thread_id,
+            "user_id": user_id,
+            "title": title,
+            "summary": summary,
+            "project_id": project_id,
+            "metadata": metadata or {},
+            "parent_id": parent_id,
+            "archived_at": None,
+        }
+        self.threads[thread_id] = thread
+        return dict(thread)
+
+    def update_thread_metadata(
+        self, thread_id: int, metadata: dict[str, Any]
+    ) -> bool:
+        thread = self.threads.get(thread_id)
+        if not thread:
+            return False
+        thread["metadata"] = dict(metadata)
+        return True
+
+    def get_chat_thread(self, thread_id: int) -> dict[str, Any] | None:
+        thread = self.threads.get(thread_id)
+        return dict(thread) if thread else None
+
+    def create_message(
+        self,
+        thread_id: int,
+        role: str,
+        content: str,
+        created_at: str | None = None,
+    ) -> int:
+        message_id = self._next_message_id
+        self._next_message_id += 1
+        message = {
+            "id": message_id,
+            "thread_id": thread_id,
+            "role": role,
+            "content": content,
+            "created_at": created_at or datetime.now(timezone.utc).isoformat(),
+        }
+        self.messages.append(message)
+        return message_id
+
+    def list_messages(
+        self,
+        thread_id: int,
+        limit: int = 50,
+        offset: int = 0,
+        exclude_kinds: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        _ = exclude_kinds
+        items = [
+            dict(message)
+            for message in self.messages
+            if int(message.get("thread_id") or 0) == int(thread_id)
+        ]
+        items.sort(key=lambda item: int(item.get("id") or 0))
+        return items[offset : offset + limit]
+
+    def count_messages(self, thread_id: int) -> int:
+        return len(
+            [
+                message
+                for message in self.messages
+                if int(message.get("thread_id") or 0) == int(thread_id)
+            ]
+        )
+
+    def write_audit_log(self, *args: Any, **kwargs: Any) -> None:
+        _ = args, kwargs
+        return None
+
+
+@pytest.fixture
+def import_store(monkeypatch):
+    store = InMemoryFlatImportStore()
+    monkeypatch.setattr(dependencies, "chatlog_db", store)
+    monkeypatch.setattr(dependencies, "_vector_store", None)
+    monkeypatch.setattr(dependencies, "init_database", lambda: store)
+    monkeypatch.setattr(chatgpt_migration, "_IMPORT_EMBEDDINGS_ENABLED", False)
+    monkeypatch.setattr(
+        chatgpt_migration,
+        "_find_existing_thread_for_source",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        chatgpt_migration,
+        "_find_existing_message_for_source",
+        lambda *_args, **_kwargs: None,
+    )
+    return store
+
+
+def test_chatgpt_import_keeps_grouping_flat_and_metadata_hidden(
+    import_store,
+    monkeypatch,
+):
+    captured_temporal_meta: list[dict[str, Any]] = []
+
+    def capture_temporal_meta(
+        chatlog_db, message_id, merged_meta, source_created_at
+    ):
+        _ = chatlog_db, message_id, source_created_at
+        captured_temporal_meta.append(dict(merged_meta))
+
+    monkeypatch.setattr(
+        chatgpt_migration,
+        "_persist_temporal_metadata",
+        capture_temporal_meta,
+    )
+
+    export = _build_mainline_export(
+        [("user", "This import stays flat.", 1), ("assistant", "Noted.", 2)],
+        thread_id="flat-thread",
+        title="Flat Import",
+    )
+    export[0]["conversation_template_id"] = "g-p-aaaaaaaa11111111"
+    export[0]["gizmo_id"] = "gizmo-alpha"
+    export[0]["gizmo_type"] = "assistants"
+
+    stats = ingest_chatgpt_export(
+        json.dumps(export).encode("utf-8"),
+        user_id="tester",
+    )
+
+    assert stats["threads_imported"] == 1
+    assert stats["messages_imported"] == 2
+    assert stats["projects_created"] == 0
+    assert stats["projects_reused"] == 0
+    assert import_store.ensure_project_calls == [
+        ("Imports", "Default bucket for imported threads")
+    ]
+
+    thread = import_store.threads[1]
+    assert thread["project_id"] == 1
+    assert thread["metadata"]["import_source"] == "chatgpt"
+    assert (
+        thread["metadata"]["source_conversation_template_id"]
+        == "g-p-aaaaaaaa11111111"
+    )
+    assert thread["metadata"]["source_gizmo_id"] == "gizmo-alpha"
+    assert thread["metadata"]["source_gizmo_type"] == "assistants"
+
+    assert captured_temporal_meta
+    assert (
+        captured_temporal_meta[0]["source_conversation_template_id"]
+        == "g-p-aaaaaaaa11111111"
+    )
+    assert captured_temporal_meta[0]["source_gizmo_id"] == "gizmo-alpha"
+    assert captured_temporal_meta[0]["source_gizmo_type"] == "assistants"
+    assert captured_temporal_meta[0]["source_thread_id"] == "flat-thread"

--- a/guardian/tests/migration/test_chatgpt_ingest.py
+++ b/guardian/tests/migration/test_chatgpt_ingest.py
@@ -389,15 +389,13 @@ def test_imported_fact_is_recalled_in_post_import_completion(monkeypatch):
     assert observed.get("has_memory_context") is True
 
 
-def test_ingest_routes_template_projects_and_tracks_project_stats(monkeypatch):
+def test_ingest_with_template_metadata_stays_in_imports_container(monkeypatch):
     mock_db = MagicMock()
     mock_db.list_projects.return_value = [{"id": 1, "name": "Imports"}]
 
     def ensure_project(name: str, _description: str = "") -> int:
         if name == "Imports":
             return 1
-        if "[11111111]" in name:
-            return 10
         return 11
 
     mock_db.ensure_project.side_effect = ensure_project
@@ -430,20 +428,6 @@ def test_ingest_routes_template_projects_and_tracks_project_stats(monkeypatch):
         lambda *_args, **_kwargs: None,
     )
 
-    project_lookup_calls = {"count": 0}
-
-    def fake_find_project(*_args, **_kwargs):
-        project_lookup_calls["count"] += 1
-        if project_lookup_calls["count"] == 1:
-            return None
-        return 10
-
-    monkeypatch.setattr(
-        chatgpt_migration,
-        "_find_existing_project_for_template",
-        fake_find_project,
-    )
-
     export = _build_mainline_export(
         [("user", "One", 1), ("assistant", "A", 2)],
         thread_id="thread-one",
@@ -455,6 +439,10 @@ def test_ingest_routes_template_projects_and_tracks_project_stats(monkeypatch):
     )
     export[0]["conversation_template_id"] = "g-p-aaaaaaaa11111111"
     export[1]["conversation_template_id"] = "g-p-aaaaaaaa11111111"
+    export[0]["gizmo_id"] = "gizmo-alpha"
+    export[0]["gizmo_type"] = "assistants"
+    export[1]["gizmo_id"] = "gizmo-alpha"
+    export[1]["gizmo_type"] = "assistants"
 
     stats = ingest_chatgpt_export(
         json.dumps(export).encode("utf-8"),
@@ -463,17 +451,22 @@ def test_ingest_routes_template_projects_and_tracks_project_stats(monkeypatch):
 
     assert stats["threads_imported"] == 2
     assert stats["messages_imported"] == 4
-    assert stats["projects_created"] == 1
-    assert stats["projects_reused"] == 1
+    assert stats["projects_created"] == 0
+    assert stats["projects_reused"] == 0
+    mock_db.ensure_project.assert_called_once_with(
+        "Imports", "Default bucket for imported threads"
+    )
 
     first_call = mock_db.create_chat_thread.call_args_list[0].kwargs
     second_call = mock_db.create_chat_thread.call_args_list[1].kwargs
-    assert first_call["project_id"] == 10
-    assert second_call["project_id"] == 10
+    assert first_call["project_id"] == 1
+    assert second_call["project_id"] == 1
     assert (
         first_call["metadata"]["source_conversation_template_id"]
         == "g-p-aaaaaaaa11111111"
     )
+    assert first_call["metadata"]["source_gizmo_id"] == "gizmo-alpha"
+    assert first_call["metadata"]["source_gizmo_type"] == "assistants"
 
 
 def test_ingest_without_template_falls_back_to_imports(monkeypatch):


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
