### PR TITLE
Refactor Command Center legibility and library convergence

### DIFF
--- a/frontend/src/features/commandCenter/CommandCenterPage.tsx
+++ b/frontend/src/features/commandCenter/CommandCenterPage.tsx
@@ -54,6 +54,164 @@ function formatTimestamp(value: number | null): string {
   return new Date(value).toLocaleString();
 }
 
+type BadgeTone = "active" | "attention" | "danger" | "info" | "neutral" | "subtle";
+
+const sectionSurfaceStyle: React.CSSProperties = {
+  background: "color-mix(in oklab, var(--panel-bg) 96%, transparent)",
+  borderColor: "var(--panel-border)",
+  borderRadius: "var(--tile-radius)",
+};
+
+const tileSurfaceStyle: React.CSSProperties = {
+  background: "color-mix(in oklab, var(--panel-bg) 94%, transparent)",
+  borderColor: "var(--panel-border)",
+  borderRadius: "var(--tile-radius)",
+};
+
+const rawSurfaceStyle: React.CSSProperties = {
+  background: "var(--surface-soft)",
+  borderColor: "var(--panel-border)",
+  borderRadius: "var(--tile-radius)",
+};
+
+function badgeToneStyle(tone: BadgeTone): React.CSSProperties {
+  switch (tone) {
+    case "active":
+      return {
+        background: "var(--accent-weak)",
+        borderColor: "color-mix(in oklab, var(--accent-strong) 35%, var(--panel-border))",
+        color: "var(--text-on-accent)",
+      };
+    case "attention":
+      return {
+        background: "color-mix(in oklab, var(--chip-bg) 82%, var(--accent-strong) 18%)",
+        borderColor: "color-mix(in oklab, var(--accent-strong) 42%, var(--panel-border))",
+        color: "var(--text)",
+      };
+    case "danger":
+      return {
+        background: "var(--danger-surface)",
+        borderColor: "var(--danger-border)",
+        color: "var(--danger-text)",
+      };
+    case "info":
+      return {
+        background: "var(--info-surface)",
+        borderColor: "var(--panel-border)",
+        color: "var(--info-text)",
+      };
+    case "neutral":
+      return {
+        background: "var(--chip-bg)",
+        borderColor: "var(--panel-border)",
+        color: "var(--text)",
+      };
+    case "subtle":
+    default:
+      return {
+        background: "var(--surface-soft)",
+        borderColor: "var(--panel-border)",
+        color: "var(--muted)",
+      };
+  }
+}
+
+function statusBadgeToneForConnection(
+  connectionState: CommandCenterConnectionState,
+  unauthorized: boolean
+): BadgeTone {
+  if (unauthorized) return "attention";
+  switch (connectionState) {
+    case "open":
+      return "active";
+    case "connecting":
+      return "info";
+    case "error":
+      return "danger";
+    default:
+      return "subtle";
+  }
+}
+
+function statusBadgeToneForHealth(status: CommandCenterHealthItem["status"]): BadgeTone {
+  switch (status) {
+    case "OK":
+      return "active";
+    case "FAIL":
+      return "danger";
+    default:
+      return "subtle";
+  }
+}
+
+function statusBadgeToneForRun(status: CommandCenterRun["status"]): BadgeTone {
+  switch (status) {
+    case "running":
+      return "info";
+    case "succeeded":
+      return "active";
+    case "failed":
+      return "danger";
+    case "needs_attention":
+      return "attention";
+    default:
+      return "subtle";
+  }
+}
+
+function BadgePill({
+  ariaLabel,
+  children,
+  className,
+  tone,
+}: {
+  ariaLabel?: string;
+  children: React.ReactNode;
+  className?: string;
+  tone: BadgeTone;
+}) {
+  return (
+    <Badge
+      aria-label={ariaLabel}
+      className={`border text-[11px] font-medium leading-none ${className ?? ""}`.trim()}
+      style={badgeToneStyle(tone)}
+    >
+      {children}
+    </Badge>
+  );
+}
+
+function SummaryTile({
+  children,
+  dataTestId,
+  label,
+  note,
+}: {
+  children: React.ReactNode;
+  dataTestId?: string;
+  label: string;
+  note: React.ReactNode;
+}) {
+  return (
+    <div
+      className="space-y-2 border p-[var(--card-pad)]"
+      data-testid={dataTestId}
+      style={tileSurfaceStyle}
+    >
+      <div
+        className="text-[11px] font-semibold uppercase tracking-[0.16em]"
+        style={{ color: "var(--muted)" }}
+      >
+        {label}
+      </div>
+      <div className="flex min-h-10 items-start justify-between gap-3">{children}</div>
+      <div className="text-xs leading-5" style={{ color: "var(--muted)" }}>
+        {note}
+      </div>
+    </div>
+  );
+}
+
 function resolveSelectedRunThreadId(run: CommandCenterRun): number | null {
   const payload = asRecord(run.lastEvent.json);
   const thread = asRecord(payload?.thread);
@@ -99,83 +257,8 @@ function resolveSelectedRunTraceUrl(run: CommandCenterRun): string | null {
   );
 }
 
