### PR TITLE
Add account export ZIP download

### DIFF
--- a/guardian/core/pgdb.py
+++ b/guardian/core/pgdb.py
@@ -3138,3 +3138,510 @@ def fetch_imported_chatgpt_messages_for_thread(
                 conn_err,
                 exc_info=True,
             )
+
+
+ACCOUNT_EXPORT_PAYLOAD_ORDER = (
+    "projects",
+    "chat_threads",
+    "chat_messages",
+    "uploaded_documents",
+    "generated_documents",
+    "uploaded_images",
+    "generated_images",
+    "media_assets",
+    "media_aliases",
+    "thread_documents",
+    "project_document_links",
+)
+
+
+def _normalize_export_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _normalize_export_value(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_normalize_export_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_normalize_export_value(item) for item in value]
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, decimal.Decimal):
+        return float(value)
+    if isinstance(value, uuid.UUID):
+        return str(value)
+    return value
+
+
+def _normalize_export_row(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: _normalize_export_value(value) for key, value in dict(row).items()
+    }
+
+
+def _export_rows(
+    cur,
+    query: str,
+    params: tuple[Any, ...] | list[Any] = (),
+) -> list[dict[str, Any]]:
+    cur.execute(query, params)
+    return [_normalize_export_row(dict(row)) for row in cur.fetchall()]
+
+
+def _export_scope_clause(
+    *clauses: tuple[str, Any | None]
+) -> tuple[str, list[Any]]:
+    active_clauses: list[str] = []
+    params: list[Any] = []
+    for clause, value in clauses:
+        if value is None:
+            continue
+        if isinstance(value, (list, tuple, set)) and len(value) == 0:
+            continue
+        active_clauses.append(f"({clause})")
+        params.append(list(value) if isinstance(value, set) else value)
+    if not active_clauses:
+        return "FALSE", params
+    return " OR ".join(active_clauses), params
+
+
+def _append_unique(values: list[Any], row_values: list[Any]) -> list[Any]:
+    seen = set(values)
+    for value in row_values:
+        if value is None or value in seen:
+            continue
+        seen.add(value)
+        values.append(value)
+    return values
+
+
+def fetch_account_export_bundle_for_user(
+    user_id: str,
+) -> dict[str, list[dict[str, Any]]]:
+    """
+    Return the complete canonical account export payload bundle for a user.
+
+    The bundle is keyed by logical family name and keeps user scoping explicit.
+    """
+    if not user_id:
+        return {family: [] for family in ACCOUNT_EXPORT_PAYLOAD_ORDER}
+
+    dsn = _resolve_dsn()
+    conn = psycopg.connect(dsn, row_factory=dict_row)
+    try:
+        with conn.cursor() as cur:
+            bundles: dict[str, list[dict[str, Any]]] = {
+                family: [] for family in ACCOUNT_EXPORT_PAYLOAD_ORDER
+            }
+
+            bundles["chat_threads"] = _export_rows(
+                cur,
+                """
+                SELECT
+                    id, user_id, title, summary, project_id,
+                    active_profile_id, parent_id, archived_at,
+                    is_diary, diary_mode, exclude_from_identity,
+                    modeling_excluded, created_at, updated_at
+                FROM chat_threads
+                WHERE user_id = %s
+                ORDER BY updated_at DESC, id DESC
+                """,
+                (user_id,),
+            )
+
+            thread_ids = [row.get("id") for row in bundles["chat_threads"]]
+            project_ids = _append_unique(
+                [],
+                [
+                    row.get("project_id")
+                    for row in bundles["chat_threads"]
+                    if row.get("project_id") is not None
+                ],
+            )
+
+            bundles["chat_messages"] = (
+                _export_rows(
+                    cur,
+                    """
+                    SELECT
+                        id, thread_id, role, content, event_at,
+                        kind, extra_meta, created_at
+                    FROM chat_messages
+                    WHERE thread_id = ANY(%s)
+                    ORDER BY COALESCE(event_at, created_at) ASC, id ASC
+                    """,
+                    (
+                        [
+                            thread_id
+                            for thread_id in thread_ids
+                            if thread_id is not None
+                        ],
+                    ),
+                )
+                if thread_ids
+                else []
+            )
+
+            document_scope_clause, document_scope_params = _export_scope_clause(
+                ("user_id = %s", user_id),
+                (
+                    "thread_id = ANY(%s)",
+                    [t for t in thread_ids if t is not None],
+                ),
+                ("project_id = ANY(%s)", project_ids),
+            )
+
+            bundles["uploaded_documents"] = _export_rows(
+                cur,
+                f"""
+                SELECT
+                    id, asset_id, project_id, thread_id, user_id,
+                    filename, filesize, mime_type, src_url, source_tag,
+                    parsed_text, embedding_status, embedding_error,
+                    embedding_started_at, embedding_completed_at,
+                    created_at, updated_at, deleted_at
+                FROM uploaded_documents
+                WHERE {document_scope_clause}
+                ORDER BY created_at ASC, id ASC
+                """,
+                tuple(document_scope_params),
+            )
+            bundles["generated_documents"] = _export_rows(
+                cur,
+                f"""
+                SELECT
+                    id, project_id, thread_id, user_id, title, content,
+                    format, model, created_at, updated_at, deleted_at
+                FROM generated_documents
+                WHERE {document_scope_clause}
+                ORDER BY created_at ASC, id ASC
+                """,
+                tuple(document_scope_params),
+            )
+            bundles["uploaded_images"] = _export_rows(
+                cur,
+                f"""
+                SELECT
+                    id, asset_id, project_id, thread_id, user_id,
+                    src_url, filename, filesize, mime_type, source_tag,
+                    created_at, updated_at, deleted_at
+                FROM uploaded_images
+                WHERE {document_scope_clause}
+                ORDER BY created_at ASC, id ASC
+                """,
+                tuple(document_scope_params),
+            )
+            bundles["generated_images"] = _export_rows(
+                cur,
+                f"""
+                SELECT
+                    id, asset_id, project_id, thread_id, user_id,
+                    src_url, prompt, model, created_at, updated_at, deleted_at
+                FROM generated_images
+                WHERE {document_scope_clause}
+                ORDER BY created_at ASC, id ASC
+                """,
+                tuple(document_scope_params),
+            )
+
+            for family in (
+                "uploaded_documents",
+                "generated_documents",
+                "uploaded_images",
+                "generated_images",
+            ):
+                project_ids = _append_unique(
+                    project_ids,
+                    [
+                        row.get("project_id")
+                        for row in bundles[family]
+                        if row.get("project_id") is not None
+                    ],
+                )
+
+            asset_ids = _append_unique(
+                [],
+                [
+                    row.get("asset_id")
+                    for row in bundles["uploaded_documents"]
+                    + bundles["uploaded_images"]
+                    + bundles["generated_images"]
+                    if row.get("asset_id") is not None
+                ],
+            )
+
+            media_scope_clause, media_scope_params = _export_scope_clause(
+                ("user_id = %s", user_id),
+                (
+                    "thread_id = ANY(%s)",
+                    [t for t in thread_ids if t is not None],
+                ),
+                ("project_id = ANY(%s)", project_ids),
+                ("id = ANY(%s)", asset_ids),
+            )
+            bundles["media_assets"] = _export_rows(
+                cur,
+                f"""
+                SELECT
+                    id, project_id, thread_id, user_id, media_kind,
+                    provenance, source_tag, content_hash,
+                    deterministic_id, normalized_slug, system_name,
+                    storage_prefix, src_url, mime_type, filesize,
+                    ingested_at, deleted_at
+                FROM media_assets
+                WHERE {media_scope_clause}
+                ORDER BY ingested_at ASC, id ASC
+                """,
+                tuple(media_scope_params),
+            )
+
+            project_ids = _append_unique(
+                project_ids,
+                [
+                    row.get("project_id")
+                    for row in bundles["media_assets"]
+                    if row.get("project_id") is not None
+                ],
+            )
+            asset_ids = _append_unique(
+                asset_ids,
+                [
+                    row.get("id")
+                    for row in bundles["media_assets"]
+                    if row.get("id") is not None
+                ],
+            )
+
+            bundles["media_aliases"] = (
+                _export_rows(
+                    cur,
+                    """
+                    SELECT
+                        id, asset_id, alias, alias_normalized,
+                        alias_type, created_at
+                    FROM media_aliases
+                    WHERE asset_id = ANY(%s)
+                    ORDER BY created_at ASC, id ASC
+                    """,
+                    (
+                        [
+                            asset_id
+                            for asset_id in asset_ids
+                            if asset_id is not None
+                        ],
+                    ),
+                )
+                if asset_ids
+                else []
+            )
+
+            bundles["thread_documents"] = (
+                _export_rows(
+                    cur,
+                    """
+                    SELECT id, thread_id, document_id, relation, created_at
+                    FROM thread_documents
+                    WHERE thread_id = ANY(%s)
+                    ORDER BY created_at ASC, id ASC
+                    """,
+                    (
+                        [
+                            thread_id
+                            for thread_id in thread_ids
+                            if thread_id is not None
+                        ],
+                    ),
+                )
+                if thread_ids
+                else []
+            )
+
+            bundles["project_document_links"] = (
+                _export_rows(
+                    cur,
+                    """
+                    SELECT
+                        id, project_id, document_id, document_type,
+                        is_enabled, attached_at, attached_by
+                    FROM project_document_links
+                    WHERE project_id = ANY(%s)
+                    ORDER BY attached_at ASC, id ASC
+                    """,
+                    (
+                        [
+                            project_id
+                            for project_id in project_ids
+                            if project_id is not None
+                        ],
+                    ),
+                )
+                if project_ids
+                else []
+            )
+
+            bundles["projects"] = (
+                _export_rows(
+                    cur,
+                    """
+                    SELECT
+                        id, name, description, icon,
+                        identity_depth, created_at, updated_at
+                    FROM projects
+                    WHERE id = ANY(%s)
+                    ORDER BY id ASC
+                    """,
+                    (
+                        [
+                            project_id
+                            for project_id in project_ids
+                            if project_id is not None
+                        ],
+                    ),
+                )
+                if project_ids
+                else []
+            )
+
+            return bundles
+    finally:
+        try:
+            conn.close()
+        except Exception as conn_err:
+            logger.debug(
+                "Failed to close account export bundle connection: %s",
+                conn_err,
+                exc_info=True,
+            )
+
+
+def _bundle_family_rows(user_id: str, family: str) -> list[dict[str, Any]]:
+    bundle = fetch_account_export_bundle_for_user(user_id)
+    return bundle.get(family, [])
+
+
+def fetch_account_export_projects_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    return _bundle_family_rows(user_id, "projects")
+
+
+def fetch_account_export_chat_threads_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    return _bundle_family_rows(user_id, "chat_threads")
+
+
+def fetch_account_export_chat_messages_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    return _bundle_family_rows(user_id, "chat_messages")
+
+
+def fetch_account_export_uploaded_documents_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    return _bundle_family_rows(user_id, "uploaded_documents")
+
+
+def fetch_account_export_generated_documents_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    return _bundle_family_rows(user_id, "generated_documents")
+
+
+def fetch_account_export_uploaded_images_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    return _bundle_family_rows(user_id, "uploaded_images")
+
+
+def fetch_account_export_generated_images_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    return _bundle_family_rows(user_id, "generated_images")
+
+
+def fetch_account_export_media_assets_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    return _bundle_family_rows(user_id, "media_assets")
+
+
+def fetch_account_export_media_aliases_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    return _bundle_family_rows(user_id, "media_aliases")
+
+
+def fetch_account_export_thread_documents_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    return _bundle_family_rows(user_id, "thread_documents")
+
+
+def fetch_account_export_project_document_links_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    return _bundle_family_rows(user_id, "project_document_links")
+
+
+def iter_account_export_payloads_for_user(
+    user_id: str,
+):
+    bundle = fetch_account_export_bundle_for_user(user_id)
+    for family, path, _reader_name in (
+        (
+            "projects",
+            "entities/projects.json",
+            "fetch_account_export_projects_for_user",
+        ),
+        (
+            "chat_threads",
+            "entities/chat_threads.json",
+            "fetch_account_export_chat_threads_for_user",
+        ),
+        (
+            "chat_messages",
+            "entities/chat_messages.json",
+            "fetch_account_export_chat_messages_for_user",
+        ),
+        (
+            "uploaded_documents",
+            "entities/uploaded_documents.json",
+            "fetch_account_export_uploaded_documents_for_user",
+        ),
+        (
+            "generated_documents",
+            "entities/generated_documents.json",
+            "fetch_account_export_generated_documents_for_user",
+        ),
+        (
+            "uploaded_images",
+            "entities/uploaded_images.json",
+            "fetch_account_export_uploaded_images_for_user",
+        ),
+        (
+            "generated_images",
+            "entities/generated_images.json",
+            "fetch_account_export_generated_images_for_user",
+        ),
+        (
+            "media_assets",
+            "entities/media_assets.json",
+            "fetch_account_export_media_assets_for_user",
+        ),
+        (
+            "media_aliases",
+            "entities/media_aliases.json",
+            "fetch_account_export_media_aliases_for_user",
+        ),
+        (
+            "thread_documents",
+            "entities/thread_documents.json",
+            "fetch_account_export_thread_documents_for_user",
+        ),
+        (
+            "project_document_links",
+            "entities/project_document_links.json",
+            "fetch_account_export_project_document_links_for_user",
+        ),
+    ):
+        yield family, path, bundle.get(family, [])

--- a/guardian/core/pgdb.py
+++ b/guardian/core/pgdb.py
@@ -2250,6 +2250,88 @@ class _AccountExportScope:
     asset_ids: tuple[str, ...]
 
 
