### PR TITLE
Implement local Persona Studio draft persistence

### DIFF
--- a/frontend/src/features/personaStudio/PersonaStudioPage.tsx
+++ b/frontend/src/features/personaStudio/PersonaStudioPage.tsx
@@ -723,6 +723,7 @@ export default function PersonaStudioPage() {
     selectedProfileId,
     activeTab,
     selectedProfile,
+    selectedSavedProfile,
     isDirty,
     hasSavedVersion,
     setSelectedProfileId,
@@ -863,6 +864,8 @@ export default function PersonaStudioPage() {
             role="region"
             aria-label="Persona Studio editor"
             data-testid="persona-studio-editor"
+            data-saved-profile-id={selectedSavedProfile?.id ?? ""}
+            data-draft-state={isDirty ? "dirty" : "clean"}
             style={{
               background: "color-mix(in srgb, var(--panel-bg) 98%, transparent)",
               borderColor: "color-mix(in oklab, var(--accent-strong) 18%, var(--panel-border))",

--- a/frontend/src/features/personaStudio/__tests__/PersonaStudioPage.persistence.test.tsx
+++ b/frontend/src/features/personaStudio/__tests__/PersonaStudioPage.persistence.test.tsx
@@ -4,96 +4,143 @@ import userEvent from "@testing-library/user-event";
 import React from "react";
 
 import PersonaStudioPage from "../PersonaStudioPage";
+import {
+  createPersonaStudioSeedState,
+  persistPersonaStudioLocalState,
+} from "../personaStudioStore";
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function seedCodeAssistantPersonaState() {
+  const state = createPersonaStudioSeedState();
+  const profile = state.profiles.find((candidate) => candidate.id === "profile-2");
+
+  if (!profile) {
+    throw new Error("Missing persona studio seed profile-2");
+  }
+
+  const savedDescription = "Saved profile description";
+  const savedProfile = {
+    ...profile,
+    name: "Code Assistant Saved",
+    description: savedDescription,
+    config: {
+      ...profile.config,
+      identity: {
+        ...profile.config.identity,
+        name: "Code Assistant Saved",
+        description: savedDescription,
+      },
+    },
+  };
+
+  state.profiles = state.profiles.map((candidate) =>
+    candidate.id === profile.id ? savedProfile : candidate
+  );
+  state.draftProfilesById = {
+    ...state.draftProfilesById,
+    [profile.id]: clone(savedProfile),
+  };
+  state.selectedProfileId = profile.id;
+  state.activeTab = "Identity";
+
+  persistPersonaStudioLocalState(state);
+}
 
 beforeEach(() => {
   window.localStorage.clear();
 });
 
 describe("Persona Studio persistence", () => {
-  it("persists the selected profile, active tab, and draft edits across remounts", async () => {
-    const user = userEvent.setup();
-    const { unmount } = render(<PersonaStudioPage />);
+  it("renders saved persona state, preserves drafts across tab changes, and round-trips save/reset", async () => {
+    seedCodeAssistantPersonaState();
 
-    await user.click(screen.getByRole("button", { name: /code assistant/i }));
+    const user = userEvent.setup();
+    render(<PersonaStudioPage />);
+
+    expect(
+      screen.getByRole("heading", { name: "Code Assistant Saved" })
+    ).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Code Assistant Saved")).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue("Saved profile description")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Saved Locally")).toBeInTheDocument();
+    expect(screen.getByText(/"name": "Code Assistant Saved"/)).toBeInTheDocument();
 
     const nameInput = screen.getByPlaceholderText(/enter persona name/i);
     await user.clear(nameInput);
     await user.type(nameInput, "Code Assistant Draft");
 
-    const descriptionInput = screen.getByPlaceholderText(/describe this persona/i);
-    await user.clear(descriptionInput);
-    await user.type(descriptionInput, "Persisted draft description");
+    expect(screen.getByDisplayValue("Code Assistant Draft")).toBeInTheDocument();
+    expect(screen.getByText("Unsaved Draft")).toBeInTheDocument();
+    expect(screen.getByText(/"name": "Code Assistant Draft"/)).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /model/i }));
-
-    unmount();
-    render(<PersonaStudioPage />);
-
-    expect(
-      screen.getByRole("heading", { name: "Code Assistant Draft" })
-    ).toBeInTheDocument();
-    expect(screen.getByText("Provider")).toBeInTheDocument();
-    expect(screen.queryByPlaceholderText(/enter persona name/i)).not.toBeInTheDocument();
-
     await user.click(screen.getByRole("button", { name: /identity/i }));
 
     expect(screen.getByDisplayValue("Code Assistant Draft")).toBeInTheDocument();
-    expect(
-      screen.getByDisplayValue("Persisted draft description")
-    ).toBeInTheDocument();
-  });
-
-  it("resets to the built-in seed before the first save and to the last saved local snapshot after save", async () => {
-    const user = userEvent.setup();
-    render(<PersonaStudioPage />);
-
-    await user.click(screen.getByRole("button", { name: /code assistant/i }));
-
-    const nameInput = screen.getByPlaceholderText(/enter persona name/i);
-    await user.clear(nameInput);
-    await user.type(nameInput, "Transient Draft");
-
-    await user.click(screen.getByRole("button", { name: /^reset$/i }));
-
-    expect(screen.getByRole("heading", { name: "Code Assistant" })).toBeInTheDocument();
-    expect(screen.getByDisplayValue("Code Assistant")).toBeInTheDocument();
-
-    const savedNameInput = screen.getByPlaceholderText(/enter persona name/i);
-    await user.clear(savedNameInput);
-    await user.type(savedNameInput, "Saved Draft");
+    expect(screen.getByText("Unsaved Draft")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /^save$/i }));
 
-    const editedNameInput = screen.getByPlaceholderText(/enter persona name/i);
-    await user.clear(editedNameInput);
-    await user.type(editedNameInput, "Unsaved Draft");
+    expect(screen.getByText("Saved Locally")).toBeInTheDocument();
+    expect(screen.queryByText("Unsaved Draft")).not.toBeInTheDocument();
+
+    await user.clear(screen.getByDisplayValue("Code Assistant Draft"));
+    await user.type(screen.getByPlaceholderText(/enter persona name/i), "Code Assistant Reset Candidate");
+
+    expect(screen.getByText("Unsaved Draft")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /^reset$/i }));
 
-    expect(screen.getByDisplayValue("Saved Draft")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Code Assistant Draft")).toBeInTheDocument();
+    expect(screen.getByText("Saved Locally")).toBeInTheDocument();
+    expect(screen.queryByText("Unsaved Draft")).not.toBeInTheDocument();
   });
 