-function connectionStyle(state: CommandCenterConnectionState): React.CSSProperties {
-  switch (state) {
-    case "open":
-      return {
-        background: "rgba(34, 197, 94, 0.12)",
-        borderColor: "rgba(34, 197, 94, 0.35)",
-      };
-    case "connecting":
-      return {
-        background: "rgba(59, 130, 246, 0.12)",
-        borderColor: "rgba(59, 130, 246, 0.35)",
-      };
-    case "error":
-      return {
-        background: "rgba(239, 68, 68, 0.12)",
-        borderColor: "rgba(239, 68, 68, 0.35)",
-      };
-    default:
-      return {
-        background: "rgba(148, 163, 184, 0.12)",
-        borderColor: "rgba(148, 163, 184, 0.28)",
-      };
-  }
-}
-
-function healthStyle(status: CommandCenterHealthItem["status"]): React.CSSProperties {
-  switch (status) {
-    case "OK":
-      return {
-        background: "rgba(34, 197, 94, 0.12)",
-        borderColor: "rgba(34, 197, 94, 0.35)",
-      };
-    case "FAIL":
-      return {
-        background: "rgba(239, 68, 68, 0.12)",
-        borderColor: "rgba(239, 68, 68, 0.35)",
-      };
-    default:
-      return {
-        background: "rgba(148, 163, 184, 0.12)",
-        borderColor: "rgba(148, 163, 184, 0.28)",
-      };
-  }
-}
-
-function runStatusStyle(status: CommandCenterRun["status"]): React.CSSProperties {
-  switch (status) {
-    case "running":
-      return {
-        background: "rgba(59, 130, 246, 0.12)",
-        borderColor: "rgba(59, 130, 246, 0.35)",
-      };
-    case "succeeded":
-      return {
-        background: "rgba(34, 197, 94, 0.12)",
-        borderColor: "rgba(34, 197, 94, 0.35)",
-      };
-    case "failed":
-      return {
-        background: "rgba(239, 68, 68, 0.12)",
-        borderColor: "rgba(239, 68, 68, 0.35)",
-      };
-    case "needs_attention":
-      return {
-        background: "rgba(250, 204, 21, 0.12)",
-        borderColor: "rgba(250, 204, 21, 0.35)",
-      };
-    default:
-      return {
-        background: "rgba(148, 163, 184, 0.12)",
-        borderColor: "rgba(148, 163, 184, 0.28)",
-      };
-  }
-}
-
 function getRunLabel(run: CommandCenterRun): string {
-  return firstString(run.taskId, run.runId, run.key) ?? "Unknown run";
+  return firstString(run.summary, run.taskId, run.runId, run.key) ?? "Unknown run";
 }
 
 function getRunEventType(run: CommandCenterRun): string {
@@ -229,130 +312,86 @@ function SummaryStrip({
 
   return (
     <Card
-      className="bezel-none rounded-2xl border"
+      className="bezel-none border"
       role="region"
       aria-label="Command Center summary strip"
       data-testid="command-center-summary-strip"
       style={{
-        background: "color-mix(in srgb, var(--panel-bg) 96%, transparent)",
-        borderColor: "var(--panel-border)",
+        ...sectionSurfaceStyle,
       }}
     >
-      <CardHeader className="space-y-1 pb-3">
+      <CardHeader className="space-y-2 pb-3">
         <CardTitle className="text-base" style={{ color: "var(--text)" }}>
-          Current runtime summary
+          Runtime snapshot
         </CardTitle>
         <p className="text-sm" style={{ color: "var(--muted)" }}>
-          Presentation-only snapshot derived from the active connection, visible
-          health surfaces, and run records on this page.
+          Live counts from the current connection, visible health surfaces, and
+          run records on this page.
         </p>
       </CardHeader>
       <CardContent className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
-        <div
-          className="space-y-2 rounded-xl border px-4 py-3"
-          style={{
-            borderColor: "var(--panel-border)",
-            background: "color-mix(in srgb, var(--panel-bg) 94%, transparent)",
-          }}
-          data-testid="command-center-summary-service"
+        <SummaryTile
+          dataTestId="command-center-summary-service"
+          label="Service status"
+          note={
+            unauthorized
+              ? "Authentication is required for live surfaces."
+              : "Current transport state from the live stream."
+          }
         >
-          <div className="text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "var(--muted)" }}>
-            Service status
-          </div>
-          <Badge
-            className="border"
-            aria-label={`Service status ${serviceStatus}`}
-            style={{
-              ...connectionStyle(connectionState),
-              color: "var(--text)",
-            }}
+          <BadgePill
+            ariaLabel={`Service status ${serviceStatus}`}
+            tone={statusBadgeToneForConnection(connectionState, unauthorized)}
           >
             {serviceStatus}
-          </Badge>
-          {unauthorized ? (
-            <div className="text-xs" style={{ color: "var(--muted)" }}>
-              Authentication is required for live surfaces.
-            </div>
-          ) : null}
-        </div>
+          </BadgePill>
+        </SummaryTile>
 
-        <div
-          className="space-y-2 rounded-xl border px-4 py-3"
-          style={{
-            borderColor: "var(--panel-border)",
-            background: "color-mix(in srgb, var(--panel-bg) 94%, transparent)",
-          }}
-          data-testid="command-center-summary-last-event"
+        <SummaryTile
+          dataTestId="command-center-summary-last-event"
+          label="Last event"
+          note="Most recent page-level event timestamp."
         >
-          <div className="text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "var(--muted)" }}>
-            Last event
-          </div>
-          <div className="text-sm font-medium" data-testid="command-center-summary-last-event-value">
+          <div
+            className="text-lg font-semibold leading-tight"
+            data-testid="command-center-summary-last-event-value"
+          >
             {formatTimestamp(lastEventAt)}
           </div>
-        </div>
+        </SummaryTile>
 
-        <div
-          className="space-y-2 rounded-xl border px-4 py-3"
-          style={{
-            borderColor: "var(--panel-border)",
-            background: "color-mix(in srgb, var(--panel-bg) 94%, transparent)",
-          }}
-          data-testid="command-center-summary-health-count"
+        <SummaryTile
+          dataTestId="command-center-summary-health-count"
+          label="Health surfaces"
+          note="Health probes currently shown."
         >
-          <div className="text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "var(--muted)" }}>
-            Health surfaces
-          </div>
           <div className="text-2xl font-semibold leading-none">{healthItems.length}</div>
-          <div className="text-xs" style={{ color: "var(--muted)" }}>
-            Health probes currently shown
-          </div>
-        </div>
+        </SummaryTile>
 
-        <div
-          className="space-y-2 rounded-xl border px-4 py-3"
-          style={{
-            borderColor: "var(--panel-border)",
-            background: "color-mix(in srgb, var(--panel-bg) 94%, transparent)",
-          }}
-          data-testid="command-center-summary-run-count"
+        <SummaryTile
+          dataTestId="command-center-summary-run-count"
+          label="Visible runs"
+          note="Run records currently visible."
         >
-          <div className="text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "var(--muted)" }}>
-            Visible runs
-          </div>
           <div className="text-2xl font-semibold leading-none">{runs.length}</div>
-          <div className="text-xs" style={{ color: "var(--muted)" }}>
-            Run records currently visible
-          </div>
-        </div>
+        </SummaryTile>
 
-        <div
-          className="space-y-2 rounded-xl border px-4 py-3"
-          style={{
-            borderColor: "var(--panel-border)",
-            background: "color-mix(in srgb, var(--panel-bg) 94%, transparent)",
-          }}
-          data-testid="command-center-summary-unknown-count"
+        <SummaryTile
+          dataTestId="command-center-summary-unknown-count"
+          label="Unknown items"
+          note={
+            unknownCount > 0
+              ? "Unresolved items remain visible."
+              : "No unknown statuses are currently visible."
+          }
         >
-          <div className="text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "var(--muted)" }}>
-            Unknown items
-          </div>
-          <Badge
-            className="border"
-            aria-label={`Unknown items ${unknownCount > 0 ? `yes ${unknownCount}` : "no"}`}
-            style={{
-              ...healthStyle(unknownCount > 0 ? "UNKNOWN" : "OK"),
-              color: "var(--text)",
-            }}
+          <div
+            className="text-2xl font-semibold leading-none"
+            aria-label={`Unknown items ${unknownCount}`}
           >
-            {unknownCount > 0 ? `Yes (${unknownCount})` : "No"}
-          </Badge>
-          <div className="text-xs" style={{ color: "var(--muted)" }}>
-            {unknownCount > 0
-              ? "One or more items are still unresolved."
-              : "No unknown statuses are currently visible."}
+            {unknownCount}
           </div>
-        </div>
+        </SummaryTile>
       </CardContent>
     </Card>
   );
@@ -368,25 +407,24 @@ function HealthStrip({
   lastCheckedAt: number | null;
   loading: boolean;
   onRefresh: () => Promise<void>;
-}) {
+  }) {
   return (
     <Card
-      className="bezel-none rounded-2xl border"
+      className="bezel-none border"
       role="region"
       aria-label="Command Center health strip"
       data-testid="command-center-health-strip"
       style={{
-        background: "color-mix(in srgb, var(--panel-bg) 96%, transparent)",
-        borderColor: "var(--panel-border)",
+        ...sectionSurfaceStyle,
       }}
     >
       <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="space-y-1">
           <CardTitle className="text-base" style={{ color: "var(--text)" }}>
-            Health Strip
+            Health
           </CardTitle>
           <p className="text-sm" style={{ color: "var(--muted)" }}>
-            Minimal snapshots of the existing health endpoints. Last checked:{" "}
+            Per-endpoint snapshots from the current health checks. Last checked:{" "}
             {formatTimestamp(lastCheckedAt)}
           </p>
         </div>
@@ -398,66 +436,83 @@ function HealthStrip({
         {healthItems.map((item) => (
           <Card
             key={item.key}
-            className="bezel-none rounded-xl border"
+            className="bezel-none border"
             data-testid={`command-center-health-${item.key}`}
             style={{
-              background: "color-mix(in srgb, var(--panel-bg) 94%, transparent)",
-              borderColor: "var(--panel-border)",
+              ...tileSurfaceStyle,
             }}
           >
-            <CardContent className="space-y-3 p-4">
-              <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <CardContent className="space-y-3 p-[var(--card-pad)]">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                 <div className="min-w-0 space-y-1">
-                  <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
+                  <div className="text-sm font-semibold leading-5" style={{ color: "var(--text)" }}>
                     {item.label}
                   </div>
-                  <div className="text-xs font-mono break-all" style={{ color: "var(--muted)" }}>
-                    Endpoint: {item.endpoint}
+                  <div className="text-xs leading-5" style={{ color: "var(--muted)" }}>
+                    {item.endpoint}
                   </div>
                 </div>
-                <Badge
-                  className="border"
+                <BadgePill
                   aria-label={`${item.label} status ${item.status}`}
-                  style={{
-                    ...healthStyle(item.status),
-                    color: "var(--text)",
-                  }}
+                  tone={statusBadgeToneForHealth(item.status)}
                 >
                   {item.status}
-                </Badge>
+                </BadgePill>
               </div>
 
-              {item.error ? (
-                <div className="text-xs" style={{ color: "var(--muted)" }}>
-                  {item.error}
-                </div>
-              ) : null}
-
-              {(item.raw || item.error) ? (
-                <details className="text-xs" style={{ color: "var(--muted)" }}>
-                  <summary className="cursor-pointer">Details</summary>
-                  <div className="mt-2 space-y-2">
-                    <div className="rounded-lg border px-3 py-2" style={{ borderColor: "var(--panel-border)" }}>
-                      <div className="text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "var(--muted)" }}>
-                        Checked
+              <details className="text-xs" style={{ color: "var(--muted)" }}>
+                <summary className="cursor-pointer text-[11px] font-semibold uppercase tracking-[0.16em]">
+                  Inspect raw details
+                </summary>
+                <div className="mt-3 space-y-2">
+                  <div className="rounded-[var(--tile-radius)] border p-3" style={rawSurfaceStyle}>
+                    <div
+                      className="text-[11px] font-semibold uppercase tracking-[0.16em]"
+                      style={{ color: "var(--muted)" }}
+                    >
+                      Checked
+                    </div>
+                    <div className="text-xs leading-5" style={{ color: "var(--text)" }}>
+                      {formatTimestamp(item.checkedAt)}
+                    </div>
+                  </div>
+                  {item.httpStatus != null ? (
+                    <div className="rounded-[var(--tile-radius)] border p-3" style={rawSurfaceStyle}>
+                      <div
+                        className="text-[11px] font-semibold uppercase tracking-[0.16em]"
+                        style={{ color: "var(--muted)" }}
+                      >
+                        HTTP status
                       </div>
-                      <div className="text-xs" style={{ color: "var(--text)" }}>
-                        {formatTimestamp(item.checkedAt)}
+                      <div className="text-xs leading-5" style={{ color: "var(--text)" }}>
+                        {item.httpStatus}
                       </div>
                     </div>
-                    <pre
-                      className="overflow-x-auto rounded-lg border p-3"
-                      style={{
-                        borderColor: "var(--panel-border)",
-                        background: "rgba(0, 0, 0, 0.12)",
-                        color: "var(--text)",
-                      }}
-                    >
-                      {item.raw ?? item.error}
-                    </pre>
-                  </div>
-                </details>
-              ) : null}
+                  ) : null}
+                  {item.error ? (
+                    <div className="rounded-[var(--tile-radius)] border p-3" style={rawSurfaceStyle}>
+                      <div
+                        className="text-[11px] font-semibold uppercase tracking-[0.16em]"
+                        style={{ color: "var(--muted)" }}
+                      >
+                        Error
+                      </div>
+                      <div className="text-xs leading-5" style={{ color: "var(--muted)" }}>
+                        {item.error}
+                      </div>
+                    </div>
+                  ) : null}
+                  <pre
+                    className="overflow-x-auto rounded-[var(--tile-radius)] border p-3 text-[11px] leading-5"
+                    style={{
+                      ...rawSurfaceStyle,
+                      color: "var(--muted)",
+                    }}
+                  >
+                    {item.raw ?? "No raw payload available."}
+                  </pre>
+                </div>
+              </details>
             </CardContent>
           </Card>
         ))}
@@ -474,32 +529,31 @@ function RunFeed({
   onSelectRun: (run: CommandCenterRun) => void;
   runs: CommandCenterRun[];
   selectedRunKey: string | null;
-}) {
+  }) {
   return (
     <Card
-      className="bezel-none rounded-2xl border"
+      className="bezel-none border"
       role="region"
       aria-label="Command Center runs feed"
       data-testid="command-center-runs-feed"
       style={{
-        background: "color-mix(in srgb, var(--panel-bg) 96%, transparent)",
-        borderColor: "var(--panel-border)",
+        ...sectionSurfaceStyle,
       }}
     >
-      <CardHeader className="space-y-1">
+      <CardHeader className="space-y-2">
         <CardTitle className="text-base" style={{ color: "var(--text)" }}>
           Runs
         </CardTitle>
         <p className="text-sm" style={{ color: "var(--muted)" }}>
-          Compact feed derived from the global SSE stream. Raw payload details stay
-          collapsed unless needed.
+          Summary-first cards derived from the global SSE stream. Raw identifiers
+          and payload text stay collapsed unless needed.
         </p>
       </CardHeader>
       <CardContent className="space-y-3">
         {runs.length === 0 ? (
           <div
-            className="rounded-xl border px-4 py-5 text-sm"
-            style={{ borderColor: "var(--panel-border)", color: "var(--muted)" }}
+            className="rounded-[var(--tile-radius)] border px-[var(--card-pad)] py-5 text-sm"
+            style={{ ...tileSurfaceStyle, color: "var(--muted)" }}
           >
             Waiting for run-identifiable events.
           </div>
@@ -507,6 +561,7 @@ function RunFeed({
           runs.map((run) => {
             const selected = run.key === selectedRunKey;
             const runLabel = getRunLabel(run);
+            const runSummary = run.summary && run.summary !== runLabel ? run.summary : null;
             const eventType = getRunEventType(run);
             const eventIds = [
               run.lastEvent.eventId ? `Event: ${run.lastEvent.eventId}` : null,
@@ -517,73 +572,78 @@ function RunFeed({
             return (
               <Card
                 key={run.key}
-                className="bezel-none rounded-xl border"
+                className="bezel-none border"
                 data-testid={`command-center-run-${run.key}`}
                 style={{
-                  background: "color-mix(in srgb, var(--panel-bg) 94%, transparent)",
-                  borderColor: selected ? "var(--accent)" : "var(--panel-border)",
+                  ...tileSurfaceStyle,
+                  borderColor: selected ? "var(--accent)" : tileSurfaceStyle.borderColor,
                 }}
               >
-                <CardContent className="space-y-3 p-4">
-                  <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                <CardContent className="space-y-3 p-[var(--card-pad)]">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                     <div className="min-w-0 space-y-1.5">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
-                          {runLabel}
+                      <div className="text-sm font-semibold leading-5" style={{ color: "var(--text)" }}>
+                        {runLabel}
+                      </div>
+                      {runSummary ? (
+                        <div className="text-xs leading-5" style={{ color: "var(--muted)" }}>
+                          {runSummary}
                         </div>
-                        <Badge
-                          className="border"
-                          aria-label={`${runLabel} status ${run.status}`}
-                          style={{
-                            ...runStatusStyle(run.status),
-                            color: "var(--text)",
-                          }}
-                        >
-                          {formatStatusLabel(run.status)}
-                        </Badge>
-                      </div>
-                      <div className="text-xs" style={{ color: "var(--muted)" }}>
-                        Last event type: {eventType}
-                      </div>
-                      <div className="text-xs" style={{ color: "var(--muted)" }}>
-                        Timestamp: {formatTimestamp(run.lastEventAt)}
-                      </div>
+                      ) : null}
                     </div>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => onSelectRun(run)}
-                      aria-label={`Open details for ${runLabel}`}
-                    >
-                      Open
-                    </Button>
+                    <div className="flex shrink-0 items-start gap-2">
+                      <BadgePill
+                        ariaLabel={`${runLabel} status ${run.status}`}
+                        tone={statusBadgeToneForRun(run.status)}
+                      >
+                        {formatStatusLabel(run.status)}
+                      </BadgePill>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onSelectRun(run)}
+                        aria-label={`Open details for ${runLabel}`}
+                      >
+                        Open
+                      </Button>
+                    </div>
                   </div>
 
-                  {run.summary ? (
-                    <div className="text-sm" style={{ color: "var(--muted)" }}>
-                      {run.summary}
-                    </div>
-                  ) : null}
+                  <div className="flex flex-wrap gap-2">
+                    <BadgePill tone="subtle">Events: {run.eventCount}</BadgePill>
+                    <BadgePill tone="subtle">Updated: {formatTimestamp(run.lastEventAt)}</BadgePill>
+                  </div>
 
                   <details className="text-xs" style={{ color: "var(--muted)" }}>
-                    <summary className="cursor-pointer">Details</summary>
-                    <div className="mt-2 space-y-3">
-                      <div className="rounded-lg border px-3 py-2" style={{ borderColor: "var(--panel-border)" }}>
-                        <div className="text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "var(--muted)" }}>
-                          Event IDs
+                    <summary className="cursor-pointer text-[11px] font-semibold uppercase tracking-[0.16em]">
+                      Inspect event details
+                    </summary>
+                    <div className="mt-3 space-y-2">
+                      <div className="rounded-[var(--tile-radius)] border p-3" style={rawSurfaceStyle}>
+                        <div
+                          className="text-[11px] font-semibold uppercase tracking-[0.16em]"
+                          style={{ color: "var(--muted)" }}
+                        >
+                          Event type
                         </div>
-                        <div className="mt-1 flex flex-wrap gap-2">
+                        <div className="text-xs leading-5" style={{ color: "var(--text)" }}>
+                          {eventType}
+                        </div>
+                      </div>
+                      <div className="rounded-[var(--tile-radius)] border p-3" style={rawSurfaceStyle}>
+                        <div
+                          className="text-[11px] font-semibold uppercase tracking-[0.16em]"
+                          style={{ color: "var(--muted)" }}
+                        >
+                          Event identifiers
+                        </div>
+                        <div className="mt-2 flex flex-wrap gap-2">
                           {eventIds.length > 0 ? (
                             eventIds.map((value) => (
-                              <Badge
-                                key={value}
-                                variant="outline"
-                                className="px-2 py-1 text-[10px]"
-                                style={{ borderColor: "var(--panel-border)" }}
-                              >
+                              <BadgePill key={value} tone="subtle">
                                 {value}
-                              </Badge>
+                              </BadgePill>
                             ))
                           ) : (
                             <span style={{ color: "var(--muted)" }}>
@@ -592,16 +652,18 @@ function RunFeed({
                           )}
                         </div>
                       </div>
-                      <div className="rounded-lg border px-3 py-2" style={{ borderColor: "var(--panel-border)" }}>
-                        <div className="text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "var(--muted)" }}>
+                      <div className="rounded-[var(--tile-radius)] border p-3" style={rawSurfaceStyle}>
+                        <div
+                          className="text-[11px] font-semibold uppercase tracking-[0.16em]"
+                          style={{ color: "var(--muted)" }}
+                        >
                           Raw message
                         </div>
                         <pre
-                          className="mt-2 overflow-x-auto rounded-lg border p-3"
+                          className="mt-2 overflow-x-auto rounded-[var(--tile-radius)] border p-3 text-[11px] leading-5"
                           style={{
-                            borderColor: "var(--panel-border)",
-                            background: "rgba(0, 0, 0, 0.12)",
-                            color: "var(--text)",
+                            ...rawSurfaceStyle,
+                            color: "var(--muted)",
                           }}
                         >
                           {run.lastEvent.raw || "No raw message available."}
@@ -663,10 +725,9 @@ export default function CommandCenterPage({
       >
         <div className="mx-auto flex max-w-2xl items-center justify-center">
           <Card
-            className="bezel-none w-full rounded-2xl border"
+            className="bezel-none w-full border"
             style={{
-              background: "color-mix(in srgb, var(--panel-bg) 96%, transparent)",
-              borderColor: "var(--panel-border)",
+              ...sectionSurfaceStyle,
             }}
           >
             <CardContent className="space-y-3 p-6">
@@ -684,44 +745,39 @@ export default function CommandCenterPage({
 
   return (
     <main
-      className="min-h-screen px-4 py-5 sm:px-6 sm:py-8"
+      className="min-h-screen overflow-auto p-[var(--card-pad)]"
       style={{ background: "var(--panel-bg)", color: "var(--text)" }}
     >
-      <div className="mx-auto flex max-w-7xl flex-col gap-5">
+      <div className="mx-auto flex max-w-7xl flex-col gap-[var(--shell-gap)]">
         <Card
-          className="bezel-none rounded-2xl border"
+          className="bezel-none border"
           style={{
-            background: "color-mix(in srgb, var(--panel-bg) 96%, transparent)",
-            borderColor: "var(--panel-border)",
+            ...sectionSurfaceStyle,
           }}
         >
-          <CardContent className="flex flex-col gap-3 p-5 sm:flex-row sm:items-start sm:justify-between">
+          <CardContent className="flex flex-col gap-4 p-[var(--card-pad)] sm:flex-row sm:items-start sm:justify-between">
             <div className="space-y-1">
+              <div
+                className="text-[11px] font-semibold uppercase tracking-[0.18em]"
+                style={{ color: "var(--muted)" }}
+              >
+                Command Center
+              </div>
               <h1 className="text-2xl font-semibold tracking-tight">Agent Command Center</h1>
               <p className="max-w-3xl text-sm leading-6" style={{ color: "var(--muted)" }}>
                 Read-only operational surface for service health, runs, approvals,
                 and task event streams.
               </p>
             </div>
-            <div className="flex flex-wrap items-center gap-3">
-              <Badge
-                className="border"
-                aria-label={`Service status ${serviceStatus}`}
-                style={{
-                  ...connectionStyle(connectionState),
-                  color: "var(--text)",
-                }}
+            <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+              <BadgePill
+                ariaLabel={`Service status ${serviceStatus}`}
+                tone={statusBadgeToneForConnection(connectionState, unauthorized)}
               >
                 {serviceStatus}
-              </Badge>
-              <div className="text-xs" style={{ color: "var(--muted)" }}>
-                Last event: {formatTimestamp(lastEventAt)}
-              </div>
-              {connectionDetail ? (
-                <div className="text-xs" style={{ color: "var(--muted)" }}>
-                  {connectionDetail}
-                </div>
-              ) : null}
+              </BadgePill>
+              <BadgePill tone="subtle">Last event: {formatTimestamp(lastEventAt)}</BadgePill>
+              {connectionDetail ? <BadgePill tone="subtle">{connectionDetail}</BadgePill> : null}
             </div>
           </CardContent>
         </Card>

--- a/frontend/src/features/commandCenter/__tests__/CommandCenterPage.test.tsx
+++ b/frontend/src/features/commandCenter/__tests__/CommandCenterPage.test.tsx
@@ -188,7 +188,7 @@ describe("CommandCenterPage", () => {
     );
     expect(screen.getByTestId("command-center-summary-health-count")).toHaveTextContent("5");
     expect(screen.getByTestId("command-center-summary-run-count")).toHaveTextContent("2");
-    expect(within(summaryStrip).getByLabelText(/unknown items yes 2/i)).toBeInTheDocument();
+    expect(within(summaryStrip).getByLabelText(/unknown items 2/i)).toBeInTheDocument();
 
     const healthStrip = screen.getByTestId("command-center-health-strip");
     expect(within(healthStrip).getByText("Core")).toBeInTheDocument();
@@ -196,23 +196,34 @@ describe("CommandCenterPage", () => {
     expect(within(healthStrip).getByText("Deps")).toBeInTheDocument();
     expect(within(healthStrip).getByText("Vector")).toBeInTheDocument();
     expect(within(healthStrip).getByText("Memory")).toBeInTheDocument();
-    expect(screen.getByLabelText("LLM status UNKNOWN")).toBeInTheDocument();
-    expect(within(healthStrip).getAllByText("Details").length).toBeGreaterThan(0);
+    expect(within(screen.getByTestId("command-center-health-core")).getByText("OK")).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("command-center-health-llm")).getByText("UNKNOWN")
+    ).toBeInTheDocument();
+    expect(within(screen.getByTestId("command-center-health-deps")).getByText("FAIL")).toBeInTheDocument();
+    expect(within(healthStrip).getAllByText("Inspect raw details").length).toBeGreaterThan(0);
 
     const runsFeed = screen.getByTestId("command-center-runs-feed");
-    expect(within(runsFeed).getByText("task-alpha")).toBeInTheDocument();
-    expect(within(runsFeed).getByText("task-bravo")).toBeInTheDocument();
-    expect(screen.getByLabelText("task-alpha status running")).toBeInTheDocument();
-    expect(screen.getByLabelText("task-bravo status unknown")).toBeInTheDocument();
-    expect(within(runsFeed).getByRole("button", { name: /open details for task-alpha/i })).toBeInTheDocument();
-    expect(within(runsFeed).getByRole("button", { name: /open details for task-bravo/i })).toBeInTheDocument();
+    expect(within(runsFeed).getByText("Processing alpha")).toBeInTheDocument();
+    expect(within(runsFeed).getByText("No classification yet")).toBeInTheDocument();
+    expect(within(screen.getByTestId("command-center-run-run-alpha")).getByText("running")).toBeInTheDocument();
+    expect(within(screen.getByTestId("command-center-run-run-bravo")).getByText("unknown")).toBeInTheDocument();
+    expect(
+      within(runsFeed).getByRole("button", { name: /open details for processing alpha/i })
+    ).toBeInTheDocument();
+    expect(
+      within(runsFeed).getByRole("button", { name: /open details for no classification yet/i })
+    ).toBeInTheDocument();
+    expect(within(runsFeed).getAllByText("Inspect event details").length).toBeGreaterThan(0);
 
     fireEvent.click(
-      within(runsFeed).getByRole("button", { name: /open details for task-alpha/i })
+      within(runsFeed).getByRole("button", { name: /open details for processing alpha/i })
     );
     expect(screen.getByTestId("run-detail-drawer")).toHaveTextContent("run-alpha");
 
     expect(screen.getByText("Approvals")).toBeInTheDocument();
+    expect(screen.getByText("attention")).toBeInTheDocument();
     expect(screen.queryByText(/composer/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/message thread/i)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Aligned Command Center with shared Codexify surface patterns using token-driven card surfaces, consistent chip styling, and tighter header rhythm.
- Reworked summary, health, and runs sections so status is the primary visual signal, with timestamps, endpoints, IDs, and raw payloads visually de-emphasized.
- Preserved runtime semantics, polling, event parsing, and backend contracts.

## Testing
- `pnpm --dir frontend/src exec vitest run features/commandCenter/__tests__/CommandCenterPage.test.tsx`