+PAYLOAD_ORDER = (
+    (
+        "projects",
+        "entities/projects.json",
+        "fetch_account_export_projects_for_user",
+    ),
+    (
+        "chat_threads",
+        "entities/chat_threads.json",
+        "fetch_account_export_chat_threads_for_user",
+    ),
+    (
+        "chat_messages",
+        "entities/chat_messages.json",
+        "fetch_account_export_chat_messages_for_user",
+    ),
+    (
+        "uploaded_documents",
+        "entities/uploaded_documents.json",
+        "fetch_account_export_uploaded_documents_for_user",
+    ),
+    (
+        "generated_documents",
+        "entities/generated_documents.json",
+        "fetch_account_export_generated_documents_for_user",
+    ),
+    (
+        "uploaded_images",
+        "entities/uploaded_images.json",
+        "fetch_account_export_uploaded_images_for_user",
+    ),
+    (
+        "generated_images",
+        "entities/generated_images.json",
+        "fetch_account_export_generated_images_for_user",
+    ),
+    (
+        "media_assets",
+        "entities/media_assets.json",
+        "fetch_account_export_media_assets_for_user",
+    ),
+    (
+        "media_aliases",
+        "entities/media_aliases.json",
+        "fetch_account_export_media_aliases_for_user",
+    ),
+    (
+        "thread_documents",
+        "entities/thread_documents.json",
+        "fetch_account_export_thread_documents_for_user",
+    ),
+    (
+        "project_document_links",
+        "entities/project_document_links.json",
+        "fetch_account_export_project_document_links_for_user",
+    ),
+)
+
+
+@contextmanager
+def _account_export_connection(
+    conn: psycopg.Connection | None = None,
+):
+    if conn is not None:
+        yield conn
+        return
+
+    dsn = _resolve_dsn()
+    new_conn = psycopg.connect(dsn, row_factory=dict_row)
+    try:
+        yield new_conn
+    finally:
+        try:
+            new_conn.close()
+        except Exception as conn_err:
+            logger.debug(
+                "Failed to close account export connection: %s",
+                conn_err,
+                exc_info=True,
+            )
+
+
 def _account_export_thread_ids(conn, user_id: str) -> tuple[int, ...]:
     if not user_id:
         return ()
@@ -2268,7 +2350,7 @@ def _account_export_thread_ids(conn, user_id: str) -> tuple[int, ...]:
 
 
 def _account_export_thread_clause(
-    thread_ids: tuple[int, ...]
+    thread_ids: tuple[int, ...],
 ) -> tuple[str, tuple[Any, ...]]:
     if not thread_ids:
         return "FALSE", ()
@@ -2438,17 +2520,35 @@ def _account_export_scope(conn, user_id: str) -> _AccountExportScope:
     )
 
 
+def iter_account_export_payloads_for_user(
+    user_id: str,
+) -> Generator[tuple[str, str, list[dict[str, Any]]], None, None]:
+    if not user_id:
+        return
+
+    with _account_export_connection() as conn:
+        with conn.transaction():
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY"
+                )
+            for family, path, reader_name in PAYLOAD_ORDER:
+                reader = globals()[reader_name]
+                rows = reader(user_id, conn=conn)
+                yield family, path, rows
+
+
 def fetch_account_export_projects_for_user(
     user_id: str,
+    *,
+    conn: psycopg.Connection | None = None,
 ) -> list[dict[str, Any]]:
     if not user_id:
         return []
 
