### PR TITLE
Codex/add threadconfig column

### DIFF
--- a/guardian/core/chat_completion_service.py
+++ b/guardian/core/chat_completion_service.py
@@ -353,6 +353,40 @@ def _latest_turn_instruction_message(
     )
 
 
+def _trace_content_snippet(content: Any, *, limit: int = 240) -> str | None:
+    text = render_content_for_inference(content).strip()
+    if not text:
+        return None
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "..."
+
+
+def _latest_turn_trace_fields(
+    latest_turn: dict[str, Any] | None,
+    *,
+    retrieval_query: str | None,
+) -> dict[str, Any]:
+    if not isinstance(latest_turn, dict):
+        return {}
+
+    fields: dict[str, Any] = {
+        "retrieval_query": str(retrieval_query or ""),
+        "retrieval_target": "latest_turn",
+        "retrieval_query_matches_latest_turn": True,
+    }
+
+    latest_turn_id = latest_turn.get("id")
+    if latest_turn_id is not None:
+        fields["latest_turn_message_id"] = latest_turn_id
+
+    latest_turn_content = _trace_content_snippet(latest_turn.get("content"))
+    if latest_turn_content is not None:
+        fields["latest_turn_content"] = latest_turn_content
+
+    return fields
+
+
 def _image_attachments_from_meta(
     latest_user_meta: dict[str, Any] | None,
 ) -> list[dict[str, Any]]:
@@ -972,6 +1006,10 @@ async def build_messages_for_llm(
     conversation_messages = [*history_messages, latest_turn]
     # Retrieval must follow the latest user turn, not earlier history.
     retrieval_query = render_content_for_inference(latest_turn.get("content"))
+    latest_turn_trace_fields = _latest_turn_trace_fields(
+        latest_turn,
+        retrieval_query=retrieval_query,
+    )
 
     context: list[dict[str, str]] = []
     latest_user_meta: dict[str, Any] | None = None
@@ -1051,6 +1089,7 @@ async def build_messages_for_llm(
         "latest_turn": latest_turn,
         "retrieved_context": retrieved_context_messages,
     }
+    completion_assembly.update(latest_turn_trace_fields)
 
     try:
         if build_guardian_system_prompt:
@@ -1134,6 +1173,12 @@ async def build_messages_for_llm(
             "latest_user": latest_user_meta,
         }
         bundle["_completion_assembly"] = completion_assembly
+
+    if trace is None:
+        trace = dict(latest_turn_trace_fields)
+    if isinstance(trace, dict):
+        trace = dict(trace)
+        trace.update(latest_turn_trace_fields)
 
     try:
         retrieval_plan = resolve_retrieval_plan(

--- a/guardian/core/chat_completion_service.py
+++ b/guardian/core/chat_completion_service.py
@@ -315,8 +315,18 @@ def _find_last_message_index(messages: list[dict[str, Any]], role: str) -> int:
     return -1
 
 
+def _coerce_message_id(raw: Any) -> int | None:
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
 def split_history_and_latest_turn(
     messages: list[dict[str, Any]] | None,
+    *,
+    latest_turn_message_id: int | None = None,
 ) -> dict[str, Any]:
     """Partition thread messages into prior history and the latest user turn."""
 
@@ -325,6 +335,21 @@ def split_history_and_latest_turn(
         for message in (messages or [])
         if isinstance(message, dict)
     ]
+    explicit_latest_turn_message_id = _coerce_message_id(latest_turn_message_id)
+    if explicit_latest_turn_message_id is not None:
+        for index, message in enumerate(safe_messages):
+            if (
+                _coerce_message_id(message.get("id"))
+                != explicit_latest_turn_message_id
+            ):
+                continue
+            if str(message.get("role") or "").strip().lower() != "user":
+                return {"history": safe_messages[:index], "latest_turn": None}
+            return {
+                "history": safe_messages[:index],
+                "latest_turn": message,
+            }
+        return {"history": safe_messages, "latest_turn": None}
     latest_user_index = _find_last_message_index(safe_messages, "user")
     if latest_user_index < 0:
         return {"history": safe_messages, "latest_turn": None}
@@ -997,10 +1022,18 @@ async def build_messages_for_llm(
     except Exception:
         pass
 
-    turn_split = split_history_and_latest_turn(items)
+    explicit_latest_turn_message_id = _coerce_message_id(
+        getattr(task, "latest_turn_message_id", None)
+    )
+    turn_split = split_history_and_latest_turn(
+        items,
+        latest_turn_message_id=explicit_latest_turn_message_id,
+    )
     history_messages = turn_split["history"]
     latest_turn = turn_split["latest_turn"]
     if latest_turn is None:
+        if explicit_latest_turn_message_id is not None:
+            raise ValueError("thread_target_turn_missing")
         raise ValueError("thread_has_no_usable_context")
 
     conversation_messages = [*history_messages, latest_turn]
@@ -1331,6 +1364,13 @@ def run_chat_completion_task(
         "thread_id": task.thread_id,
         "payload_summary": payload_summary,
     }
+    if isinstance(trace, dict):
+        result["latest_turn_message_id"] = trace.get("latest_turn_message_id")
+        result["retrieval_query"] = trace.get("retrieval_query")
+        result["retrieval_target"] = trace.get("retrieval_target")
+        result["retrieval_query_matches_latest_turn"] = trace.get(
+            "retrieval_query_matches_latest_turn"
+        )
 
     if not persist_assistant_message:
         return result

--- a/guardian/core/chat_completion_service.py
+++ b/guardian/core/chat_completion_service.py
@@ -334,6 +334,25 @@ def split_history_and_latest_turn(
     }
 
 
+def _latest_turn_instruction_message(
+    completion_assembly: dict[str, Any] | None,
+) -> str | None:
+    """Return the explicit instruction for latest-turn-only answering."""
+
+    if not isinstance(completion_assembly, dict):
+        return None
+    latest_turn = completion_assembly.get("latest_turn")
+    if not isinstance(latest_turn, dict):
+        return None
+    return (
+        "Completion targeting guidance:\n"
+        "- Use prior messages as context only.\n"
+        "- Treat the most recent user message as the only response target.\n"
+        "- Do not re-answer older turns unless the most recent user message "
+        "explicitly asks you to revisit them."
+    )
+
+
 def _image_attachments_from_meta(
     latest_user_meta: dict[str, Any] | None,
 ) -> list[dict[str, Any]]:
@@ -1066,6 +1085,10 @@ async def build_messages_for_llm(
             "Answer concisely, avoid speculation, and clearly mark any uncertainty."
         )
 
+    latest_turn_instruction = _latest_turn_instruction_message(
+        completion_assembly
+    )
+
     if isinstance(bundle, dict):
         try:
             existing_meta = bundle.get("_prompt_meta") or {}
@@ -1076,6 +1099,10 @@ async def build_messages_for_llm(
             bundle["_prompt_meta"] = dict(prompt_meta or {})
 
     messages_for_llm.append({"role": "system", "content": system_content})
+    if latest_turn_instruction:
+        messages_for_llm.append(
+            {"role": "system", "content": latest_turn_instruction}
+        )
 
     doc_message, doc_count = _build_document_context_message(bundle)
     if doc_message:

--- a/guardian/core/chat_completion_service.py
+++ b/guardian/core/chat_completion_service.py
@@ -970,7 +970,8 @@ async def build_messages_for_llm(
         raise ValueError("thread_has_no_usable_context")
 
     conversation_messages = [*history_messages, latest_turn]
-    latest_message = render_content_for_inference(latest_turn.get("content"))
+    # Retrieval must follow the latest user turn, not earlier history.
+    retrieval_query = render_content_for_inference(latest_turn.get("content"))
 
     context: list[dict[str, str]] = []
     latest_user_meta: dict[str, Any] | None = None
@@ -1018,7 +1019,7 @@ async def build_messages_for_llm(
         bundle, trace = await _assemble_context_bundle(
             broker,
             thread_id=thread_id,
-            query=latest_message,
+            query=retrieval_query,
             depth_mode=depth,
             user_id=user_for_context,
             project_id=project_id_for_prompt,
@@ -1136,7 +1137,7 @@ async def build_messages_for_llm(
 
     try:
         retrieval_plan = resolve_retrieval_plan(
-            latest_message,
+            retrieval_query,
             depth,
             active_thread_id=thread_id,
             active_project_id=project_id_for_prompt,

--- a/guardian/core/chat_completion_service.py
+++ b/guardian/core/chat_completion_service.py
@@ -315,6 +315,25 @@ def _find_last_message_index(messages: list[dict[str, Any]], role: str) -> int:
     return -1
 
 
+def split_history_and_latest_turn(
+    messages: list[dict[str, Any]] | None,
+) -> dict[str, Any]:
+    """Partition thread messages into prior history and the latest user turn."""
+
+    safe_messages = [
+        dict(message)
+        for message in (messages or [])
+        if isinstance(message, dict)
+    ]
+    latest_user_index = _find_last_message_index(safe_messages, "user")
+    if latest_user_index < 0:
+        return {"history": safe_messages, "latest_turn": None}
+    return {
+        "history": safe_messages[:latest_user_index],
+        "latest_turn": safe_messages[latest_user_index],
+    }
+
+
 def _image_attachments_from_meta(
     latest_user_meta: dict[str, Any] | None,
 ) -> list[dict[str, Any]]:
@@ -925,9 +944,18 @@ async def build_messages_for_llm(
     except Exception:
         pass
 
+    turn_split = split_history_and_latest_turn(items)
+    history_messages = turn_split["history"]
+    latest_turn = turn_split["latest_turn"]
+    if latest_turn is None:
+        raise ValueError("thread_has_no_usable_context")
+
+    conversation_messages = [*history_messages, latest_turn]
+    latest_message = render_content_for_inference(latest_turn.get("content"))
+
     context: list[dict[str, str]] = []
     latest_user_meta: dict[str, Any] | None = None
-    for msg in items:
+    for msg in conversation_messages:
         role = str(msg.get("role") or "").strip()
         raw_content = msg.get("content")
         if isinstance(raw_content, str):
@@ -944,14 +972,6 @@ async def build_messages_for_llm(
 
     if not context:
         raise ValueError("thread_has_no_usable_context")
-
-    latest_message = ""
-    for msg in reversed(items):
-        if str(msg.get("role") or "").strip() == "user":
-            lm = render_content_for_inference(msg.get("content"))
-            if lm:
-                latest_message = lm
-                break
 
     depth = str(task.depth_mode or "normal").strip().lower()
     user_for_context = (thread_info or {}).get("user_id", "default")
@@ -1005,6 +1025,12 @@ async def build_messages_for_llm(
 
     messages_for_llm: list[dict[str, str]] = []
     prompt_meta: dict[str, Any] = {}
+    retrieved_context_messages: list[dict[str, str]] = []
+    completion_assembly = {
+        "history": history_messages,
+        "latest_turn": latest_turn,
+        "retrieved_context": retrieved_context_messages,
+    }
 
     try:
         if build_guardian_system_prompt:
@@ -1053,13 +1079,17 @@ async def build_messages_for_llm(
 
     doc_message, doc_count = _build_document_context_message(bundle)
     if doc_message:
-        messages_for_llm.append({"role": "system", "content": doc_message})
+        retrieved_context_messages.append(
+            {"role": "system", "content": doc_message}
+        )
 
     context_message, context_meta = build_context_system_message_with_meta(
         bundle
     )
     if context_message:
-        messages_for_llm.append({"role": "system", "content": context_message})
+        retrieved_context_messages.append(
+            {"role": "system", "content": context_message}
+        )
     prompt_meta["context"] = context_meta
     prompt_meta.setdefault("docs", {})
     prompt_meta["docs"].update(
@@ -1075,6 +1105,7 @@ async def build_messages_for_llm(
         bundle["_attachment_meta"] = {
             "latest_user": latest_user_meta,
         }
+        bundle["_completion_assembly"] = completion_assembly
 
     try:
         retrieval_plan = resolve_retrieval_plan(
@@ -1101,6 +1132,7 @@ async def build_messages_for_llm(
 
     _persist_thread_trace_candidate(task, trace)
 
+    messages_for_llm.extend(retrieved_context_messages)
     messages_for_llm.extend(context)
 
     model = thread_execution.model

--- a/guardian/routes/chat.py
+++ b/guardian/routes/chat.py
@@ -47,6 +47,7 @@ from guardian.core.chat_completion_service import (
     DEBUG_RAG_TRACE_CANDIDATE_METADATA_KEY,
     _merge_thread_metadata_patch,
     resolve_thread_completion_settings,
+    split_history_and_latest_turn,
 )
 from guardian.core.event_graph import get_event_writer
 from guardian.depth import (
@@ -243,6 +244,7 @@ def _publish_completion_start_event(
         "thread_id": thread_id,
         "origin": task.origin,
         "turn_id": turn_id,
+        "latest_turn_message_id": getattr(task, "latest_turn_message_id", None),
     }
     try:
         publish_result = task_events.publish_with_visibility(
@@ -2147,6 +2149,10 @@ async def chat_complete(
 
     limit = int(body.max_context or 50)
     items = chatlog_db.list_messages(thread_id, limit=limit, offset=0)
+    try:
+        items = sorted(items, key=lambda m: m.get("id") or 0)
+    except Exception:
+        pass
     context: List[Dict[str, str]] = []
     for msg in items:
         role = str(msg.get("role") or "").strip()
@@ -2161,6 +2167,16 @@ async def chat_complete(
         raise HTTPException(
             status_code=400, detail="Thread has no usable context"
         )
+    latest_turn = split_history_and_latest_turn(items)["latest_turn"]
+    if latest_turn is None:
+        raise HTTPException(
+            status_code=400, detail="Thread has no usable context"
+        )
+    latest_turn_message_id = (
+        _coerce_message_id(latest_turn.get("id"))
+        if isinstance(latest_turn, dict)
+        else None
+    )
 
     requested_depth_raw = normalize_requested_depth_raw(body.depth_mode)
     # Binary projection: deep iff raw request is exactly "deep".
@@ -2275,6 +2291,7 @@ async def chat_complete(
 
     task = ChatCompletionTask(
         thread_id=thread_id,
+        latest_turn_message_id=latest_turn_message_id,
         provider=provider,
         model=model,
         requested_provider=body.provider,

--- a/guardian/tasks/types.py
+++ b/guardian/tasks/types.py
@@ -24,6 +24,14 @@ def _base_kwargs(payload: dict[str, Any]) -> dict[str, Any]:
     return base
 
 
+def _coerce_optional_positive_int(raw: Any) -> int | None:
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
 @dataclass
 class BaseTask:
     task_id: str = field(default_factory=lambda: str(uuid.uuid4()))
@@ -59,6 +67,7 @@ class WarmupTask(BaseTask):
 class ChatCompletionTask(BaseTask):
     type: str = "chat_completion"
     thread_id: int = 0
+    latest_turn_message_id: int | None = None
     model: str | None = None
     provider: str | None = None
     requested_model: str | None = None
@@ -76,6 +85,9 @@ class ChatCompletionTask(BaseTask):
         base.setdefault("type", cls.type)
         return cls(
             thread_id=int(payload.get("thread_id") or 0),
+            latest_turn_message_id=_coerce_optional_positive_int(
+                payload.get("latest_turn_message_id")
+            ),
             model=payload.get("model"),
             provider=payload.get("provider"),
             requested_model=payload.get("requested_model"),

--- a/guardian/workers/chat_worker.py
+++ b/guardian/workers/chat_worker.py
@@ -171,6 +171,10 @@ def _extract_turn_id(task: ChatCompletionTask) -> str:
     return match.group("turn_id").strip().lower() if match else ""
 
 
+def _extract_latest_turn_message_id(task: ChatCompletionTask) -> int | None:
+    return _coerce_message_id(getattr(task, "latest_turn_message_id", None))
+
+
 def _persist_turn_id_metadata(
     *, thread_id: int, message_id: int, turn_id: str
 ) -> bool:
@@ -1655,6 +1659,7 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
     run_id = uuid.uuid4().hex
     started = time.monotonic()
     turn_id = _extract_turn_id(task)
+    latest_turn_message_id = _extract_latest_turn_message_id(task)
     _safe_publish(
         task.task_id,
         "task.running",
@@ -1664,6 +1669,7 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
             "origin": task.origin,
             "thread_id": task.thread_id,
             "turn_id": turn_id,
+            "latest_turn_message_id": latest_turn_message_id,
         },
     )
     logger.info(
@@ -1698,6 +1704,7 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
                     "duration_ms": duration_ms,
                     "thread_id": task.thread_id,
                     "turn_id": turn_id,
+                    "latest_turn_message_id": latest_turn_message_id,
                     "message_id": existing_message_id,
                     "provider": task.provider,
                     "model": task.model,
@@ -1716,6 +1723,7 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
                     "thread_id": task.thread_id,
                     "origin": task.origin,
                     "turn_id": turn_id,
+                    "latest_turn_message_id": latest_turn_message_id,
                 },
             )
             clear_cancelled(task.task_id)
@@ -1750,6 +1758,7 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
                         "duration_ms": duration_ms,
                         "thread_id": task.thread_id,
                         "turn_id": turn_id,
+                        "latest_turn_message_id": latest_turn_message_id,
                         "message_id": existing_message_id,
                         "deduplicated": True,
                         "provider": task.provider,
@@ -1784,6 +1793,24 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
             cancel_check=lambda: is_cancelled(task.task_id),
             persist_assistant_message=True,
         )
+        result_trace = (
+            result.get("trace") if isinstance(result.get("trace"), dict) else {}
+        )
+        result_latest_turn_message_id = _coerce_message_id(
+            result.get("latest_turn_message_id")
+        )
+        if result_latest_turn_message_id is None and isinstance(
+            result_trace, dict
+        ):
+            result_latest_turn_message_id = _coerce_message_id(
+                result_trace.get("latest_turn_message_id")
+            )
+        result_retrieval_query = result.get("retrieval_query")
+        if result_retrieval_query is None and isinstance(result_trace, dict):
+            result_retrieval_query = result_trace.get("retrieval_query")
+        result_retrieval_target = result.get("retrieval_target")
+        if result_retrieval_target is None and isinstance(result_trace, dict):
+            result_retrieval_target = result_trace.get("retrieval_target")
         message_id = _coerce_message_id(result.get("message_id"))
         if message_id is None:
             logger.error(
@@ -1898,6 +1925,11 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
                 "duration_ms": duration_ms,
                 "thread_id": task.thread_id,
                 "turn_id": turn_id,
+                "latest_turn_message_id": (
+                    latest_turn_message_id
+                    if latest_turn_message_id is not None
+                    else result_latest_turn_message_id
+                ),
                 "message_id": message_id,
                 "provider": result.get("provider"),
                 "model": result.get("model"),
@@ -1926,6 +1958,11 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
                 "catalog_version_hash": result.get("catalog_version_hash"),
                 "assistant_message_audio_autogenerate": audio_autogenerate_scheduled,
                 "payload_summary": result.get("payload_summary"),
+                "retrieval_query": result_retrieval_query,
+                "retrieval_target": result_retrieval_target,
+                "retrieval_query_matches_latest_turn": result.get(
+                    "retrieval_query_matches_latest_turn"
+                ),
             },
         )
         logger.info(
@@ -1946,6 +1983,7 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
                 "thread_id": task.thread_id,
                 "origin": task.origin,
                 "turn_id": turn_id,
+                "latest_turn_message_id": latest_turn_message_id,
             },
         )
         clear_cancelled(task.task_id)
@@ -1968,6 +2006,7 @@ def _run_chat_task(task: ChatCompletionTask) -> None:
             "thread_id": task.thread_id,
             "origin": task.origin,
             "turn_id": turn_id,
+            "latest_turn_message_id": latest_turn_message_id,
         }
         for key in (
             "provider",

--- a/tests/core/test_chat_completion_service_latest_turn.py
+++ b/tests/core/test_chat_completion_service_latest_turn.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from guardian.core import chat_completion_service
+from guardian.core.chat_completion_service import split_history_and_latest_turn
+from guardian.tasks.types import ChatCompletionTask
+
+
+def _seed_completion_service(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    messages: list[dict[str, object]],
+) -> dict[str, object]:
+    captured: dict[str, object] = {}
+    mock_chatlog_db = MagicMock()
+    mock_chatlog_db.get_chat_thread.return_value = {
+        "id": 1,
+        "user_id": "user-1",
+        "project_id": 42,
+    }
+    mock_chatlog_db.list_messages.return_value = messages
+
+    class _FakeBroker:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def assemble(
+            self,
+            thread_id,
+            query,
+            depth_mode,
+            user_id,
+            project_id=None,
+            source_mode="project",
+        ):
+            captured["thread_id"] = thread_id
+            captured["query"] = query
+            captured["depth_mode"] = depth_mode
+            captured["user_id"] = user_id
+            captured["project_id"] = project_id
+            captured["source_mode"] = source_mode
+            return {"semantic": []}, {
+                "documents": [],
+                "graph": [],
+                "source_mode": source_mode,
+                "widen_reason": "none",
+            }
+
+    settings = SimpleNamespace(
+        LLM_PROVIDER="local",
+        LOCAL_LLM_MODEL="local-model",
+        DEFAULT_LOCAL_MODEL="local-model",
+        LLM_MODEL="local-model",
+    )
+
+    monkeypatch.setattr(
+        chat_completion_service, "get_settings", lambda: settings
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "validate_llm_config",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "build_guardian_system_prompt",
+        lambda **kwargs: ("BASE SYSTEM", {}),
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "build_context_system_message_with_meta",
+        lambda *args, **kwargs: (None, {}),
+    )
+    monkeypatch.setattr(chat_completion_service, "ContextBroker", _FakeBroker)
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "chatlog_db",
+        mock_chatlog_db,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "CHAT_PROVIDER",
+        "local",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "DEFAULT_MODEL",
+        "local-model",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_vector_store",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_memory_store",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_sensors",
+        None,
+        raising=False,
+    )
+    return captured
+
+
+def test_split_history_and_latest_turn_selects_latest_user_message() -> None:
+    messages = [
+        {"id": 1, "role": "system", "content": "BASE SYSTEM"},
+        {"id": 2, "role": "user", "content": "first question"},
+        {"id": 3, "role": "assistant", "content": "first answer"},
+        {"id": 4, "role": "user", "content": "second question"},
+        {"id": 5, "role": "assistant", "content": "stale assistant"},
+    ]
+
+    result = split_history_and_latest_turn(messages)
+
+    assert [msg["id"] for msg in result["history"]] == [1, 2, 3]
+    assert result["latest_turn"] is not None
+    assert result["latest_turn"]["id"] == 4
+    assert result["latest_turn"]["content"] == "second question"
+    assert all(msg["id"] != 5 for msg in result["history"])
+
+
+def test_split_history_and_latest_turn_returns_safe_null_when_no_user() -> None:
+    messages = [
+        {"id": 1, "role": "assistant", "content": "answer only"},
+        {"id": 2, "role": "assistant", "content": "still answer only"},
+    ]
+
+    result = split_history_and_latest_turn(messages)
+
+    assert [msg["id"] for msg in result["history"]] == [1, 2]
+    assert result["latest_turn"] is None
+
+
+@pytest.mark.asyncio
+async def test_build_messages_for_llm_fails_safely_without_user_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_completion_service(
+        monkeypatch,
+        messages=[
+            {"id": 1, "role": "assistant", "content": "answer only"},
+            {"id": 2, "role": "assistant", "content": "more answer only"},
+        ],
+    )
+
+    task = ChatCompletionTask(thread_id=1, provider="local", model=None)
+
+    with pytest.raises(ValueError, match="thread_has_no_usable_context"):
+        await chat_completion_service.build_messages_for_llm(task)
+
+
+@pytest.mark.asyncio
+async def test_build_messages_for_llm_preserves_latest_turn_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _seed_completion_service(
+        monkeypatch,
+        messages=[
+            {"id": 1, "role": "system", "content": "BASE SYSTEM"},
+            {"id": 2, "role": "user", "content": "first question"},
+            {"id": 3, "role": "assistant", "content": "first answer"},
+            {"id": 4, "role": "user", "content": "second question"},
+            {"id": 5, "role": "assistant", "content": "stale assistant"},
+        ],
+    )
+
+    task = ChatCompletionTask(thread_id=1, provider="local", model=None)
+    (
+        messages,
+        provider,
+        model,
+        bundle,
+        trace,
+    ) = await chat_completion_service.build_messages_for_llm(task)
+
+    assert provider == "local"
+    assert model == "local-model"
+    assert captured["query"] == "second question"
+    assert messages[-1] == {"role": "user", "content": "second question"}
+    assert all(msg.get("content") != "stale assistant" for msg in messages)
+
+    completion_assembly = bundle["_completion_assembly"]
+    assert [msg["id"] for msg in completion_assembly["history"]] == [1, 2, 3]
+    assert completion_assembly["latest_turn"]["id"] == 4
+    assert isinstance(completion_assembly["retrieved_context"], list)
+    assert trace["source_mode"] == "project"

--- a/tests/core/test_chat_completion_service_latest_turn.py
+++ b/tests/core/test_chat_completion_service_latest_turn.py
@@ -145,6 +145,27 @@ def test_split_history_and_latest_turn_returns_safe_null_when_no_user() -> None:
     assert result["latest_turn"] is None
 
 
+def test_split_history_and_latest_turn_honors_explicit_target_message_id() -> (
+    None
+):
+    messages = [
+        {"id": 1, "role": "system", "content": "BASE SYSTEM"},
+        {"id": 2, "role": "user", "content": "first question"},
+        {"id": 3, "role": "assistant", "content": "first answer"},
+        {"id": 4, "role": "user", "content": "second question"},
+        {"id": 5, "role": "assistant", "content": "second answer"},
+        {"id": 6, "role": "user", "content": "newer question"},
+    ]
+
+    result = split_history_and_latest_turn(messages, latest_turn_message_id=4)
+
+    assert [msg["id"] for msg in result["history"]] == [1, 2, 3]
+    assert result["latest_turn"] is not None
+    assert result["latest_turn"]["id"] == 4
+    assert result["latest_turn"]["content"] == "second question"
+    assert all(msg["id"] != 6 for msg in result["history"])
+
+
 @pytest.mark.asyncio
 async def test_build_messages_for_llm_fails_safely_without_user_turn(
     monkeypatch: pytest.MonkeyPatch,
@@ -198,3 +219,73 @@ async def test_build_messages_for_llm_preserves_latest_turn_boundary(
     assert completion_assembly["latest_turn"]["id"] == 4
     assert isinstance(completion_assembly["retrieved_context"], list)
     assert trace["source_mode"] == "project"
+
+
+@pytest.mark.asyncio
+async def test_build_messages_for_llm_honors_explicit_target_message_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _seed_completion_service(
+        monkeypatch,
+        messages=[
+            {"id": 1, "role": "system", "content": "BASE SYSTEM"},
+            {"id": 2, "role": "user", "content": "first question"},
+            {"id": 3, "role": "assistant", "content": "first answer"},
+            {"id": 4, "role": "user", "content": "second question"},
+            {"id": 5, "role": "assistant", "content": "second answer"},
+            {"id": 6, "role": "user", "content": "newer question"},
+        ],
+    )
+
+    task = ChatCompletionTask(
+        thread_id=1,
+        provider="local",
+        model=None,
+        latest_turn_message_id=4,
+    )
+    (
+        messages,
+        provider,
+        model,
+        bundle,
+        trace,
+    ) = await chat_completion_service.build_messages_for_llm(task)
+
+    assert provider == "local"
+    assert model == "local-model"
+    assert captured["query"] == "second question"
+    assert messages[-1] == {"role": "user", "content": "second question"}
+    assert [msg["content"] for msg in messages if msg["role"] == "user"] == [
+        "first question",
+        "second question",
+    ]
+    completion_assembly = bundle["_completion_assembly"]
+    assert [msg["id"] for msg in completion_assembly["history"]] == [1, 2, 3]
+    assert completion_assembly["latest_turn"]["id"] == 4
+    assert trace["latest_turn_message_id"] == 4
+    assert trace["retrieval_query"] == "second question"
+    assert trace["retrieval_target"] == "latest_turn"
+
+
+@pytest.mark.asyncio
+async def test_build_messages_for_llm_fails_when_explicit_target_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_completion_service(
+        monkeypatch,
+        messages=[
+            {"id": 1, "role": "user", "content": "first question"},
+            {"id": 2, "role": "assistant", "content": "first answer"},
+            {"id": 3, "role": "user", "content": "second question"},
+        ],
+    )
+
+    task = ChatCompletionTask(
+        thread_id=1,
+        provider="local",
+        model=None,
+        latest_turn_message_id=999,
+    )
+
+    with pytest.raises(ValueError, match="thread_target_turn_missing"):
+        await chat_completion_service.build_messages_for_llm(task)

--- a/tests/core/test_chat_completion_service_latest_turn_prompting.py
+++ b/tests/core/test_chat_completion_service_latest_turn_prompting.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from guardian.core import chat_completion_service
+from guardian.tasks.types import ChatCompletionTask
+
+
+def _seed_prompt_service(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    messages: list[dict[str, object]],
+) -> None:
+    mock_chatlog_db = MagicMock()
+    mock_chatlog_db.get_chat_thread.return_value = {
+        "id": 1,
+        "user_id": "user-1",
+        "project_id": 42,
+    }
+    mock_chatlog_db.list_messages.return_value = messages
+
+    class _FakeBroker:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def assemble(
+            self,
+            thread_id,
+            query,
+            depth_mode,
+            user_id,
+            project_id=None,
+            source_mode="project",
+        ):
+            return {"semantic": []}, {
+                "documents": [],
+                "graph": [],
+                "source_mode": source_mode,
+                "widen_reason": "none",
+            }
+
+    settings = SimpleNamespace(
+        LLM_PROVIDER="local",
+        LOCAL_LLM_MODEL="local-model",
+        DEFAULT_LOCAL_MODEL="local-model",
+        LLM_MODEL="local-model",
+    )
+
+    monkeypatch.setattr(
+        chat_completion_service, "get_settings", lambda: settings
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "validate_llm_config",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "build_guardian_system_prompt",
+        lambda **kwargs: ("BASE SYSTEM", {}),
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "build_context_system_message_with_meta",
+        lambda *args, **kwargs: (None, {}),
+    )
+    monkeypatch.setattr(chat_completion_service, "ContextBroker", _FakeBroker)
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "chatlog_db",
+        mock_chatlog_db,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "CHAT_PROVIDER",
+        "local",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "DEFAULT_MODEL",
+        "local-model",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_vector_store",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_memory_store",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_sensors",
+        None,
+        raising=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_messages_for_llm_adds_latest_turn_only_instruction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_prompt_service(
+        monkeypatch,
+        messages=[
+            {"id": 1, "role": "system", "content": "BASE SYSTEM"},
+            {"id": 2, "role": "user", "content": "first question"},
+            {"id": 3, "role": "assistant", "content": "first answer"},
+            {"id": 4, "role": "user", "content": "second question"},
+            {"id": 5, "role": "assistant", "content": "stale assistant"},
+        ],
+    )
+
+    task = ChatCompletionTask(thread_id=1, provider="local", model=None)
+    (
+        messages,
+        provider,
+        model,
+        bundle,
+        trace,
+    ) = await chat_completion_service.build_messages_for_llm(task)
+
+    assert provider == "local"
+    assert model == "local-model"
+    assert messages[0] == {"role": "system", "content": "BASE SYSTEM"}
+    assert "prior messages as context only" in messages[1]["content"]
+    assert "most recent user message" in messages[1]["content"]
+    assert [msg["content"] for msg in messages if msg["role"] == "user"] == [
+        "first question",
+        "second question",
+    ]
+    assert messages[-1] == {"role": "user", "content": "second question"}
+    assert all(msg["content"] != "stale assistant" for msg in messages)
+    assert bundle["_completion_assembly"]["latest_turn"]["id"] == 4
+    assert [
+        msg["content"]
+        for msg in bundle["_completion_assembly"]["history"]
+        if msg["role"] == "user"
+    ] == [
+        "first question",
+    ]
+    assert trace["source_mode"] == "project"
+
+
+@pytest.mark.asyncio
+async def test_build_messages_for_llm_keeps_normal_single_turn_threads_functional(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_prompt_service(
+        monkeypatch,
+        messages=[
+            {"id": 1, "role": "user", "content": "What changed?"},
+        ],
+    )
+
+    task = ChatCompletionTask(thread_id=1, provider="local", model=None)
+    (
+        messages,
+        provider,
+        model,
+        bundle,
+        trace,
+    ) = await chat_completion_service.build_messages_for_llm(task)
+
+    assert provider == "local"
+    assert model == "local-model"
+    assert messages[0] == {"role": "system", "content": "BASE SYSTEM"}
+    assert "most recent user message" in messages[1]["content"]
+    assert messages[-1] == {"role": "user", "content": "What changed?"}
+    assert bundle["_completion_assembly"]["history"] == []
+    assert (
+        bundle["_completion_assembly"]["latest_turn"]["content"]
+        == "What changed?"
+    )
+    assert trace["source_mode"] == "project"

--- a/tests/core/test_chat_completion_service_latest_turn_regression.py
+++ b/tests/core/test_chat_completion_service_latest_turn_regression.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from guardian.core import chat_completion_service
+from guardian.tasks.types import ChatCompletionTask
+
+
+def _seed_completion_service(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    messages: list[dict[str, object]],
+) -> dict[str, object]:
+    captured: dict[str, object] = {}
+    mock_chatlog_db = MagicMock()
+    mock_chatlog_db.get_chat_thread.return_value = {
+        "id": 1,
+        "user_id": "user-1",
+        "project_id": 42,
+    }
+    mock_chatlog_db.list_messages.return_value = messages
+
+    class _FakeBroker:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def assemble(
+            self,
+            thread_id,
+            query,
+            depth_mode,
+            user_id,
+            project_id=None,
+            source_mode="project",
+        ):
+            captured["thread_id"] = thread_id
+            captured["query"] = query
+            captured["depth_mode"] = depth_mode
+            captured["user_id"] = user_id
+            captured["project_id"] = project_id
+            captured["source_mode"] = source_mode
+            return {"semantic": []}, {
+                "documents": [],
+                "graph": [],
+                "source_mode": source_mode,
+                "widen_reason": "none",
+            }
+
+    settings = SimpleNamespace(
+        LLM_PROVIDER="local",
+        LOCAL_LLM_MODEL="local-model",
+        DEFAULT_LOCAL_MODEL="local-model",
+        LLM_MODEL="local-model",
+    )
+
+    monkeypatch.setattr(
+        chat_completion_service, "get_settings", lambda: settings
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "validate_llm_config",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "build_guardian_system_prompt",
+        lambda **kwargs: ("BASE SYSTEM", {}),
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "build_context_system_message_with_meta",
+        lambda *args, **kwargs: (None, {}),
+    )
+    monkeypatch.setattr(chat_completion_service, "ContextBroker", _FakeBroker)
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "chatlog_db",
+        mock_chatlog_db,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "CHAT_PROVIDER",
+        "local",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "DEFAULT_MODEL",
+        "local-model",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_vector_store",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_memory_store",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_sensors",
+        None,
+        raising=False,
+    )
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_build_messages_for_llm_targets_only_latest_turn_in_multi_turn_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _seed_completion_service(
+        monkeypatch,
+        messages=[
+            {"id": 1, "role": "system", "content": "BASE SYSTEM"},
+            {"id": 2, "role": "user", "content": "question A"},
+            {"id": 3, "role": "assistant", "content": "answer A"},
+            {"id": 4, "role": "user", "content": "question B"},
+            {"id": 5, "role": "assistant", "content": "answer B"},
+            {"id": 6, "role": "user", "content": "question C"},
+        ],
+    )
+
+    task = ChatCompletionTask(thread_id=1, provider="local", model=None)
+    (
+        messages,
+        provider,
+        model,
+        bundle,
+        trace,
+    ) = await chat_completion_service.build_messages_for_llm(task)
+
+    assert provider == "local"
+    assert model == "local-model"
+    assert messages[0] == {"role": "system", "content": "BASE SYSTEM"}
+    assert "most recent user message" in messages[1]["content"]
+    assert "prior messages as context only" in messages[1]["content"]
+    assert [msg["content"] for msg in messages if msg["role"] == "user"] == [
+        "question A",
+        "question B",
+        "question C",
+    ]
+    assert messages[-1] == {"role": "user", "content": "question C"}
+    assert captured["query"] == "question C"
+
+    completion_assembly = bundle["_completion_assembly"]
+    assert [msg["id"] for msg in completion_assembly["history"]] == [
+        1,
+        2,
+        3,
+        4,
+        5,
+    ]
+    assert [
+        msg["content"]
+        for msg in completion_assembly["history"]
+        if msg["role"] == "user"
+    ] == [
+        "question A",
+        "question B",
+    ]
+    assert [
+        msg["content"]
+        for msg in completion_assembly["history"]
+        if msg["role"] == "assistant"
+    ] == [
+        "answer A",
+        "answer B",
+    ]
+    assert completion_assembly["latest_turn"]["id"] == 6
+    assert completion_assembly["latest_turn"]["content"] == "question C"
+    assert trace["source_mode"] == "project"
+
+
+@pytest.mark.asyncio
+async def test_build_messages_for_llm_keeps_single_user_turn_functional(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _seed_completion_service(
+        monkeypatch,
+        messages=[
+            {"id": 1, "role": "user", "content": "What changed?"},
+        ],
+    )
+
+    task = ChatCompletionTask(thread_id=1, provider="local", model=None)
+    (
+        messages,
+        provider,
+        model,
+        bundle,
+        trace,
+    ) = await chat_completion_service.build_messages_for_llm(task)
+
+    assert provider == "local"
+    assert model == "local-model"
+    assert "most recent user message" in messages[1]["content"]
+    assert captured["query"] == "What changed?"
+    assert messages[-1] == {"role": "user", "content": "What changed?"}
+    assert bundle["_completion_assembly"]["history"] == []
+    assert (
+        bundle["_completion_assembly"]["latest_turn"]["content"]
+        == "What changed?"
+    )
+    assert trace["source_mode"] == "project"

--- a/tests/core/test_chat_completion_service_latest_turn_retrieval.py
+++ b/tests/core/test_chat_completion_service_latest_turn_retrieval.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from guardian.core import chat_completion_service
+from guardian.tasks.types import ChatCompletionTask
+
+
+def _seed_retrieval_service(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    messages: list[dict[str, object]],
+) -> dict[str, object]:
+    captured: dict[str, object] = {}
+    mock_chatlog_db = MagicMock()
+    mock_chatlog_db.get_chat_thread.return_value = {
+        "id": 1,
+        "user_id": "user-1",
+        "project_id": 42,
+    }
+    mock_chatlog_db.list_messages.return_value = messages
+
+    class _FakeBroker:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def assemble(
+            self,
+            thread_id,
+            query,
+            depth_mode,
+            user_id,
+            project_id=None,
+            source_mode="project",
+        ):
+            captured["thread_id"] = thread_id
+            captured["query"] = query
+            captured["depth_mode"] = depth_mode
+            captured["user_id"] = user_id
+            captured["project_id"] = project_id
+            captured["source_mode"] = source_mode
+            return {"semantic": []}, {
+                "documents": [],
+                "graph": [],
+                "source_mode": source_mode,
+                "widen_reason": "none",
+            }
+
+    settings = SimpleNamespace(
+        LLM_PROVIDER="local",
+        LOCAL_LLM_MODEL="local-model",
+        DEFAULT_LOCAL_MODEL="local-model",
+        LLM_MODEL="local-model",
+    )
+
+    monkeypatch.setattr(
+        chat_completion_service, "get_settings", lambda: settings
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "validate_llm_config",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "build_guardian_system_prompt",
+        lambda **kwargs: ("BASE SYSTEM", {}),
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "build_context_system_message_with_meta",
+        lambda *args, **kwargs: (None, {}),
+    )
+    monkeypatch.setattr(chat_completion_service, "ContextBroker", _FakeBroker)
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "chatlog_db",
+        mock_chatlog_db,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "CHAT_PROVIDER",
+        "local",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "DEFAULT_MODEL",
+        "local-model",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_vector_store",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_memory_store",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_sensors",
+        None,
+        raising=False,
+    )
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_build_messages_for_llm_uses_newest_user_turn_for_retrieval_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _seed_retrieval_service(
+        monkeypatch,
+        messages=[
+            {"id": 1, "role": "user", "content": "question A"},
+            {"id": 2, "role": "assistant", "content": "answer A"},
+            {"id": 3, "role": "user", "content": "question B"},
+        ],
+    )
+
+    task = ChatCompletionTask(thread_id=1, provider="local", model=None)
+    (
+        messages,
+        provider,
+        model,
+        bundle,
+        trace,
+    ) = await chat_completion_service.build_messages_for_llm(task)
+
+    assert provider == "local"
+    assert model == "local-model"
+    assert captured["query"] == "question B"
+    assert (
+        bundle["_completion_assembly"]["latest_turn"]["content"] == "question B"
+    )
+    assert messages[-1] == {"role": "user", "content": "question B"}
+    assert [msg["content"] for msg in messages if msg["role"] == "user"] == [
+        "question A",
+        "question B",
+    ]
+    assert trace["source_mode"] == "project"
+
+
+@pytest.mark.asyncio
+async def test_build_messages_for_llm_keeps_older_user_turns_out_of_retrieval_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _seed_retrieval_service(
+        monkeypatch,
+        messages=[
+            {"id": 1, "role": "user", "content": "question A"},
+            {"id": 2, "role": "assistant", "content": "answer A"},
+            {"id": 3, "role": "user", "content": "question B"},
+            {"id": 4, "role": "assistant", "content": "answer B"},
+            {"id": 5, "role": "user", "content": "question C"},
+        ],
+    )
+
+    task = ChatCompletionTask(thread_id=1, provider="local", model=None)
+    (
+        messages,
+        _provider,
+        _model,
+        bundle,
+        trace,
+    ) = await chat_completion_service.build_messages_for_llm(task)
+
+    assert captured["query"] == "question C"
+    assert bundle["_completion_assembly"]["latest_turn"]["id"] == 5
+    assert [msg["id"] for msg in bundle["_completion_assembly"]["history"]] == [
+        1,
+        2,
+        3,
+        4,
+    ]
+    assert [
+        msg["content"]
+        for msg in bundle["_completion_assembly"]["history"]
+        if msg["role"] == "user"
+    ] == [
+        "question A",
+        "question B",
+    ]
+    assert messages[-1] == {"role": "user", "content": "question C"}
+    assert [msg["content"] for msg in messages if msg["role"] == "user"] == [
+        "question A",
+        "question B",
+        "question C",
+    ]
+    assert trace["source_mode"] == "project"
+
+
+@pytest.mark.asyncio
+async def test_build_messages_for_llm_keeps_single_turn_retrieval_normal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _seed_retrieval_service(
+        monkeypatch,
+        messages=[
+            {"id": 1, "role": "user", "content": "What changed?"},
+        ],
+    )
+
+    task = ChatCompletionTask(thread_id=1, provider="local", model=None)
+    (
+        messages,
+        provider,
+        model,
+        bundle,
+        trace,
+    ) = await chat_completion_service.build_messages_for_llm(task)
+
+    assert provider == "local"
+    assert model == "local-model"
+    assert captured["query"] == "What changed?"
+    assert bundle["_completion_assembly"]["history"] == []
+    assert (
+        bundle["_completion_assembly"]["latest_turn"]["content"]
+        == "What changed?"
+    )
+    assert messages[-1] == {"role": "user", "content": "What changed?"}
+    assert trace["source_mode"] == "project"
+
+
+@pytest.mark.asyncio
+async def test_build_messages_for_llm_fails_safe_without_latest_user_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_retrieval_service(
+        monkeypatch,
+        messages=[
+            {"id": 1, "role": "assistant", "content": "answer only"},
+            {"id": 2, "role": "assistant", "content": "still answer only"},
+        ],
+    )
+
+    task = ChatCompletionTask(thread_id=1, provider="local", model=None)
+
+    with pytest.raises(ValueError, match="thread_has_no_usable_context"):
+        await chat_completion_service.build_messages_for_llm(task)

--- a/tests/core/test_chat_completion_service_latest_turn_trace.py
+++ b/tests/core/test_chat_completion_service_latest_turn_trace.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from guardian.core import chat_completion_service
+from guardian.core.chat_completion_service import _latest_turn_trace_fields
+from guardian.tasks.types import ChatCompletionTask
+
+
+def _seed_trace_service(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    messages: list[dict[str, object]],
+) -> dict[str, object]:
+    captured: dict[str, object] = {}
+    mock_chatlog_db = MagicMock()
+    mock_chatlog_db.get_chat_thread.return_value = {
+        "id": 1,
+        "user_id": "user-1",
+        "project_id": 42,
+    }
+    mock_chatlog_db.list_messages.return_value = messages
+
+    class _FakeBroker:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def assemble(
+            self,
+            thread_id,
+            query,
+            depth_mode,
+            user_id,
+            project_id=None,
+            source_mode="project",
+        ):
+            captured["thread_id"] = thread_id
+            captured["query"] = query
+            captured["depth_mode"] = depth_mode
+            captured["user_id"] = user_id
+            captured["project_id"] = project_id
+            captured["source_mode"] = source_mode
+            return {"semantic": []}, {
+                "documents": [],
+                "graph": [],
+                "source_mode": source_mode,
+                "widen_reason": "none",
+            }
+
+    settings = SimpleNamespace(
+        LLM_PROVIDER="local",
+        LOCAL_LLM_MODEL="local-model",
+        DEFAULT_LOCAL_MODEL="local-model",
+        LLM_MODEL="local-model",
+    )
+
+    monkeypatch.setattr(
+        chat_completion_service, "get_settings", lambda: settings
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "validate_llm_config",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "build_guardian_system_prompt",
+        lambda **kwargs: ("BASE SYSTEM", {}),
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "build_context_system_message_with_meta",
+        lambda *args, **kwargs: (None, {}),
+    )
+    monkeypatch.setattr(chat_completion_service, "ContextBroker", _FakeBroker)
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "chatlog_db",
+        mock_chatlog_db,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "CHAT_PROVIDER",
+        "local",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "DEFAULT_MODEL",
+        "local-model",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_vector_store",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_memory_store",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_sensors",
+        None,
+        raising=False,
+    )
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_build_messages_for_llm_emits_latest_turn_trace_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _seed_trace_service(
+        monkeypatch,
+        messages=[
+            {"id": 1, "role": "user", "content": "question A"},
+            {"id": 2, "role": "assistant", "content": "answer A"},
+            {"id": 3, "role": "user", "content": "question B"},
+            {"id": 4, "role": "assistant", "content": "stale assistant"},
+        ],
+    )
+
+    task = ChatCompletionTask(thread_id=1, provider="local", model=None)
+    (
+        messages,
+        provider,
+        model,
+        bundle,
+        trace,
+    ) = await chat_completion_service.build_messages_for_llm(task)
+
+    assert provider == "local"
+    assert model == "local-model"
+    assert captured["query"] == "question B"
+    assert messages[-1] == {"role": "user", "content": "question B"}
+
+    completion_assembly = bundle["_completion_assembly"]
+    assert completion_assembly["latest_turn"]["id"] == 3
+    assert completion_assembly["latest_turn"]["content"] == "question B"
+    assert completion_assembly["retrieval_query"] == "question B"
+    assert completion_assembly["retrieval_target"] == "latest_turn"
+    assert completion_assembly["retrieval_query_matches_latest_turn"] is True
+
+    assert trace["latest_turn_message_id"] == 3
+    assert trace["latest_turn_content"] == "question B"
+    assert trace["retrieval_query"] == "question B"
+    assert trace["retrieval_target"] == "latest_turn"
+    assert trace["retrieval_query_matches_latest_turn"] is True
+
+
+@pytest.mark.asyncio
+async def test_build_messages_for_llm_keeps_single_turn_trace_truthful(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_trace_service(
+        monkeypatch,
+        messages=[
+            {"id": 11, "role": "user", "content": "What changed?"},
+        ],
+    )
+
+    task = ChatCompletionTask(thread_id=1, provider="local", model=None)
+    (
+        messages,
+        _provider,
+        _model,
+        bundle,
+        trace,
+    ) = await chat_completion_service.build_messages_for_llm(task)
+
+    assert messages[-1] == {"role": "user", "content": "What changed?"}
+    assert bundle["_completion_assembly"]["latest_turn"]["id"] == 11
+    assert trace["latest_turn_message_id"] == 11
+    assert trace["retrieval_query"] == "What changed?"
+    assert trace["retrieval_target"] == "latest_turn"
+    assert trace["retrieval_query_matches_latest_turn"] is True
+
+
+@pytest.mark.asyncio
+async def test_build_messages_for_llm_fails_safe_without_user_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_trace_service(
+        monkeypatch,
+        messages=[
+            {"id": 1, "role": "assistant", "content": "answer only"},
+            {"id": 2, "role": "assistant", "content": "still answer only"},
+        ],
+    )
+
+    task = ChatCompletionTask(thread_id=1, provider="local", model=None)
+
+    with pytest.raises(ValueError, match="thread_has_no_usable_context"):
+        await chat_completion_service.build_messages_for_llm(task)
+
+    assert (
+        _latest_turn_trace_fields(None, retrieval_query="stale history") == {}
+    )

--- a/tests/routes/test_chat_complete_latest_turn_integrity.py
+++ b/tests/routes/test_chat_complete_latest_turn_integrity.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+
+def _thread_config_snapshot() -> dict[str, object]:
+    return {
+        "providerId": "local",
+        "modelId": "qwen3.5:14b",
+        "inferenceMode": "fast",
+        "retrievalSource": "project",
+        "personaId": None,
+    }
+
+
+def test_chat_complete_queues_latest_user_turn_identity(
+    test_client, mock_db, monkeypatch
+):
+    mock_db.get_chat_thread.return_value = {
+        "id": 1,
+        "user_id": "test_user",
+        "project_id": 1,
+        "thread_config": _thread_config_snapshot(),
+    }
+    mock_db.list_messages.return_value = [
+        {"id": 1, "role": "user", "content": "question A"},
+        {"id": 2, "role": "assistant", "content": "answer A"},
+        {"id": 3, "role": "user", "content": "question B"},
+        {"id": 4, "role": "assistant", "content": "stale answer"},
+    ]
+
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        "guardian.routes.chat.acquire_turn_lock", lambda *a, **k: True
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat.release_turn_lock", lambda *a, **k: True
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat._publish_completion_start_event",
+        lambda **_kwargs: {"ok": True, "event_id": "evt-1"},
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat._get_task_completed_payload",
+        lambda *_args, **_kwargs: None,
+    )
+
+    def _capture_enqueue(task, queue_name):
+        captured["task"] = task
+        captured["queue_name"] = queue_name
+        captured["queued_payload"] = task.to_dict()
+        return None
+
+    monkeypatch.setattr("guardian.routes.chat.enqueue", _capture_enqueue)
+
+    response = test_client.post("/chat/1/complete", json={})
+
+    assert response.status_code == 200
+    assert captured["queue_name"] == "codexify:queue:chat"
+    task = captured["task"]
+    assert getattr(task, "latest_turn_message_id") == 3
+    assert captured["queued_payload"]["latest_turn_message_id"] == 3
+    assert "turn_id=" in getattr(task, "origin")
+
+
+def test_chat_complete_rejects_threads_without_a_user_turn(
+    test_client, mock_db, monkeypatch
+):
+    mock_db.get_chat_thread.return_value = {
+        "id": 1,
+        "user_id": "test_user",
+        "project_id": 1,
+        "thread_config": _thread_config_snapshot(),
+    }
+    mock_db.list_messages.return_value = [
+        {"id": 1, "role": "assistant", "content": "answer only"},
+        {"id": 2, "role": "assistant", "content": "still answer only"},
+    ]
+
+    enqueue_calls: list[object] = []
+    publish_calls: list[object] = []
+
+    monkeypatch.setattr(
+        "guardian.routes.chat.acquire_turn_lock", lambda *a, **k: True
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat.release_turn_lock", lambda *a, **k: True
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat.enqueue",
+        lambda *a, **k: enqueue_calls.append((a, k)),
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat._publish_completion_start_event",
+        lambda *a, **k: publish_calls.append((a, k)),
+    )
+
+    response = test_client.post("/chat/1/complete", json={})
+
+    assert response.status_code == 400
+    assert enqueue_calls == []
+    assert publish_calls == []

--- a/tests/routes/test_chat_profile_trace.py
+++ b/tests/routes/test_chat_profile_trace.py
@@ -60,6 +60,38 @@ def test_rag_trace_exposes_payload_summary(monkeypatch):
     chat._rag_traces.pop(77, None)
 
 
+def test_rag_trace_exposes_latest_turn_targeting_fields(monkeypatch):
+    chat._thread_latest_task[91] = "task-91"
+
+    monkeypatch.setattr(
+        chat,
+        "_get_task_completed_payload",
+        lambda _task_id: {
+            "trace": {
+                "documents": [],
+                "graph": [],
+                "latest_turn_message_id": 12,
+                "latest_turn_content": "question B",
+                "retrieval_query": "question B",
+                "retrieval_target": "latest_turn",
+                "retrieval_query_matches_latest_turn": True,
+            },
+            "payload_summary": {"message_count": 2},
+        },
+    )
+
+    trace = chat.get_latest_rag_trace(91, api_key="test-key")
+
+    assert trace["latest_turn_message_id"] == 12
+    assert trace["latest_turn_content"] == "question B"
+    assert trace["retrieval_query"] == "question B"
+    assert trace["retrieval_target"] == "latest_turn"
+    assert trace["retrieval_query_matches_latest_turn"] is True
+
+    chat._thread_latest_task.pop(91, None)
+    chat._rag_traces.pop(91, None)
+
+
 def test_rag_trace_uses_persisted_candidate_for_completed_task(monkeypatch):
     thread_id = 88
     task_id = str(uuid.uuid4())

--- a/tests/workers/test_chat_worker_latest_turn_integrity.py
+++ b/tests/workers/test_chat_worker_latest_turn_integrity.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from typing import Any
+
+from guardian.tasks.types import ChatCompletionTask, task_from_dict
+from guardian.workers import chat_worker
+
+TURN_ID = "11111111-1111-4111-8111-111111111111"
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self._values: dict[str, bytes] = {}
+
+    def setex(self, name: str, _ttl: int, value: str) -> bool:
+        self._values[name] = str(value).encode("utf-8")
+        return True
+
+    def get(self, name: str) -> bytes | None:
+        return self._values.get(name)
+
+
+def _isolate_turn_anchor(monkeypatch) -> _FakeRedis:
+    fake_redis = _FakeRedis()
+    monkeypatch.setattr(chat_worker, "get_redis_client", lambda: fake_redis)
+    return fake_redis
+
+
+def _build_task_payload(
+    *,
+    task_id: str = "task-1",
+    latest_turn_message_id: int = 4,
+) -> dict[str, Any]:
+    return {
+        "task_id": task_id,
+        "type": "chat_completion",
+        "created_at": "2026-04-02T00:00:00+00:00",
+        "origin": f"api:chat.complete|turn_id={TURN_ID}",
+        "thread_id": 7,
+        "provider": "local",
+        "model": "test-model",
+        "latest_turn_message_id": latest_turn_message_id,
+    }
+
+
+def test_worker_preserves_latest_turn_message_id_through_completion(
+    monkeypatch,
+):
+    _isolate_turn_anchor(monkeypatch)
+    task = task_from_dict(_build_task_payload())
+    assert isinstance(task, ChatCompletionTask)
+    assert task.latest_turn_message_id == 4
+
+    published: list[tuple[str, dict[str, Any]]] = []
+    observed_target_ids: list[int | None] = []
+
+    monkeypatch.setattr(chat_worker, "is_cancelled", lambda *_: False)
+    monkeypatch.setattr(chat_worker, "clear_cancelled", lambda *_: None)
+    monkeypatch.setattr(chat_worker, "release_turn_lock", lambda *_: True)
+    monkeypatch.setattr(
+        chat_worker,
+        "_find_assistant_message_for_turn",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_find_assistant_message_id_by_turn_id",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_persist_turn_id_metadata",
+        lambda **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_schedule_assistant_message_audio_generation",
+        lambda **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_safe_emit_live_event",
+        lambda *_args, **_kwargs: None,
+    )
+
+    def fake_run_chat_completion_task(task, **_kwargs):
+        observed_target_ids.append(
+            getattr(task, "latest_turn_message_id", None)
+        )
+        return {
+            "message_id": 42,
+            "provider": "local",
+            "model": "test-model",
+            "assistant_text": "answer B",
+            "selection_source": "default",
+            "latest_turn_message_id": 4,
+            "retrieval_query": "question B",
+            "retrieval_target": "latest_turn",
+            "retrieval_query_matches_latest_turn": True,
+            "payload_summary": {"message_count": 4},
+        }
+
+    monkeypatch.setattr(
+        chat_worker,
+        "run_chat_completion_task",
+        fake_run_chat_completion_task,
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_safe_publish",
+        lambda _task_id, event_type, data: published.append(
+            (event_type, dict(data or {}))
+        ),
+    )
+
+    chat_worker._run_chat_task(task)
+
+    event_types = [event_type for event_type, _payload in published]
+    assert observed_target_ids == [4]
+    assert "task.running" in event_types
+    assert "task.completed" in event_types
+    completed_payload = next(
+        payload
+        for event_type, payload in published
+        if event_type == "task.completed"
+    )
+    assert completed_payload["latest_turn_message_id"] == 4
+    assert completed_payload["retrieval_query"] == "question B"
+    assert completed_payload["retrieval_target"] == "latest_turn"
+    assert completed_payload["retrieval_query_matches_latest_turn"] is True
+    assert "task.failed" not in event_types
+
+
+def test_worker_missing_target_turn_surfaces_explicit_failure(
+    monkeypatch,
+):
+    _isolate_turn_anchor(monkeypatch)
+    task = task_from_dict(_build_task_payload(latest_turn_message_id=99))
+    assert isinstance(task, ChatCompletionTask)
+
+    published: list[tuple[str, dict[str, Any]]] = []
+    live_events: list[tuple[str, dict[str, Any]]] = []
+
+    monkeypatch.setattr(chat_worker, "is_cancelled", lambda *_: False)
+    monkeypatch.setattr(chat_worker, "clear_cancelled", lambda *_: None)
+    monkeypatch.setattr(chat_worker, "release_turn_lock", lambda *_: True)
+    monkeypatch.setattr(
+        chat_worker,
+        "_find_assistant_message_for_turn",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_find_assistant_message_id_by_turn_id",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_safe_emit_live_event",
+        lambda event_type, payload: live_events.append(
+            (event_type, dict(payload or {}))
+        ),
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "run_chat_completion_task",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            ValueError("thread_target_turn_missing")
+        ),
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_safe_publish",
+        lambda _task_id, event_type, data: published.append(
+            (event_type, dict(data or {}))
+        ),
+    )
+
+    chat_worker._run_chat_task(task)
+
+    event_types = [event_type for event_type, _payload in published]
+    assert "task.failed" in event_types
+    failure_payload = next(
+        payload
+        for event_type, payload in published
+        if event_type == "task.failed"
+    )
+    assert failure_payload["latest_turn_message_id"] == 99
+    assert "thread_target_turn_missing" in failure_payload["error"]
+    assert live_events
+    assert live_events[-1][1]["latest_turn_message_id"] == 99


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
