### PR TITLE
Add batched ChatGPT import embedding retries and startup sweep

### DIFF
--- a/backend/rag/chatgpt_migration.py
+++ b/backend/rag/chatgpt_migration.py
@@ -5,6 +5,7 @@ import logging
 import multiprocessing as mp
 import os
 from datetime import datetime, timezone
+from time import perf_counter
 from typing import Any, Dict, List, Optional, Tuple
 
 from guardian.core import dependencies
@@ -37,6 +38,48 @@ _MAX_EMBED_TEXT_CHARS = int(
 _EMBED_SUBPROCESS_TIMEOUT_S = float(
     os.getenv("CODEXIFY_CHATGPT_IMPORT_EMBED_TIMEOUT_SECONDS", "180")
 )
+
+
+def _parse_positive_int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(str(raw).strip())
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid %s=%r; using default=%d",
+            name,
+            raw,
+            default,
+        )
+        return default
+    if value <= 0:
+        logger.warning(
+            "Invalid %s=%r; using default=%d",
+            name,
+            raw,
+            default,
+        )
+        return default
+    return value
+
+
+_IMPORT_EMBED_BATCH_SIZE = _parse_positive_int_env(
+    "CODEXIFY_CHATGPT_IMPORT_EMBED_BATCH_SIZE", 16
+)
+
+
+def _iter_embedding_batches(
+    items: List[Dict[str, Any]],
+    message_ids: List[int],
+    batch_size: int,
+):
+    for start in range(0, len(items), batch_size):
+        yield (
+            items[start : start + batch_size],
+            message_ids[start : start + batch_size],
+        )
 
 
 def _detect_non_json_hint(content: bytes) -> Optional[str]:
@@ -95,19 +138,21 @@ def _embed_items_best_effort(
         "embeddings_persisted": 0,
         "embeddings_failed": candidates,
         "embedding_coverage_degraded": candidates > 0,
+        "failure_class": None,
     }
     if not items:
         diagnostics["embedding_coverage_degraded"] = False
         return diagnostics
 
     if vector_store is None:
+        diagnostics["failure_class"] = "vector_store_unavailable"
         logger.warning(
             "ChatGPT import embedding unavailable; skipped candidate batch size=%d",
             candidates,
         )
         return diagnostics
 
-    def _embed_in_process() -> Dict[str, Any]:
+    if not _IMPORT_EMBED_ISOLATED:
         try:
             persisted = vector_store.add_texts(items)
             if persisted is None:
@@ -122,15 +167,15 @@ def _embed_items_best_effort(
             diagnostics["embedding_coverage_degraded"] = (
                 diagnostics["embeddings_failed"] > 0
             )
+            if diagnostics["embedding_coverage_degraded"]:
+                diagnostics["failure_class"] = "partial_write"
         except Exception as exc:
+            diagnostics["failure_class"] = type(exc).__name__
             logger.warning(
                 "ChatGPT import embedding write failed in-process: %s",
                 exc,
             )
         return diagnostics
-
-    if not _IMPORT_EMBED_ISOLATED:
-        return _embed_in_process()
 
     try:
         ctx = mp.get_context("spawn")
@@ -140,29 +185,32 @@ def _embed_items_best_effort(
         if proc.is_alive():
             proc.terminate()
             proc.join(timeout=5.0)
+            diagnostics["failure_class"] = "subprocess_timeout"
             logger.warning(
                 "ChatGPT import embedding timed out after %.1fs; skipped batch size=%d",
                 _EMBED_SUBPROCESS_TIMEOUT_S,
                 candidates,
             )
-            return _embed_in_process()
+            return diagnostics
         if proc.exitcode != 0:
+            diagnostics["failure_class"] = f"subprocess_exit_{proc.exitcode}"
             logger.warning(
                 "ChatGPT import embedding subprocess failed with exit code=%s for batch size=%d",
                 proc.exitcode,
                 candidates,
             )
-            return _embed_in_process()
+            return diagnostics
         diagnostics["embeddings_persisted"] = candidates
         diagnostics["embeddings_failed"] = 0
         diagnostics["embedding_coverage_degraded"] = False
         return diagnostics
     except Exception as exc:
+        diagnostics["failure_class"] = type(exc).__name__
         logger.warning(
             "ChatGPT import embedding subprocess launch failed: %s",
             exc,
         )
-        return _embed_in_process()
+        return diagnostics
 
 
 def _fetch_retryable_chatgpt_embedding_items(
@@ -337,6 +385,96 @@ def _persist_chatgpt_embedding_attempt_outcome(
             len(message_ids),
             exc,
         )
+
+
+def _log_chatgpt_embedding_batch(
+    *,
+    operation: str,
+    batch_index: int,
+    batch_total: int,
+    candidate_count: int,
+    persisted_count: int,
+    failed_count: int,
+    elapsed_ms: float,
+    failure_class: Optional[str],
+) -> None:
+    level = logger.warning if failed_count > 0 else logger.info
+    level(
+        "ChatGPT %s embedding batch batch_index=%d batch_total=%d candidate_count=%d persisted_count=%d failed_count=%d elapsed_ms=%.1f failure_class=%s",
+        operation,
+        batch_index,
+        batch_total,
+        candidate_count,
+        persisted_count,
+        failed_count,
+        elapsed_ms,
+        failure_class or "none",
+    )
+
+
+def _process_chatgpt_embedding_batches(
+    *,
+    chatlog_db,
+    items: List[Dict[str, Any]],
+    message_ids: List[int],
+    vector_store: Any,
+    operation: str,
+    failure_reason: str,
+) -> Dict[str, Any]:
+    diagnostics: Dict[str, Any] = {
+        "embedding_candidates": 0,
+        "embeddings_persisted": 0,
+        "embeddings_failed": 0,
+        "embedding_coverage_degraded": False,
+    }
+    if not items:
+        return diagnostics
+
+    batch_size = max(1, int(_IMPORT_EMBED_BATCH_SIZE))
+    batch_total = (len(items) + batch_size - 1) // batch_size
+    for batch_index, (batch_items, batch_message_ids) in enumerate(
+        _iter_embedding_batches(items, message_ids, batch_size),
+        start=1,
+    ):
+        started_at = perf_counter()
+        batch_diagnostics = _embed_items_best_effort(batch_items, vector_store)
+        elapsed_ms = (perf_counter() - started_at) * 1000.0
+
+        persisted_count = int(batch_diagnostics.get("embeddings_persisted", 0))
+        failed_count = int(batch_diagnostics.get("embeddings_failed", 0))
+        _persist_chatgpt_embedding_attempt_outcome(
+            chatlog_db,
+            message_ids=batch_message_ids,
+            persisted_count=persisted_count,
+            failure_reason=(
+                failure_reason
+                if batch_diagnostics.get("embedding_coverage_degraded")
+                else None
+            ),
+        )
+        _log_chatgpt_embedding_batch(
+            operation=operation,
+            batch_index=batch_index,
+            batch_total=batch_total,
+            candidate_count=int(
+                batch_diagnostics.get("embedding_candidates", 0)
+            ),
+            persisted_count=persisted_count,
+            failed_count=failed_count,
+            elapsed_ms=elapsed_ms,
+            failure_class=batch_diagnostics.get("failure_class"),
+        )
+
+        diagnostics["embedding_candidates"] += int(
+            batch_diagnostics.get("embedding_candidates", 0)
+        )
+        diagnostics["embeddings_persisted"] += persisted_count
+        diagnostics["embeddings_failed"] += failed_count
+
+    diagnostics["embedding_coverage_degraded"] = (
+        diagnostics["embeddings_failed"] > 0
+    )
+    return diagnostics
 
 
 def _validate_chatgpt_export_payload(data: Any) -> List[Dict[str, Any]]:
@@ -1292,26 +1430,13 @@ def ingest_chatgpt_export(
             logger.error("Failed to import conversation: %s", e)
             continue
 
-    if _vector_store and pending_embed_items:
-        embedding_diagnostics = _embed_items_best_effort(
-            pending_embed_items, _vector_store
-        )
-    else:
-        embedding_diagnostics = _embed_items_best_effort(
-            pending_embed_items, None
-        )
-
-    _persist_chatgpt_embedding_attempt_outcome(
-        chatlog_db,
+    embedding_diagnostics = _process_chatgpt_embedding_batches(
+        chatlog_db=chatlog_db,
+        items=pending_embed_items,
         message_ids=pending_embed_message_ids,
-        persisted_count=int(
-            embedding_diagnostics.get("embeddings_persisted", 0)
-        ),
-        failure_reason=(
-            "embedding_coverage_degraded"
-            if embedding_diagnostics.get("embedding_coverage_degraded")
-            else None
-        ),
+        vector_store=_vector_store,
+        operation="import",
+        failure_reason="embedding_coverage_degraded",
     )
 
     return {
@@ -1330,7 +1455,7 @@ def ingest_chatgpt_export(
 
 
 def retry_chatgpt_import_embeddings(
-    *, user_id: Optional[str] = None
+    *, user_id: Optional[str] = None, limit: int = 5000
 ) -> Dict[str, Any]:
     if not user_id:
         raise ValueError(
@@ -1344,7 +1469,9 @@ def retry_chatgpt_import_embeddings(
         raise RuntimeError("Database not available")
 
     retryable_items = _fetch_retryable_chatgpt_embedding_items(
-        chatlog_db, user_id=user_id
+        chatlog_db,
+        user_id=user_id,
+        limit=limit,
     )
     if not retryable_items:
         return {
@@ -1367,16 +1494,13 @@ def retry_chatgpt_import_embeddings(
     if _IMPORT_EMBEDDINGS_ENABLED:
         vector_store = getattr(dependencies, "_vector_store", None) or None
 
-    diagnostics = _embed_items_best_effort(payload_items, vector_store)
-    _persist_chatgpt_embedding_attempt_outcome(
-        chatlog_db,
+    diagnostics = _process_chatgpt_embedding_batches(
+        chatlog_db=chatlog_db,
+        items=payload_items,
         message_ids=message_ids,
-        persisted_count=int(diagnostics.get("embeddings_persisted", 0)),
-        failure_reason=(
-            "embedding_retry_degraded"
-            if diagnostics.get("embedding_coverage_degraded")
-            else None
-        ),
+        vector_store=vector_store,
+        operation="retry",
+        failure_reason="embedding_retry_degraded",
     )
     return {
         "embedding_candidates": int(diagnostics.get("embedding_candidates", 0)),

--- a/guardian/guardian_api.py
+++ b/guardian/guardian_api.py
@@ -67,6 +67,7 @@ from guardian.core.dependencies import (
     ENABLE_CONNECTOR_WORKER,
     ENABLE_OUTBOX,
     allowed_origins,
+    get_single_user_id,
     init_database,
     init_services,
     require_api_key,
@@ -207,7 +208,29 @@ def _env_bool(name: str, default: bool) -> bool:
     return str(raw).strip().lower() in _TRUTHY_VALUES
 
 
+def _env_positive_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(str(raw).strip())
+    except (TypeError, ValueError):
+        logger.warning(
+            "[startup] invalid %s=%r; using default=%d", name, raw, default
+        )
+        return default
+    if value <= 0:
+        logger.warning(
+            "[startup] invalid %s=%r; using default=%d", name, raw, default
+        )
+        return default
+    return value
+
+
 _BETA_CORE_ONLY = _env_bool("CODEXIFY_BETA_CORE_ONLY", default=False)
+_CHATGPT_IMPORT_STARTUP_RETRY_CAP = _env_positive_int(
+    "CODEXIFY_CHATGPT_IMPORT_STARTUP_RETRY_CAP", 128
+)
 _SUPPORTED_PROFILE_MANIFEST = get_active_supported_profile()
 
 
@@ -276,6 +299,41 @@ def _codex_routes_enabled() -> bool:
     if _BETA_CORE_ONLY:
         return False
     return _env_bool("CODEXIFY_ENABLE_CODEX_ROUTES", default=True)
+
+
+def _run_chatgpt_import_startup_sweep() -> None:
+    user_id = get_single_user_id()
+    retry_cap = _CHATGPT_IMPORT_STARTUP_RETRY_CAP
+    try:
+        from backend.rag.chatgpt_migration import (
+            retry_chatgpt_import_embeddings as retry_chatgpt_import_embeddings_service,
+        )
+
+        stats = retry_chatgpt_import_embeddings_service(
+            user_id=user_id,
+            limit=retry_cap,
+        )
+        level = (
+            logger.warning
+            if stats.get("embedding_coverage_degraded")
+            else logger.info
+        )
+        level(
+            "[startup] ChatGPT import sweep user_id=%s limit=%d candidates=%d persisted=%d failed=%d degraded=%s",
+            user_id,
+            retry_cap,
+            int(stats.get("embedding_candidates", 0)),
+            int(stats.get("embeddings_persisted", 0)),
+            int(stats.get("embeddings_failed", 0)),
+            bool(stats.get("embedding_coverage_degraded", False)),
+        )
+    except Exception as exc:
+        logger.warning(
+            "[startup] ChatGPT import sweep failed user_id=%s limit=%d: %s",
+            user_id,
+            retry_cap,
+            exc,
+        )
 
 
 from guardian.realtime import collaboration
@@ -533,6 +591,8 @@ async def app_lifespan(app: FastAPI):
         logger.warning(
             "[startup] Failed to sync inference provider rows: %s", exc
         )
+
+    _run_chatgpt_import_startup_sweep()
 
     # Initialize Neo4j connection if graph logging is enabled
     if (

--- a/guardian/tests/migration/test_chatgpt_ingest.py
+++ b/guardian/tests/migration/test_chatgpt_ingest.py
@@ -48,8 +48,10 @@ def _build_mainline_export(
 class DeterministicVectorStore:
     def __init__(self) -> None:
         self._items: list[dict[str, Any]] = []
+        self.batch_sizes: list[int] = []
 
     def add_texts(self, items: list[dict[str, Any]]) -> int:
+        self.batch_sizes.append(len(items))
         for item in items:
             text = str(item.get("text") or "")
             meta = dict(item.get("meta") or {})
@@ -358,6 +360,7 @@ def test_imported_fact_is_recalled_in_post_import_completion(monkeypatch):
     monkeypatch.setattr(
         chat_worker.event_bus, "emit_event", lambda *_args, **_kwargs: None
     )
+    monkeypatch.setattr(chatgpt_migration, "_IMPORT_EMBED_ISOLATED", False)
 
     stats = ingest_chatgpt_export(
         json.dumps(export).encode("utf-8"),
@@ -701,3 +704,131 @@ def test_ingest_is_idempotent_on_reimport(monkeypatch):
     assert stats_first["messages_imported"] == 2
     assert stats_second["threads_imported"] == 0
     assert stats_second["messages_imported"] == 0
+
+
+def test_ingest_batches_embedding_follow_up_and_skips_hot_replay(monkeypatch):
+    mock_db = MagicMock()
+    mock_db.ensure_project.return_value = 1
+    mock_db.list_projects.return_value = [{"id": 1, "name": "Imports"}]
+    mock_db.create_chat_thread.return_value = {"id": 42}
+
+    message_ids = iter([1, 2, 3, 4, 5])
+
+    def fake_create_message(*_args, **_kwargs):
+        return next(message_ids)
+
+    batch_sizes: list[int] = []
+
+    def fake_add_texts(items: list[dict[str, Any]]) -> int:
+        batch_sizes.append(len(items))
+        if len(batch_sizes) == 2:
+            raise RuntimeError("hot batch failed")
+        return len(items)
+
+    vector_store = MagicMock()
+    vector_store.add_texts.side_effect = fake_add_texts
+
+    monkeypatch.setattr(dependencies, "chatlog_db", mock_db)
+    monkeypatch.setattr(dependencies, "_vector_store", vector_store)
+    monkeypatch.setattr(dependencies, "init_database", lambda: mock_db)
+    monkeypatch.setattr(chatgpt_migration, "_IMPORT_EMBED_ISOLATED", False)
+    monkeypatch.setattr(chatgpt_migration, "_IMPORT_EMBED_BATCH_SIZE", 2)
+    monkeypatch.setattr(
+        chatgpt_migration,
+        "_find_existing_thread_for_source",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        chatgpt_migration,
+        "_find_existing_message_for_source",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        chatgpt_migration,
+        "_persist_temporal_metadata",
+        lambda *_args, **_kwargs: None,
+    )
+    mock_db.create_message.side_effect = fake_create_message
+
+    export = _build_mainline_export(
+        [
+            ("user", "Alpha", 1),
+            ("assistant", "Bravo", 2),
+            ("user", "Charlie", 3),
+            ("assistant", "Delta", 4),
+            ("user", "Echo", 5),
+        ],
+        thread_id="batch-thread",
+    )
+
+    stats = ingest_chatgpt_export(
+        json.dumps(export).encode("utf-8"),
+        user_id="tester",
+    )
+
+    assert stats["threads_imported"] == 1
+    assert stats["messages_imported"] == 5
+    assert stats["embedding_candidates"] == 5
+    assert stats["embeddings_persisted"] == 3
+    assert stats["embeddings_failed"] == 2
+    assert stats["embedding_coverage_degraded"] is True
+    assert vector_store.add_texts.call_count == 3
+    assert batch_sizes == [2, 2, 1]
+    assert mock_db.create_message.call_count == 5
+
+
+def test_retry_chatgpt_import_embeddings_batches_retry_items(monkeypatch):
+    dummy_db = object()
+    retry_items = [
+        {
+            "message_id": 301,
+            "text": "Recovered import chunk A",
+            "meta": {"message_id": 301, "thread_id": 21},
+        },
+        {
+            "message_id": 302,
+            "text": "Recovered import chunk B",
+            "meta": {"message_id": 302, "thread_id": 21},
+        },
+        {
+            "message_id": 303,
+            "text": "Recovered import chunk C",
+            "meta": {"message_id": 303, "thread_id": 21},
+        },
+        {
+            "message_id": 304,
+            "text": "Recovered import chunk D",
+            "meta": {"message_id": 304, "thread_id": 21},
+        },
+        {
+            "message_id": 305,
+            "text": "Recovered import chunk E",
+            "meta": {"message_id": 305, "thread_id": 21},
+        },
+    ]
+
+    monkeypatch.setattr(dependencies, "chatlog_db", dummy_db)
+    monkeypatch.setattr(
+        dependencies, "_vector_store", DeterministicVectorStore()
+    )
+    monkeypatch.setattr(dependencies, "init_database", lambda: dummy_db)
+    monkeypatch.setattr(chatgpt_migration, "_IMPORT_EMBED_ISOLATED", False)
+    monkeypatch.setattr(chatgpt_migration, "_IMPORT_EMBED_BATCH_SIZE", 2)
+    monkeypatch.setattr(
+        chatgpt_migration,
+        "_fetch_retryable_chatgpt_embedding_items",
+        lambda _db, *, user_id, limit=5000: retry_items
+        if user_id == "tester"
+        else [],
+    )
+
+    stats = chatgpt_migration.retry_chatgpt_import_embeddings(
+        user_id="tester",
+        limit=5,
+    )
+
+    assert stats["embedding_candidates"] == 5
+    assert stats["embeddings_persisted"] == 5
+    assert stats["embeddings_failed"] == 0
+    assert stats["embedding_coverage_degraded"] is False
+    assert dependencies._vector_store.batch_sizes == [2, 2, 1]

--- a/tests/core/test_supported_profile_startup.py
+++ b/tests/core/test_supported_profile_startup.py
@@ -10,6 +10,8 @@ _GUARDIAN_API_ENV_KEYS = (
     "GUARDIAN_API_KEY",
     "ENABLE_CONNECTOR_WORKER",
     "CODEXIFY_SUPPORTED_PROFILE",
+    "CODEXIFY_SINGLE_USER_ID",
+    "CODEXIFY_CHATGPT_IMPORT_STARTUP_RETRY_CAP",
     "LLM_PROVIDER",
     "ALLOW_CLOUD_PROVIDERS",
     "CODEXIFY_LOCAL_ONLY_MODE",
@@ -37,6 +39,10 @@ def _load_guardian_api(monkeypatch, **env_overrides):
     fake_db = _fake_db()
     monkeypatch.setenv("GUARDIAN_API_KEY", "test-api-key")
     monkeypatch.setenv("ENABLE_CONNECTOR_WORKER", "0")
+    monkeypatch.setenv(
+        "CODEXIFY_BETA_CORE_ONLY",
+        env_overrides.pop("CODEXIFY_BETA_CORE_ONLY", "false"),
+    )
     monkeypatch.setenv("CODEXIFY_SUPPORTED_PROFILE", "v1-local-core-web-mcp")
     monkeypatch.setenv(
         "LLM_PROVIDER", env_overrides.pop("LLM_PROVIDER", "local")
@@ -80,6 +86,9 @@ def _load_guardian_api(monkeypatch, **env_overrides):
     import guardian.guardian_api as guardian_api
 
     guardian_api = importlib.reload(guardian_api)
+    monkeypatch.setattr(
+        guardian_api, "assert_config_coherence", lambda _settings: None
+    )
     monkeypatch.setattr(
         guardian_api.dependencies, "init_database", lambda: fake_db
     )
@@ -171,3 +180,64 @@ def test_supported_profile_startup_fails_on_provider_drift(monkeypatch) -> None:
             guardian_api._refresh_supported_profile_state(
                 guardian_api.app, guardian_api.get_settings()
             )
+
+
+def test_startup_chatgpt_import_sweep_uses_single_user_cap(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    with _loaded_guardian_api(
+        monkeypatch,
+        CODEXIFY_SINGLE_USER_ID="single-user",
+        CODEXIFY_CHATGPT_IMPORT_STARTUP_RETRY_CAP="7",
+    ) as guardian_api:
+
+        def fake_retry(*, user_id, limit=5000):
+            captured["user_id"] = user_id
+            captured["limit"] = limit
+            return {
+                "embedding_candidates": 0,
+                "embeddings_persisted": 0,
+                "embeddings_failed": 0,
+                "embedding_coverage_degraded": False,
+            }
+
+        monkeypatch.setattr(
+            "backend.rag.chatgpt_migration.retry_chatgpt_import_embeddings",
+            fake_retry,
+        )
+
+        with TestClient(guardian_api.app):
+            pass
+
+    assert captured["user_id"] == "single-user"
+    assert captured["limit"] == 7
+
+
+def test_startup_chatgpt_import_sweep_uses_default_cap(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    with _loaded_guardian_api(
+        monkeypatch,
+        CODEXIFY_SINGLE_USER_ID="single-user",
+    ) as guardian_api:
+
+        def fake_retry(*, user_id, limit=5000):
+            captured["user_id"] = user_id
+            captured["limit"] = limit
+            return {
+                "embedding_candidates": 0,
+                "embeddings_persisted": 0,
+                "embeddings_failed": 0,
+                "embedding_coverage_degraded": False,
+            }
+
+        monkeypatch.setattr(
+            "backend.rag.chatgpt_migration.retry_chatgpt_import_embeddings",
+            fake_retry,
+        )
+
+        with TestClient(guardian_api.app):
+            pass
+
+    assert captured["user_id"] == "single-user"
+    assert captured["limit"] == 128

--- a/tests/routes/test_migration_routes.py
+++ b/tests/routes/test_migration_routes.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -24,44 +24,46 @@ def _single_user_identity_env(monkeypatch: pytest.MonkeyPatch) -> None:
 class StubVectorStore:
     def __init__(self) -> None:
         self.items: list[dict] = []
+        self.batch_sizes: list[int] = []
 
     def add_texts(self, items: list[dict]) -> int:
+        self.batch_sizes.append(len(items))
         self.items.extend(items)
         return len(items)
 
 
-def _build_mainline_export() -> bytes:
+def _build_mainline_export(
+    turns: list[tuple[str, str, float]] | None = None,
+) -> bytes:
+    if turns is None:
+        turns = [
+            ("user", "Route-imported fact: ORBIT-ROUTE-314.", 1),
+            ("assistant", "Stored for recall.", 2),
+        ]
     payload = [
         {
             "id": "route-conv-1",
             "title": "Route Recall Fixture",
-            "current_node": "m2",
-            "mapping": {
-                "m1": {
-                    "id": "m1",
-                    "parent": None,
-                    "children": ["m2"],
-                    "message": {
-                        "author": {"role": "user"},
-                        "content": {
-                            "parts": ["Route-imported fact: ORBIT-ROUTE-314."]
-                        },
-                        "create_time": 1,
-                    },
-                },
-                "m2": {
-                    "id": "m2",
-                    "parent": "m1",
-                    "children": [],
-                    "message": {
-                        "author": {"role": "assistant"},
-                        "content": {"parts": ["Stored for recall."]},
-                        "create_time": 2,
-                    },
-                },
-            },
+            "current_node": f"m{len(turns)}",
+            "mapping": {},
         }
     ]
+    parent = None
+    for idx, (role, text, create_time) in enumerate(turns, start=1):
+        node_id = f"m{idx}"
+        payload[0]["mapping"][node_id] = {
+            "id": node_id,
+            "parent": parent,
+            "children": [],
+            "message": {
+                "author": {"role": role},
+                "content": {"parts": [text]},
+                "create_time": create_time,
+            },
+        }
+        if parent is not None:
+            payload[0]["mapping"][parent]["children"].append(node_id)
+        parent = node_id
     return json.dumps(payload).encode("utf-8")
 
 
@@ -408,6 +410,84 @@ def test_migration_route_executes_real_ingest_and_embeds(
     )
 
 
+def test_migration_route_batches_embedding_follow_up(
+    test_client,
+    mock_db,
+    monkeypatch,
+):
+    vector_store = StubVectorStore()
+    message_ids = iter([91, 92, 93, 94, 95])
+
+    def fake_create_message(
+        thread_id: int,
+        role: str,
+        content: str,
+        created_at: str | None = None,
+    ) -> int:
+        _ = thread_id, role, content, created_at
+        return next(message_ids)
+
+    mock_db.create_chat_thread.return_value = {"id": 42}
+    mock_db.create_message.side_effect = fake_create_message
+    mock_db.ensure_project.return_value = 1
+
+    monkeypatch.setattr(chatgpt_migration, "_IMPORT_EMBED_ISOLATED", False)
+    monkeypatch.setattr(chatgpt_migration, "_IMPORT_EMBED_BATCH_SIZE", 2)
+    monkeypatch.setattr(dependencies, "_vector_store", vector_store)
+    monkeypatch.setattr(dependencies, "chatlog_db", mock_db)
+    monkeypatch.setattr(dependencies, "init_database", lambda: mock_db)
+
+    monkeypatch.setattr(
+        chatgpt_migration,
+        "_find_existing_thread_for_source",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        chatgpt_migration,
+        "_find_existing_message_for_source",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        chatgpt_migration,
+        "_persist_temporal_metadata",
+        lambda *_args, **_kwargs: None,
+    )
+
+    files = {
+        "file": (
+            "conversations-batched.json",
+            _build_mainline_export(
+                [
+                    ("user", "Route chunk 1", 1),
+                    ("assistant", "Route chunk 2", 2),
+                    ("user", "Route chunk 3", 3),
+                    ("assistant", "Route chunk 4", 4),
+                    ("user", "Route chunk 5", 5),
+                ]
+            ),
+            "application/json",
+        )
+    }
+
+    response = test_client.post(
+        "/api/upload-chatgpt-export",
+        files=files,
+        headers={"X-User-Id": "spoofed_user"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["threads_imported"] == 1
+    assert data["messages_imported"] == 5
+    assert data["embedding_candidates"] == 5
+    assert data["embeddings_persisted"] == 5
+    assert data["embeddings_failed"] == 0
+    assert data["embedding_coverage_degraded"] is False
+    assert vector_store.batch_sizes == [2, 2, 1]
+    assert len(vector_store.items) == 5
+    assert mock_db.create_message.call_count == 5
+
+
 def test_embed_items_best_effort_handles_subprocess_segfault(monkeypatch):
     class _FakeProcess:
         def __init__(self, *_args, **_kwargs) -> None:
@@ -435,16 +515,19 @@ def test_embed_items_best_effort_handles_subprocess_segfault(monkeypatch):
     monkeypatch.setattr(
         chatgpt_migration.mp, "get_context", lambda *_: _FakeContext()
     )
+    vector_store = MagicMock()
 
     # Should swallow subprocess failure and return explicit degradation diagnostics.
     diagnostics = chatgpt_migration._embed_items_best_effort(
         items=[{"text": "hello", "meta": {"thread_id": 1}}],
-        vector_store=object(),
+        vector_store=vector_store,
     )
     assert diagnostics["embedding_candidates"] == 1
     assert diagnostics["embeddings_persisted"] == 0
     assert diagnostics["embeddings_failed"] == 1
     assert diagnostics["embedding_coverage_degraded"] is True
+    assert diagnostics["failure_class"] == "subprocess_exit_139"
+    vector_store.add_texts.assert_not_called()
 
 
 def test_migration_route_reports_embedding_degradation_on_exit_139(


### PR DESCRIPTION
## Summary
- Batch ChatGPT import and retry embeddings with configurable batch sizing and explicit failure classification
- Add startup retry sweep for the single-user deployment path with a capped retry limit
- Expand tests to cover batched embedding persistence, retry behavior, and startup sweep wiring

## Testing
- Not run (not requested)