### PR TITLE
Fix runtime status contract discovery and harden fallback resolution

### DIFF
--- a/frontend/src/contracts/__tests__/runtimeTokens.test.ts
+++ b/frontend/src/contracts/__tests__/runtimeTokens.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  RUNTIME_STATUS_PRESENTATIONS,
+  describeRuntimeStatusPresentation,
+} from "@/contracts/runtimeTokens";
+
+const EXPECTED_RUNTIME_STATUS_PRESENTATIONS = {
+  healthy: { label: "healthy", tone: "active", isFallback: false },
+  degraded: { label: "degraded", tone: "attention", isFallback: false },
+  unknown: { label: "unknown", tone: "subtle", isFallback: false },
+  active: { label: "active", tone: "active", isFallback: false },
+  stale: { label: "stale", tone: "attention", isFallback: false },
+  offline: { label: "offline", tone: "danger", isFallback: false },
+  online: { label: "online", tone: "active", isFallback: false },
+  running: { label: "running", tone: "info", isFallback: false },
+  queued: { label: "queued", tone: "neutral", isFallback: false },
+  open: { label: "open", tone: "active", isFallback: false },
+  connecting: { label: "connecting", tone: "info", isFallback: false },
+  closed: { label: "closed", tone: "subtle", isFallback: false },
+  error: { label: "error", tone: "danger", isFallback: false },
+  OK: { label: "OK", tone: "active", isFallback: false },
+  FAIL: { label: "FAIL", tone: "danger", isFallback: false },
+  UNKNOWN: { label: "UNKNOWN", tone: "subtle", isFallback: false },
+  attention: { label: "attention", tone: "attention", isFallback: false },
+  needs_attention: { label: "needs attention", tone: "attention", isFallback: false },
+  succeeded: { label: "succeeded", tone: "active", isFallback: false },
+  failed: { label: "failed", tone: "danger", isFallback: false },
+  unauthorized: { label: "unauthorized", tone: "attention", isFallback: false },
+} as const;
+
+const FALLBACK_PRESENTATION = {
+  label: "unknown",
+  tone: "subtle",
+  isFallback: true,
+} as const;
+
+describe("runtimeTokens contract", () => {
+  it("keeps the runtime status registry bounded and explicit", () => {
+    expect(RUNTIME_STATUS_PRESENTATIONS).toEqual(
+      EXPECTED_RUNTIME_STATUS_PRESENTATIONS
+    );
+  });
+
+  it("resolves canonical runtime statuses through the presentation helper", () => {
+    for (const [status, presentation] of Object.entries(
+      EXPECTED_RUNTIME_STATUS_PRESENTATIONS
+    )) {
+      expect(describeRuntimeStatusPresentation(status)).toEqual(presentation);
+    }
+  });
+
+  it("keeps case handling explicit and trim-only", () => {
+    expect(describeRuntimeStatusPresentation(" degraded ")).toEqual(
+      EXPECTED_RUNTIME_STATUS_PRESENTATIONS.degraded
+    );
+    expect(describeRuntimeStatusPresentation("Degraded")).toEqual({
+      label: "Degraded",
+      tone: "subtle",
+      isFallback: true,
+    });
+  });
+
+  it("returns visible fallback presentations for unmapped and empty inputs", () => {
+    for (const input of [null, undefined, "", "   "]) {
+      expect(describeRuntimeStatusPresentation(input)).toEqual(
+        FALLBACK_PRESENTATION
+      );
+    }
+
+    const fallback = describeRuntimeStatusPresentation("mystery_signal");
+    expect(fallback).toEqual({
+      label: "mystery signal",
+      tone: "subtle",
+      isFallback: true,
+    });
+    expect(fallback.tone).not.toBe(EXPECTED_RUNTIME_STATUS_PRESENTATIONS.healthy.tone);
+  });
+
+  it("does not treat prototype-chain names as registered statuses", () => {
+    expect(describeRuntimeStatusPresentation("constructor")).toEqual({
+      label: "constructor",
+      tone: "subtle",
+      isFallback: true,
+    });
+  });
+});

--- a/frontend/src/contracts/runtimeTokens.ts
+++ b/frontend/src/contracts/runtimeTokens.ts
@@ -75,6 +75,8 @@ export interface RuntimeStatusPresentation {
   isFallback: boolean;
 }
 
+// Keep this registry explicit and bounded. Only operator-facing status tokens
+// that we intentionally recognize should resolve here.
 export const RUNTIME_STATUS_PRESENTATIONS = {
   healthy: { label: "healthy", tone: "active", isFallback: false },
   degraded: { label: "degraded", tone: "attention", isFallback: false },
@@ -99,8 +101,20 @@ export const RUNTIME_STATUS_PRESENTATIONS = {
   unauthorized: { label: "unauthorized", tone: "attention", isFallback: false },
 } as const satisfies Record<string, RuntimeStatusPresentation>;
 
+const RUNTIME_STATUS_FALLBACK_PRESENTATION: RuntimeStatusPresentation = {
+  label: "unknown",
+  tone: "subtle",
+  isFallback: true,
+};
+
 function humanizeRuntimeStatus(value: string): string {
   return value.replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function isRuntimeStatusPresentationKey(
+  status: string
+): status is keyof typeof RUNTIME_STATUS_PRESENTATIONS {
+  return Object.prototype.hasOwnProperty.call(RUNTIME_STATUS_PRESENTATIONS, status);
 }
 
 export function describeRuntimeStatusPresentation(
@@ -108,23 +122,16 @@ export function describeRuntimeStatusPresentation(
 ): RuntimeStatusPresentation {
   const normalized = typeof status === "string" ? status.trim() : "";
   if (!normalized) {
-    return {
-      label: "unknown",
-      tone: "subtle",
-      isFallback: true,
-    };
+    return RUNTIME_STATUS_FALLBACK_PRESENTATION;
   }
 
-  const presentation =
-    RUNTIME_STATUS_PRESENTATIONS[
-      normalized as keyof typeof RUNTIME_STATUS_PRESENTATIONS
-    ];
-  if (presentation) return presentation;
+  if (isRuntimeStatusPresentationKey(normalized)) {
+    return RUNTIME_STATUS_PRESENTATIONS[normalized];
+  }
 
   return {
+    ...RUNTIME_STATUS_FALLBACK_PRESENTATION,
     label: humanizeRuntimeStatus(normalized),
-    tone: "subtle",
-    isFallback: true,
   };
 }
 

--- a/frontend/src/vitest.config.ts
+++ b/frontend/src/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     include: [
       "components/**/*.test.{ts,tsx}",
       "features/**/*.test.{ts,tsx}",
+      "contracts/**/*.test.{ts,tsx}",
       "lib/**/*.test.{ts,tsx}",
       "persona/**/*.test.{ts,tsx}",
       "test/**/*.test.{ts,tsx}"


### PR DESCRIPTION
## Summary
- Add a direct contract test suite for `runtimeTokens` covering canonical presentations, fallback handling, case behavior, and registry bounds.
- Harden `describeRuntimeStatusPresentation(...)` with an explicit fallback object and own-property lookup so unknown tokens cannot resolve through the prototype chain.
- Include `contracts/**/*.test.{ts,tsx}` in default Vitest discovery so the contract seam runs in normal frontend test coverage.

## Testing
- `pnpm --dir frontend/src exec vitest run contracts/__tests__/runtimeTokens.test.ts features/commandCenter/__tests__/CommandCenterPage.test.tsx`