-    dsn = _resolve_dsn()
-    conn = psycopg.connect(dsn, row_factory=dict_row)
-    try:
-        with conn.cursor() as cur:
-            scope = _account_export_scope(conn, user_id)
+    with _account_export_connection(conn) as export_conn:
+        with export_conn.cursor() as cur:
+            scope = _account_export_scope(export_conn, user_id)
             if not scope.project_ids:
                 return []
             cur.execute(
@@ -2461,27 +2561,18 @@ def fetch_account_export_projects_for_user(
                 (list(scope.project_ids),),
             )
             return [_normalize_export_row(dict(row)) for row in cur.fetchall()]
-    finally:
-        try:
-            conn.close()
-        except Exception as conn_err:
-            logger.debug(
-                "Failed to close account export project connection: %s",
-                conn_err,
-                exc_info=True,
-            )
 
 
 def fetch_account_export_chat_threads_for_user(
     user_id: str,
+    *,
+    conn: psycopg.Connection | None = None,
 ) -> list[dict[str, Any]]:
     if not user_id:
         return []
 
-    dsn = _resolve_dsn()
-    conn = psycopg.connect(dsn, row_factory=dict_row)
-    try:
-        with conn.cursor() as cur:
+    with _account_export_connection(conn) as export_conn:
+        with export_conn.cursor() as cur:
             cur.execute(
                 """
                 SELECT
@@ -2511,28 +2602,19 @@ def fetch_account_export_chat_threads_for_user(
                 _normalize_export_row(PgDB._normalize_thread(dict(row)))
                 for row in rows
             ]
-    finally:
-        try:
-            conn.close()
-        except Exception as conn_err:
-            logger.debug(
-                "Failed to close account export thread connection: %s",
-                conn_err,
-                exc_info=True,
-            )
 
 
 def fetch_account_export_chat_messages_for_user(
     user_id: str,
+    *,
+    conn: psycopg.Connection | None = None,
 ) -> list[dict[str, Any]]:
     if not user_id:
         return []
 
-    dsn = _resolve_dsn()
-    conn = psycopg.connect(dsn, row_factory=dict_row)
-    try:
-        with conn.cursor() as cur:
-            scope = _account_export_scope(conn, user_id)
+    with _account_export_connection(conn) as export_conn:
+        with export_conn.cursor() as cur:
+            scope = _account_export_scope(export_conn, user_id)
             if not scope.thread_ids:
                 return []
             cur.execute(
@@ -2557,28 +2639,19 @@ def fetch_account_export_chat_messages_for_user(
                 _normalize_export_row(_normalize_export_message_row(dict(row)))
                 for row in rows
             ]
-    finally:
-        try:
-            conn.close()
-        except Exception as conn_err:
-            logger.debug(
-                "Failed to close account export message connection: %s",
-                conn_err,
-                exc_info=True,
-            )
 
 
 def fetch_account_export_uploaded_documents_for_user(
     user_id: str,
+    *,
+    conn: psycopg.Connection | None = None,
 ) -> list[dict[str, Any]]:
     if not user_id:
         return []
 
-    dsn = _resolve_dsn()
-    conn = psycopg.connect(dsn, row_factory=dict_row)
-    try:
-        with conn.cursor() as cur:
-            scope = _account_export_scope(conn, user_id)
+    with _account_export_connection(conn) as export_conn:
+        with export_conn.cursor() as cur:
+            scope = _account_export_scope(export_conn, user_id)
             thread_clause, thread_params = _account_export_thread_clause(
                 scope.thread_ids
             )
@@ -2612,28 +2685,19 @@ def fetch_account_export_uploaded_documents_for_user(
             )
             rows = cur.fetchall()
             return [_normalize_export_row(dict(row)) for row in rows]
-    finally:
-        try:
-            conn.close()
-        except Exception as conn_err:
-            logger.debug(
-                "Failed to close uploaded document export connection: %s",
-                conn_err,
-                exc_info=True,
-            )
 
 
 def fetch_account_export_generated_documents_for_user(
     user_id: str,
+    *,
+    conn: psycopg.Connection | None = None,
 ) -> list[dict[str, Any]]:
     if not user_id:
         return []
 
-    dsn = _resolve_dsn()
-    conn = psycopg.connect(dsn, row_factory=dict_row)
-    try:
-        with conn.cursor() as cur:
-            scope = _account_export_scope(conn, user_id)
+    with _account_export_connection(conn) as export_conn:
+        with export_conn.cursor() as cur:
+            scope = _account_export_scope(export_conn, user_id)
             thread_clause, thread_params = _account_export_thread_clause(
                 scope.thread_ids
             )
@@ -2660,28 +2724,19 @@ def fetch_account_export_generated_documents_for_user(
             )
             rows = cur.fetchall()
             return [_normalize_export_row(dict(row)) for row in rows]
-    finally:
-        try:
-            conn.close()
-        except Exception as conn_err:
-            logger.debug(
-                "Failed to close generated document export connection: %s",
-                conn_err,
-                exc_info=True,
-            )
 
 
 def fetch_account_export_uploaded_images_for_user(
     user_id: str,
+    *,
+    conn: psycopg.Connection | None = None,
 ) -> list[dict[str, Any]]:
     if not user_id:
         return []
 
-    dsn = _resolve_dsn()
-    conn = psycopg.connect(dsn, row_factory=dict_row)
-    try:
-        with conn.cursor() as cur:
-            scope = _account_export_scope(conn, user_id)
+    with _account_export_connection(conn) as export_conn:
+        with export_conn.cursor() as cur:
+            scope = _account_export_scope(export_conn, user_id)
             thread_clause, thread_params = _account_export_thread_clause(
                 scope.thread_ids
             )
@@ -2710,28 +2765,19 @@ def fetch_account_export_uploaded_images_for_user(
             )
             rows = cur.fetchall()
             return [_normalize_export_row(dict(row)) for row in rows]
-    finally:
-        try:
-            conn.close()
-        except Exception as conn_err:
-            logger.debug(
-                "Failed to close uploaded image export connection: %s",
-                conn_err,
-                exc_info=True,
-            )
 
 
 def fetch_account_export_generated_images_for_user(
     user_id: str,
+    *,
+    conn: psycopg.Connection | None = None,
 ) -> list[dict[str, Any]]:
     if not user_id:
         return []
 
-    dsn = _resolve_dsn()
-    conn = psycopg.connect(dsn, row_factory=dict_row)
-    try:
-        with conn.cursor() as cur:
-            scope = _account_export_scope(conn, user_id)
+    with _account_export_connection(conn) as export_conn:
+        with export_conn.cursor() as cur:
+            scope = _account_export_scope(export_conn, user_id)
             thread_clause, thread_params = _account_export_thread_clause(
                 scope.thread_ids
             )
@@ -2758,28 +2804,19 @@ def fetch_account_export_generated_images_for_user(
             )
             rows = cur.fetchall()
             return [_normalize_export_row(dict(row)) for row in rows]
-    finally:
-        try:
-            conn.close()
-        except Exception as conn_err:
-            logger.debug(
-                "Failed to close generated image export connection: %s",
-                conn_err,
-                exc_info=True,
-            )
 
 
 def fetch_account_export_media_assets_for_user(
     user_id: str,
+    *,
+    conn: psycopg.Connection | None = None,
 ) -> list[dict[str, Any]]:
     if not user_id:
         return []
 
-    dsn = _resolve_dsn()
-    conn = psycopg.connect(dsn, row_factory=dict_row)
-    try:
-        with conn.cursor() as cur:
-            scope = _account_export_scope(conn, user_id)
+    with _account_export_connection(conn) as export_conn:
+        with export_conn.cursor() as cur:
+            scope = _account_export_scope(export_conn, user_id)
             thread_clause, thread_params = _account_export_thread_clause(
                 scope.thread_ids
             )
@@ -2812,28 +2849,19 @@ def fetch_account_export_media_assets_for_user(
             )
             rows = cur.fetchall()
             return [_normalize_export_row(dict(row)) for row in rows]
-    finally:
-        try:
-            conn.close()
-        except Exception as conn_err:
-            logger.debug(
-                "Failed to close media asset export connection: %s",
-                conn_err,
-                exc_info=True,
-            )
 
 
 def fetch_account_export_media_aliases_for_user(
     user_id: str,
+    *,
+    conn: psycopg.Connection | None = None,
 ) -> list[dict[str, Any]]:
     if not user_id:
         return []
 
-    dsn = _resolve_dsn()
-    conn = psycopg.connect(dsn, row_factory=dict_row)
-    try:
-        with conn.cursor() as cur:
-            scope = _account_export_scope(conn, user_id)
+    with _account_export_connection(conn) as export_conn:
+        with export_conn.cursor() as cur:
+            scope = _account_export_scope(export_conn, user_id)
             if not scope.asset_ids:
                 return []
             cur.execute(
@@ -2853,28 +2881,19 @@ def fetch_account_export_media_aliases_for_user(
             )
             rows = cur.fetchall()
             return [_normalize_export_row(dict(row)) for row in rows]
-    finally:
-        try:
-            conn.close()
-        except Exception as conn_err:
-            logger.debug(
-                "Failed to close media alias export connection: %s",
-                conn_err,
-                exc_info=True,
-            )
 
 
 def fetch_account_export_thread_documents_for_user(
     user_id: str,
+    *,
+    conn: psycopg.Connection | None = None,
 ) -> list[dict[str, Any]]:
     if not user_id:
         return []
 
-    dsn = _resolve_dsn()
-    conn = psycopg.connect(dsn, row_factory=dict_row)
-    try:
-        with conn.cursor() as cur:
-            scope = _account_export_scope(conn, user_id)
+    with _account_export_connection(conn) as export_conn:
+        with export_conn.cursor() as cur:
+            scope = _account_export_scope(export_conn, user_id)
             if not scope.thread_ids:
                 return []
             cur.execute(
@@ -2893,28 +2912,19 @@ def fetch_account_export_thread_documents_for_user(
             )
             rows = cur.fetchall()
             return [_normalize_export_row(dict(row)) for row in rows]
-    finally:
-        try:
-            conn.close()
-        except Exception as conn_err:
-            logger.debug(
-                "Failed to close thread document export connection: %s",
-                conn_err,
-                exc_info=True,
-            )
 
 
 def fetch_account_export_project_document_links_for_user(
     user_id: str,
+    *,
+    conn: psycopg.Connection | None = None,
 ) -> list[dict[str, Any]]:
     if not user_id:
         return []
 
-    dsn = _resolve_dsn()
-    conn = psycopg.connect(dsn, row_factory=dict_row)
-    try:
-        with conn.cursor() as cur:
-            scope = _account_export_scope(conn, user_id)
+    with _account_export_connection(conn) as export_conn:
+        with export_conn.cursor() as cur:
+            scope = _account_export_scope(export_conn, user_id)
             if not scope.project_ids:
                 return []
             cur.execute(
@@ -2935,15 +2945,6 @@ def fetch_account_export_project_document_links_for_user(
             )
             rows = cur.fetchall()
             return [_normalize_export_row(dict(row)) for row in rows]
-    finally:
-        try:
-            conn.close()
-        except Exception as conn_err:
-            logger.debug(
-                "Failed to close project document export connection: %s",
-                conn_err,
-                exc_info=True,
-            )
 
 
 def fetch_imported_chatgpt_threads_for_user(

--- a/guardian/core/pgdb.py
+++ b/guardian/core/pgdb.py
@@ -16,6 +16,7 @@ import logging
 import os
 import uuid
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from typing import Any, Dict, Generator, List, Optional, Tuple
 
@@ -2220,6 +2221,729 @@ def _normalize_export_message_row(row: dict[str, Any]) -> dict[str, Any]:
         normalized.get("extra_meta")
     )
     return normalized
+
+
+def _normalize_export_value(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {
+            key: _normalize_export_value(item) for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_normalize_export_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_normalize_export_value(item) for item in value]
+    return value
+
+
+def _normalize_export_row(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: _normalize_export_value(value) for key, value in dict(row).items()
+    }
+
+
+@dataclass(frozen=True)
+class _AccountExportScope:
+    thread_ids: tuple[int, ...]
+    project_ids: tuple[int, ...]
+    asset_ids: tuple[str, ...]
+
+
+def _account_export_thread_ids(conn, user_id: str) -> tuple[int, ...]:
+    if not user_id:
+        return ()
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id
+            FROM chat_threads
+            WHERE user_id = %s
+            ORDER BY updated_at ASC, id ASC
+            """,
+            (user_id,),
+        )
+        rows = cur.fetchall()
+    return tuple(int(row["id"]) for row in rows if row.get("id") is not None)
+
+
+def _account_export_thread_clause(
+    thread_ids: tuple[int, ...]
+) -> tuple[str, tuple[Any, ...]]:
+    if not thread_ids:
+        return "FALSE", ()
+    return "thread_id = ANY(%s::int[])", (list(thread_ids),)
+
+
+def _account_export_scope(conn, user_id: str) -> _AccountExportScope:
+    thread_ids = _account_export_thread_ids(conn, user_id)
+    thread_clause, thread_params = _account_export_thread_clause(thread_ids)
+
+    project_ids: set[int] = set()
+    project_queries: list[tuple[str, tuple[Any, ...]]] = [
+        (
+            """
+            SELECT project_id
+            FROM chat_threads
+            WHERE user_id = %s
+              AND project_id IS NOT NULL
+            """,
+            (user_id,),
+        ),
+        (
+            """
+            SELECT project_id
+            FROM generated_documents
+            WHERE user_id = %s
+              AND project_id IS NOT NULL
+            """,
+            (user_id,),
+        ),
+        (
+            f"""
+            SELECT project_id
+            FROM generated_documents
+            WHERE {thread_clause}
+              AND project_id IS NOT NULL
+            """,
+            thread_params,
+        ),
+        (
+            """
+            SELECT project_id
+            FROM uploaded_documents
+            WHERE user_id = %s
+              AND project_id IS NOT NULL
+            """,
+            (user_id,),
+        ),
+        (
+            f"""
+            SELECT project_id
+            FROM uploaded_documents
+            WHERE {thread_clause}
+              AND project_id IS NOT NULL
+            """,
+            thread_params,
+        ),
+        (
+            """
+            SELECT project_id
+            FROM generated_images
+            WHERE user_id = %s
+              AND project_id IS NOT NULL
+            """,
+            (user_id,),
+        ),
+        (
+            f"""
+            SELECT project_id
+            FROM generated_images
+            WHERE {thread_clause}
+              AND project_id IS NOT NULL
+            """,
+            thread_params,
+        ),
+        (
+            """
+            SELECT project_id
+            FROM uploaded_images
+            WHERE user_id = %s
+              AND project_id IS NOT NULL
+            """,
+            (user_id,),
+        ),
+        (
+            f"""
+            SELECT project_id
+            FROM uploaded_images
+            WHERE {thread_clause}
+              AND project_id IS NOT NULL
+            """,
+            thread_params,
+        ),
+        (
+            """
+            SELECT project_id
+            FROM media_assets
+            WHERE user_id = %s
+              AND project_id IS NOT NULL
+            """,
+            (user_id,),
+        ),
+        (
+            f"""
+            SELECT project_id
+            FROM media_assets
+            WHERE {thread_clause}
+              AND project_id IS NOT NULL
+            """,
+            thread_params,
+        ),
+        (
+            """
+            SELECT project_id
+            FROM project_document_links
+            WHERE attached_by = %s
+              AND project_id IS NOT NULL
+            """,
+            (user_id,),
+        ),
+    ]
+
+    asset_ids: set[str] = set()
+    asset_queries: list[tuple[str, tuple[Any, ...]]] = [
+        (
+            """
+            SELECT id
+            FROM media_assets
+            WHERE user_id = %s
+            """,
+            (user_id,),
+        ),
+        (
+            f"""
+            SELECT id
+            FROM media_assets
+            WHERE {thread_clause}
+            """,
+            thread_params,
+        ),
+    ]
+
+    with conn.cursor() as cur:
+        for query, params in project_queries:
+            cur.execute(query, params)
+            for row in cur.fetchall():
+                project_id = row.get("project_id")
+                if project_id is None:
+                    continue
+                try:
+                    project_ids.add(int(project_id))
+                except (TypeError, ValueError):
+                    continue
+
+        for query, params in asset_queries:
+            cur.execute(query, params)
+            for row in cur.fetchall():
+                asset_id = row.get("id")
+                if asset_id is None:
+                    continue
+                asset_ids.add(str(asset_id))
+
+    return _AccountExportScope(
+        thread_ids=thread_ids,
+        project_ids=tuple(sorted(project_ids)),
+        asset_ids=tuple(sorted(asset_ids)),
+    )
+
+
+def fetch_account_export_projects_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    if not user_id:
+        return []
+
+    dsn = _resolve_dsn()
+    conn = psycopg.connect(dsn, row_factory=dict_row)
+    try:
+        with conn.cursor() as cur:
+            scope = _account_export_scope(conn, user_id)
+            if not scope.project_ids:
+                return []
+            cur.execute(
+                """
+                SELECT id, name, description, icon, identity_depth, created_at, updated_at
+                FROM projects
+                WHERE id = ANY(%s::int[])
+                ORDER BY id ASC
+                """,
+                (list(scope.project_ids),),
+            )
+            return [_normalize_export_row(dict(row)) for row in cur.fetchall()]
+    finally:
+        try:
+            conn.close()
+        except Exception as conn_err:
+            logger.debug(
+                "Failed to close account export project connection: %s",
+                conn_err,
+                exc_info=True,
+            )
+
+
+def fetch_account_export_chat_threads_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    if not user_id:
+        return []
+
+    dsn = _resolve_dsn()
+    conn = psycopg.connect(dsn, row_factory=dict_row)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT
+                    id,
+                    user_id,
+                    title,
+                    summary,
+                    project_id,
+                    parent_id,
+                    archived_at,
+                    is_diary,
+                    diary_mode,
+                    exclude_from_identity,
+                    modeling_excluded,
+                    metadata,
+                    active_profile_id,
+                    created_at,
+                    updated_at
+                FROM chat_threads
+                WHERE user_id = %s
+                ORDER BY created_at ASC, id ASC
+                """,
+                (user_id,),
+            )
+            rows = cur.fetchall()
+            return [
+                _normalize_export_row(PgDB._normalize_thread(dict(row)))
+                for row in rows
+            ]
+    finally:
+        try:
+            conn.close()
+        except Exception as conn_err:
+            logger.debug(
+                "Failed to close account export thread connection: %s",
+                conn_err,
+                exc_info=True,
+            )
+
+
+def fetch_account_export_chat_messages_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    if not user_id:
+        return []
+
+    dsn = _resolve_dsn()
+    conn = psycopg.connect(dsn, row_factory=dict_row)
+    try:
+        with conn.cursor() as cur:
+            scope = _account_export_scope(conn, user_id)
+            if not scope.thread_ids:
+                return []
+            cur.execute(
+                """
+                SELECT
+                    id,
+                    thread_id,
+                    role,
+                    content,
+                    event_at,
+                    kind,
+                    extra_meta,
+                    created_at
+                FROM chat_messages
+                WHERE thread_id = ANY(%s::int[])
+                ORDER BY thread_id ASC, COALESCE(event_at, created_at) ASC, id ASC
+                """,
+                (list(scope.thread_ids),),
+            )
+            rows = cur.fetchall()
+            return [
+                _normalize_export_row(_normalize_export_message_row(dict(row)))
+                for row in rows
+            ]
+    finally:
+        try:
+            conn.close()
+        except Exception as conn_err:
+            logger.debug(
+                "Failed to close account export message connection: %s",
+                conn_err,
+                exc_info=True,
+            )
+
+
+def fetch_account_export_uploaded_documents_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    if not user_id:
+        return []
+
+    dsn = _resolve_dsn()
+    conn = psycopg.connect(dsn, row_factory=dict_row)
+    try:
+        with conn.cursor() as cur:
+            scope = _account_export_scope(conn, user_id)
+            thread_clause, thread_params = _account_export_thread_clause(
+                scope.thread_ids
+            )
+            cur.execute(
+                f"""
+                SELECT
+                    id,
+                    asset_id,
+                    project_id,
+                    thread_id,
+                    user_id,
+                    filename,
+                    filesize,
+                    mime_type,
+                    src_url,
+                    source_tag,
+                    parsed_text,
+                    embedding_status,
+                    embedding_error,
+                    embedding_started_at,
+                    embedding_completed_at,
+                    created_at,
+                    updated_at,
+                    deleted_at
+                FROM uploaded_documents
+                WHERE user_id = %s
+                   OR {thread_clause}
+                ORDER BY created_at ASC, id ASC
+                """,
+                (user_id, *thread_params),
+            )
+            rows = cur.fetchall()
+            return [_normalize_export_row(dict(row)) for row in rows]
+    finally:
+        try:
+            conn.close()
+        except Exception as conn_err:
+            logger.debug(
+                "Failed to close uploaded document export connection: %s",
+                conn_err,
+                exc_info=True,
+            )
+
+
+def fetch_account_export_generated_documents_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    if not user_id:
+        return []
+
+    dsn = _resolve_dsn()
+    conn = psycopg.connect(dsn, row_factory=dict_row)
+    try:
+        with conn.cursor() as cur:
+            scope = _account_export_scope(conn, user_id)
+            thread_clause, thread_params = _account_export_thread_clause(
+                scope.thread_ids
+            )
+            cur.execute(
+                f"""
+                SELECT
+                    id,
+                    project_id,
+                    thread_id,
+                    user_id,
+                    title,
+                    content,
+                    format,
+                    model,
+                    created_at,
+                    updated_at,
+                    deleted_at
+                FROM generated_documents
+                WHERE user_id = %s
+                   OR {thread_clause}
+                ORDER BY created_at ASC, id ASC
+                """,
+                (user_id, *thread_params),
+            )
+            rows = cur.fetchall()
+            return [_normalize_export_row(dict(row)) for row in rows]
+    finally:
+        try:
+            conn.close()
+        except Exception as conn_err:
+            logger.debug(
+                "Failed to close generated document export connection: %s",
+                conn_err,
+                exc_info=True,
+            )
+
+
+def fetch_account_export_uploaded_images_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    if not user_id:
+        return []
+
+    dsn = _resolve_dsn()
+    conn = psycopg.connect(dsn, row_factory=dict_row)
+    try:
+        with conn.cursor() as cur:
+            scope = _account_export_scope(conn, user_id)
+            thread_clause, thread_params = _account_export_thread_clause(
+                scope.thread_ids
+            )
+            cur.execute(
+                f"""
+                SELECT
+                    id,
+                    asset_id,
+                    project_id,
+                    thread_id,
+                    user_id,
+                    src_url,
+                    filename,
+                    filesize,
+                    mime_type,
+                    source_tag,
+                    created_at,
+                    updated_at,
+                    deleted_at
+                FROM uploaded_images
+                WHERE user_id = %s
+                   OR {thread_clause}
+                ORDER BY created_at ASC, id ASC
+                """,
+                (user_id, *thread_params),
+            )
+            rows = cur.fetchall()
+            return [_normalize_export_row(dict(row)) for row in rows]
+    finally:
+        try:
+            conn.close()
+        except Exception as conn_err:
+            logger.debug(
+                "Failed to close uploaded image export connection: %s",
+                conn_err,
+                exc_info=True,
+            )
+
+
+def fetch_account_export_generated_images_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    if not user_id:
+        return []
+
+    dsn = _resolve_dsn()
+    conn = psycopg.connect(dsn, row_factory=dict_row)
+    try:
+        with conn.cursor() as cur:
+            scope = _account_export_scope(conn, user_id)
+            thread_clause, thread_params = _account_export_thread_clause(
+                scope.thread_ids
+            )
+            cur.execute(
+                f"""
+                SELECT
+                    id,
+                    asset_id,
+                    project_id,
+                    thread_id,
+                    user_id,
+                    src_url,
+                    prompt,
+                    model,
+                    created_at,
+                    updated_at,
+                    deleted_at
+                FROM generated_images
+                WHERE user_id = %s
+                   OR {thread_clause}
+                ORDER BY created_at ASC, id ASC
+                """,
+                (user_id, *thread_params),
+            )
+            rows = cur.fetchall()
+            return [_normalize_export_row(dict(row)) for row in rows]
+    finally:
+        try:
+            conn.close()
+        except Exception as conn_err:
+            logger.debug(
+                "Failed to close generated image export connection: %s",
+                conn_err,
+                exc_info=True,
+            )
+
+
+def fetch_account_export_media_assets_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    if not user_id:
+        return []
+
+    dsn = _resolve_dsn()
+    conn = psycopg.connect(dsn, row_factory=dict_row)
+    try:
+        with conn.cursor() as cur:
+            scope = _account_export_scope(conn, user_id)
+            thread_clause, thread_params = _account_export_thread_clause(
+                scope.thread_ids
+            )
+            cur.execute(
+                f"""
+                SELECT
+                    id,
+                    project_id,
+                    thread_id,
+                    user_id,
+                    media_kind,
+                    provenance,
+                    source_tag,
+                    content_hash,
+                    deterministic_id,
+                    normalized_slug,
+                    system_name,
+                    storage_prefix,
+                    src_url,
+                    mime_type,
+                    filesize,
+                    ingested_at,
+                    deleted_at
+                FROM media_assets
+                WHERE user_id = %s
+                   OR {thread_clause}
+                ORDER BY ingested_at ASC, id ASC
+                """,
+                (user_id, *thread_params),
+            )
+            rows = cur.fetchall()
+            return [_normalize_export_row(dict(row)) for row in rows]
+    finally:
+        try:
+            conn.close()
+        except Exception as conn_err:
+            logger.debug(
+                "Failed to close media asset export connection: %s",
+                conn_err,
+                exc_info=True,
+            )
+
+
+def fetch_account_export_media_aliases_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    if not user_id:
+        return []
+
+    dsn = _resolve_dsn()
+    conn = psycopg.connect(dsn, row_factory=dict_row)
+    try:
+        with conn.cursor() as cur:
+            scope = _account_export_scope(conn, user_id)
+            if not scope.asset_ids:
+                return []
+            cur.execute(
+                """
+                SELECT
+                    id,
+                    asset_id,
+                    alias,
+                    alias_normalized,
+                    alias_type,
+                    created_at
+                FROM media_aliases
+                WHERE asset_id = ANY(%s::text[])
+                ORDER BY created_at ASC, id ASC
+                """,
+                (list(scope.asset_ids),),
+            )
+            rows = cur.fetchall()
+            return [_normalize_export_row(dict(row)) for row in rows]
+    finally:
+        try:
+            conn.close()
+        except Exception as conn_err:
+            logger.debug(
+                "Failed to close media alias export connection: %s",
+                conn_err,
+                exc_info=True,
+            )
+
+
+def fetch_account_export_thread_documents_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    if not user_id:
+        return []
+
+    dsn = _resolve_dsn()
+    conn = psycopg.connect(dsn, row_factory=dict_row)
+    try:
+        with conn.cursor() as cur:
+            scope = _account_export_scope(conn, user_id)
+            if not scope.thread_ids:
+                return []
+            cur.execute(
+                """
+                SELECT
+                    id,
+                    thread_id,
+                    document_id,
+                    relation,
+                    created_at
+                FROM thread_documents
+                WHERE thread_id = ANY(%s::int[])
+                ORDER BY thread_id ASC, created_at ASC, id ASC
+                """,
+                (list(scope.thread_ids),),
+            )
+            rows = cur.fetchall()
+            return [_normalize_export_row(dict(row)) for row in rows]
+    finally:
+        try:
+            conn.close()
+        except Exception as conn_err:
+            logger.debug(
+                "Failed to close thread document export connection: %s",
+                conn_err,
+                exc_info=True,
+            )
+
+
+def fetch_account_export_project_document_links_for_user(
+    user_id: str,
+) -> list[dict[str, Any]]:
+    if not user_id:
+        return []
+
+    dsn = _resolve_dsn()
+    conn = psycopg.connect(dsn, row_factory=dict_row)
+    try:
+        with conn.cursor() as cur:
+            scope = _account_export_scope(conn, user_id)
+            if not scope.project_ids:
+                return []
+            cur.execute(
+                """
+                SELECT
+                    id,
+                    project_id,
+                    document_id,
+                    document_type,
+                    is_enabled,
+                    attached_at,
+                    attached_by
+                FROM project_document_links
+                WHERE project_id = ANY(%s::int[])
+                ORDER BY project_id ASC, attached_at ASC, id ASC
+                """,
+                (list(scope.project_ids),),
+            )
+            rows = cur.fetchall()
+            return [_normalize_export_row(dict(row)) for row in rows]
+    finally:
+        try:
+            conn.close()
+        except Exception as conn_err:
+            logger.debug(
+                "Failed to close project document export connection: %s",
+                conn_err,
+                exc_info=True,
+            )
 
 
 def fetch_imported_chatgpt_threads_for_user(

--- a/guardian/routes/api_exports.py
+++ b/guardian/routes/api_exports.py
@@ -13,6 +13,10 @@ from fastapi.responses import Response, StreamingResponse
 
 from guardian.core import db
 from guardian.core.auth import AuthenticatedUser, require_user
+from guardian.services.account_export import (
+    ZIP_FILENAME,
+    build_account_export_zip,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -293,6 +297,33 @@ def export_threads(user: AuthenticatedUser = Depends(require_user)):
         raise HTTPException(
             status_code=500, detail="Failed to start export"
         ) from exc
+
+
+@router.get(
+    "/account.zip",
+    summary="Download the authenticated user's canonical account export ZIP",
+)
+def export_account_zip(user: AuthenticatedUser = Depends(require_user)):
+    try:
+        payload = build_account_export_zip(db, user)
+    except Exception as exc:
+        logger.exception(
+            "Failed to build account export zip for user %s: %s",
+            user.id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to build account export",
+        ) from exc
+
+    return Response(
+        content=payload,
+        media_type="application/zip",
+        headers={
+            "Content-Disposition": f'attachment; filename="{ZIP_FILENAME}"'
+        },
+    )
 
 
 @router.get(

--- a/guardian/routes/api_exports.py
+++ b/guardian/routes/api_exports.py
@@ -2,6 +2,7 @@
 import io
 import json
 import logging
+import os
 import re
 import zipfile
 from datetime import datetime, timezone
@@ -9,7 +10,8 @@ from typing import Any, Iterable, Literal, Optional
 
 import orjson
 from fastapi import APIRouter, Depends, HTTPException, Query
-from fastapi.responses import Response, StreamingResponse
+from fastapi.responses import FileResponse, Response, StreamingResponse
+from starlette.background import BackgroundTask
 
 from guardian.core import db
 from guardian.core.auth import AuthenticatedUser, require_user
@@ -68,6 +70,13 @@ def _safe_filename(
     if len(text) > max_length:
         text = text[:max_length].rstrip()
     return text or default
+
+
+def _cleanup_export_file(path: str) -> None:
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        return
 
 
 def _source_thread_short(
@@ -305,7 +314,7 @@ def export_threads(user: AuthenticatedUser = Depends(require_user)):
 )
 def export_account_zip(user: AuthenticatedUser = Depends(require_user)):
     try:
-        payload = build_account_export_zip(db, user)
+        zip_path = build_account_export_zip(db, user)
     except Exception as exc:
         logger.exception(
             "Failed to build account export zip for user %s: %s",
@@ -317,12 +326,11 @@ def export_account_zip(user: AuthenticatedUser = Depends(require_user)):
             detail="Failed to build account export",
         ) from exc
 
-    return Response(
-        content=payload,
+    return FileResponse(
+        zip_path,
         media_type="application/zip",
-        headers={
-            "Content-Disposition": f'attachment; filename="{ZIP_FILENAME}"'
-        },
+        filename=ZIP_FILENAME,
+        background=BackgroundTask(_cleanup_export_file, zip_path),
     )
 
 

--- a/guardian/services/account_export.py
+++ b/guardian/services/account_export.py
@@ -3,18 +3,27 @@ from __future__ import annotations
 import hashlib
 import importlib.metadata
 import json
+import logging
+import mimetypes
 import os
 import tempfile
 import zipfile
+from collections import OrderedDict
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, datetime, timezone
 from decimal import Decimal
-from typing import Any, Iterable
+from pathlib import Path
+from typing import Any, Mapping
 
 from guardian.core.auth import AuthenticatedUser
+from guardian.core.media_signing import extract_media_path
+from guardian.core.storage import FileNotFoundError as StorageFileNotFoundError
+from guardian.core.storage import StorageError, create_storage_from_env
 
-MANIFEST_SCHEMA_VERSION = "1"
+logger = logging.getLogger(__name__)
+
+MANIFEST_SCHEMA_VERSION = "account-export.v1"
 EXPORT_KIND = "full_account"
 ZIP_FILENAME = "Codexify-Export.zip"
 PAYLOAD_ORDER = (
@@ -75,22 +84,70 @@ PAYLOAD_ORDER = (
     ),
 )
 
-OMITTED_BINARY_COVERAGE = (
-    "uploaded_documents.binary_payload",
-    "generated_documents.binary_payload",
-    "uploaded_images.binary_payload",
-    "generated_images.binary_payload",
-    "media_assets.binary_payload",
+PAYLOAD_FAMILIES = tuple(entry[0] for entry in PAYLOAD_ORDER)
+BINARY_FAMILIES = {
+    "uploaded_documents",
+    "generated_documents",
+    "uploaded_images",
+    "generated_images",
+    "media_assets",
+}
+OMITTED_FAMILIES = (
+    "memory_entries",
+    "oauth_connections",
+    "personal_facts",
+    "personal_fact_evidences",
+    "personal_fact_revisions",
+    "tts_outputs",
+    "message_audio_assets",
+    "connector_configs",
+    "connector_runs",
+    "raw_documents",
+    "sync_jobs",
+    "agent_deployments",
+    "agent_runs",
+    "agent_run_steps",
+    "agent_run_attempts",
+    "agent_run_artifacts",
+    "agent_confidence_reports",
+    "events_outbox",
 )
 
 
-@dataclass(frozen=True)
+@dataclass(slots=True)
 class _PayloadArtifact:
     family: str
     path: str
+    body: bytes
     row_count: int
     size_bytes: int
     sha256: str
+
+
+@dataclass(slots=True)
+class _BlobArtifact:
+    canonical_key: str
+    path: str
+    body: bytes
+    size_bytes: int
+    sha256: str
+    family: str
+    mime_type: str | None
+
+
+@dataclass(slots=True)
+class _BlobGroup:
+    canonical_key: str
+    rows: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
+    path: str | None = None
+    body: bytes | None = None
+    sha256: str | None = None
+    size_bytes: int | None = None
+    mime_type: str | None = None
+    source_locator: str | None = None
+    source_family: str | None = None
+    status: str = "unresolved"
+    missing_reason: str | None = None
 
 
 def _json_default(value: Any) -> Any:
@@ -134,16 +191,265 @@ def _reader_rows(
     return [dict(row) for row in rows]
 
 
-def _iter_account_export_payloads(
+def _load_rows_by_family(
     db: Any, user: AuthenticatedUser
-) -> Iterable[tuple[str, str, list[dict[str, Any]]]]:
+) -> dict[str, list[dict[str, Any]]]:
+    bundle_reader = getattr(db, "fetch_account_export_bundle_for_user", None)
+    if callable(bundle_reader):
+        bundle = bundle_reader(user.id)
+        if not isinstance(bundle, Mapping):
+            raise RuntimeError(
+                "fetch_account_export_bundle_for_user must return a mapping"
+            )
+        return {
+            family: [dict(row) for row in bundle.get(family, []) or []]
+            for family in PAYLOAD_FAMILIES
+        }
+
     iterator = getattr(db, "iter_account_export_payloads_for_user", None)
     if callable(iterator):
-        yield from iterator(user.id)
-        return
+        rows_by_family = {family: [] for family in PAYLOAD_FAMILIES}
+        for family, _path, rows in iterator(user.id):
+            rows_by_family[family] = [dict(row) for row in rows or []]
+        return rows_by_family
 
-    for family, path, reader_name in PAYLOAD_ORDER:
-        yield family, path, _reader_rows(db, reader_name, user.id)
+    rows_by_family: dict[str, list[dict[str, Any]]] = {}
+    for family, _path, reader_name in PAYLOAD_ORDER:
+        rows_by_family[family] = _reader_rows(db, reader_name, user.id)
+    return rows_by_family
+
+
+def _family_rows(
+    rows_by_family: dict[str, list[dict[str, Any]]]
+) -> list[tuple[str, dict[str, Any]]]:
+    ordered: list[tuple[str, dict[str, Any]]] = []
+    for family in PAYLOAD_FAMILIES:
+        for row in rows_by_family.get(family, []):
+            ordered.append((family, row))
+    return ordered
+
+
+def _source_locator(family: str, row: dict[str, Any]) -> str:
+    if family == "generated_documents":
+        return f"generated_document:{row.get('id')}"
+
+    src_url = str(row.get("src_url") or "").strip()
+    if src_url:
+        return src_url
+
+    storage_prefix = str(row.get("storage_prefix") or "").strip()
+    system_name = str(row.get("system_name") or "").strip()
+    if storage_prefix and system_name:
+        prefix = storage_prefix.strip("/")
+        return f"/media/{prefix}/{system_name}"
+
+    filename = str(row.get("filename") or "").strip()
+    if filename:
+        return filename
+
+    return f"{family}:{row.get('id')}"
+
+
+def _generated_document_mime_type(row: dict[str, Any]) -> str:
+    fmt = str(row.get("format") or "").strip().lower()
+    mapping = {
+        "txt": "text/plain; charset=utf-8",
+        "md": "text/markdown; charset=utf-8",
+        "markdown": "text/markdown; charset=utf-8",
+        "html": "text/html; charset=utf-8",
+        "htm": "text/html; charset=utf-8",
+        "json": "application/json; charset=utf-8",
+        "xml": "application/xml; charset=utf-8",
+        "csv": "text/csv; charset=utf-8",
+    }
+    return mapping.get(fmt, "text/plain; charset=utf-8")
+
+
+def _generated_document_extension(row: dict[str, Any]) -> str:
+    fmt = str(row.get("format") or "").strip().lower()
+    if fmt in {"md", "markdown"}:
+        return "md"
+    if fmt in {"txt", "text", "plain"}:
+        return "txt"
+    if fmt in {"html", "htm", "json", "xml", "csv"}:
+        return fmt
+    return "txt"
+
+
+def _blob_extension(
+    family: str, row: dict[str, Any], mime_type: str | None
+) -> str:
+    if family == "generated_documents":
+        return _generated_document_extension(row)
+
+    if mime_type:
+        guessed = mimetypes.guess_extension(mime_type.split(";", 1)[0].strip())
+        if guessed:
+            return guessed.lstrip(".")
+
+    filename = str(row.get("filename") or "").strip()
+    if filename:
+        suffix = Path(filename).suffix.lstrip(".")
+        if suffix:
+            return suffix
+
+    locator = _source_locator(family, row)
+    suffix = Path(extract_media_path(locator)).suffix.lstrip(".")
+    if suffix:
+        return suffix
+
+    return "bin"
+
+
+def _blob_root(family: str, row: dict[str, Any]) -> str:
+    if family == "generated_documents":
+        return "blobs/documents/generated"
+    if family == "uploaded_documents":
+        return "blobs/documents/uploaded"
+    if family == "uploaded_images":
+        return "blobs/images/uploaded"
+    if family == "generated_images":
+        return "blobs/images/generated"
+    if family == "media_assets":
+        media_kind = str(row.get("media_kind") or "").strip().lower()
+        provenance = str(row.get("provenance") or "").strip().lower()
+        if media_kind == "document" and provenance == "uploaded":
+            return "blobs/documents/uploaded"
+        if media_kind == "document" and provenance == "generated":
+            return "blobs/documents/generated"
+        if media_kind == "image" and provenance == "uploaded":
+            return "blobs/images/uploaded"
+        if media_kind == "image" and provenance == "generated":
+            return "blobs/images/generated"
+    return "blobs/media"
+
+
+def _canonical_blob_key(family: str, row: dict[str, Any]) -> str:
+    if family == "generated_documents":
+        content = str(row.get("content") or "").encode("utf-8")
+        return f"generated-document:{hashlib.sha256(content).hexdigest()}"
+
+    asset_id = row.get("asset_id")
+    if asset_id:
+        return f"asset:{asset_id}"
+
+    if family == "media_assets":
+        return f"asset:{row.get('id')}"
+
+    locator = _source_locator(family, row)
+    if locator:
+        return f"source:{locator}"
+
+    return f"row:{family}:{row.get('id')}"
+
+
+def _resolve_blob_candidate(
+    family: str, row: dict[str, Any], storage: Any
+) -> tuple[bytes, str | None, str, str] | None:
+    if family == "generated_documents":
+        data = str(row.get("content") or "").encode("utf-8")
+        mime_type = _generated_document_mime_type(row)
+        locator = _source_locator(family, row)
+        extension = _blob_extension(family, row, mime_type)
+        return data, mime_type, locator, extension
+
+    locator = _source_locator(family, row)
+    if not locator:
+        return None
+
+    try:
+        data = storage.download_file(extract_media_path(locator))
+    except (StorageFileNotFoundError, StorageError, FileNotFoundError):
+        return None
+    except Exception:
+        logger.warning(
+            "Failed to resolve blob for %s row %s from %s",
+            family,
+            row.get("id"),
+            locator,
+            exc_info=True,
+        )
+        return None
+
+    mime_type = str(row.get("mime_type") or "").strip() or None
+    extension = _blob_extension(family, row, mime_type)
+    return data, mime_type, locator, extension
+
+
+def _build_blob_groups(
+    rows_by_family: dict[str, list[dict[str, Any]]],
+    storage: Any,
+) -> dict[str, _BlobGroup]:
+    groups: OrderedDict[str, _BlobGroup] = OrderedDict()
+    for family, row in _family_rows(rows_by_family):
+        if family not in BINARY_FAMILIES:
+            continue
+        key = _canonical_blob_key(family, row)
+        group = groups.get(key)
+        if group is None:
+            group = _BlobGroup(canonical_key=key)
+            groups[key] = group
+        group.rows.append((family, row))
+
+    for group in groups.values():
+        for family, row in group.rows:
+            resolved = _resolve_blob_candidate(family, row, storage)
+            if resolved is None:
+                continue
+
+            body, mime_type, locator, extension = resolved
+            digest = hashlib.sha256(body).hexdigest()
+            group.path = f"{_blob_root(family, row)}/{digest}.{extension}"
+            group.body = body
+            group.sha256 = digest
+            group.size_bytes = len(body)
+            group.mime_type = mime_type
+            group.source_locator = locator
+            group.source_family = family
+            group.status = "bundled"
+            break
+
+        if group.status != "bundled":
+            group.missing_reason = (
+                "blob could not be resolved from current storage"
+            )
+
+    return dict(groups)
+
+
+def _decorate_binary_row(
+    family: str, row: dict[str, Any], group: _BlobGroup
+) -> dict[str, Any]:
+    blob_status = "bundled" if group.status == "bundled" else "unresolved"
+    canonical_blob_id = group.canonical_key
+    blob: dict[str, Any] = {
+        "status": blob_status,
+        "canonical_blob_id": canonical_blob_id,
+        "source_family": family,
+        "row_id": row.get("id"),
+        "asset_id": row.get("asset_id")
+        or (row.get("id") if family == "media_assets" else None),
+        "source_locator": _source_locator(family, row),
+        "mime_type": group.mime_type or row.get("mime_type"),
+        "content_hash": group.sha256 or row.get("content_hash"),
+        "size_bytes": (
+            group.size_bytes
+            if group.size_bytes is not None
+            else row.get("filesize")
+        ),
+    }
+
+    if blob_status == "bundled":
+        blob["bundle_path"] = group.path
+        blob["sha256"] = group.sha256
+    else:
+        blob["bundle_path"] = None
+        blob["sha256"] = None
+        blob["missing_reason"] = group.missing_reason
+
+    decorated = dict(row)
+    decorated["export"] = {"blob": blob}
+    return decorated
 
 
 def _build_manifest(
@@ -151,22 +457,63 @@ def _build_manifest(
     user: AuthenticatedUser,
     created_at: str,
     app_version: str,
-    payload_files: Iterable[_PayloadArtifact],
+    payload_files: list[_PayloadArtifact],
+    blob_files: list[_BlobArtifact],
+    rows_by_family: dict[str, list[dict[str, Any]]],
+    decorated_binary_rows: dict[str, list[dict[str, Any]]],
+    unresolved_rows: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    payload_files_list = list(payload_files)
     entity_counts = {
-        payload.family: payload.row_count for payload in payload_files_list
+        artifact.family: artifact.row_count for artifact in payload_files
     }
-    integrity = {
-        "algorithm": "sha256",
-        "payload_files": {
-            payload.path: {
-                "sha256": payload.sha256,
-                "size_bytes": payload.size_bytes,
-            }
-            for payload in payload_files_list
-        },
+    payload_integrity = {
+        artifact.path: {
+            "sha256": artifact.sha256,
+            "size_bytes": artifact.size_bytes,
+        }
+        for artifact in payload_files
     }
+    blob_integrity = {
+        artifact.path: {
+            "sha256": artifact.sha256,
+            "size_bytes": artifact.size_bytes,
+        }
+        for artifact in blob_files
+    }
+    all_integrity = {**payload_integrity, **blob_integrity}
+    bundled_families = sorted(
+        {
+            family
+            for family, rows in decorated_binary_rows.items()
+            if rows
+            and any(
+                row.get("export", {}).get("blob", {}).get("status") == "bundled"
+                for row in rows
+            )
+        }
+    )
+    missing_families = sorted(
+        {
+            family
+            for family, rows in decorated_binary_rows.items()
+            if rows
+            and any(
+                row.get("export", {}).get("blob", {}).get("status")
+                == "unresolved"
+                for row in rows
+            )
+        }
+    )
+    binary_complete_families = sorted(
+        family
+        for family in BINARY_FAMILIES
+        if rows_by_family.get(family)
+        and all(
+            row.get("export", {}).get("blob", {}).get("status") == "bundled"
+            for row in decorated_binary_rows.get(family, [])
+        )
+    )
+
     return {
         "schema_version": MANIFEST_SCHEMA_VERSION,
         "app_version": app_version,
@@ -174,18 +521,33 @@ def _build_manifest(
         "created_at": created_at,
         "user_id": user.id,
         "entity_counts": entity_counts,
-        "integrity": integrity,
+        "integrity": {
+            "algorithm": "sha256",
+            "payload_files": payload_integrity,
+            "blob_files": blob_integrity,
+            "files": all_integrity,
+        },
         "compatibility": {
             "reader": "account_export.v1",
-            "restore_mode": "metadata_only",
-            "binary_payloads_included": False,
+            "restore_mode": "not_implemented",
+            "binary_payloads_included": bool(blob_files),
+            "blob_layout": "canonical-content-hash-v1",
         },
-        "blob_mode": "metadata_only",
-        "included_families": [payload.family for payload in payload_files_list],
-        "omitted_families": list(OMITTED_BINARY_COVERAGE),
+        "blob_mode": "canonical_bundled" if blob_files else "metadata_only",
+        "included_families": list(PAYLOAD_FAMILIES),
+        "binary_complete_families": binary_complete_families,
+        "omitted_families": list(OMITTED_FAMILIES),
+        "blob_coverage": {
+            "bundled_families": bundled_families,
+            "missing_families": missing_families,
+            "bundled_blob_paths": [artifact.path for artifact in blob_files],
+            "unresolved_rows": unresolved_rows,
+        },
         "notes": [
             "manifest.json is the source of truth for this archive.",
-            "This export slice includes metadata rows only; binary document, image, and media payloads are not bundled.",
+            "Restore/import is not implemented in this task.",
+            "Resolvable document, image, and media bytes are bundled as canonical blob files; unresolved rows are retained with export.blob.status='unresolved'.",
+            "Generated documents are exported from stored UTF-8 content because the current schema stores the document body in the database rather than a separate binary file.",
             "Projects are exported by reachability from user-owned rows because project ownership is not stored directly on the projects table.",
         ],
     }
@@ -199,7 +561,17 @@ def build_account_export_zip(
 ) -> str:
     created_at = datetime.now(timezone.utc).isoformat()
     resolved_app_version = app_version or _resolve_app_version()
+    rows_by_family = _load_rows_by_family(db, user)
+    storage = create_storage_from_env()
+    blob_groups = _build_blob_groups(rows_by_family, storage)
+
     payload_files: list[_PayloadArtifact] = []
+    blob_files: list[_BlobArtifact] = []
+    decorated_binary_rows: dict[str, list[dict[str, Any]]] = {
+        family: [] for family in BINARY_FAMILIES
+    }
+    unresolved_rows: list[dict[str, Any]] = []
+
     temp_zip = tempfile.NamedTemporaryFile(
         mode="wb",
         suffix=".zip",
@@ -207,23 +579,75 @@ def build_account_export_zip(
         delete=False,
     )
     temp_path = temp_zip.name
+
     try:
         with temp_zip:
             with zipfile.ZipFile(
                 temp_zip, mode="w", compression=zipfile.ZIP_DEFLATED
             ) as archive:
-                for family, path, rows in _iter_account_export_payloads(
-                    db, user
-                ):
-                    body = _dump_json(rows)
+                for family, path, _reader in PAYLOAD_ORDER:
+                    source_rows = rows_by_family.get(family, [])
+                    payload_rows: list[dict[str, Any]] = []
+                    for row in source_rows:
+                        if family in BINARY_FAMILIES:
+                            group = blob_groups[
+                                _canonical_blob_key(family, row)
+                            ]
+                            decorated = _decorate_binary_row(family, row, group)
+                            payload_rows.append(decorated)
+                            decorated_binary_rows[family].append(decorated)
+                            blob = decorated["export"]["blob"]
+                            if blob["status"] == "unresolved":
+                                unresolved_rows.append(
+                                    {
+                                        "family": family,
+                                        "row_id": row.get("id"),
+                                        "canonical_blob_id": blob[
+                                            "canonical_blob_id"
+                                        ],
+                                        "source_locator": blob[
+                                            "source_locator"
+                                        ],
+                                        "reason": blob["missing_reason"],
+                                    }
+                                )
+                        else:
+                            payload_rows.append(dict(row))
+
+                    body = _dump_json(payload_rows)
                     archive.writestr(path, body)
                     payload_files.append(
                         _PayloadArtifact(
                             family=family,
                             path=path,
-                            row_count=len(rows),
+                            body=body,
+                            row_count=len(payload_rows),
                             size_bytes=len(body),
                             sha256=hashlib.sha256(body).hexdigest(),
+                        )
+                    )
+
+                for group in sorted(
+                    blob_groups.values(),
+                    key=lambda item: (item.path or "", item.canonical_key),
+                ):
+                    if (
+                        group.status != "bundled"
+                        or group.path is None
+                        or group.body is None
+                    ):
+                        continue
+                    archive.writestr(group.path, group.body)
+                    blob_files.append(
+                        _BlobArtifact(
+                            canonical_key=group.canonical_key,
+                            path=group.path,
+                            body=group.body,
+                            size_bytes=group.size_bytes or len(group.body),
+                            sha256=group.sha256
+                            or hashlib.sha256(group.body).hexdigest(),
+                            family=group.source_family or "media",
+                            mime_type=group.mime_type,
                         )
                     )
 
@@ -232,6 +656,10 @@ def build_account_export_zip(
                     created_at=created_at,
                     app_version=resolved_app_version,
                     payload_files=payload_files,
+                    blob_files=blob_files,
+                    rows_by_family=rows_by_family,
+                    decorated_binary_rows=decorated_binary_rows,
+                    unresolved_rows=unresolved_rows,
                 )
                 archive.writestr("manifest.json", _dump_json(manifest))
         return temp_path

--- a/guardian/services/account_export.py
+++ b/guardian/services/account_export.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import hashlib
 import importlib.metadata
-import io
 import json
+import os
+import tempfile
 import zipfile
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from decimal import Decimal
@@ -83,10 +85,11 @@ OMITTED_BINARY_COVERAGE = (
 
 
 @dataclass(frozen=True)
-class _PayloadFile:
+class _PayloadArtifact:
     family: str
     path: str
-    body: bytes
+    row_count: int
+    size_bytes: int
     sha256: str
 
 
@@ -131,22 +134,16 @@ def _reader_rows(
     return [dict(row) for row in rows]
 
 
-def _build_payload_files(
+def _iter_account_export_payloads(
     db: Any, user: AuthenticatedUser
-) -> list[_PayloadFile]:
-    payloads: list[_PayloadFile] = []
+) -> Iterable[tuple[str, str, list[dict[str, Any]]]]:
+    iterator = getattr(db, "iter_account_export_payloads_for_user", None)
+    if callable(iterator):
+        yield from iterator(user.id)
+        return
+
     for family, path, reader_name in PAYLOAD_ORDER:
-        rows = _reader_rows(db, reader_name, user.id)
-        body = _dump_json(rows)
-        payloads.append(
-            _PayloadFile(
-                family=family,
-                path=path,
-                body=body,
-                sha256=hashlib.sha256(body).hexdigest(),
-            )
-        )
-    return payloads
+        yield family, path, _reader_rows(db, reader_name, user.id)
 
 
 def _build_manifest(
@@ -154,19 +151,18 @@ def _build_manifest(
     user: AuthenticatedUser,
     created_at: str,
     app_version: str,
-    payload_files: Iterable[_PayloadFile],
+    payload_files: Iterable[_PayloadArtifact],
 ) -> dict[str, Any]:
     payload_files_list = list(payload_files)
     entity_counts = {
-        payload.family: len(json.loads(payload.body.decode("utf-8")))
-        for payload in payload_files_list
+        payload.family: payload.row_count for payload in payload_files_list
     }
     integrity = {
         "algorithm": "sha256",
         "payload_files": {
             payload.path: {
                 "sha256": payload.sha256,
-                "size_bytes": len(payload.body),
+                "size_bytes": payload.size_bytes,
             }
             for payload in payload_files_list
         },
@@ -200,23 +196,46 @@ def build_account_export_zip(
     user: AuthenticatedUser,
     *,
     app_version: str | None = None,
-) -> bytes:
+) -> str:
     created_at = datetime.now(timezone.utc).isoformat()
     resolved_app_version = app_version or _resolve_app_version()
-    payload_files = _build_payload_files(db, user)
-    manifest = _build_manifest(
-        user=user,
-        created_at=created_at,
-        app_version=resolved_app_version,
-        payload_files=payload_files,
+    payload_files: list[_PayloadArtifact] = []
+    temp_zip = tempfile.NamedTemporaryFile(
+        mode="wb",
+        suffix=".zip",
+        prefix="codexify-account-export-",
+        delete=False,
     )
+    temp_path = temp_zip.name
+    try:
+        with temp_zip:
+            with zipfile.ZipFile(
+                temp_zip, mode="w", compression=zipfile.ZIP_DEFLATED
+            ) as archive:
+                for family, path, rows in _iter_account_export_payloads(
+                    db, user
+                ):
+                    body = _dump_json(rows)
+                    archive.writestr(path, body)
+                    payload_files.append(
+                        _PayloadArtifact(
+                            family=family,
+                            path=path,
+                            row_count=len(rows),
+                            size_bytes=len(body),
+                            sha256=hashlib.sha256(body).hexdigest(),
+                        )
+                    )
 
-    buffer = io.BytesIO()
-    with zipfile.ZipFile(
-        buffer, mode="w", compression=zipfile.ZIP_DEFLATED
-    ) as archive:
-        for payload in payload_files:
-            archive.writestr(payload.path, payload.body)
-        archive.writestr("manifest.json", _dump_json(manifest))
-
-    return buffer.getvalue()
+                manifest = _build_manifest(
+                    user=user,
+                    created_at=created_at,
+                    app_version=resolved_app_version,
+                    payload_files=payload_files,
+                )
+                archive.writestr("manifest.json", _dump_json(manifest))
+        return temp_path
+    except Exception:
+        with suppress(Exception):
+            os.unlink(temp_path)
+        raise

--- a/guardian/services/account_export.py
+++ b/guardian/services/account_export.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import io
+import json
+import zipfile
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from typing import Any, Iterable
+
+from guardian.core.auth import AuthenticatedUser
+
+MANIFEST_SCHEMA_VERSION = "1"
+EXPORT_KIND = "full_account"
+ZIP_FILENAME = "Codexify-Export.zip"
+PAYLOAD_ORDER = (
+    (
+        "projects",
+        "entities/projects.json",
+        "fetch_account_export_projects_for_user",
+    ),
+    (
+        "chat_threads",
+        "entities/chat_threads.json",
+        "fetch_account_export_chat_threads_for_user",
+    ),
+    (
+        "chat_messages",
+        "entities/chat_messages.json",
+        "fetch_account_export_chat_messages_for_user",
+    ),
+    (
+        "uploaded_documents",
+        "entities/uploaded_documents.json",
+        "fetch_account_export_uploaded_documents_for_user",
+    ),
+    (
+        "generated_documents",
+        "entities/generated_documents.json",
+        "fetch_account_export_generated_documents_for_user",
+    ),
+    (
+        "uploaded_images",
+        "entities/uploaded_images.json",
+        "fetch_account_export_uploaded_images_for_user",
+    ),
+    (
+        "generated_images",
+        "entities/generated_images.json",
+        "fetch_account_export_generated_images_for_user",
+    ),
+    (
+        "media_assets",
+        "entities/media_assets.json",
+        "fetch_account_export_media_assets_for_user",
+    ),
+    (
+        "media_aliases",
+        "entities/media_aliases.json",
+        "fetch_account_export_media_aliases_for_user",
+    ),
+    (
+        "thread_documents",
+        "entities/thread_documents.json",
+        "fetch_account_export_thread_documents_for_user",
+    ),
+    (
+        "project_document_links",
+        "entities/project_document_links.json",
+        "fetch_account_export_project_document_links_for_user",
+    ),
+)
+
+OMITTED_BINARY_COVERAGE = (
+    "uploaded_documents.binary_payload",
+    "generated_documents.binary_payload",
+    "uploaded_images.binary_payload",
+    "generated_images.binary_payload",
+    "media_assets.binary_payload",
+)
+
+
+@dataclass(frozen=True)
+class _PayloadFile:
+    family: str
+    path: str
+    body: bytes
+    sha256: str
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, (datetime, date)):
+        if isinstance(value, datetime) and value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc).isoformat()
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return float(value)
+    return str(value)
+
+
+def _dump_json(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=_json_default,
+    ).encode("utf-8")
+
+
+def _resolve_app_version() -> str:
+    try:
+        return importlib.metadata.version("guardian_codex")
+    except Exception:
+        return "0.1.0"
+
+
+def _reader_rows(
+    db: Any, method_name: str, user_id: str
+) -> list[dict[str, Any]]:
+    reader = getattr(db, method_name, None)
+    if not callable(reader):
+        raise RuntimeError(
+            f"Account export reader {method_name} is not available on {type(db).__name__}"
+        )
+    rows = reader(user_id)
+    if rows is None:
+        return []
+    return [dict(row) for row in rows]
+
+
+def _build_payload_files(
+    db: Any, user: AuthenticatedUser
+) -> list[_PayloadFile]:
+    payloads: list[_PayloadFile] = []
+    for family, path, reader_name in PAYLOAD_ORDER:
+        rows = _reader_rows(db, reader_name, user.id)
+        body = _dump_json(rows)
+        payloads.append(
+            _PayloadFile(
+                family=family,
+                path=path,
+                body=body,
+                sha256=hashlib.sha256(body).hexdigest(),
+            )
+        )
+    return payloads
+
+
+def _build_manifest(
+    *,
+    user: AuthenticatedUser,
+    created_at: str,
+    app_version: str,
+    payload_files: Iterable[_PayloadFile],
+) -> dict[str, Any]:
+    payload_files_list = list(payload_files)
+    entity_counts = {
+        payload.family: len(json.loads(payload.body.decode("utf-8")))
+        for payload in payload_files_list
+    }
+    integrity = {
+        "algorithm": "sha256",
+        "payload_files": {
+            payload.path: {
+                "sha256": payload.sha256,
+                "size_bytes": len(payload.body),
+            }
+            for payload in payload_files_list
+        },
+    }
+    return {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "app_version": app_version,
+        "export_kind": EXPORT_KIND,
+        "created_at": created_at,
+        "user_id": user.id,
+        "entity_counts": entity_counts,
+        "integrity": integrity,
+        "compatibility": {
+            "reader": "account_export.v1",
+            "restore_mode": "metadata_only",
+            "binary_payloads_included": False,
+        },
+        "blob_mode": "metadata_only",
+        "included_families": [payload.family for payload in payload_files_list],
+        "omitted_families": list(OMITTED_BINARY_COVERAGE),
+        "notes": [
+            "manifest.json is the source of truth for this archive.",
+            "This export slice includes metadata rows only; binary document, image, and media payloads are not bundled.",
+            "Projects are exported by reachability from user-owned rows because project ownership is not stored directly on the projects table.",
+        ],
+    }
+
+
+def build_account_export_zip(
+    db: Any,
+    user: AuthenticatedUser,
+    *,
+    app_version: str | None = None,
+) -> bytes:
+    created_at = datetime.now(timezone.utc).isoformat()
+    resolved_app_version = app_version or _resolve_app_version()
+    payload_files = _build_payload_files(db, user)
+    manifest = _build_manifest(
+        user=user,
+        created_at=created_at,
+        app_version=resolved_app_version,
+        payload_files=payload_files,
+    )
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(
+        buffer, mode="w", compression=zipfile.ZIP_DEFLATED
+    ) as archive:
+        for payload in payload_files:
+            archive.writestr(payload.path, payload.body)
+        archive.writestr("manifest.json", _dump_json(manifest))
+
+    return buffer.getvalue()

--- a/guardian/tests/core/test_pgdb_account_export.py
+++ b/guardian/tests/core/test_pgdb_account_export.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from guardian.core import pgdb
+
+
+class _FakeCursor:
+    def __init__(self, executed: list[tuple[str, object | None]]) -> None:
+        self.executed = executed
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+    def fetchall(self):
+        return []
+
+
+class _FakeTransaction:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeConnection:
+    def __init__(self, snapshot: dict[str, list[dict[str, object]]]) -> None:
+        self.snapshot = deepcopy(snapshot)
+        self.executed: list[tuple[str, object | None]] = []
+        self.transaction_entered = False
+        self.closed = False
+
+    def cursor(self):
+        return _FakeCursor(self.executed)
+
+    def transaction(self):
+        self.transaction_entered = True
+        return _FakeTransaction()
+
+    def close(self):
+        self.closed = True
+
+
+def test_iter_account_export_payloads_for_user_uses_one_snapshot(
+    monkeypatch,
+):
+    live_rows = {
+        "chat_threads": [
+            {"id": 1, "title": "Thread A"},
+        ],
+        "chat_messages": [
+            {"id": 10, "thread_id": 1, "content": "before"},
+        ],
+    }
+    connections: list[_FakeConnection] = []
+
+    def fake_connect(*args, **kwargs):
+        _ = args, kwargs
+        conn = _FakeConnection(live_rows)
+        connections.append(conn)
+        return conn
+
+    def _reader(key: str):
+        def _read(user_id: str, *, conn=None):
+            assert user_id == "user-123"
+            assert conn is connections[0]
+            return list(conn.snapshot[key])
+
+        return _read
+
+    monkeypatch.setattr(pgdb, "_resolve_dsn", lambda: "postgresql://test")
+    monkeypatch.setattr(pgdb.psycopg, "connect", fake_connect)
+    monkeypatch.setattr(
+        pgdb,
+        "PAYLOAD_ORDER",
+        (
+            (
+                "chat_threads",
+                "entities/chat_threads.json",
+                "fetch_account_export_chat_threads_for_user",
+            ),
+            (
+                "chat_messages",
+                "entities/chat_messages.json",
+                "fetch_account_export_chat_messages_for_user",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        pgdb,
+        "fetch_account_export_chat_threads_for_user",
+        _reader("chat_threads"),
+    )
+    monkeypatch.setattr(
+        pgdb,
+        "fetch_account_export_chat_messages_for_user",
+        _reader("chat_messages"),
+    )
+
+    iterator = pgdb.iter_account_export_payloads_for_user("user-123")
+    first_family, first_path, first_rows = next(iterator)
+
+    assert first_family == "chat_threads"
+    assert first_path == "entities/chat_threads.json"
+    assert first_rows == [{"id": 1, "title": "Thread A"}]
+
+    live_rows["chat_threads"].append({"id": 2, "title": "Thread B"})
+    live_rows["chat_messages"].append(
+        {"id": 11, "thread_id": 2, "content": "after"}
+    )
+
+    remaining = list(iterator)
+
+    assert remaining == [
+        (
+            "chat_messages",
+            "entities/chat_messages.json",
+            [{"id": 10, "thread_id": 1, "content": "before"}],
+        )
+    ]
+
+    assert len(connections) == 1
+    assert connections[0].transaction_entered is True
+    assert connections[0].closed is True
+    assert connections[0].executed[0][0] == (
+        "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY"
+    )

--- a/tests/routes/test_account_export.py
+++ b/tests/routes/test_account_export.py
@@ -6,6 +6,7 @@ import json
 import os
 import zipfile
 from datetime import datetime, timezone
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -13,13 +14,16 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 os.environ.setdefault("CODEXIFY_EMBEDDINGS_BACKEND", "mock")
-os.environ.setdefault("STORAGE_BASE_PATH", "/tmp/test_media")
 os.environ.setdefault("GUARDIAN_API_KEY", "test-key")
 
 from guardian.routes import api_exports
+from guardian.services.account_export import (
+    ZIP_FILENAME,
+    build_account_export_zip,
+)
 
 USER_ID = "user-123"
-EXPECTED_FILES = [
+EXPECTED_PAYLOAD_FILES = [
     "entities/projects.json",
     "entities/chat_threads.json",
     "entities/chat_messages.json",
@@ -36,6 +40,12 @@ EXPECTED_FILES = [
 
 def _utc(value: str) -> datetime:
     return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _write_blob(base_path: Path, relative_path: str, data: bytes) -> None:
+    blob_path = base_path / relative_path
+    blob_path.parent.mkdir(parents=True, exist_ok=True)
+    blob_path.write_bytes(data)
 
 
 def _build_rows() -> dict[str, list[dict[str, object]]]:
@@ -73,7 +83,6 @@ def _build_rows() -> dict[str, list[dict[str, object]]]:
                 "diary_mode": False,
                 "exclude_from_identity": False,
                 "modeling_excluded": False,
-                "metadata": {"source": "manual"},
                 "active_profile_id": "profile-a",
                 "created_at": _utc("2026-03-05T00:00:00Z"),
                 "updated_at": _utc("2026-03-05T01:00:00Z"),
@@ -90,7 +99,6 @@ def _build_rows() -> dict[str, list[dict[str, object]]]:
                 "diary_mode": True,
                 "exclude_from_identity": True,
                 "modeling_excluded": True,
-                "metadata": {"source": "imported"},
                 "active_profile_id": None,
                 "created_at": _utc("2026-03-06T00:00:00Z"),
                 "updated_at": _utc("2026-03-10T00:00:00Z"),
@@ -146,7 +154,7 @@ def _build_rows() -> dict[str, list[dict[str, object]]]:
                 "filename": "brief.pdf",
                 "filesize": 1234,
                 "mime_type": "application/pdf",
-                "src_url": "file:///tmp/brief.pdf",
+                "src_url": "/media/documents/brief.pdf",
                 "source_tag": "uploaded",
                 "parsed_text": "Brief text",
                 "embedding_status": "completed",
@@ -180,7 +188,7 @@ def _build_rows() -> dict[str, list[dict[str, object]]]:
                 "project_id": 10,
                 "thread_id": 101,
                 "user_id": USER_ID,
-                "src_url": "file:///tmp/uploaded.png",
+                "src_url": "/media/images/uploaded.png",
                 "filename": "uploaded.png",
                 "filesize": 2048,
                 "mime_type": "image/png",
@@ -188,7 +196,22 @@ def _build_rows() -> dict[str, list[dict[str, object]]]:
                 "created_at": _utc("2026-03-05T03:00:00Z"),
                 "updated_at": _utc("2026-03-05T03:05:00Z"),
                 "deleted_at": None,
-            }
+            },
+            {
+                "id": "ui-missing",
+                "asset_id": "asset-img-missing",
+                "project_id": 20,
+                "thread_id": 102,
+                "user_id": USER_ID,
+                "src_url": "/media/images/missing.png",
+                "filename": "missing.png",
+                "filesize": 1024,
+                "mime_type": "image/png",
+                "source_tag": "uploaded",
+                "created_at": _utc("2026-03-12T03:00:00Z"),
+                "updated_at": _utc("2026-03-12T03:05:00Z"),
+                "deleted_at": None,
+            },
         ],
         "generated_images": [
             {
@@ -197,7 +220,7 @@ def _build_rows() -> dict[str, list[dict[str, object]]]:
                 "project_id": 20,
                 "thread_id": 102,
                 "user_id": USER_ID,
-                "src_url": "file:///tmp/generated.png",
+                "src_url": "/media/generated_images/generated.png",
                 "prompt": "a schematic of a distributed system",
                 "model": "dall-e-3",
                 "created_at": _utc("2026-03-10T03:00:00Z"),
@@ -218,8 +241,8 @@ def _build_rows() -> dict[str, list[dict[str, object]]]:
                 "deterministic_id": "docdet1",
                 "normalized_slug": "brief",
                 "system_name": "brief.pdf",
-                "storage_prefix": "documents",
-                "src_url": "file:///tmp/brief.pdf",
+                "storage_prefix": "documents/",
+                "src_url": "/media/documents/brief.pdf",
                 "mime_type": "application/pdf",
                 "filesize": 1234,
                 "ingested_at": _utc("2026-03-05T02:00:00Z"),
@@ -237,8 +260,8 @@ def _build_rows() -> dict[str, list[dict[str, object]]]:
                 "deterministic_id": "imgdet1",
                 "normalized_slug": "uploaded",
                 "system_name": "uploaded.png",
-                "storage_prefix": "images",
-                "src_url": "file:///tmp/uploaded.png",
+                "storage_prefix": "images/",
+                "src_url": "/media/images/uploaded.png",
                 "mime_type": "image/png",
                 "filesize": 2048,
                 "ingested_at": _utc("2026-03-05T03:00:00Z"),
@@ -256,8 +279,8 @@ def _build_rows() -> dict[str, list[dict[str, object]]]:
                 "deterministic_id": "imgdet2",
                 "normalized_slug": "generated",
                 "system_name": "generated.png",
-                "storage_prefix": "generated_images",
-                "src_url": "file:///tmp/generated.png",
+                "storage_prefix": "generated_images/",
+                "src_url": "/media/generated_images/generated.png",
                 "mime_type": "image/png",
                 "filesize": 4096,
                 "ingested_at": _utc("2026-03-10T03:00:00Z"),
@@ -322,41 +345,36 @@ def _build_rows() -> dict[str, list[dict[str, object]]]:
 
 
 def _build_fake_db(rows: dict[str, list[dict[str, object]]]):
-    calls: dict[str, str] = {}
+    calls: list[str] = []
 
-    def _record(name: str):
-        def _reader(user_id: str):
-            calls[name] = user_id
-            return list(rows[name])
+    def _fetch(user_id: str):
+        calls.append(user_id)
+        return rows
 
-        return _reader
+    return SimpleNamespace(fetch_account_export_bundle_for_user=_fetch), calls
 
-    db = SimpleNamespace(
-        fetch_account_export_projects_for_user=_record("projects"),
-        fetch_account_export_chat_threads_for_user=_record("chat_threads"),
-        fetch_account_export_chat_messages_for_user=_record("chat_messages"),
-        fetch_account_export_uploaded_documents_for_user=_record(
-            "uploaded_documents"
-        ),
-        fetch_account_export_generated_documents_for_user=_record(
-            "generated_documents"
-        ),
-        fetch_account_export_uploaded_images_for_user=_record(
-            "uploaded_images"
-        ),
-        fetch_account_export_generated_images_for_user=_record(
-            "generated_images"
-        ),
-        fetch_account_export_media_assets_for_user=_record("media_assets"),
-        fetch_account_export_media_aliases_for_user=_record("media_aliases"),
-        fetch_account_export_thread_documents_for_user=_record(
-            "thread_documents"
-        ),
-        fetch_account_export_project_document_links_for_user=_record(
-            "project_document_links"
-        ),
+
+@pytest.fixture
+def storage_base_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    base_path = tmp_path / "storage"
+    monkeypatch.setenv("STORAGE_BASE_PATH", str(base_path))
+    monkeypatch.setenv("STORAGE_URL_PREFIX", "/media")
+    _write_blob(base_path, "documents/brief.pdf", b"brief-pdf-bytes")
+    _write_blob(base_path, "images/uploaded.png", b"uploaded-image-bytes")
+    _write_blob(
+        base_path, "generated_images/generated.png", b"generated-image-bytes"
     )
-    return db, calls
+    return base_path
+
+
+@pytest.fixture
+def rows(storage_base_path: Path) -> dict[str, list[dict[str, object]]]:
+    return _build_rows()
+
+
+@pytest.fixture
+def fake_db(rows):
+    return _build_fake_db(rows)
 
 
 @pytest.fixture
@@ -367,18 +385,18 @@ def app() -> FastAPI:
 
 
 @pytest.fixture
-def rows() -> dict[str, list[dict[str, object]]]:
-    return _build_rows()
-
-
-@pytest.fixture
-def fake_db(rows):
-    return _build_fake_db(rows)
-
-
-@pytest.fixture
 def client(app: FastAPI) -> TestClient:
     return TestClient(app)
+
+
+def _read_archive(payload: bytes) -> zipfile.ZipFile:
+    archive = zipfile.ZipFile(io.BytesIO(payload), "r")
+    assert archive.testzip() is None
+    return archive
+
+
+def _load_json(archive: zipfile.ZipFile, path: str):
+    return json.loads(archive.read(path).decode("utf-8"))
 
 
 def test_account_export_zip_requires_auth(client: TestClient) -> None:
@@ -386,30 +404,35 @@ def test_account_export_zip_requires_auth(client: TestClient) -> None:
     assert response.status_code == 401
 
 
-def test_account_export_zip_writes_archive_to_temp_file(
-    fake_db,
-) -> None:
-    db, _ = fake_db
-    zip_path = api_exports.build_account_export_zip(
+def test_account_export_zip_writes_archive_to_temp_file(fake_db) -> None:
+    db, _calls = fake_db
+    zip_path = build_account_export_zip(
         db,
         SimpleNamespace(id=USER_ID),
     )
 
     try:
         assert os.path.exists(zip_path)
-
         with zipfile.ZipFile(zip_path, "r") as archive:
             assert archive.testzip() is None
-            assert sorted(archive.namelist()) == sorted(
-                ["manifest.json", *EXPECTED_FILES]
-            )
+            names = archive.namelist()
+            assert "manifest.json" in names
+            for path in EXPECTED_PAYLOAD_FILES:
+                assert path in names
+            manifest = json.loads(archive.read("manifest.json").decode("utf-8"))
+            assert manifest["blob_mode"] == "canonical_bundled"
+            assert manifest["compatibility"]["binary_payloads_included"] is True
+            assert manifest["binary_complete_families"]
     finally:
         if os.path.exists(zip_path):
             os.unlink(zip_path)
 
 
 def test_account_export_zip_returns_truthful_manifest(
-    client: TestClient, fake_db, monkeypatch: pytest.MonkeyPatch, rows
+    client: TestClient,
+    fake_db,
+    monkeypatch: pytest.MonkeyPatch,
+    rows,
 ) -> None:
     db, calls = fake_db
     monkeypatch.setattr(api_exports, "db", db, raising=True)
@@ -425,69 +448,123 @@ def test_account_export_zip_returns_truthful_manifest(
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/zip"
     assert response.headers["content-disposition"] == (
-        'attachment; filename="Codexify-Export.zip"'
+        f'attachment; filename="{ZIP_FILENAME}"'
     )
+    assert calls == [USER_ID]
 
-    archive = zipfile.ZipFile(io.BytesIO(response.content), "r")
-    assert archive.testzip() is None
-    assert sorted(archive.namelist()) == sorted(
-        ["manifest.json", *EXPECTED_FILES]
-    )
+    archive = _read_archive(response.content)
+    names = archive.namelist()
+    assert "manifest.json" in names
+    for path in EXPECTED_PAYLOAD_FILES:
+        assert path in names
 
-    manifest = json.loads(archive.read("manifest.json").decode("utf-8"))
-    assert manifest["schema_version"] == "1"
+    manifest = _load_json(archive, "manifest.json")
+    assert manifest["schema_version"] == "account-export.v1"
+    assert manifest["app_version"] == "0.1.0"
     assert manifest["export_kind"] == "full_account"
     assert manifest["user_id"] == USER_ID
-    assert manifest["blob_mode"] == "metadata_only"
-    assert manifest["compatibility"]["binary_payloads_included"] is False
+    assert manifest["blob_mode"] == "canonical_bundled"
+    assert manifest["compatibility"]["restore_mode"] == "not_implemented"
+    assert manifest["compatibility"]["binary_payloads_included"] is True
     assert manifest["integrity"]["algorithm"] == "sha256"
-    assert "binary" in " ".join(manifest["notes"]).lower()
-
-    assert manifest["included_families"] == [
-        "projects",
-        "chat_threads",
-        "chat_messages",
-        "uploaded_documents",
-        "generated_documents",
-        "uploaded_images",
-        "generated_images",
-        "media_assets",
-        "media_aliases",
-        "thread_documents",
-        "project_document_links",
-    ]
+    assert (
+        "restore/import is not implemented"
+        in " ".join(manifest["notes"]).lower()
+    )
 
     expected_counts = {name: len(value) for name, value in rows.items()}
     assert manifest["entity_counts"] == expected_counts
 
-    payload_files = manifest["integrity"]["payload_files"]
-    assert set(payload_files) == set(EXPECTED_FILES)
+    payload_integrity = manifest["integrity"]["payload_files"]
+    blob_integrity = manifest["integrity"]["blob_files"]
+    all_integrity = manifest["integrity"]["files"]
 
-    for path in EXPECTED_FILES:
+    assert set(payload_integrity) == set(EXPECTED_PAYLOAD_FILES)
+    assert set(all_integrity) == set(payload_integrity) | set(blob_integrity)
+
+    for path in EXPECTED_PAYLOAD_FILES:
         payload_bytes = archive.read(path)
         payload = json.loads(payload_bytes.decode("utf-8"))
+        family = path.rsplit("/", 1)[-1].removesuffix(".json")
+        assert len(payload) == expected_counts[family]
         assert (
-            len(payload)
-            == expected_counts[path.rsplit("/", 1)[-1].removesuffix(".json")]
+            payload_integrity[path]["sha256"]
+            == hashlib.sha256(payload_bytes).hexdigest()
         )
+        assert payload_integrity[path]["size_bytes"] == len(payload_bytes)
 
-        digest = hashlib.sha256(payload_bytes).hexdigest()
-        assert payload_files[path]["sha256"] == digest
-        assert payload_files[path]["size_bytes"] == len(payload_bytes)
+    bundled_blob_paths = manifest["blob_coverage"]["bundled_blob_paths"]
+    assert bundled_blob_paths
+    assert len(bundled_blob_paths) == len(set(bundled_blob_paths))
+    assert set(blob_integrity) == set(bundled_blob_paths)
 
-    assert calls == {
-        "projects": USER_ID,
-        "chat_threads": USER_ID,
-        "chat_messages": USER_ID,
-        "uploaded_documents": USER_ID,
-        "generated_documents": USER_ID,
-        "uploaded_images": USER_ID,
-        "generated_images": USER_ID,
-        "media_assets": USER_ID,
-        "media_aliases": USER_ID,
-        "thread_documents": USER_ID,
-        "project_document_links": USER_ID,
-    }
+    for path in bundled_blob_paths:
+        blob_bytes = archive.read(path)
+        assert (
+            blob_integrity[path]["sha256"]
+            == hashlib.sha256(blob_bytes).hexdigest()
+        )
+        assert blob_integrity[path]["size_bytes"] == len(blob_bytes)
 
-    assert "uploaded_documents.binary_payload" in manifest["omitted_families"]
-    assert "generated_images.binary_payload" in manifest["omitted_families"]
+    uploaded_documents = _load_json(archive, "entities/uploaded_documents.json")
+    generated_documents = _load_json(
+        archive, "entities/generated_documents.json"
+    )
+    uploaded_images = _load_json(archive, "entities/uploaded_images.json")
+    generated_images = _load_json(archive, "entities/generated_images.json")
+    media_assets = _load_json(archive, "entities/media_assets.json")
+
+    doc_blob_path = uploaded_documents[0]["export"]["blob"]["bundle_path"]
+    media_doc_blob_path = next(
+        row["export"]["blob"]["bundle_path"]
+        for row in media_assets
+        if row["id"] == "asset-doc-1"
+    )
+    assert doc_blob_path == media_doc_blob_path
+
+    uploaded_image_blob_path = next(
+        row["export"]["blob"]["bundle_path"]
+        for row in uploaded_images
+        if row["id"] == "ui-1"
+    )
+    media_image_blob_path = next(
+        row["export"]["blob"]["bundle_path"]
+        for row in media_assets
+        if row["id"] == "asset-img-1"
+    )
+    assert uploaded_image_blob_path == media_image_blob_path
+
+    generated_image_blob_path = generated_images[0]["export"]["blob"][
+        "bundle_path"
+    ]
+    media_generated_blob_path = next(
+        row["export"]["blob"]["bundle_path"]
+        for row in media_assets
+        if row["id"] == "asset-img-2"
+    )
+    assert generated_image_blob_path == media_generated_blob_path
+
+    unresolved_row = next(
+        row for row in uploaded_images if row["id"] == "ui-missing"
+    )
+    assert unresolved_row["export"]["blob"]["status"] == "unresolved"
+    assert unresolved_row["export"]["blob"]["bundle_path"] is None
+    assert unresolved_row["export"]["blob"]["missing_reason"]
+
+    assert manifest["blob_coverage"]["missing_families"] == ["uploaded_images"]
+    assert "uploaded_images" in manifest["blob_coverage"]["bundled_families"]
+    assert manifest["binary_complete_families"] == [
+        "generated_documents",
+        "generated_images",
+        "media_assets",
+        "uploaded_documents",
+    ]
+    assert manifest["blob_coverage"]["unresolved_rows"] == [
+        {
+            "family": "uploaded_images",
+            "row_id": "ui-missing",
+            "canonical_blob_id": "asset:asset-img-missing",
+            "source_locator": "/media/images/missing.png",
+            "reason": "blob could not be resolved from current storage",
+        }
+    ]

--- a/tests/routes/test_account_export.py
+++ b/tests/routes/test_account_export.py
@@ -386,6 +386,28 @@ def test_account_export_zip_requires_auth(client: TestClient) -> None:
     assert response.status_code == 401
 
 
+def test_account_export_zip_writes_archive_to_temp_file(
+    fake_db,
+) -> None:
+    db, _ = fake_db
+    zip_path = api_exports.build_account_export_zip(
+        db,
+        SimpleNamespace(id=USER_ID),
+    )
+
+    try:
+        assert os.path.exists(zip_path)
+
+        with zipfile.ZipFile(zip_path, "r") as archive:
+            assert archive.testzip() is None
+            assert sorted(archive.namelist()) == sorted(
+                ["manifest.json", *EXPECTED_FILES]
+            )
+    finally:
+        if os.path.exists(zip_path):
+            os.unlink(zip_path)
+
+
 def test_account_export_zip_returns_truthful_manifest(
     client: TestClient, fake_db, monkeypatch: pytest.MonkeyPatch, rows
 ) -> None:

--- a/tests/routes/test_account_export.py
+++ b/tests/routes/test_account_export.py
@@ -1,0 +1,471 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import zipfile
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("CODEXIFY_EMBEDDINGS_BACKEND", "mock")
+os.environ.setdefault("STORAGE_BASE_PATH", "/tmp/test_media")
+os.environ.setdefault("GUARDIAN_API_KEY", "test-key")
+
+from guardian.routes import api_exports
+
+USER_ID = "user-123"
+EXPECTED_FILES = [
+    "entities/projects.json",
+    "entities/chat_threads.json",
+    "entities/chat_messages.json",
+    "entities/uploaded_documents.json",
+    "entities/generated_documents.json",
+    "entities/uploaded_images.json",
+    "entities/generated_images.json",
+    "entities/media_assets.json",
+    "entities/media_aliases.json",
+    "entities/thread_documents.json",
+    "entities/project_document_links.json",
+]
+
+
+def _utc(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _build_rows() -> dict[str, list[dict[str, object]]]:
+    return {
+        "projects": [
+            {
+                "id": 10,
+                "name": "Project Alpha",
+                "description": "Primary workspace",
+                "icon": "A",
+                "identity_depth": "deep",
+                "created_at": _utc("2026-03-01T00:00:00Z"),
+                "updated_at": _utc("2026-03-02T00:00:00Z"),
+            },
+            {
+                "id": 20,
+                "name": "Project Beta",
+                "description": "Secondary workspace",
+                "icon": "B",
+                "identity_depth": "light",
+                "created_at": _utc("2026-03-03T00:00:00Z"),
+                "updated_at": _utc("2026-03-04T00:00:00Z"),
+            },
+        ],
+        "chat_threads": [
+            {
+                "id": 101,
+                "user_id": USER_ID,
+                "title": "Launch planning",
+                "summary": "Thread summary",
+                "project_id": 10,
+                "parent_id": None,
+                "archived_at": None,
+                "is_diary": False,
+                "diary_mode": False,
+                "exclude_from_identity": False,
+                "modeling_excluded": False,
+                "metadata": {"source": "manual"},
+                "active_profile_id": "profile-a",
+                "created_at": _utc("2026-03-05T00:00:00Z"),
+                "updated_at": _utc("2026-03-05T01:00:00Z"),
+            },
+            {
+                "id": 102,
+                "user_id": USER_ID,
+                "title": "Post-launch review",
+                "summary": "Follow-up thread",
+                "project_id": 20,
+                "parent_id": 101,
+                "archived_at": _utc("2026-03-10T00:00:00Z"),
+                "is_diary": True,
+                "diary_mode": True,
+                "exclude_from_identity": True,
+                "modeling_excluded": True,
+                "metadata": {"source": "imported"},
+                "active_profile_id": None,
+                "created_at": _utc("2026-03-06T00:00:00Z"),
+                "updated_at": _utc("2026-03-10T00:00:00Z"),
+            },
+        ],
+        "chat_messages": [
+            {
+                "id": 1,
+                "thread_id": 101,
+                "role": "user",
+                "content": "Hello",
+                "event_at": _utc("2026-03-05T01:00:00Z"),
+                "kind": "chat",
+                "extra_meta": {
+                    "source_thread_id": "source-1",
+                    "source_message_id": "m1",
+                    "turn_index": 0,
+                },
+                "created_at": _utc("2026-03-05T01:00:00Z"),
+            },
+            {
+                "id": 2,
+                "thread_id": 101,
+                "role": "assistant",
+                "content": "Hi",
+                "event_at": _utc("2026-03-05T01:01:00Z"),
+                "kind": "tool",
+                "extra_meta": {
+                    "source_thread_id": "source-1",
+                    "source_message_id": "m2",
+                    "turn_index": 1,
+                },
+                "created_at": _utc("2026-03-05T01:01:00Z"),
+            },
+            {
+                "id": 3,
+                "thread_id": 102,
+                "role": "user",
+                "content": "Follow up",
+                "event_at": _utc("2026-03-10T01:00:00Z"),
+                "kind": "chat",
+                "extra_meta": {"source_thread_id": "source-2"},
+                "created_at": _utc("2026-03-10T01:00:00Z"),
+            },
+        ],
+        "uploaded_documents": [
+            {
+                "id": "ud-1",
+                "asset_id": "asset-doc-1",
+                "project_id": 10,
+                "thread_id": 101,
+                "user_id": USER_ID,
+                "filename": "brief.pdf",
+                "filesize": 1234,
+                "mime_type": "application/pdf",
+                "src_url": "file:///tmp/brief.pdf",
+                "source_tag": "uploaded",
+                "parsed_text": "Brief text",
+                "embedding_status": "completed",
+                "embedding_error": None,
+                "embedding_started_at": _utc("2026-03-05T02:00:00Z"),
+                "embedding_completed_at": _utc("2026-03-05T02:01:00Z"),
+                "created_at": _utc("2026-03-05T02:00:00Z"),
+                "updated_at": _utc("2026-03-05T02:02:00Z"),
+                "deleted_at": None,
+            }
+        ],
+        "generated_documents": [
+            {
+                "id": "gd-1",
+                "project_id": 20,
+                "thread_id": 102,
+                "user_id": USER_ID,
+                "title": "Launch brief",
+                "content": "Drafted content",
+                "format": "md",
+                "model": "gpt-4.1",
+                "created_at": _utc("2026-03-10T02:00:00Z"),
+                "updated_at": _utc("2026-03-10T02:05:00Z"),
+                "deleted_at": _utc("2026-03-12T00:00:00Z"),
+            }
+        ],
+        "uploaded_images": [
+            {
+                "id": "ui-1",
+                "asset_id": "asset-img-1",
+                "project_id": 10,
+                "thread_id": 101,
+                "user_id": USER_ID,
+                "src_url": "file:///tmp/uploaded.png",
+                "filename": "uploaded.png",
+                "filesize": 2048,
+                "mime_type": "image/png",
+                "source_tag": "uploaded",
+                "created_at": _utc("2026-03-05T03:00:00Z"),
+                "updated_at": _utc("2026-03-05T03:05:00Z"),
+                "deleted_at": None,
+            }
+        ],
+        "generated_images": [
+            {
+                "id": "gi-1",
+                "asset_id": "asset-img-2",
+                "project_id": 20,
+                "thread_id": 102,
+                "user_id": USER_ID,
+                "src_url": "file:///tmp/generated.png",
+                "prompt": "a schematic of a distributed system",
+                "model": "dall-e-3",
+                "created_at": _utc("2026-03-10T03:00:00Z"),
+                "updated_at": _utc("2026-03-10T03:05:00Z"),
+                "deleted_at": None,
+            }
+        ],
+        "media_assets": [
+            {
+                "id": "asset-doc-1",
+                "project_id": 10,
+                "thread_id": 101,
+                "user_id": USER_ID,
+                "media_kind": "document",
+                "provenance": "uploaded",
+                "source_tag": "uploaded",
+                "content_hash": "hash-doc-1",
+                "deterministic_id": "docdet1",
+                "normalized_slug": "brief",
+                "system_name": "brief.pdf",
+                "storage_prefix": "documents",
+                "src_url": "file:///tmp/brief.pdf",
+                "mime_type": "application/pdf",
+                "filesize": 1234,
+                "ingested_at": _utc("2026-03-05T02:00:00Z"),
+                "deleted_at": None,
+            },
+            {
+                "id": "asset-img-1",
+                "project_id": 10,
+                "thread_id": 101,
+                "user_id": USER_ID,
+                "media_kind": "image",
+                "provenance": "uploaded",
+                "source_tag": "uploaded",
+                "content_hash": "hash-img-1",
+                "deterministic_id": "imgdet1",
+                "normalized_slug": "uploaded",
+                "system_name": "uploaded.png",
+                "storage_prefix": "images",
+                "src_url": "file:///tmp/uploaded.png",
+                "mime_type": "image/png",
+                "filesize": 2048,
+                "ingested_at": _utc("2026-03-05T03:00:00Z"),
+                "deleted_at": None,
+            },
+            {
+                "id": "asset-img-2",
+                "project_id": 20,
+                "thread_id": 102,
+                "user_id": USER_ID,
+                "media_kind": "image",
+                "provenance": "generated",
+                "source_tag": "generated",
+                "content_hash": "hash-img-2",
+                "deterministic_id": "imgdet2",
+                "normalized_slug": "generated",
+                "system_name": "generated.png",
+                "storage_prefix": "generated_images",
+                "src_url": "file:///tmp/generated.png",
+                "mime_type": "image/png",
+                "filesize": 4096,
+                "ingested_at": _utc("2026-03-10T03:00:00Z"),
+                "deleted_at": None,
+            },
+        ],
+        "media_aliases": [
+            {
+                "id": "alias-1",
+                "asset_id": "asset-doc-1",
+                "alias": "Brief PDF",
+                "alias_normalized": "brief-pdf",
+                "alias_type": "original_name",
+                "created_at": _utc("2026-03-05T02:03:00Z"),
+            },
+            {
+                "id": "alias-2",
+                "asset_id": "asset-img-2",
+                "alias": "Generation prompt",
+                "alias_normalized": "generation-prompt",
+                "alias_type": "prompt",
+                "created_at": _utc("2026-03-10T03:06:00Z"),
+            },
+        ],
+        "thread_documents": [
+            {
+                "id": 1,
+                "thread_id": 101,
+                "document_id": "ud-1",
+                "relation": "attached",
+                "created_at": _utc("2026-03-05T04:00:00Z"),
+            },
+            {
+                "id": 2,
+                "thread_id": 102,
+                "document_id": "gd-1",
+                "relation": "autosave",
+                "created_at": _utc("2026-03-10T04:00:00Z"),
+            },
+        ],
+        "project_document_links": [
+            {
+                "id": 1,
+                "project_id": 10,
+                "document_id": "ud-1",
+                "document_type": "uploaded",
+                "is_enabled": True,
+                "attached_at": _utc("2026-03-05T05:00:00Z"),
+                "attached_by": USER_ID,
+            },
+            {
+                "id": 2,
+                "project_id": 20,
+                "document_id": "gd-1",
+                "document_type": "generated",
+                "is_enabled": False,
+                "attached_at": _utc("2026-03-10T05:00:00Z"),
+                "attached_by": USER_ID,
+            },
+        ],
+    }
+
+
+def _build_fake_db(rows: dict[str, list[dict[str, object]]]):
+    calls: dict[str, str] = {}
+
+    def _record(name: str):
+        def _reader(user_id: str):
+            calls[name] = user_id
+            return list(rows[name])
+
+        return _reader
+
+    db = SimpleNamespace(
+        fetch_account_export_projects_for_user=_record("projects"),
+        fetch_account_export_chat_threads_for_user=_record("chat_threads"),
+        fetch_account_export_chat_messages_for_user=_record("chat_messages"),
+        fetch_account_export_uploaded_documents_for_user=_record(
+            "uploaded_documents"
+        ),
+        fetch_account_export_generated_documents_for_user=_record(
+            "generated_documents"
+        ),
+        fetch_account_export_uploaded_images_for_user=_record(
+            "uploaded_images"
+        ),
+        fetch_account_export_generated_images_for_user=_record(
+            "generated_images"
+        ),
+        fetch_account_export_media_assets_for_user=_record("media_assets"),
+        fetch_account_export_media_aliases_for_user=_record("media_aliases"),
+        fetch_account_export_thread_documents_for_user=_record(
+            "thread_documents"
+        ),
+        fetch_account_export_project_document_links_for_user=_record(
+            "project_document_links"
+        ),
+    )
+    return db, calls
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    application = FastAPI()
+    application.include_router(api_exports.router)
+    return application
+
+
+@pytest.fixture
+def rows() -> dict[str, list[dict[str, object]]]:
+    return _build_rows()
+
+
+@pytest.fixture
+def fake_db(rows):
+    return _build_fake_db(rows)
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+def test_account_export_zip_requires_auth(client: TestClient) -> None:
+    response = client.get("/exports/account.zip", headers={"X-API-Key": ""})
+    assert response.status_code == 401
+
+
+def test_account_export_zip_returns_truthful_manifest(
+    client: TestClient, fake_db, monkeypatch: pytest.MonkeyPatch, rows
+) -> None:
+    db, calls = fake_db
+    monkeypatch.setattr(api_exports, "db", db, raising=True)
+
+    response = client.get(
+        "/exports/account.zip",
+        headers={
+            "X-API-Key": os.environ["GUARDIAN_API_KEY"],
+            "X-Guardian-Identity": USER_ID,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/zip"
+    assert response.headers["content-disposition"] == (
+        'attachment; filename="Codexify-Export.zip"'
+    )
+
+    archive = zipfile.ZipFile(io.BytesIO(response.content), "r")
+    assert archive.testzip() is None
+    assert sorted(archive.namelist()) == sorted(
+        ["manifest.json", *EXPECTED_FILES]
+    )
+
+    manifest = json.loads(archive.read("manifest.json").decode("utf-8"))
+    assert manifest["schema_version"] == "1"
+    assert manifest["export_kind"] == "full_account"
+    assert manifest["user_id"] == USER_ID
+    assert manifest["blob_mode"] == "metadata_only"
+    assert manifest["compatibility"]["binary_payloads_included"] is False
+    assert manifest["integrity"]["algorithm"] == "sha256"
+    assert "binary" in " ".join(manifest["notes"]).lower()
+
+    assert manifest["included_families"] == [
+        "projects",
+        "chat_threads",
+        "chat_messages",
+        "uploaded_documents",
+        "generated_documents",
+        "uploaded_images",
+        "generated_images",
+        "media_assets",
+        "media_aliases",
+        "thread_documents",
+        "project_document_links",
+    ]
+
+    expected_counts = {name: len(value) for name, value in rows.items()}
+    assert manifest["entity_counts"] == expected_counts
+
+    payload_files = manifest["integrity"]["payload_files"]
+    assert set(payload_files) == set(EXPECTED_FILES)
+
+    for path in EXPECTED_FILES:
+        payload_bytes = archive.read(path)
+        payload = json.loads(payload_bytes.decode("utf-8"))
+        assert (
+            len(payload)
+            == expected_counts[path.rsplit("/", 1)[-1].removesuffix(".json")]
+        )
+
+        digest = hashlib.sha256(payload_bytes).hexdigest()
+        assert payload_files[path]["sha256"] == digest
+        assert payload_files[path]["size_bytes"] == len(payload_bytes)
+
+    assert calls == {
+        "projects": USER_ID,
+        "chat_threads": USER_ID,
+        "chat_messages": USER_ID,
+        "uploaded_documents": USER_ID,
+        "generated_documents": USER_ID,
+        "uploaded_images": USER_ID,
+        "generated_images": USER_ID,
+        "media_assets": USER_ID,
+        "media_aliases": USER_ID,
+        "thread_documents": USER_ID,
+        "project_document_links": USER_ID,
+    }
+
+    assert "uploaded_documents.binary_payload" in manifest["omitted_families"]
+    assert "generated_images.binary_payload" in manifest["omitted_families"]


### PR DESCRIPTION
## Summary
- Add a canonical `/exports/account.zip` endpoint for downloading the authenticated user’s account export
- Build the archive from account export readers, with a manifest that includes counts, hashes, versioning, and compatibility metadata
- Extend PostgreSQL export helpers to support the account export bundle and add route coverage for the ZIP and manifest contents

## Testing
- Not run (not requested)