### PR TITLE
Restore imported projects natively and clean import rail

### DIFF
--- a/frontend/src/components/sidebar/ProjectList.tsx
+++ b/frontend/src/components/sidebar/ProjectList.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import clsx from "clsx";
 import { FolderOpen, Loader2, PlusCircle, Trash2 } from "lucide-react";
 import type { Project } from "@/types/common";
+import { getProjectPresentation } from "./sidebarPresentation";
 
 type Props = {
   projects: Project[];
@@ -23,13 +24,24 @@ export default function ProjectList({
   className,
 }: Props) {
   const [deletingProjectId, setDeletingProjectId] = React.useState<string | null>(null);
-  const query = search.toLowerCase();
-  const filtered = query ? projects.filter((p) => p.name.toLowerCase().includes(query)) : projects;
+  const query = search.trim().toLowerCase();
+  const filtered = query
+    ? projects.filter((project) => {
+        const presentation = getProjectPresentation(project.name);
+        return [
+          presentation.label,
+          presentation.rawName,
+          presentation.badge ?? "",
+          project.name,
+        ].some((value) => String(value ?? "").toLowerCase().includes(query));
+      })
+    : projects;
   const handleDeleteProject = React.useCallback(
     async (project: Project) => {
       if (!onDeleteProject) return;
       const projectId = String(project.id);
-      const projectName = String(project.name || "").trim() || "this project";
+      const presentation = getProjectPresentation(project.name);
+      const projectName = presentation.label || "this project";
       const confirmed = window.confirm(
         `Delete project "${projectName}"? This will remove the project and unassign its threads.`
       );
@@ -45,19 +57,24 @@ export default function ProjectList({
   );
 
   return (
-    <div className={clsx("flex-1 min-h-0 overflow-auto pt-[5px]", className)}>
+    <div className={clsx("min-h-0 overflow-auto pt-[5px]", className)}>
       <div className="flex flex-col gap-2">
-        {filtered.map((p) => (
-          <ProjectTileCard
-            key={p.id}
-            label={p.name}
-            icon={p.icon}
-            active={currentId === String(p.id)}
-            onClick={() => onPick(String(p.id))}
-            onDelete={onDeleteProject ? () => void handleDeleteProject(p) : undefined}
-            deleting={deletingProjectId === String(p.id)}
-          />
-        ))}
+        {filtered.map((p) => {
+          const presentation = getProjectPresentation(p.name);
+          return (
+            <ProjectTileCard
+              key={p.id}
+              label={presentation.label}
+              rawName={presentation.rawName}
+              badge={presentation.badge}
+              icon={p.icon}
+              active={currentId === String(p.id)}
+              onClick={() => onPick(String(p.id))}
+              onDelete={onDeleteProject ? () => void handleDeleteProject(p) : undefined}
+              deleting={deletingProjectId === String(p.id)}
+            />
+          );
+        })}
       </div>
       {onOpenNewProject && (
         <button
@@ -74,6 +91,8 @@ export default function ProjectList({
 
 function ProjectTileCard({
   label,
+  rawName,
+  badge,
   icon,
   active,
   onClick,
@@ -81,6 +100,8 @@ function ProjectTileCard({
   deleting = false,
 }: {
   label: string;
+  rawName: string;
+  badge: string | null;
   icon?: React.ReactNode;
   active?: boolean;
   onClick?: () => void;
@@ -106,9 +127,24 @@ function ProjectTileCard({
           active && "project-tile--active"
         )}
         aria-pressed={active}
+        title={rawName}
       >
         {iconNode}
-        <span className="project-tile__label" title={label}>{label}</span>
+        <span className="flex min-w-0 flex-1 items-center gap-2">
+          <span className="project-tile__label" title={rawName}>{label}</span>
+          {badge ? (
+            <span
+              className="inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold leading-none"
+              style={{
+                background: "color-mix(in oklab, var(--accent) 12%, transparent)",
+                borderColor: "color-mix(in oklab, var(--accent-strong) 18%, var(--panel-border))",
+                color: "var(--accent-strong)",
+              }}
+            >
+              {badge}
+            </span>
+          ) : null}
+        </span>
       </button>
       {onDelete && (
         <button

--- a/frontend/src/components/sidebar/SidebarRoot.tsx
+++ b/frontend/src/components/sidebar/SidebarRoot.tsx
@@ -9,6 +9,13 @@ import ProjectList from "./ProjectList";
 import CreateProjectModal from "./CreateProjectModal";
 import useSidebarThreads from "./useSidebarThreads";
 import useProjectsCache from "./useProjectsCache";
+import {
+  getProjectPresentation,
+  getThreadPresentation,
+  isGeneralLikeProjectName,
+  pickCanonicalGeneralProject,
+  type ProjectPresentation,
+} from "./sidebarPresentation";
 import { useLegacyThreads } from "@/contexts/LegacyThreadsContext";
 import api from "@/lib/api";
 
@@ -75,18 +82,6 @@ function getComputedStyleVar(name: string, fallback = ""): string {
   }
 }
 
-function normalizeProjectName(value: unknown): string {
-  return String(value ?? "")
-    .trim()
-    .toLowerCase()
-    .replace(/\s+/g, " ");
-}
-
-function isDefaultProjectAlias(value: unknown): boolean {
-  const normalized = normalizeProjectName(value);
-  return normalized === "general" || normalized === "loose threads";
-}
-
 async function deleteProjectApi(projectId: string | number) {
   const paths = [`/api/projects/${projectId}`, `/projects/${projectId}`];
   let lastErr: any = null;
@@ -122,6 +117,20 @@ async function createProjectApi(payload: ProjectCreatePayload) {
 }
 
 const SIDEBAR_RAIL = "px-3";
+const BROWSE_MODE_STORAGE_KEY = "cfy.sidebarBrowseMode";
+const LEGACY_SIDEBAR_TAB_KEY = "cfy.sidebarTab";
+
+function readStoredBrowseMode(): "grouped" | "flat" {
+  if (typeof window === "undefined") return "grouped";
+  const stored = window.localStorage.getItem(BROWSE_MODE_STORAGE_KEY);
+  if (stored === "grouped" || stored === "flat") {
+    return stored;
+  }
+  const legacy = window.localStorage.getItem(LEGACY_SIDEBAR_TAB_KEY);
+  if (legacy === "projects" || legacy === "grouped") return "grouped";
+  if (legacy === "threads" || legacy === "flat") return "flat";
+  return "grouped";
+}
 
 export default function SidebarRoot({
   threads,
@@ -139,8 +148,8 @@ export default function SidebarRoot({
   onBeforeDeleteThread,
   onCreateProject,
 }: Props) {
-  const [tab, setTab] = React.useState<"threads" | "projects">(() =>
-    (typeof window === "undefined" ? "threads" : ((localStorage.getItem("cfy.sidebarTab") as any) || "threads"))
+  const [browseMode, setBrowseMode] = React.useState<"grouped" | "flat">(() =>
+    readStoredBrowseMode()
   );
   const [q, setQ] = React.useState("");
   const { enabled: legacyEnabled, open: openLegacy } = useLegacyThreads();
@@ -166,23 +175,64 @@ export default function SidebarRoot({
     refreshProjectsFromServer,
   } = useProjectsCache({ initialProjects: projects, threadsForLooseCount: sidebarThreads });
 
+  const canonicalGeneralProject = React.useMemo(
+    () => pickCanonicalGeneralProject(projectList),
+    [projectList]
+  );
+
+  const currentProject = React.useMemo(
+    () =>
+      currentProjectId == null
+        ? null
+        : projectList.find((project) => String(project.id) === String(currentProjectId)) ?? null,
+    [currentProjectId, projectList]
+  );
+
+  const visibleProjects = React.useMemo(() => {
+    const canonicalId = canonicalGeneralProject?.id != null
+      ? String(canonicalGeneralProject.id)
+      : null;
+    return projectList.filter((project) => {
+      if (!isGeneralLikeProjectName(project?.name)) return true;
+      return canonicalId != null && String(project.id) === canonicalId;
+    });
+  }, [canonicalGeneralProject, projectList]);
+
+  const projectPresentationById = React.useMemo(() => {
+    const map = new Map<string, ProjectPresentation>();
+    for (const project of projectList) {
+      map.set(String(project.id), getProjectPresentation(project.name));
+    }
+    return map;
+  }, [projectList]);
+
   const scopeLabel = React.useMemo(() => {
     if (currentProjectId === null) return "General";
-    if (currentProjectId) {
-      const proj = projectList.find((p) => String(p.id) === String(currentProjectId));
-      return proj?.name ?? hookScopeLabel;
+    if (currentProject) {
+      return getProjectPresentation(currentProject.name).label;
     }
     return hookScopeLabel;
-  }, [currentProjectId, hookScopeLabel, projectList]);
+  }, [currentProject, currentProjectId, hookScopeLabel]);
+
+  const scopeBadge = React.useMemo(() => {
+    if (currentProjectId == null || !currentProject) return null;
+    return getProjectPresentation(currentProject.name).badge;
+  }, [currentProject, currentProjectId]);
 
   React.useEffect(() => {
     if (currentProjectId !== null) return;
-    const defaultProject = projectList.find((project) =>
-      isDefaultProjectAlias(project?.name)
-    );
+    const defaultProject = canonicalGeneralProject;
     if (!defaultProject?.id) return;
     setScope(String(defaultProject.id));
-  }, [currentProjectId, projectList, setScope]);
+  }, [canonicalGeneralProject, currentProjectId, setScope]);
+
+  React.useEffect(() => {
+    if (!currentProject || !canonicalGeneralProject?.id) return;
+    if (!isGeneralLikeProjectName(currentProject.name)) return;
+    const canonicalId = String(canonicalGeneralProject.id);
+    if (String(currentProject.id) === canonicalId) return;
+    setScope(canonicalId);
+  }, [canonicalGeneralProject, currentProject, setScope]);
 
   const columnClass = clsx("w-full", SIDEBAR_RAIL);
 
@@ -223,19 +273,60 @@ export default function SidebarRoot({
 
   React.useEffect(() => {
     try {
-      localStorage.setItem("cfy.sidebarTab", tab);
+      localStorage.setItem(BROWSE_MODE_STORAGE_KEY, browseMode);
+      localStorage.setItem(
+        LEGACY_SIDEBAR_TAB_KEY,
+        browseMode === "grouped" ? "projects" : "threads"
+      );
     } catch {
       /* ignore */
     }
-  }, [tab]);
+  }, [browseMode]);
+
+  const groupedMode = browseMode === "grouped";
+  const searchPlaceholder = groupedMode
+    ? "Search projects and threads…"
+    : "Search threads…";
+
+  const filteredProjects = React.useMemo(() => {
+    if (!q) return visibleProjects;
+    const s = q.toLowerCase();
+    return visibleProjects.filter((project) => {
+      const presentation = getProjectPresentation(project.name);
+      return [
+        presentation.label,
+        presentation.rawName,
+        presentation.badge ?? "",
+        project.name,
+      ].some((value) => String(value ?? "").toLowerCase().includes(s));
+    });
+  }, [q, visibleProjects]);
 
   const filteredThreads = React.useMemo(() => {
-    if (!q) return displayThreads;
+    const sourceThreads = browseMode === "flat"
+      ? sidebarThreads.filter((thread) => !thread.archivedAt)
+      : displayThreads;
+    if (!q) return sourceThreads;
     const s = q.toLowerCase();
-    return displayThreads.filter(
-      (t) => t.title.toLowerCase().includes(s) || (t.lastMessage ?? "").toLowerCase().includes(s)
-    );
-  }, [displayThreads, q]);
+    return sourceThreads.filter((thread) => {
+      const threadPresentation = getThreadPresentation(thread);
+      const projectPresentation =
+        thread.projectId != null
+          ? projectPresentationById.get(String(thread.projectId)) ?? null
+          : null;
+      const searchableValues = [
+        threadPresentation.label,
+        threadPresentation.rawTitle,
+        thread.title,
+        thread.lastMessage ?? "",
+        thread.metadata ? JSON.stringify(thread.metadata) : "",
+        projectPresentation?.label ?? "",
+        projectPresentation?.rawName ?? "",
+        projectPresentation?.badge ?? "",
+      ];
+      return searchableValues.some((value) => String(value ?? "").toLowerCase().includes(s));
+    });
+  }, [browseMode, displayThreads, projectPresentationById, q, sidebarThreads]);
 
   const handleDelete = React.useCallback(
     async (id: string) => {
@@ -312,7 +403,7 @@ export default function SidebarRoot({
           return exists ? prev : [newProj, ...prev];
         });
 
-        setTab("projects");
+        setBrowseMode("grouped");
         setQ("");
         setScope(String(newProj.id));
         setShowProjectModal(false);
@@ -349,9 +440,7 @@ export default function SidebarRoot({
         String(currentProjectId) === normalizedId;
       const fallbackProjectId = deletingSelectedProject
         ? (() => {
-            const generalProject = remaining.find((project) =>
-              isDefaultProjectAlias(project?.name)
-            );
+            const generalProject = pickCanonicalGeneralProject(remaining);
             if (generalProject?.id != null) {
               return String(generalProject.id);
             }
@@ -436,30 +525,30 @@ export default function SidebarRoot({
       >
         <div className={clsx("flex items-center gap-[14px] w-full", SIDEBAR_RAIL)}>
           <div className="flex-1 flex justify-center mt-[3px]">
-            <div className="glass-pill" role="tablist" aria-label="Sidebar tabs">
-              <button
-                role="tab"
-                className="pill-tab text-xs"
-                data-testid="sidebar-threads-tab"
-                data-state={tab === "threads" ? "active" : undefined}
-                onClick={() => setTab("threads")}
-                onKeyDown={(e) => {
-                  if (e.key === "ArrowRight" || e.key === "ArrowDown") setTab("projects");
-                }}
-              >
-                Threads
-              </button>
+            <div className="glass-pill" role="tablist" aria-label="Sidebar browse modes">
               <button
                 role="tab"
                 className="pill-tab text-xs"
                 data-testid="sidebar-projects-tab"
-                data-state={tab === "projects" ? "active" : undefined}
-                onClick={() => setTab("projects")}
+                data-state={groupedMode ? "active" : undefined}
+                onClick={() => setBrowseMode("grouped")}
                 onKeyDown={(e) => {
-                  if (e.key === "ArrowLeft" || e.key === "ArrowUp") setTab("threads");
+                  if (e.key === "ArrowRight" || e.key === "ArrowDown") setBrowseMode("flat");
                 }}
               >
-                Projects
+                Grouped
+              </button>
+              <button
+                role="tab"
+                className="pill-tab text-xs"
+                data-testid="sidebar-threads-tab"
+                data-state={!groupedMode ? "active" : undefined}
+                onClick={() => setBrowseMode("flat")}
+                onKeyDown={(e) => {
+                  if (e.key === "ArrowLeft" || e.key === "ArrowUp") setBrowseMode("grouped");
+                }}
+              >
+                Flat
               </button>
             </div>
             {legacyEnabled && (
@@ -475,7 +564,7 @@ export default function SidebarRoot({
           </div>
         </div>
 
-        <div className={clsx(columnClass, tab === "projects" && "mb-[5px]")}>
+        <div className={clsx(columnClass, groupedMode && "mb-[5px]")}>
           <div
             className="flex items-center gap-[calc(var(--radius-micro)/2)] rounded-[var(--tile-radius)] border bg-[var(--chip-bg)] px-[var(--radius-micro)] focus-within:ring-2 focus-within:ring-[var(--accent)]"
             style={{ borderColor: "var(--panel-border)" }}
@@ -490,7 +579,7 @@ export default function SidebarRoot({
             <Input
               data-testid="sidebar-search-input"
               className="h-[calc(var(--radius-micro)*3)] min-w-0 flex-1 border-0 bg-transparent px-0 py-0 shadow-none focus:ring-0 focus:outline-none"
-              placeholder={tab === "projects" ? "Search projects…" : "Search threads…"}
+              placeholder={searchPlaceholder}
               value={q}
               onChange={(e) => setQ(e.target.value)}
               style={{ color: "var(--text)" }}
@@ -498,24 +587,59 @@ export default function SidebarRoot({
           </div>
         </div>
 
-        {tab === "projects" ? (
-          <ProjectList
-            projects={projectList}
-            search={q}
-            currentId={currentProjectId}
-            onPick={(id) => { setScope(id); setTab("threads"); }}
-            onDeleteProject={handleDeleteProject}
-            onOpenNewProject={() => {
-              setProjectModalError(null);
-              setShowProjectModal(true);
-            }}
-            className={clsx("flex-1 min-h-0 mt-[5px]", columnClass)}
-          />
+        {groupedMode ? (
+          <div className={clsx("flex flex-1 min-h-0 flex-col gap-3", SIDEBAR_RAIL)}>
+            <section className="flex-none">
+              <div className="mb-2 inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-[color:var(--muted)]">
+                <span>Projects</span>
+              </div>
+              <ProjectList
+                projects={filteredProjects}
+                search=""
+                currentId={currentProjectId}
+                onPick={(id) => {
+                  setScope(id);
+                }}
+                onDeleteProject={handleDeleteProject}
+                onOpenNewProject={() => {
+                  setProjectModalError(null);
+                  setShowProjectModal(true);
+                }}
+                className={clsx("max-h-[240px]", columnClass)}
+              />
+            </section>
+            <section className="flex-1 min-h-0">
+              <div className="mb-2 inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-[color:var(--muted)]">
+                <span>Threads</span>
+              </div>
+              <ThreadList
+                threads={filteredThreads}
+                activeId={activeId}
+                scopeLabel={scopeLabel}
+                scopeBadge={scopeBadge}
+                browseMode="grouped"
+                projectPresentationsById={projectPresentationById}
+                onSelect={onSelect}
+                onNewChat={onNewChat}
+                creatingThread={creatingThread}
+                hasMore={hasMoreThreads}
+                isLoadingMore={loadingMoreThreads}
+                onLoadMore={onLoadMoreThreads}
+                onRename={renameThread}
+                onArchiveToggle={handleArchiveToggle}
+                onDelete={handleDelete}
+                className={clsx("flex-1 min-h-0", columnClass)}
+              />
+            </section>
+          </div>
         ) : (
           <ThreadList
             threads={filteredThreads}
             activeId={activeId}
-            scopeLabel={scopeLabel}
+            scopeLabel="All threads"
+            scopeBadge={null}
+            browseMode="flat"
+            projectPresentationsById={projectPresentationById}
             onSelect={onSelect}
             onNewChat={onNewChat}
             creatingThread={creatingThread}

--- a/frontend/src/components/sidebar/ThreadList.tsx
+++ b/frontend/src/components/sidebar/ThreadList.tsx
@@ -14,11 +14,20 @@ import {
 import type { ThreadAction } from "@/types/common";
 import type { Thread } from "@/types/ui";
 import TileShell from "@/components/surface/TileShell";
+import {
+  getThreadPresentation,
+  type ProjectPresentation,
+} from "./sidebarPresentation";
+
+type BrowseMode = "grouped" | "flat";
 
 type ThreadListProps = {
   threads: Thread[];
   activeId: string | null;
   scopeLabel: string;
+  scopeBadge?: string | null;
+  browseMode?: BrowseMode;
+  projectPresentationsById?: Map<string, ProjectPresentation>;
   onSelect: (id: string) => void;
   onNewChat: () => void;
   onRename: (threadId: string, title: string) => Promise<void>;
@@ -71,6 +80,9 @@ export default function ThreadList({
   threads,
   activeId,
   scopeLabel,
+  scopeBadge = null,
+  browseMode = "grouped",
+  projectPresentationsById,
   onSelect,
   onNewChat,
   onRename,
@@ -88,9 +100,12 @@ export default function ThreadList({
       activeId={activeId}
       onSelect={onSelect}
       className={className}
-      rectH={60}
+      rectH={browseMode === "flat" ? 58 : 60}
       showHeader
       scopeLabel={scopeLabel}
+      scopeBadge={scopeBadge}
+      browseMode={browseMode}
+      projectPresentationsById={projectPresentationsById}
       onNewChat={onNewChat}
       onRename={onRename}
       onArchiveToggle={onArchiveToggle}
@@ -111,6 +126,9 @@ function ThreadPreviewList({
   rectH = 60,
   showHeader = false,
   scopeLabel,
+  scopeBadge,
+  browseMode = "grouped",
+  projectPresentationsById,
   onNewChat,
   onRename,
   onArchiveToggle,
@@ -126,6 +144,9 @@ function ThreadPreviewList({
   rectH?: number;
   showHeader?: boolean;
   scopeLabel?: string;
+  scopeBadge?: string | null;
+  browseMode?: BrowseMode;
+  projectPresentationsById?: Map<string, ProjectPresentation>;
   onNewChat?: () => void;
   onRename: (threadId: string, title: string) => Promise<void>;
   onArchiveToggle: (threadId: string, archived: boolean) => Promise<void>;
@@ -162,8 +183,20 @@ function ThreadPreviewList({
       {showHeader && (
         <div className="flex items-center justify-between pb-2">
           <div className="inline-flex items-center gap-1 text-xs opacity-70">
-            <ChevronDown className="h-3 w-3" /> <span>Project:</span>{" "}
+            <ChevronDown className="h-3 w-3" /> <span>{browseMode === "flat" ? "Flat:" : "Project:"}</span>{" "}
             <span className="font-medium">{scopeLabel ?? "—"}</span>
+            {browseMode === "grouped" && scopeBadge ? (
+              <span
+                className="inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold leading-none"
+                style={{
+                  background: "color-mix(in oklab, var(--accent) 12%, transparent)",
+                  borderColor: "color-mix(in oklab, var(--accent-strong) 18%, var(--panel-border))",
+                  color: "var(--accent-strong)",
+                }}
+              >
+                {scopeBadge}
+              </span>
+            ) : null}
           </div>
           {onNewChat && (
             <button type="button" className="icon-inline" onClick={onNewChat}>
@@ -179,6 +212,12 @@ function ThreadPreviewList({
             thread={t}
             active={t.id === activeId}
             isDarkMode={isDarkMode}
+            browseMode={browseMode}
+            projectPresentation={
+              projectPresentationsById && t.projectId != null
+                ? projectPresentationsById.get(String(t.projectId)) ?? null
+                : null
+            }
             onSelect={onSelect}
             rectH={rectH}
             onRename={onRename}
@@ -201,6 +240,8 @@ function ThreadTileRow({
   thread,
   active,
   isDarkMode,
+  browseMode,
+  projectPresentation,
   onSelect,
   rectH = 60,
   className,
@@ -211,6 +252,8 @@ function ThreadTileRow({
   thread: Thread;
   active: boolean;
   isDarkMode: boolean;
+  browseMode: BrowseMode;
+  projectPresentation?: ProjectPresentation | null;
   onSelect: (id: string) => void;
   rectH?: number;
   className?: string;
@@ -367,11 +410,58 @@ function ThreadTileRow({
         ? false
         : heuristicCloud;
 
-  const safeTitle = (thread.title || "").trim() || "Untitled";
+  const presentation = getThreadPresentation(thread);
+  const safeTitle = presentation.label || (thread.title || "").trim() || "Untitled";
+  const flatProjectPresentation =
+    browseMode === "flat" ? (projectPresentation ?? null) : null;
+  const provenanceBadge = presentation.badge ? (
+    <span
+      data-testid={`thread-badge-${String(thread.id)}`}
+      className="inline-flex shrink-0 items-center rounded-full border px-1.5 py-0.5 text-[10px] font-semibold leading-none"
+      style={{
+        background: "color-mix(in oklab, var(--accent) 12%, transparent)",
+        borderColor: "color-mix(in oklab, var(--accent-strong) 18%, var(--panel-border))",
+        color: "var(--accent-strong)",
+      }}
+    >
+      {presentation.badge}
+    </span>
+  ) : null;
+  const projectBadge = flatProjectPresentation ? (
+    <span
+      data-testid={`thread-project-${String(thread.id)}`}
+      className="inline-flex shrink-0 items-center rounded-full border px-1.5 py-0.5 text-[10px] font-semibold leading-none"
+      style={{
+        background: "color-mix(in oklab, var(--panel-sheet) 72%, transparent)",
+        borderColor: "color-mix(in oklab, var(--panel-border) 80%, transparent)",
+        color: "var(--muted)",
+      }}
+      title={flatProjectPresentation.rawName}
+    >
+      {flatProjectPresentation.label}
+    </span>
+  ) : null;
+  const projectProvenanceBadge = browseMode === "flat" && flatProjectPresentation?.badge ? (
+    <span
+      data-testid={`thread-project-badge-${String(thread.id)}`}
+      className="inline-flex shrink-0 items-center rounded-full border px-1.5 py-0.5 text-[10px] font-semibold leading-none"
+      style={{
+        background: "color-mix(in oklab, var(--accent) 10%, transparent)",
+        borderColor: "color-mix(in oklab, var(--panel-border) 80%, transparent)",
+        color: "var(--muted)",
+      }}
+      title={flatProjectPresentation.rawName}
+    >
+      {flatProjectPresentation.badge}
+    </span>
+  ) : null;
   const titleNode = (
-    <span key="title" className="thread-title block truncate" title={safeTitle}>
-      <span className="inline-flex items-center gap-1 truncate">
+    <span key="title" className="thread-title block truncate" title={presentation.rawTitle}>
+      <span className="inline-flex min-w-0 items-center gap-1 truncate">
         <span className="truncate">{safeTitle}</span>
+        {provenanceBadge}
+        {projectBadge}
+        {projectProvenanceBadge}
         {isCloud ? (
           <span
             className="inline-flex items-center justify-center rounded-full text-[10px] px-1.5 py-0.5"
@@ -421,7 +511,10 @@ function ThreadTileRow({
         type="button"
         onClick={() => onSelect(thread.id)}
         data-testid={`thread-tile-${thread.id}`}
-        className="thread-preview w-full text-left text-[var(--text)] transition-transform duration-150 ease-out hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-strong)] dark:text-white"
+        className={clsx(
+          "thread-preview w-full text-left text-[var(--text)] transition-transform duration-150 ease-out hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-strong)] dark:text-white",
+          browseMode === "flat" && "thread-preview--flat"
+        )}
         borderColor={active ? highlightBorder : undefined}
         style={tileStyle}
       >

--- a/frontend/src/components/sidebar/__tests__/ProjectList.test.tsx
+++ b/frontend/src/components/sidebar/__tests__/ProjectList.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+
+import ProjectList from "../ProjectList";
+
+describe("ProjectList presentation", () => {
+  it("renders clean project labels while preserving provenance badges", () => {
+    render(
+      <ProjectList
+        projects={[
+          { id: "1", name: "ChatGPT: Recovery Sprint", icon: "🗂️" },
+          { id: "2", name: "Imports", icon: "📁" },
+        ]}
+        search=""
+        currentId={null}
+        onPick={vi.fn()}
+      />
+    );
+
+    const recoveryButton = screen.getByRole("button", { name: /Recovery Sprint/ });
+    const generalButton = screen.getByRole("button", { name: /General/ });
+
+    expect(screen.getByText("Recovery Sprint")).toBeInTheDocument();
+    expect(screen.queryByText("ChatGPT: Recovery Sprint")).not.toBeInTheDocument();
+    expect(within(recoveryButton).getByText("ChatGPT")).toBeVisible();
+    expect(within(generalButton).getByText("Imported")).toBeVisible();
+  });
+});

--- a/frontend/src/components/sidebar/__tests__/SidebarRoot.test.tsx
+++ b/frontend/src/components/sidebar/__tests__/SidebarRoot.test.tsx
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+
+import SidebarRoot from "../SidebarRoot";
+import type { Thread } from "@/types/ui";
+
+const mockSetScope = vi.fn();
+const mockSidebarState = vi.hoisted(() => ({
+  currentProjectId: "imports-1" as string | null,
+}));
+const mockProjectsState = vi.hoisted(() => ({
+  list: [
+    { id: "imports-1", name: "Imports", icon: "📁" },
+    { id: "proj-1", name: "ChatGPT: Recovery Sprint", icon: "🗂️" },
+  ],
+}));
+
+function createThread(id: string, overrides: Partial<Thread> = {}): Thread {
+  return {
+    id,
+    title: `Thread ${id}`,
+    lastMessage: "",
+    unread: 0,
+    participants: [],
+    messages: [],
+    ...overrides,
+  };
+}
+
+vi.mock("../useSidebarThreads", () => ({
+  default: () => ({
+    threads: [
+      createThread("thread-1", {
+        title: "ChatGPT: Draft agenda",
+        lastMessage: "Imported thread",
+        projectId: "imports-1",
+        metadata: { import_source: "chatgpt" },
+      }),
+      createThread("thread-2", {
+        title: "ChatGPT: Loose note",
+        lastMessage: "Loose fallback",
+        projectId: null,
+        metadata: { import_source: "chatgpt" },
+      }),
+      createThread("thread-3", {
+        title: "Project sync",
+        lastMessage: "Project thread",
+        projectId: "proj-1",
+      }),
+    ],
+    displayThreads: [
+      createThread("thread-1", {
+        title: "ChatGPT: Draft agenda",
+        lastMessage: "Imported thread",
+        projectId: "imports-1",
+        metadata: { import_source: "chatgpt" },
+      }),
+      createThread("thread-2", {
+        title: "ChatGPT: Loose note",
+        lastMessage: "Loose fallback",
+        projectId: null,
+        metadata: { import_source: "chatgpt" },
+      }),
+    ],
+    scopeLabel: "General",
+    currentProjectId: mockSidebarState.currentProjectId,
+    setScope: mockSetScope,
+    renameThread: vi.fn(),
+    toggleArchiveThread: vi.fn(),
+    deleteThread: vi.fn(),
+    looseCount: 1,
+  }),
+}));
+
+vi.mock("../useProjectsCache", () => ({
+  default: () => ({
+    projectList: mockProjectsState.list,
+    setProjectList: vi.fn(),
+    refreshProjectsFromServer: vi.fn(),
+    looseCount: 1,
+  }),
+}));
+
+vi.mock("@/contexts/LegacyThreadsContext", () => ({
+  useLegacyThreads: () => ({
+    enabled: false,
+    open: vi.fn(),
+  }),
+}));
+
+describe("SidebarRoot rail modes", () => {
+  beforeEach(() => {
+    mockSetScope.mockReset();
+    window.localStorage.clear();
+  });
+
+  it("shows grouped projects, clean titles, and flat thread chips for recovered data", () => {
+    render(
+      <SidebarRoot
+        threads={[]}
+        activeId={null}
+        onSelect={vi.fn()}
+        onNewChat={vi.fn()}
+      />
+    );
+
+    const groupedTab = screen.getByRole("tab", { name: "Grouped" });
+    const flatTab = screen.getByRole("tab", { name: "Flat" });
+
+    expect(groupedTab).toHaveAttribute("data-state", "active");
+    expect(screen.getByText("Projects")).toBeVisible();
+    expect(screen.getByText("Threads")).toBeVisible();
+
+    const recoveryProject = screen.getByText("Recovery Sprint", {
+      selector: ".project-tile__label",
+    }).closest("button");
+    const generalProject = screen.getByText("General", {
+      selector: ".project-tile__label",
+    }).closest("button");
+    if (!recoveryProject || !generalProject) {
+      throw new Error("Expected project tiles to be present");
+    }
+    expect(within(recoveryProject).getByText("ChatGPT")).toBeVisible();
+    expect(within(generalProject).getByText("Imported")).toBeVisible();
+    expect(screen.getByText("Recovery Sprint")).toBeVisible();
+    expect(screen.queryByText("ChatGPT: Recovery Sprint")).not.toBeInTheDocument();
+
+    expect(screen.getByText("Draft agenda")).toBeVisible();
+    expect(screen.getByTestId("thread-badge-thread-1")).toHaveTextContent("ChatGPT");
+
+    fireEvent.click(flatTab);
+
+    expect(flatTab).toHaveAttribute("data-state", "active");
+    expect(screen.queryByText("Projects")).not.toBeInTheDocument();
+    expect(screen.getByText("Flat:")).toBeVisible();
+    expect(screen.getByTestId("thread-project-thread-3")).toHaveTextContent(
+      "Recovery Sprint"
+    );
+    expect(screen.getByTestId("thread-project-thread-1")).toHaveTextContent("General");
+    expect(screen.getByTestId("thread-project-badge-thread-1")).toHaveTextContent(
+      "Imported"
+    );
+  });
+});

--- a/frontend/src/components/sidebar/__tests__/ThreadList.test.tsx
+++ b/frontend/src/components/sidebar/__tests__/ThreadList.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 
 import ThreadList from "../ThreadList";
+import type { ProjectPresentation } from "../sidebarPresentation";
 import type { Thread } from "@/types/ui";
 
 function createThread(overrides: Partial<Thread> = {}): Thread {
@@ -16,12 +17,24 @@ function createThread(overrides: Partial<Thread> = {}): Thread {
   };
 }
 
-function renderThreadList(overrides: Partial<Thread> = {}, activeId: string | null = null) {
+function renderThreadList(
+  overrides: Partial<Thread> = {},
+  activeId: string | null = null,
+  options: {
+    browseMode?: "grouped" | "flat";
+    projectPresentationsById?: Map<string, ProjectPresentation>;
+    scopeLabel?: string;
+    scopeBadge?: string | null;
+  } = {}
+) {
   return render(
     <ThreadList
       threads={[createThread(overrides)]}
       activeId={activeId}
-      scopeLabel="General"
+      scopeLabel={options.scopeLabel ?? "General"}
+      scopeBadge={options.scopeBadge ?? null}
+      browseMode={options.browseMode}
+      projectPresentationsById={options.projectPresentationsById}
       onSelect={vi.fn()}
       onNewChat={vi.fn()}
       onRename={vi.fn().mockResolvedValue(undefined)}
@@ -70,5 +83,38 @@ describe("ThreadList dark mode surface contract", () => {
     expect(screen.getByText("Project:")).toBeInTheDocument();
     expect(screen.getByText("General")).toBeInTheDocument();
     expect(screen.queryByText("Scope:")).not.toBeInTheDocument();
+  });
+
+  it("cleans visible thread titles and keeps project context visible in flat mode", () => {
+    renderThreadList(
+      {
+        title: "ChatGPT: Draft brief",
+        metadata: { import_source: "chatgpt" },
+        projectId: "proj-1",
+      },
+      null,
+      {
+        browseMode: "flat",
+        scopeLabel: "All threads",
+        projectPresentationsById: new Map<string, ProjectPresentation>([
+          [
+            "proj-1",
+            {
+              label: "Recovery Sprint",
+              badge: null,
+              rawName: "ChatGPT: Recovery Sprint",
+              isFallback: false,
+            },
+          ],
+        ]),
+      }
+    );
+
+    expect(screen.getByText("Draft brief")).toBeInTheDocument();
+    expect(screen.getByText("ChatGPT")).toBeInTheDocument();
+    expect(screen.getByTestId("thread-project-thread-1")).toHaveTextContent(
+      "Recovery Sprint"
+    );
+    expect(screen.queryByText("ChatGPT: Draft brief")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/sidebar/__tests__/useProjectsCache.test.tsx
+++ b/frontend/src/components/sidebar/__tests__/useProjectsCache.test.tsx
@@ -43,4 +43,20 @@ describe("useProjectsCache", () => {
 
     await waitFor(() => expect(api.get).toHaveBeenCalledTimes(1));
   });
+
+  it("treats Imports as the canonical general project when it is the only fallback bucket", async () => {
+    (api.get as any).mockResolvedValueOnce({
+      data: {
+        projects: [{ id: 1, name: "Imports", icon: "📁" }],
+      },
+    });
+
+    render(<ProjectsHarness />);
+
+    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(window.localStorage.getItem("cfy.generalProjectId")).toBe("1")
+    );
+    expect(window.localStorage.getItem("cfy.defaultProjectId")).toBe("1");
+  });
 });

--- a/frontend/src/components/sidebar/__tests__/useSidebarThreads.test.tsx
+++ b/frontend/src/components/sidebar/__tests__/useSidebarThreads.test.tsx
@@ -17,7 +17,11 @@ const mockApi = api as unknown as {
   delete: ReturnType<typeof vi.fn>;
 };
 
-function createThread(id: string, title?: string): Thread {
+function createThread(
+  id: string,
+  title?: string,
+  overrides: Partial<Thread> = {}
+): Thread {
   return {
     id,
     title: title ?? `Thread ${id}`,
@@ -25,6 +29,7 @@ function createThread(id: string, title?: string): Thread {
     unread: 0,
     participants: [],
     messages: [],
+    ...overrides,
   };
 }
 
@@ -127,5 +132,30 @@ describe("useSidebarThreads delete flow", () => {
       )
     ).toBe(true);
     toastCapture.cleanup();
+  });
+
+  it("treats Imports as the General fallback scope when resolving sidebar threads", () => {
+    const threads = [
+      createThread("11", "Imported project thread", { projectId: "imports-1" }),
+      createThread("22", "Loose thread", { projectId: null }),
+      createThread("33", "Project thread", { projectId: "proj-1" }),
+    ];
+
+    const { result } = renderHook(() =>
+      useSidebarThreads({
+        initialThreads: threads,
+        projectId: "imports-1",
+        projects: [
+          { id: "imports-1", name: "Imports", icon: "📁" },
+          { id: "proj-1", name: "Project Alpha", icon: "📁" },
+        ],
+      })
+    );
+
+    expect(result.current.scopeLabel).toBe("General");
+    expect(result.current.displayThreads.map((thread) => thread.id)).toEqual([
+      "11",
+      "22",
+    ]);
   });
 });

--- a/frontend/src/components/sidebar/sidebarPresentation.ts
+++ b/frontend/src/components/sidebar/sidebarPresentation.ts
@@ -1,0 +1,132 @@
+import type { Thread } from "@/types/ui";
+
+type ProjectLike = {
+  id: string | number;
+  name?: unknown;
+};
+
+type ThreadLike = Pick<Thread, "title" | "metadata">;
+
+export type ProjectPresentation = {
+  label: string;
+  badge: string | null;
+  rawName: string;
+  isFallback: boolean;
+};
+
+export type ThreadPresentation = {
+  label: string;
+  badge: string | null;
+  rawTitle: string;
+};
+
+const GENERAL_LIKE_NAMES = new Set(["general", "loose threads", "imports"]);
+
+const CHATGPT_PREFIX_PATTERNS = [
+  /^(?:imported from\s+)?chatgpt(?:[\s:–—-]+|\s+)/i,
+  /^(?:chatgpt|imported from chatgpt)\s*[\-:–—()]+\s*/i,
+];
+
+function normalizeName(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+}
+
+export function isGeneralLikeProjectName(value: unknown): boolean {
+  return GENERAL_LIKE_NAMES.has(normalizeName(value));
+}
+
+export function pickCanonicalGeneralProject<T extends ProjectLike>(
+  projects: T[]
+): T | null {
+  if (!Array.isArray(projects) || projects.length === 0) {
+    return null;
+  }
+
+  const preferredNames = ["general", "loose threads", "imports"];
+  for (const preferredName of preferredNames) {
+    const match = projects.find(
+      (project) => normalizeName(project?.name) === preferredName
+    );
+    if (match) return match;
+  }
+
+  return projects.find((project) => isGeneralLikeProjectName(project?.name)) ?? null;
+}
+
+function stripChatGptPrefix(rawTitle: string): string {
+  let next = rawTitle.trim();
+  for (const pattern of CHATGPT_PREFIX_PATTERNS) {
+    const stripped = next.replace(pattern, "").trim();
+    if (stripped !== next) {
+      next = stripped;
+    }
+  }
+  return next || rawTitle.trim();
+}
+
+function normalizeMetadata(metadata: unknown): Record<string, unknown> | null {
+  return metadata && typeof metadata === "object"
+    ? (metadata as Record<string, unknown>)
+    : null;
+}
+
+function getImportedProvenanceLabel(
+  metadata: Record<string, unknown> | null,
+  rawTitle: string
+): string | null {
+  const importSource = normalizeName(
+    metadata?.import_source ?? metadata?.source ?? metadata?.origin
+  );
+  const hasChatGptMetadata =
+    importSource.includes("chatgpt") ||
+    metadata?.source_thread_id != null ||
+    metadata?.source_conversation_template_id != null ||
+    metadata?.source_gizmo_id != null ||
+    metadata?.source_gizmo_type != null;
+
+  if (hasChatGptMetadata) {
+    return "ChatGPT";
+  }
+
+  return CHATGPT_PREFIX_PATTERNS.some((pattern) => pattern.test(rawTitle))
+    ? "ChatGPT"
+    : null;
+}
+
+export function getProjectPresentation(name: unknown): ProjectPresentation {
+  const rawName = String(name ?? "").trim() || "Untitled";
+  const normalized = normalizeName(rawName);
+
+  if (GENERAL_LIKE_NAMES.has(normalized)) {
+    return {
+      label: "General",
+      badge: normalized === "imports" ? "Imported" : normalized === "loose threads" ? "Legacy" : null,
+      rawName,
+      isFallback: true,
+    };
+  }
+
+  const stripped = stripChatGptPrefix(rawName);
+  return {
+    label: stripped || rawName,
+    badge: stripped !== rawName ? "ChatGPT" : null,
+    rawName,
+    isFallback: false,
+  };
+}
+
+export function getThreadPresentation(thread: ThreadLike): ThreadPresentation {
+  const rawTitle = String(thread?.title ?? "").trim() || "Untitled";
+  const metadata = normalizeMetadata(thread?.metadata);
+  const provenanceLabel = getImportedProvenanceLabel(metadata, rawTitle);
+  const label = stripChatGptPrefix(rawTitle);
+
+  return {
+    label: label || "Untitled",
+    badge: provenanceLabel,
+    rawTitle,
+  };
+}

--- a/frontend/src/components/sidebar/useProjectsCache.ts
+++ b/frontend/src/components/sidebar/useProjectsCache.ts
@@ -6,6 +6,9 @@ import api from "@/lib/api";
 import type { Project } from "@/types/common";
 import type { Thread } from "@/types/ui";
 import { logOnce } from "@/lib/logging/logOnce";
+import {
+  pickCanonicalGeneralProject,
+} from "./sidebarPresentation";
 
 type UseProjectsCacheOptions = {
   initialProjects?: Project[];
@@ -163,9 +166,7 @@ export function useProjectsCache({
   }, [projectList]);
 
   useEffect(() => {
-    const defaultProject = projectList.find((project) =>
-      isDefaultAliasName(project?.name)
-    );
+    const defaultProject = pickCanonicalGeneralProject(projectList);
     if (!defaultProject?.id) return;
     try {
       if (typeof window === "undefined") return;

--- a/frontend/src/components/sidebar/useSidebarThreads.ts
+++ b/frontend/src/components/sidebar/useSidebarThreads.ts
@@ -5,6 +5,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import api from "@/lib/api";
 import type { Project } from "@/types/common";
 import type { Thread } from "@/types/ui";
+import {
+  isGeneralLikeProjectName,
+} from "./sidebarPresentation";
 
 type UseSidebarThreadsOptions = {
   initialThreads: Thread[];
@@ -359,41 +362,36 @@ export function useSidebarThreads({
   );
 
   const currentProjectId = onProjectChange ? (projectId ?? null) : localProjectId;
-  const generalProjectId = useMemo(() => {
-    const fromProjects = projects.find((project) => isDefaultAliasName(project?.name));
-    if (fromProjects?.id != null) {
-      return String(fromProjects.id);
+  const generalProjectIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const project of projects) {
+      if (isGeneralLikeProjectName(project?.name) && project?.id != null) {
+        ids.add(String(project.id));
+      }
     }
-    return readStoredGeneralProjectId();
+    const stored = readStoredGeneralProjectId();
+    if (stored) {
+      ids.add(stored);
+    }
+    return ids;
   }, [projects]);
 
   const scopedThreads = useMemo(() => {
-    const includesUnassignedAndGeneral = (scopeId: string | null): boolean => {
-      if (!scopeId) return false;
-      if (!generalProjectId) return false;
-      return String(scopeId) === String(generalProjectId);
+    const includesGeneralScope = (scopeId: string | null): boolean => {
+      if (!scopeId) return true;
+      return generalProjectIds.has(String(scopeId));
     };
 
-    const base =
-      currentProjectId === null
-        ? threadList.filter((t) => {
-            if (!t.projectId) return true;
-            if (!generalProjectId) return false;
-            return String(t.projectId) === String(generalProjectId);
-          })
-        : currentProjectId
-        ? includesUnassignedAndGeneral(currentProjectId)
-          ? threadList.filter(
-              (t) =>
-                !t.projectId
-                || String(t.projectId ?? "") === String(currentProjectId)
-            )
-          : threadList.filter(
-              (t) => String(t.projectId ?? "") === String(currentProjectId)
-            )
-        : threadList;
+    const base = includesGeneralScope(currentProjectId)
+      ? threadList.filter((t) => {
+          if (!t.projectId) return true;
+          return generalProjectIds.has(String(t.projectId));
+        })
+      : threadList.filter(
+          (t) => String(t.projectId ?? "") === String(currentProjectId)
+        );
     return base.filter((t) => !t.archivedAt);
-  }, [currentProjectId, generalProjectId, threadList]);
+  }, [currentProjectId, generalProjectIds, threadList]);
 
   const displayThreads = useMemo(() => {
     const titleMap = stableTitleRef.current;
@@ -416,12 +414,13 @@ export function useSidebarThreads({
 
   const scopeLabel = useMemo(() => {
     if (currentProjectId === null) return "General";
+    if (generalProjectIds.has(String(currentProjectId))) return "General";
     if (currentProjectId) {
       const proj = projects.find((p) => String(p.id) === String(currentProjectId));
       return proj?.name ?? "Project";
     }
     return "All";
-  }, [currentProjectId, projects]);
+  }, [currentProjectId, generalProjectIds, projects]);
 
   const looseCount = useMemo(() => threadList.filter((t) => !t.projectId).length, [threadList]);
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -170,6 +170,18 @@ textarea:disabled::placeholder {
   opacity: 0.7;
 }
 
+.thread-preview--flat .fc-inner > div {
+  gap: 0.3rem;
+}
+
+.thread-preview--flat .thread-title {
+  font-weight: 550;
+}
+
+.thread-preview--flat .thread-snippet {
+  opacity: 0.62;
+}
+
 .project-tile {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
