### PR TITLE
Restore imported projects natively with clean titles

### DIFF
--- a/docs/audits/latest.json
+++ b/docs/audits/latest.json
@@ -1,4 +1,3 @@
 version https://git-lfs.github.com/spec/v1
 oid sha256:b2706cb8da55e864d3ec66c02347e5890a414e509db7ec77a285a04f3a8eba22
 size 36815
-        

--- a/frontend/src/components/sidebar/ProjectList.tsx
+++ b/frontend/src/components/sidebar/ProjectList.tsx
@@ -2,6 +2,11 @@ import * as React from "react";
 import clsx from "clsx";
 import { FolderOpen, Loader2, PlusCircle, Trash2 } from "lucide-react";
 import type { Project } from "@/types/common";
+import {
+  cleanSidebarProjectTitle,
+  normalizeSidebarProjects,
+  projectMatchesSidebarQuery,
+} from "./sidebarPresentation";
 
 type Props = {
   projects: Project[];
@@ -24,12 +29,15 @@ export default function ProjectList({
 }: Props) {
   const [deletingProjectId, setDeletingProjectId] = React.useState<string | null>(null);
   const query = search.toLowerCase();
-  const filtered = query ? projects.filter((p) => p.name.toLowerCase().includes(query)) : projects;
+  const visibleProjects = React.useMemo(() => normalizeSidebarProjects(projects), [projects]);
+  const filtered = query
+    ? visibleProjects.filter((project) => projectMatchesSidebarQuery(project, query))
+    : visibleProjects;
   const handleDeleteProject = React.useCallback(
     async (project: Project) => {
       if (!onDeleteProject) return;
       const projectId = String(project.id);
-      const projectName = String(project.name || "").trim() || "this project";
+      const projectName = cleanSidebarProjectTitle(project as any) || "this project";
       const confirmed = window.confirm(
         `Delete project "${projectName}"? This will remove the project and unassign its threads.`
       );
@@ -50,7 +58,7 @@ export default function ProjectList({
         {filtered.map((p) => (
           <ProjectTileCard
             key={p.id}
-            label={p.name}
+            label={cleanSidebarProjectTitle(p as any)}
             icon={p.icon}
             active={currentId === String(p.id)}
             onClick={() => onPick(String(p.id))}

--- a/frontend/src/components/sidebar/SidebarRoot.tsx
+++ b/frontend/src/components/sidebar/SidebarRoot.tsx
@@ -11,7 +11,7 @@ import useSidebarThreads from "./useSidebarThreads";
 import useProjectsCache from "./useProjectsCache";
 import {
   cleanSidebarProjectTitle,
-  isSidebarGeneralProjectName,
+  resolveSidebarGeneralProjectId,
 } from "./sidebarPresentation";
 import { useLegacyThreads } from "@/contexts/LegacyThreadsContext";
 import api from "@/lib/api";
@@ -168,10 +168,7 @@ export default function SidebarRoot({
 
   React.useEffect(() => {
     if (!projectList.length) return;
-    const defaultProject = projectList.find((project) =>
-      isSidebarGeneralProjectName(project?.name)
-    );
-    const defaultProjectId = defaultProject?.id != null ? String(defaultProject.id) : null;
+    const defaultProjectId = resolveSidebarGeneralProjectId(projectList);
     if (currentProjectId === null) {
       if (defaultProjectId) {
         setScope(defaultProjectId);
@@ -349,16 +346,7 @@ export default function SidebarRoot({
         currentProjectId != null &&
         String(currentProjectId) === normalizedId;
       const fallbackProjectId = deletingSelectedProject
-        ? (() => {
-            const generalProject = remaining.find((project) =>
-              isSidebarGeneralProjectName(project?.name)
-            );
-            if (generalProject?.id != null) {
-              return String(generalProject.id);
-            }
-            const nextProject = remaining[0];
-            return nextProject?.id != null ? String(nextProject.id) : null;
-          })()
+        ? resolveSidebarGeneralProjectId(remaining) ?? (remaining[0]?.id != null ? String(remaining[0].id) : null)
         : null;
       try {
         await deleteProjectApi(normalizedId);

--- a/frontend/src/components/sidebar/SidebarRoot.tsx
+++ b/frontend/src/components/sidebar/SidebarRoot.tsx
@@ -9,6 +9,10 @@ import ProjectList from "./ProjectList";
 import CreateProjectModal from "./CreateProjectModal";
 import useSidebarThreads from "./useSidebarThreads";
 import useProjectsCache from "./useProjectsCache";
+import {
+  cleanSidebarProjectTitle,
+  isSidebarGeneralProjectName,
+} from "./sidebarPresentation";
 import { useLegacyThreads } from "@/contexts/LegacyThreadsContext";
 import api from "@/lib/api";
 
@@ -75,18 +79,6 @@ function getComputedStyleVar(name: string, fallback = ""): string {
   }
 }
 
-function normalizeProjectName(value: unknown): string {
-  return String(value ?? "")
-    .trim()
-    .toLowerCase()
-    .replace(/\s+/g, " ");
-}
-
-function isDefaultProjectAlias(value: unknown): boolean {
-  const normalized = normalizeProjectName(value);
-  return normalized === "general" || normalized === "loose threads";
-}
-
 async function deleteProjectApi(projectId: string | number) {
   const paths = [`/api/projects/${projectId}`, `/projects/${projectId}`];
   let lastErr: any = null;
@@ -150,7 +142,12 @@ export default function SidebarRoot({
   const [projectModalError, setProjectModalError] = React.useState<string | null>(null);
 
   const {
-    threads: sidebarThreads,
+    projectList,
+    setProjectList,
+    refreshProjectsFromServer,
+  } = useProjectsCache({ initialProjects: projects, threadsForLooseCount: threads });
+
+  const {
     displayThreads,
     scopeLabel: hookScopeLabel,
     currentProjectId,
@@ -158,30 +155,34 @@ export default function SidebarRoot({
     renameThread,
     toggleArchiveThread,
     deleteThread,
-  } = useSidebarThreads({ initialThreads: threads, projectId, onProjectChange });
-
-  const {
-    projectList,
-    setProjectList,
-    refreshProjectsFromServer,
-  } = useProjectsCache({ initialProjects: projects, threadsForLooseCount: sidebarThreads });
+  } = useSidebarThreads({ initialThreads: threads, projectId, onProjectChange, projects: projectList });
 
   const scopeLabel = React.useMemo(() => {
     if (currentProjectId === null) return "General";
     if (currentProjectId) {
       const proj = projectList.find((p) => String(p.id) === String(currentProjectId));
-      return proj?.name ?? hookScopeLabel;
+      return proj ? cleanSidebarProjectTitle(proj as any) : hookScopeLabel;
     }
     return hookScopeLabel;
   }, [currentProjectId, hookScopeLabel, projectList]);
 
   React.useEffect(() => {
-    if (currentProjectId !== null) return;
+    if (!projectList.length) return;
     const defaultProject = projectList.find((project) =>
-      isDefaultProjectAlias(project?.name)
+      isSidebarGeneralProjectName(project?.name)
     );
-    if (!defaultProject?.id) return;
-    setScope(String(defaultProject.id));
+    const defaultProjectId = defaultProject?.id != null ? String(defaultProject.id) : null;
+    if (currentProjectId === null) {
+      if (defaultProjectId) {
+        setScope(defaultProjectId);
+      }
+      return;
+    }
+    const currentProjectExists = projectList.some(
+      (project) => String(project.id) === String(currentProjectId)
+    );
+    if (currentProjectExists) return;
+    setScope(defaultProjectId);
   }, [currentProjectId, projectList, setScope]);
 
   const columnClass = clsx("w-full", SIDEBAR_RAIL);
@@ -350,7 +351,7 @@ export default function SidebarRoot({
       const fallbackProjectId = deletingSelectedProject
         ? (() => {
             const generalProject = remaining.find((project) =>
-              isDefaultProjectAlias(project?.name)
+              isSidebarGeneralProjectName(project?.name)
             );
             if (generalProject?.id != null) {
               return String(generalProject.id);
@@ -372,7 +373,7 @@ export default function SidebarRoot({
             new CustomEvent("cfy:toast", {
               detail: {
                 kind: "success",
-                message: `Project "${existing.name}" deleted`,
+                message: `Project "${cleanSidebarProjectTitle(existing as any)}" deleted`,
               },
             })
           );

--- a/frontend/src/components/sidebar/ThreadList.tsx
+++ b/frontend/src/components/sidebar/ThreadList.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import clsx from "clsx";
 import {
   ChevronDown,
-  Bolt,
   Plus,
   MoreVertical,
   Pencil,
@@ -355,37 +354,8 @@ function ThreadTileRow({
     ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
     : <Trash2 className="h-4 w-4" aria-hidden="true" />;
 
-  const canonicalMode = thread.profileMode;
-  const heuristicProvider = (thread.providerOverride || thread.modelOverride || "").toLowerCase();
-  const heuristicCloud = heuristicProvider
-    ? !heuristicProvider.includes("ollama")
-    : null;
-  const isCloud =
-    canonicalMode === "cloud"
-      ? true
-      : canonicalMode === "local"
-        ? false
-        : heuristicCloud;
-
   const safeTitle = (thread.title || "").trim() || "Untitled";
-  const titleNode = (
-    <span key="title" className="thread-title block truncate" title={safeTitle}>
-      <span className="inline-flex items-center gap-1 truncate">
-        <span className="truncate">{safeTitle}</span>
-        {isCloud ? (
-          <span
-            className="inline-flex items-center justify-center rounded-full text-[10px] px-1.5 py-0.5"
-            style={{
-              background: "color-mix(in oklab, var(--accent), transparent 40%)",
-              color: "var(--accent-strong)",
-            }}
-          >
-            <Bolt className="h-3 w-3" />
-          </span>
-        ) : null}
-      </span>
-    </span>
-  );
+  const titleNode = <span key="title" className="thread-title block truncate" title={safeTitle}>{safeTitle}</span>;
   const snippet = typeof thread.lastMessage === "string" ? thread.lastMessage.trim() : "";
   const snippetNode = (
     <span

--- a/frontend/src/components/sidebar/__tests__/ProjectList.test.tsx
+++ b/frontend/src/components/sidebar/__tests__/ProjectList.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import ProjectList from "../ProjectList";
+import type { Project } from "@/types/common";
+
+function createProject(overrides: Partial<Project> & Record<string, unknown> = {}): Project {
+  return {
+    id: "proj-1",
+    name: "ChatGPT - Quarterly Planning",
+    icon: "📁",
+    ...overrides,
+  } as Project;
+}
+
+describe("ProjectList imported project presentation", () => {
+  it("cleans imported titles and keeps native project selection intact", () => {
+    const onPick = vi.fn();
+
+    render(
+      <ProjectList
+        projects={[
+          createProject({ metadata: { import_source: "chatgpt" } }),
+          { id: "proj-2", name: "Engineering", icon: "🧭" },
+        ]}
+        search=""
+        currentId={null}
+        onPick={onPick}
+      />
+    );
+
+    expect(screen.getByText("Quarterly Planning")).toBeInTheDocument();
+    expect(screen.getByText("Engineering")).toBeInTheDocument();
+    expect(screen.queryByText("ChatGPT - Quarterly Planning")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Quarterly Planning"));
+
+    expect(onPick).toHaveBeenCalledWith("proj-1");
+  });
+});

--- a/frontend/src/components/sidebar/__tests__/SidebarRoot.test.tsx
+++ b/frontend/src/components/sidebar/__tests__/SidebarRoot.test.tsx
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import api from "@/lib/api";
+import SidebarRoot from "../SidebarRoot";
+
+const mockSetScope = vi.fn();
+const mockSidebarState = vi.hoisted(() => ({
+  currentProjectId: "stale-project" as string | null,
+}));
+
+vi.mock("../useSidebarThreads", () => ({
+  default: () => ({
+    displayThreads: [],
+    scopeLabel: "Project",
+    currentProjectId: mockSidebarState.currentProjectId,
+    setScope: mockSetScope,
+    renameThread: vi.fn(),
+    toggleArchiveThread: vi.fn(),
+    deleteThread: vi.fn(),
+    looseCount: 0,
+  }),
+}));
+
+vi.mock("../ThreadList", () => ({
+  default: () => <div data-testid="thread-list" />,
+}));
+
+vi.mock("@/lib/api", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+const mockApi = api as unknown as {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+};
+
+describe("SidebarRoot project presentation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    window.localStorage.setItem("cfy.sidebarTab", "projects");
+    mockSidebarState.currentProjectId = "stale-project";
+    mockApi.get.mockResolvedValue({
+      data: {
+        projects: [
+          { id: "general-1", name: "General", icon: "📁" },
+          { id: "general-2", name: "Loose Threads", icon: "📁" },
+          {
+            id: "proj-1",
+            name: "ChatGPT - Quarterly Planning",
+            icon: "📁",
+            metadata: { import_source: "chatgpt" },
+          },
+          { id: "proj-2", name: "Engineering", icon: "🧭" },
+        ],
+      },
+    });
+  });
+
+  it("renders imported projects natively with one General bucket", async () => {
+    render(<SidebarRoot threads={[]} activeId={null} onSelect={vi.fn()} onNewChat={vi.fn()} />);
+
+    expect(await screen.findByText("Quarterly Planning")).toBeInTheDocument();
+    expect(screen.queryByText("ChatGPT - Quarterly Planning")).not.toBeInTheDocument();
+    expect(screen.getAllByText("General")).toHaveLength(1);
+    expect(screen.getByText("Engineering")).toBeInTheDocument();
+    expect(screen.queryByText("Imports")).not.toBeInTheDocument();
+
+    await waitFor(() => expect(mockSetScope).toHaveBeenCalledWith("general-1"));
+  });
+});

--- a/frontend/src/components/sidebar/__tests__/ThreadList.test.tsx
+++ b/frontend/src/components/sidebar/__tests__/ThreadList.test.tsx
@@ -71,4 +71,15 @@ describe("ThreadList dark mode surface contract", () => {
     expect(screen.getByText("General")).toBeInTheDocument();
     expect(screen.queryByText("Scope:")).not.toBeInTheDocument();
   });
+
+  it("does not render provider badges in the main thread list", () => {
+    const { container } = renderThreadList({
+      profileMode: "cloud",
+      providerOverride: "openai",
+      modelOverride: "gpt-4",
+    });
+
+    expect(container.querySelector("svg[data-lucide='bolt'], svg.lucide-bolt")).toBeNull();
+    expect(screen.getByText("Research notes")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/sidebar/__tests__/useProjectsCache.test.tsx
+++ b/frontend/src/components/sidebar/__tests__/useProjectsCache.test.tsx
@@ -73,4 +73,31 @@ describe("useProjectsCache", () => {
     expect(screen.getByTestId("project-names")).not.toHaveTextContent("ChatGPT - Quarterly Planning");
     expect(screen.getByTestId("project-meta")).toHaveTextContent('"import_source":"chatgpt"');
   });
+
+  it("keeps the canonical General project when an imported alias also cleans to General", async () => {
+    (api.get as any).mockResolvedValueOnce({
+      data: {
+        projects: [
+          {
+            id: 1,
+            name: "ChatGPT - General",
+            icon: "📁",
+            metadata: { import_source: "chatgpt" },
+          },
+          { id: 2, name: "General", icon: "📁" },
+          { id: 3, name: "Loose Threads", icon: "📁" },
+          { id: 4, name: "Engineering", icon: "🧭" },
+        ],
+      },
+    });
+
+    render(<ProjectsHarness />);
+
+    await waitFor(() => expect(screen.getByTestId("project-count")).toHaveTextContent("2"));
+    expect(screen.getByTestId("project-names")).toHaveTextContent("General|Engineering");
+    expect(screen.getByTestId("project-names")).not.toHaveTextContent("ChatGPT - General");
+    expect(screen.getByTestId("project-names")).not.toHaveTextContent("Loose Threads");
+    await waitFor(() => expect(window.localStorage.getItem("cfy.generalProjectId")).toBe("2"));
+    expect(window.localStorage.getItem("cfy.defaultProjectId")).toBe("2");
+  });
 });

--- a/frontend/src/components/sidebar/__tests__/useProjectsCache.test.tsx
+++ b/frontend/src/components/sidebar/__tests__/useProjectsCache.test.tsx
@@ -17,7 +17,13 @@ vi.mock("@/lib/logging/logOnce", () => ({
 function ProjectsHarness() {
   const { projectList } = useProjectsCache();
 
-  return <div data-testid="project-count">{projectList.length}</div>;
+  return (
+    <div>
+      <div data-testid="project-count">{projectList.length}</div>
+      <div data-testid="project-names">{projectList.map((project) => project.name).join("|")}</div>
+      <div data-testid="project-meta">{JSON.stringify(projectList[0] ?? null)}</div>
+    </div>
+  );
 }
 
 describe("useProjectsCache", () => {
@@ -42,5 +48,29 @@ describe("useProjectsCache", () => {
     document.dispatchEvent(new Event("visibilitychange"));
 
     await waitFor(() => expect(api.get).toHaveBeenCalledTimes(1));
+  });
+
+  it("cleans imported project labels and collapses duplicate General aliases", async () => {
+    (api.get as any).mockResolvedValueOnce({
+      data: {
+        projects: [
+          {
+            id: 1,
+            name: "ChatGPT - Quarterly Planning",
+            icon: "📁",
+            metadata: { import_source: "chatgpt" },
+          },
+          { id: 2, name: "General", icon: "📁" },
+          { id: 3, name: "Loose Threads", icon: "📁" },
+        ],
+      },
+    });
+
+    render(<ProjectsHarness />);
+
+    expect(await screen.findByTestId("project-count")).toHaveTextContent("2");
+    expect(screen.getByTestId("project-names")).toHaveTextContent("Quarterly Planning|General");
+    expect(screen.getByTestId("project-names")).not.toHaveTextContent("ChatGPT - Quarterly Planning");
+    expect(screen.getByTestId("project-meta")).toHaveTextContent('"import_source":"chatgpt"');
   });
 });

--- a/frontend/src/components/sidebar/__tests__/useSidebarThreads.test.tsx
+++ b/frontend/src/components/sidebar/__tests__/useSidebarThreads.test.tsx
@@ -17,7 +17,7 @@ const mockApi = api as unknown as {
   delete: ReturnType<typeof vi.fn>;
 };
 
-function createThread(id: string, title?: string): Thread {
+function createThread(id: string, title?: string, projectId?: string | null): Thread {
   return {
     id,
     title: title ?? `Thread ${id}`,
@@ -25,6 +25,7 @@ function createThread(id: string, title?: string): Thread {
     unread: 0,
     participants: [],
     messages: [],
+    projectId,
   };
 }
 
@@ -127,5 +128,36 @@ describe("useSidebarThreads delete flow", () => {
       )
     ).toBe(true);
     toastCapture.cleanup();
+  });
+
+  it("treats unknown project ids as General in the sidebar bucket", () => {
+    const initialThreads = [
+      createThread("11", "General thread"),
+      createThread("22", "Imported thread", "imported-project"),
+      createThread("33", "Scoped thread", "project-1"),
+    ];
+
+    const projects = [
+      { id: "general-1", name: "General", icon: "📁" },
+      { id: "project-1", name: "Engineering", icon: "🧭" },
+    ];
+
+    const { result } = renderHook(
+      ({ threads, sidebarProjects }) =>
+        useSidebarThreads({
+          initialThreads: threads,
+          projects: sidebarProjects,
+        }),
+      {
+        initialProps: {
+          threads: initialThreads,
+          sidebarProjects: projects,
+        },
+      }
+    );
+
+    expect(result.current.scopeLabel).toBe("General");
+    expect(result.current.displayThreads.map((thread) => thread.id)).toEqual(["11", "22"]);
+    expect(result.current.looseCount).toBe(2);
   });
 });

--- a/frontend/src/components/sidebar/__tests__/useSidebarThreads.test.tsx
+++ b/frontend/src/components/sidebar/__tests__/useSidebarThreads.test.tsx
@@ -160,4 +160,41 @@ describe("useSidebarThreads delete flow", () => {
     expect(result.current.displayThreads.map((thread) => thread.id)).toEqual(["11", "22"]);
     expect(result.current.looseCount).toBe(2);
   });
+
+  it("prefers the canonical General project id when an imported alias also cleans to General", () => {
+    const initialThreads = [
+      createThread("11", "Canonical general thread", "general-2"),
+      createThread("22", "Imported general thread", "general-1"),
+      createThread("33", "Scoped thread", "project-1"),
+    ];
+
+    const projects = [
+      {
+        id: "general-1",
+        name: "ChatGPT - General",
+        icon: "📁",
+        metadata: { import_source: "chatgpt" },
+      },
+      { id: "general-2", name: "General", icon: "📁" },
+      { id: "project-1", name: "Engineering", icon: "🧭" },
+    ];
+
+    const { result } = renderHook(
+      ({ threads, sidebarProjects }) =>
+        useSidebarThreads({
+          initialThreads: threads,
+          projects: sidebarProjects,
+        }),
+      {
+        initialProps: {
+          threads: initialThreads,
+          sidebarProjects: projects,
+        },
+      }
+    );
+
+    expect(result.current.scopeLabel).toBe("General");
+    expect(result.current.displayThreads.map((thread) => thread.id)).toEqual(["11"]);
+    expect(result.current.looseCount).toBe(1);
+  });
 });

--- a/frontend/src/components/sidebar/sidebarPresentation.ts
+++ b/frontend/src/components/sidebar/sidebarPresentation.ts
@@ -1,0 +1,158 @@
+import type { Project } from "@/types/common";
+import type { Thread } from "@/types/ui";
+
+export type SidebarProjectRecord = Project & Record<string, unknown>;
+
+const GENERAL_PROJECT_ALIASES = new Set(["general", "loose threads"]);
+const IMPORTED_PROVIDER_PREFIXES = [
+  "chatgpt",
+  "openai",
+  "claude",
+  "anthropic",
+  "gemini",
+  "perplexity",
+];
+
+function normalizeText(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+export function isSidebarGeneralProjectName(value: unknown): boolean {
+  return GENERAL_PROJECT_ALIASES.has(normalizeText(value).toLowerCase());
+}
+
+function hasImportedProvenance(project: Record<string, unknown>): boolean {
+  const directMarkers = [
+    project.import_source,
+    project.importSource,
+    project.imported_at,
+    project.importedAt,
+    project.imported_from,
+    project.importedFrom,
+    project.restored_at,
+    project.restoredAt,
+    project.restored_from,
+    project.restoredFrom,
+    project.import_profile,
+    project.importProfile,
+    project.source_thread_id,
+    project.sourceThreadId,
+    project.source_conversation_template_id,
+    project.sourceConversationTemplateId,
+    project.source_gizmo_id,
+    project.sourceGizmoId,
+    project.source_gizmo_type,
+    project.sourceGizmoType,
+  ];
+
+  for (const marker of directMarkers) {
+    if (typeof marker === "string" && marker.trim()) {
+      return true;
+    }
+    if (typeof marker === "number" && Number.isFinite(marker)) {
+      return true;
+    }
+  }
+
+  const metadata = project.metadata;
+  if (metadata && typeof metadata === "object") {
+    const meta = metadata as Record<string, unknown>;
+    if (hasImportedProvenance(meta)) {
+      return true;
+    }
+    const provenance = meta.provenance;
+    if (typeof provenance === "string" && /import|restore/i.test(provenance)) {
+      return true;
+    }
+    const origin = meta.origin;
+    if (typeof origin === "string" && /import/i.test(origin)) {
+      return true;
+    }
+  }
+
+  const provenance = project.provenance;
+  if (typeof provenance === "string" && /import|restore/i.test(provenance)) {
+    return true;
+  }
+
+  return false;
+}
+
+function stripImportedProviderPrefix(name: string): string {
+  const trimmed = normalizeText(name);
+  for (const provider of IMPORTED_PROVIDER_PREFIXES) {
+    const match = trimmed.match(
+      new RegExp(`^${provider}\\s*[-–—:|/]\\s*`, "i")
+    );
+    if (!match) continue;
+    const rest = trimmed.slice(match[0].length).trim();
+    if (rest) return rest;
+  }
+  return trimmed;
+}
+
+export function cleanSidebarProjectTitle(
+  project: Partial<SidebarProjectRecord> & Record<string, unknown>
+): string {
+  const rawName = normalizeText(project.name ?? project.project_name ?? "Untitled");
+  if (isSidebarGeneralProjectName(rawName)) {
+    return "General";
+  }
+  if (!hasImportedProvenance(project)) {
+    return rawName;
+  }
+  const cleaned = stripImportedProviderPrefix(rawName);
+  return cleaned || rawName;
+}
+
+export function normalizeSidebarProject<T extends SidebarProjectRecord>(project: T): T {
+  return {
+    ...project,
+    id: String(project.id ?? project.project_id ?? ""),
+    name: cleanSidebarProjectTitle(project),
+  } as T;
+}
+
+export function normalizeSidebarProjects<T extends SidebarProjectRecord>(projects: readonly T[]): T[] {
+  return projects.map((project) => normalizeSidebarProject(project));
+}
+
+export function normalizeSidebarProjectId(value: unknown): string | null {
+  const id = normalizeText(value);
+  return id || null;
+}
+
+export function resolveSidebarThreadBucketId(
+  thread: Pick<Thread, "projectId">,
+  projects: ReadonlyArray<Pick<Project, "id">>,
+  generalProjectId: string | null
+): string | null {
+  const threadProjectId = normalizeSidebarProjectId(thread.projectId);
+  if (!threadProjectId) {
+    return generalProjectId;
+  }
+  if (generalProjectId && threadProjectId === generalProjectId) {
+    return generalProjectId;
+  }
+  const knownProjectIds = new Set(projects.map((project) => String(project.id)));
+  if (knownProjectIds.has(threadProjectId)) {
+    return threadProjectId;
+  }
+  return generalProjectId;
+}
+
+export function threadBelongsToGeneral(
+  thread: Pick<Thread, "projectId">,
+  projects: ReadonlyArray<Pick<Project, "id">>,
+  generalProjectId: string | null
+): boolean {
+  const bucketId = resolveSidebarThreadBucketId(thread, projects, generalProjectId);
+  return bucketId === generalProjectId || bucketId === null;
+}
+
+export function projectMatchesSidebarQuery(project: SidebarProjectRecord, query: string): boolean {
+  if (!query.trim()) return true;
+  return cleanSidebarProjectTitle(project).toLowerCase().includes(query.trim().toLowerCase());
+}

--- a/frontend/src/components/sidebar/sidebarPresentation.ts
+++ b/frontend/src/components/sidebar/sidebarPresentation.ts
@@ -80,6 +80,14 @@ function hasImportedProvenance(project: Record<string, unknown>): boolean {
   return false;
 }
 
+function isSidebarGeneralProjectCandidate(
+  project: Partial<SidebarProjectRecord> & Record<string, unknown>
+): boolean {
+  const rawName = normalizeText(project.name ?? project.project_name ?? "");
+  const cleanedName = cleanSidebarProjectTitle(project);
+  return isSidebarGeneralProjectName(rawName) || isSidebarGeneralProjectName(cleanedName);
+}
+
 function stripImportedProviderPrefix(name: string): string {
   const trimmed = normalizeText(name);
   for (const provider of IMPORTED_PROVIDER_PREFIXES) {
@@ -117,6 +125,57 @@ export function normalizeSidebarProject<T extends SidebarProjectRecord>(project:
 
 export function normalizeSidebarProjects<T extends SidebarProjectRecord>(projects: readonly T[]): T[] {
   return projects.map((project) => normalizeSidebarProject(project));
+}
+
+export function selectSidebarGeneralProject<T extends SidebarProjectRecord>(
+  projects: readonly T[]
+): T | null {
+  const candidates = projects.filter((project) => isSidebarGeneralProjectCandidate(project));
+  if (!candidates.length) return null;
+
+  const isExactGeneral = (project: T) =>
+    normalizeText(project.name ?? project.project_name ?? "").toLowerCase() === "general";
+
+  // Prefer the exact General row first, then the best remaining non-imported alias.
+  return (
+    candidates.find((project) => isExactGeneral(project))
+    || candidates.find((project) => !hasImportedProvenance(project))
+    || candidates[0]
+  );
+}
+
+export function resolveSidebarGeneralProjectId<T extends SidebarProjectRecord>(
+  projects: readonly T[],
+  fallback: string | null = null
+): string | null {
+  const project = selectSidebarGeneralProject(projects);
+  return project?.id != null ? String(project.id) : fallback;
+}
+
+export function collapseSidebarGeneralProjectAliases<T extends SidebarProjectRecord>(
+  projects: readonly T[]
+): T[] {
+  const normalized = projects.map((project) => normalizeSidebarProject(project));
+  const canonical = selectSidebarGeneralProject(projects);
+  if (!canonical) return normalized;
+
+  const canonicalId = String(canonical.id);
+  let keptCanonical = false;
+
+  return normalized.reduce<T[]>((acc, project) => {
+    if (!isSidebarGeneralProjectName(project?.name)) {
+      acc.push(project);
+      return acc;
+    }
+
+    if (String(project.id) !== canonicalId || keptCanonical) {
+      return acc;
+    }
+
+    acc.push(project);
+    keptCanonical = true;
+    return acc;
+  }, []);
 }
 
 export function normalizeSidebarProjectId(value: unknown): string | null {

--- a/frontend/src/components/sidebar/useProjectsCache.ts
+++ b/frontend/src/components/sidebar/useProjectsCache.ts
@@ -6,6 +6,11 @@ import api from "@/lib/api";
 import type { Project } from "@/types/common";
 import type { Thread } from "@/types/ui";
 import { logOnce } from "@/lib/logging/logOnce";
+import {
+  isSidebarGeneralProjectName,
+  normalizeSidebarProject,
+  normalizeSidebarProjects,
+} from "./sidebarPresentation";
 
 type UseProjectsCacheOptions = {
   initialProjects?: Project[];
@@ -20,42 +25,31 @@ type UseProjectsCacheResult = {
 };
 
 const STORAGE_KEY = "cfy.projectsCache";
-function normalizeProjectName(value: unknown): string {
-  return String(value ?? "")
-    .trim()
-    .toLowerCase()
-    .replace(/\s+/g, " ");
-}
-
-function isDefaultAliasName(value: unknown): boolean {
-  const normalized = normalizeProjectName(value);
-  return normalized === "general" || normalized === "loose threads";
-}
 
 function normalizeDefaultProjectAliases(list: Project[]): Project[] {
-  const defaults = list.filter((project) => isDefaultAliasName(project?.name));
+  const defaults = list.filter((project) => isSidebarGeneralProjectName(project?.name));
   if (defaults.length <= 1) {
-    return list.map((project) =>
-      isDefaultAliasName(project?.name)
-        ? { ...project, name: "General" }
-        : project
-    );
+    return list.map((project) => normalizeSidebarProject(project));
   }
 
   const canonical =
-    defaults.find((project) => normalizeProjectName(project.name) === "general") ||
+    defaults.find((project) => isSidebarGeneralProjectName(project.name) && String(project.name).trim().toLowerCase() === "general") ||
     defaults[0];
   const canonicalId = String(canonical.id);
+  const mergedCanonical = defaults.reduce(
+    (acc, project) => ({ ...acc, ...project, name: "General", id: String(canonicalId) }),
+    { ...canonical, name: "General", id: String(canonicalId) }
+  );
 
   return list
     .filter((project) => {
-      if (!isDefaultAliasName(project?.name)) return true;
+      if (!isSidebarGeneralProjectName(project?.name)) return true;
       return String(project.id) === canonicalId;
     })
     .map((project) =>
-      isDefaultAliasName(project?.name)
-        ? { ...project, name: "General" }
-        : project
+      String(project.id) === canonicalId && isSidebarGeneralProjectName(project?.name)
+        ? normalizeSidebarProject(mergedCanonical)
+        : normalizeSidebarProject(project)
     );
 }
 
@@ -69,11 +63,13 @@ function normalizeProjectsResponse(res: any): Project[] {
   const normalized = list
     .filter(Boolean)
     .map((p: any) => ({
-      id: String(p.id ?? p.project_id),
+      ...p,
+      id: String(p.id ?? p.project_id ?? ""),
       name: p.name ?? p.project_name ?? "Untitled",
       icon: p.icon ?? "📁",
       color: p.color,
-    }));
+    }))
+    .filter((project: any) => String(project.id).trim().length > 0);
   return normalizeDefaultProjectAliases(normalized);
 }
 
@@ -82,7 +78,9 @@ function readProjectsCache(): Project[] {
     if (typeof window === "undefined") return [];
     const raw = window.localStorage.getItem(STORAGE_KEY);
     const arr = raw ? JSON.parse(raw) : [];
-    return Array.isArray(arr) ? arr.filter((p) => p && p.id && p.name) : [];
+    return Array.isArray(arr)
+      ? arr.filter((p) => p && p.id && p.name).map((project) => normalizeSidebarProject(project))
+      : [];
   } catch {
     return [];
   }
@@ -91,7 +89,7 @@ function readProjectsCache(): Project[] {
 function writeProjectsCache(list: Project[]) {
   try {
     if (typeof window === "undefined") return;
-    const compact = list.map((p) => ({ id: String(p.id), name: p.name, icon: p.icon, color: p.color }));
+    const compact = normalizeSidebarProjects(list as Project[]);
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(compact));
   } catch {
     /* ignore */
@@ -99,31 +97,41 @@ function writeProjectsCache(list: Project[]) {
 }
 
 function mergeProjects(primary: Project[], secondary: Project[]): Project[] {
-  const seen = new Set<string>();
-  const out: Project[] = [];
+  const seen = new Map<string, Project>();
   const push = (p?: Project) => {
     if (!p) return;
-    const key = String(p.id ?? "");
-    const nameKey = `name:${p.name}`;
-    if (key && seen.has(key)) return;
-    if (!key && seen.has(nameKey)) return;
-    if (key) seen.add(key);
-    else seen.add(nameKey);
-    out.push({ id: String(p.id), name: p.name, icon: p.icon, color: p.color });
+    const normalized = normalizeSidebarProject(p as any);
+    const key = String(normalized.id ?? "");
+    const nameKey = `name:${normalized.name}`;
+    const existingKey = key || nameKey;
+    const previous = seen.get(existingKey);
+    const merged = previous ? normalizeSidebarProject({ ...previous, ...normalized } as any) : normalized;
+    seen.set(existingKey, merged);
   };
   primary.forEach(push);
   secondary.forEach(push);
-  return normalizeDefaultProjectAliases(out);
+  return normalizeDefaultProjectAliases(Array.from(seen.values()));
 }
 
 /**
  * Compare two project records by visible fields to avoid no-op updates.
  */
 function sameProject(a: Project, b: Project): boolean {
+  const aRest = { ...a } as Record<string, unknown>;
+  const bRest = { ...b } as Record<string, unknown>;
+  delete aRest.id;
+  delete aRest.name;
+  delete aRest.icon;
+  delete aRest.color;
+  delete bRest.id;
+  delete bRest.name;
+  delete bRest.icon;
+  delete bRest.color;
   return String(a.id) === String(b.id)
     && (a.name ?? "") === (b.name ?? "")
     && (a.icon ?? "") === (b.icon ?? "")
-    && (a.color ?? "") === (b.color ?? "");
+    && (a.color ?? "") === (b.color ?? "")
+    && JSON.stringify(aRest) === JSON.stringify(bRest);
 }
 
 /**
@@ -164,7 +172,7 @@ export function useProjectsCache({
 
   useEffect(() => {
     const defaultProject = projectList.find((project) =>
-      isDefaultAliasName(project?.name)
+      isSidebarGeneralProjectName(project?.name)
     );
     if (!defaultProject?.id) return;
     try {

--- a/frontend/src/components/sidebar/useProjectsCache.ts
+++ b/frontend/src/components/sidebar/useProjectsCache.ts
@@ -7,9 +7,9 @@ import type { Project } from "@/types/common";
 import type { Thread } from "@/types/ui";
 import { logOnce } from "@/lib/logging/logOnce";
 import {
-  isSidebarGeneralProjectName,
+  collapseSidebarGeneralProjectAliases,
+  resolveSidebarGeneralProjectId,
   normalizeSidebarProject,
-  normalizeSidebarProjects,
 } from "./sidebarPresentation";
 
 type UseProjectsCacheOptions = {
@@ -25,33 +25,6 @@ type UseProjectsCacheResult = {
 };
 
 const STORAGE_KEY = "cfy.projectsCache";
-
-function normalizeDefaultProjectAliases(list: Project[]): Project[] {
-  const defaults = list.filter((project) => isSidebarGeneralProjectName(project?.name));
-  if (defaults.length <= 1) {
-    return list.map((project) => normalizeSidebarProject(project));
-  }
-
-  const canonical =
-    defaults.find((project) => isSidebarGeneralProjectName(project.name) && String(project.name).trim().toLowerCase() === "general") ||
-    defaults[0];
-  const canonicalId = String(canonical.id);
-  const mergedCanonical = defaults.reduce(
-    (acc, project) => ({ ...acc, ...project, name: "General", id: String(canonicalId) }),
-    { ...canonical, name: "General", id: String(canonicalId) }
-  );
-
-  return list
-    .filter((project) => {
-      if (!isSidebarGeneralProjectName(project?.name)) return true;
-      return String(project.id) === canonicalId;
-    })
-    .map((project) =>
-      String(project.id) === canonicalId && isSidebarGeneralProjectName(project?.name)
-        ? normalizeSidebarProject(mergedCanonical)
-        : normalizeSidebarProject(project)
-    );
-}
 
 function normalizeProjectsResponse(res: any): Project[] {
   const payload = res?.data ?? res;
@@ -70,7 +43,7 @@ function normalizeProjectsResponse(res: any): Project[] {
       color: p.color,
     }))
     .filter((project: any) => String(project.id).trim().length > 0);
-  return normalizeDefaultProjectAliases(normalized);
+  return collapseSidebarGeneralProjectAliases(normalized);
 }
 
 function readProjectsCache(): Project[] {
@@ -79,7 +52,7 @@ function readProjectsCache(): Project[] {
     const raw = window.localStorage.getItem(STORAGE_KEY);
     const arr = raw ? JSON.parse(raw) : [];
     return Array.isArray(arr)
-      ? arr.filter((p) => p && p.id && p.name).map((project) => normalizeSidebarProject(project))
+      ? collapseSidebarGeneralProjectAliases(arr.filter((p) => p && p.id && p.name))
       : [];
   } catch {
     return [];
@@ -89,7 +62,7 @@ function readProjectsCache(): Project[] {
 function writeProjectsCache(list: Project[]) {
   try {
     if (typeof window === "undefined") return;
-    const compact = normalizeSidebarProjects(list as Project[]);
+    const compact = collapseSidebarGeneralProjectAliases(list as Project[]);
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(compact));
   } catch {
     /* ignore */
@@ -110,7 +83,7 @@ function mergeProjects(primary: Project[], secondary: Project[]): Project[] {
   };
   primary.forEach(push);
   secondary.forEach(push);
-  return normalizeDefaultProjectAliases(Array.from(seen.values()));
+  return collapseSidebarGeneralProjectAliases(Array.from(seen.values()));
 }
 
 /**
@@ -171,20 +144,12 @@ export function useProjectsCache({
   }, [projectList]);
 
   useEffect(() => {
-    const defaultProject = projectList.find((project) =>
-      isSidebarGeneralProjectName(project?.name)
-    );
-    if (!defaultProject?.id) return;
+    const defaultProjectId = resolveSidebarGeneralProjectId(projectList);
+    if (!defaultProjectId) return;
     try {
       if (typeof window === "undefined") return;
-      window.localStorage.setItem(
-        "cfy.generalProjectId",
-        String(defaultProject.id)
-      );
-      window.localStorage.setItem(
-        "cfy.defaultProjectId",
-        String(defaultProject.id)
-      );
+      window.localStorage.setItem("cfy.generalProjectId", defaultProjectId);
+      window.localStorage.setItem("cfy.defaultProjectId", defaultProjectId);
     } catch {
       /* ignore */
     }

--- a/frontend/src/components/sidebar/useSidebarThreads.ts
+++ b/frontend/src/components/sidebar/useSidebarThreads.ts
@@ -5,6 +5,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import api from "@/lib/api";
 import type { Project } from "@/types/common";
 import type { Thread } from "@/types/ui";
+import {
+  cleanSidebarProjectTitle,
+  resolveSidebarThreadBucketId,
+  isSidebarGeneralProjectName,
+  threadBelongsToGeneral,
+} from "./sidebarPresentation";
 
 type UseSidebarThreadsOptions = {
   initialThreads: Thread[];
@@ -360,7 +366,7 @@ export function useSidebarThreads({
 
   const currentProjectId = onProjectChange ? (projectId ?? null) : localProjectId;
   const generalProjectId = useMemo(() => {
-    const fromProjects = projects.find((project) => isDefaultAliasName(project?.name));
+    const fromProjects = projects.find((project) => isSidebarGeneralProjectName(project?.name));
     if (fromProjects?.id != null) {
       return String(fromProjects.id);
     }
@@ -368,32 +374,23 @@ export function useSidebarThreads({
   }, [projects]);
 
   const scopedThreads = useMemo(() => {
-    const includesUnassignedAndGeneral = (scopeId: string | null): boolean => {
-      if (!scopeId) return false;
-      if (!generalProjectId) return false;
-      return String(scopeId) === String(generalProjectId);
-    };
+    const isGeneralScope =
+      currentProjectId === null
+      || (generalProjectId != null && String(currentProjectId) === String(generalProjectId));
+
+    const resolveBucket = (thread: Thread) =>
+      resolveSidebarThreadBucketId(thread, projects, generalProjectId);
 
     const base =
-      currentProjectId === null
-        ? threadList.filter((t) => {
-            if (!t.projectId) return true;
-            if (!generalProjectId) return false;
-            return String(t.projectId) === String(generalProjectId);
-          })
-        : currentProjectId
-        ? includesUnassignedAndGeneral(currentProjectId)
-          ? threadList.filter(
-              (t) =>
-                !t.projectId
-                || String(t.projectId ?? "") === String(currentProjectId)
-            )
-          : threadList.filter(
-              (t) => String(t.projectId ?? "") === String(currentProjectId)
-            )
-        : threadList;
-    return base.filter((t) => !t.archivedAt);
-  }, [currentProjectId, generalProjectId, threadList]);
+      currentProjectId === null || isGeneralScope
+        ? threadList.filter((thread) => threadBelongsToGeneral(thread, projects, generalProjectId))
+        : threadList.filter((thread) => {
+            const bucketId = resolveBucket(thread);
+            return bucketId != null && String(bucketId) === String(currentProjectId);
+          });
+
+    return base.filter((thread) => !thread.archivedAt);
+  }, [currentProjectId, generalProjectId, projects, threadList]);
 
   const displayThreads = useMemo(() => {
     const titleMap = stableTitleRef.current;
@@ -418,12 +415,15 @@ export function useSidebarThreads({
     if (currentProjectId === null) return "General";
     if (currentProjectId) {
       const proj = projects.find((p) => String(p.id) === String(currentProjectId));
-      return proj?.name ?? "Project";
+      return proj ? cleanSidebarProjectTitle(proj) : "Project";
     }
     return "All";
   }, [currentProjectId, projects]);
 
-  const looseCount = useMemo(() => threadList.filter((t) => !t.projectId).length, [threadList]);
+  const looseCount = useMemo(
+    () => threadList.filter((thread) => threadBelongsToGeneral(thread, projects, generalProjectId)).length,
+    [generalProjectId, projects, threadList]
+  );
 
   return {
     threads: threadList,

--- a/frontend/src/components/sidebar/useSidebarThreads.ts
+++ b/frontend/src/components/sidebar/useSidebarThreads.ts
@@ -8,7 +8,7 @@ import type { Thread } from "@/types/ui";
 import {
   cleanSidebarProjectTitle,
   resolveSidebarThreadBucketId,
-  isSidebarGeneralProjectName,
+  resolveSidebarGeneralProjectId,
   threadBelongsToGeneral,
 } from "./sidebarPresentation";
 
@@ -366,11 +366,7 @@ export function useSidebarThreads({
 
   const currentProjectId = onProjectChange ? (projectId ?? null) : localProjectId;
   const generalProjectId = useMemo(() => {
-    const fromProjects = projects.find((project) => isSidebarGeneralProjectName(project?.name));
-    if (fromProjects?.id != null) {
-      return String(fromProjects.id);
-    }
-    return readStoredGeneralProjectId();
+    return resolveSidebarGeneralProjectId(projects, readStoredGeneralProjectId());
   }, [projects]);
 
   const scopedThreads = useMemo(() => {


### PR DESCRIPTION
## Summary
- Added sidebar presentation helpers to clean imported/restored project titles, preserve provenance metadata, and resolve thread buckets against General.
- Routed project and thread sidebar rendering through the native project path, with stale or unclaimed imported threads falling back to General.
- Removed provider badges from the main thread list and added focused sidebar tests for cleaned titles, duplicate General collapse, and fallback behavior.

## Testing
- `pnpm --dir frontend/src exec vitest run components/sidebar/__tests__/ProjectList.test.tsx components/sidebar/__tests__/SidebarRoot.test.tsx components/sidebar/__tests__/ThreadList.test.tsx components/sidebar/__tests__/useProjectsCache.test.tsx components/sidebar/__tests__/useSidebarThreads.test.tsx`