-  it("restores the local seed workspace when resetting all persona studio data", async () => {
+  it("duplicates the current draft into a new persona and leaves the original saved profile intact", async () => {
+    seedCodeAssistantPersonaState();
+
     const user = userEvent.setup();
     render(<PersonaStudioPage />);
 
-    await user.click(screen.getByRole("button", { name: /code assistant/i }));
-
     const nameInput = screen.getByPlaceholderText(/enter persona name/i);
     await user.clear(nameInput);
-    await user.type(nameInput, "Reset All Draft");
+    await user.type(nameInput, "Code Assistant Working");
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
 
-    await user.click(screen.getByRole("button", { name: /model/i }));
+    expect(screen.getByText("Saved Locally")).toBeInTheDocument();
 
-    await user.click(
-      screen.getByRole("button", {
-        name: /reset all local persona studio data/i,
-      })
-    );
+    await user.click(screen.getByRole("button", { name: /save as new/i }));
 
-    expect(screen.getByRole("heading", { name: "Guardian Default" })).toBeInTheDocument();
-    expect(screen.getByDisplayValue("Guardian Default")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /identity/i })).toBeInTheDocument();
-    expect(screen.queryByText("Provider")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Code Assistant Working Copy" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /code assistant working copy/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /code assistant working(?! copy)/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Saved Locally")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /code assistant working(?! copy)/i }));
+
+    expect(
+      screen.getByRole("heading", { name: "Code Assistant Working" })
+    ).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Code Assistant Working")).toBeInTheDocument();
+  });
+
+  it("does not render chat composer or message thread UI", () => {
+    render(<PersonaStudioPage />);
+
+    expect(screen.queryByTestId("composer-shell")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("composer-input")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("chat-conversation-lane")).not.toBeInTheDocument();
+    expect(screen.queryByText(/message thread/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/personaStudio/personaStudioStore.ts
+++ b/frontend/src/features/personaStudio/personaStudioStore.ts
@@ -80,9 +80,9 @@ export type EditorTab =
 
 export type PersonaStudioLocalState = {
   profiles: PersonaProfileDraft[];
+  draftProfilesById: Record<string, PersonaProfileDraft>;
   selectedProfileId: string;
   activeTab: EditorTab;
-  lastSavedProfiles: Record<string, PersonaProfileDraft>;
 };
 
 export const PERSONA_STUDIO_STORAGE_KEY = "cfy.personaStudio.localState.v1";
@@ -432,6 +432,33 @@ function normalizePersonaProfileDraft(
   };
 }
 
+function normalizePersonaProfileArray(
+  value: unknown,
+  fallbackProfiles: PersonaProfileDraft[]
+): PersonaProfileDraft[] {
+  if (!Array.isArray(value)) return clone(fallbackProfiles);
+
+  const nextProfiles: PersonaProfileDraft[] = [];
+  const seenProfileIds = new Set<string>();
+
+  for (const profileValue of value) {
+    const fallbackId =
+      isRecord(profileValue) && typeof profileValue.id === "string"
+        ? profileValue.id
+        : fallbackProfiles[0]?.id ?? PERSONA_STUDIO_SEED_PROFILES[0]?.id ?? "";
+    const normalized = normalizePersonaProfileDraft(
+      profileValue,
+      getSeedProfileReference(fallbackId)
+    );
+
+    if (seenProfileIds.has(normalized.id)) continue;
+    seenProfileIds.add(normalized.id);
+    nextProfiles.push(normalized);
+  }
+
+  return nextProfiles.length > 0 ? nextProfiles : clone(fallbackProfiles);
+}
+
 function getSeedProfileReference(profileId?: string | null): PersonaProfileDraft {
   return (
     PERSONA_STUDIO_SEED_PROFILES.find((profile) => profile.id === profileId) ??
@@ -489,32 +516,59 @@ function getSeedProfileReference(profileId?: string | null): PersonaProfileDraft
   );
 }
 
+function createPersonaProfileMap(
+  profiles: PersonaProfileDraft[]
+): Record<string, PersonaProfileDraft> {
+  return Object.fromEntries(
+    profiles.map((profile) => [profile.id, cloneProfile(profile)])
+  );
+}
+
+function createDefaultCopyName(
+  sourceName: string,
+  existingProfiles: PersonaProfileDraft[]
+): string {
+  const baseName = sourceName.trim() || "Persona";
+  const normalizedBase = baseName.replace(/\s+Copy(?:\s+\d+)?$/i, "");
+  const existingNames = new Set(existingProfiles.map((profile) => profile.name));
+
+  let candidate = `${normalizedBase} Copy`;
+  let copyIndex = 2;
+
+  while (existingNames.has(candidate)) {
+    candidate = `${normalizedBase} Copy ${copyIndex}`;
+    copyIndex += 1;
+  }
+
+  return candidate;
+}
+
 function normalizePersonaStudioLocalState(
   value: unknown
 ): PersonaStudioLocalState {
   if (!isRecord(value)) return createPersonaStudioSeedState();
 
   const rawProfiles = Array.isArray(value.profiles) ? value.profiles : [];
-  const nextProfiles: PersonaProfileDraft[] = [];
-  const seenProfileIds = new Set<string>();
+  const rawDraftProfilesById = isRecord(value.draftProfilesById)
+    ? value.draftProfilesById
+    : null;
+  const rawLegacySavedProfiles = isRecord(value.lastSavedProfiles)
+    ? value.lastSavedProfiles
+    : null;
 
-  for (const profileValue of rawProfiles) {
-    const fallbackId =
-      isRecord(profileValue) && typeof profileValue.id === "string"
-        ? profileValue.id
-        : PERSONA_STUDIO_SEED_PROFILES[0]?.id ?? "";
-    const normalized = normalizePersonaProfileDraft(
-      profileValue,
-      getSeedProfileReference(fallbackId)
-    );
+  const profileSource =
+    rawProfiles.length > 0
+      ? rawProfiles
+      : rawDraftProfilesById && Object.keys(rawDraftProfilesById).length > 0
+        ? Object.values(rawDraftProfilesById)
+        : rawLegacySavedProfiles && Object.keys(rawLegacySavedProfiles).length > 0
+          ? Object.values(rawLegacySavedProfiles)
+          : PERSONA_STUDIO_SEED_PROFILES;
 
-    if (seenProfileIds.has(normalized.id)) continue;
-    seenProfileIds.add(normalized.id);
-    nextProfiles.push(normalized);
-  }
-
-  const profiles =
-    nextProfiles.length > 0 ? nextProfiles : clone(PERSONA_STUDIO_SEED_PROFILES);
+  const profiles = normalizePersonaProfileArray(
+    profileSource,
+    PERSONA_STUDIO_SEED_PROFILES
+  );
   const profilesById = new Map(profiles.map((profile) => [profile.id, profile]));
 
   const selectedProfileId =
@@ -522,19 +576,47 @@ function normalizePersonaStudioLocalState(
       ? value.selectedProfileId
       : profiles[0]?.id ?? PERSONA_STUDIO_SEED_PROFILES[0]?.id ?? "";
 
-  const lastSavedProfiles: Record<string, PersonaProfileDraft> = {};
-  if (isRecord(value.lastSavedProfiles)) {
-    for (const [profileId, savedValue] of Object.entries(value.lastSavedProfiles)) {
-      const fallback = profilesById.get(profileId) ?? getSeedProfileReference(profileId);
-      lastSavedProfiles[profileId] = normalizePersonaProfileDraft(savedValue, fallback);
+  if (rawDraftProfilesById) {
+    const draftProfilesById: Record<string, PersonaProfileDraft> = {};
+
+    for (const profile of profiles) {
+      draftProfilesById[profile.id] = normalizePersonaProfileDraft(
+        rawDraftProfilesById[profile.id],
+        profile
+      );
     }
+
+    return {
+      profiles,
+      draftProfilesById,
+      selectedProfileId,
+      activeTab: normalizeEditorTab(value.activeTab) ?? "Identity",
+    };
+  }
+
+  if (rawLegacySavedProfiles) {
+    const draftProfilesById = createPersonaProfileMap(profiles);
+    const savedProfiles = profiles.map((profile) => {
+      const fallback = getSeedProfileReference(profile.id);
+      return normalizePersonaProfileDraft(
+        rawLegacySavedProfiles[profile.id] ?? fallback,
+        fallback
+      );
+    });
+
+    return {
+      profiles: savedProfiles,
+      draftProfilesById,
+      selectedProfileId,
+      activeTab: normalizeEditorTab(value.activeTab) ?? "Identity",
+    };
   }
 
   return {
     profiles,
+    draftProfilesById: createPersonaProfileMap(profiles),
     selectedProfileId,
     activeTab: normalizeEditorTab(value.activeTab) ?? "Identity",
-    lastSavedProfiles,
   };
 }
 
@@ -551,9 +633,9 @@ export function getPersonaStudioSeedProfile(
 export function createPersonaStudioSeedState(): PersonaStudioLocalState {
   return {
     profiles: clone(PERSONA_STUDIO_SEED_PROFILES),
+    draftProfilesById: createPersonaProfileMap(PERSONA_STUDIO_SEED_PROFILES),
     selectedProfileId: PERSONA_STUDIO_SEED_PROFILES[0]?.id ?? "",
     activeTab: "Identity",
-    lastSavedProfiles: {},
   };
 }
 
@@ -621,13 +703,16 @@ export function usePersonaStudioLocalDraftState() {
   }, [state]);
 
   const selectedProfile = useMemo(
-    () => state.profiles.find((profile) => profile.id === state.selectedProfileId) ?? null,
-    [state.profiles, state.selectedProfileId]
+    () =>
+      state.draftProfilesById[state.selectedProfileId] ??
+      state.profiles.find((profile) => profile.id === state.selectedProfileId) ??
+      null,
+    [state.draftProfilesById, state.profiles, state.selectedProfileId]
   );
 
   const selectedSavedProfile = useMemo(
-    () => state.lastSavedProfiles[state.selectedProfileId] ?? null,
-    [state.lastSavedProfiles, state.selectedProfileId]
+    () => state.profiles.find((profile) => profile.id === state.selectedProfileId) ?? null,
+    [state.profiles, state.selectedProfileId]
   );
 
   const seedProfile = useMemo(
@@ -636,14 +721,18 @@ export function usePersonaStudioLocalDraftState() {
   );
 
   const isDirty = selectedProfile
-    ? !sameProfileDraft(selectedProfile, selectedSavedProfile ?? seedProfile)
+    ? !sameProfileDraft(selectedProfile, selectedSavedProfile)
     : false;
 
   const hasSavedVersion = Boolean(selectedSavedProfile);
 
   const setSelectedProfileId = useCallback((profileId: string) => {
     setState((previous) => {
-      if (!previous.profiles.some((profile) => profile.id === profileId)) {
+      const nextSelectedProfile = previous.profiles.find(
+        (profile) => profile.id === profileId
+      );
+
+      if (!nextSelectedProfile) {
         return previous;
       }
 
@@ -651,8 +740,19 @@ export function usePersonaStudioLocalDraftState() {
         return previous;
       }
 
+      if (previous.draftProfilesById[profileId]) {
+        return {
+          ...previous,
+          selectedProfileId: profileId,
+        };
+      }
+
       return {
         ...previous,
+        draftProfilesById: {
+          ...previous.draftProfilesById,
+          [profileId]: cloneProfile(nextSelectedProfile),
+        },
         selectedProfileId: profileId,
       };
     });
@@ -678,14 +778,17 @@ export function usePersonaStudioLocalDraftState() {
 
         if (!currentProfile) return previous;
 
-        const nextProfile = updater(currentProfile);
-        if (sameProfileDraft(nextProfile, currentProfile)) return previous;
+        const currentDraft =
+          previous.draftProfilesById[currentProfile.id] ?? cloneProfile(currentProfile);
+        const nextProfile = updater(cloneProfile(currentDraft));
+        if (sameProfileDraft(nextProfile, currentDraft)) return previous;
 
         return {
           ...previous,
-          profiles: previous.profiles.map((profile) =>
-            profile.id === currentProfile.id ? nextProfile : profile
-          ),
+          draftProfilesById: {
+            ...previous.draftProfilesById,
+            [currentProfile.id]: nextProfile,
+          },
         };
       });
     },
@@ -700,11 +803,22 @@ export function usePersonaStudioLocalDraftState() {
 
       if (!currentProfile) return previous;
 
+      const currentDraft =
+        previous.draftProfilesById[currentProfile.id] ?? cloneProfile(currentProfile);
+      const nextProfile = cloneProfile(currentDraft);
+
+      if (sameProfileDraft(nextProfile, currentProfile)) {
+        return previous;
+      }
+
       return {
         ...previous,
-        lastSavedProfiles: {
-          ...previous.lastSavedProfiles,
-          [currentProfile.id]: cloneProfile(currentProfile),
+        profiles: previous.profiles.map((profile) =>
+          profile.id === currentProfile.id ? nextProfile : profile
+        ),
+        draftProfilesById: {
+          ...previous.draftProfilesById,
+          [currentProfile.id]: cloneProfile(nextProfile),
         },
       };
     });
@@ -719,19 +833,30 @@ export function usePersonaStudioLocalDraftState() {
       if (!currentProfile) return previous;
 
       const nextId = createNextProfileId(previous.profiles);
-      const nextProfile = cloneProfile(currentProfile);
+      const currentDraft =
+        previous.draftProfilesById[currentProfile.id] ?? cloneProfile(currentProfile);
+      const nextProfile = cloneProfile(currentDraft);
       nextProfile.id = nextId;
-      nextProfile.name = `${currentProfile.name} (Copy)`;
+      nextProfile.name = createDefaultCopyName(currentDraft.name, previous.profiles);
+      nextProfile.description = currentDraft.description;
       nextProfile.isDefault = false;
+      nextProfile.config = {
+        ...nextProfile.config,
+        identity: {
+          ...nextProfile.config.identity,
+          name: nextProfile.name,
+          description: nextProfile.description,
+        },
+      };
 
       return {
         ...previous,
         profiles: [...previous.profiles, nextProfile],
-        selectedProfileId: nextId,
-        lastSavedProfiles: {
-          ...previous.lastSavedProfiles,
+        draftProfilesById: {
+          ...previous.draftProfilesById,
           [nextId]: cloneProfile(nextProfile),
         },
+        selectedProfileId: nextId,
       };
     });
   }, []);
@@ -744,17 +869,19 @@ export function usePersonaStudioLocalDraftState() {
 
       if (!currentProfile) return previous;
 
-      const fallbackProfile =
-        previous.lastSavedProfiles[currentProfile.id] ??
-        getPersonaStudioSeedProfile(currentProfile.id);
+      const nextProfile = cloneProfile(currentProfile);
+      const currentDraft = previous.draftProfilesById[currentProfile.id];
 
-      const nextProfile = cloneProfile(fallbackProfile);
+      if (sameProfileDraft(currentDraft, nextProfile)) {
+        return previous;
+      }
 
       return {
         ...previous,
-        profiles: previous.profiles.map((profile) =>
-          profile.id === currentProfile.id ? nextProfile : profile
-        ),
+        draftProfilesById: {
+          ...previous.draftProfilesById,
+          [currentProfile.id]: nextProfile,
+        },
       };
     });
   }, []);


### PR DESCRIPTION
## Summary
- Split Persona Studio state into saved persona records and editable draft buffers in the frontend store.
- Wired Save, Reset, and Save As New to operate on real local draft state, with deterministic duplicate naming and immediate persona selection.
- Updated the Persona Studio persistence test to cover saved-state rendering, unsaved edits, save/reset behavior, Save As New duplication, and absence of chat composer/thread UI.

## Testing
- `pnpm --dir frontend/src exec vitest run features/personaStudio/__tests__/PersonaStudioPage.persistence.test.tsx`