### PR TITLE
feat: add metadata account restore route

### DIFF
--- a/guardian/core/pgdb.py
+++ b/guardian/core/pgdb.py
@@ -2087,6 +2087,563 @@ class PgDB(ChatDB):
         remaining = max(int(freq - delta_minutes), 0)
         return False, f"Next summarization available in {remaining} min"
 
+    # ---- account restore helpers --------------------------------------
+    def _restore_account_export_rows(
+        self,
+        *,
+        table_name: str,
+        pk_column: str,
+        columns: tuple[str, ...],
+        rows: list[dict[str, Any]],
+        conn: psycopg.Connection | None = None,
+        json_columns: tuple[str, ...] = (),
+        unique_key_columns: tuple[tuple[str, ...], ...] = (),
+        sequence_column: str | None = None,
+    ) -> dict[str, int]:
+        if conn is None:
+            with self._connect() as restore_conn:
+                return self._restore_account_export_rows(
+                    table_name=table_name,
+                    pk_column=pk_column,
+                    columns=columns,
+                    rows=rows,
+                    conn=restore_conn,
+                    json_columns=json_columns,
+                    unique_key_columns=unique_key_columns,
+                    sequence_column=sequence_column,
+                )
+
+        imported = 0
+        skipped = 0
+        failed = 0
+        unresolved = 0
+        columns = tuple(columns)
+        json_column_set = set(json_columns)
+
+        with conn.cursor() as cur:
+            for index, raw_row in enumerate(rows):
+                row = dict(raw_row or {})
+                normalized_row = self._restore_account_export_normalize_row(
+                    table_name=table_name,
+                    row=row,
+                    columns=columns,
+                )
+                pk_value = normalized_row.get(pk_column)
+                if pk_value is None:
+                    raise ValueError(
+                        f"{table_name} row {index} is missing primary key column {pk_column}"
+                    )
+
+                existing = self._restore_account_export_fetch_row(
+                    cur,
+                    table_name=table_name,
+                    columns=columns,
+                    pk_column=pk_column,
+                    pk_value=pk_value,
+                )
+                if existing is not None:
+                    if existing == normalized_row:
+                        skipped += 1
+                        continue
+                    raise ValueError(
+                        f"{table_name} row {pk_value!r} conflicts with an existing row"
+                    )
+
+                for unique_columns in unique_key_columns:
+                    conflict = (
+                        self._restore_account_export_fetch_unique_conflict(
+                            cur,
+                            table_name=table_name,
+                            columns=columns,
+                            pk_column=pk_column,
+                            pk_value=pk_value,
+                            unique_columns=unique_columns,
+                            row=normalized_row,
+                        )
+                    )
+                    if conflict is not None:
+                        raise ValueError(
+                            f"{table_name} row {pk_value!r} conflicts with an existing row on {unique_columns}"
+                        )
+
+                try:
+                    inserted = self._restore_account_export_insert_row(
+                        cur,
+                        table_name=table_name,
+                        pk_column=pk_column,
+                        columns=columns,
+                        row=normalized_row,
+                        json_column_set=json_column_set,
+                    )
+                except pg_errors.UniqueViolation as exc:
+                    raise ValueError(
+                        f"{table_name} row {pk_value!r} conflicts with an existing row"
+                    ) from exc
+
+                if inserted:
+                    imported += 1
+                    continue
+
+                existing = self._restore_account_export_fetch_row(
+                    cur,
+                    table_name=table_name,
+                    columns=columns,
+                    pk_column=pk_column,
+                    pk_value=pk_value,
+                )
+                if existing is not None and existing == normalized_row:
+                    skipped += 1
+                    continue
+
+                raise ValueError(
+                    f"{table_name} row {pk_value!r} could not be restored idempotently"
+                )
+
+            if sequence_column is not None:
+                self._restore_account_export_sync_sequence(
+                    cur,
+                    table_name=table_name,
+                    sequence_column=sequence_column,
+                )
+
+        return {
+            "imported": imported,
+            "skipped": skipped,
+            "failed": failed,
+            "unresolved": unresolved,
+        }
+
+    @staticmethod
+    def _restore_account_export_normalize_row(
+        *,
+        table_name: str,
+        row: dict[str, Any],
+        columns: tuple[str, ...],
+    ) -> dict[str, Any]:
+        missing = [column for column in columns if column not in row]
+        if missing:
+            raise ValueError(
+                f"{table_name} row is missing required columns: {missing}"
+            )
+        normalized: dict[str, Any] = {}
+        for column in columns:
+            normalized[column] = _normalize_export_value(row.get(column))
+        return normalized
+
+    def _restore_account_export_fetch_row(
+        self,
+        cur,
+        *,
+        table_name: str,
+        columns: tuple[str, ...],
+        pk_column: str,
+        pk_value: Any,
+    ) -> dict[str, Any] | None:
+        column_sql = ", ".join(columns)
+        cur.execute(
+            f"""
+            SELECT {column_sql}
+            FROM {table_name}
+            WHERE {pk_column} = %s
+            """,
+            (pk_value,),
+        )
+        row = cur.fetchone()
+        if not row:
+            return None
+        return {
+            column: _normalize_export_value(row.get(column))
+            for column in columns
+        }
+
+    def _restore_account_export_fetch_unique_conflict(
+        self,
+        cur,
+        *,
+        table_name: str,
+        columns: tuple[str, ...],
+        pk_column: str,
+        pk_value: Any,
+        unique_columns: tuple[str, ...],
+        row: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        if not unique_columns:
+            return None
+        where_clause = " AND ".join(
+            f"{column} = %s" for column in unique_columns
+        )
+        params = [row.get(column) for column in unique_columns]
+        params.append(pk_value)
+        cur.execute(
+            f"""
+            SELECT {", ".join(columns)}
+            FROM {table_name}
+            WHERE {where_clause}
+              AND {pk_column} <> %s
+            LIMIT 1
+            """,
+            params,
+        )
+        found = cur.fetchone()
+        if not found:
+            return None
+        return {
+            column: _normalize_export_value(found.get(column))
+            for column in columns
+        }
+
+    def _restore_account_export_insert_row(
+        self,
+        cur,
+        *,
+        table_name: str,
+        pk_column: str,
+        columns: tuple[str, ...],
+        row: dict[str, Any],
+        json_column_set: set[str],
+    ) -> bool:
+        placeholders = ", ".join(["%s"] * len(columns))
+        column_sql = ", ".join(columns)
+        params: list[Any] = []
+        for column in columns:
+            value = row.get(column)
+            if column in json_column_set:
+                params.append(_to_json(value))
+            else:
+                params.append(value)
+        cur.execute(
+            f"""
+            INSERT INTO {table_name} ({column_sql})
+            VALUES ({placeholders})
+            ON CONFLICT ({pk_column}) DO NOTHING
+            RETURNING {pk_column}
+            """,
+            params,
+        )
+        return cur.fetchone() is not None
+
+    def _restore_account_export_sync_sequence(
+        self,
+        cur,
+        *,
+        table_name: str,
+        sequence_column: str,
+    ) -> None:
+        cur.execute(
+            "SELECT pg_get_serial_sequence(%s, %s) AS sequence_name",
+            (f"public.{table_name}", sequence_column),
+        )
+        row = cur.fetchone() or {}
+        sequence_name = row.get("sequence_name")
+        if not sequence_name:
+            return
+
+        cur.execute(
+            f"SELECT COALESCE(MAX({sequence_column}), 0) AS max_id FROM {table_name}"
+        )
+        max_row = cur.fetchone() or {}
+        max_value = int(max_row.get("max_id") or 0)
+        if max_value > 0:
+            cur.execute(
+                "SELECT setval(%s, %s, true)", (sequence_name, max_value)
+            )
+        else:
+            cur.execute("SELECT setval(%s, %s, false)", (sequence_name, 1))
+
+    def restore_account_export_projects(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        conn: psycopg.Connection | None = None,
+    ) -> dict[str, int]:
+        return self._restore_account_export_rows(
+            table_name="projects",
+            pk_column="id",
+            columns=(
+                "id",
+                "name",
+                "description",
+                "icon",
+                "identity_depth",
+                "created_at",
+                "updated_at",
+            ),
+            rows=rows,
+            conn=conn,
+            unique_key_columns=(("name",),),
+            sequence_column="id",
+        )
+
+    def restore_account_export_chat_threads(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        conn: psycopg.Connection | None = None,
+    ) -> dict[str, int]:
+        return self._restore_account_export_rows(
+            table_name="chat_threads",
+            pk_column="id",
+            columns=(
+                "id",
+                "user_id",
+                "title",
+                "summary",
+                "project_id",
+                "parent_id",
+                "archived_at",
+                "is_diary",
+                "diary_mode",
+                "exclude_from_identity",
+                "modeling_excluded",
+                "metadata",
+                "active_profile_id",
+                "created_at",
+                "updated_at",
+            ),
+            rows=rows,
+            conn=conn,
+            json_columns=("metadata",),
+            sequence_column="id",
+        )
+
+    def restore_account_export_chat_messages(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        conn: psycopg.Connection | None = None,
+    ) -> dict[str, int]:
+        return self._restore_account_export_rows(
+            table_name="chat_messages",
+            pk_column="id",
+            columns=(
+                "id",
+                "thread_id",
+                "role",
+                "content",
+                "event_at",
+                "kind",
+                "extra_meta",
+                "created_at",
+            ),
+            rows=rows,
+            conn=conn,
+            json_columns=("extra_meta",),
+            sequence_column="id",
+        )
+
+    def restore_account_export_media_assets(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        conn: psycopg.Connection | None = None,
+    ) -> dict[str, int]:
+        return self._restore_account_export_rows(
+            table_name="media_assets",
+            pk_column="id",
+            columns=(
+                "id",
+                "project_id",
+                "thread_id",
+                "user_id",
+                "media_kind",
+                "provenance",
+                "source_tag",
+                "content_hash",
+                "deterministic_id",
+                "normalized_slug",
+                "system_name",
+                "storage_prefix",
+                "src_url",
+                "mime_type",
+                "filesize",
+                "ingested_at",
+                "deleted_at",
+            ),
+            rows=rows,
+            conn=conn,
+        )
+
+    def restore_account_export_media_aliases(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        conn: psycopg.Connection | None = None,
+    ) -> dict[str, int]:
+        return self._restore_account_export_rows(
+            table_name="media_aliases",
+            pk_column="id",
+            columns=(
+                "id",
+                "asset_id",
+                "alias",
+                "alias_normalized",
+                "alias_type",
+                "created_at",
+            ),
+            rows=rows,
+            conn=conn,
+        )
+
+    def restore_account_export_uploaded_documents(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        conn: psycopg.Connection | None = None,
+    ) -> dict[str, int]:
+        return self._restore_account_export_rows(
+            table_name="uploaded_documents",
+            pk_column="id",
+            columns=(
+                "id",
+                "asset_id",
+                "project_id",
+                "thread_id",
+                "user_id",
+                "filename",
+                "filesize",
+                "mime_type",
+                "src_url",
+                "source_tag",
+                "parsed_text",
+                "embedding_status",
+                "embedding_error",
+                "embedding_started_at",
+                "embedding_completed_at",
+                "created_at",
+                "updated_at",
+                "deleted_at",
+            ),
+            rows=rows,
+            conn=conn,
+        )
+
+    def restore_account_export_generated_documents(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        conn: psycopg.Connection | None = None,
+    ) -> dict[str, int]:
+        return self._restore_account_export_rows(
+            table_name="generated_documents",
+            pk_column="id",
+            columns=(
+                "id",
+                "project_id",
+                "thread_id",
+                "user_id",
+                "title",
+                "content",
+                "format",
+                "model",
+                "created_at",
+                "updated_at",
+                "deleted_at",
+            ),
+            rows=rows,
+            conn=conn,
+        )
+
+    def restore_account_export_uploaded_images(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        conn: psycopg.Connection | None = None,
+    ) -> dict[str, int]:
+        return self._restore_account_export_rows(
+            table_name="uploaded_images",
+            pk_column="id",
+            columns=(
+                "id",
+                "asset_id",
+                "project_id",
+                "thread_id",
+                "user_id",
+                "src_url",
+                "filename",
+                "filesize",
+                "mime_type",
+                "source_tag",
+                "created_at",
+                "updated_at",
+                "deleted_at",
+            ),
+            rows=rows,
+            conn=conn,
+        )
+
+    def restore_account_export_generated_images(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        conn: psycopg.Connection | None = None,
+    ) -> dict[str, int]:
+        return self._restore_account_export_rows(
+            table_name="generated_images",
+            pk_column="id",
+            columns=(
+                "id",
+                "asset_id",
+                "project_id",
+                "thread_id",
+                "user_id",
+                "src_url",
+                "prompt",
+                "model",
+                "created_at",
+                "updated_at",
+                "deleted_at",
+            ),
+            rows=rows,
+            conn=conn,
+        )
+
+    def restore_account_export_thread_documents(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        conn: psycopg.Connection | None = None,
+    ) -> dict[str, int]:
+        return self._restore_account_export_rows(
+            table_name="thread_documents",
+            pk_column="id",
+            columns=(
+                "id",
+                "thread_id",
+                "document_id",
+                "relation",
+                "created_at",
+            ),
+            rows=rows,
+            conn=conn,
+            sequence_column="id",
+        )
+
+    def restore_account_export_project_document_links(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        conn: psycopg.Connection | None = None,
+    ) -> dict[str, int]:
+        return self._restore_account_export_rows(
+            table_name="project_document_links",
+            pk_column="id",
+            columns=(
+                "id",
+                "project_id",
+                "document_id",
+                "document_type",
+                "is_enabled",
+                "attached_at",
+                "attached_by",
+            ),
+            rows=rows,
+            conn=conn,
+            unique_key_columns=(
+                ("project_id", "document_id", "document_type"),
+            ),
+            sequence_column="id",
+        )
+
 
 logger = logging.getLogger(__name__)
 

--- a/guardian/routes/migration.py
+++ b/guardian/routes/migration.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from guardian.core.dependencies import (
@@ -9,6 +10,10 @@ from guardian.core.dependencies import (
     chatlog_db,
     get_request_user_id,
     require_api_key,
+)
+from guardian.services.account_restore import (
+    AccountRestoreError,
+    AccountRestoreService,
 )
 
 logger = logging.getLogger(__name__)
@@ -33,6 +38,66 @@ class EmbeddingRetryStats(BaseModel):
     embeddings_persisted: int = 0
     embeddings_failed: int = 0
     embedding_coverage_degraded: bool = False
+
+
+@router.post("/api/imports/account/metadata")
+@router.post("/imports/account/metadata")
+async def import_account_metadata(
+    file: UploadFile = File(...),
+    user_id: str = Depends(get_request_user_id),
+    api_key: str = Depends(require_api_key),
+):
+    """
+    Import a canonical Codexify account export ZIP as a metadata-only restore.
+
+    This slice restores relational metadata and links only. Blob write-back is
+    not implemented here.
+    """
+    _ = api_key
+
+    if chatlog_db is None:
+        error = AccountRestoreError(
+            "Account database is not available",
+            code="restore_backend_unavailable",
+            status_code=503,
+            validated=False,
+            notes=[
+                "Metadata restore is unavailable until the account database is configured.",
+            ],
+        )
+        return JSONResponse(
+            status_code=error.status_code, content=error.to_payload()
+        )
+
+    try:
+        chunks = bytearray()
+        while True:
+            chunk = await file.read(1024 * 1024)
+            if not chunk:
+                break
+            chunks.extend(chunk)
+
+        service = AccountRestoreService(chatlog_db)
+        report = service.restore_from_zip(bytes(chunks), user_id=user_id)
+        return report
+    except AccountRestoreError as exc:
+        return JSONResponse(
+            status_code=exc.status_code, content=exc.to_payload()
+        )
+    except Exception:
+        logger.exception("Account metadata restore failed")
+        error = AccountRestoreError(
+            "Unexpected account metadata restore failure",
+            code="account_restore_unexpected_error",
+            status_code=500,
+            validated=False,
+            notes=[
+                "The archive was not restored.",
+            ],
+        )
+        return JSONResponse(
+            status_code=error.status_code, content=error.to_payload()
+        )
 
 
 from backend.rag.chatgpt_migration import ingest_chatgpt_export

--- a/guardian/services/account_restore.py
+++ b/guardian/services/account_restore.py
@@ -1,0 +1,1464 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import logging
+import zipfile
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from guardian.services.account_export import (
+    EXPORT_KIND,
+    MANIFEST_SCHEMA_VERSION,
+    PAYLOAD_FAMILIES,
+    PAYLOAD_ORDER,
+)
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_SCHEMA_VERSIONS = {MANIFEST_SCHEMA_VERSION}
+
+# Restore order is dependency-safe for the current schema. It differs from the
+# export order because `chat_threads` must exist before any row that points at a
+# thread, and `media_assets` must exist before document/image rows that carry an
+# `asset_id` FK.
+RESTORE_ORDER = (
+    "projects",
+    "chat_threads",
+    "chat_messages",
+    "media_assets",
+    "media_aliases",
+    "uploaded_documents",
+    "generated_documents",
+    "uploaded_images",
+    "generated_images",
+    "thread_documents",
+    "project_document_links",
+)
+
+RESTORE_METHODS = {
+    family: f"restore_account_export_{family}" for family in RESTORE_ORDER
+}
+
+PAYLOAD_PATHS = {family: path for family, path, _ in PAYLOAD_ORDER}
+REQUIRED_PAYLOAD_PATHS = tuple(
+    PAYLOAD_PATHS[family] for family in PAYLOAD_FAMILIES
+)
+
+
+def _zero_counts() -> dict[str, int]:
+    return {
+        "imported": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unresolved": 0,
+    }
+
+
+def _empty_blob_coverage() -> dict[str, Any]:
+    return {
+        "bundled_families": [],
+        "missing_families": [],
+        "bundled_blob_paths": [],
+        "unresolved_rows": [],
+        "validated_only": True,
+    }
+
+
+def _empty_family_reports() -> list[dict[str, Any]]:
+    return [
+        {
+            "family": family,
+            "status": "not_started",
+            "payload_rows": 0,
+            "imported": 0,
+            "skipped": 0,
+            "failed": 0,
+            "unresolved": 0,
+        }
+        for family in RESTORE_ORDER
+    ]
+
+
+def _sort_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _normalize_row_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _normalize_row_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_row_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_normalize_row_value(item) for item in value]
+    if hasattr(value, "isoformat"):
+        try:
+            return value.isoformat()
+        except Exception:
+            return str(value)
+    return value
+
+
+def _copy_default(value: Any) -> Any:
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, list):
+        return list(value)
+    if isinstance(value, tuple):
+        return list(value)
+    return value
+
+
+@dataclass(slots=True)
+class ParsedArchive:
+    manifest: dict[str, Any]
+    payload_rows: dict[str, list[dict[str, Any]]]
+    archive_names: tuple[str, ...]
+    integrity_files: dict[str, dict[str, Any]]
+    archive_includes_blob_coverage: bool
+    blob_coverage: dict[str, Any]
+    schema_version: str
+    export_kind: str
+    user_id: str
+
+
+@dataclass(slots=True)
+class FamilyRestoreReport:
+    family: str
+    status: str
+    payload_rows: int
+    imported: int = 0
+    skipped: int = 0
+    failed: int = 0
+    unresolved: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "family": self.family,
+            "status": self.status,
+            "payload_rows": self.payload_rows,
+            "imported": self.imported,
+            "skipped": self.skipped,
+            "failed": self.failed,
+            "unresolved": self.unresolved,
+        }
+
+
+class AccountRestoreError(Exception):
+    status_code = 400
+    code = "account_restore_failed"
+    validated = False
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str | None = None,
+        status_code: int | None = None,
+        validated: bool | None = None,
+        schema_version: str | None = None,
+        export_kind: str | None = None,
+        archive_includes_blob_coverage: bool = False,
+        blob_coverage: dict[str, Any] | None = None,
+        families: list[dict[str, Any]] | None = None,
+        counts: dict[str, int] | None = None,
+        notes: list[str] | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code or self.code
+        self.status_code = status_code or self.status_code
+        self.validated = self.validated if validated is None else validated
+        self.schema_version = schema_version
+        self.export_kind = export_kind
+        self.archive_includes_blob_coverage = archive_includes_blob_coverage
+        self.blob_coverage = blob_coverage or _empty_blob_coverage()
+        self.families = families or _empty_family_reports()
+        self.counts = counts or _zero_counts()
+        self.notes = list(notes or [])
+        self.details = details or {}
+
+    def to_payload(self) -> dict[str, Any]:
+        notes = list(self.notes)
+        if self.message and self.message not in notes:
+            notes.append(self.message)
+        return {
+            "ok": False,
+            "schema_version": self.schema_version,
+            "export_kind": self.export_kind,
+            "validated": self.validated,
+            "metadata_restore_only": True,
+            "blob_restore_supported": False,
+            "archive_includes_blob_coverage": self.archive_includes_blob_coverage,
+            "blob_coverage": self.blob_coverage or _empty_blob_coverage(),
+            "families": self.families or _empty_family_reports(),
+            "counts": self.counts or _zero_counts(),
+            "notes": notes,
+            "error": {
+                "code": self.code,
+                "message": self.message,
+                "details": self.details,
+            },
+        }
+
+
+class AccountRestoreValidationError(AccountRestoreError):
+    status_code = 400
+    code = "account_restore_validation_failed"
+    validated = False
+
+
+class AccountRestoreConflictError(AccountRestoreError):
+    status_code = 409
+    code = "account_restore_conflict"
+    validated = True
+
+
+class AccountRestoreService:
+    def __init__(self, db: Any):
+        self.db = db
+
+    def restore_from_zip(
+        self, archive_bytes: bytes, *, user_id: str
+    ) -> dict[str, Any]:
+        parsed = self._parse_and_validate_archive(
+            archive_bytes, user_id=user_id
+        )
+        families, counts = self._rehydrate(parsed)
+        return self._build_success_report(parsed, families, counts)
+
+    def _parse_and_validate_archive(
+        self, archive_bytes: bytes, *, user_id: str
+    ) -> ParsedArchive:
+        try:
+            with zipfile.ZipFile(io.BytesIO(archive_bytes), "r") as archive:
+                archive_names = tuple(
+                    info.filename
+                    for info in archive.infolist()
+                    if not info.is_dir()
+                )
+                duplicate_names = sorted(
+                    name
+                    for name, count in Counter(archive_names).items()
+                    if count > 1
+                )
+                if duplicate_names:
+                    raise self._validation_error(
+                        "duplicate_entries",
+                        "Archive contains duplicate file entries",
+                        details={"duplicate_paths": duplicate_names},
+                    )
+
+                if "manifest.json" not in archive_names:
+                    raise self._validation_error(
+                        "manifest_missing",
+                        "manifest.json is required for account restore",
+                    )
+
+                try:
+                    manifest = json.loads(
+                        archive.read("manifest.json").decode("utf-8")
+                    )
+                except (
+                    Exception
+                ) as exc:  # pragma: no cover - defensive decode guard
+                    raise self._validation_error(
+                        "manifest_invalid",
+                        "manifest.json is not valid JSON",
+                        details={"reason": str(exc)},
+                    ) from exc
+
+                if not isinstance(manifest, dict):
+                    raise self._validation_error(
+                        "manifest_invalid",
+                        "manifest.json must decode to a JSON object",
+                    )
+
+                schema_version = str(
+                    manifest.get("schema_version") or ""
+                ).strip()
+                export_kind = str(manifest.get("export_kind") or "").strip()
+                manifest_user_id = str(manifest.get("user_id") or "").strip()
+
+                if not schema_version:
+                    raise self._validation_error(
+                        "manifest_invalid",
+                        "manifest.json is missing schema_version",
+                        manifest=manifest,
+                    )
+                if schema_version not in SUPPORTED_SCHEMA_VERSIONS:
+                    raise self._validation_error(
+                        "schema_version_unsupported",
+                        f"Unsupported archive schema_version: {schema_version}",
+                        manifest=manifest,
+                    )
+                if not export_kind:
+                    raise self._validation_error(
+                        "manifest_invalid",
+                        "manifest.json is missing export_kind",
+                        manifest=manifest,
+                    )
+                if export_kind != EXPORT_KIND:
+                    raise self._validation_error(
+                        "export_kind_invalid",
+                        f"Unsupported export_kind: {export_kind}",
+                        manifest=manifest,
+                    )
+                if not manifest_user_id:
+                    raise self._validation_error(
+                        "manifest_invalid",
+                        "manifest.json is missing user_id",
+                        manifest=manifest,
+                    )
+                if user_id and manifest_user_id != str(user_id):
+                    raise self._validation_error(
+                        "user_mismatch",
+                        "Archive user_id does not match the authenticated user",
+                        status_code=403,
+                        manifest=manifest,
+                        details={
+                            "archive_user_id": manifest_user_id,
+                            "authenticated_user_id": user_id,
+                        },
+                    )
+
+                entity_counts = manifest.get("entity_counts")
+                if not isinstance(entity_counts, dict):
+                    raise self._validation_error(
+                        "manifest_invalid",
+                        "manifest.json is missing entity_counts",
+                        manifest=manifest,
+                    )
+
+                included_families = manifest.get("included_families")
+                if not isinstance(included_families, list) or {
+                    str(item) for item in included_families
+                } != set(PAYLOAD_FAMILIES):
+                    raise self._validation_error(
+                        "manifest_invalid",
+                        "manifest.json must enumerate the canonical payload families",
+                        manifest=manifest,
+                        details={"expected_families": list(PAYLOAD_FAMILIES)},
+                    )
+
+                integrity = manifest.get("integrity")
+                if not isinstance(integrity, dict):
+                    raise self._validation_error(
+                        "integrity_missing",
+                        "manifest.json is missing integrity metadata",
+                        manifest=manifest,
+                    )
+
+                if (
+                    str(integrity.get("algorithm") or "").strip().lower()
+                    != "sha256"
+                ):
+                    raise self._validation_error(
+                        "integrity_algorithm_unsupported",
+                        "Only sha256 integrity digests are supported",
+                        manifest=manifest,
+                    )
+
+                integrity_files = integrity.get("files")
+                if not isinstance(integrity_files, dict):
+                    raise self._validation_error(
+                        "integrity_missing",
+                        "manifest.json is missing integrity.files",
+                        manifest=manifest,
+                    )
+
+                manifest_blob_coverage = manifest.get("blob_coverage")
+                blob_coverage = (
+                    dict(manifest_blob_coverage)
+                    if isinstance(manifest_blob_coverage, dict)
+                    else {}
+                )
+                blob_coverage.setdefault("validated_only", True)
+                archive_includes_blob_coverage = bool(
+                    blob_coverage.get("bundled_blob_paths")
+                )
+
+                unknown_files = sorted(
+                    name
+                    for name in archive_names
+                    if name != "manifest.json" and name not in integrity_files
+                )
+                if unknown_files:
+                    raise self._validation_error(
+                        "unexpected_files",
+                        "Archive contains files that are not declared in the manifest",
+                        manifest=manifest,
+                        details={"unexpected_paths": unknown_files},
+                    )
+
+                payload_rows: dict[str, list[dict[str, Any]]] = {}
+                for family, path, _reader_name in PAYLOAD_ORDER:
+                    if path not in archive_names:
+                        raise self._validation_error(
+                            "payload_missing",
+                            f"Archive is missing required payload file: {path}",
+                            manifest=manifest,
+                            details={"family": family, "path": path},
+                        )
+
+                    expected_digest = integrity_files.get(path)
+                    if not isinstance(expected_digest, dict):
+                        raise self._validation_error(
+                            "integrity_missing",
+                            f"Archive integrity metadata is missing for {path}",
+                            manifest=manifest,
+                            details={"path": path},
+                        )
+
+                    payload_bytes = archive.read(path)
+                    self._validate_digest(
+                        manifest=manifest,
+                        path=path,
+                        body=payload_bytes,
+                        expected=expected_digest,
+                    )
+
+                    try:
+                        rows = json.loads(payload_bytes.decode("utf-8"))
+                    except Exception as exc:
+                        raise self._validation_error(
+                            "payload_invalid",
+                            f"Payload file {path} is not valid JSON",
+                            manifest=manifest,
+                            details={"path": path, "reason": str(exc)},
+                        ) from exc
+
+                    if not isinstance(rows, list):
+                        raise self._validation_error(
+                            "payload_invalid",
+                            f"Payload file {path} must contain a JSON array",
+                            manifest=manifest,
+                            details={"path": path},
+                        )
+
+                    normalized_rows: list[dict[str, Any]] = []
+                    for index, row in enumerate(rows):
+                        if not isinstance(row, dict):
+                            raise self._validation_error(
+                                "payload_invalid",
+                                f"Payload file {path} contains a non-object row",
+                                manifest=manifest,
+                                details={"path": path, "row_index": index},
+                            )
+                        normalized_rows.append(dict(row))
+
+                    declared_count = entity_counts.get(family)
+                    if declared_count is None:
+                        raise self._validation_error(
+                            "manifest_invalid",
+                            f"manifest.json is missing entity_counts[{family!r}]",
+                            manifest=manifest,
+                            details={"family": family},
+                        )
+                    if int(declared_count) != len(normalized_rows):
+                        raise self._validation_error(
+                            "payload_count_mismatch",
+                            f"Entity count for {family} does not match the payload",
+                            manifest=manifest,
+                            details={
+                                "family": family,
+                                "declared": int(declared_count),
+                                "actual": len(normalized_rows),
+                            },
+                        )
+                    payload_rows[family] = normalized_rows
+
+                for path, expected in integrity_files.items():
+                    if path == "manifest.json":
+                        continue
+                    if path not in archive_names:
+                        raise self._validation_error(
+                            "integrity_missing",
+                            f"Archive is missing integrity-covered file: {path}",
+                            manifest=manifest,
+                            details={"path": path},
+                        )
+                    self._validate_digest(
+                        manifest=manifest,
+                        path=path,
+                        body=archive.read(path),
+                        expected=expected,
+                    )
+
+                self._validate_relationships(
+                    manifest=manifest,
+                    payload_rows=payload_rows,
+                )
+
+                return ParsedArchive(
+                    manifest=manifest,
+                    payload_rows=payload_rows,
+                    archive_names=archive_names,
+                    integrity_files=dict(integrity_files),
+                    archive_includes_blob_coverage=archive_includes_blob_coverage,
+                    blob_coverage=blob_coverage,
+                    schema_version=schema_version,
+                    export_kind=export_kind,
+                    user_id=manifest_user_id,
+                )
+        except zipfile.BadZipFile as exc:
+            raise self._validation_error(
+                "invalid_zip",
+                "Uploaded file is not a valid ZIP archive",
+                details={"reason": str(exc)},
+            ) from exc
+
+    def _validate_digest(
+        self,
+        *,
+        manifest: dict[str, Any],
+        path: str,
+        body: bytes,
+        expected: dict[str, Any],
+    ) -> None:
+        sha256 = hashlib.sha256(body).hexdigest()
+        size_bytes = len(body)
+        expected_sha256 = str(expected.get("sha256") or "").strip().lower()
+        expected_size = expected.get("size_bytes")
+        if expected_sha256 != sha256 or int(expected_size) != size_bytes:
+            raise self._validation_error(
+                "integrity_mismatch",
+                f"Integrity digest mismatch for {path}",
+                manifest=manifest,
+                details={
+                    "path": path,
+                    "expected_sha256": expected_sha256,
+                    "actual_sha256": sha256,
+                    "expected_size_bytes": expected_size,
+                    "actual_size_bytes": size_bytes,
+                },
+            )
+
+    def _validate_relationships(
+        self,
+        *,
+        manifest: dict[str, Any],
+        payload_rows: dict[str, list[dict[str, Any]]],
+    ) -> None:
+        projects = self._index_rows(payload_rows["projects"], "id", manifest)
+        threads = self._index_rows(payload_rows["chat_threads"], "id", manifest)
+        messages = self._index_rows(
+            payload_rows["chat_messages"], "id", manifest
+        )
+        media_assets = self._index_rows(
+            payload_rows["media_assets"], "id", manifest
+        )
+        media_aliases = self._index_rows(
+            payload_rows["media_aliases"], "id", manifest
+        )
+        uploaded_documents = self._index_rows(
+            payload_rows["uploaded_documents"], "id", manifest
+        )
+        generated_documents = self._index_rows(
+            payload_rows["generated_documents"], "id", manifest
+        )
+        uploaded_images = self._index_rows(
+            payload_rows["uploaded_images"], "id", manifest
+        )
+        generated_images = self._index_rows(
+            payload_rows["generated_images"], "id", manifest
+        )
+        thread_documents = self._index_rows(
+            payload_rows["thread_documents"], "id", manifest
+        )
+        project_document_links = self._index_rows(
+            payload_rows["project_document_links"], "id", manifest
+        )
+
+        document_ids_uploaded = set(uploaded_documents)
+        document_ids_generated = set(generated_documents)
+        document_ids_all = document_ids_uploaded | document_ids_generated
+        if document_ids_uploaded & document_ids_generated:
+            raise self._validation_error(
+                "document_id_ambiguity",
+                "Uploaded and generated documents must not share archive IDs",
+                manifest=manifest,
+                details={
+                    "colliding_document_ids": sorted(
+                        document_ids_uploaded & document_ids_generated
+                    )
+                },
+            )
+
+        for row in payload_rows["projects"]:
+            project_id = row.get("id")
+            if project_id is None:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "projects rows require an id",
+                    manifest=manifest,
+                )
+            identity_depth = str(row.get("identity_depth") or "light").strip()
+            if identity_depth not in {"light", "deep"}:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "projects.identity_depth must be light or deep",
+                    manifest=manifest,
+                    details={"project_id": project_id},
+                )
+
+        for row in payload_rows["chat_threads"]:
+            thread_id = row.get("id")
+            if thread_id is None:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "chat_threads rows require an id",
+                    manifest=manifest,
+                )
+            project_id = row.get("project_id")
+            if project_id is not None and project_id not in projects:
+                raise self._validation_error(
+                    "relationship_missing",
+                    "chat_threads.project_id does not reference a restored project",
+                    manifest=manifest,
+                    details={"thread_id": thread_id, "project_id": project_id},
+                )
+            parent_id = row.get("parent_id")
+            if parent_id is not None and parent_id not in threads:
+                raise self._validation_error(
+                    "relationship_missing",
+                    "chat_threads.parent_id does not reference a restored thread",
+                    manifest=manifest,
+                    details={"thread_id": thread_id, "parent_id": parent_id},
+                )
+
+        thread_ids = set(threads)
+        for row in payload_rows["chat_messages"]:
+            message_id = row.get("id")
+            thread_id = row.get("thread_id")
+            if message_id is None or thread_id is None:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "chat_messages rows require id and thread_id",
+                    manifest=manifest,
+                )
+            if thread_id not in thread_ids:
+                raise self._validation_error(
+                    "relationship_missing",
+                    "chat_messages.thread_id does not reference a restored thread",
+                    manifest=manifest,
+                    details={"message_id": message_id, "thread_id": thread_id},
+                )
+
+        for row in payload_rows["media_assets"]:
+            asset_id = row.get("id")
+            project_id = row.get("project_id")
+            thread_id = row.get("thread_id")
+            if asset_id is None or project_id is None:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "media_assets rows require id and project_id",
+                    manifest=manifest,
+                )
+            kind = str(row.get("media_kind") or "").strip()
+            provenance = str(row.get("provenance") or "").strip()
+            if kind not in {"document", "image", "audio", "video", "other"}:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "media_assets.media_kind is invalid",
+                    manifest=manifest,
+                    details={"asset_id": asset_id, "media_kind": kind},
+                )
+            if provenance not in {
+                "uploaded",
+                "generated",
+                "imported",
+                "system",
+            }:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "media_assets.provenance is invalid",
+                    manifest=manifest,
+                    details={"asset_id": asset_id, "provenance": provenance},
+                )
+            if project_id not in projects:
+                raise self._validation_error(
+                    "relationship_missing",
+                    "media_assets.project_id does not reference a restored project",
+                    manifest=manifest,
+                    details={"asset_id": asset_id, "project_id": project_id},
+                )
+            if thread_id is not None and thread_id not in thread_ids:
+                raise self._validation_error(
+                    "relationship_missing",
+                    "media_assets.thread_id does not reference a restored thread",
+                    manifest=manifest,
+                    details={"asset_id": asset_id, "thread_id": thread_id},
+                )
+
+        asset_ids = set(media_assets)
+        for row in payload_rows["media_aliases"]:
+            alias_id = row.get("id")
+            asset_id = row.get("asset_id")
+            alias_type = str(row.get("alias_type") or "").strip()
+            if alias_id is None or asset_id is None:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "media_aliases rows require id and asset_id",
+                    manifest=manifest,
+                )
+            if not row.get("alias"):
+                raise self._validation_error(
+                    "payload_invalid",
+                    "media_aliases rows require alias text",
+                    manifest=manifest,
+                    details={"alias_id": alias_id},
+                )
+            if alias_type not in {
+                "original_name",
+                "prompt",
+                "user_alias",
+                "system_generated",
+            }:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "media_aliases.alias_type is invalid",
+                    manifest=manifest,
+                    details={"alias_id": alias_id, "alias_type": alias_type},
+                )
+            if asset_id not in asset_ids:
+                raise self._validation_error(
+                    "relationship_missing",
+                    "media_aliases.asset_id does not reference a restored media asset",
+                    manifest=manifest,
+                    details={"alias_id": alias_id, "asset_id": asset_id},
+                )
+
+        for row in payload_rows["uploaded_documents"]:
+            document_id = row.get("id")
+            project_id = row.get("project_id")
+            thread_id = row.get("thread_id")
+            asset_id = row.get("asset_id")
+            embedding_status = str(row.get("embedding_status") or "").strip()
+            if document_id is None or row.get("filename") is None:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "uploaded_documents rows require id and filename",
+                    manifest=manifest,
+                )
+            if embedding_status not in {
+                "pending",
+                "processing",
+                "ready",
+                "failed",
+            }:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "uploaded_documents.embedding_status is invalid",
+                    manifest=manifest,
+                    details={
+                        "document_id": document_id,
+                        "embedding_status": embedding_status,
+                    },
+                )
+            if project_id is not None and project_id not in projects:
+                raise self._validation_error(
+                    "relationship_missing",
+                    "uploaded_documents.project_id does not reference a restored project",
+                    manifest=manifest,
+                    details={
+                        "document_id": document_id,
+                        "project_id": project_id,
+                    },
+                )
+            if thread_id is not None and thread_id not in thread_ids:
+                raise self._validation_error(
+                    "relationship_missing",
+                    "uploaded_documents.thread_id does not reference a restored thread",
+                    manifest=manifest,
+                    details={
+                        "document_id": document_id,
+                        "thread_id": thread_id,
+                    },
+                )
+            if asset_id is not None and asset_id not in asset_ids:
+                raise self._validation_error(
+                    "relationship_missing",
+                    "uploaded_documents.asset_id does not reference a restored media asset",
+                    manifest=manifest,
+                    details={"document_id": document_id, "asset_id": asset_id},
+                )
+
+        for row in payload_rows["generated_documents"]:
+            document_id = row.get("id")
+            project_id = row.get("project_id")
+            thread_id = row.get("thread_id")
+            document_format = str(row.get("format") or "").strip().lower()
+            if document_id is None:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "generated_documents rows require id",
+                    manifest=manifest,
+                )
+            if project_id is None:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "generated_documents rows require project_id",
+                    manifest=manifest,
+                    details={"document_id": document_id},
+                )
+            if not row.get("title"):
+                raise self._validation_error(
+                    "payload_invalid",
+                    "generated_documents rows require title",
+                    manifest=manifest,
+                    details={"document_id": document_id},
+                )
+            if document_format not in {
+                "txt",
+                "md",
+                "docx",
+                "pdf",
+                "html",
+                "json",
+            }:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "generated_documents.format is invalid",
+                    manifest=manifest,
+                    details={
+                        "document_id": document_id,
+                        "format": document_format,
+                    },
+                )
+            if project_id is not None and project_id not in projects:
+                raise self._validation_error(
+                    "relationship_missing",
+                    "generated_documents.project_id does not reference a restored project",
+                    manifest=manifest,
+                    details={
+                        "document_id": document_id,
+                        "project_id": project_id,
+                    },
+                )
+            if thread_id is not None and thread_id not in thread_ids:
+                raise self._validation_error(
+                    "relationship_missing",
+                    "generated_documents.thread_id does not reference a restored thread",
+                    manifest=manifest,
+                    details={
+                        "document_id": document_id,
+                        "thread_id": thread_id,
+                    },
+                )
+
+        for row in payload_rows["uploaded_images"]:
+            image_id = row.get("id")
+            project_id = row.get("project_id")
+            thread_id = row.get("thread_id")
+            asset_id = row.get("asset_id")
+            if image_id is None or row.get("filename") is None:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "uploaded_images rows require id and filename",
+                    manifest=manifest,
+                )
+            if project_id is None:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "uploaded_images rows require project_id",
+                    manifest=manifest,
+                    details={"image_id": image_id},
+                )
+            if thread_id is None:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "uploaded_images rows require thread_id",
+                    manifest=manifest,
+                    details={"image_id": image_id},
+                )
+            if project_id not in projects:
+                raise self._validation_error(
+                    "relationship_missing",
+                    "uploaded_images.project_id does not reference a restored project",
+                    manifest=manifest,
+                    details={"image_id": image_id, "project_id": project_id},
+                )
+            if thread_id not in thread_ids:
+                raise self._validation_error(
+                    "relationship_missing",
+                    "uploaded_images.thread_id does not reference a restored thread",
+                    manifest=manifest,
+                    details={"image_id": image_id, "thread_id": thread_id},
+                )
+            if asset_id is not None and asset_id not in asset_ids:
+                raise self._validation_error(
+                    "relationship_missing",
+                    "uploaded_images.asset_id does not reference a restored media asset",
+                    manifest=manifest,
+                    details={"image_id": image_id, "asset_id": asset_id},
+                )
+
+        for row in payload_rows["generated_images"]:
+            image_id = row.get("id")
+            project_id = row.get("project_id")
+            thread_id = row.get("thread_id")
+            asset_id = row.get("asset_id")
+            if image_id is None:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "generated_images rows require id",
+                    manifest=manifest,
+                )
+            if project_id is None:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "generated_images rows require project_id",
+                    manifest=manifest,
+                    details={"image_id": image_id},
+                )
+            if thread_id is None:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "generated_images rows require thread_id",
+                    manifest=manifest,
+                    details={"image_id": image_id},
+                )
+            if project_id not in projects:
+                raise self._validation_error(
+                    "relationship_missing",
+                    "generated_images.project_id does not reference a restored project",
+                    manifest=manifest,
+                    details={"image_id": image_id, "project_id": project_id},
+                )
+            if thread_id not in thread_ids:
+                raise self._validation_error(
+                    "relationship_missing",
+                    "generated_images.thread_id does not reference a restored thread",
+                    manifest=manifest,
+                    details={"image_id": image_id, "thread_id": thread_id},
+                )
+            if asset_id is not None and asset_id not in asset_ids:
+                raise self._validation_error(
+                    "relationship_missing",
+                    "generated_images.asset_id does not reference a restored media asset",
+                    manifest=manifest,
+                    details={"image_id": image_id, "asset_id": asset_id},
+                )
+
+        for row in payload_rows["thread_documents"]:
+            link_id = row.get("id")
+            thread_id = row.get("thread_id")
+            document_id = row.get("document_id")
+            relation = str(row.get("relation") or "").strip()
+            if link_id is None or thread_id is None or document_id is None:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "thread_documents rows require id, thread_id, and document_id",
+                    manifest=manifest,
+                )
+            if thread_id not in thread_ids:
+                raise self._validation_error(
+                    "relationship_missing",
+                    "thread_documents.thread_id does not reference a restored thread",
+                    manifest=manifest,
+                    details={"link_id": link_id, "thread_id": thread_id},
+                )
+            if relation not in {"autosave", "attached", "reference"}:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "thread_documents.relation is invalid",
+                    manifest=manifest,
+                    details={"link_id": link_id, "relation": relation},
+                )
+            if document_id not in document_ids_all:
+                raise self._validation_error(
+                    "relationship_missing",
+                    "thread_documents.document_id does not reference a restored document",
+                    manifest=manifest,
+                    details={"link_id": link_id, "document_id": document_id},
+                )
+
+        for row in payload_rows["project_document_links"]:
+            link_id = row.get("id")
+            project_id = row.get("project_id")
+            document_id = row.get("document_id")
+            document_type = str(row.get("document_type") or "").strip()
+            if link_id is None or project_id is None or document_id is None:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "project_document_links rows require id, project_id, and document_id",
+                    manifest=manifest,
+                )
+            if project_id not in projects:
+                raise self._validation_error(
+                    "relationship_missing",
+                    "project_document_links.project_id does not reference a restored project",
+                    manifest=manifest,
+                    details={"link_id": link_id, "project_id": project_id},
+                )
+            if document_type not in {"uploaded", "generated"}:
+                raise self._validation_error(
+                    "payload_invalid",
+                    "project_document_links.document_type is invalid",
+                    manifest=manifest,
+                    details={
+                        "link_id": link_id,
+                        "document_type": document_type,
+                    },
+                )
+            if (
+                document_type == "uploaded"
+                and document_id not in document_ids_uploaded
+            ):
+                raise self._validation_error(
+                    "relationship_missing",
+                    "project_document_links.document_id does not match an uploaded document",
+                    manifest=manifest,
+                    details={"link_id": link_id, "document_id": document_id},
+                )
+            if (
+                document_type == "generated"
+                and document_id not in document_ids_generated
+            ):
+                raise self._validation_error(
+                    "relationship_missing",
+                    "project_document_links.document_id does not match a generated document",
+                    manifest=manifest,
+                    details={"link_id": link_id, "document_id": document_id},
+                )
+
+    def _index_rows(
+        self,
+        rows: list[dict[str, Any]],
+        key_name: str,
+        manifest: dict[str, Any],
+    ) -> dict[Any, dict[str, Any]]:
+        indexed: dict[Any, dict[str, Any]] = {}
+        for index, row in enumerate(rows):
+            key = row.get(key_name)
+            if key is None:
+                raise self._validation_error(
+                    "payload_invalid",
+                    f"{manifest.get('export_kind')} payload row is missing {key_name}",
+                    manifest=manifest,
+                    details={"row_index": index, "key_name": key_name},
+                )
+            if key in indexed:
+                raise self._validation_error(
+                    "duplicate_ids",
+                    "Archive contains duplicate row IDs",
+                    manifest=manifest,
+                    details={"key_name": key_name, "duplicate_id": key},
+                )
+            indexed[key] = row
+        return indexed
+
+    def _rehydrate(
+        self, parsed: ParsedArchive
+    ) -> tuple[list[dict[str, Any]], dict[str, int]]:
+        counts = _zero_counts()
+        family_reports: list[FamilyRestoreReport] = []
+        unresolved_rows: list[dict[str, Any]] = []
+        if isinstance(parsed.blob_coverage, dict):
+            maybe_rows = parsed.blob_coverage.get("unresolved_rows") or []
+            if isinstance(maybe_rows, list):
+                unresolved_rows = [
+                    row for row in maybe_rows if isinstance(row, dict)
+                ]
+        unresolved_by_family = Counter(
+            family
+            for family in (
+                str(row.get("family") or "").strip() for row in unresolved_rows
+            )
+            if family
+        )
+
+        def _call_restore(
+            method_name: str, rows: list[dict[str, Any]], conn: Any | None
+        ) -> dict[str, Any]:
+            helper = getattr(self.db, method_name, None)
+            if not callable(helper):
+                raise AccountRestoreError(
+                    f"Restore helper {method_name} is not available on {type(self.db).__name__}",
+                    code="restore_helper_missing",
+                    status_code=500,
+                    validated=True,
+                    schema_version=parsed.schema_version,
+                    export_kind=parsed.export_kind,
+                    archive_includes_blob_coverage=parsed.archive_includes_blob_coverage,
+                    blob_coverage=parsed.blob_coverage,
+                    families=[report.to_dict() for report in family_reports],
+                    counts=dict(counts),
+                    notes=[
+                        "Archive validation succeeded before restore began.",
+                    ],
+                )
+            if conn is None:
+                result = helper(rows)
+            else:
+                result = helper(rows, conn=conn)
+            if not isinstance(result, dict):
+                raise AccountRestoreError(
+                    f"Restore helper {method_name} must return a mapping of counts",
+                    code="restore_helper_invalid",
+                    status_code=500,
+                    validated=True,
+                    schema_version=parsed.schema_version,
+                    export_kind=parsed.export_kind,
+                    archive_includes_blob_coverage=parsed.archive_includes_blob_coverage,
+                    blob_coverage=parsed.blob_coverage,
+                    families=[report.to_dict() for report in family_reports],
+                    counts=dict(counts),
+                )
+            return result
+
+        def _record_family(
+            family: str, rows: list[dict[str, Any]], result: dict[str, Any]
+        ) -> None:
+            imported = int(result.get("imported") or 0)
+            skipped = int(result.get("skipped") or 0)
+            failed = int(result.get("failed") or 0)
+            unresolved = int(result.get("unresolved") or 0)
+            unresolved += int(unresolved_by_family.get(family, 0))
+            payload_rows = len(rows)
+            if failed:
+                status = "failed"
+            elif unresolved:
+                status = "unresolved"
+            elif payload_rows == 0:
+                status = "empty"
+            elif imported and skipped:
+                status = "partial"
+            elif imported:
+                status = "imported"
+            elif skipped:
+                status = "already_present"
+            else:
+                status = "empty"
+            family_report = FamilyRestoreReport(
+                family=family,
+                status=status,
+                payload_rows=payload_rows,
+                imported=imported,
+                skipped=skipped,
+                failed=failed,
+                unresolved=unresolved,
+            )
+            family_reports.append(family_report)
+            counts["imported"] += imported
+            counts["skipped"] += skipped
+            counts["failed"] += failed
+            counts["unresolved"] += unresolved
+
+        ordered_rows = {
+            "projects": self._sort_projects(parsed.payload_rows["projects"]),
+            "chat_threads": self._sort_threads(
+                parsed.payload_rows["chat_threads"]
+            ),
+            "chat_messages": self._sort_chat_messages(
+                parsed.payload_rows["chat_messages"]
+            ),
+            "media_assets": self._sort_media_assets(
+                parsed.payload_rows["media_assets"]
+            ),
+            "media_aliases": self._sort_media_aliases(
+                parsed.payload_rows["media_aliases"]
+            ),
+            "uploaded_documents": self._sort_documents(
+                parsed.payload_rows["uploaded_documents"]
+            ),
+            "generated_documents": self._sort_documents(
+                parsed.payload_rows["generated_documents"]
+            ),
+            "uploaded_images": self._sort_documents(
+                parsed.payload_rows["uploaded_images"]
+            ),
+            "generated_images": self._sort_documents(
+                parsed.payload_rows["generated_images"]
+            ),
+            "thread_documents": self._sort_thread_documents(
+                parsed.payload_rows["thread_documents"]
+            ),
+            "project_document_links": self._sort_project_document_links(
+                parsed.payload_rows["project_document_links"]
+            ),
+        }
+
+        try:
+            if hasattr(self.db, "_connect") and callable(
+                getattr(self.db, "_connect")
+            ):
+                with self.db._connect() as conn:  # type: ignore[attr-defined]
+                    for family in RESTORE_ORDER:
+                        rows = ordered_rows[family]
+                        result = _call_restore(
+                            RESTORE_METHODS[family], rows, conn
+                        )
+                        _record_family(family, rows, result)
+            else:
+                for family in RESTORE_ORDER:
+                    rows = ordered_rows[family]
+                    result = _call_restore(RESTORE_METHODS[family], rows, None)
+                    _record_family(family, rows, result)
+        except AccountRestoreError:
+            raise
+        except ValueError as exc:
+            raise self._restore_conflict(
+                parsed=parsed,
+                family_reports=family_reports,
+                counts=counts,
+                message=str(exc),
+                details={"reason": str(exc)},
+            ) from exc
+        except Exception as exc:
+            raise AccountRestoreError(
+                f"Account metadata restore failed: {exc}",
+                code="restore_failed",
+                status_code=500,
+                validated=True,
+                schema_version=parsed.schema_version,
+                export_kind=parsed.export_kind,
+                archive_includes_blob_coverage=parsed.archive_includes_blob_coverage,
+                blob_coverage=parsed.blob_coverage,
+                families=[report.to_dict() for report in family_reports],
+                counts=dict(counts),
+                notes=[
+                    "Archive validation succeeded before restore began.",
+                ],
+                details={"reason": str(exc)},
+            ) from exc
+
+        return [report.to_dict() for report in family_reports], counts
+
+    def _restore_conflict(
+        self,
+        *,
+        parsed: ParsedArchive,
+        family_reports: list[FamilyRestoreReport],
+        counts: dict[str, int],
+        message: str,
+        details: dict[str, Any],
+    ) -> AccountRestoreConflictError:
+        if family_reports:
+            family_reports = list(family_reports)
+            family_reports[-1] = FamilyRestoreReport(
+                family=family_reports[-1].family,
+                status="failed",
+                payload_rows=family_reports[-1].payload_rows,
+                imported=family_reports[-1].imported,
+                skipped=family_reports[-1].skipped,
+                failed=1,
+                unresolved=family_reports[-1].unresolved,
+            )
+        else:
+            family_reports = _empty_family_reports()  # type: ignore[assignment]
+        counts = dict(counts)
+        counts["failed"] = counts.get("failed", 0) + 1
+        return AccountRestoreConflictError(
+            message,
+            validated=True,
+            schema_version=parsed.schema_version,
+            export_kind=parsed.export_kind,
+            archive_includes_blob_coverage=parsed.archive_includes_blob_coverage,
+            blob_coverage=parsed.blob_coverage,
+            families=[
+                report.to_dict()
+                if isinstance(report, FamilyRestoreReport)
+                else report
+                for report in family_reports
+            ],
+            counts=counts,
+            notes=[
+                "Archive validation succeeded before restore began.",
+                "The archive conflicts with pre-existing rows and was not merged.",
+            ],
+            details=details,
+        )
+
+    def _build_success_report(
+        self,
+        parsed: ParsedArchive,
+        families: list[dict[str, Any]],
+        counts: dict[str, int],
+    ) -> dict[str, Any]:
+        notes = [
+            "Metadata restore only; blob restoration is not implemented in this slice.",
+            "Bundled blob files were validated against manifest digests and not written back to storage.",
+        ]
+        if parsed.blob_coverage.get("missing_families"):
+            notes.append(
+                "The archive manifest reports incomplete blob coverage; unresolved blob rows were validated only."
+            )
+        if parsed.blob_coverage.get("unresolved_rows"):
+            notes.append(
+                "Some bundled blob rows remain unresolved in this slice; metadata was restored without blob write-back."
+            )
+        return {
+            "ok": True,
+            "schema_version": parsed.schema_version,
+            "export_kind": parsed.export_kind,
+            "validated": True,
+            "metadata_restore_only": True,
+            "blob_restore_supported": False,
+            "archive_includes_blob_coverage": parsed.archive_includes_blob_coverage,
+            "blob_coverage": {
+                **parsed.blob_coverage,
+                "validated_only": True,
+            },
+            "families": families,
+            "counts": counts,
+            "notes": notes,
+        }
+
+    def _sort_projects(
+        self, rows: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        return sorted(rows, key=lambda row: (_sort_text(row.get("id")),))
+
+    def _sort_threads(self, rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        indexed: dict[Any, dict[str, Any]] = {
+            row.get("id"): row for row in rows
+        }
+        order: list[dict[str, Any]] = []
+        visiting: set[Any] = set()
+        visited: set[Any] = set()
+
+        def visit(thread_id: Any) -> None:
+            if thread_id in visited:
+                return
+            if thread_id in visiting:
+                raise ValueError("chat_threads contains a cycle")
+            row = indexed.get(thread_id)
+            if row is None:
+                raise ValueError(f"chat_threads row {thread_id!r} missing")
+            visiting.add(thread_id)
+            parent_id = row.get("parent_id")
+            if parent_id is not None:
+                visit(parent_id)
+            visiting.remove(thread_id)
+            visited.add(thread_id)
+            order.append(row)
+
+        for thread_id in sorted(
+            indexed,
+            key=lambda value: (
+                _sort_text(indexed[value].get("created_at")),
+                _sort_text(value),
+            ),
+        ):
+            visit(thread_id)
+        return order
+
+    def _sort_chat_messages(
+        self, rows: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        return sorted(
+            rows,
+            key=lambda row: (
+                _sort_text(row.get("thread_id")),
+                _sort_text(row.get("event_at") or row.get("created_at")),
+                _sort_text(row.get("id")),
+            ),
+        )
+
+    def _sort_media_assets(
+        self, rows: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        return sorted(
+            rows,
+            key=lambda row: (
+                _sort_text(row.get("ingested_at")),
+                _sort_text(row.get("id")),
+            ),
+        )
+
+    def _sort_media_aliases(
+        self, rows: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        return sorted(
+            rows,
+            key=lambda row: (
+                _sort_text(row.get("asset_id")),
+                _sort_text(row.get("created_at")),
+                _sort_text(row.get("id")),
+            ),
+        )
+
+    def _sort_documents(
+        self, rows: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        return sorted(
+            rows,
+            key=lambda row: (
+                _sort_text(row.get("created_at")),
+                _sort_text(row.get("id")),
+            ),
+        )
+
+    def _sort_thread_documents(
+        self, rows: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        return sorted(
+            rows,
+            key=lambda row: (
+                _sort_text(row.get("thread_id")),
+                _sort_text(row.get("created_at")),
+                _sort_text(row.get("id")),
+            ),
+        )
+
+    def _sort_project_document_links(
+        self, rows: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        return sorted(
+            rows,
+            key=lambda row: (
+                _sort_text(row.get("project_id")),
+                _sort_text(row.get("attached_at")),
+                _sort_text(row.get("id")),
+            ),
+        )
+
+    def _validation_error(
+        self,
+        code: str,
+        message: str,
+        *,
+        status_code: int = 400,
+        manifest: dict[str, Any] | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> AccountRestoreValidationError:
+        schema_version = None
+        export_kind = None
+        archive_includes_blob_coverage = False
+        blob_coverage = _empty_blob_coverage()
+        if isinstance(manifest, dict):
+            schema_version = str(manifest.get("schema_version") or None)
+            export_kind = str(manifest.get("export_kind") or None)
+            blob = manifest.get("blob_coverage")
+            if isinstance(blob, dict):
+                blob_coverage = {**blob, "validated_only": True}
+                archive_includes_blob_coverage = bool(
+                    blob_coverage.get("bundled_blob_paths")
+                )
+        return AccountRestoreValidationError(
+            message,
+            code=code,
+            status_code=status_code,
+            validated=False,
+            schema_version=schema_version,
+            export_kind=export_kind,
+            archive_includes_blob_coverage=archive_includes_blob_coverage,
+            blob_coverage=blob_coverage,
+            notes=[
+                "No database writes were performed.",
+            ],
+            details=details,
+        )
+
+
+def _restore_connection(conn: Any | None, db: Any):
+    if conn is not None:
+        return conn
+    return db._connect()

--- a/tests/routes/test_account_restore.py
+++ b/tests/routes/test_account_restore.py
@@ -1,0 +1,932 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+import zipfile
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("CODEXIFY_EMBEDDINGS_BACKEND", "mock")
+os.environ.setdefault("GUARDIAN_API_KEY", "test-key")
+os.environ.setdefault("LOCAL_DEV", "1")
+os.environ.setdefault("STORAGE_BASE_PATH", "/tmp/test_media")
+os.environ.setdefault("STORAGE_URL_PREFIX", "/media")
+
+from guardian.routes import migration as migration_routes
+from guardian.services.account_export import (
+    ZIP_FILENAME,
+    build_account_export_zip,
+)
+from guardian.services.account_restore import RESTORE_ORDER
+
+USER_ID = "user-123"
+
+
+def _utc(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _write_blob(base_path: Path, relative_path: str, data: bytes) -> None:
+    blob_path = base_path / relative_path
+    blob_path.parent.mkdir(parents=True, exist_ok=True)
+    blob_path.write_bytes(data)
+
+
+def _build_rows() -> dict[str, list[dict[str, object]]]:
+    return {
+        "projects": [
+            {
+                "id": 10,
+                "name": "Project Alpha",
+                "description": "Primary workspace",
+                "icon": "A",
+                "identity_depth": "deep",
+                "created_at": _utc("2026-03-01T00:00:00Z"),
+                "updated_at": _utc("2026-03-02T00:00:00Z"),
+            }
+        ],
+        "chat_threads": [
+            {
+                "id": 101,
+                "user_id": USER_ID,
+                "title": "Launch planning",
+                "summary": "Thread summary",
+                "project_id": 10,
+                "parent_id": None,
+                "archived_at": None,
+                "is_diary": False,
+                "diary_mode": False,
+                "exclude_from_identity": False,
+                "modeling_excluded": False,
+                "metadata": {"source_thread_id": "source-1"},
+                "active_profile_id": "profile-a",
+                "created_at": _utc("2026-03-05T00:00:00Z"),
+                "updated_at": _utc("2026-03-05T01:00:00Z"),
+            },
+            {
+                "id": 102,
+                "user_id": USER_ID,
+                "title": "Post-launch review",
+                "summary": "Follow-up thread",
+                "project_id": 10,
+                "parent_id": 101,
+                "archived_at": _utc("2026-03-10T00:00:00Z"),
+                "is_diary": True,
+                "diary_mode": True,
+                "exclude_from_identity": True,
+                "modeling_excluded": True,
+                "metadata": {"source_thread_id": "source-2"},
+                "active_profile_id": None,
+                "created_at": _utc("2026-03-06T00:00:00Z"),
+                "updated_at": _utc("2026-03-10T00:00:00Z"),
+            },
+        ],
+        "chat_messages": [
+            {
+                "id": 1,
+                "thread_id": 101,
+                "role": "user",
+                "content": "Hello",
+                "event_at": _utc("2026-03-05T01:00:00Z"),
+                "kind": "chat",
+                "extra_meta": {
+                    "source_thread_id": "source-1",
+                    "source_message_id": "m1",
+                    "turn_index": 0,
+                },
+                "created_at": _utc("2026-03-05T01:00:00Z"),
+            },
+            {
+                "id": 2,
+                "thread_id": 102,
+                "role": "assistant",
+                "content": "Hi",
+                "event_at": _utc("2026-03-06T01:01:00Z"),
+                "kind": "tool",
+                "extra_meta": {
+                    "source_thread_id": "source-2",
+                    "source_message_id": "m2",
+                    "turn_index": 1,
+                },
+                "created_at": _utc("2026-03-06T01:01:00Z"),
+            },
+        ],
+        "uploaded_documents": [
+            {
+                "id": "ud-1",
+                "asset_id": "asset-doc-1",
+                "project_id": 10,
+                "thread_id": 101,
+                "user_id": USER_ID,
+                "filename": "brief.pdf",
+                "filesize": 1234,
+                "mime_type": "application/pdf",
+                "src_url": "/media/documents/brief.pdf",
+                "source_tag": "uploaded",
+                "parsed_text": "Brief text",
+                "embedding_status": "ready",
+                "embedding_error": None,
+                "embedding_started_at": _utc("2026-03-05T02:00:00Z"),
+                "embedding_completed_at": _utc("2026-03-05T02:01:00Z"),
+                "created_at": _utc("2026-03-05T02:00:00Z"),
+                "updated_at": _utc("2026-03-05T02:02:00Z"),
+                "deleted_at": None,
+            }
+        ],
+        "generated_documents": [
+            {
+                "id": "gd-1",
+                "project_id": 10,
+                "thread_id": 102,
+                "user_id": USER_ID,
+                "title": "Launch brief",
+                "content": "Drafted content",
+                "format": "md",
+                "model": "gpt-4.1",
+                "created_at": _utc("2026-03-10T02:00:00Z"),
+                "updated_at": _utc("2026-03-10T02:05:00Z"),
+                "deleted_at": _utc("2026-03-12T00:00:00Z"),
+            }
+        ],
+        "uploaded_images": [
+            {
+                "id": "ui-1",
+                "asset_id": "asset-img-1",
+                "project_id": 10,
+                "thread_id": 101,
+                "user_id": USER_ID,
+                "src_url": "/media/images/uploaded.png",
+                "filename": "uploaded.png",
+                "filesize": 2048,
+                "mime_type": "image/png",
+                "source_tag": "uploaded",
+                "created_at": _utc("2026-03-05T03:00:00Z"),
+                "updated_at": _utc("2026-03-05T03:05:00Z"),
+                "deleted_at": None,
+            },
+            {
+                "id": "ui-missing",
+                "asset_id": "asset-img-missing",
+                "project_id": 10,
+                "thread_id": 102,
+                "user_id": USER_ID,
+                "src_url": "/media/images/missing.png",
+                "filename": "missing.png",
+                "filesize": 1024,
+                "mime_type": "image/png",
+                "source_tag": "uploaded",
+                "created_at": _utc("2026-03-12T03:00:00Z"),
+                "updated_at": _utc("2026-03-12T03:05:00Z"),
+                "deleted_at": None,
+            },
+        ],
+        "generated_images": [
+            {
+                "id": "gi-1",
+                "asset_id": "asset-img-2",
+                "project_id": 10,
+                "thread_id": 102,
+                "user_id": USER_ID,
+                "src_url": "/media/generated_images/generated.png",
+                "prompt": "a schematic of a distributed system",
+                "model": "dall-e-3",
+                "created_at": _utc("2026-03-10T03:00:00Z"),
+                "updated_at": _utc("2026-03-10T03:05:00Z"),
+                "deleted_at": None,
+            }
+        ],
+        "media_assets": [
+            {
+                "id": "asset-doc-1",
+                "project_id": 10,
+                "thread_id": 101,
+                "user_id": USER_ID,
+                "media_kind": "document",
+                "provenance": "uploaded",
+                "source_tag": "uploaded",
+                "content_hash": "hash-doc-1",
+                "deterministic_id": "docdet1",
+                "normalized_slug": "brief",
+                "system_name": "brief.pdf",
+                "storage_prefix": "documents/",
+                "src_url": "/media/documents/brief.pdf",
+                "mime_type": "application/pdf",
+                "filesize": 1234,
+                "ingested_at": _utc("2026-03-05T02:00:00Z"),
+                "deleted_at": None,
+            },
+            {
+                "id": "asset-img-1",
+                "project_id": 10,
+                "thread_id": 101,
+                "user_id": USER_ID,
+                "media_kind": "image",
+                "provenance": "uploaded",
+                "source_tag": "uploaded",
+                "content_hash": "hash-img-1",
+                "deterministic_id": "imgdet1",
+                "normalized_slug": "uploaded",
+                "system_name": "uploaded.png",
+                "storage_prefix": "images/",
+                "src_url": "/media/images/uploaded.png",
+                "mime_type": "image/png",
+                "filesize": 2048,
+                "ingested_at": _utc("2026-03-05T03:00:00Z"),
+                "deleted_at": None,
+            },
+            {
+                "id": "asset-img-2",
+                "project_id": 10,
+                "thread_id": 102,
+                "user_id": USER_ID,
+                "media_kind": "image",
+                "provenance": "generated",
+                "source_tag": "generated",
+                "content_hash": "hash-img-2",
+                "deterministic_id": "imgdet2",
+                "normalized_slug": "generated",
+                "system_name": "generated.png",
+                "storage_prefix": "generated_images/",
+                "src_url": "/media/generated_images/generated.png",
+                "mime_type": "image/png",
+                "filesize": 4096,
+                "ingested_at": _utc("2026-03-10T03:00:00Z"),
+                "deleted_at": None,
+            },
+            {
+                "id": "asset-img-missing",
+                "project_id": 10,
+                "thread_id": 102,
+                "user_id": USER_ID,
+                "media_kind": "image",
+                "provenance": "uploaded",
+                "source_tag": "uploaded",
+                "content_hash": "hash-img-missing",
+                "deterministic_id": "imgdet3",
+                "normalized_slug": "missing",
+                "system_name": "missing.png",
+                "storage_prefix": "images/",
+                "src_url": "/media/images/missing.png",
+                "mime_type": "image/png",
+                "filesize": 1024,
+                "ingested_at": _utc("2026-03-12T03:00:00Z"),
+                "deleted_at": None,
+            },
+        ],
+        "media_aliases": [
+            {
+                "id": "alias-1",
+                "asset_id": "asset-doc-1",
+                "alias": "Brief PDF",
+                "alias_normalized": "brief-pdf",
+                "alias_type": "original_name",
+                "created_at": _utc("2026-03-05T02:03:00Z"),
+            },
+            {
+                "id": "alias-2",
+                "asset_id": "asset-img-2",
+                "alias": "Generation prompt",
+                "alias_normalized": "generation-prompt",
+                "alias_type": "prompt",
+                "created_at": _utc("2026-03-10T03:06:00Z"),
+            },
+        ],
+        "thread_documents": [
+            {
+                "id": 1,
+                "thread_id": 101,
+                "document_id": "ud-1",
+                "relation": "attached",
+                "created_at": _utc("2026-03-05T04:00:00Z"),
+            },
+            {
+                "id": 2,
+                "thread_id": 102,
+                "document_id": "gd-1",
+                "relation": "autosave",
+                "created_at": _utc("2026-03-10T04:00:00Z"),
+            },
+        ],
+        "project_document_links": [
+            {
+                "id": 1,
+                "project_id": 10,
+                "document_id": "ud-1",
+                "document_type": "uploaded",
+                "is_enabled": True,
+                "attached_at": _utc("2026-03-05T05:00:00Z"),
+                "attached_by": USER_ID,
+            },
+            {
+                "id": 2,
+                "project_id": 10,
+                "document_id": "gd-1",
+                "document_type": "generated",
+                "is_enabled": False,
+                "attached_at": _utc("2026-03-10T05:00:00Z"),
+                "attached_by": USER_ID,
+            },
+        ],
+    }
+
+
+def _build_export_db(rows: dict[str, list[dict[str, object]]]):
+    calls: list[str] = []
+
+    def _fetch(user_id: str):
+        calls.append(user_id)
+        return rows
+
+    return SimpleNamespace(fetch_account_export_bundle_for_user=_fetch), calls
+
+
+def _zip_bytes_from_archive(archive_path: str) -> bytes:
+    payload = Path(archive_path).read_bytes()
+    return payload
+
+
+def _read_manifest(archive_bytes: bytes) -> dict[str, Any]:
+    with zipfile.ZipFile(io.BytesIO(archive_bytes), "r") as archive:
+        return json.loads(archive.read("manifest.json").decode("utf-8"))
+
+
+def _rewrite_archive_member(
+    archive_bytes: bytes,
+    member_path: str,
+    transform,
+) -> bytes:
+    src = zipfile.ZipFile(io.BytesIO(archive_bytes), "r")
+    buffer = io.BytesIO()
+    try:
+        with zipfile.ZipFile(
+            buffer, "w", compression=zipfile.ZIP_DEFLATED
+        ) as dst:
+            for info in src.infolist():
+                if info.is_dir():
+                    continue
+                body = src.read(info.filename)
+                if info.filename == member_path:
+                    body = transform(body)
+                dst.writestr(info.filename, body)
+        return buffer.getvalue()
+    finally:
+        src.close()
+
+
+class FakeAccountRestoreDB:
+    TABLE_SPECS = {
+        "projects": {
+            "pk": "id",
+            "columns": (
+                "id",
+                "name",
+                "description",
+                "icon",
+                "identity_depth",
+                "created_at",
+                "updated_at",
+            ),
+            "unique": (("name",),),
+        },
+        "chat_threads": {
+            "pk": "id",
+            "columns": (
+                "id",
+                "user_id",
+                "title",
+                "summary",
+                "project_id",
+                "parent_id",
+                "archived_at",
+                "is_diary",
+                "diary_mode",
+                "exclude_from_identity",
+                "modeling_excluded",
+                "metadata",
+                "active_profile_id",
+                "created_at",
+                "updated_at",
+            ),
+        },
+        "chat_messages": {
+            "pk": "id",
+            "columns": (
+                "id",
+                "thread_id",
+                "role",
+                "content",
+                "event_at",
+                "kind",
+                "extra_meta",
+                "created_at",
+            ),
+        },
+        "media_assets": {
+            "pk": "id",
+            "columns": (
+                "id",
+                "project_id",
+                "thread_id",
+                "user_id",
+                "media_kind",
+                "provenance",
+                "source_tag",
+                "content_hash",
+                "deterministic_id",
+                "normalized_slug",
+                "system_name",
+                "storage_prefix",
+                "src_url",
+                "mime_type",
+                "filesize",
+                "ingested_at",
+                "deleted_at",
+            ),
+        },
+        "media_aliases": {
+            "pk": "id",
+            "columns": (
+                "id",
+                "asset_id",
+                "alias",
+                "alias_normalized",
+                "alias_type",
+                "created_at",
+            ),
+        },
+        "uploaded_documents": {
+            "pk": "id",
+            "columns": (
+                "id",
+                "asset_id",
+                "project_id",
+                "thread_id",
+                "user_id",
+                "filename",
+                "filesize",
+                "mime_type",
+                "src_url",
+                "source_tag",
+                "parsed_text",
+                "embedding_status",
+                "embedding_error",
+                "embedding_started_at",
+                "embedding_completed_at",
+                "created_at",
+                "updated_at",
+                "deleted_at",
+            ),
+        },
+        "generated_documents": {
+            "pk": "id",
+            "columns": (
+                "id",
+                "project_id",
+                "thread_id",
+                "user_id",
+                "title",
+                "content",
+                "format",
+                "model",
+                "created_at",
+                "updated_at",
+                "deleted_at",
+            ),
+        },
+        "uploaded_images": {
+            "pk": "id",
+            "columns": (
+                "id",
+                "asset_id",
+                "project_id",
+                "thread_id",
+                "user_id",
+                "src_url",
+                "filename",
+                "filesize",
+                "mime_type",
+                "source_tag",
+                "created_at",
+                "updated_at",
+                "deleted_at",
+            ),
+        },
+        "generated_images": {
+            "pk": "id",
+            "columns": (
+                "id",
+                "asset_id",
+                "project_id",
+                "thread_id",
+                "user_id",
+                "src_url",
+                "prompt",
+                "model",
+                "created_at",
+                "updated_at",
+                "deleted_at",
+            ),
+        },
+        "thread_documents": {
+            "pk": "id",
+            "columns": (
+                "id",
+                "thread_id",
+                "document_id",
+                "relation",
+                "created_at",
+            ),
+        },
+        "project_document_links": {
+            "pk": "id",
+            "columns": (
+                "id",
+                "project_id",
+                "document_id",
+                "document_type",
+                "is_enabled",
+                "attached_at",
+                "attached_by",
+            ),
+            "unique": (("project_id", "document_id", "document_type"),),
+        },
+    }
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.tables: dict[str, dict[Any, dict[str, Any]]] = {
+            family: {} for family in self.TABLE_SPECS
+        }
+
+    @staticmethod
+    def _normalize(value: Any) -> Any:
+        if isinstance(value, dict):
+            return {
+                key: FakeAccountRestoreDB._normalize(item)
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [FakeAccountRestoreDB._normalize(item) for item in value]
+        if hasattr(value, "isoformat"):
+            try:
+                return value.isoformat()
+            except Exception:
+                return str(value)
+        return value
+
+    def _restore_family(
+        self, family: str, rows: list[dict[str, Any]]
+    ) -> dict[str, int]:
+        self.calls.append(family)
+        spec = self.TABLE_SPECS[family]
+        pk_column = str(spec["pk"])
+        columns = tuple(spec["columns"])
+        unique_keys = tuple(spec.get("unique", ()))
+        imported = 0
+        skipped = 0
+        for raw_row in rows:
+            row = dict(raw_row)
+            normalized = {
+                column: self._normalize(row.get(column)) for column in columns
+            }
+            missing = [column for column in columns if column not in row]
+            if missing:
+                raise ValueError(
+                    f"{family} row is missing required columns: {missing}"
+                )
+            pk_value = normalized[pk_column]
+            existing = self.tables[family].get(pk_value)
+            if existing is not None:
+                if existing == normalized:
+                    skipped += 1
+                    continue
+                raise ValueError(
+                    f"{family} row {pk_value!r} conflicts with existing data"
+                )
+            for unique_columns in unique_keys:
+                for other_pk, existing_row in self.tables[family].items():
+                    if other_pk == pk_value:
+                        continue
+                    if all(
+                        existing_row.get(column) == normalized.get(column)
+                        for column in unique_columns
+                    ):
+                        raise ValueError(
+                            f"{family} row {pk_value!r} conflicts with unique key {unique_columns}"
+                        )
+            self.tables[family][pk_value] = normalized
+            imported += 1
+        return {
+            "imported": imported,
+            "skipped": skipped,
+            "failed": 0,
+            "unresolved": 0,
+        }
+
+    def restore_account_export_projects(self, rows, *, conn=None):
+        _ = conn
+        return self._restore_family("projects", rows)
+
+    def restore_account_export_chat_threads(self, rows, *, conn=None):
+        _ = conn
+        return self._restore_family("chat_threads", rows)
+
+    def restore_account_export_chat_messages(self, rows, *, conn=None):
+        _ = conn
+        return self._restore_family("chat_messages", rows)
+
+    def restore_account_export_media_assets(self, rows, *, conn=None):
+        _ = conn
+        return self._restore_family("media_assets", rows)
+
+    def restore_account_export_media_aliases(self, rows, *, conn=None):
+        _ = conn
+        return self._restore_family("media_aliases", rows)
+
+    def restore_account_export_uploaded_documents(self, rows, *, conn=None):
+        _ = conn
+        return self._restore_family("uploaded_documents", rows)
+
+    def restore_account_export_generated_documents(self, rows, *, conn=None):
+        _ = conn
+        return self._restore_family("generated_documents", rows)
+
+    def restore_account_export_uploaded_images(self, rows, *, conn=None):
+        _ = conn
+        return self._restore_family("uploaded_images", rows)
+
+    def restore_account_export_generated_images(self, rows, *, conn=None):
+        _ = conn
+        return self._restore_family("generated_images", rows)
+
+    def restore_account_export_thread_documents(self, rows, *, conn=None):
+        _ = conn
+        return self._restore_family("thread_documents", rows)
+
+    def restore_account_export_project_document_links(self, rows, *, conn=None):
+        _ = conn
+        return self._restore_family("project_document_links", rows)
+
+
+@pytest.fixture
+def rows() -> dict[str, list[dict[str, object]]]:
+    return _build_rows()
+
+
+@pytest.fixture
+def archive_package(
+    rows: dict[str, list[dict[str, object]]],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    base_path = tmp_path / "storage"
+    monkeypatch.setenv("STORAGE_BASE_PATH", str(base_path))
+    monkeypatch.setenv("STORAGE_URL_PREFIX", "/media")
+    _write_blob(base_path, "documents/brief.pdf", b"brief-pdf-bytes")
+    _write_blob(base_path, "images/uploaded.png", b"uploaded-image-bytes")
+    _write_blob(
+        base_path, "generated_images/generated.png", b"generated-image-bytes"
+    )
+
+    export_db, export_calls = _build_export_db(rows)
+    archive_path = build_account_export_zip(
+        export_db,
+        SimpleNamespace(id=USER_ID),
+    )
+    try:
+        payload = _zip_bytes_from_archive(archive_path)
+        manifest = _read_manifest(payload)
+        yield payload, manifest, export_calls
+    finally:
+        if os.path.exists(archive_path):
+            os.unlink(archive_path)
+
+
+@pytest.fixture
+def restore_db() -> FakeAccountRestoreDB:
+    return FakeAccountRestoreDB()
+
+
+@pytest.fixture
+def app(
+    restore_db: FakeAccountRestoreDB, monkeypatch: pytest.MonkeyPatch
+) -> FastAPI:
+    monkeypatch.setattr(
+        migration_routes, "chatlog_db", restore_db, raising=True
+    )
+    application = FastAPI()
+    application.include_router(migration_routes.router)
+    return application
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+def _post_archive(
+    client: TestClient,
+    archive_bytes: bytes,
+    *,
+    path: str = "/imports/account/metadata",
+    headers: dict[str, str] | None = None,
+):
+    request_headers = {
+        "X-API-Key": os.environ["GUARDIAN_API_KEY"],
+        "X-User-Id": USER_ID,
+    }
+    if headers:
+        request_headers.update(headers)
+    files = {"file": (ZIP_FILENAME, archive_bytes, "application/zip")}
+    return client.post(path, files=files, headers=request_headers)
+
+
+def test_account_metadata_restore_requires_auth(
+    client: TestClient, archive_package
+):
+    archive_bytes, _manifest, _export_calls = archive_package
+    response = client.post(
+        "/imports/account/metadata",
+        files={"file": (ZIP_FILENAME, archive_bytes, "application/zip")},
+    )
+    assert response.status_code in {401, 403}
+
+
+def test_account_metadata_restore_rejects_invalid_manifest_before_write(
+    client: TestClient,
+    archive_package,
+    restore_db: FakeAccountRestoreDB,
+):
+    archive_bytes, _manifest, _export_calls = archive_package
+
+    def _mutate_manifest(body: bytes) -> bytes:
+        manifest = json.loads(body.decode("utf-8"))
+        manifest["export_kind"] = "partial_account"
+        return json.dumps(
+            manifest, ensure_ascii=False, separators=(",", ":")
+        ).encode("utf-8")
+
+    mutated = _rewrite_archive_member(
+        archive_bytes, "manifest.json", _mutate_manifest
+    )
+    response = _post_archive(client, mutated)
+
+    assert response.status_code == 400
+    data = response.json()
+    assert data["ok"] is False
+    assert data["validated"] is False
+    assert data["error"]["code"] == "export_kind_invalid"
+    assert restore_db.calls == []
+
+
+def test_account_metadata_restore_rejects_integrity_mismatch_before_write(
+    client: TestClient,
+    archive_package,
+    restore_db: FakeAccountRestoreDB,
+):
+    archive_bytes, _manifest, _export_calls = archive_package
+
+    def _mutate_payload(body: bytes) -> bytes:
+        payload = json.loads(body.decode("utf-8"))
+        payload[0]["filename"] = "broken.pdf"
+        return json.dumps(
+            payload, ensure_ascii=False, separators=(",", ":")
+        ).encode("utf-8")
+
+    mutated = _rewrite_archive_member(
+        archive_bytes, "entities/uploaded_documents.json", _mutate_payload
+    )
+    response = _post_archive(client, mutated)
+
+    assert response.status_code == 400
+    data = response.json()
+    assert data["ok"] is False
+    assert data["validated"] is False
+    assert data["error"]["code"] == "integrity_mismatch"
+    assert restore_db.calls == []
+
+
+def test_account_metadata_restore_imports_clean_fixture(
+    client: TestClient,
+    archive_package,
+    restore_db: FakeAccountRestoreDB,
+    rows: dict[str, list[dict[str, object]]],
+):
+    archive_bytes, manifest, export_calls = archive_package
+    assert export_calls == [USER_ID]
+
+    response = _post_archive(client, archive_bytes)
+    assert response.status_code == 200
+    report = response.json()
+
+    assert report["ok"] is True
+    assert report["validated"] is True
+    assert report["metadata_restore_only"] is True
+    assert report["blob_restore_supported"] is False
+    assert report["archive_includes_blob_coverage"] is True
+    assert report["blob_coverage"]["validated_only"] is True
+    assert "not written back to storage" in " ".join(report["notes"]).lower()
+
+    assert [family["family"] for family in report["families"]] == list(
+        RESTORE_ORDER
+    )
+    assert restore_db.calls == list(RESTORE_ORDER)
+
+    expected_total = sum(len(value) for value in rows.values())
+    expected_unresolved = len(manifest["blob_coverage"]["unresolved_rows"])
+    assert report["counts"]["imported"] == expected_total
+    assert report["counts"]["skipped"] == 0
+    assert report["counts"]["failed"] == 0
+    assert report["counts"]["unresolved"] == expected_unresolved
+
+    per_family = {family["family"]: family for family in report["families"]}
+    for family_name, payload_rows in rows.items():
+        assert per_family[family_name]["payload_rows"] == len(payload_rows)
+        assert per_family[family_name]["imported"] == len(payload_rows)
+        assert per_family[family_name]["failed"] == 0
+
+    assert restore_db.tables["projects"][10]["name"] == "Project Alpha"
+    assert restore_db.tables["chat_threads"][102]["parent_id"] == 101
+    assert (
+        restore_db.tables["chat_threads"][101]["metadata"]["source_thread_id"]
+        == "source-1"
+    )
+    assert restore_db.tables["thread_documents"][1]["document_id"] == "ud-1"
+    assert (
+        restore_db.tables["project_document_links"][2]["document_type"]
+        == "generated"
+    )
+    assert (
+        restore_db.tables["media_assets"]["asset-img-missing"]["src_url"]
+        == "/media/images/missing.png"
+    )
+    assert (
+        restore_db.tables["uploaded_images"]["ui-missing"]["asset_id"]
+        == "asset-img-missing"
+    )
+
+
+def test_account_metadata_restore_is_idempotent_on_reimport(
+    client: TestClient,
+    archive_package,
+    restore_db: FakeAccountRestoreDB,
+):
+    archive_bytes, manifest, _export_calls = archive_package
+
+    first_response = _post_archive(client, archive_bytes)
+    assert first_response.status_code == 200
+    first_state = deepcopy(restore_db.tables)
+
+    second_response = _post_archive(client, archive_bytes)
+    assert second_response.status_code == 200
+    report = second_response.json()
+
+    expected_total = sum(
+        len(family_rows) for family_rows in first_state.values()
+    )
+    assert report["counts"]["imported"] == 0
+    assert report["counts"]["skipped"] == expected_total
+    assert report["counts"]["failed"] == 0
+    assert report["counts"]["unresolved"] == len(
+        manifest["blob_coverage"]["unresolved_rows"]
+    )
+    assert any(
+        family["status"] == "already_present" for family in report["families"]
+    )
+    assert any(
+        family["status"] == "unresolved" for family in report["families"]
+    )
+    assert restore_db.tables == first_state
+
+
+def test_account_metadata_restore_reports_metadata_only_and_blob_validation(
+    client: TestClient,
+    archive_package,
+):
+    archive_bytes, manifest, _export_calls = archive_package
+    response = _post_archive(client, archive_bytes)
+
+    assert response.status_code == 200
+    report = response.json()
+    assert report["metadata_restore_only"] is True
+    assert report["blob_restore_supported"] is False
+    assert report["archive_includes_blob_coverage"] is True
+    assert report["blob_coverage"]["validated_only"] is True
+    assert report["blob_coverage"]["bundled_blob_paths"]
+    assert (
+        report["blob_coverage"]["unresolved_rows"]
+        == manifest["blob_coverage"]["unresolved_rows"]
+    )
+    assert any(
+        "validated" in note.lower()
+        and "not written back to storage" in note.lower()
+        for note in report["notes"]
+    )


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
