### PR TITLE
Add coherent run and trace observability to Command Center

### DIFF
--- a/frontend/src/features/commandCenter/CommandCenterPage.tsx
+++ b/frontend/src/features/commandCenter/CommandCenterPage.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 import RunDetailDrawer from "@/features/commandCenter/components/RunDetailDrawer";
+import RunSummaryCard from "@/features/commandCenter/components/RunSummaryCard";
 import useCommandCenterEvents from "@/features/commandCenter/hooks/useCommandCenterEvents";
 import useHealthSummary from "@/features/commandCenter/hooks/useHealthSummary";
 import type {
@@ -238,23 +239,6 @@ function resolveSelectedRunTraceUrl(run: CommandCenterRun): string | null {
     response?.traceUrl,
     result?.trace_url,
     result?.traceUrl
-  );
-}
-
-function getRunLabel(run: CommandCenterRun): string {
-  return firstString(run.summary, run.taskId, run.runId, run.key) ?? "Unknown run";
-}
-
-function getRunEventType(run: CommandCenterRun): string {
-  return (
-    firstString(
-      run.lastType,
-      run.lastKind,
-      run.lastEvent.type,
-      run.lastEvent.kind,
-      run.lastEvent.sseType,
-      run.lastEvent.status
-    ) ?? "unknown"
   );
 }
 
@@ -528,117 +512,13 @@ function RunFeed({
         ) : (
           runs.map((run) => {
             const selected = run.key === selectedRunKey;
-            const runLabel = getRunLabel(run);
-            const runSummary = run.summary && run.summary !== runLabel ? run.summary : null;
-            const eventType = getRunEventType(run);
-            const eventIds = [
-              run.lastEvent.eventId ? `Event: ${run.lastEvent.eventId}` : null,
-              run.runId ? `Run: ${run.runId}` : null,
-              run.taskId ? `Task: ${run.taskId}` : null,
-            ].filter((value): value is string => Boolean(value));
-
             return (
-              <Card
+              <RunSummaryCard
                 key={run.key}
-                className="bezel-none border"
-                data-testid={`command-center-run-${run.key}`}
-                style={{
-                  ...tileSurfaceStyle,
-                  borderColor: selected ? "var(--accent)" : tileSurfaceStyle.borderColor,
-                }}
-              >
-                <CardContent className="space-y-3 p-[var(--card-pad)]">
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                    <div className="min-w-0 space-y-1.5">
-                      <div className="text-sm font-semibold leading-5" style={{ color: "var(--text)" }}>
-                        {runLabel}
-                      </div>
-                      {runSummary ? (
-                        <div className="text-xs leading-5" style={{ color: "var(--muted)" }}>
-                          {runSummary}
-                        </div>
-                      ) : null}
-                    </div>
-                    <div className="flex shrink-0 items-start gap-2">
-                      <StatusPill
-                        ariaLabelPrefix={`${runLabel} status`}
-                        status={run.status}
-                      />
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => onSelectRun(run)}
-                        aria-label={`Open details for ${runLabel}`}
-                      >
-                        Open
-                      </Button>
-                    </div>
-                  </div>
-
-                  <div className="flex flex-wrap gap-2">
-                    <BadgePill tone="subtle">Events: {run.eventCount}</BadgePill>
-                    <BadgePill tone="subtle">Updated: {formatTimestamp(run.lastEventAt)}</BadgePill>
-                  </div>
-
-                  <details className="text-xs" style={{ color: "var(--muted)" }}>
-                    <summary className="cursor-pointer text-[11px] font-semibold uppercase tracking-[0.16em]">
-                      Inspect event details
-                    </summary>
-                    <div className="mt-3 space-y-2">
-                      <div className="rounded-[var(--tile-radius)] border p-3" style={rawSurfaceStyle}>
-                        <div
-                          className="text-[11px] font-semibold uppercase tracking-[0.16em]"
-                          style={{ color: "var(--muted)" }}
-                        >
-                          Event type
-                        </div>
-                        <div className="text-xs leading-5" style={{ color: "var(--text)" }}>
-                          {eventType}
-                        </div>
-                      </div>
-                      <div className="rounded-[var(--tile-radius)] border p-3" style={rawSurfaceStyle}>
-                        <div
-                          className="text-[11px] font-semibold uppercase tracking-[0.16em]"
-                          style={{ color: "var(--muted)" }}
-                        >
-                          Event identifiers
-                        </div>
-                        <div className="mt-2 flex flex-wrap gap-2">
-                          {eventIds.length > 0 ? (
-                            eventIds.map((value) => (
-                              <BadgePill key={value} tone="subtle">
-                                {value}
-                              </BadgePill>
-                            ))
-                          ) : (
-                            <span style={{ color: "var(--muted)" }}>
-                              No raw event identifiers available.
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                      <div className="rounded-[var(--tile-radius)] border p-3" style={rawSurfaceStyle}>
-                        <div
-                          className="text-[11px] font-semibold uppercase tracking-[0.16em]"
-                          style={{ color: "var(--muted)" }}
-                        >
-                          Raw message
-                        </div>
-                        <pre
-                          className="mt-2 overflow-x-auto rounded-[var(--tile-radius)] border p-3 text-[11px] leading-5"
-                          style={{
-                            ...rawSurfaceStyle,
-                            color: "var(--muted)",
-                          }}
-                        >
-                          {run.lastEvent.raw || "No raw message available."}
-                        </pre>
-                      </div>
-                    </div>
-                  </details>
-                </CardContent>
-              </Card>
+                onOpen={onSelectRun}
+                run={run}
+                selected={selected}
+              />
             );
           })
         )}

--- a/frontend/src/features/commandCenter/CommandCenterPage.tsx
+++ b/frontend/src/features/commandCenter/CommandCenterPage.tsx
@@ -9,8 +9,14 @@ import RunSummaryCard from "@/features/commandCenter/components/RunSummaryCard";
 import useCommandCenterEvents from "@/features/commandCenter/hooks/useCommandCenterEvents";
 import useHealthSummary from "@/features/commandCenter/hooks/useHealthSummary";
 import type {
+  CommandCenterConnectionState,
   CommandCenterHealthItem,
   CommandCenterRun,
+} from "@/features/commandCenter/types";
+import {
+  COMMAND_CENTER_HEALTH_STATES,
+  COMMAND_CENTER_RUN_STATUSES,
+  describeCommandCenterHealthStatePresentation,
 } from "@/features/commandCenter/types";
 import {
   describeRuntimeStatusPresentation,
@@ -179,8 +185,12 @@ function countUnknownItems(
   healthItems: CommandCenterHealthItem[],
   runs: CommandCenterRun[]
 ): number {
-  const healthUnknownCount = healthItems.filter((item) => item.status === "UNKNOWN").length;
-  const runUnknownCount = runs.filter((run) => run.status === "unknown").length;
+  const healthUnknownCount = healthItems.filter(
+    (item) => item.status === COMMAND_CENTER_HEALTH_STATES.UNKNOWN
+  ).length;
+  const runUnknownCount = runs.filter(
+    (run) => run.status === COMMAND_CENTER_RUN_STATUSES.UNKNOWN
+  ).length;
   return healthUnknownCount + runUnknownCount;
 }
 
@@ -294,7 +304,7 @@ function HealthStrip({
   lastCheckedAt: number | null;
   loading: boolean;
   onRefresh: () => Promise<void>;
-  }) {
+}) {
   return (
     <Card
       className="bezel-none border"
@@ -320,87 +330,93 @@ function HealthStrip({
         </Button>
       </CardHeader>
       <CardContent className="space-y-3">
-        {healthItems.map((item) => (
-          <Card
-            key={item.key}
-            className="bezel-none border"
-            data-testid={`command-center-health-${item.key}`}
-            style={{
-              ...tileSurfaceStyle,
-            }}
-          >
-            <CardContent className="space-y-3 p-[var(--card-pad)]">
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                <div className="min-w-0 space-y-1">
-                  <div className="text-sm font-semibold leading-5" style={{ color: "var(--text)" }}>
-                    {item.label}
-                  </div>
-                  <div className="text-xs leading-5" style={{ color: "var(--muted)" }}>
-                    {item.endpoint}
-                  </div>
-                </div>
-                <StatusPill
-                  ariaLabelPrefix={`${item.label} status`}
-                  status={item.status}
-                />
-              </div>
+        {healthItems.map((item) => {
+          const presentation = describeCommandCenterHealthStatePresentation(item.status);
 
-              <details className="text-xs" style={{ color: "var(--muted)" }}>
-                <summary className="cursor-pointer text-[11px] font-semibold uppercase tracking-[0.16em]">
-                  Inspect raw details
-                </summary>
-                <div className="mt-3 space-y-2">
-                  <div className="rounded-[var(--tile-radius)] border p-3" style={rawSurfaceStyle}>
-                    <div
-                      className="text-[11px] font-semibold uppercase tracking-[0.16em]"
-                      style={{ color: "var(--muted)" }}
-                    >
-                      Checked
+          return (
+            <Card
+              key={item.key}
+              className="bezel-none border"
+              data-testid={`command-center-health-${item.key}`}
+              style={{
+                ...tileSurfaceStyle,
+              }}
+            >
+              <CardContent className="space-y-3 p-[var(--card-pad)]">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="min-w-0 space-y-1">
+                    <div className="text-sm font-semibold leading-5" style={{ color: "var(--text)" }}>
+                      {item.label}
                     </div>
-                    <div className="text-xs leading-5" style={{ color: "var(--text)" }}>
-                      {formatTimestamp(item.checkedAt)}
+                    <div className="text-xs leading-5" style={{ color: "var(--muted)" }}>
+                      {item.endpoint}
                     </div>
                   </div>
-                  {item.httpStatus != null ? (
+                  <BadgePill
+                    ariaLabel={`${item.label} status ${presentation.label}`}
+                    tone={presentation.tone}
+                  >
+                    {presentation.label}
+                  </BadgePill>
+                </div>
+
+                <details className="text-xs" style={{ color: "var(--muted)" }}>
+                  <summary className="cursor-pointer text-[11px] font-semibold uppercase tracking-[0.16em]">
+                    Inspect raw details
+                  </summary>
+                  <div className="mt-3 space-y-2">
                     <div className="rounded-[var(--tile-radius)] border p-3" style={rawSurfaceStyle}>
                       <div
                         className="text-[11px] font-semibold uppercase tracking-[0.16em]"
                         style={{ color: "var(--muted)" }}
                       >
-                        HTTP status
+                        Checked
                       </div>
                       <div className="text-xs leading-5" style={{ color: "var(--text)" }}>
-                        {item.httpStatus}
+                        {formatTimestamp(item.checkedAt)}
                       </div>
                     </div>
-                  ) : null}
-                  {item.error ? (
-                    <div className="rounded-[var(--tile-radius)] border p-3" style={rawSurfaceStyle}>
-                      <div
-                        className="text-[11px] font-semibold uppercase tracking-[0.16em]"
-                        style={{ color: "var(--muted)" }}
-                      >
-                        Error
+                    {item.httpStatus != null ? (
+                      <div className="rounded-[var(--tile-radius)] border p-3" style={rawSurfaceStyle}>
+                        <div
+                          className="text-[11px] font-semibold uppercase tracking-[0.16em]"
+                          style={{ color: "var(--muted)" }}
+                        >
+                          HTTP status
+                        </div>
+                        <div className="text-xs leading-5" style={{ color: "var(--text)" }}>
+                          {item.httpStatus}
+                        </div>
                       </div>
-                      <div className="text-xs leading-5" style={{ color: "var(--muted)" }}>
-                        {item.error}
+                    ) : null}
+                    {item.error ? (
+                      <div className="rounded-[var(--tile-radius)] border p-3" style={rawSurfaceStyle}>
+                        <div
+                          className="text-[11px] font-semibold uppercase tracking-[0.16em]"
+                          style={{ color: "var(--muted)" }}
+                        >
+                          Error
+                        </div>
+                        <div className="text-xs leading-5" style={{ color: "var(--muted)" }}>
+                          {item.error}
+                        </div>
                       </div>
-                    </div>
-                  ) : null}
-                  <pre
-                    className="overflow-x-auto rounded-[var(--tile-radius)] border p-3 text-[11px] leading-5"
-                    style={{
-                      ...rawSurfaceStyle,
-                      color: "var(--muted)",
-                    }}
-                  >
-                    {item.raw ?? "No raw payload available."}
-                  </pre>
-                </div>
-              </details>
-            </CardContent>
-          </Card>
-        ))}
+                    ) : null}
+                    <pre
+                      className="overflow-x-auto rounded-[var(--tile-radius)] border p-3 text-[11px] leading-5"
+                      style={{
+                        ...rawSurfaceStyle,
+                        color: "var(--muted)",
+                      }}
+                    >
+                      {item.raw ?? "No raw payload available."}
+                    </pre>
+                  </div>
+                </details>
+              </CardContent>
+            </Card>
+          );
+        })}
       </CardContent>
     </Card>
   );

--- a/frontend/src/features/commandCenter/CommandCenterPage.tsx
+++ b/frontend/src/features/commandCenter/CommandCenterPage.tsx
@@ -21,33 +21,11 @@ type CommandCenterPageProps = {
   enabled: boolean;
 };
 
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  return value as Record<string, unknown>;
-}
-
 function firstString(...values: unknown[]): string | null {
   for (const value of values) {
     if (typeof value !== "string") continue;
     const trimmed = value.trim();
     if (trimmed) return trimmed;
-  }
-  return null;
-}
-
-function firstNumber(...values: unknown[]): number | null {
-  for (const value of values) {
-    if (typeof value === "number" && Number.isFinite(value)) {
-      return value;
-    }
-    if (typeof value === "string") {
-      const trimmed = value.trim();
-      if (!trimmed) continue;
-      const parsed = Number(trimmed);
-      if (Number.isFinite(parsed)) return parsed;
-    }
   }
   return null;
 }
@@ -194,51 +172,6 @@ function SummaryTile({
         {note}
       </div>
     </div>
-  );
-}
-
-function resolveSelectedRunThreadId(run: CommandCenterRun): number | null {
-  const payload = asRecord(run.lastEvent.json);
-  const thread = asRecord(payload?.thread);
-  const task = asRecord(payload?.task);
-  const nestedRun = asRecord(payload?.run);
-  const context = asRecord(payload?.context);
-  const nestedPayload = asRecord(payload?.payload);
-
-  return firstNumber(
-    run.threadId,
-    payload?.thread_id,
-    payload?.threadId,
-    thread?.id,
-    thread?.thread_id,
-    thread?.threadId,
-    nestedRun?.thread_id,
-    nestedRun?.threadId,
-    task?.thread_id,
-    task?.threadId,
-    context?.thread_id,
-    context?.threadId,
-    nestedPayload?.thread_id,
-    nestedPayload?.threadId
-  );
-}
-
-function resolveSelectedRunTraceUrl(run: CommandCenterRun): string | null {
-  const payload = asRecord(run.lastEvent.json);
-  const nestedRun = asRecord(payload?.run);
-  const response = asRecord(payload?.response);
-  const result = asRecord(payload?.result);
-
-  return firstString(
-    run.traceUrl,
-    payload?.trace_url,
-    payload?.traceUrl,
-    nestedRun?.trace_url,
-    nestedRun?.traceUrl,
-    response?.trace_url,
-    response?.traceUrl,
-    result?.trace_url,
-    result?.traceUrl
   );
 }
 
@@ -665,15 +598,7 @@ export default function CommandCenterPage({
   const [selectedRunKey, setSelectedRunKey] = React.useState<string | null>(null);
 
   const selectedRun = React.useMemo<CommandCenterRun | null>(
-    () => {
-      const run = runs.find((candidate) => candidate.key === selectedRunKey) ?? null;
-      if (!run) return null;
-      return {
-        ...run,
-        threadId: resolveSelectedRunThreadId(run),
-        traceUrl: resolveSelectedRunTraceUrl(run),
-      };
-    },
+    () => runs.find((candidate) => candidate.key === selectedRunKey) ?? null,
     [runs, selectedRunKey]
   );
 

--- a/frontend/src/features/commandCenter/__tests__/CommandCenterPage.test.tsx
+++ b/frontend/src/features/commandCenter/__tests__/CommandCenterPage.test.tsx
@@ -69,51 +69,160 @@ const mockedHealthItems: CommandCenterHealthItem[] = [
 const mockedRuns: CommandCenterRun[] = [
   {
     eventCount: 4,
-    key: "run-alpha",
+    events: [
+      {
+        eventId: "evt-1",
+        json: { type: "chat.completion", thread_id: 42 },
+        kind: null,
+        latestTurnMessageId: "501",
+        raw: '{"type":"chat.completion","thread_id":42}',
+        receivedAt: Date.parse("2026-04-01T15:58:00Z"),
+        requestId: null,
+        runId: "run-alpha",
+        sseType: "task.created",
+        state: "created",
+        status: null,
+        summary: "chat completion created",
+        taskId: "task-alpha",
+        taskType: "chat.completion",
+        terminalOutcome: null,
+        threadId: 42,
+        turnId: "turn-alpha",
+        type: "task.created",
+      },
+      {
+        eventId: "evt-2",
+        json: { thread_id: 42 },
+        kind: null,
+        latestTurnMessageId: "501",
+        raw: '{"thread_id":42}',
+        receivedAt: Date.parse("2026-04-01T15:58:10Z"),
+        requestId: null,
+        runId: "run-alpha",
+        sseType: "task.running",
+        state: "running",
+        status: null,
+        summary: "chat completion running",
+        taskId: "task-alpha",
+        taskType: null,
+        terminalOutcome: null,
+        threadId: 42,
+        turnId: "turn-alpha",
+        type: "task.running",
+      },
+      {
+        eventId: "evt-3",
+        json: { thread_id: 42 },
+        kind: null,
+        latestTurnMessageId: "501",
+        raw: '{"thread_id":42}',
+        receivedAt: Date.parse("2026-04-01T15:58:20Z"),
+        requestId: null,
+        runId: "run-alpha",
+        sseType: "task.chunk",
+        state: "chunk",
+        status: null,
+        summary: "chat completion chunk",
+        taskId: "task-alpha",
+        taskType: null,
+        terminalOutcome: null,
+        threadId: 42,
+        turnId: "turn-alpha",
+        type: "task.chunk",
+      },
+      {
+        eventId: "evt-4",
+        json: { thread_id: 42, message_id: 501 },
+        kind: null,
+        latestTurnMessageId: "501",
+        raw: '{"thread_id":42,"message_id":501}',
+        receivedAt: Date.parse("2026-04-01T15:58:30Z"),
+        requestId: null,
+        runId: "run-alpha",
+        sseType: "task.completed",
+        state: "completed",
+        status: null,
+        summary: "chat completion completed",
+        taskId: "task-alpha",
+        taskType: null,
+        terminalOutcome: "succeeded",
+        threadId: 42,
+        turnId: "turn-alpha",
+        type: "task.completed",
+      },
+    ],
+    identityKind: "task",
+    key: "task-alpha",
     lastEvent: {
-      eventId: "evt-1",
-      json: { message: "Processing alpha" },
-      kind: "task.started",
-      raw: '{"message":"Processing alpha"}',
+      eventId: "evt-4",
+      json: { thread_id: 42, message_id: 501 },
+      kind: null,
+      latestTurnMessageId: "501",
+      raw: '{"thread_id":42,"message_id":501}',
       receivedAt: Date.parse("2026-04-01T15:58:30Z"),
+      requestId: null,
       runId: "run-alpha",
-      sseType: "message",
-      status: "running",
-      summary: "Processing alpha",
+      sseType: "task.completed",
+      state: "completed",
+      status: null,
+      summary: "chat completion completed",
       taskId: "task-alpha",
-      type: "task.started",
+      taskType: null,
+      terminalOutcome: "succeeded",
+      threadId: 42,
+      turnId: "turn-alpha",
+      type: "task.completed",
     },
     lastEventAt: Date.parse("2026-04-01T15:58:30Z"),
-    lastKind: "task.started",
-    lastType: "task.started",
+    lastKind: null,
+    lastType: "task.completed",
+    latestTurnMessageId: "501",
+    requestId: null,
     runId: "run-alpha",
-    status: "running",
-    summary: "Processing alpha",
+    runType: "chat completion",
+    state: "completed",
+    status: "succeeded",
+    summary: "chat completion · completed",
     taskId: "task-alpha",
+    terminalOutcome: "succeeded",
+    threadId: 42,
+    turnId: "turn-alpha",
   },
   {
-    eventCount: 2,
-    key: "run-bravo",
+    eventCount: 1,
+    identityKind: "synthetic",
+    key: "event-raw-bravo",
     lastEvent: {
-      eventId: "evt-2",
+      eventId: "evt-raw-1",
       json: { message: "No classification yet" },
-      kind: "task.updated",
+      kind: null,
+      latestTurnMessageId: null,
       raw: '{"message":"No classification yet"}',
       receivedAt: Date.parse("2026-04-01T15:57:30Z"),
-      runId: "run-bravo",
+      requestId: null,
+      runId: null,
       sseType: "message",
+      state: null,
       status: "unknown",
       summary: "No classification yet",
-      taskId: "task-bravo",
-      type: "task.updated",
+      taskId: null,
+      taskType: null,
+      terminalOutcome: null,
+      threadId: null,
+      turnId: null,
+      type: null,
     },
     lastEventAt: Date.parse("2026-04-01T15:57:30Z"),
-    lastKind: "task.updated",
-    lastType: "task.updated",
-    runId: "run-bravo",
+    lastKind: null,
+    lastType: null,
+    requestId: null,
+    runId: null,
+    runType: null,
+    state: null,
     status: "unknown",
-    summary: "No classification yet",
-    taskId: "task-bravo",
+    summary: "unclassified event",
+    taskId: null,
+    terminalOutcome: null,
   },
 ];
 
@@ -258,24 +367,31 @@ describe("CommandCenterPage", () => {
     expect(within(healthStrip).getAllByText("Inspect raw details").length).toBeGreaterThan(0);
 
     const runsFeed = screen.getByTestId("command-center-runs-feed");
-    expect(within(runsFeed).getByText("Processing alpha")).toBeInTheDocument();
-    expect(within(runsFeed).getByText("No classification yet")).toBeInTheDocument();
-    expect(within(screen.getByTestId("command-center-run-run-alpha")).getByText("running")).toBeInTheDocument();
-    expect(within(screen.getByTestId("command-center-run-run-bravo")).getByText("unknown")).toBeInTheDocument();
+    expect(within(runsFeed).getByText("chat completion")).toBeInTheDocument();
+    expect(within(runsFeed).getByText("Unknown run")).toBeInTheDocument();
+    expect(within(screen.getByTestId("command-center-run-task-alpha")).getByText(/^completed$/)).toBeInTheDocument();
+    expect(within(screen.getByTestId("command-center-run-task-alpha")).getByText(/^succeeded$/)).toBeInTheDocument();
+    expect(within(screen.getByTestId("command-center-run-event-raw-bravo")).getByText(/^unknown$/)).toBeInTheDocument();
+    expect(within(screen.getByTestId("command-center-run-task-alpha")).getByText("Events: 4")).toBeInTheDocument();
+    expect(within(screen.getByTestId("command-center-run-task-alpha")).getByText("Task: task-alpha")).toBeInTheDocument();
+    expect(within(screen.getByTestId("command-center-run-task-alpha")).getByText("Thread: 42")).toBeInTheDocument();
+    expect(within(screen.getByTestId("command-center-run-task-alpha")).getByText("Latest turn message: 501")).toBeInTheDocument();
+    expect(within(screen.getByTestId("command-center-run-task-alpha")).getByText("Turn: turn-alpha")).toBeInTheDocument();
     expect(
-      within(runsFeed).getByRole("button", { name: /open details for processing alpha/i })
+      within(runsFeed).getByRole("button", { name: /open details for chat completion/i })
     ).toBeInTheDocument();
     expect(
-      within(runsFeed).getByRole("button", { name: /open details for no classification yet/i })
+      within(runsFeed).getByRole("button", { name: /open details for unknown run/i })
     ).toBeInTheDocument();
-    expect(within(runsFeed).getAllByText("Inspect event details").length).toBeGreaterThan(0);
+    expect(within(runsFeed).getAllByText("Inspect raw events").length).toBeGreaterThan(0);
     expect(screen.getByText("attention")).toBeInTheDocument();
     expect(screen.getByText("mystery signal")).toBeInTheDocument();
+    expect(within(runsFeed).queryByText("Unknown")).not.toBeInTheDocument();
 
     fireEvent.click(
-      within(runsFeed).getByRole("button", { name: /open details for processing alpha/i })
+      within(runsFeed).getByRole("button", { name: /open details for chat completion/i })
     );
-    expect(screen.getByTestId("run-detail-drawer")).toHaveTextContent("run-alpha");
+    expect(screen.getByTestId("run-detail-drawer")).toHaveTextContent("task-alpha");
 
     expect(screen.getByText("Approvals")).toBeInTheDocument();
     expect(screen.getByText("attention")).toBeInTheDocument();

--- a/frontend/src/features/commandCenter/__tests__/CommandCenterPage.test.tsx
+++ b/frontend/src/features/commandCenter/__tests__/CommandCenterPage.test.tsx
@@ -192,6 +192,24 @@ const mockedRuns: CommandCenterRun[] = [
     summary: "chat completion · completed",
     taskId: "task-alpha",
     terminalOutcome: COMMAND_CENTER_RUN_TERMINAL_OUTCOMES.COMPLETED,
+    traceEvidence: {
+      documentCount: 4,
+      graphCount: 1,
+      latestTurnContentPresent: true,
+      latestTurnMessageId: "501",
+      latestTurnTracePresent: true,
+      memoryCount: 2,
+      retrievalQuery: "How does the cache behave?",
+      retrievalQueryMatchesLatestTurn: true,
+      retrievalQueryPresent: true,
+      retrievalTarget: "search-index",
+      sourceMode: "personal_knowledge",
+      tracePresenceState: "latest_turn_trace_present",
+      tracePresent: true,
+      traceUrl: "/api/chat/debug/rag-trace/42/latest",
+      widenReason: "explicit_personal_knowledge",
+    },
+    traceUrl: "/api/chat/debug/rag-trace/42/latest",
     threadId: 42,
     turnId: "turn-alpha",
   },
@@ -305,7 +323,13 @@ vi.mock("../hooks/useHealthSummary", () => ({
 
 vi.mock("../components/RunDetailDrawer", () => ({
   default: ({ run }: { run: CommandCenterRun | null }) =>
-    run ? <div data-testid="run-detail-drawer">Selected run: {run.key}</div> : null,
+    run ? (
+      <div data-testid="run-detail-drawer">
+        Selected run: {run.key} · thread {run.threadId ?? "none"} · latest turn{" "}
+        {run.latestTurnMessageId ?? "none"} · trace{" "}
+        {run.traceEvidence?.tracePresent ? "present" : "none"}
+      </div>
+    ) : null,
 }));
 
 beforeEach(() => {
@@ -413,6 +437,9 @@ describe("CommandCenterPage", () => {
       within(runsFeed).getByRole("button", { name: /open details for chat completion/i })
     );
     expect(screen.getByTestId("run-detail-drawer")).toHaveTextContent("task-alpha");
+    expect(screen.getByTestId("run-detail-drawer")).toHaveTextContent("thread 42");
+    expect(screen.getByTestId("run-detail-drawer")).toHaveTextContent("latest turn 501");
+    expect(screen.getByTestId("run-detail-drawer")).toHaveTextContent("trace present");
 
     expect(screen.getByText("Approvals")).toBeInTheDocument();
     expect(screen.getByText("attention")).toBeInTheDocument();

--- a/frontend/src/features/commandCenter/__tests__/CommandCenterPage.test.tsx
+++ b/frontend/src/features/commandCenter/__tests__/CommandCenterPage.test.tsx
@@ -10,6 +10,12 @@ import type {
   CommandCenterHealthItem,
   CommandCenterRun,
 } from "@/features/commandCenter/types";
+import {
+  COMMAND_CENTER_HEALTH_STATES,
+  COMMAND_CENTER_RUN_STATUSES,
+  COMMAND_CENTER_RUN_TERMINAL_OUTCOMES,
+  describeCommandCenterHealthStatePresentation,
+} from "@/features/commandCenter/types";
 
 const mockRefresh = vi.fn();
 
@@ -22,7 +28,7 @@ const mockedHealthItems: CommandCenterHealthItem[] = [
     key: "core",
     label: "Core",
     raw: '{"ok":true}',
-    status: "OK",
+    status: COMMAND_CENTER_HEALTH_STATES.OK,
   },
   {
     checkedAt: Date.parse("2026-04-01T15:59:01Z"),
@@ -32,7 +38,7 @@ const mockedHealthItems: CommandCenterHealthItem[] = [
     key: "llm",
     label: "LLM",
     raw: '{"status":"degraded"}',
-    status: "UNKNOWN",
+    status: COMMAND_CENTER_HEALTH_STATES.DEGRADED,
   },
   {
     checkedAt: Date.parse("2026-04-01T15:59:02Z"),
@@ -42,7 +48,7 @@ const mockedHealthItems: CommandCenterHealthItem[] = [
     key: "deps",
     label: "Deps",
     raw: '{"status":"fail"}',
-    status: "FAIL",
+    status: COMMAND_CENTER_HEALTH_STATES.DOWN,
   },
   {
     checkedAt: Date.parse("2026-04-01T15:59:03Z"),
@@ -52,7 +58,7 @@ const mockedHealthItems: CommandCenterHealthItem[] = [
     key: "vector",
     label: "Vector",
     raw: '{"ok":true}',
-    status: "OK",
+    status: COMMAND_CENTER_HEALTH_STATES.OK,
   },
   {
     checkedAt: Date.parse("2026-04-01T15:59:04Z"),
@@ -61,8 +67,8 @@ const mockedHealthItems: CommandCenterHealthItem[] = [
     httpStatus: 200,
     key: "memory",
     label: "Memory",
-    raw: '{"ok":true}',
-    status: "OK",
+    raw: '{"status":"unknown"}',
+    status: COMMAND_CENTER_HEALTH_STATES.UNKNOWN,
   },
 ];
 
@@ -145,7 +151,7 @@ const mockedRuns: CommandCenterRun[] = [
         summary: "chat completion completed",
         taskId: "task-alpha",
         taskType: null,
-        terminalOutcome: "succeeded",
+        terminalOutcome: COMMAND_CENTER_RUN_TERMINAL_OUTCOMES.COMPLETED,
         threadId: 42,
         turnId: "turn-alpha",
         type: "task.completed",
@@ -168,7 +174,7 @@ const mockedRuns: CommandCenterRun[] = [
       summary: "chat completion completed",
       taskId: "task-alpha",
       taskType: null,
-      terminalOutcome: "succeeded",
+      terminalOutcome: COMMAND_CENTER_RUN_TERMINAL_OUTCOMES.COMPLETED,
       threadId: 42,
       turnId: "turn-alpha",
       type: "task.completed",
@@ -179,12 +185,13 @@ const mockedRuns: CommandCenterRun[] = [
     latestTurnMessageId: "501",
     requestId: null,
     runId: "run-alpha",
+    runKind: "chat_completion",
     runType: "chat completion",
     state: "completed",
-    status: "succeeded",
+    status: COMMAND_CENTER_RUN_STATUSES.COMPLETED,
     summary: "chat completion · completed",
     taskId: "task-alpha",
-    terminalOutcome: "succeeded",
+    terminalOutcome: COMMAND_CENTER_RUN_TERMINAL_OUTCOMES.COMPLETED,
     threadId: 42,
     turnId: "turn-alpha",
   },
@@ -331,6 +338,20 @@ describe("CommandCenterPage", () => {
       tone: "subtle",
       isFallback: true,
     });
+
+    const healthSamples = [
+      [COMMAND_CENTER_HEALTH_STATES.OK, { label: "OK", tone: "active", isFallback: false }],
+      [
+        COMMAND_CENTER_HEALTH_STATES.DEGRADED,
+        { label: "Degraded", tone: "attention", isFallback: false },
+      ],
+      [COMMAND_CENTER_HEALTH_STATES.DOWN, { label: "Down", tone: "danger", isFallback: false }],
+      [COMMAND_CENTER_HEALTH_STATES.UNKNOWN, { label: "Unknown", tone: "subtle", isFallback: false }],
+    ] as const;
+
+    for (const [status, expected] of healthSamples) {
+      expect(describeCommandCenterHealthStatePresentation(status)).toMatchObject(expected);
+    }
   });
 
   it("renders a signal-first hierarchy for operators", () => {
@@ -361,17 +382,17 @@ describe("CommandCenterPage", () => {
     expect(within(healthStrip).getByText("Memory")).toBeInTheDocument();
     expect(within(screen.getByTestId("command-center-health-core")).getByText("OK")).toBeInTheDocument();
     expect(
-      within(screen.getByTestId("command-center-health-llm")).getByText("UNKNOWN")
+      within(screen.getByTestId("command-center-health-llm")).getByText("Degraded")
     ).toBeInTheDocument();
-    expect(within(screen.getByTestId("command-center-health-deps")).getByText("FAIL")).toBeInTheDocument();
+    expect(within(screen.getByTestId("command-center-health-deps")).getByText("Down")).toBeInTheDocument();
+    expect(within(screen.getByTestId("command-center-health-memory")).getByText("Unknown")).toBeInTheDocument();
     expect(within(healthStrip).getAllByText("Inspect raw details").length).toBeGreaterThan(0);
 
     const runsFeed = screen.getByTestId("command-center-runs-feed");
     expect(within(runsFeed).getByText("chat completion")).toBeInTheDocument();
     expect(within(runsFeed).getByText("Unknown run")).toBeInTheDocument();
-    expect(within(screen.getByTestId("command-center-run-task-alpha")).getByText(/^completed$/)).toBeInTheDocument();
-    expect(within(screen.getByTestId("command-center-run-task-alpha")).getByText(/^succeeded$/)).toBeInTheDocument();
-    expect(within(screen.getByTestId("command-center-run-event-raw-bravo")).getByText(/^unknown$/)).toBeInTheDocument();
+    expect(within(screen.getByTestId("command-center-run-task-alpha")).getAllByText("Completed").length).toBeGreaterThan(1);
+    expect(within(screen.getByTestId("command-center-run-event-raw-bravo")).getByText("Unknown")).toBeInTheDocument();
     expect(within(screen.getByTestId("command-center-run-task-alpha")).getByText("Events: 4")).toBeInTheDocument();
     expect(within(screen.getByTestId("command-center-run-task-alpha")).getByText("Task: task-alpha")).toBeInTheDocument();
     expect(within(screen.getByTestId("command-center-run-task-alpha")).getByText("Thread: 42")).toBeInTheDocument();
@@ -386,7 +407,7 @@ describe("CommandCenterPage", () => {
     expect(within(runsFeed).getAllByText("Inspect raw events").length).toBeGreaterThan(0);
     expect(screen.getByText("attention")).toBeInTheDocument();
     expect(screen.getByText("mystery signal")).toBeInTheDocument();
-    expect(within(runsFeed).queryByText("Unknown")).not.toBeInTheDocument();
+    expect(within(runsFeed).getByText("Unknown")).toBeInTheDocument();
 
     fireEvent.click(
       within(runsFeed).getByRole("button", { name: /open details for chat completion/i })

--- a/frontend/src/features/commandCenter/__tests__/RagTracePanel.test.tsx
+++ b/frontend/src/features/commandCenter/__tests__/RagTracePanel.test.tsx
@@ -14,6 +14,23 @@ vi.mock("@/lib/api", async () => {
 });
 
 const fetchLatestRagTraceMock = vi.mocked(fetchLatestRagTrace);
+const canonicalTraceEvidence: NonNullable<CommandCenterRun["traceEvidence"]> = {
+  documentCount: 4,
+  graphCount: 1,
+  latestTurnContentPresent: true,
+  latestTurnMessageId: "msg-4",
+  latestTurnTracePresent: true,
+  memoryCount: 2,
+  retrievalQuery: "How does the cache behave?",
+  retrievalQueryMatchesLatestTurn: true,
+  retrievalQueryPresent: true,
+  retrievalTarget: "search-index",
+  sourceMode: "personal_knowledge",
+  tracePresenceState: "latest_turn_trace_present",
+  tracePresent: true,
+  traceUrl: "/api/chat/debug/rag-trace/42/latest",
+  widenReason: "explicit_personal_knowledge",
+};
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -47,12 +64,14 @@ function buildRun(
     lastEventAt: Date.now(),
     lastKind: "task.completed",
     lastType: "task.completed",
+    latestTurnMessageId: "msg-4",
     runId: "run_001",
     status: "completed",
     summary: "Task completed",
     taskId: "task_001",
     threadId: 42,
     traceUrl: "/api/chat/debug/rag-trace/42/latest",
+    traceEvidence: null,
     ...overrides,
   };
 }
@@ -74,8 +93,10 @@ describe("RagTracePanel", () => {
 
     pending.resolve({ documents: [], graph: [] });
     expect(
-      await screen.findByText("No retrieval evidence available for this thread yet.")
+      await screen.findByText("No trace evidence exists for this run.")
     ).toBeInTheDocument();
+    expect(screen.getByText("Thread: 42")).toBeInTheDocument();
+    expect(screen.getByText("Latest turn message: msg-4")).toBeInTheDocument();
   });
 
   test("renders explicit empty states for no selected run and no resolvable thread", async () => {
@@ -96,7 +117,7 @@ describe("RagTracePanel", () => {
     );
 
     expect(
-      await screen.findByText("No resolvable thread available for this run.")
+      await screen.findByText("No thread identity available for this run.")
     ).toBeInTheDocument();
     expect(fetchLatestRagTraceMock).not.toHaveBeenCalled();
   });
@@ -120,10 +141,20 @@ describe("RagTracePanel", () => {
       graph: [],
     });
 
-    render(<RagTracePanel run={buildRun()} />);
+    render(
+      <RagTracePanel
+        run={buildRun({
+          traceEvidence: canonicalTraceEvidence,
+        })}
+      />
+    );
 
     expect(await screen.findByRole("heading", { name: "Semantic Results" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Memory Results" })).not.toBeInTheDocument();
+    expect(screen.getByText("Thread: 42")).toBeInTheDocument();
+    expect(screen.getByText("Latest turn message: msg-4")).toBeInTheDocument();
+    expect(screen.getByText("Trace summary: Latest turn trace present")).toBeInTheDocument();
+    expect(screen.getByText("Live trace: Aligned to this run/thread")).toBeInTheDocument();
     expect(
       screen.getByText("Original evidence text: keep this wording intact.")
     ).toBeInTheDocument();
@@ -173,7 +204,13 @@ describe("RagTracePanel", () => {
       ],
     });
 
-    render(<RagTracePanel run={buildRun()} />);
+    render(
+      <RagTracePanel
+        run={buildRun({
+          traceEvidence: canonicalTraceEvidence,
+        })}
+      />
+    );
 
     const semanticHeading = await screen.findByRole("heading", {
       name: "Semantic Results",
@@ -181,6 +218,10 @@ describe("RagTracePanel", () => {
     const memoryHeading = screen.getByRole("heading", {
       name: "Memory Results",
     });
+    expect(screen.getByText("Thread: 42")).toBeInTheDocument();
+    expect(screen.getByText("Latest turn message: msg-4")).toBeInTheDocument();
+    expect(screen.getByText("Trace summary: Latest turn trace present")).toBeInTheDocument();
+    expect(screen.getByText("Live trace: Aligned to this run/thread")).toBeInTheDocument();
     expect(
       semanticHeading.compareDocumentPosition(memoryHeading) &
         Node.DOCUMENT_POSITION_FOLLOWING
@@ -201,7 +242,7 @@ describe("RagTracePanel", () => {
     ).toBeTruthy();
   });
 
-  test("renders an unavailable state when the resolved thread has no trace yet", async () => {
+  test("renders a truthful no-trace state when no trace evidence exists", async () => {
     fetchLatestRagTraceMock.mockResolvedValue({
       documents: [],
       graph: [],
@@ -210,7 +251,32 @@ describe("RagTracePanel", () => {
     render(<RagTracePanel run={buildRun()} />);
 
     expect(
-      await screen.findByText("No retrieval evidence available for this thread yet.")
+      await screen.findByText("No trace evidence exists for this run.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Trace summary: No trace evidence exists for this run")).toBeInTheDocument();
+    expect(screen.getByText("Live trace: No trace evidence exists for this run")).toBeInTheDocument();
+  });
+
+  test("renders a mismatch state when trace summary is present but the live trace is empty", async () => {
+    fetchLatestRagTraceMock.mockResolvedValue({
+      documents: [],
+      graph: [],
+    });
+
+    render(
+      <RagTracePanel
+        run={buildRun({
+          traceEvidence: canonicalTraceEvidence,
+        })}
+      />
+    );
+
+    expect(
+      await screen.findByText("Trace summary present, live trace unavailable.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Trace summary: Latest turn trace present")).toBeInTheDocument();
+    expect(
+      screen.getByText("Live trace: Trace summary present, live trace unavailable")
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/features/commandCenter/__tests__/RagTracePanel.test.tsx
+++ b/frontend/src/features/commandCenter/__tests__/RagTracePanel.test.tsx
@@ -48,7 +48,7 @@ function buildRun(
     lastKind: "task.completed",
     lastType: "task.completed",
     runId: "run_001",
-    status: "succeeded",
+    status: "completed",
     summary: "Task completed",
     taskId: "task_001",
     threadId: 42,

--- a/frontend/src/features/commandCenter/__tests__/RunDetailsPanel.test.tsx
+++ b/frontend/src/features/commandCenter/__tests__/RunDetailsPanel.test.tsx
@@ -165,7 +165,7 @@ const lifecycleEvents: CommandCenterEvent[] = [
     summary: "chat completion completed",
     taskId: "task-1",
     taskType: "chat.completion",
-    terminalOutcome: "succeeded",
+    terminalOutcome: "completed",
     threadId: 42,
     traceUrl: "/api/chat/debug/rag-trace/42/latest",
     turnId: "turn-1",
@@ -194,9 +194,10 @@ function buildRun(overrides: Partial<CommandCenterRun> = {}): CommandCenterRun {
     ],
     requestId: null,
     runId: "run-1",
+    runKind: "chat_completion",
     runType: "chat completion",
     state: "completed",
-    status: "succeeded",
+    status: "completed",
     streamingEvidence: {
       chunkCount: 1,
       firstChunkAt: lifecycleEvents[3].receivedAt,
@@ -204,7 +205,7 @@ function buildRun(overrides: Partial<CommandCenterRun> = {}): CommandCenterRun {
     },
     summary: "chat completion · completed",
     taskId: "task-1",
-    terminalOutcome: "succeeded",
+    terminalOutcome: "completed",
     timings: {
       completedAt: Date.parse("2026-04-01T16:00:05Z"),
       firstOutputAt: baseTimestamp + 3000,
@@ -225,7 +226,7 @@ function buildRun(overrides: Partial<CommandCenterRun> = {}): CommandCenterRun {
       retrievalQueryPresent: true,
       retrievalTarget: "search-index",
       sourceMode: "personal_knowledge",
-      tracePresenceState: "latest-turn trace present",
+      tracePresenceState: "latest_turn_trace_present",
       tracePresent: true,
       traceUrl: "/api/chat/debug/rag-trace/42/latest",
       widenReason: "explicit_personal_knowledge",
@@ -246,6 +247,7 @@ describe("RunDetailsPanel", () => {
         "QUEUED → AWAITING_MODEL → AWAITING_FIRST_TOKEN → STREAMING → COMPLETED"
       )
     ).toBeInTheDocument();
+    expect(screen.getAllByText("Completed").length).toBeGreaterThan(0);
   });
 
   it("renders timings only when they are present", () => {
@@ -277,7 +279,7 @@ describe("RunDetailsPanel", () => {
       screen.getByText("Widen reason: explicit_personal_knowledge")
     ).toBeInTheDocument();
     expect(
-      screen.getByText("Trace status: latest-turn trace present")
+      screen.getByText("Trace status: Latest turn trace present")
     ).toBeInTheDocument();
     expect(screen.getAllByText("Latest turn message: msg-4")).toHaveLength(2);
     expect(screen.getByText("Retrieval query:")).toBeInTheDocument();
@@ -320,7 +322,7 @@ describe("RunDetailsPanel", () => {
     expect(screen.getByText("Run: run-1")).toBeInTheDocument();
     expect(screen.getByText("Source: Project")).toBeInTheDocument();
     expect(screen.getByText("Widen reason: none")).toBeInTheDocument();
-    expect(screen.getByText("Trace status: none")).toBeInTheDocument();
+    expect(screen.getByText("Trace status: No trace")).toBeInTheDocument();
     expect(screen.getByText("No trace evidence recorded.")).toBeInTheDocument();
     expect(screen.queryByText("Retrieval query:")).not.toBeInTheDocument();
     expect(screen.queryByText("Documents: 4")).not.toBeInTheDocument();

--- a/frontend/src/features/commandCenter/__tests__/RunDetailsPanel.test.tsx
+++ b/frontend/src/features/commandCenter/__tests__/RunDetailsPanel.test.tsx
@@ -281,6 +281,8 @@ describe("RunDetailsPanel", () => {
     expect(
       screen.getByText("Trace status: Latest turn trace present")
     ).toBeInTheDocument();
+    expect(screen.getByText("Trace panel:")).toBeInTheDocument();
+    expect(screen.getByText("Aligned to this run/thread")).toBeInTheDocument();
     expect(screen.getAllByText("Latest turn message: msg-4")).toHaveLength(2);
     expect(screen.getByText("Retrieval query:")).toBeInTheDocument();
     expect(screen.getByText("How does the cache behave?")).toBeInTheDocument();
@@ -323,7 +325,11 @@ describe("RunDetailsPanel", () => {
     expect(screen.getByText("Source: Project")).toBeInTheDocument();
     expect(screen.getByText("Widen reason: none")).toBeInTheDocument();
     expect(screen.getByText("Trace status: No trace")).toBeInTheDocument();
-    expect(screen.getByText("No trace evidence recorded.")).toBeInTheDocument();
+    expect(screen.getByText("Trace panel:")).toBeInTheDocument();
+    expect(screen.getByText("Empty but expected")).toBeInTheDocument();
+    expect(
+      screen.getByText("No detailed trace payload is currently available.")
+    ).toBeInTheDocument();
     expect(screen.queryByText("Retrieval query:")).not.toBeInTheDocument();
     expect(screen.queryByText("Documents: 4")).not.toBeInTheDocument();
   });
@@ -338,7 +344,7 @@ describe("RunDetailsPanel", () => {
     );
 
     expect(
-      screen.getByText("No retrieval or trace evidence recorded.")
+      screen.getByText("No trace evidence exists for this run.")
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/features/commandCenter/__tests__/RunDetailsPanel.test.tsx
+++ b/frontend/src/features/commandCenter/__tests__/RunDetailsPanel.test.tsx
@@ -214,14 +214,21 @@ function buildRun(overrides: Partial<CommandCenterRun> = {}): CommandCenterRun {
       warmupAt: baseTimestamp + 1000,
     },
     traceEvidence: {
+      documentCount: 4,
+      graphCount: 1,
       latestTurnContentPresent: true,
+      latestTurnMessageId: "msg-4",
       latestTurnTracePresent: true,
+      memoryCount: 2,
       retrievalQuery: "How does the cache behave?",
       retrievalQueryMatchesLatestTurn: true,
       retrievalQueryPresent: true,
       retrievalTarget: "search-index",
+      sourceMode: "personal_knowledge",
+      tracePresenceState: "latest-turn trace present",
       tracePresent: true,
       traceUrl: "/api/chat/debug/rag-trace/42/latest",
+      widenReason: "explicit_personal_knowledge",
     },
     traceUrl: "/api/chat/debug/rag-trace/42/latest",
     threadId: 42,
@@ -262,19 +269,44 @@ describe("RunDetailsPanel", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders stable identity and trace presence without a full trace payload", () => {
+  it("renders compact retrieval and trace summary when canonical fields exist", () => {
+    render(<RunDetailsPanel run={buildRun()} />);
+
+    expect(screen.getByText("Source: Personal Knowledge")).toBeInTheDocument();
+    expect(
+      screen.getByText("Widen reason: explicit_personal_knowledge")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Trace status: latest-turn trace present")
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Latest turn message: msg-4")).toHaveLength(2);
+    expect(screen.getByText("Retrieval query:")).toBeInTheDocument();
+    expect(screen.getByText("How does the cache behave?")).toBeInTheDocument();
+    expect(screen.getByText("Documents: 4")).toBeInTheDocument();
+    expect(screen.getByText("Memory: 2")).toBeInTheDocument();
+    expect(screen.getByText("Graph: 1")).toBeInTheDocument();
+  });
+
+  it("renders a truthful trace summary when only partial fields are available", () => {
     render(
       <RunDetailsPanel
         run={buildRun({
           traceEvidence: {
+            documentCount: null,
+            graphCount: null,
             latestTurnContentPresent: false,
-            latestTurnTracePresent: true,
+            latestTurnMessageId: null,
+            latestTurnTracePresent: false,
+            memoryCount: null,
             retrievalQuery: null,
             retrievalQueryMatchesLatestTurn: null,
-            retrievalQueryPresent: true,
+            retrievalQueryPresent: false,
             retrievalTarget: null,
-            tracePresent: true,
+            sourceMode: "project",
+            tracePresenceState: "none",
+            tracePresent: false,
             traceUrl: null,
+            widenReason: "none",
           },
           traceUrl: null,
         })}
@@ -284,11 +316,28 @@ describe("RunDetailsPanel", () => {
     expect(screen.getByText("Grouping key: task-1")).toBeInTheDocument();
     expect(screen.getByText("Task: task-1")).toBeInTheDocument();
     expect(screen.getByText("Thread: 42")).toBeInTheDocument();
-    expect(screen.getByText("Latest turn message: msg-4")).toBeInTheDocument();
+    expect(screen.getAllByText("Latest turn message: msg-4")).toHaveLength(2);
     expect(screen.getByText("Run: run-1")).toBeInTheDocument();
-    expect(screen.getByText("Trace present: Yes")).toBeInTheDocument();
-    expect(screen.getByText("Latest-turn trace present: Yes")).toBeInTheDocument();
-    expect(screen.getByText("Retrieval query present: Yes")).toBeInTheDocument();
+    expect(screen.getByText("Source: Project")).toBeInTheDocument();
+    expect(screen.getByText("Widen reason: none")).toBeInTheDocument();
+    expect(screen.getByText("Trace status: none")).toBeInTheDocument();
+    expect(screen.getByText("No trace evidence recorded.")).toBeInTheDocument();
+    expect(screen.queryByText("Retrieval query:")).not.toBeInTheDocument();
+    expect(screen.queryByText("Documents: 4")).not.toBeInTheDocument();
+  });
+
+  it("renders a truthful empty state when no trace evidence is present", () => {
+    render(
+      <RunDetailsPanel
+        run={buildRun({
+          traceEvidence: null,
+        })}
+      />
+    );
+
+    expect(
+      screen.getByText("No retrieval or trace evidence recorded.")
+    ).toBeInTheDocument();
   });
 
   it("keeps raw events collapsed until opened", () => {

--- a/frontend/src/features/commandCenter/__tests__/RunDetailsPanel.test.tsx
+++ b/frontend/src/features/commandCenter/__tests__/RunDetailsPanel.test.tsx
@@ -1,0 +1,321 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import RunDetailsPanel from "../components/RunDetailsPanel";
+
+import type {
+  CommandCenterEvent,
+  CommandCenterRun,
+} from "@/features/commandCenter/types";
+
+const baseTimestamp = Date.parse("2026-04-01T16:00:00Z");
+
+const lifecycleEvents: CommandCenterEvent[] = [
+  {
+    completedAt: null,
+    durationMs: null,
+    eventId: "evt-1",
+    firstOutputAt: null,
+    firstTokenAt: null,
+    json: { thread_id: 42, type: "chat.completion" },
+    kind: null,
+    latestTurnContent: null,
+    latestTurnMessageId: "msg-1",
+    lifecycleState: "QUEUED",
+    raw: '{"thread_id":42,"type":"chat.completion"}',
+    queuedAt: baseTimestamp,
+    receivedAt: baseTimestamp,
+    requestId: null,
+    retrievalQuery: null,
+    retrievalQueryMatchesLatestTurn: null,
+    retrievalTarget: null,
+    runId: "run-1",
+    sseType: "task.created",
+    state: "created",
+    status: null,
+    summary: "chat completion created",
+    taskId: "task-1",
+    taskType: "chat.completion",
+    terminalOutcome: null,
+    threadId: 42,
+    traceUrl: null,
+    turnId: "turn-1",
+    type: "task.created",
+    warmupAt: null,
+  },
+  {
+    completedAt: null,
+    durationMs: null,
+    eventId: "evt-2",
+    firstOutputAt: null,
+    firstTokenAt: null,
+    json: { thread_id: 42, type: "chat.completion" },
+    kind: null,
+    latestTurnContent: null,
+    latestTurnMessageId: "msg-2",
+    lifecycleState: "AWAITING_MODEL",
+    raw: '{"thread_id":42,"type":"chat.completion"}',
+    queuedAt: null,
+    receivedAt: baseTimestamp + 1000,
+    requestId: null,
+    retrievalQuery: null,
+    retrievalQueryMatchesLatestTurn: null,
+    retrievalTarget: null,
+    runId: "run-1",
+    sseType: "task.running",
+    state: "running",
+    status: null,
+    summary: "chat completion running",
+    taskId: "task-1",
+    taskType: "chat.completion",
+    terminalOutcome: null,
+    threadId: 42,
+    traceUrl: null,
+    turnId: "turn-1",
+    type: "task.running",
+    warmupAt: null,
+  },
+  {
+    completedAt: null,
+    durationMs: null,
+    eventId: "evt-3",
+    firstOutputAt: null,
+    firstTokenAt: baseTimestamp + 2000,
+    json: { thread_id: 42, type: "chat.completion" },
+    kind: null,
+    latestTurnContent: null,
+    latestTurnMessageId: "msg-3",
+    lifecycleState: "AWAITING_FIRST_TOKEN",
+    raw: '{"thread_id":42,"type":"chat.completion"}',
+    queuedAt: null,
+    receivedAt: baseTimestamp + 2000,
+    requestId: null,
+    retrievalQuery: null,
+    retrievalQueryMatchesLatestTurn: null,
+    retrievalTarget: null,
+    runId: "run-1",
+    sseType: "task.state",
+    state: "awaiting first token",
+    status: null,
+    summary: "chat completion awaiting first token",
+    taskId: "task-1",
+    taskType: "chat.completion",
+    terminalOutcome: null,
+    threadId: 42,
+    traceUrl: null,
+    turnId: "turn-1",
+    type: "task.state",
+    warmupAt: null,
+  },
+  {
+    completedAt: null,
+    durationMs: null,
+    eventId: "evt-4",
+    firstOutputAt: baseTimestamp + 3000,
+    firstTokenAt: null,
+    json: { thread_id: 42, token: "Hello" },
+    kind: null,
+    latestTurnContent: "Hello",
+    latestTurnMessageId: "msg-3",
+    lifecycleState: "STREAMING",
+    raw: '{"thread_id":42,"token":"Hello"}',
+    queuedAt: null,
+    receivedAt: baseTimestamp + 3000,
+    requestId: null,
+    retrievalQuery: null,
+    retrievalQueryMatchesLatestTurn: null,
+    retrievalTarget: null,
+    runId: "run-1",
+    sseType: "task.chunk",
+    state: "chunk",
+    status: null,
+    summary: "chat completion chunk",
+    taskId: "task-1",
+    taskType: "chat.completion",
+    terminalOutcome: null,
+    threadId: 42,
+    traceUrl: null,
+    turnId: "turn-1",
+    type: "task.chunk",
+    warmupAt: null,
+  },
+  {
+    completedAt: Date.parse("2026-04-01T16:00:05Z"),
+    durationMs: 4200,
+    eventId: "evt-5",
+    firstOutputAt: null,
+    firstTokenAt: null,
+    json: { retrieval_query: "How does the cache behave?" },
+    kind: null,
+    latestTurnContent: null,
+    latestTurnMessageId: "msg-4",
+    lifecycleState: "COMPLETED",
+    raw: '{"retrieval_query":"How does the cache behave?"}',
+    queuedAt: null,
+    receivedAt: baseTimestamp + 4000,
+    requestId: null,
+    retrievalQuery: "How does the cache behave?",
+    retrievalQueryMatchesLatestTurn: true,
+    retrievalTarget: "search-index",
+    runId: "run-1",
+    sseType: "task.completed",
+    state: "completed",
+    status: null,
+    summary: "chat completion completed",
+    taskId: "task-1",
+    taskType: "chat.completion",
+    terminalOutcome: "succeeded",
+    threadId: 42,
+    traceUrl: "/api/chat/debug/rag-trace/42/latest",
+    turnId: "turn-1",
+    type: "task.completed",
+    warmupAt: null,
+  },
+];
+
+function buildRun(overrides: Partial<CommandCenterRun> = {}): CommandCenterRun {
+  return {
+    eventCount: lifecycleEvents.length,
+    events: lifecycleEvents,
+    identityKind: "task",
+    key: "task-1",
+    lastEvent: lifecycleEvents[lifecycleEvents.length - 1],
+    lastEventAt: lifecycleEvents[lifecycleEvents.length - 1].receivedAt,
+    lastKind: null,
+    lastType: "task.completed",
+    latestTurnMessageId: "msg-4",
+    lifecycleStates: [
+      "QUEUED",
+      "AWAITING_MODEL",
+      "AWAITING_FIRST_TOKEN",
+      "STREAMING",
+      "COMPLETED",
+    ],
+    requestId: null,
+    runId: "run-1",
+    runType: "chat completion",
+    state: "completed",
+    status: "succeeded",
+    streamingEvidence: {
+      chunkCount: 1,
+      firstChunkAt: lifecycleEvents[3].receivedAt,
+      hasStreamedContent: true,
+    },
+    summary: "chat completion · completed",
+    taskId: "task-1",
+    terminalOutcome: "succeeded",
+    timings: {
+      completedAt: Date.parse("2026-04-01T16:00:05Z"),
+      firstOutputAt: baseTimestamp + 3000,
+      firstTokenAt: baseTimestamp + 2000,
+      queuedAt: baseTimestamp,
+      totalDurationMs: 4200,
+      warmupAt: baseTimestamp + 1000,
+    },
+    traceEvidence: {
+      latestTurnContentPresent: true,
+      latestTurnTracePresent: true,
+      retrievalQuery: "How does the cache behave?",
+      retrievalQueryMatchesLatestTurn: true,
+      retrievalQueryPresent: true,
+      retrievalTarget: "search-index",
+      tracePresent: true,
+      traceUrl: "/api/chat/debug/rag-trace/42/latest",
+    },
+    traceUrl: "/api/chat/debug/rag-trace/42/latest",
+    threadId: 42,
+    turnId: "turn-1",
+    ...overrides,
+  };
+}
+
+describe("RunDetailsPanel", () => {
+  it("renders lifecycle states in order", () => {
+    render(<RunDetailsPanel run={buildRun()} />);
+
+    expect(
+      screen.getByText(
+        "QUEUED → AWAITING_MODEL → AWAITING_FIRST_TOKEN → STREAMING → COMPLETED"
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("renders timings only when they are present", () => {
+    const { rerender } = render(<RunDetailsPanel run={buildRun()} />);
+
+    expect(screen.getByText(/Queued:/)).toBeInTheDocument();
+    expect(screen.getByText(/Total:/)).toBeInTheDocument();
+
+    rerender(
+      <RunDetailsPanel
+        run={buildRun({
+          timings: null,
+        })}
+      />
+    );
+
+    expect(screen.queryByText(/Queued:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Total:/)).not.toBeInTheDocument();
+    expect(
+      screen.getByText("No structured timing evidence recorded.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders stable identity and trace presence without a full trace payload", () => {
+    render(
+      <RunDetailsPanel
+        run={buildRun({
+          traceEvidence: {
+            latestTurnContentPresent: false,
+            latestTurnTracePresent: true,
+            retrievalQuery: null,
+            retrievalQueryMatchesLatestTurn: null,
+            retrievalQueryPresent: true,
+            retrievalTarget: null,
+            tracePresent: true,
+            traceUrl: null,
+          },
+          traceUrl: null,
+        })}
+      />
+    );
+
+    expect(screen.getByText("Grouping key: task-1")).toBeInTheDocument();
+    expect(screen.getByText("Task: task-1")).toBeInTheDocument();
+    expect(screen.getByText("Thread: 42")).toBeInTheDocument();
+    expect(screen.getByText("Latest turn message: msg-4")).toBeInTheDocument();
+    expect(screen.getByText("Run: run-1")).toBeInTheDocument();
+    expect(screen.getByText("Trace present: Yes")).toBeInTheDocument();
+    expect(screen.getByText("Latest-turn trace present: Yes")).toBeInTheDocument();
+    expect(screen.getByText("Retrieval query present: Yes")).toBeInTheDocument();
+  });
+
+  it("keeps raw events collapsed until opened", () => {
+    render(
+      <RunDetailsPanel
+        run={buildRun({
+          events: [
+            {
+              ...lifecycleEvents[0],
+              json: { message: "Secondary payload" },
+              raw: '{"message":"Secondary payload"}',
+              summary: "Secondary payload",
+            },
+          ],
+          eventCount: 1,
+        })}
+      />
+    );
+
+    expect(screen.queryByText("Secondary payload")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/"message":\s+"Secondary payload"/)
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Raw events"));
+
+    expect(screen.getByText("Secondary payload")).toBeInTheDocument();
+    expect(screen.getByText(/"message":\s+"Secondary payload"/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/commandCenter/__tests__/RunSummaryCard.test.tsx
+++ b/frontend/src/features/commandCenter/__tests__/RunSummaryCard.test.tsx
@@ -109,6 +109,11 @@ const canonicalRun: CommandCenterRun = {
   runType: "chat completion",
   state: "completed",
   status: "succeeded",
+  streamingEvidence: {
+    chunkCount: 1,
+    firstChunkAt: baseTimestamp + 2000,
+    hasStreamedContent: true,
+  },
   summary: "chat completion · completed",
   taskId: "task-1",
   terminalOutcome: "succeeded",
@@ -170,6 +175,7 @@ describe("RunSummaryCard", () => {
     expect(within(card).getByText("Thread: 42")).toBeInTheDocument();
     expect(within(card).getByText("Turn: turn-1")).toBeInTheDocument();
     expect(within(card).getByText("Latest turn message: msg-4")).toBeInTheDocument();
+    expect(within(card).getByText("Chunks: 1")).toBeInTheDocument();
     expect(within(card).getByText("Inspect raw events")).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /open details for chat completion/i })

--- a/frontend/src/features/commandCenter/__tests__/RunSummaryCard.test.tsx
+++ b/frontend/src/features/commandCenter/__tests__/RunSummaryCard.test.tsx
@@ -1,0 +1,196 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+
+import RunSummaryCard from "../components/RunSummaryCard";
+
+import type {
+  CommandCenterEvent,
+  CommandCenterRun,
+} from "@/features/commandCenter/types";
+
+const baseTimestamp = Date.parse("2026-04-01T16:00:00Z");
+
+const canonicalEvents: CommandCenterEvent[] = [
+  {
+    eventId: "evt-1",
+    json: { type: "chat.completion", thread_id: 42 },
+    kind: null,
+    latestTurnMessageId: "msg-1",
+    raw: '{"type":"chat.completion","thread_id":42}',
+    receivedAt: baseTimestamp,
+    requestId: null,
+    runId: "run-task-1",
+    sseType: "task.created",
+    state: "created",
+    status: null,
+    summary: "chat completion created",
+    taskId: "task-1",
+    taskType: "chat.completion",
+    terminalOutcome: null,
+    threadId: 42,
+    turnId: "turn-1",
+    type: "task.created",
+  },
+  {
+    eventId: "evt-2",
+    json: { type: "chat.completion", thread_id: 42 },
+    kind: null,
+    latestTurnMessageId: "msg-2",
+    raw: '{"type":"chat.completion","thread_id":42}',
+    receivedAt: baseTimestamp + 1000,
+    requestId: null,
+    runId: "run-task-1",
+    sseType: "task.running",
+    state: "running",
+    status: null,
+    summary: "chat completion running",
+    taskId: "task-1",
+    taskType: "chat.completion",
+    terminalOutcome: null,
+    threadId: 42,
+    turnId: "turn-1",
+    type: "task.running",
+  },
+  {
+    eventId: "evt-3",
+    json: { type: "chat.completion", thread_id: 42 },
+    kind: null,
+    latestTurnMessageId: "msg-3",
+    raw: '{"type":"chat.completion","thread_id":42}',
+    receivedAt: baseTimestamp + 2000,
+    requestId: null,
+    runId: "run-task-1",
+    sseType: "task.chunk",
+    state: "chunk",
+    status: null,
+    summary: "chat completion chunk",
+    taskId: "task-1",
+    taskType: "chat.completion",
+    terminalOutcome: null,
+    threadId: 42,
+    turnId: "turn-1",
+    type: "task.chunk",
+  },
+  {
+    eventId: "evt-4",
+    json: { type: "chat.completion", thread_id: 42, message_id: "msg-4" },
+    kind: null,
+    latestTurnMessageId: "msg-4",
+    raw: '{"type":"chat.completion","thread_id":42,"message_id":"msg-4"}',
+    receivedAt: baseTimestamp + 3000,
+    requestId: null,
+    runId: "run-task-1",
+    sseType: "task.completed",
+    state: "completed",
+    status: null,
+    summary: "chat completion completed",
+    taskId: "task-1",
+    taskType: "chat.completion",
+    terminalOutcome: "succeeded",
+    threadId: 42,
+    turnId: "turn-1",
+    type: "task.completed",
+  },
+];
+
+const canonicalRun: CommandCenterRun = {
+  eventCount: canonicalEvents.length,
+  events: canonicalEvents,
+  identityKind: "task",
+  key: "task-1",
+  lastEvent: canonicalEvents[3],
+  lastEventAt: canonicalEvents[3].receivedAt,
+  lastKind: null,
+  lastType: "task.completed",
+  latestTurnMessageId: "msg-4",
+  requestId: null,
+  runId: "run-task-1",
+  runType: "chat completion",
+  state: "completed",
+  status: "succeeded",
+  summary: "chat completion · completed",
+  taskId: "task-1",
+  terminalOutcome: "succeeded",
+  threadId: 42,
+  turnId: "turn-1",
+};
+
+const unknownRun: CommandCenterRun = {
+  eventCount: 1,
+  identityKind: "synthetic",
+  key: "event-raw-1",
+  lastEvent: {
+    eventId: "evt-raw-1",
+    json: { message: "No stable identity" },
+    kind: null,
+    latestTurnMessageId: null,
+    raw: '{"message":"No stable identity"}',
+    receivedAt: baseTimestamp,
+    requestId: null,
+    runId: null,
+    sseType: "message",
+    state: null,
+    status: "unknown",
+    summary: "No stable identity",
+    taskId: null,
+    taskType: null,
+    terminalOutcome: null,
+    threadId: null,
+    turnId: null,
+    type: null,
+  },
+  lastEventAt: baseTimestamp,
+  lastKind: null,
+  lastType: null,
+  requestId: null,
+  runId: null,
+  runType: null,
+  state: null,
+  status: "unknown",
+  summary: "unclassified event",
+  taskId: null,
+  terminalOutcome: null,
+};
+
+describe("RunSummaryCard", () => {
+  it("renders canonical task states as semantic labels with identity and counts", () => {
+    const onOpen = vi.fn();
+
+    render(<RunSummaryCard onOpen={onOpen} run={canonicalRun} />);
+
+    const card = screen.getByTestId("command-center-run-task-1");
+
+    expect(within(card).getByText("chat completion")).toBeInTheDocument();
+    expect(within(card).getByText(/^completed$/)).toBeInTheDocument();
+    expect(within(card).getByText(/^succeeded$/)).toBeInTheDocument();
+    expect(within(card).getByText("Events: 4")).toBeInTheDocument();
+    expect(within(card).getByText(/Updated:/)).toBeInTheDocument();
+    expect(within(card).getByText("Task: task-1")).toBeInTheDocument();
+    expect(within(card).getByText("Thread: 42")).toBeInTheDocument();
+    expect(within(card).getByText("Turn: turn-1")).toBeInTheDocument();
+    expect(within(card).getByText("Latest turn message: msg-4")).toBeInTheDocument();
+    expect(within(card).getByText("Inspect raw events")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /open details for chat completion/i })
+    ).toBeInTheDocument();
+  });
+
+  it("keeps unknown labels only on truly unclassified runs", () => {
+    const onOpen = vi.fn();
+
+    render(
+      <>
+        <RunSummaryCard onOpen={onOpen} run={canonicalRun} />
+        <RunSummaryCard onOpen={onOpen} run={unknownRun} />
+      </>
+    );
+
+    expect(within(screen.getByTestId("command-center-run-task-1")).queryByText("Unknown run")).toBeNull();
+    expect(within(screen.getByTestId("command-center-run-event-raw-1")).getByText("Unknown run")).toBeInTheDocument();
+    expect(within(screen.getByTestId("command-center-run-event-raw-1")).getByText(/^unknown$/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /open details for unknown run/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/commandCenter/__tests__/RunSummaryCard.test.tsx
+++ b/frontend/src/features/commandCenter/__tests__/RunSummaryCard.test.tsx
@@ -87,7 +87,7 @@ const canonicalEvents: CommandCenterEvent[] = [
     summary: "chat completion completed",
     taskId: "task-1",
     taskType: "chat.completion",
-    terminalOutcome: "succeeded",
+    terminalOutcome: "completed",
     threadId: 42,
     turnId: "turn-1",
     type: "task.completed",
@@ -106,9 +106,10 @@ const canonicalRun: CommandCenterRun = {
   latestTurnMessageId: "msg-4",
   requestId: null,
   runId: "run-task-1",
+  runKind: "chat_completion",
   runType: "chat completion",
   state: "completed",
-  status: "succeeded",
+  status: "completed",
   streamingEvidence: {
     chunkCount: 1,
     firstChunkAt: baseTimestamp + 2000,
@@ -116,7 +117,7 @@ const canonicalRun: CommandCenterRun = {
   },
   summary: "chat completion · completed",
   taskId: "task-1",
-  terminalOutcome: "succeeded",
+  terminalOutcome: "completed",
   threadId: 42,
   turnId: "turn-1",
 };
@@ -167,8 +168,7 @@ describe("RunSummaryCard", () => {
     const card = screen.getByTestId("command-center-run-task-1");
 
     expect(within(card).getByText("chat completion")).toBeInTheDocument();
-    expect(within(card).getByText(/^completed$/)).toBeInTheDocument();
-    expect(within(card).getByText(/^succeeded$/)).toBeInTheDocument();
+    expect(within(card).getAllByText("Completed").length).toBeGreaterThan(1);
     expect(within(card).getByText("Events: 4")).toBeInTheDocument();
     expect(within(card).getByText(/Updated:/)).toBeInTheDocument();
     expect(within(card).getByText("Task: task-1")).toBeInTheDocument();
@@ -194,7 +194,7 @@ describe("RunSummaryCard", () => {
 
     expect(within(screen.getByTestId("command-center-run-task-1")).queryByText("Unknown run")).toBeNull();
     expect(within(screen.getByTestId("command-center-run-event-raw-1")).getByText("Unknown run")).toBeInTheDocument();
-    expect(within(screen.getByTestId("command-center-run-event-raw-1")).getByText(/^unknown$/)).toBeInTheDocument();
+    expect(within(screen.getByTestId("command-center-run-event-raw-1")).getByText("Unknown")).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /open details for unknown run/i })
     ).toBeInTheDocument();

--- a/frontend/src/features/commandCenter/__tests__/commandCenterRunAggregation.test.tsx
+++ b/frontend/src/features/commandCenter/__tests__/commandCenterRunAggregation.test.tsx
@@ -49,6 +49,7 @@ describe("commandCenterRunAggregation", () => {
         "task.running",
         {
           latest_turn_message_id: "msg-2",
+          origin: "api:chat.complete|turn_id=turn-1|source_mode=personal_knowledge",
           warmup_at: "2026-04-01T16:00:02Z",
           run_id: "run-1",
           task_id: "task-1",
@@ -66,6 +67,20 @@ describe("commandCenterRunAggregation", () => {
         {
           latest_turn_message_id: "msg-3",
           first_token_at: "2026-04-01T16:00:03Z",
+          trace: {
+            latest_turn_message_id: "msg-4",
+            retrieval_query: "How does the cache behave?",
+            retrieval_query_matches_latest_turn: true,
+            retrieval_target: "search-index",
+            source_mode: "personal_knowledge",
+            trace_url: "/api/chat/debug/rag-trace/42/latest",
+            widen_reason: "explicit_personal_knowledge",
+            payload_summary: {
+              graph_count: 1,
+              memory_count: 2,
+              semantic_count: 4,
+            },
+          },
           run_id: "run-1",
           state: "awaiting_first_token",
           task_id: "task-1",
@@ -160,13 +175,20 @@ describe("commandCenterRunAggregation", () => {
     });
     expect(run?.traceUrl).toBe("/api/chat/debug/rag-trace/42/latest");
     expect(run?.traceEvidence).toMatchObject({
+      documentCount: 4,
+      graphCount: 1,
       latestTurnTracePresent: true,
+      latestTurnMessageId: "msg-4",
+      memoryCount: 2,
       retrievalQuery: "How does the cache behave?",
       retrievalQueryMatchesLatestTurn: true,
       retrievalQueryPresent: true,
       retrievalTarget: "search-index",
+      sourceMode: "personal_knowledge",
+      tracePresenceState: "latest-turn trace present",
       tracePresent: true,
       traceUrl: "/api/chat/debug/rag-trace/42/latest",
+      widenReason: "explicit_personal_knowledge",
     });
     expect(
       run?.events?.some(
@@ -278,6 +300,7 @@ describe("commandCenterRunAggregation", () => {
     expect(run?.status).toBe("succeeded");
     expect(run?.summary).toBe("chat completion · completed");
     expect(run?.lastEventAt).toBe(completed.receivedAt);
+    expect(run?.traceEvidence).toBeNull();
     expect(run?.timings).toMatchObject({
       completedAt: Date.parse("2026-04-01T16:10:05Z"),
       totalDurationMs: 1800,

--- a/frontend/src/features/commandCenter/__tests__/commandCenterRunAggregation.test.tsx
+++ b/frontend/src/features/commandCenter/__tests__/commandCenterRunAggregation.test.tsx
@@ -1,0 +1,263 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  aggregateCommandCenterEvents,
+  normalizeCommandCenterEvent,
+} from "../commandCenterRunAggregation";
+
+function useSequentialNow(start = Date.parse("2026-04-01T16:00:00Z")): void {
+  let current = start;
+  vi.spyOn(Date, "now").mockImplementation(() => current++);
+}
+
+function makeMessage(
+  type: string,
+  data: Record<string, unknown>,
+  lastEventId: string
+): MessageEvent<string> {
+  return new MessageEvent(type, {
+    data: JSON.stringify(data),
+    lastEventId,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("commandCenterRunAggregation", () => {
+  it("collapses lifecycle events with the same task_id into one run", () => {
+    useSequentialNow();
+
+    const created = normalizeCommandCenterEvent(
+      makeMessage(
+        "task.created",
+        {
+          latest_turn_message_id: "msg-1",
+          run_id: "run-1",
+          task_id: "task-1",
+          thread_id: 42,
+          turn_id: "turn-1",
+          type: "chat.completion",
+        },
+        "evt-1"
+      )
+    );
+    const running = normalizeCommandCenterEvent(
+      makeMessage(
+        "task.running",
+        {
+          latest_turn_message_id: "msg-2",
+          run_id: "run-1",
+          task_id: "task-1",
+          thread_id: 42,
+          turn_id: "turn-1",
+          type: "chat.completion",
+        },
+        "evt-2"
+      )
+    );
+    const taskState = normalizeCommandCenterEvent(
+      makeMessage(
+        "task.state",
+        {
+          latest_turn_message_id: "msg-3",
+          run_id: "run-1",
+          state: "blocked_waiting_for_user",
+          task_id: "task-1",
+          thread_id: 42,
+          turn_id: "turn-1",
+          type: "chat.completion",
+        },
+        "evt-3"
+      )
+    );
+    const completed = normalizeCommandCenterEvent(
+      makeMessage(
+        "task.completed",
+        {
+          latest_turn_message_id: "msg-4",
+          message_id: "msg-4",
+          run_id: "run-1",
+          task_id: "task-1",
+          thread_id: 42,
+          turn_id: "turn-1",
+          type: "chat.completion",
+        },
+        "evt-4"
+      )
+    );
+
+    const result = aggregateCommandCenterEvents([
+      created,
+      running,
+      taskState,
+      completed,
+    ]);
+
+    expect(result.runs).toHaveLength(1);
+
+    const run = result.runs[0];
+    expect(run).toBeDefined();
+    expect(run?.taskId).toBe("task-1");
+    expect(run?.identityKind).toBe("task");
+    expect(run?.eventCount).toBe(4);
+    expect(run?.runType).toBe("chat completion");
+    expect(run?.state).toBe("completed");
+    expect(run?.terminalOutcome).toBe("succeeded");
+    expect(run?.status).toBe("succeeded");
+    expect(run?.summary).toBe("chat completion · completed");
+    expect(run?.lastType).toBe("task.completed");
+    expect(run?.latestTurnMessageId).toBe("msg-4");
+    expect(run?.threadId).toBe(42);
+    expect(run?.turnId).toBe("turn-1");
+    expect(run?.events).toHaveLength(4);
+    expect(
+      run?.events?.some(
+        (event) => event.type === "task.state" && event.state === "blocked waiting for user"
+      )
+    ).toBe(true);
+  });
+
+  it("keeps chunk events on the same run record instead of creating new cards", () => {
+    useSequentialNow();
+
+    const created = normalizeCommandCenterEvent(
+      makeMessage(
+        "task.created",
+        {
+          task_id: "task-2",
+          thread_id: 7,
+          type: "chat.completion",
+        },
+        "evt-10"
+      )
+    );
+    const chunkOne = normalizeCommandCenterEvent(
+      makeMessage(
+        "task.progress",
+        {
+          task_id: "task-2",
+          thread_id: 7,
+          type: "chat.completion",
+        },
+        "evt-11"
+      )
+    );
+    const chunkTwo = normalizeCommandCenterEvent(
+      makeMessage(
+        "task.progress",
+        {
+          task_id: "task-2",
+          thread_id: 7,
+          type: "chat.completion",
+        },
+        "evt-12"
+      )
+    );
+
+    expect(chunkOne.type).toBe("task.chunk");
+    expect(chunkTwo.type).toBe("task.chunk");
+
+    const result = aggregateCommandCenterEvents([created, chunkOne, chunkTwo]);
+
+    expect(result.runs).toHaveLength(1);
+
+    const run = result.runs[0];
+    expect(run).toBeDefined();
+    expect(run?.eventCount).toBe(3);
+    expect(run?.runType).toBe("chat completion");
+    expect(run?.state).toBe("chunk");
+    expect(run?.status).toBe("running");
+    expect(run?.summary).toBe("chat completion · chunk");
+    expect(run?.lastType).toBe("task.chunk");
+    expect(run?.events?.filter((event) => event.type === "task.chunk")).toHaveLength(2);
+  });
+
+  it("updates the existing run record when the terminal event arrives", () => {
+    useSequentialNow();
+
+    const created = normalizeCommandCenterEvent(
+      makeMessage(
+        "task.created",
+        {
+          task_id: "task-3",
+          thread_id: 8,
+          type: "chat.completion",
+        },
+        "evt-20"
+      )
+    );
+    const completed = normalizeCommandCenterEvent(
+      makeMessage(
+        "task.completed",
+        {
+          latest_turn_message_id: "msg-9",
+          message_id: "msg-9",
+          task_id: "task-3",
+          thread_id: 8,
+          type: "chat.completion",
+        },
+        "evt-21"
+      )
+    );
+
+    const result = aggregateCommandCenterEvents([created, completed]);
+
+    expect(result.runs).toHaveLength(1);
+
+    const run = result.runs[0];
+    expect(run).toBeDefined();
+    expect(run?.eventCount).toBe(2);
+    expect(run?.lastType).toBe("task.completed");
+    expect(run?.state).toBe("completed");
+    expect(run?.terminalOutcome).toBe("succeeded");
+    expect(run?.status).toBe("succeeded");
+    expect(run?.summary).toBe("chat completion · completed");
+    expect(run?.lastEventAt).toBe(completed.receivedAt);
+  });
+
+  it("keeps unclassified events visible without polluting classified runs", () => {
+    useSequentialNow();
+
+    const classified = normalizeCommandCenterEvent(
+      makeMessage(
+        "task.created",
+        {
+          task_id: "task-4",
+          thread_id: 9,
+          type: "chat.completion",
+        },
+        "evt-30"
+      )
+    );
+    const unclassified = normalizeCommandCenterEvent(
+      makeMessage(
+        "message",
+        {
+          message: "No stable identity yet",
+        },
+        "evt-31"
+      )
+    );
+
+    const result = aggregateCommandCenterEvents([classified, unclassified]);
+
+    expect(result.runs).toHaveLength(2);
+
+    const classifiedRun = result.runs.find((run) => run.taskId === "task-4");
+    const unclassifiedRun = result.runs.find(
+      (run) => run.identityKind === "synthetic" && run.status === "unknown"
+    );
+
+    expect(classifiedRun).toBeDefined();
+    expect(classifiedRun?.eventCount).toBe(1);
+    expect(classifiedRun?.summary).toBe("chat completion · created");
+    expect(unclassifiedRun).toBeDefined();
+    expect(unclassifiedRun?.runType).toBeNull();
+    expect(unclassifiedRun?.summary).toBe("unclassified event");
+    expect(unclassifiedRun?.eventCount).toBe(1);
+    expect(unclassifiedRun?.taskId).toBeNull();
+    expect(unclassifiedRun?.requestId).toBeNull();
+  });
+});

--- a/frontend/src/features/commandCenter/__tests__/commandCenterRunAggregation.test.tsx
+++ b/frontend/src/features/commandCenter/__tests__/commandCenterRunAggregation.test.tsx
@@ -34,6 +34,7 @@ describe("commandCenterRunAggregation", () => {
         "task.created",
         {
           latest_turn_message_id: "msg-1",
+          queued_at: "2026-04-01T16:00:00Z",
           run_id: "run-1",
           task_id: "task-1",
           thread_id: 42,
@@ -48,10 +49,12 @@ describe("commandCenterRunAggregation", () => {
         "task.running",
         {
           latest_turn_message_id: "msg-2",
+          warmup_at: "2026-04-01T16:00:02Z",
           run_id: "run-1",
           task_id: "task-1",
           thread_id: 42,
           turn_id: "turn-1",
+          state: "awaiting_model",
           type: "chat.completion",
         },
         "evt-2"
@@ -62,8 +65,9 @@ describe("commandCenterRunAggregation", () => {
         "task.state",
         {
           latest_turn_message_id: "msg-3",
+          first_token_at: "2026-04-01T16:00:03Z",
           run_id: "run-1",
-          state: "blocked_waiting_for_user",
+          state: "awaiting_first_token",
           task_id: "task-1",
           thread_id: 42,
           turn_id: "turn-1",
@@ -72,16 +76,38 @@ describe("commandCenterRunAggregation", () => {
         "evt-3"
       )
     );
+    const chunk = normalizeCommandCenterEvent(
+      makeMessage(
+        "task.progress",
+        {
+          first_output_at: "2026-04-01T16:00:04Z",
+          latest_turn_message_id: "msg-3",
+          run_id: "run-1",
+          task_id: "task-1",
+          thread_id: 42,
+          token: "Hello",
+          turn_id: "turn-1",
+          type: "chat.completion",
+        },
+        "evt-3a"
+      )
+    );
     const completed = normalizeCommandCenterEvent(
       makeMessage(
         "task.completed",
         {
+          completed_at: "2026-04-01T16:00:05Z",
+          duration_ms: 4200,
           latest_turn_message_id: "msg-4",
           message_id: "msg-4",
           run_id: "run-1",
+          retrieval_query: "How does the cache behave?",
+          retrieval_query_matches_latest_turn: true,
+          retrieval_target: "search-index",
           task_id: "task-1",
           thread_id: 42,
           turn_id: "turn-1",
+          trace_url: "/api/chat/debug/rag-trace/42/latest",
           type: "chat.completion",
         },
         "evt-4"
@@ -92,6 +118,7 @@ describe("commandCenterRunAggregation", () => {
       created,
       running,
       taskState,
+      chunk,
       completed,
     ]);
 
@@ -101,7 +128,7 @@ describe("commandCenterRunAggregation", () => {
     expect(run).toBeDefined();
     expect(run?.taskId).toBe("task-1");
     expect(run?.identityKind).toBe("task");
-    expect(run?.eventCount).toBe(4);
+    expect(run?.eventCount).toBe(5);
     expect(run?.runType).toBe("chat completion");
     expect(run?.state).toBe("completed");
     expect(run?.terminalOutcome).toBe("succeeded");
@@ -111,10 +138,39 @@ describe("commandCenterRunAggregation", () => {
     expect(run?.latestTurnMessageId).toBe("msg-4");
     expect(run?.threadId).toBe(42);
     expect(run?.turnId).toBe("turn-1");
-    expect(run?.events).toHaveLength(4);
+    expect(run?.events).toHaveLength(5);
+    expect(run?.lifecycleStates).toEqual([
+      "QUEUED",
+      "AWAITING_MODEL",
+      "AWAITING_FIRST_TOKEN",
+      "STREAMING",
+      "COMPLETED",
+    ]);
+    expect(run?.streamingEvidence).toMatchObject({
+      chunkCount: 1,
+      hasStreamedContent: true,
+    });
+    expect(run?.timings).toMatchObject({
+      completedAt: Date.parse("2026-04-01T16:00:05Z"),
+      firstOutputAt: Date.parse("2026-04-01T16:00:04Z"),
+      firstTokenAt: Date.parse("2026-04-01T16:00:03Z"),
+      queuedAt: Date.parse("2026-04-01T16:00:00Z"),
+      totalDurationMs: 4200,
+      warmupAt: Date.parse("2026-04-01T16:00:02Z"),
+    });
+    expect(run?.traceUrl).toBe("/api/chat/debug/rag-trace/42/latest");
+    expect(run?.traceEvidence).toMatchObject({
+      latestTurnTracePresent: true,
+      retrievalQuery: "How does the cache behave?",
+      retrievalQueryMatchesLatestTurn: true,
+      retrievalQueryPresent: true,
+      retrievalTarget: "search-index",
+      tracePresent: true,
+      traceUrl: "/api/chat/debug/rag-trace/42/latest",
+    });
     expect(
       run?.events?.some(
-        (event) => event.type === "task.state" && event.state === "blocked waiting for user"
+        (event) => event.type === "task.state" && event.state === "awaiting first token"
       )
     ).toBe(true);
   });
@@ -171,6 +227,11 @@ describe("commandCenterRunAggregation", () => {
     expect(run?.status).toBe("running");
     expect(run?.summary).toBe("chat completion · chunk");
     expect(run?.lastType).toBe("task.chunk");
+    expect(run?.lifecycleStates).toEqual(["QUEUED", "STREAMING"]);
+    expect(run?.streamingEvidence).toMatchObject({
+      chunkCount: 2,
+      hasStreamedContent: true,
+    });
     expect(run?.events?.filter((event) => event.type === "task.chunk")).toHaveLength(2);
   });
 
@@ -192,6 +253,8 @@ describe("commandCenterRunAggregation", () => {
       makeMessage(
         "task.completed",
         {
+          completed_at: "2026-04-01T16:10:05Z",
+          duration_ms: 1800,
           latest_turn_message_id: "msg-9",
           message_id: "msg-9",
           task_id: "task-3",
@@ -215,6 +278,10 @@ describe("commandCenterRunAggregation", () => {
     expect(run?.status).toBe("succeeded");
     expect(run?.summary).toBe("chat completion · completed");
     expect(run?.lastEventAt).toBe(completed.receivedAt);
+    expect(run?.timings).toMatchObject({
+      completedAt: Date.parse("2026-04-01T16:10:05Z"),
+      totalDurationMs: 1800,
+    });
   });
 
   it("keeps unclassified events visible without polluting classified runs", () => {

--- a/frontend/src/features/commandCenter/__tests__/commandCenterRunAggregation.test.tsx
+++ b/frontend/src/features/commandCenter/__tests__/commandCenterRunAggregation.test.tsx
@@ -4,6 +4,12 @@ import {
   aggregateCommandCenterEvents,
   normalizeCommandCenterEvent,
 } from "../commandCenterRunAggregation";
+import {
+  COMMAND_CENTER_RUN_KINDS,
+  COMMAND_CENTER_RUN_STATUSES,
+  COMMAND_CENTER_RUN_TERMINAL_OUTCOMES,
+  COMMAND_CENTER_TRACE_PRESENCE_STATES,
+} from "@/features/commandCenter/types";
 
 function useSequentialNow(start = Date.parse("2026-04-01T16:00:00Z")): void {
   let current = start;
@@ -144,10 +150,11 @@ describe("commandCenterRunAggregation", () => {
     expect(run?.taskId).toBe("task-1");
     expect(run?.identityKind).toBe("task");
     expect(run?.eventCount).toBe(5);
+    expect(run?.runKind).toBe(COMMAND_CENTER_RUN_KINDS.CHAT_COMPLETION);
     expect(run?.runType).toBe("chat completion");
     expect(run?.state).toBe("completed");
-    expect(run?.terminalOutcome).toBe("succeeded");
-    expect(run?.status).toBe("succeeded");
+    expect(run?.terminalOutcome).toBe(COMMAND_CENTER_RUN_TERMINAL_OUTCOMES.COMPLETED);
+    expect(run?.status).toBe(COMMAND_CENTER_RUN_STATUSES.COMPLETED);
     expect(run?.summary).toBe("chat completion · completed");
     expect(run?.lastType).toBe("task.completed");
     expect(run?.latestTurnMessageId).toBe("msg-4");
@@ -185,7 +192,7 @@ describe("commandCenterRunAggregation", () => {
       retrievalQueryPresent: true,
       retrievalTarget: "search-index",
       sourceMode: "personal_knowledge",
-      tracePresenceState: "latest-turn trace present",
+      tracePresenceState: COMMAND_CENTER_TRACE_PRESENCE_STATES.LATEST_TURN_TRACE_PRESENT,
       tracePresent: true,
       traceUrl: "/api/chat/debug/rag-trace/42/latest",
       widenReason: "explicit_personal_knowledge",
@@ -296,8 +303,8 @@ describe("commandCenterRunAggregation", () => {
     expect(run?.eventCount).toBe(2);
     expect(run?.lastType).toBe("task.completed");
     expect(run?.state).toBe("completed");
-    expect(run?.terminalOutcome).toBe("succeeded");
-    expect(run?.status).toBe("succeeded");
+    expect(run?.terminalOutcome).toBe(COMMAND_CENTER_RUN_TERMINAL_OUTCOMES.COMPLETED);
+    expect(run?.status).toBe(COMMAND_CENTER_RUN_STATUSES.COMPLETED);
     expect(run?.summary).toBe("chat completion · completed");
     expect(run?.lastEventAt).toBe(completed.receivedAt);
     expect(run?.traceEvidence).toBeNull();

--- a/frontend/src/features/commandCenter/commandCenterRunAggregation.ts
+++ b/frontend/src/features/commandCenter/commandCenterRunAggregation.ts
@@ -350,6 +350,92 @@ function readLatestTurnContent(records: Record<string, unknown>[]): string | nul
   return readKey(records, ["latest_turn_content", "latestTurnContent"]);
 }
 
+function normalizeSourceModeToken(value: string | null): string | null {
+  if (!value) return null;
+
+  const normalized = normalizeToken(value).replace(/[.\s-]+/g, "_");
+  if (normalized === "project" || normalized === "personal_knowledge") {
+    return normalized;
+  }
+  return normalized || null;
+}
+
+function readSourceMode(records: Record<string, unknown>[]): string | null {
+  const explicit = readKey(records, ["source_mode", "sourceMode"]);
+  if (explicit) {
+    return normalizeSourceModeToken(explicit);
+  }
+
+  const origin = readKey(records, ["origin"]);
+  if (origin) {
+    const match = origin.match(/(?:^|\|)\s*source_mode=([^|]+)/i);
+    if (match?.[1]) {
+      return normalizeSourceModeToken(match[1]);
+    }
+  }
+
+  return null;
+}
+
+function readWidenReason(records: Record<string, unknown>[]): string | null {
+  const explicit = readKey(records, ["widen_reason", "widenReason"]);
+  return explicit ? normalizeToken(explicit) : null;
+}
+
+function readNestedNumber(
+  record: Record<string, unknown>,
+  nestedKeys: string[],
+  countKeys: string[]
+): number | null {
+  for (const nestedKey of nestedKeys) {
+    const nested = asRecord(record[nestedKey]);
+    if (!nested) continue;
+    for (const countKey of countKeys) {
+      const value = firstNumber(nested[countKey]);
+      if (value != null) return value;
+    }
+  }
+  return null;
+}
+
+function readCollectionCount(
+  records: Record<string, unknown>[],
+  {
+    countKeys,
+    nestedKeys,
+    nestedCountKeys,
+    arrayKeys,
+  }: {
+    countKeys: string[];
+    nestedKeys?: string[];
+    nestedCountKeys?: string[];
+    arrayKeys?: string[];
+  }
+): number | null {
+  for (const record of records) {
+    for (const key of countKeys) {
+      const value = firstNumber(record[key]);
+      if (value != null) return value;
+    }
+
+    const nestedCount =
+      nestedKeys && nestedKeys.length > 0
+        ? readNestedNumber(record, nestedKeys, nestedCountKeys ?? countKeys)
+        : null;
+    if (nestedCount != null) {
+      return nestedCount;
+    }
+
+    for (const key of arrayKeys ?? []) {
+      const value = record[key];
+      if (Array.isArray(value)) {
+        return value.length;
+      }
+    }
+  }
+  return null;
+}
+
 function inferLifecycleStateFromCanonicalType(
   canonicalType: string | null
 ): string | null {
@@ -747,6 +833,8 @@ function deriveRunTraceEvidence(
   events: CommandCenterEvent[],
   latestTurnMessageId: string | null
 ): CommandCenterRunTraceEvidence | null {
+  const sourceMode = lastDefined(events, (event) => event.sourceMode) as string | null;
+  const widenReason = lastDefined(events, (event) => event.widenReason) as string | null;
   const traceUrl = lastDefined(events, (event) => event.traceUrl) as string | null;
   const retrievalQuery = lastDefined(events, (event) => event.retrievalQuery) as string | null;
   const retrievalTarget = lastDefined(events, (event) => event.retrievalTarget) as string | null;
@@ -755,45 +843,65 @@ function deriveRunTraceEvidence(
     (event) => event.retrievalQueryMatchesLatestTurn
   ) as boolean | null;
   const latestTurnContent = lastDefined(events, (event) => event.latestTurnContent) as string | null;
+  const documentCount = lastDefined(events, (event) => event.documentCount) as number | null;
+  const memoryCount = lastDefined(events, (event) => event.memoryCount) as number | null;
+  const graphCount = lastDefined(events, (event) => event.graphCount) as number | null;
 
-  const tracePresent = Boolean(
-    traceUrl ||
+  const hasRetrievalSummary = Boolean(
+    sourceMode ||
+      widenReason != null ||
+      traceUrl ||
       retrievalQuery ||
       retrievalTarget ||
       retrievalQueryMatchesLatestTurn != null ||
-      latestTurnContent
+      latestTurnContent ||
+      documentCount != null ||
+      memoryCount != null ||
+      graphCount != null
+  );
+  const tracePresent = Boolean(
+    widenReason != null ||
+      traceUrl ||
+      retrievalQuery ||
+      retrievalTarget ||
+      retrievalQueryMatchesLatestTurn != null ||
+      latestTurnContent ||
+      documentCount != null ||
+      memoryCount != null ||
+      graphCount != null
   );
   const latestTurnTracePresent = Boolean(
-    latestTurnMessageId &&
-      (
-      retrievalQuery ||
-      retrievalTarget ||
-      retrievalQueryMatchesLatestTurn != null ||
-      latestTurnContent
-      )
+    latestTurnMessageId && tracePresent
   );
+  const tracePresenceState: CommandCenterRunTraceEvidence["tracePresenceState"] =
+    latestTurnTracePresent
+    ? "latest-turn trace present"
+    : tracePresent
+      ? "trace present"
+      : "none";
   const retrievalQueryPresent = Boolean(retrievalQuery);
   const latestTurnContentPresent = Boolean(latestTurnContent);
 
-  if (
-    !tracePresent &&
-    !latestTurnTracePresent &&
-    !retrievalQueryPresent &&
-    !latestTurnContentPresent &&
-    !traceUrl
-  ) {
+  if (!hasRetrievalSummary) {
     return null;
   }
 
   return {
+    documentCount,
+    graphCount,
     latestTurnContentPresent,
+    latestTurnMessageId,
     latestTurnTracePresent,
+    memoryCount,
     retrievalQuery,
     retrievalQueryMatchesLatestTurn,
     retrievalQueryPresent,
     retrievalTarget,
+    sourceMode,
+    tracePresenceState,
     tracePresent,
     traceUrl,
+    widenReason,
   };
 }
 
@@ -1040,6 +1148,36 @@ export function normalizeCommandCenterEvent(
   ]);
   const latestTurnContent = readLatestTurnContent(records);
   const traceUrl = readTraceUrl(records);
+  const sourceMode = readSourceMode(records);
+  const widenReason = readWidenReason(records);
+  const documentCount = readCollectionCount(records, {
+    countKeys: [
+      "semantic_count",
+      "document_count",
+      "documents_count",
+      "linked_document_count",
+    ],
+    nestedKeys: ["payload_summary"],
+    nestedCountKeys: [
+      "semantic_count",
+      "document_count",
+      "documents_count",
+      "linked_document_count",
+    ],
+    arrayKeys: ["documents"],
+  });
+  const memoryCount = readCollectionCount(records, {
+    countKeys: ["memory_count"],
+    nestedKeys: ["payload_summary", "memory_context"],
+    nestedCountKeys: ["memory_count", "count"],
+    arrayKeys: ["memory"],
+  });
+  const graphCount = readCollectionCount(records, {
+    countKeys: ["graph_count"],
+    nestedKeys: ["payload_summary", "graph_context"],
+    nestedCountKeys: ["graph_count", "count"],
+    arrayKeys: ["graph"],
+  });
   const summary = summarizeEvent(
     raw,
     canonicalType,
@@ -1059,6 +1197,11 @@ export function normalizeCommandCenterEvent(
     firstTokenAt,
     latestTurnMessageId: ids.latestTurnMessageId,
     latestTurnContent,
+    sourceMode,
+    widenReason,
+    documentCount,
+    memoryCount,
+    graphCount,
     lifecycleState,
     raw,
     receivedAt: Date.now(),

--- a/frontend/src/features/commandCenter/commandCenterRunAggregation.ts
+++ b/frontend/src/features/commandCenter/commandCenterRunAggregation.ts
@@ -4,11 +4,19 @@ import type {
   CommandCenterEvent,
   CommandCenterRun,
   CommandCenterRunIdentityKind,
+  CommandCenterRunKind,
   CommandCenterRunStatus,
   CommandCenterRunTerminalOutcome,
   CommandCenterRunStreamingEvidence,
   CommandCenterRunTimings,
   CommandCenterRunTraceEvidence,
+} from "@/features/commandCenter/types";
+import {
+  COMMAND_CENTER_RUN_STATUSES,
+  COMMAND_CENTER_RUN_KINDS,
+  COMMAND_CENTER_RUN_TERMINAL_OUTCOMES,
+  COMMAND_CENTER_TRACE_PRESENCE_STATES,
+  normalizeCommandCenterTerminalOutcome,
 } from "@/features/commandCenter/types";
 
 const RUN_EVENT_LIMIT = 50;
@@ -25,6 +33,7 @@ type MutableRun = {
   latestTurnMessageId: string | null;
   requestId: string | null;
   runId: string | null;
+  runKind: CommandCenterRunKind | null;
   runType: string | null;
   state: string | null;
   status: CommandCenterRunStatus;
@@ -569,21 +578,14 @@ function deriveTerminalOutcome(
   canonicalType: string | null,
   records: Record<string, unknown>[]
 ): CommandCenterRun["terminalOutcome"] | null {
-  const explicitOutcome = normalizeToken(
+  const explicitOutcome = normalizeCommandCenterTerminalOutcome(
     readToken(records, ["terminal_outcome", "terminalOutcome", "outcome"])
   );
-  switch (explicitOutcome) {
-    case "succeeded":
-    case "failed":
-    case "cancelled":
-      return explicitOutcome;
-    default:
-      break;
-  }
+  if (explicitOutcome) return explicitOutcome;
 
   switch (normalizeToken(canonicalType)) {
     case "task.completed":
-      return "succeeded";
+      return "completed";
     case "task.failed":
       return "failed";
     case "task.cancelled":
@@ -613,64 +615,103 @@ function deriveRunType(
   return humanizeToken(rawType);
 }
 
+function deriveRunKind(
+  canonicalType: string | null,
+  taskType: string | null,
+  sseType: string | null
+): CommandCenterRunKind {
+  const normalizedTaskType = normalizeToken(taskType);
+  if (normalizedTaskType === "chat.completion" || normalizedTaskType === "chat_completion") {
+    return COMMAND_CENTER_RUN_KINDS.CHAT_COMPLETION;
+  }
+
+  const normalizedCanonical = normalizeToken(canonicalType);
+  if (
+    normalizedCanonical.startsWith("task.") &&
+    normalizeToken(sseType) === "task.completed" &&
+    normalizedTaskType === "chat.completion"
+  ) {
+    return COMMAND_CENTER_RUN_KINDS.CHAT_COMPLETION;
+  }
+
+  return COMMAND_CENTER_RUN_KINDS.UNKNOWN;
+}
+
 function deriveRunStatus(
   state: string | null,
   terminalOutcome: CommandCenterRun["terminalOutcome"] | null,
   rawStatus: string | null,
   canonicalType: string | null
 ): CommandCenterRunStatus {
-  if (terminalOutcome === "succeeded") return "succeeded";
-  if (terminalOutcome === "failed") return "failed";
-  if (terminalOutcome === "cancelled") return "needs_attention";
+  if (terminalOutcome === COMMAND_CENTER_RUN_TERMINAL_OUTCOMES.COMPLETED) {
+    return COMMAND_CENTER_RUN_STATUSES.COMPLETED;
+  }
+  if (terminalOutcome === COMMAND_CENTER_RUN_TERMINAL_OUTCOMES.FAILED) {
+    return COMMAND_CENTER_RUN_STATUSES.FAILED;
+  }
+  if (terminalOutcome === COMMAND_CENTER_RUN_TERMINAL_OUTCOMES.CANCELLED) {
+    return COMMAND_CENTER_RUN_STATUSES.CANCELLED;
+  }
 
   const normalizedState = normalizeToken(state);
   if (normalizedState) {
-    if (/(failed|error)/.test(normalizedState)) return "failed";
-    if (/(cancelled|canceled)/.test(normalizedState)) return "needs_attention";
+    if (/(failed|error)/.test(normalizedState)) {
+      return COMMAND_CENTER_RUN_STATUSES.FAILED;
+    }
+    if (/(cancelled|canceled)/.test(normalizedState)) {
+      return COMMAND_CENTER_RUN_STATUSES.CANCELLED;
+    }
     if (
       /(blocked|waiting|approval|clarification|pending|needs attention)/.test(
         normalizedState
       )
     ) {
-      return "needs_attention";
+      return COMMAND_CENTER_RUN_STATUSES.NEEDS_ATTENTION;
     }
     if (
       /(completed|succeeded|success|done)/.test(normalizedState)
     ) {
-      return "succeeded";
+      return COMMAND_CENTER_RUN_STATUSES.COMPLETED;
     }
     if (
       /(created|running|chunk|state|streaming|processing|started)/.test(
         normalizedState
       )
     ) {
-      return "running";
+      return COMMAND_CENTER_RUN_STATUSES.RUNNING;
     }
   }
 
   const normalizedStatus = normalizeToken(rawStatus);
   if (normalizedStatus) {
-    if (/(failed|error)/.test(normalizedStatus)) return "failed";
+    if (/(failed|error)/.test(normalizedStatus)) {
+      return COMMAND_CENTER_RUN_STATUSES.FAILED;
+    }
     if (
       /(blocked|waiting|approval|clarification|pending|attention)/.test(
         normalizedStatus
       )
     ) {
-      return "needs_attention";
+      return COMMAND_CENTER_RUN_STATUSES.NEEDS_ATTENTION;
     }
-    if (/(running|created|chunk|streaming|processing|started)/.test(normalizedStatus)) {
-      return "running";
+    if (
+      /(running|created|chunk|streaming|processing|started)/.test(normalizedStatus)
+    ) {
+      return COMMAND_CENTER_RUN_STATUSES.RUNNING;
     }
     if (/(complete|completed|succeeded|success|done)/.test(normalizedStatus)) {
-      return "succeeded";
+      return COMMAND_CENTER_RUN_STATUSES.COMPLETED;
+    }
+    if (/(cancelled|canceled)/.test(normalizedStatus)) {
+      return COMMAND_CENTER_RUN_STATUSES.CANCELLED;
     }
   }
 
   if (isCanonicalTaskEventType(canonicalType)) {
-    return "running";
+    return COMMAND_CENTER_RUN_STATUSES.RUNNING;
   }
 
-  return "unknown";
+  return COMMAND_CENTER_RUN_STATUSES.UNKNOWN;
 }
 
 function summarizeEvent(
@@ -694,9 +735,6 @@ function summarizeEvent(
   if (taskType || (canonical && canonical.startsWith("task."))) {
     const runTypeLabel = taskType ? humanizeToken(taskType) : "task";
     const stateLabel = state ? humanizeToken(state) : null;
-    if (stateLabel && terminalOutcome === "succeeded") {
-      return `${runTypeLabel} ${stateLabel}`;
-    }
     if (stateLabel) {
       return `${runTypeLabel} ${stateLabel}`;
     }
@@ -730,10 +768,6 @@ function buildRunSummary(
 
   if (!stateLabel || stateLabel === typeLabel) {
     return typeLabel;
-  }
-
-  if (terminalOutcome === "succeeded") {
-    return `${typeLabel} · ${stateLabel}`;
   }
 
   return `${typeLabel} · ${stateLabel}`;
@@ -875,10 +909,10 @@ function deriveRunTraceEvidence(
   );
   const tracePresenceState: CommandCenterRunTraceEvidence["tracePresenceState"] =
     latestTurnTracePresent
-    ? "latest-turn trace present"
-    : tracePresent
-      ? "trace present"
-      : "none";
+      ? COMMAND_CENTER_TRACE_PRESENCE_STATES.LATEST_TURN_TRACE_PRESENT
+      : tracePresent
+        ? COMMAND_CENTER_TRACE_PRESENCE_STATES.TRACE_PRESENT
+        : COMMAND_CENTER_TRACE_PRESENCE_STATES.NONE;
   const retrievalQueryPresent = Boolean(retrievalQuery);
   const latestTurnContentPresent = Boolean(latestTurnContent);
 
@@ -925,6 +959,7 @@ function finalizeRun(run: MutableRun): CommandCenterRun {
     latestTurnMessageId: run.latestTurnMessageId,
     requestId: run.requestId,
     runId: run.runId,
+    runKind: run.runKind,
     runType: run.runType,
     state: run.state,
     status: run.status,
@@ -1043,10 +1078,11 @@ function mergeRuns(target: MutableRun, source: MutableRun): MutableRun {
     latestTurnMessageId: latest.latestTurnMessageId ?? older.latestTurnMessageId,
     requestId: latest.requestId ?? older.requestId,
     runId: latest.runId ?? older.runId,
+    runKind: latest.runKind ?? older.runKind,
     runType: latest.runType ?? older.runType,
     state: latest.state ?? older.state,
     status:
-      latest.status !== "unknown"
+      latest.status !== COMMAND_CENTER_RUN_STATUSES.UNKNOWN
         ? latest.status
         : older.status,
     summary: latest.summary ?? older.summary,
@@ -1102,6 +1138,7 @@ export function normalizeCommandCenterEvent(
   const taskType = readTaskType(records);
   const state = deriveTaskState(canonicalType, records);
   const terminalOutcome = deriveTerminalOutcome(canonicalType, records);
+  const runKind = deriveRunKind(canonicalType, taskType, rawEventType);
   const lifecycleState = readLifecycleState(records, canonicalType);
   const queuedAt = readTimestamp(records, [
     "queued_at",
@@ -1208,6 +1245,7 @@ export function normalizeCommandCenterEvent(
     queuedAt,
     requestId: ids.requestId,
     runId: ids.runId,
+    runKind,
     retrievalQuery,
     retrievalQueryMatchesLatestTurn,
     retrievalTarget,
@@ -1255,9 +1293,10 @@ export function aggregateCommandCenterEvents(
       latestTurnMessageId: event.latestTurnMessageId,
       requestId: event.requestId,
       runId: event.runId,
+      runKind: null,
       runType: null,
       state: event.state,
-      status: "unknown",
+      status: COMMAND_CENTER_RUN_STATUSES.UNKNOWN,
       summary: event.summary,
       taskId: event.taskId,
       terminalOutcome: event.terminalOutcome,
@@ -1321,7 +1360,10 @@ export function aggregateCommandCenterEvents(
     const key = resolvedKey || `event:${index}:${event.receivedAt}`;
     const run = ensureRun(key, identityKind, event);
     const runType = deriveRunType(event.type, event.taskType, event.sseType);
+    const runKind = deriveRunKind(event.type, event.taskType, event.sseType);
     const nextRunType = runType ?? run.runType;
+    const nextRunKind =
+      runKind !== COMMAND_CENTER_RUN_KINDS.UNKNOWN ? runKind : run.runKind;
     const nextState = event.state ?? run.state;
     const nextOutcome = event.terminalOutcome ?? run.terminalOutcome;
     const summaryStatus = deriveRunStatus(
@@ -1346,10 +1388,12 @@ export function aggregateCommandCenterEvents(
     run.latestTurnMessageId = event.latestTurnMessageId ?? run.latestTurnMessageId;
     run.requestId = event.requestId ?? run.requestId;
     run.runId = event.runId ?? run.runId;
+    run.runKind = nextRunKind;
     run.runType = nextRunType;
     run.state = nextState;
     run.status =
-      summaryStatus !== "unknown" || run.status === "unknown"
+      summaryStatus !== COMMAND_CENTER_RUN_STATUSES.UNKNOWN ||
+      run.status === COMMAND_CENTER_RUN_STATUSES.UNKNOWN
         ? summaryStatus
         : run.status;
     run.summary = summary;

--- a/frontend/src/features/commandCenter/commandCenterRunAggregation.ts
+++ b/frontend/src/features/commandCenter/commandCenterRunAggregation.ts
@@ -6,6 +6,9 @@ import type {
   CommandCenterRunIdentityKind,
   CommandCenterRunStatus,
   CommandCenterRunTerminalOutcome,
+  CommandCenterRunStreamingEvidence,
+  CommandCenterRunTimings,
+  CommandCenterRunTraceEvidence,
 } from "@/features/commandCenter/types";
 
 const RUN_EVENT_LIMIT = 50;
@@ -114,14 +117,120 @@ function parseJson(raw: string): Record<string, unknown> | null {
   }
 }
 
-function pushRecord(
-  records: Record<string, unknown>[],
-  value: unknown
-): void {
-  const record = asRecord(value);
-  if (!record) return;
-  if (!records.includes(record)) {
-    records.push(record);
+const NESTED_RECORD_KEYS = [
+  "data",
+  "event",
+  "meta",
+  "metadata",
+  "payload",
+  "response",
+  "result",
+  "run",
+  "task",
+  "trace",
+  "context",
+  "lifecycle",
+  "runtime",
+  "thread",
+  "timings",
+] as const;
+
+function parseTimestamp(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value !== "string") return null;
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const parsed = Number(trimmed);
+  if (Number.isFinite(parsed) && /^(?:\d+)(?:\.\d+)?$/.test(trimmed)) {
+    return parsed;
+  }
+
+  const parsedDate = Date.parse(trimmed);
+  return Number.isFinite(parsedDate) ? parsedDate : null;
+}
+
+function parseBoolean(value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
+    return null;
+  }
+  if (typeof value !== "string") return null;
+
+  const normalized = normalizeToken(value);
+  if (["true", "yes", "y", "1", "present", "available"].includes(normalized)) {
+    return true;
+  }
+  if (["false", "no", "n", "0", "missing", "absent", "unavailable"].includes(normalized)) {
+    return false;
+  }
+  return null;
+}
+
+function formatLifecycleStateToken(value: string): string {
+  return value
+    .trim()
+    .replace(/[.\s-]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toUpperCase();
+}
+
+function normalizeLifecycleStateToken(value: string | null): string | null {
+  if (!value) return null;
+
+  const normalized = normalizeToken(value).replace(/[.\s-]+/g, "_");
+  switch (normalized) {
+    case "accepted":
+    case "accepted_degraded":
+    case "created":
+    case "queued":
+      return "QUEUED";
+    case "dispatching":
+      return "DISPATCHING";
+    case "awaiting_ack":
+    case "waiting_for_ack":
+    case "awaiting_confirmation":
+      return "AWAITING_ACK";
+    case "awaiting_model":
+    case "running":
+    case "model_warming":
+      return "AWAITING_MODEL";
+    case "awaiting_first_token":
+    case "first_token_pending":
+      return "AWAITING_FIRST_TOKEN";
+    case "streaming":
+    case "chunk":
+    case "progress":
+      return "STREAMING";
+    case "completed":
+    case "done":
+    case "success":
+    case "succeeded":
+      return "COMPLETED";
+    case "cancelled":
+    case "canceled":
+      return "CANCELLED";
+    case "timed_out":
+    case "timeout":
+      return "TIMED_OUT";
+    case "failed_retryable":
+      return "FAILED_RETRYABLE";
+    case "failed_fatal":
+    case "failed":
+    case "error":
+      return "FAILED_FATAL";
+    case "orphaned":
+      return "ORPHANED";
+    case "replayed":
+      return "REPLAYED";
+    default:
+      return formatLifecycleStateToken(value);
   }
 }
 
@@ -129,23 +238,35 @@ function collectRecords(json: Record<string, unknown> | null): Record<string, un
   const records: Record<string, unknown>[] = [];
   if (!json) return records;
 
-  pushRecord(records, json);
-  pushRecord(records, json.data);
-  pushRecord(records, json.run);
-  pushRecord(records, json.payload);
-  pushRecord(records, json.task);
-  pushRecord(records, json.event);
-  pushRecord(records, json.thread);
-  pushRecord(records, json.context);
+  const queue: Record<string, unknown>[] = [];
+  const seen = new Set<Record<string, unknown>>();
 
-  for (const record of [...records]) {
-    pushRecord(records, record.data);
-    pushRecord(records, record.run);
-    pushRecord(records, record.payload);
-    pushRecord(records, record.task);
-    pushRecord(records, record.event);
-    pushRecord(records, record.thread);
-    pushRecord(records, record.context);
+  const enqueue = (value: unknown): void => {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+        const parsed = parseJson(trimmed);
+        if (parsed && !seen.has(parsed)) {
+          seen.add(parsed);
+          queue.push(parsed);
+        }
+      }
+    }
+    const record = asRecord(value);
+    if (!record || seen.has(record)) return;
+    seen.add(record);
+    queue.push(record);
+  };
+
+  enqueue(json);
+
+  while (queue.length > 0) {
+    const record = queue.shift();
+    if (!record) continue;
+    records.push(record);
+    for (const key of NESTED_RECORD_KEYS) {
+      enqueue(record[key]);
+    }
   }
 
   return records;
@@ -189,6 +310,86 @@ function readThreadId(records: Record<string, unknown>[]): number | null {
     if (value != null) return value;
   }
   return readNumber(records, ["thread_id", "threadId"]);
+}
+
+function readTimestamp(records: Record<string, unknown>[], keys: string[]): number | null {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = parseTimestamp(record[key]);
+      if (value != null) return value;
+    }
+  }
+  return null;
+}
+
+function readBoolean(records: Record<string, unknown>[], keys: string[]): boolean | null {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = parseBoolean(record[key]);
+      if (value != null) return value;
+    }
+  }
+  return null;
+}
+
+function readTaskType(records: Record<string, unknown>[]): string | null {
+  for (const record of records) {
+    const value = firstToken(record.type, record.task_type, record.taskType);
+    if (!value) continue;
+    if (looksLikeEventType(value)) continue;
+    return value;
+  }
+  return null;
+}
+
+function readTraceUrl(records: Record<string, unknown>[]): string | null {
+  return readKey(records, ["trace_url", "traceUrl"]);
+}
+
+function readLatestTurnContent(records: Record<string, unknown>[]): string | null {
+  return readKey(records, ["latest_turn_content", "latestTurnContent"]);
+}
+
+function inferLifecycleStateFromCanonicalType(
+  canonicalType: string | null
+): string | null {
+  switch (normalizeToken(canonicalType)) {
+    case "task.created":
+      return "QUEUED";
+    case "task.running":
+      return "AWAITING_MODEL";
+    case "task.state":
+      return "STATE";
+    case "task.chunk":
+      return "STREAMING";
+    case "task.completed":
+      return "COMPLETED";
+    case "task.failed":
+      return "FAILED_FATAL";
+    case "task.cancelled":
+      return "CANCELLED";
+    default:
+      return null;
+  }
+}
+
+function readLifecycleState(
+  records: Record<string, unknown>[],
+  canonicalType: string | null
+): string | null {
+  const explicit = readToken(records, [
+    "lifecycle_state",
+    "lifecycleState",
+    "request_state",
+    "requestState",
+    "phase",
+    "state",
+  ]);
+  if (explicit) {
+    return normalizeLifecycleStateToken(explicit);
+  }
+
+  return inferLifecycleStateFromCanonicalType(canonicalType);
 }
 
 function isJsonLike(raw: string): boolean {
@@ -452,6 +653,185 @@ function buildRunSummary(
   return `${typeLabel} · ${stateLabel}`;
 }
 
+function firstDefined<T>(
+  items: T[],
+  selector: (item: T) => unknown
+): unknown | null {
+  for (const item of items) {
+    const value = selector(item);
+    if (value != null) return value;
+  }
+  return null;
+}
+
+function lastDefined<T>(
+  items: T[],
+  selector: (item: T) => unknown
+): unknown | null {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const value = selector(items[index]);
+    if (value != null) return value;
+  }
+  return null;
+}
+
+function deriveLifecycleStates(events: CommandCenterEvent[]): string[] {
+  const states: string[] = [];
+  let previous: string | null = null;
+
+  for (const event of events) {
+    const state = event.lifecycleState;
+    if (!state) continue;
+    if (state === previous) continue;
+    states.push(state);
+    previous = state;
+  }
+
+  return states;
+}
+
+function deriveRunTimings(
+  events: CommandCenterEvent[]
+): CommandCenterRunTimings | null {
+  const queuedAt = firstDefined(events, (event) => event.queuedAt) as number | null;
+  const warmupAt = firstDefined(events, (event) => event.warmupAt) as number | null;
+  const firstTokenAt = firstDefined(events, (event) => event.firstTokenAt) as number | null;
+  const firstOutputAt = firstDefined(events, (event) => event.firstOutputAt) as number | null;
+  const completedAt = lastDefined(events, (event) => event.completedAt) as number | null;
+  let totalDurationMs = lastDefined(events, (event) => event.durationMs) as number | null;
+
+  if (
+    totalDurationMs == null &&
+    queuedAt != null &&
+    completedAt != null &&
+    completedAt >= queuedAt
+  ) {
+    totalDurationMs = completedAt - queuedAt;
+  }
+
+  if (
+    queuedAt == null &&
+    warmupAt == null &&
+    firstTokenAt == null &&
+    firstOutputAt == null &&
+    completedAt == null &&
+    totalDurationMs == null
+  ) {
+    return null;
+  }
+
+  return {
+    completedAt,
+    firstOutputAt,
+    firstTokenAt,
+    queuedAt,
+    totalDurationMs,
+    warmupAt,
+  };
+}
+
+function deriveRunStreamingEvidence(
+  events: CommandCenterEvent[]
+): CommandCenterRunStreamingEvidence | null {
+  const chunkEvents = events.filter((event) => normalizeToken(event.type) === "task.chunk");
+  if (chunkEvents.length === 0) return null;
+
+  return {
+    chunkCount: chunkEvents.length,
+    firstChunkAt: chunkEvents[0]?.receivedAt ?? null,
+    hasStreamedContent: true,
+  };
+}
+
+function deriveRunTraceEvidence(
+  events: CommandCenterEvent[],
+  latestTurnMessageId: string | null
+): CommandCenterRunTraceEvidence | null {
+  const traceUrl = lastDefined(events, (event) => event.traceUrl) as string | null;
+  const retrievalQuery = lastDefined(events, (event) => event.retrievalQuery) as string | null;
+  const retrievalTarget = lastDefined(events, (event) => event.retrievalTarget) as string | null;
+  const retrievalQueryMatchesLatestTurn = lastDefined(
+    events,
+    (event) => event.retrievalQueryMatchesLatestTurn
+  ) as boolean | null;
+  const latestTurnContent = lastDefined(events, (event) => event.latestTurnContent) as string | null;
+
+  const tracePresent = Boolean(
+    traceUrl ||
+      retrievalQuery ||
+      retrievalTarget ||
+      retrievalQueryMatchesLatestTurn != null ||
+      latestTurnContent
+  );
+  const latestTurnTracePresent = Boolean(
+    latestTurnMessageId &&
+      (
+      retrievalQuery ||
+      retrievalTarget ||
+      retrievalQueryMatchesLatestTurn != null ||
+      latestTurnContent
+      )
+  );
+  const retrievalQueryPresent = Boolean(retrievalQuery);
+  const latestTurnContentPresent = Boolean(latestTurnContent);
+
+  if (
+    !tracePresent &&
+    !latestTurnTracePresent &&
+    !retrievalQueryPresent &&
+    !latestTurnContentPresent &&
+    !traceUrl
+  ) {
+    return null;
+  }
+
+  return {
+    latestTurnContentPresent,
+    latestTurnTracePresent,
+    retrievalQuery,
+    retrievalQueryMatchesLatestTurn,
+    retrievalQueryPresent,
+    retrievalTarget,
+    tracePresent,
+    traceUrl,
+  };
+}
+
+function finalizeRun(run: MutableRun): CommandCenterRun {
+  const lifecycleStates = deriveLifecycleStates(run.events);
+  const timings = deriveRunTimings(run.events);
+  const streamingEvidence = deriveRunStreamingEvidence(run.events);
+  const traceEvidence = deriveRunTraceEvidence(run.events, run.latestTurnMessageId);
+  const traceUrl = traceEvidence?.traceUrl ?? null;
+
+  return {
+    eventCount: run.eventCount,
+    events: run.events,
+    identityKind: run.identityKind,
+    key: run.key,
+    lifecycleStates: lifecycleStates.length > 0 ? lifecycleStates : undefined,
+    lastEvent: run.lastEvent,
+    lastEventAt: run.lastEventAt,
+    lastKind: run.lastKind,
+    lastType: run.lastType,
+    latestTurnMessageId: run.latestTurnMessageId,
+    requestId: run.requestId,
+    runId: run.runId,
+    runType: run.runType,
+    state: run.state,
+    status: run.status,
+    streamingEvidence,
+    summary: run.summary,
+    taskId: run.taskId,
+    terminalOutcome: run.terminalOutcome,
+    timings,
+    traceEvidence,
+    traceUrl,
+    turnId: run.turnId,
+    threadId: run.threadId,
+  };
+}
+
 function normalizeEventIds(
   records: Record<string, unknown>[]
 ): {
@@ -611,9 +991,55 @@ export function normalizeCommandCenterEvent(
     normalizeCanonicalEventType(candidateEventType) ??
     firstToken(candidateEventType);
   const ids = normalizeEventIds(records);
-  const taskType = readToken(records, ["type", "task_type", "taskType"]);
+  const taskType = readTaskType(records);
   const state = deriveTaskState(canonicalType, records);
   const terminalOutcome = deriveTerminalOutcome(canonicalType, records);
+  const lifecycleState = readLifecycleState(records, canonicalType);
+  const queuedAt = readTimestamp(records, [
+    "queued_at",
+    "queuedAt",
+    "created_at",
+    "createdAt",
+    "started_at",
+    "startedAt",
+  ]);
+  const warmupAt = readTimestamp(records, ["warmup_at", "warmupAt"]);
+  const firstTokenAt = readTimestamp(records, [
+    "first_token_at",
+    "firstTokenAt",
+  ]);
+  const firstOutputAt = readTimestamp(records, [
+    "first_output_at",
+    "firstOutputAt",
+  ]);
+  const completedAt = readTimestamp(records, [
+    "completed_at",
+    "completedAt",
+    "finished_at",
+    "finishedAt",
+  ]);
+  const durationMs = readNumber(records, [
+    "duration_ms",
+    "durationMs",
+    "total_duration_ms",
+    "totalDurationMs",
+    "elapsed_ms",
+    "elapsedMs",
+  ]);
+  const retrievalQuery = readKey(records, [
+    "retrieval_query",
+    "retrievalQuery",
+  ]);
+  const retrievalTarget = readKey(records, [
+    "retrieval_target",
+    "retrievalTarget",
+  ]);
+  const retrievalQueryMatchesLatestTurn = readBoolean(records, [
+    "retrieval_query_matches_latest_turn",
+    "retrievalQueryMatchesLatestTurn",
+  ]);
+  const latestTurnContent = readLatestTurnContent(records);
+  const traceUrl = readTraceUrl(records);
   const summary = summarizeEvent(
     raw,
     canonicalType,
@@ -627,11 +1053,21 @@ export function normalizeCommandCenterEvent(
     eventId: firstString(message.lastEventId),
     json,
     kind: readToken(records, ["kind"]),
+    completedAt,
+    durationMs,
+    firstOutputAt,
+    firstTokenAt,
     latestTurnMessageId: ids.latestTurnMessageId,
+    latestTurnContent,
+    lifecycleState,
     raw,
     receivedAt: Date.now(),
+    queuedAt,
     requestId: ids.requestId,
     runId: ids.runId,
+    retrievalQuery,
+    retrievalQueryMatchesLatestTurn,
+    retrievalTarget,
     sseType: rawEventType ?? payloadEventType ?? "message",
     state,
     status: readToken(records, ["status", "raw_status", "rawStatus"]),
@@ -641,6 +1077,8 @@ export function normalizeCommandCenterEvent(
     terminalOutcome,
     threadId: ids.threadId,
     turnId: ids.turnId,
+    traceUrl,
+    warmupAt,
     type: canonicalType,
   };
 }
@@ -804,11 +1242,13 @@ export function aggregateCommandCenterEvents(
     }
   });
 
+  const finalizedRuns = Array.from(runs.values())
+    .map((run) => finalizeRun(run))
+    .sort((left, right) => right.lastEventAt - left.lastEventAt);
+
   return {
     approvals: approvals.sort((left, right) => right.receivedAt - left.receivedAt),
-    runs: Array.from(runs.values()).sort(
-      (left, right) => right.lastEventAt - left.lastEventAt
-    ),
+    runs: finalizedRuns,
   };
 }
 

--- a/frontend/src/features/commandCenter/commandCenterRunAggregation.ts
+++ b/frontend/src/features/commandCenter/commandCenterRunAggregation.ts
@@ -1,0 +1,819 @@
+import type {
+  CommandCenterApproval,
+  CommandCenterCanonicalTaskEventType,
+  CommandCenterEvent,
+  CommandCenterRun,
+  CommandCenterRunIdentityKind,
+  CommandCenterRunStatus,
+  CommandCenterRunTerminalOutcome,
+} from "@/features/commandCenter/types";
+
+const RUN_EVENT_LIMIT = 50;
+
+type MutableRun = {
+  eventCount: number;
+  events: CommandCenterEvent[];
+  identityKind: CommandCenterRunIdentityKind;
+  key: string;
+  lastEvent: CommandCenterEvent;
+  lastEventAt: number;
+  lastKind: string | null;
+  lastType: string | null;
+  latestTurnMessageId: string | null;
+  requestId: string | null;
+  runId: string | null;
+  runType: string | null;
+  state: string | null;
+  status: CommandCenterRunStatus;
+  summary: string;
+  taskId: string | null;
+  terminalOutcome: CommandCenterRunTerminalOutcome | null;
+  threadId: number | null;
+  turnId: string | null;
+};
+
+type AggregationResult = {
+  approvals: CommandCenterApproval[];
+  runs: CommandCenterRun[];
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+function firstToken(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return String(value);
+    }
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+function firstNumber(...values: unknown[]): number | null {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (!trimmed) continue;
+      const parsed = Number(trimmed);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return null;
+}
+
+function normalizeToken(value: string | null): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase();
+}
+
+function humanizeToken(value: string | null): string {
+  const normalized = String(value ?? "")
+    .trim()
+    .replace(/[._-]+/g, " ")
+    .replace(/\s+/g, " ");
+  return normalized.toLowerCase();
+}
+
+function coerceRawPayload(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value ?? "");
+  } catch {
+    return String(value ?? "");
+  }
+}
+
+function parseJson(raw: string): Record<string, unknown> | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    return asRecord(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function pushRecord(
+  records: Record<string, unknown>[],
+  value: unknown
+): void {
+  const record = asRecord(value);
+  if (!record) return;
+  if (!records.includes(record)) {
+    records.push(record);
+  }
+}
+
+function collectRecords(json: Record<string, unknown> | null): Record<string, unknown>[] {
+  const records: Record<string, unknown>[] = [];
+  if (!json) return records;
+
+  pushRecord(records, json);
+  pushRecord(records, json.data);
+  pushRecord(records, json.run);
+  pushRecord(records, json.payload);
+  pushRecord(records, json.task);
+  pushRecord(records, json.event);
+  pushRecord(records, json.thread);
+  pushRecord(records, json.context);
+
+  for (const record of [...records]) {
+    pushRecord(records, record.data);
+    pushRecord(records, record.run);
+    pushRecord(records, record.payload);
+    pushRecord(records, record.task);
+    pushRecord(records, record.event);
+    pushRecord(records, record.thread);
+    pushRecord(records, record.context);
+  }
+
+  return records;
+}
+
+function readKey(records: Record<string, unknown>[], keys: string[]): string | null {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = firstString(record[key]);
+      if (value) return value;
+    }
+  }
+  return null;
+}
+
+function readToken(records: Record<string, unknown>[], keys: string[]): string | null {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = firstToken(record[key]);
+      if (value) return value;
+    }
+  }
+  return null;
+}
+
+function readNumber(records: Record<string, unknown>[], keys: string[]): number | null {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = firstNumber(record[key]);
+      if (value != null) return value;
+    }
+  }
+  return null;
+}
+
+function readThreadId(records: Record<string, unknown>[]): number | null {
+  for (const record of records) {
+    const thread = asRecord(record.thread);
+    if (!thread) continue;
+    const value = firstNumber(thread.thread_id, thread.threadId, thread.id);
+    if (value != null) return value;
+  }
+  return readNumber(records, ["thread_id", "threadId"]);
+}
+
+function isJsonLike(raw: string): boolean {
+  const trimmed = raw.trim();
+  return trimmed.startsWith("{") || trimmed.startsWith("[");
+}
+
+function isCanonicalTaskEventType(
+  value: string | null
+): value is CommandCenterCanonicalTaskEventType {
+  switch (normalizeToken(value)) {
+    case "task.created":
+    case "task.running":
+    case "task.state":
+    case "task.chunk":
+    case "task.completed":
+    case "task.failed":
+    case "task.cancelled":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function looksLikeEventType(value: string | null): boolean {
+  return /^(task|run|browser|message|thread|connector|completion)\./.test(
+    normalizeToken(value)
+  );
+}
+
+function normalizeCanonicalEventType(value: string | null): string | null {
+  switch (normalizeToken(value)) {
+    case "task.progress":
+      return "task.chunk";
+    case "task.updated":
+      return "task.state";
+    case "completion.error":
+      return "task.failed";
+    case "task.created":
+    case "task.running":
+    case "task.state":
+    case "task.chunk":
+    case "task.completed":
+    case "task.failed":
+    case "task.cancelled":
+      return normalizeToken(value);
+    default:
+      return null;
+  }
+}
+
+function deriveTaskState(
+  canonicalType: string | null,
+  records: Record<string, unknown>[]
+): string | null {
+  const explicitState = readToken(records, [
+    "state",
+    "lifecycle_state",
+    "lifecycleState",
+    "status",
+  ]);
+  const canonical = normalizeToken(canonicalType);
+
+  if (canonical === "task.state") {
+    return explicitState ? humanizeToken(explicitState) : "state";
+  }
+
+  if (explicitState) {
+    return humanizeToken(explicitState);
+  }
+
+  switch (canonical) {
+    case "task.created":
+      return "created";
+    case "task.running":
+      return "running";
+    case "task.chunk":
+      return "chunk";
+    case "task.completed":
+      return "completed";
+    case "task.failed":
+      return "failed";
+    case "task.cancelled":
+      return "cancelled";
+    default:
+      return null;
+  }
+}
+
+function deriveTerminalOutcome(
+  canonicalType: string | null,
+  records: Record<string, unknown>[]
+): CommandCenterRun["terminalOutcome"] | null {
+  const explicitOutcome = normalizeToken(
+    readToken(records, ["terminal_outcome", "terminalOutcome", "outcome"])
+  );
+  switch (explicitOutcome) {
+    case "succeeded":
+    case "failed":
+    case "cancelled":
+      return explicitOutcome;
+    default:
+      break;
+  }
+
+  switch (normalizeToken(canonicalType)) {
+    case "task.completed":
+      return "succeeded";
+    case "task.failed":
+      return "failed";
+    case "task.cancelled":
+      return "cancelled";
+    default:
+      return null;
+  }
+}
+
+function deriveRunType(
+  canonicalType: string | null,
+  taskType: string | null,
+  sseType: string | null
+): string | null {
+  if (taskType) return humanizeToken(taskType);
+
+  const canonical = normalizeToken(canonicalType);
+  if (canonical && canonical.startsWith("task.")) {
+    return "task";
+  }
+
+  const rawType = normalizeToken(sseType);
+  if (!rawType || rawType === "message") {
+    return null;
+  }
+
+  return humanizeToken(rawType);
+}
+
+function deriveRunStatus(
+  state: string | null,
+  terminalOutcome: CommandCenterRun["terminalOutcome"] | null,
+  rawStatus: string | null,
+  canonicalType: string | null
+): CommandCenterRunStatus {
+  if (terminalOutcome === "succeeded") return "succeeded";
+  if (terminalOutcome === "failed") return "failed";
+  if (terminalOutcome === "cancelled") return "needs_attention";
+
+  const normalizedState = normalizeToken(state);
+  if (normalizedState) {
+    if (/(failed|error)/.test(normalizedState)) return "failed";
+    if (/(cancelled|canceled)/.test(normalizedState)) return "needs_attention";
+    if (
+      /(blocked|waiting|approval|clarification|pending|needs attention)/.test(
+        normalizedState
+      )
+    ) {
+      return "needs_attention";
+    }
+    if (
+      /(completed|succeeded|success|done)/.test(normalizedState)
+    ) {
+      return "succeeded";
+    }
+    if (
+      /(created|running|chunk|state|streaming|processing|started)/.test(
+        normalizedState
+      )
+    ) {
+      return "running";
+    }
+  }
+
+  const normalizedStatus = normalizeToken(rawStatus);
+  if (normalizedStatus) {
+    if (/(failed|error)/.test(normalizedStatus)) return "failed";
+    if (
+      /(blocked|waiting|approval|clarification|pending|attention)/.test(
+        normalizedStatus
+      )
+    ) {
+      return "needs_attention";
+    }
+    if (/(running|created|chunk|streaming|processing|started)/.test(normalizedStatus)) {
+      return "running";
+    }
+    if (/(complete|completed|succeeded|success|done)/.test(normalizedStatus)) {
+      return "succeeded";
+    }
+  }
+
+  if (isCanonicalTaskEventType(canonicalType)) {
+    return "running";
+  }
+
+  return "unknown";
+}
+
+function summarizeEvent(
+  raw: string,
+  canonicalType: string | null,
+  taskType: string | null,
+  state: string | null,
+  terminalOutcome: CommandCenterRun["terminalOutcome"] | null,
+  records: Record<string, unknown>[]
+): string {
+  const summary = readKey(records, [
+    "summary",
+    "message",
+    "error",
+    "reason",
+    "details",
+  ]);
+  if (summary) return summary;
+
+  const canonical = normalizeToken(canonicalType);
+  if (taskType || (canonical && canonical.startsWith("task."))) {
+    const runTypeLabel = taskType ? humanizeToken(taskType) : "task";
+    const stateLabel = state ? humanizeToken(state) : null;
+    if (stateLabel && terminalOutcome === "succeeded") {
+      return `${runTypeLabel} ${stateLabel}`;
+    }
+    if (stateLabel) {
+      return `${runTypeLabel} ${stateLabel}`;
+    }
+    return runTypeLabel;
+  }
+
+  const rawStatus = readKey(records, ["status", "raw_status", "rawStatus"]);
+  if (rawStatus) return rawStatus;
+
+  if (state) return humanizeToken(state);
+
+  const trimmedRaw = raw.trim();
+  if (trimmedRaw && !isJsonLike(trimmedRaw)) {
+    return trimmedRaw.length > 160
+      ? `${trimmedRaw.slice(0, 157)}...`
+      : trimmedRaw;
+  }
+
+  return canonicalType ?? "Event received";
+}
+
+function buildRunSummary(
+  runType: string | null,
+  state: string | null,
+  terminalOutcome: CommandCenterRun["terminalOutcome"] | null,
+  status: CommandCenterRunStatus
+): string {
+  const typeLabel =
+    runType ?? (status !== "unknown" ? "task" : null) ?? "unclassified event";
+  const stateLabel = state ? humanizeToken(state) : null;
+
+  if (!stateLabel || stateLabel === typeLabel) {
+    return typeLabel;
+  }
+
+  if (terminalOutcome === "succeeded") {
+    return `${typeLabel} · ${stateLabel}`;
+  }
+
+  return `${typeLabel} · ${stateLabel}`;
+}
+
+function normalizeEventIds(
+  records: Record<string, unknown>[]
+): {
+  latestTurnMessageId: string | null;
+  requestId: string | null;
+  runId: string | null;
+  taskId: string | null;
+  threadId: number | null;
+  turnId: string | null;
+} {
+  const latestTurnMessageId =
+    readToken(records, [
+      "latest_turn_message_id",
+      "latestTurnMessageId",
+      "message_id",
+      "messageId",
+      "id",
+    ]) ?? null;
+
+  return {
+    latestTurnMessageId,
+    requestId: readToken(records, ["request_id", "requestId"]),
+    runId: readToken(records, ["run_id", "runId"]),
+    taskId: readToken(records, ["task_id", "taskId"]),
+    threadId: readThreadId(records),
+    turnId: readToken(records, ["turn_id", "turnId"]),
+  };
+}
+
+function getEventIdentity(
+  event: CommandCenterEvent
+): { identityKind: CommandCenterRunIdentityKind; key: string } {
+  if (event.taskId) {
+    return { identityKind: "task", key: event.taskId };
+  }
+  if (event.requestId) {
+    return { identityKind: "request", key: event.requestId };
+  }
+  if (event.runId) {
+    return { identityKind: "run", key: event.runId };
+  }
+  if (event.eventId) {
+    return { identityKind: "synthetic", key: `event:${event.eventId}` };
+  }
+  return {
+    identityKind: "synthetic",
+    key: `event:${event.type ?? "unknown"}:${event.receivedAt}`,
+  };
+}
+
+function resolveAlias(aliases: Map<string, string>, key: string): string {
+  let current = key;
+  let next = aliases.get(current);
+  while (next && next !== current) {
+    current = next;
+    next = aliases.get(current);
+  }
+  return current;
+}
+
+function appendBoundedEvents(
+  previous: CommandCenterEvent[],
+  next: CommandCenterEvent
+): CommandCenterEvent[] {
+  const appended = [...previous, next];
+  if (appended.length <= RUN_EVENT_LIMIT) return appended;
+  return appended.slice(appended.length - RUN_EVENT_LIMIT);
+}
+
+function mergeEventLists(
+  left: CommandCenterEvent[],
+  right: CommandCenterEvent[]
+): CommandCenterEvent[] {
+  const combined = [...left, ...right];
+  combined.sort((a, b) => {
+    if (a.receivedAt !== b.receivedAt) {
+      return a.receivedAt - b.receivedAt;
+    }
+    return (a.eventId ?? "").localeCompare(b.eventId ?? "");
+  });
+  if (combined.length <= RUN_EVENT_LIMIT) return combined;
+  return combined.slice(combined.length - RUN_EVENT_LIMIT);
+}
+
+function mergeRuns(target: MutableRun, source: MutableRun): MutableRun {
+  const keepTarget = target.lastEventAt >= source.lastEventAt;
+  const latest = keepTarget ? target : source;
+  const older = keepTarget ? source : target;
+
+  return {
+    ...latest,
+    eventCount: target.eventCount + source.eventCount,
+    events: mergeEventLists(target.events, source.events),
+    identityKind:
+      latest.identityKind === "synthetic" ? older.identityKind : latest.identityKind,
+    key: latest.key,
+    lastEvent: latest.lastEvent,
+    lastEventAt: latest.lastEventAt,
+    lastKind: latest.lastKind ?? older.lastKind,
+    lastType: latest.lastType ?? older.lastType,
+    latestTurnMessageId: latest.latestTurnMessageId ?? older.latestTurnMessageId,
+    requestId: latest.requestId ?? older.requestId,
+    runId: latest.runId ?? older.runId,
+    runType: latest.runType ?? older.runType,
+    state: latest.state ?? older.state,
+    status:
+      latest.status !== "unknown"
+        ? latest.status
+        : older.status,
+    summary: latest.summary ?? older.summary,
+    taskId: latest.taskId ?? older.taskId,
+    terminalOutcome: latest.terminalOutcome ?? older.terminalOutcome,
+    threadId: latest.threadId ?? older.threadId,
+    turnId: latest.turnId ?? older.turnId,
+  };
+}
+
+function isApprovalEvent(event: CommandCenterEvent): boolean {
+  const haystack = [
+    event.kind,
+    event.type,
+    event.sseType,
+    event.state,
+    event.status,
+  ]
+    .map((value) => normalizeToken(value))
+    .filter(Boolean)
+    .join(" ");
+
+  if (!haystack) return false;
+
+  return (
+    haystack.includes("approval") ||
+    haystack.includes("approval_required") ||
+    haystack.includes("clarification_required") ||
+    haystack.includes("blocked_waiting_for_user") ||
+    haystack.includes("run.blocked") ||
+    /\bblocked\b/.test(haystack)
+  );
+}
+
+export function normalizeCommandCenterEvent(
+  message: MessageEvent<string>
+): CommandCenterEvent {
+  const raw = coerceRawPayload(message.data);
+  const json = parseJson(raw);
+  const records = collectRecords(json);
+  const rawEventType = firstString(message.type);
+  const payloadEventType = readToken(records, ["event_type", "eventType"]);
+  const candidateEventType =
+    rawEventType && rawEventType !== "message"
+      ? rawEventType
+      : payloadEventType && looksLikeEventType(payloadEventType)
+        ? payloadEventType
+        : null;
+  const canonicalType =
+    normalizeCanonicalEventType(candidateEventType) ??
+    firstToken(candidateEventType);
+  const ids = normalizeEventIds(records);
+  const taskType = readToken(records, ["type", "task_type", "taskType"]);
+  const state = deriveTaskState(canonicalType, records);
+  const terminalOutcome = deriveTerminalOutcome(canonicalType, records);
+  const summary = summarizeEvent(
+    raw,
+    canonicalType,
+    taskType,
+    state,
+    terminalOutcome,
+    records
+  );
+
+  return {
+    eventId: firstString(message.lastEventId),
+    json,
+    kind: readToken(records, ["kind"]),
+    latestTurnMessageId: ids.latestTurnMessageId,
+    raw,
+    receivedAt: Date.now(),
+    requestId: ids.requestId,
+    runId: ids.runId,
+    sseType: rawEventType ?? payloadEventType ?? "message",
+    state,
+    status: readToken(records, ["status", "raw_status", "rawStatus"]),
+    summary,
+    taskId: ids.taskId,
+    taskType,
+    terminalOutcome,
+    threadId: ids.threadId,
+    turnId: ids.turnId,
+    type: canonicalType,
+  };
+}
+
+export function aggregateCommandCenterEvents(
+  events: CommandCenterEvent[]
+): AggregationResult {
+  const aliases = new Map<string, string>();
+  const runs = new Map<string, MutableRun>();
+  const approvals: CommandCenterApproval[] = [];
+
+  const ensureRun = (
+    key: string,
+    identityKind: CommandCenterRunIdentityKind,
+    event: CommandCenterEvent
+  ): MutableRun => {
+    const existing = runs.get(key);
+    if (existing) {
+      return existing;
+    }
+
+    const created: MutableRun = {
+      eventCount: 0,
+      events: [],
+      identityKind,
+      key,
+      lastEvent: event,
+      lastEventAt: event.receivedAt,
+      lastKind: event.kind,
+      lastType: event.type,
+      latestTurnMessageId: event.latestTurnMessageId,
+      requestId: event.requestId,
+      runId: event.runId,
+      runType: null,
+      state: event.state,
+      status: "unknown",
+      summary: event.summary,
+      taskId: event.taskId,
+      terminalOutcome: event.terminalOutcome,
+      threadId: event.threadId,
+      turnId: event.turnId,
+    };
+    runs.set(key, created);
+    return created;
+  };
+
+  const collapse = (primary: string, secondary: string): string => {
+    const resolvedPrimary = resolveAlias(aliases, primary);
+    const resolvedSecondary = resolveAlias(aliases, secondary);
+    if (resolvedPrimary === resolvedSecondary) return resolvedPrimary;
+
+    const primaryRun = runs.get(resolvedPrimary);
+    const secondaryRun = runs.get(resolvedSecondary);
+    if (secondaryRun) {
+      if (primaryRun) {
+        runs.set(resolvedPrimary, mergeRuns(primaryRun, secondaryRun));
+      } else {
+        runs.set(resolvedPrimary, { ...secondaryRun, key: resolvedPrimary });
+      }
+      runs.delete(resolvedSecondary);
+    }
+
+    aliases.set(resolvedSecondary, resolvedPrimary);
+    return resolvedPrimary;
+  };
+
+  const registerAliases = (
+    primaryKey: string,
+    identityKind: CommandCenterRunIdentityKind,
+    event: CommandCenterEvent
+  ): string => {
+    const aliasesToRegister = [event.taskId, event.requestId, event.runId]
+      .filter((value): value is string => Boolean(value))
+      .filter((value) => value !== primaryKey);
+
+    let nextKey = primaryKey;
+    for (const aliasKey of aliasesToRegister) {
+      nextKey = collapse(nextKey, aliasKey);
+    }
+
+    aliases.set(primaryKey, nextKey);
+    if (identityKind === "task" && event.requestId) {
+      aliases.set(event.requestId, nextKey);
+    }
+    if (identityKind === "task" && event.runId) {
+      aliases.set(event.runId, nextKey);
+    }
+    if (identityKind === "request" && event.runId) {
+      aliases.set(event.runId, nextKey);
+    }
+    return resolveAlias(aliases, nextKey);
+  };
+
+  events.forEach((event, index) => {
+    const { identityKind, key: rawKey } = getEventIdentity(event);
+    const resolvedKey = resolveAlias(aliases, rawKey) || rawKey;
+    const key = resolvedKey || `event:${index}:${event.receivedAt}`;
+    const run = ensureRun(key, identityKind, event);
+    const runType = deriveRunType(event.type, event.taskType, event.sseType);
+    const nextRunType = runType ?? run.runType;
+    const nextState = event.state ?? run.state;
+    const nextOutcome = event.terminalOutcome ?? run.terminalOutcome;
+    const summaryStatus = deriveRunStatus(
+      nextState,
+      nextOutcome,
+      event.status,
+      event.type
+    );
+    const summary = buildRunSummary(
+      nextRunType,
+      nextState,
+      nextOutcome,
+      summaryStatus
+    );
+
+    run.eventCount += 1;
+    run.events = appendBoundedEvents(run.events, event);
+    run.lastEvent = event;
+    run.lastEventAt = event.receivedAt;
+    run.lastKind = event.kind;
+    run.lastType = event.type;
+    run.latestTurnMessageId = event.latestTurnMessageId ?? run.latestTurnMessageId;
+    run.requestId = event.requestId ?? run.requestId;
+    run.runId = event.runId ?? run.runId;
+    run.runType = nextRunType;
+    run.state = nextState;
+    run.status =
+      summaryStatus !== "unknown" || run.status === "unknown"
+        ? summaryStatus
+        : run.status;
+    run.summary = summary;
+    run.taskId = event.taskId ?? run.taskId;
+    run.terminalOutcome = nextOutcome;
+    run.threadId = event.threadId ?? run.threadId;
+    run.turnId = event.turnId ?? run.turnId;
+    runs.set(key, run);
+
+    const collapsedKey = registerAliases(key, identityKind, event);
+    if (collapsedKey !== key) {
+      const collapsedRun = runs.get(collapsedKey);
+      if (collapsedRun) {
+        runs.set(collapsedKey, mergeRuns(collapsedRun, run));
+      } else {
+        runs.set(collapsedKey, { ...run, key: collapsedKey });
+      }
+      runs.delete(key);
+    }
+
+    if (isApprovalEvent(event)) {
+      approvals.push({
+        event,
+        key: `${key}:${index}:${event.receivedAt}`,
+        label: humanizeToken(event.kind ?? event.type ?? event.sseType ?? event.status),
+        receivedAt: event.receivedAt,
+        runId: event.runId,
+        runKey: key,
+        status: event.status,
+        summary: event.summary,
+        taskId: event.taskId,
+      });
+    }
+  });
+
+  return {
+    approvals: approvals.sort((left, right) => right.receivedAt - left.receivedAt),
+    runs: Array.from(runs.values()).sort(
+      (left, right) => right.lastEventAt - left.lastEventAt
+    ),
+  };
+}
+
+export function deriveCommandCenterRunIdentity(
+  event: CommandCenterEvent
+): { identityKind: CommandCenterRunIdentityKind; key: string } {
+  return getEventIdentity(event);
+}

--- a/frontend/src/features/commandCenter/components/RagTracePanel.tsx
+++ b/frontend/src/features/commandCenter/components/RagTracePanel.tsx
@@ -5,11 +5,16 @@ import { Card, CardContent } from "@/components/ui/card";
 import useRagTrace from "@/features/commandCenter/hooks/useRagTrace";
 import type {
   CommandCenterRagTraceItem,
+  CommandCenterRagTracePayload,
+  CommandCenterRagTraceUnavailableReason,
   CommandCenterRun,
 } from "@/features/commandCenter/types";
+import { describeCommandCenterTracePresencePresentation } from "@/features/commandCenter/types";
 
 type RagTracePanelProps = {
+  latestTurnMessageId?: string | null;
   run: CommandCenterRun | null;
+  threadId?: number | null;
 };
 
 function itemChromeStyle(): React.CSSProperties {
@@ -23,6 +28,11 @@ function formatScore(score: number | null): string | null {
   if (score == null) return null;
   const rounded = score.toFixed(3);
   return rounded.replace(/0+$/, "").replace(/\.$/, "");
+}
+
+function clipInlineText(value: string, limit = 96): string {
+  if (value.length <= limit) return value;
+  return `${value.slice(0, Math.max(0, limit - 1))}…`;
 }
 
 function EmptyState({
@@ -73,7 +83,10 @@ function EvidenceCard({ item }: { item: CommandCenterRagTraceItem }) {
     <Card className="bezel-none rounded-xl border" style={itemChromeStyle()}>
       <CardContent className="space-y-3 p-4">
         <div className="flex flex-wrap items-center justify-between gap-2">
-          <div className="text-xs font-semibold uppercase tracking-[0.12em]" style={{ color: "var(--muted)" }}>
+          <div
+            className="text-xs font-semibold uppercase tracking-[0.12em]"
+            style={{ color: "var(--muted)" }}
+          >
             Evidence {item.id}
           </div>
           {score ? (
@@ -134,7 +147,155 @@ function EvidenceSection({
   );
 }
 
-export default function RagTracePanel({ run }: RagTracePanelProps) {
+function TraceScopeCard({
+  liveTraceLabel,
+  latestTurnMessageId,
+  resolvedThreadId,
+  run,
+}: {
+  liveTraceLabel: string;
+  latestTurnMessageId: string | null;
+  resolvedThreadId: number | null;
+  run: CommandCenterRun;
+}) {
+  const traceEvidence = run.traceEvidence ?? null;
+  const traceSummaryLabel = traceEvidence
+    ? describeCommandCenterTracePresencePresentation(
+        traceEvidence.tracePresenceState
+      ).label
+    : "No trace evidence exists for this run";
+
+  return (
+    <Card className="bezel-none rounded-xl border" style={itemChromeStyle()}>
+      <CardContent className="space-y-3 p-4">
+        <div className="space-y-1">
+          <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
+            Retrieval Trace
+          </div>
+          <div className="text-xs leading-5" style={{ color: "var(--muted)" }}>
+            The same thread and latest-turn identity are carried from the run
+            detail into this trace view.
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <MetadataChip
+            label="Thread"
+            value={resolvedThreadId != null ? String(resolvedThreadId) : null}
+          />
+          <MetadataChip
+            label="Latest turn message"
+            value={latestTurnMessageId}
+          />
+          {traceEvidence?.retrievalQuery ? (
+            <MetadataChip
+              label="Retrieval query"
+              value={clipInlineText(traceEvidence.retrievalQuery, 72)}
+            />
+          ) : null}
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <MetadataChip label="Trace summary" value={traceSummaryLabel} />
+          <MetadataChip label="Live trace" value={liveTraceLabel} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function describeLiveTraceLabel({
+  error,
+  loading,
+  run,
+  trace,
+  unavailable,
+  unavailableReason,
+}: {
+  error: string | null;
+  loading: boolean;
+  run: CommandCenterRun;
+  trace: CommandCenterRagTracePayload | null;
+  unavailable: boolean;
+  unavailableReason: CommandCenterRagTraceUnavailableReason | null;
+}): string {
+  if (loading) {
+    return "Loading scoped trace";
+  }
+  if (error) {
+    return "Trace unavailable";
+  }
+  if (trace) {
+    return "Aligned to this run/thread";
+  }
+  if (!unavailable) {
+    return "Trace unavailable";
+  }
+
+  switch (unavailableReason) {
+    case "no_thread":
+      return "Trace panel unavailable";
+    case "no_trace":
+      if (run.traceEvidence?.tracePresent) {
+        return "Trace summary present, live trace unavailable";
+      }
+      if (run.traceEvidence) {
+        return "Empty but expected";
+      }
+      return "No trace evidence exists for this run";
+    default:
+      return "Trace panel unavailable";
+  }
+}
+
+function describeUnavailableState({
+  run,
+  unavailableReason,
+}: {
+  run: CommandCenterRun;
+  unavailableReason: CommandCenterRagTraceUnavailableReason | null;
+}): string {
+  if (unavailableReason === "no_thread") {
+    return "No thread identity available for this run.";
+  }
+  if (unavailableReason === "no_trace") {
+    if (run.traceEvidence?.tracePresent) {
+      return "Trace summary present, live trace unavailable.";
+    }
+    if (run.traceEvidence) {
+      return "Empty but expected.";
+    }
+    return "No trace evidence exists for this run.";
+  }
+  return "Trace panel unavailable.";
+}
+
+export default function RagTracePanel({
+  latestTurnMessageId,
+  run,
+  threadId,
+}: RagTracePanelProps) {
+  const effectiveRun = React.useMemo(() => {
+    if (!run) return run;
+
+    const resolvedThreadId = threadId ?? run.threadId ?? null;
+    const resolvedLatestTurnMessageId =
+      latestTurnMessageId ?? run.latestTurnMessageId ?? run.traceEvidence?.latestTurnMessageId ?? null;
+
+    if (
+      resolvedThreadId === run.threadId &&
+      resolvedLatestTurnMessageId === run.latestTurnMessageId
+    ) {
+      return run;
+    }
+
+    return {
+      ...run,
+      latestTurnMessageId: resolvedLatestTurnMessageId,
+      threadId: resolvedThreadId,
+    };
+  }, [latestTurnMessageId, run, threadId]);
+
   const {
     error,
     loading,
@@ -142,14 +303,52 @@ export default function RagTracePanel({ run }: RagTracePanelProps) {
     trace,
     unavailable,
     unavailableReason,
-  } = useRagTrace(run);
+  } = useRagTrace(effectiveRun);
+
+  const scopeThreadId = resolvedThreadId ?? threadId ?? run?.threadId ?? null;
+  const scopeLatestTurnMessageId =
+    latestTurnMessageId ?? run?.latestTurnMessageId ?? run?.traceEvidence?.latestTurnMessageId ?? null;
+  const liveTraceLabel = run
+    ? describeLiveTraceLabel({
+        error,
+        loading,
+        run,
+        trace,
+        unavailable,
+        unavailableReason,
+      })
+    : "No run selected";
 
   if (loading) {
-    return <EmptyState role="status">Loading retrieval trace…</EmptyState>;
+    return (
+      <div className="space-y-3">
+        {run ? (
+          <TraceScopeCard
+            latestTurnMessageId={scopeLatestTurnMessageId}
+            liveTraceLabel={liveTraceLabel}
+            resolvedThreadId={scopeThreadId}
+            run={run}
+          />
+        ) : null}
+        <EmptyState role="status">Loading retrieval trace…</EmptyState>
+      </div>
+    );
   }
 
   if (error) {
-    return <EmptyState role="alert">{error}</EmptyState>;
+    return (
+      <div className="space-y-3">
+        {run ? (
+          <TraceScopeCard
+            latestTurnMessageId={scopeLatestTurnMessageId}
+            liveTraceLabel={liveTraceLabel}
+            resolvedThreadId={scopeThreadId}
+            run={run}
+          />
+        ) : null}
+        <EmptyState role="alert">{error}</EmptyState>
+      </div>
+    );
   }
 
   if (unavailable) {
@@ -160,44 +359,52 @@ export default function RagTracePanel({ run }: RagTracePanelProps) {
         </EmptyState>
       );
     }
-    if (unavailableReason === "no_thread") {
-      return (
-        <EmptyState>
-          No resolvable thread available for this run.
-        </EmptyState>
-      );
-    }
+
     return (
-      <EmptyState>
-        No retrieval evidence available for this thread yet.
-      </EmptyState>
+      <div className="space-y-3">
+        {run ? (
+          <TraceScopeCard
+            latestTurnMessageId={scopeLatestTurnMessageId}
+            liveTraceLabel={liveTraceLabel}
+            resolvedThreadId={scopeThreadId}
+            run={run}
+          />
+        ) : null}
+        <EmptyState>
+          {run
+            ? describeUnavailableState({ run, unavailableReason })
+            : "Trace panel unavailable."}
+        </EmptyState>
+      </div>
     );
   }
 
   if (!trace) {
-    return null;
+    return (
+      <div className="space-y-3">
+        {run ? (
+          <TraceScopeCard
+            latestTurnMessageId={scopeLatestTurnMessageId}
+            liveTraceLabel={liveTraceLabel}
+            resolvedThreadId={scopeThreadId}
+            run={run}
+          />
+        ) : null}
+        <EmptyState>No detailed trace payload is currently available.</EmptyState>
+      </div>
+    );
   }
 
   return (
     <div className="space-y-4">
-      <Card className="bezel-none rounded-xl border" style={itemChromeStyle()}>
-        <CardContent className="space-y-3 p-4">
-          <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
-            Retrieval Trace
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <span
-              className="rounded-full border px-2 py-1 text-xs"
-              style={{
-                borderColor: "var(--panel-border)",
-                color: "var(--muted)",
-              }}
-            >
-              Resolved thread: {resolvedThreadId ?? trace.resolvedThreadId}
-            </span>
-          </div>
-        </CardContent>
-      </Card>
+      {run ? (
+        <TraceScopeCard
+          latestTurnMessageId={scopeLatestTurnMessageId}
+          liveTraceLabel={liveTraceLabel}
+          resolvedThreadId={scopeThreadId}
+          run={run}
+        />
+      ) : null}
 
       <EvidenceSection items={trace.semantic} title="Semantic Results" />
       <EvidenceSection items={trace.memory} title="Memory Results" />

--- a/frontend/src/features/commandCenter/components/RunDetailDrawer.tsx
+++ b/frontend/src/features/commandCenter/components/RunDetailDrawer.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import RunDetailsPanel from "@/features/commandCenter/components/RunDetailsPanel";
 import RagTracePanel from "@/features/commandCenter/components/RagTracePanel";
 import {
   Sheet,
@@ -298,33 +299,7 @@ export default function RunDetailDrawer({
             </SheetHeader>
 
             <div className="space-y-4 p-4">
-              <Card
-                className="bezel-none rounded-xl border"
-                style={{
-                  background: "color-mix(in srgb, var(--panel-bg) 94%, transparent)",
-                  borderColor: "var(--panel-border)",
-                }}
-              >
-                <CardContent className="space-y-3 p-4">
-                  <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
-                    Identifiers
-                  </div>
-                  <div className="flex flex-wrap gap-2 text-xs" style={{ color: "var(--muted)" }}>
-                    <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
-                      Grouping key: {run.key}
-                    </span>
-                    <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
-                      Task: {run.taskId ?? "—"}
-                    </span>
-                    <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
-                      Run: {run.runId ?? "—"}
-                    </span>
-                    <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
-                      Thread: {run.threadId ?? "—"}
-                    </span>
-                  </div>
-                </CardContent>
-              </Card>
+              <RunDetailsPanel run={run} />
 
               <div className="flex flex-wrap gap-2">
                 <Button

--- a/frontend/src/features/commandCenter/components/RunDetailDrawer.tsx
+++ b/frontend/src/features/commandCenter/components/RunDetailDrawer.tsx
@@ -151,6 +151,9 @@ export default function RunDetailDrawer({
   const [showRawJson, setShowRawJson] = React.useState(false);
   const sourceRef = React.useRef<GuardianEventSource | null>(null);
   const open = Boolean(run);
+  const traceScopeThreadId = run?.threadId ?? null;
+  const traceScopeLatestTurnMessageId =
+    run?.latestTurnMessageId ?? run?.traceEvidence?.latestTurnMessageId ?? null;
 
   React.useEffect(() => {
     const source = sourceRef.current;
@@ -296,6 +299,18 @@ export default function RunDetailDrawer({
                   {connectionDetail}
                 </div>
               ) : null}
+              {run && (traceScopeThreadId != null || traceScopeLatestTurnMessageId) ? (
+                <div className="text-xs" style={{ color: "var(--muted)" }}>
+                  Trace scope:{" "}
+                  {traceScopeThreadId != null ? `thread ${traceScopeThreadId}` : "thread unavailable"}
+                  {traceScopeLatestTurnMessageId ? (
+                    <>
+                      {" "}
+                      · latest turn message {traceScopeLatestTurnMessageId}
+                    </>
+                  ) : null}
+                </div>
+              ) : null}
             </SheetHeader>
 
             <div className="space-y-4 p-4">
@@ -411,17 +426,21 @@ export default function RunDetailDrawer({
               )}
                 </>
               ) : (
-                <div className="space-y-3">
-                  <div>
-                    <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
-                      Retrieval Diagnostics
-                    </div>
+                  <div className="space-y-3">
+                    <div>
+                      <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
+                        Retrieval Diagnostics
+                      </div>
                     <div className="text-xs" style={{ color: "var(--muted)" }}>
                       Latest thread-scoped retrieval evidence from the existing RAG
                       trace debug endpoint.
                     </div>
                   </div>
-                  <RagTracePanel run={run} />
+                  <RagTracePanel
+                    latestTurnMessageId={traceScopeLatestTurnMessageId}
+                    run={run}
+                    threadId={traceScopeThreadId}
+                  />
                 </div>
               )}
             </div>

--- a/frontend/src/features/commandCenter/components/RunDetailsPanel.tsx
+++ b/frontend/src/features/commandCenter/components/RunDetailsPanel.tsx
@@ -28,6 +28,22 @@ function formatDuration(value: number | null): string {
   return `${value} ms`;
 }
 
+function formatSourceMode(value: string | null): string {
+  switch (String(value ?? "").trim()) {
+    case "project":
+      return "Project";
+    case "personal_knowledge":
+      return "Personal Knowledge";
+    default:
+      return value ? value.replace(/[._-]+/g, " ") : "—";
+  }
+}
+
+function clipInlineText(value: string, limit = 96): string {
+  if (value.length <= limit) return value;
+  return `${value.slice(0, Math.max(0, limit - 1))}…`;
+}
+
 function getEvents(run: CommandCenterRun): CommandCenterEvent[] {
   return run.events?.length ? run.events : [run.lastEvent];
 }
@@ -311,32 +327,76 @@ export default function RunDetailsPanel({ run }: RunDetailsPanelProps) {
         )}
       </SectionCard>
 
-      <SectionCard title="Trace" note="Presence flags only. The raw trace viewer lives elsewhere.">
+      <SectionCard
+        title="Trace / Retrieval"
+        note="Compact retrieval context and trace presence. Raw trace details stay secondary."
+      >
         {traceEvidence ? (
-          <div className="flex flex-wrap gap-2 text-xs" style={{ color: "var(--muted)" }}>
-            <Chip label="Trace present" value={traceEvidence.tracePresent ? "Yes" : "No"} />
-            <Chip
-              label="Latest-turn trace present"
-              value={traceEvidence.latestTurnTracePresent ? "Yes" : "No"}
-            />
-            <Chip
-              label="Retrieval query present"
-              value={traceEvidence.retrievalQueryPresent ? "Yes" : "No"}
-            />
-            <Chip
-              label="Retrieval query matched latest turn"
-              value={
-                traceEvidence.retrievalQueryMatchesLatestTurn == null
-                  ? "—"
-                  : traceEvidence.retrievalQueryMatchesLatestTurn
-                    ? "Yes"
-                    : "No"
-              }
-            />
+          <div className="space-y-3">
+            <div className="flex flex-wrap gap-2 text-xs" style={{ color: "var(--muted)" }}>
+              {traceEvidence.sourceMode ? (
+                <Chip label="Source" value={formatSourceMode(traceEvidence.sourceMode)} />
+              ) : null}
+              {traceEvidence.widenReason != null ? (
+                <Chip label="Widen reason" value={traceEvidence.widenReason} />
+              ) : null}
+              <Chip label="Trace status" value={traceEvidence.tracePresenceState} />
+              {traceEvidence.latestTurnMessageId ?? run.latestTurnMessageId ? (
+                <Chip
+                  label="Latest turn message"
+                  value={traceEvidence.latestTurnMessageId ?? run.latestTurnMessageId}
+                />
+              ) : null}
+            </div>
+
+            {traceEvidence.retrievalQuery ? (
+              <div
+                className="rounded-[var(--tile-radius)] border px-3 py-2 text-xs leading-5"
+                style={{
+                  background: "var(--surface-soft)",
+                  borderColor: "var(--panel-border)",
+                  color: "var(--muted)",
+                }}
+              >
+                <span className="font-semibold" style={{ color: "var(--text)" }}>
+                  Retrieval query:
+                </span>{" "}
+                <span title={traceEvidence.retrievalQuery}>
+                  {clipInlineText(traceEvidence.retrievalQuery)}
+                </span>
+              </div>
+            ) : null}
+
+            <div className="flex flex-wrap gap-2 text-xs" style={{ color: "var(--muted)" }}>
+              {traceEvidence.documentCount != null ? (
+                <Chip label="Documents" value={traceEvidence.documentCount} />
+              ) : null}
+              {traceEvidence.memoryCount != null ? (
+                <Chip label="Memory" value={traceEvidence.memoryCount} />
+              ) : null}
+              {traceEvidence.graphCount != null ? (
+                <Chip label="Graph" value={traceEvidence.graphCount} />
+              ) : null}
+            </div>
+
+            {!traceEvidence.tracePresent ? (
+              <div
+                className="rounded-[var(--tile-radius)] border px-3 py-2 text-xs"
+                style={{
+                  borderColor: "var(--panel-border)",
+                  color: "var(--muted)",
+                }}
+              >
+                No trace evidence recorded.
+              </div>
+            ) : null}
           </div>
         ) : (
-          <div className="rounded-[var(--tile-radius)] border px-3 py-2 text-xs" style={{ borderColor: "var(--panel-border)", color: "var(--muted)" }}>
-            No structured trace evidence recorded.
+          <div
+            className="rounded-[var(--tile-radius)] border px-3 py-2 text-xs"
+            style={{ borderColor: "var(--panel-border)", color: "var(--muted)" }}
+          >
+            No retrieval or trace evidence recorded.
           </div>
         )}
       </SectionCard>

--- a/frontend/src/features/commandCenter/components/RunDetailsPanel.tsx
+++ b/frontend/src/features/commandCenter/components/RunDetailsPanel.tsx
@@ -2,11 +2,17 @@ import * as React from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
-import { describeRuntimeStatusPresentation } from "@/contracts/runtimeTokens";
 
 import type {
   CommandCenterEvent,
   CommandCenterRun,
+} from "@/features/commandCenter/types";
+import {
+  describeCommandCenterRunKindLabel,
+  describeCommandCenterRunStatusPresentation,
+  describeCommandCenterRunTerminalOutcomePresentation,
+  describeCommandCenterTracePresencePresentation,
+  type CommandCenterStatusTone,
 } from "@/features/commandCenter/types";
 
 type RunDetailsPanelProps = {
@@ -48,55 +54,34 @@ function getEvents(run: CommandCenterRun): CommandCenterEvent[] {
   return run.events?.length ? run.events : [run.lastEvent];
 }
 
-function runStateStyle(status: CommandCenterRun["status"]): React.CSSProperties {
-  switch (status) {
-    case "running":
+function badgeToneStyle(tone: CommandCenterStatusTone): React.CSSProperties {
+  switch (tone) {
+    case "active":
+      return {
+        background: "rgba(34, 197, 94, 0.12)",
+        borderColor: "rgba(34, 197, 94, 0.35)",
+      };
+    case "attention":
+      return {
+        background: "rgba(250, 204, 21, 0.12)",
+        borderColor: "rgba(250, 204, 21, 0.35)",
+      };
+    case "danger":
+      return {
+        background: "rgba(239, 68, 68, 0.12)",
+        borderColor: "rgba(239, 68, 68, 0.35)",
+      };
+    case "info":
       return {
         background: "rgba(59, 130, 246, 0.12)",
         borderColor: "rgba(59, 130, 246, 0.35)",
       };
-    case "succeeded":
-      return {
-        background: "rgba(34, 197, 94, 0.12)",
-        borderColor: "rgba(34, 197, 94, 0.35)",
-      };
-    case "failed":
-      return {
-        background: "rgba(239, 68, 68, 0.12)",
-        borderColor: "rgba(239, 68, 68, 0.35)",
-      };
-    case "needs_attention":
-      return {
-        background: "rgba(250, 204, 21, 0.12)",
-        borderColor: "rgba(250, 204, 21, 0.35)",
-      };
-    default:
+    case "neutral":
       return {
         background: "rgba(148, 163, 184, 0.12)",
         borderColor: "rgba(148, 163, 184, 0.28)",
       };
-  }
-}
-
-function runOutcomeStyle(
-  outcome: CommandCenterRun["terminalOutcome"] | null | undefined
-): React.CSSProperties {
-  switch (outcome) {
-    case "succeeded":
-      return {
-        background: "rgba(34, 197, 94, 0.12)",
-        borderColor: "rgba(34, 197, 94, 0.35)",
-      };
-    case "failed":
-      return {
-        background: "rgba(239, 68, 68, 0.12)",
-        borderColor: "rgba(239, 68, 68, 0.35)",
-      };
-    case "cancelled":
-      return {
-        background: "rgba(250, 204, 21, 0.12)",
-        borderColor: "rgba(250, 204, 21, 0.35)",
-      };
+    case "subtle":
     default:
       return {
         background: "rgba(148, 163, 184, 0.12)",
@@ -203,7 +188,10 @@ export default function RunDetailsPanel({ run }: RunDetailsPanelProps) {
 
   if (!run) return null;
 
-  const statusPresentation = describeRuntimeStatusPresentation(run.status);
+  const statusPresentation = describeCommandCenterRunStatusPresentation(run.status);
+  const terminalOutcomePresentation = describeCommandCenterRunTerminalOutcomePresentation(
+    run.terminalOutcome
+  );
   const lifecycleStates = run.lifecycleStates ?? [];
   const timings = run.timings ?? null;
   const streamingEvidence = run.streamingEvidence ?? null;
@@ -231,33 +219,33 @@ export default function RunDetailsPanel({ run }: RunDetailsPanelProps) {
       >
         <CardContent className="space-y-3 p-4">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-            <div className="space-y-1">
-              <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
-                Run details
-              </div>
-              <div className="text-xs leading-5" style={{ color: "var(--muted)" }}>
-                {run.runType ?? "task"} · {run.summary}
+          <div className="space-y-1">
+            <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
+              Run details
+            </div>
+            <div className="text-xs leading-5" style={{ color: "var(--muted)" }}>
+                {describeCommandCenterRunKindLabel(run.runKind) ?? run.runType ?? "task"} · {run.summary}
               </div>
             </div>
             <div className="flex flex-wrap gap-2">
               <Badge
                 className="border text-[11px] font-medium leading-none"
                 style={{
-                  ...runStateStyle(run.status),
+                  ...badgeToneStyle(statusPresentation.tone),
                   color: "var(--text)",
                 }}
               >
-                {run.state ?? run.status}
+                {statusPresentation.label}
               </Badge>
-              {run.terminalOutcome ? (
+              {terminalOutcomePresentation ? (
                 <Badge
                   className="border text-[11px] font-medium leading-none"
                   style={{
-                    ...runOutcomeStyle(run.terminalOutcome),
+                    ...badgeToneStyle(terminalOutcomePresentation.tone),
                     color: "var(--text)",
                   }}
                 >
-                  {run.terminalOutcome}
+                  {terminalOutcomePresentation.label}
                 </Badge>
               ) : null}
               <Badge
@@ -293,8 +281,11 @@ export default function RunDetailsPanel({ run }: RunDetailsPanelProps) {
       <SectionCard title="Lifecycle" note="Ordered states and terminal outcome from the aggregated run record.">
         <div className="space-y-3">
           <div className="flex flex-wrap gap-2 text-xs" style={{ color: "var(--muted)" }}>
-            <Chip label="Current state" value={run.state ?? "unknown"} />
-            <Chip label="Terminal result" value={run.terminalOutcome ?? "not reached"} />
+            <Chip label="Current state" value={statusPresentation.label} />
+            <Chip
+              label="Terminal result"
+              value={terminalOutcomePresentation?.label ?? "not reached"}
+            />
             <Chip
               label="Streaming"
               value={
@@ -340,7 +331,12 @@ export default function RunDetailsPanel({ run }: RunDetailsPanelProps) {
               {traceEvidence.widenReason != null ? (
                 <Chip label="Widen reason" value={traceEvidence.widenReason} />
               ) : null}
-              <Chip label="Trace status" value={traceEvidence.tracePresenceState} />
+              <Chip
+                label="Trace status"
+                value={describeCommandCenterTracePresencePresentation(
+                  traceEvidence.tracePresenceState
+                ).label}
+              />
               {traceEvidence.latestTurnMessageId ?? run.latestTurnMessageId ? (
                 <Chip
                   label="Latest turn message"

--- a/frontend/src/features/commandCenter/components/RunDetailsPanel.tsx
+++ b/frontend/src/features/commandCenter/components/RunDetailsPanel.tsx
@@ -1,0 +1,370 @@
+import * as React from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { describeRuntimeStatusPresentation } from "@/contracts/runtimeTokens";
+
+import type {
+  CommandCenterEvent,
+  CommandCenterRun,
+} from "@/features/commandCenter/types";
+
+type RunDetailsPanelProps = {
+  run: CommandCenterRun | null;
+};
+
+function formatTimestamp(value: number | null): string {
+  if (value == null) return "—";
+  return new Date(value).toLocaleString();
+}
+
+function formatDuration(value: number | null): string {
+  if (value == null) return "—";
+  if (value >= 1000) {
+    const seconds = value / 1000;
+    const rounded = seconds % 1 === 0 ? seconds.toFixed(0) : seconds.toFixed(2);
+    return `${rounded}s`;
+  }
+  return `${value} ms`;
+}
+
+function getEvents(run: CommandCenterRun): CommandCenterEvent[] {
+  return run.events?.length ? run.events : [run.lastEvent];
+}
+
+function runStateStyle(status: CommandCenterRun["status"]): React.CSSProperties {
+  switch (status) {
+    case "running":
+      return {
+        background: "rgba(59, 130, 246, 0.12)",
+        borderColor: "rgba(59, 130, 246, 0.35)",
+      };
+    case "succeeded":
+      return {
+        background: "rgba(34, 197, 94, 0.12)",
+        borderColor: "rgba(34, 197, 94, 0.35)",
+      };
+    case "failed":
+      return {
+        background: "rgba(239, 68, 68, 0.12)",
+        borderColor: "rgba(239, 68, 68, 0.35)",
+      };
+    case "needs_attention":
+      return {
+        background: "rgba(250, 204, 21, 0.12)",
+        borderColor: "rgba(250, 204, 21, 0.35)",
+      };
+    default:
+      return {
+        background: "rgba(148, 163, 184, 0.12)",
+        borderColor: "rgba(148, 163, 184, 0.28)",
+      };
+  }
+}
+
+function runOutcomeStyle(
+  outcome: CommandCenterRun["terminalOutcome"] | null | undefined
+): React.CSSProperties {
+  switch (outcome) {
+    case "succeeded":
+      return {
+        background: "rgba(34, 197, 94, 0.12)",
+        borderColor: "rgba(34, 197, 94, 0.35)",
+      };
+    case "failed":
+      return {
+        background: "rgba(239, 68, 68, 0.12)",
+        borderColor: "rgba(239, 68, 68, 0.35)",
+      };
+    case "cancelled":
+      return {
+        background: "rgba(250, 204, 21, 0.12)",
+        borderColor: "rgba(250, 204, 21, 0.35)",
+      };
+    default:
+      return {
+        background: "rgba(148, 163, 184, 0.12)",
+        borderColor: "rgba(148, 163, 184, 0.28)",
+      };
+  }
+}
+
+function SectionCard({
+  children,
+  title,
+  note,
+}: {
+  children: React.ReactNode;
+  note?: string;
+  title: string;
+}) {
+  return (
+    <Card
+      className="bezel-none rounded-xl border"
+      style={{
+        background: "color-mix(in srgb, var(--panel-bg) 94%, transparent)",
+        borderColor: "var(--panel-border)",
+      }}
+    >
+      <CardContent className="space-y-3 p-4">
+        <div className="space-y-1">
+          <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
+            {title}
+          </div>
+          {note ? (
+            <div className="text-xs leading-5" style={{ color: "var(--muted)" }}>
+              {note}
+            </div>
+          ) : null}
+        </div>
+        {children}
+      </CardContent>
+    </Card>
+  );
+}
+
+function Chip({
+  label,
+  value,
+}: {
+  label: string;
+  value: React.ReactNode;
+}) {
+  return (
+    <span
+      className="rounded-full border px-2 py-1"
+      style={{ borderColor: "var(--panel-border)" }}
+    >
+      {label}: {value}
+    </span>
+  );
+}
+
+function EventCard({ event }: { event: CommandCenterEvent }) {
+  return (
+    <div
+      className="space-y-2 rounded-[var(--tile-radius)] border p-3"
+      style={{
+        background: "var(--surface-soft)",
+        borderColor: "var(--panel-border)",
+      }}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="space-y-1">
+          <div
+            className="text-[11px] font-semibold uppercase tracking-[0.16em]"
+            style={{ color: "var(--muted)" }}
+          >
+            {event.type ?? event.sseType ?? "event"}
+          </div>
+          <div className="text-xs" style={{ color: "var(--muted)" }}>
+            {event.lifecycleState ?? event.state ?? "unclassified"}
+          </div>
+        </div>
+        <div className="text-[11px]" style={{ color: "var(--muted)" }}>
+          {formatTimestamp(event.receivedAt)}
+        </div>
+      </div>
+      <div className="text-sm leading-5" style={{ color: "var(--text)" }}>
+        {event.summary}
+      </div>
+      <pre
+        className="overflow-x-auto rounded-[var(--tile-radius)] border p-3 text-[11px] leading-5"
+        style={{
+          background: "var(--panel-bg)",
+          borderColor: "var(--panel-border)",
+          color: "var(--muted)",
+        }}
+      >
+        {event.json ? JSON.stringify(event.json, null, 2) : event.raw}
+      </pre>
+    </div>
+  );
+}
+
+export default function RunDetailsPanel({ run }: RunDetailsPanelProps) {
+  const [showRawEvents, setShowRawEvents] = React.useState(false);
+
+  if (!run) return null;
+
+  const statusPresentation = describeRuntimeStatusPresentation(run.status);
+  const lifecycleStates = run.lifecycleStates ?? [];
+  const timings = run.timings ?? null;
+  const streamingEvidence = run.streamingEvidence ?? null;
+  const traceEvidence = run.traceEvidence ?? null;
+  const events = getEvents(run);
+  const timingFields = [
+    ["Queued", timings?.queuedAt ?? null],
+    ["Warmup", timings?.warmupAt ?? null],
+    ["First token", timings?.firstTokenAt ?? null],
+    ["First output", timings?.firstOutputAt ?? null],
+    ["Completed", timings?.completedAt ?? null],
+  ] as const;
+  const visibleTimingFields = timingFields.filter(([, value]) => value != null);
+  const hasTimingEvidence =
+    visibleTimingFields.length > 0 || timings?.totalDurationMs != null;
+
+  return (
+    <div data-testid="run-details-panel" className="space-y-3">
+      <Card
+        className="bezel-none rounded-xl border"
+        style={{
+          background: "color-mix(in srgb, var(--panel-bg) 94%, transparent)",
+          borderColor: "var(--panel-border)",
+        }}
+      >
+        <CardContent className="space-y-3 p-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="space-y-1">
+              <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
+                Run details
+              </div>
+              <div className="text-xs leading-5" style={{ color: "var(--muted)" }}>
+                {run.runType ?? "task"} · {run.summary}
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Badge
+                className="border text-[11px] font-medium leading-none"
+                style={{
+                  ...runStateStyle(run.status),
+                  color: "var(--text)",
+                }}
+              >
+                {run.state ?? run.status}
+              </Badge>
+              {run.terminalOutcome ? (
+                <Badge
+                  className="border text-[11px] font-medium leading-none"
+                  style={{
+                    ...runOutcomeStyle(run.terminalOutcome),
+                    color: "var(--text)",
+                  }}
+                >
+                  {run.terminalOutcome}
+                </Badge>
+              ) : null}
+              <Badge
+                className="border text-[11px] font-medium leading-none"
+                style={{
+                  background: "rgba(148, 163, 184, 0.12)",
+                  borderColor: "rgba(148, 163, 184, 0.28)",
+                  color: "var(--text)",
+                }}
+              >
+                {statusPresentation.label}
+              </Badge>
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-2 text-xs" style={{ color: "var(--muted)" }}>
+            <Chip label="Events" value={run.eventCount} />
+            <Chip label="Updated" value={formatTimestamp(run.lastEventAt)} />
+          </div>
+        </CardContent>
+      </Card>
+
+      <SectionCard title="Identity" note="Stable run identity and target fields when available.">
+        <div className="flex flex-wrap gap-2 text-xs" style={{ color: "var(--muted)" }}>
+          <Chip label="Grouping key" value={run.key} />
+          <Chip label="Task" value={run.taskId ?? "—"} />
+          <Chip label="Thread" value={run.threadId ?? "—"} />
+          <Chip label="Latest turn message" value={run.latestTurnMessageId ?? "—"} />
+          <Chip label="Run" value={run.runId ?? "—"} />
+          <Chip label="Request" value={run.requestId ?? "—"} />
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Lifecycle" note="Ordered states and terminal outcome from the aggregated run record.">
+        <div className="space-y-3">
+          <div className="flex flex-wrap gap-2 text-xs" style={{ color: "var(--muted)" }}>
+            <Chip label="Current state" value={run.state ?? "unknown"} />
+            <Chip label="Terminal result" value={run.terminalOutcome ?? "not reached"} />
+            <Chip
+              label="Streaming"
+              value={
+                streamingEvidence
+                  ? `${streamingEvidence.chunkCount} chunks`
+                  : "No chunk evidence"
+              }
+            />
+          </div>
+          <div className="rounded-[var(--tile-radius)] border p-3 text-sm leading-6" style={{ borderColor: "var(--panel-border)", color: "var(--text)" }}>
+            {lifecycleStates.length > 0 ? lifecycleStates.join(" → ") : "No structured lifecycle path recorded."}
+          </div>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Timing" note="Only recorded timestamps and durations are shown.">
+        {hasTimingEvidence ? (
+          <div className="flex flex-wrap gap-2 text-xs" style={{ color: "var(--muted)" }}>
+            {visibleTimingFields.map(([label, value]) => (
+              <Chip key={label} label={label} value={formatTimestamp(value)} />
+            ))}
+            {timings?.totalDurationMs != null ? (
+              <Chip label="Total" value={formatDuration(timings.totalDurationMs)} />
+            ) : null}
+          </div>
+        ) : (
+          <div className="rounded-[var(--tile-radius)] border px-3 py-2 text-xs" style={{ borderColor: "var(--panel-border)", color: "var(--muted)" }}>
+            No structured timing evidence recorded.
+          </div>
+        )}
+      </SectionCard>
+
+      <SectionCard title="Trace" note="Presence flags only. The raw trace viewer lives elsewhere.">
+        {traceEvidence ? (
+          <div className="flex flex-wrap gap-2 text-xs" style={{ color: "var(--muted)" }}>
+            <Chip label="Trace present" value={traceEvidence.tracePresent ? "Yes" : "No"} />
+            <Chip
+              label="Latest-turn trace present"
+              value={traceEvidence.latestTurnTracePresent ? "Yes" : "No"}
+            />
+            <Chip
+              label="Retrieval query present"
+              value={traceEvidence.retrievalQueryPresent ? "Yes" : "No"}
+            />
+            <Chip
+              label="Retrieval query matched latest turn"
+              value={
+                traceEvidence.retrievalQueryMatchesLatestTurn == null
+                  ? "—"
+                  : traceEvidence.retrievalQueryMatchesLatestTurn
+                    ? "Yes"
+                    : "No"
+              }
+            />
+          </div>
+        ) : (
+          <div className="rounded-[var(--tile-radius)] border px-3 py-2 text-xs" style={{ borderColor: "var(--panel-border)", color: "var(--muted)" }}>
+            No structured trace evidence recorded.
+          </div>
+        )}
+      </SectionCard>
+
+      <div className="text-xs" style={{ color: "var(--muted)" }}>
+        <button
+          type="button"
+          className="cursor-pointer text-[11px] font-semibold uppercase tracking-[0.16em]"
+          aria-expanded={showRawEvents}
+          aria-controls="run-details-raw-events"
+          onClick={() => setShowRawEvents((current) => !current)}
+        >
+          {showRawEvents ? "Hide raw events" : "Raw events"}
+        </button>
+        {showRawEvents ? (
+          <div
+            className="mt-3 space-y-3"
+            id="run-details-raw-events"
+          >
+            {events.map((event, index) => (
+              <EventCard
+                key={`${event.eventId ?? event.receivedAt}-${index}`}
+                event={event}
+              />
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/commandCenter/components/RunDetailsPanel.tsx
+++ b/frontend/src/features/commandCenter/components/RunDetailsPanel.tsx
@@ -50,6 +50,21 @@ function clipInlineText(value: string, limit = 96): string {
   return `${value.slice(0, Math.max(0, limit - 1))}…`;
 }
 
+function describeTracePanelExpectation(run: CommandCenterRun): string {
+  const traceEvidence = run.traceEvidence ?? null;
+
+  if (!traceEvidence) {
+    return "No trace evidence exists for this run";
+  }
+  if (!traceEvidence.tracePresent) {
+    return "Empty but expected";
+  }
+  if (run.threadId != null || run.traceUrl) {
+    return "Aligned to this run/thread";
+  }
+  return "Unavailable";
+}
+
 function getEvents(run: CommandCenterRun): CommandCenterEvent[] {
   return run.events?.length ? run.events : [run.lastEvent];
 }
@@ -196,6 +211,7 @@ export default function RunDetailsPanel({ run }: RunDetailsPanelProps) {
   const timings = run.timings ?? null;
   const streamingEvidence = run.streamingEvidence ?? null;
   const traceEvidence = run.traceEvidence ?? null;
+  const tracePanelExpectation = describeTracePanelExpectation(run);
   const events = getEvents(run);
   const timingFields = [
     ["Queued", timings?.queuedAt ?? null],
@@ -219,12 +235,13 @@ export default function RunDetailsPanel({ run }: RunDetailsPanelProps) {
       >
         <CardContent className="space-y-3 p-4">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div className="space-y-1">
-            <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
-              Run details
-            </div>
-            <div className="text-xs leading-5" style={{ color: "var(--muted)" }}>
-                {describeCommandCenterRunKindLabel(run.runKind) ?? run.runType ?? "task"} · {run.summary}
+            <div className="space-y-1">
+              <div className="text-sm font-semibold" style={{ color: "var(--text)" }}>
+                Run details
+              </div>
+              <div className="text-xs leading-5" style={{ color: "var(--muted)" }}>
+                {describeCommandCenterRunKindLabel(run.runKind) ?? run.runType ?? "task"} ·{" "}
+                {run.summary}
               </div>
             </div>
             <div className="flex flex-wrap gap-2">
@@ -345,6 +362,23 @@ export default function RunDetailsPanel({ run }: RunDetailsPanelProps) {
               ) : null}
             </div>
 
+            <div
+              className="rounded-[var(--tile-radius)] border px-3 py-2 text-xs leading-5"
+              style={{
+                background: "var(--surface-soft)",
+                borderColor: "var(--panel-border)",
+                color: "var(--muted)",
+              }}
+            >
+              <span className="font-semibold" style={{ color: "var(--text)" }}>
+                Trace panel:
+              </span>{" "}
+              {tracePanelExpectation}
+              {tracePanelExpectation === "Aligned to this run/thread" ? (
+                <span> Use the RAG Trace tab for the scoped payload.</span>
+              ) : null}
+            </div>
+
             {traceEvidence.retrievalQuery ? (
               <div
                 className="rounded-[var(--tile-radius)] border px-3 py-2 text-xs leading-5"
@@ -383,7 +417,7 @@ export default function RunDetailsPanel({ run }: RunDetailsPanelProps) {
                   color: "var(--muted)",
                 }}
               >
-                No trace evidence recorded.
+                No detailed trace payload is currently available.
               </div>
             ) : null}
           </div>
@@ -392,7 +426,7 @@ export default function RunDetailsPanel({ run }: RunDetailsPanelProps) {
             className="rounded-[var(--tile-radius)] border px-3 py-2 text-xs"
             style={{ borderColor: "var(--panel-border)", color: "var(--muted)" }}
           >
-            No retrieval or trace evidence recorded.
+            No trace evidence exists for this run.
           </div>
         )}
       </SectionCard>

--- a/frontend/src/features/commandCenter/components/RunSummaryCard.tsx
+++ b/frontend/src/features/commandCenter/components/RunSummaryCard.tsx
@@ -97,6 +97,10 @@ function RunIdentityChips({ run }: { run: CommandCenterRun }) {
     chips.push({ label: "Latest turn message", value: run.latestTurnMessageId });
   }
 
+  if (run.streamingEvidence?.chunkCount) {
+    chips.push({ label: "Chunks", value: run.streamingEvidence.chunkCount });
+  }
+
   if (chips.length === 0) {
     return (
       <span style={{ color: "var(--muted)" }}>

--- a/frontend/src/features/commandCenter/components/RunSummaryCard.tsx
+++ b/frontend/src/features/commandCenter/components/RunSummaryCard.tsx
@@ -1,0 +1,273 @@
+import type { CSSProperties } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { describeRuntimeStatusPresentation } from "@/contracts/runtimeTokens";
+
+import type { CommandCenterEvent, CommandCenterRun } from "@/features/commandCenter/types";
+
+type RunSummaryCardProps = {
+  onOpen: (run: CommandCenterRun) => void;
+  run: CommandCenterRun;
+  selected?: boolean;
+};
+
+function formatTimestamp(value: number | null): string {
+  if (!value) return "Never";
+  return new Date(value).toLocaleString();
+}
+
+function runStateStyle(status: CommandCenterRun["status"]): CSSProperties {
+  switch (status) {
+    case "running":
+      return {
+        background: "rgba(59, 130, 246, 0.12)",
+        borderColor: "rgba(59, 130, 246, 0.35)",
+      };
+    case "succeeded":
+      return {
+        background: "rgba(34, 197, 94, 0.12)",
+        borderColor: "rgba(34, 197, 94, 0.35)",
+      };
+    case "failed":
+      return {
+        background: "rgba(239, 68, 68, 0.12)",
+        borderColor: "rgba(239, 68, 68, 0.35)",
+      };
+    case "needs_attention":
+      return {
+        background: "rgba(250, 204, 21, 0.12)",
+        borderColor: "rgba(250, 204, 21, 0.35)",
+      };
+    default:
+      return {
+        background: "rgba(148, 163, 184, 0.12)",
+        borderColor: "rgba(148, 163, 184, 0.28)",
+      };
+  }
+}
+
+function runOutcomeStyle(
+  outcome: CommandCenterRun["terminalOutcome"] | null | undefined
+): CSSProperties {
+  switch (outcome) {
+    case "succeeded":
+      return {
+        background: "rgba(34, 197, 94, 0.12)",
+        borderColor: "rgba(34, 197, 94, 0.35)",
+      };
+    case "failed":
+      return {
+        background: "rgba(239, 68, 68, 0.12)",
+        borderColor: "rgba(239, 68, 68, 0.35)",
+      };
+    case "cancelled":
+      return {
+        background: "rgba(250, 204, 21, 0.12)",
+        borderColor: "rgba(250, 204, 21, 0.35)",
+      };
+    default:
+      return {
+        background: "rgba(148, 163, 184, 0.12)",
+        borderColor: "rgba(148, 163, 184, 0.28)",
+      };
+  }
+}
+
+function RunIdentityChips({ run }: { run: CommandCenterRun }) {
+  const chips: Array<{ label: string; value: string | number }> = [];
+
+  if (run.taskId) {
+    chips.push({ label: "Task", value: run.taskId });
+  } else if (run.requestId || run.runId) {
+    chips.push({ label: "Target", value: run.requestId ?? run.runId ?? "—" });
+  }
+
+  if (run.threadId != null) {
+    chips.push({ label: "Thread", value: run.threadId });
+  }
+
+  if (run.turnId) {
+    chips.push({ label: "Turn", value: run.turnId });
+  }
+
+  if (run.latestTurnMessageId) {
+    chips.push({ label: "Latest turn message", value: run.latestTurnMessageId });
+  }
+
+  if (chips.length === 0) {
+    return (
+      <span style={{ color: "var(--muted)" }}>
+        No stable task identity available.
+      </span>
+    );
+  }
+
+  return (
+    <>
+      {chips.map((chip) => (
+        <span
+          key={`${chip.label}:${String(chip.value)}`}
+          className="rounded-full border px-2 py-1"
+          style={{ borderColor: "var(--panel-border)" }}
+        >
+          {chip.label}: {chip.value}
+        </span>
+      ))}
+    </>
+  );
+}
+
+function getRunTitle(run: CommandCenterRun): string {
+  if (run.runType) return run.runType;
+  if (run.identityKind === "synthetic" || run.status === "unknown") {
+    return "Unknown run";
+  }
+  return "task";
+}
+
+function getRunSubtitle(run: CommandCenterRun, title: string): string | null {
+  if (!run.summary) return null;
+  if (run.summary === title) return null;
+  return run.summary;
+}
+
+function getEvents(run: CommandCenterRun): CommandCenterEvent[] {
+  return run.events?.length ? run.events : [run.lastEvent];
+}
+
+export default function RunSummaryCard({
+  onOpen,
+  run,
+  selected = false,
+}: RunSummaryCardProps) {
+  const title = getRunTitle(run);
+  const subtitle = getRunSubtitle(run, title);
+  const events = getEvents(run);
+  const statusPresentation = describeRuntimeStatusPresentation(run.status);
+
+  return (
+    <Card
+      className={cn(
+        "bezel-none rounded-xl border transition-colors",
+        selected && "ring-1 ring-[var(--accent)]"
+      )}
+      data-testid={`command-center-run-${run.key}`}
+      style={{
+        background: "color-mix(in srgb, var(--panel-bg) 94%, transparent)",
+        borderColor: selected ? "var(--accent)" : "var(--panel-border)",
+      }}
+    >
+      <CardContent className="space-y-4 p-[var(--card-pad)]">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0 space-y-1.5">
+            <div className="text-sm font-semibold leading-5" style={{ color: "var(--text)" }}>
+              {title}
+            </div>
+            {subtitle ? (
+              <div className="text-xs leading-5" style={{ color: "var(--muted)" }}>
+                {subtitle}
+              </div>
+            ) : null}
+          </div>
+
+          <div className="flex shrink-0 items-start gap-2">
+            <Badge
+              className="border text-[11px] font-medium leading-none"
+              style={{
+                ...runStateStyle(run.status),
+                color: "var(--text)",
+              }}
+            >
+              {run.state ?? run.status}
+            </Badge>
+            {run.terminalOutcome ? (
+              <Badge
+                className="border text-[11px] font-medium leading-none"
+                style={{
+                  ...runOutcomeStyle(run.terminalOutcome),
+                  color: "var(--text)",
+                }}
+              >
+                {run.terminalOutcome}
+              </Badge>
+            ) : null}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => onOpen(run)}
+              aria-label={`Open details for ${title}`}
+            >
+              Open
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2 text-xs" style={{ color: "var(--muted)" }}>
+          <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
+            Type: {title}
+          </span>
+          <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
+            Events: {run.eventCount}
+          </span>
+          <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
+            Updated: {formatTimestamp(run.lastEventAt)}
+          </span>
+          <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
+            Status: {statusPresentation.label}
+          </span>
+        </div>
+
+        <div className="flex flex-wrap gap-2 text-xs" style={{ color: "var(--muted)" }}>
+          <RunIdentityChips run={run} />
+        </div>
+
+        <details className="text-xs" style={{ color: "var(--muted)" }}>
+          <summary className="cursor-pointer text-[11px] font-semibold uppercase tracking-[0.16em]">
+            Inspect raw events
+          </summary>
+          <div className="mt-3 space-y-3">
+            {events.map((event, index) => (
+              <div
+                key={`${event.eventId ?? event.receivedAt}-${index}`}
+                className="space-y-2 rounded-[var(--tile-radius)] border p-3"
+                style={{
+                  background: "var(--surface-soft)",
+                  borderColor: "var(--panel-border)",
+                }}
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div
+                    className="text-[11px] font-semibold uppercase tracking-[0.16em]"
+                    style={{ color: "var(--muted)" }}
+                  >
+                    {event.type ?? event.sseType ?? "event"}
+                  </div>
+                  <div className="text-[11px]" style={{ color: "var(--muted)" }}>
+                    {formatTimestamp(event.receivedAt)}
+                  </div>
+                </div>
+                <div className="text-xs leading-5" style={{ color: "var(--text)" }}>
+                  {event.summary}
+                </div>
+                <pre
+                  className="overflow-x-auto rounded-[var(--tile-radius)] border p-3 text-[11px] leading-5"
+                  style={{
+                    background: "var(--panel-bg)",
+                    borderColor: "var(--panel-border)",
+                    color: "var(--muted)",
+                  }}
+                >
+                  {event.raw || "No raw payload available."}
+                </pre>
+              </div>
+            ))}
+          </div>
+        </details>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/commandCenter/components/RunSummaryCard.tsx
+++ b/frontend/src/features/commandCenter/components/RunSummaryCard.tsx
@@ -4,9 +4,15 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
-import { describeRuntimeStatusPresentation } from "@/contracts/runtimeTokens";
 
 import type { CommandCenterEvent, CommandCenterRun } from "@/features/commandCenter/types";
+import {
+  COMMAND_CENTER_RUN_STATUSES,
+  describeCommandCenterRunKindLabel,
+  describeCommandCenterRunStatusPresentation,
+  describeCommandCenterRunTerminalOutcomePresentation,
+  type CommandCenterStatusTone,
+} from "@/features/commandCenter/types";
 
 type RunSummaryCardProps = {
   onOpen: (run: CommandCenterRun) => void;
@@ -19,55 +25,34 @@ function formatTimestamp(value: number | null): string {
   return new Date(value).toLocaleString();
 }
 
-function runStateStyle(status: CommandCenterRun["status"]): CSSProperties {
-  switch (status) {
-    case "running":
+function badgeToneStyle(tone: CommandCenterStatusTone): CSSProperties {
+  switch (tone) {
+    case "active":
+      return {
+        background: "rgba(34, 197, 94, 0.12)",
+        borderColor: "rgba(34, 197, 94, 0.35)",
+      };
+    case "attention":
+      return {
+        background: "rgba(250, 204, 21, 0.12)",
+        borderColor: "rgba(250, 204, 21, 0.35)",
+      };
+    case "danger":
+      return {
+        background: "rgba(239, 68, 68, 0.12)",
+        borderColor: "rgba(239, 68, 68, 0.35)",
+      };
+    case "info":
       return {
         background: "rgba(59, 130, 246, 0.12)",
         borderColor: "rgba(59, 130, 246, 0.35)",
       };
-    case "succeeded":
-      return {
-        background: "rgba(34, 197, 94, 0.12)",
-        borderColor: "rgba(34, 197, 94, 0.35)",
-      };
-    case "failed":
-      return {
-        background: "rgba(239, 68, 68, 0.12)",
-        borderColor: "rgba(239, 68, 68, 0.35)",
-      };
-    case "needs_attention":
-      return {
-        background: "rgba(250, 204, 21, 0.12)",
-        borderColor: "rgba(250, 204, 21, 0.35)",
-      };
-    default:
+    case "neutral":
       return {
         background: "rgba(148, 163, 184, 0.12)",
         borderColor: "rgba(148, 163, 184, 0.28)",
       };
-  }
-}
-
-function runOutcomeStyle(
-  outcome: CommandCenterRun["terminalOutcome"] | null | undefined
-): CSSProperties {
-  switch (outcome) {
-    case "succeeded":
-      return {
-        background: "rgba(34, 197, 94, 0.12)",
-        borderColor: "rgba(34, 197, 94, 0.35)",
-      };
-    case "failed":
-      return {
-        background: "rgba(239, 68, 68, 0.12)",
-        borderColor: "rgba(239, 68, 68, 0.35)",
-      };
-    case "cancelled":
-      return {
-        background: "rgba(250, 204, 21, 0.12)",
-        borderColor: "rgba(250, 204, 21, 0.35)",
-      };
+    case "subtle":
     default:
       return {
         background: "rgba(148, 163, 184, 0.12)",
@@ -125,8 +110,10 @@ function RunIdentityChips({ run }: { run: CommandCenterRun }) {
 }
 
 function getRunTitle(run: CommandCenterRun): string {
+  const runKindLabel = describeCommandCenterRunKindLabel(run.runKind);
+  if (runKindLabel) return runKindLabel;
   if (run.runType) return run.runType;
-  if (run.identityKind === "synthetic" || run.status === "unknown") {
+  if (run.identityKind === "synthetic" || run.status === COMMAND_CENTER_RUN_STATUSES.UNKNOWN) {
     return "Unknown run";
   }
   return "task";
@@ -150,7 +137,10 @@ export default function RunSummaryCard({
   const title = getRunTitle(run);
   const subtitle = getRunSubtitle(run, title);
   const events = getEvents(run);
-  const statusPresentation = describeRuntimeStatusPresentation(run.status);
+  const statusPresentation = describeCommandCenterRunStatusPresentation(run.status);
+  const terminalOutcomePresentation = describeCommandCenterRunTerminalOutcomePresentation(
+    run.terminalOutcome
+  );
 
   return (
     <Card
@@ -181,21 +171,21 @@ export default function RunSummaryCard({
             <Badge
               className="border text-[11px] font-medium leading-none"
               style={{
-                ...runStateStyle(run.status),
+                ...badgeToneStyle(statusPresentation.tone),
                 color: "var(--text)",
               }}
             >
-              {run.state ?? run.status}
+              {statusPresentation.label}
             </Badge>
-            {run.terminalOutcome ? (
+            {terminalOutcomePresentation ? (
               <Badge
                 className="border text-[11px] font-medium leading-none"
                 style={{
-                  ...runOutcomeStyle(run.terminalOutcome),
+                  ...badgeToneStyle(terminalOutcomePresentation.tone),
                   color: "var(--text)",
                 }}
               >
-                {run.terminalOutcome}
+                {terminalOutcomePresentation.label}
               </Badge>
             ) : null}
             <Button

--- a/frontend/src/features/commandCenter/components/RunsPanel.tsx
+++ b/frontend/src/features/commandCenter/components/RunsPanel.tsx
@@ -5,6 +5,10 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
 import type { CommandCenterRun } from "@/features/commandCenter/types";
+import {
+  describeCommandCenterRunStatusPresentation,
+  type CommandCenterStatusTone,
+} from "@/features/commandCenter/types";
 
 type RunsPanelProps = {
   onSelectRun: (run: CommandCenterRun) => void;
@@ -17,28 +21,34 @@ function formatTimestamp(value: number | null): string {
   return new Date(value).toLocaleString();
 }
 
-function renderStatusStyle(status: CommandCenterRun["status"]): CSSProperties {
-  switch (status) {
-    case "running":
-      return {
-        background: "rgba(59, 130, 246, 0.12)",
-        borderColor: "rgba(59, 130, 246, 0.35)",
-      };
-    case "succeeded":
+function renderStatusStyle(tone: CommandCenterStatusTone): CSSProperties {
+  switch (tone) {
+    case "active":
       return {
         background: "rgba(34, 197, 94, 0.12)",
         borderColor: "rgba(34, 197, 94, 0.35)",
       };
-    case "failed":
-      return {
-        background: "rgba(239, 68, 68, 0.12)",
-        borderColor: "rgba(239, 68, 68, 0.35)",
-      };
-    case "needs_attention":
+    case "attention":
       return {
         background: "rgba(250, 204, 21, 0.12)",
         borderColor: "rgba(250, 204, 21, 0.35)",
       };
+    case "danger":
+      return {
+        background: "rgba(239, 68, 68, 0.12)",
+        borderColor: "rgba(239, 68, 68, 0.35)",
+      };
+    case "info":
+      return {
+        background: "rgba(59, 130, 246, 0.12)",
+        borderColor: "rgba(59, 130, 246, 0.35)",
+      };
+    case "neutral":
+      return {
+        background: "rgba(148, 163, 184, 0.12)",
+        borderColor: "rgba(148, 163, 184, 0.28)",
+      };
+    case "subtle":
     default:
       return {
         background: "rgba(148, 163, 184, 0.12)",
@@ -57,6 +67,7 @@ function RunRow({
   selected: boolean;
 }) {
   const displayId = run.taskId ?? run.runId ?? run.key;
+  const statusPresentation = describeCommandCenterRunStatusPresentation(run.status);
 
   return (
     <button
@@ -87,11 +98,11 @@ function RunRow({
             <Badge
               className="border"
               style={{
-                ...renderStatusStyle(run.status),
+                ...renderStatusStyle(statusPresentation.tone),
                 color: "var(--text)",
               }}
             >
-              {run.status.replace(/_/g, " ")}
+              {statusPresentation.label}
             </Badge>
           </div>
 

--- a/frontend/src/features/commandCenter/hooks/useCommandCenterEvents.ts
+++ b/frontend/src/features/commandCenter/hooks/useCommandCenterEvents.ts
@@ -12,17 +12,19 @@ import {
   resolveSseEndpoint,
 } from "@/lib/runtimeConfig";
 
+import {
+  aggregateCommandCenterEvents,
+  normalizeCommandCenterEvent,
+} from "@/features/commandCenter/commandCenterRunAggregation";
+
 import type {
   CommandCenterApproval,
   CommandCenterConnectionState,
   CommandCenterEvent,
   CommandCenterRun,
-  CommandCenterRunStatus,
 } from "@/features/commandCenter/types";
 
 const EVENT_BUFFER_LIMIT = 500;
-const UUIDISH_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 type UseCommandCenterEventsOptions = {
   enabled: boolean;
@@ -38,179 +40,6 @@ type UseCommandCenterEventsResult = {
   unauthorized: boolean;
 };
 
-type DerivationResult = {
-  approvals: CommandCenterApproval[];
-  runs: CommandCenterRun[];
-};
-
-type MutableRun = {
-  eventCount: number;
-  key: string;
-  lastEvent: CommandCenterEvent;
-  lastEventAt: number;
-  lastKind: string | null;
-  lastType: string | null;
-  runId: string | null;
-  status: CommandCenterRunStatus;
-  summary: string;
-  taskId: string | null;
-};
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  return value as Record<string, unknown>;
-}
-
-function firstString(...values: unknown[]): string | null {
-  for (const value of values) {
-    if (typeof value !== "string") continue;
-    const trimmed = value.trim();
-    if (trimmed) return trimmed;
-  }
-  return null;
-}
-
-function looksLikeTaskIdentifier(value: string | null): boolean {
-  if (!value) return false;
-  const trimmed = value.trim();
-  if (!trimmed) return false;
-  return /^task[_:-]/i.test(trimmed) || UUIDISH_RE.test(trimmed);
-}
-
-function normalizeToken(value: string | null): string {
-  return String(value ?? "")
-    .trim()
-    .toLowerCase();
-}
-
-function coerceRawPayload(value: unknown): string {
-  if (typeof value === "string") return value;
-  try {
-    return JSON.stringify(value ?? "");
-  } catch {
-    return String(value ?? "");
-  }
-}
-
-function parseJson(raw: string): Record<string, unknown> | null {
-  const trimmed = raw.trim();
-  if (!trimmed) return null;
-  try {
-    return asRecord(JSON.parse(trimmed));
-  } catch {
-    return null;
-  }
-}
-
-function collectRecords(json: Record<string, unknown> | null): Array<Record<string, unknown>> {
-  if (!json) return [];
-  const nestedData = asRecord(json.data);
-  const nestedRun = asRecord(json.run);
-  const nestedDataRun = nestedData ? asRecord(nestedData.run) : null;
-  return [json, nestedData, nestedRun, nestedDataRun].filter(
-    (value): value is Record<string, unknown> => Boolean(value)
-  );
-}
-
-function readKey(records: Array<Record<string, unknown>>, keys: string[]): string | null {
-  for (const record of records) {
-    for (const key of keys) {
-      const value = firstString(record[key]);
-      if (value) return value;
-    }
-  }
-  return null;
-}
-
-function summarizeEvent(
-  raw: string,
-  json: Record<string, unknown> | null,
-  sseType: string | null
-): string {
-  const records = collectRecords(json);
-  const summary = readKey(records, [
-    "summary",
-    "message",
-    "error",
-    "reason",
-    "status",
-  ]);
-  if (summary) return summary;
-  const trimmedRaw = raw.trim();
-  if (trimmedRaw) {
-    return trimmedRaw.length > 160
-      ? `${trimmedRaw.slice(0, 157)}...`
-      : trimmedRaw;
-  }
-  return sseType ?? "Event received";
-}
-
-function normalizeEvent(message: MessageEvent<string>): CommandCenterEvent {
-  const raw = coerceRawPayload(message.data);
-  const json = parseJson(raw);
-  const records = collectRecords(json);
-  const fallbackTaskId = readKey(records, ["id"]);
-  const sseType = firstString(message.type) ?? "message";
-
-  return {
-    eventId: firstString(message.lastEventId),
-    json,
-    kind: readKey(records, ["kind", "event_type", "eventType"]),
-    raw,
-    receivedAt: Date.now(),
-    runId: readKey(records, ["run_id", "runId"]),
-    sseType,
-    status: readKey(records, ["status", "raw_status", "rawStatus"]),
-    summary: summarizeEvent(raw, json, sseType),
-    taskId:
-      readKey(records, ["task_id", "taskId", "task"]) ||
-      (looksLikeTaskIdentifier(fallbackTaskId) ? fallbackTaskId : null),
-    type: readKey(records, ["type"]),
-  };
-}
-
-function deriveRunStatus(event: CommandCenterEvent): CommandCenterRunStatus {
-  const signal = normalizeToken(event.kind ?? event.type ?? event.sseType);
-  if (!signal) return "unknown";
-  if (/(fail|error)/.test(signal)) return "failed";
-  if (/(complete|done|success|succeeded)/.test(signal)) return "succeeded";
-  if (/(start|running|progress)/.test(signal)) return "running";
-  if (/(approval|blocked|clarification)/.test(signal)) return "needs_attention";
-  return "unknown";
-}
-
-function isApprovalEvent(event: CommandCenterEvent): boolean {
-  const haystack = [
-    event.kind,
-    event.type,
-    event.sseType,
-    event.status,
-  ]
-    .map(normalizeToken)
-    .filter(Boolean)
-    .join(" ");
-  if (!haystack) return false;
-  return (
-    haystack.includes("approval") ||
-    haystack.includes("approval_required") ||
-    haystack.includes("clarification_required") ||
-    haystack.includes("blocked_waiting_for_user") ||
-    haystack.includes("run.blocked") ||
-    /\bblocked\b/.test(haystack)
-  );
-}
-
-function humanizeLabel(value: string | null): string {
-  const normalized = firstString(value) ?? "needs_attention";
-  return normalized
-    .replace(/[._]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim()
-    .replace(/\b\w/g, (match) => match.toUpperCase());
-}
-
 function appendBoundedEvent(
   previous: CommandCenterEvent[],
   next: CommandCenterEvent
@@ -218,141 +47,6 @@ function appendBoundedEvent(
   const appended = [...previous, next];
   if (appended.length <= EVENT_BUFFER_LIMIT) return appended;
   return appended.slice(appended.length - EVENT_BUFFER_LIMIT);
-}
-
-function resolveAlias(aliases: Map<string, string>, key: string): string {
-  let current = key;
-  let next = aliases.get(current);
-  while (next && next !== current) {
-    current = next;
-    next = aliases.get(current);
-  }
-  return current;
-}
-
-function mergeRuns(target: MutableRun, source: MutableRun): MutableRun {
-  return {
-    ...target,
-    eventCount: target.eventCount + source.eventCount,
-    lastEvent:
-      target.lastEventAt >= source.lastEventAt ? target.lastEvent : source.lastEvent,
-    lastEventAt: Math.max(target.lastEventAt, source.lastEventAt),
-    lastKind:
-      target.lastEventAt >= source.lastEventAt ? target.lastKind : source.lastKind,
-    lastType:
-      target.lastEventAt >= source.lastEventAt ? target.lastType : source.lastType,
-    runId: target.runId ?? source.runId,
-    status:
-      target.status !== "unknown"
-        ? target.status
-        : source.status,
-    summary:
-      target.lastEventAt >= source.lastEventAt ? target.summary : source.summary,
-    taskId: target.taskId ?? source.taskId,
-  };
-}
-
-function deriveEvents(events: CommandCenterEvent[]): DerivationResult {
-  const aliases = new Map<string, string>();
-  const runs = new Map<string, MutableRun>();
-  const approvals: CommandCenterApproval[] = [];
-
-  const ensureRun = (key: string, event: CommandCenterEvent): MutableRun => {
-    const existing = runs.get(key);
-    if (existing) return existing;
-    const created: MutableRun = {
-      eventCount: 0,
-      key,
-      lastEvent: event,
-      lastEventAt: event.receivedAt,
-      lastKind: null,
-      lastType: null,
-      runId: null,
-      status: "unknown",
-      summary: event.summary,
-      taskId: null,
-    };
-    runs.set(key, created);
-    return created;
-  };
-
-  const collapse = (primary: string, secondary: string): string => {
-    const resolvedPrimary = resolveAlias(aliases, primary);
-    const resolvedSecondary = resolveAlias(aliases, secondary);
-    if (resolvedPrimary === resolvedSecondary) return resolvedPrimary;
-    const primaryRun = runs.get(resolvedPrimary);
-    const secondaryRun = runs.get(resolvedSecondary);
-    if (secondaryRun) {
-      if (primaryRun) {
-        runs.set(resolvedPrimary, mergeRuns(primaryRun, secondaryRun));
-      } else {
-        runs.set(resolvedPrimary, { ...secondaryRun, key: resolvedPrimary });
-      }
-      runs.delete(resolvedSecondary);
-    }
-    aliases.set(resolvedSecondary, resolvedPrimary);
-    return resolvedPrimary;
-  };
-
-  const resolveRunKey = (event: CommandCenterEvent): string | null => {
-    if (event.taskId) {
-      let primary = resolveAlias(aliases, event.taskId);
-      if (event.runId) {
-        primary = collapse(primary, event.runId);
-      }
-      aliases.set(event.taskId, primary);
-      if (event.runId) aliases.set(event.runId, primary);
-      return primary;
-    }
-
-    if (event.runId) {
-      const primary = resolveAlias(aliases, event.runId);
-      aliases.set(event.runId, primary);
-      return primary;
-    }
-
-    return event.eventId ? resolveAlias(aliases, event.eventId) : null;
-  };
-
-  events.forEach((event, index) => {
-    const key = resolveRunKey(event) ?? `event:${index}:${event.receivedAt}`;
-    const run = ensureRun(key, event);
-    const nextStatus = deriveRunStatus(event);
-
-    run.eventCount += 1;
-    run.lastEvent = event;
-    run.lastEventAt = event.receivedAt;
-    run.lastKind = event.kind;
-    run.lastType = event.type ?? event.sseType;
-    run.runId = event.runId ?? run.runId;
-    run.summary = event.summary;
-    run.taskId = event.taskId ?? run.taskId;
-    if (nextStatus !== "unknown" || run.status === "unknown") {
-      run.status = nextStatus;
-    }
-    runs.set(key, run);
-
-    if (isApprovalEvent(event)) {
-      approvals.push({
-        event,
-        key: `${key}:${index}:${event.receivedAt}`,
-        label: humanizeLabel(event.kind ?? event.type ?? event.sseType ?? event.status),
-        receivedAt: event.receivedAt,
-        runId: event.runId,
-        runKey: key,
-        status: event.status,
-        summary: event.summary,
-        taskId: event.taskId,
-      });
-    }
-  });
-
-  return {
-    approvals: approvals.sort((left, right) => right.receivedAt - left.receivedAt),
-    runs: Array.from(runs.values()).sort(
-      (left, right) => right.lastEventAt - left.lastEventAt
-    ),
-  };
 }
 
 function tapMessageEvents(
@@ -439,7 +133,7 @@ export function useCommandCenterEvents(
     setUnauthorized(false);
 
     const restoreDispatch = tapMessageEvents(source, (message) => {
-      const normalized = normalizeEvent(message);
+      const normalized = normalizeCommandCenterEvent(message);
       setEvents((previous) => appendBoundedEvent(previous, normalized));
       setLastEventAt(normalized.receivedAt);
     });
@@ -481,7 +175,10 @@ export function useCommandCenterEvents(
     };
   }, [auth.ready, auth.status, auth.token, enabled]);
 
-  const derived = React.useMemo(() => deriveEvents(events), [events]);
+  const derived = React.useMemo(
+    () => aggregateCommandCenterEvents(events),
+    [events]
+  );
 
   return {
     approvals: derived.approvals,

--- a/frontend/src/features/commandCenter/hooks/useHealthSummary.ts
+++ b/frontend/src/features/commandCenter/hooks/useHealthSummary.ts
@@ -11,8 +11,9 @@ import {
 
 import type {
   CommandCenterHealthItem,
-  CommandCenterHealthStatus,
+  CommandCenterHealthState,
 } from "@/features/commandCenter/types";
+import { COMMAND_CENTER_HEALTH_STATES } from "@/features/commandCenter/types";
 
 const POLL_INTERVAL_MS = 5_000;
 
@@ -94,21 +95,29 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value as Record<string, unknown>;
 }
 
-function classifyStatus(data: Record<string, unknown> | null): CommandCenterHealthStatus {
-  if (!data) return "UNKNOWN";
+function classifyStatus(data: Record<string, unknown> | null): CommandCenterHealthState {
+  if (!data) return COMMAND_CENTER_HEALTH_STATES.UNKNOWN;
   const status = String(data.status ?? "")
     .trim()
     .toLowerCase();
-  if (data.ok === true || status === "ok" || status === "online") {
-    return "OK";
+  if (data.ok === true || status === "ok" || status === "online" || status === "healthy") {
+    return COMMAND_CENTER_HEALTH_STATES.OK;
   }
   if (
-    data.ok === false ||
-    ["error", "offline", "misconfigured", "fail", "failed"].includes(status)
+    status === "degraded" ||
+    status === "warning" ||
+    status === "warn" ||
+    data.degraded === true
   ) {
-    return "FAIL";
+    return COMMAND_CENTER_HEALTH_STATES.DEGRADED;
   }
-  return "UNKNOWN";
+  if (data.ok === false) {
+    return COMMAND_CENTER_HEALTH_STATES.DOWN;
+  }
+  if (["error", "offline", "misconfigured", "fail", "failed", "down"].includes(status)) {
+    return COMMAND_CENTER_HEALTH_STATES.DOWN;
+  }
+  return COMMAND_CENTER_HEALTH_STATES.UNKNOWN;
 }
 
 function createDefaultItems(): CommandCenterHealthItem[] {
@@ -120,7 +129,7 @@ function createDefaultItems(): CommandCenterHealthItem[] {
     key: definition.key,
     label: definition.label,
     raw: null,
-    status: "UNKNOWN",
+    status: COMMAND_CENTER_HEALTH_STATES.UNKNOWN,
   }));
 }
 
@@ -147,7 +156,7 @@ async function fetchHealthItem(
         ? await response.json().catch(() => null)
         : await response.text().catch(() => null);
       const record = asRecord(body);
-      const status = response.ok ? classifyStatus(record) : "FAIL";
+      const status = response.ok ? classifyStatus(record) : COMMAND_CENTER_HEALTH_STATES.DOWN;
 
       if (response.status === 404 && index < definition.paths.length - 1) {
         continue;
@@ -179,7 +188,7 @@ async function fetchHealthItem(
         key: definition.key,
         label: definition.label,
         raw: toRaw(message),
-        status: "FAIL",
+        status: COMMAND_CENTER_HEALTH_STATES.DOWN,
       };
     }
   }
@@ -192,7 +201,7 @@ async function fetchHealthItem(
     key: definition.key,
     label: definition.label,
     raw: null,
-    status: "FAIL",
+    status: COMMAND_CENTER_HEALTH_STATES.DOWN,
   };
 }
 
@@ -221,7 +230,7 @@ export function useHealthSummary(
           checkedAt: Date.now(),
           error: "Backend outage fuse active",
           raw: "Backend outage fuse active",
-          status: "FAIL",
+          status: COMMAND_CENTER_HEALTH_STATES.DOWN,
         }))
       );
       setLastCheckedAt(Date.now());

--- a/frontend/src/features/commandCenter/types.ts
+++ b/frontend/src/features/commandCenter/types.ts
@@ -12,6 +12,35 @@ export type CommandCenterRunStatus =
   | "unknown";
 
 export type CommandCenterHealthStatus = "OK" | "FAIL" | "UNKNOWN";
+export type CommandCenterRunIdentityKind =
+  | "task"
+  | "request"
+  | "run"
+  | "synthetic";
+
+export type CommandCenterRunLifecycleState =
+  | "created"
+  | "running"
+  | "state"
+  | "chunk"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "unknown";
+
+export type CommandCenterRunTerminalOutcome =
+  | "succeeded"
+  | "failed"
+  | "cancelled";
+
+export type CommandCenterCanonicalTaskEventType =
+  | "task.created"
+  | "task.running"
+  | "task.state"
+  | "task.chunk"
+  | "task.completed"
+  | "task.failed"
+  | "task.cancelled";
 
 export type CommandCenterJson = Record<string, unknown> | null;
 export type CommandCenterRagTraceUnavailableReason =
@@ -25,25 +54,40 @@ export interface CommandCenterEvent {
   kind: string | null;
   raw: string;
   receivedAt: number;
+  requestId: string | null;
   runId: string | null;
+  taskType: string | null;
   sseType: string | null;
   status: string | null;
   summary: string;
   taskId: string | null;
+  latestTurnMessageId: string | null;
+  state: string | null;
+  terminalOutcome: CommandCenterRunTerminalOutcome | null;
+  threadId: number | null;
+  turnId: string | null;
   type: string | null;
 }
 
 export interface CommandCenterRun {
   eventCount: number;
+  events?: CommandCenterEvent[];
+  identityKind?: CommandCenterRunIdentityKind;
   key: string;
   lastEvent: CommandCenterEvent;
   lastEventAt: number;
   lastKind: string | null;
   lastType: string | null;
+  latestTurnMessageId?: string | null;
+  requestId?: string | null;
   runId: string | null;
+  runType?: string | null;
+  state?: CommandCenterRunLifecycleState | string | null;
   status: CommandCenterRunStatus;
   summary: string;
   taskId: string | null;
+  terminalOutcome?: CommandCenterRunTerminalOutcome | null;
+  turnId?: string | null;
   threadId?: number | null;
   traceUrl?: string | null;
 }

--- a/frontend/src/features/commandCenter/types.ts
+++ b/frontend/src/features/commandCenter/types.ts
@@ -4,14 +4,160 @@ export type CommandCenterConnectionState =
   | "error"
   | "closed";
 
-export type CommandCenterRunStatus =
-  | "running"
-  | "succeeded"
-  | "failed"
-  | "needs_attention"
-  | "unknown";
+export type CommandCenterStatusTone =
+  | "active"
+  | "attention"
+  | "danger"
+  | "info"
+  | "neutral"
+  | "subtle";
 
-export type CommandCenterHealthStatus = "OK" | "FAIL" | "UNKNOWN";
+export interface CommandCenterStatusPresentation {
+  isFallback: boolean;
+  label: string;
+  tone: CommandCenterStatusTone;
+}
+
+export const COMMAND_CENTER_HEALTH_STATES = {
+  OK: "ok",
+  DEGRADED: "degraded",
+  DOWN: "down",
+  UNKNOWN: "unknown",
+} as const;
+
+export type CommandCenterHealthState =
+  (typeof COMMAND_CENTER_HEALTH_STATES)[keyof typeof COMMAND_CENTER_HEALTH_STATES];
+
+export const COMMAND_CENTER_HEALTH_STATE_PRESENTATIONS = {
+  [COMMAND_CENTER_HEALTH_STATES.OK]: {
+    isFallback: false,
+    label: "OK",
+    tone: "active",
+  },
+  [COMMAND_CENTER_HEALTH_STATES.DEGRADED]: {
+    isFallback: false,
+    label: "Degraded",
+    tone: "attention",
+  },
+  [COMMAND_CENTER_HEALTH_STATES.DOWN]: {
+    isFallback: false,
+    label: "Down",
+    tone: "danger",
+  },
+  [COMMAND_CENTER_HEALTH_STATES.UNKNOWN]: {
+    isFallback: false,
+    label: "Unknown",
+    tone: "subtle",
+  },
+} as const satisfies Record<CommandCenterHealthState, CommandCenterStatusPresentation>;
+
+export const COMMAND_CENTER_RUN_STATUSES = {
+  RUNNING: "running",
+  COMPLETED: "completed",
+  FAILED: "failed",
+  CANCELLED: "cancelled",
+  NEEDS_ATTENTION: "needs_attention",
+  UNKNOWN: "unknown",
+} as const;
+
+export type CommandCenterRunStatus =
+  (typeof COMMAND_CENTER_RUN_STATUSES)[keyof typeof COMMAND_CENTER_RUN_STATUSES];
+
+export const COMMAND_CENTER_RUN_STATUS_PRESENTATIONS = {
+  [COMMAND_CENTER_RUN_STATUSES.RUNNING]: {
+    isFallback: false,
+    label: "Running",
+    tone: "info",
+  },
+  [COMMAND_CENTER_RUN_STATUSES.COMPLETED]: {
+    isFallback: false,
+    label: "Completed",
+    tone: "active",
+  },
+  [COMMAND_CENTER_RUN_STATUSES.FAILED]: {
+    isFallback: false,
+    label: "Failed",
+    tone: "danger",
+  },
+  [COMMAND_CENTER_RUN_STATUSES.CANCELLED]: {
+    isFallback: false,
+    label: "Cancelled",
+    tone: "attention",
+  },
+  [COMMAND_CENTER_RUN_STATUSES.NEEDS_ATTENTION]: {
+    isFallback: false,
+    label: "Needs attention",
+    tone: "attention",
+  },
+  [COMMAND_CENTER_RUN_STATUSES.UNKNOWN]: {
+    isFallback: false,
+    label: "Unknown",
+    tone: "subtle",
+  },
+} as const satisfies Record<CommandCenterRunStatus, CommandCenterStatusPresentation>;
+
+export const COMMAND_CENTER_RUN_TERMINAL_OUTCOMES = {
+  COMPLETED: "completed",
+  FAILED: "failed",
+  CANCELLED: "cancelled",
+} as const;
+
+export type CommandCenterRunTerminalOutcome =
+  (typeof COMMAND_CENTER_RUN_TERMINAL_OUTCOMES)[keyof typeof COMMAND_CENTER_RUN_TERMINAL_OUTCOMES];
+
+export const COMMAND_CENTER_RUN_TERMINAL_OUTCOME_PRESENTATIONS = {
+  [COMMAND_CENTER_RUN_TERMINAL_OUTCOMES.COMPLETED]: {
+    isFallback: false,
+    label: "Completed",
+    tone: "active",
+  },
+  [COMMAND_CENTER_RUN_TERMINAL_OUTCOMES.FAILED]: {
+    isFallback: false,
+    label: "Failed",
+    tone: "danger",
+  },
+  [COMMAND_CENTER_RUN_TERMINAL_OUTCOMES.CANCELLED]: {
+    isFallback: false,
+    label: "Cancelled",
+    tone: "attention",
+  },
+} as const satisfies Record<CommandCenterRunTerminalOutcome, CommandCenterStatusPresentation>;
+
+export const COMMAND_CENTER_TRACE_PRESENCE_STATES = {
+  NONE: "none",
+  TRACE_PRESENT: "trace_present",
+  LATEST_TURN_TRACE_PRESENT: "latest_turn_trace_present",
+} as const;
+
+export type CommandCenterRunTracePresenceState =
+  (typeof COMMAND_CENTER_TRACE_PRESENCE_STATES)[keyof typeof COMMAND_CENTER_TRACE_PRESENCE_STATES];
+
+export const COMMAND_CENTER_TRACE_PRESENCE_PRESENTATIONS = {
+  [COMMAND_CENTER_TRACE_PRESENCE_STATES.NONE]: {
+    isFallback: false,
+    label: "No trace",
+    tone: "subtle",
+  },
+  [COMMAND_CENTER_TRACE_PRESENCE_STATES.TRACE_PRESENT]: {
+    isFallback: false,
+    label: "Trace present",
+    tone: "info",
+  },
+  [COMMAND_CENTER_TRACE_PRESENCE_STATES.LATEST_TURN_TRACE_PRESENT]: {
+    isFallback: false,
+    label: "Latest turn trace present",
+    tone: "active",
+  },
+} as const satisfies Record<CommandCenterRunTracePresenceState, CommandCenterStatusPresentation>;
+
+export const COMMAND_CENTER_RUN_KINDS = {
+  CHAT_COMPLETION: "chat_completion",
+  UNKNOWN: "unknown",
+} as const;
+
+export type CommandCenterRunKind =
+  (typeof COMMAND_CENTER_RUN_KINDS)[keyof typeof COMMAND_CENTER_RUN_KINDS];
+
 export type CommandCenterRunIdentityKind =
   | "task"
   | "request"
@@ -29,16 +175,6 @@ export type CommandCenterRunLifecycleState =
   | "unknown";
 
 export type CommandCenterRunLifecyclePath = string[];
-
-export type CommandCenterRunTerminalOutcome =
-  | "succeeded"
-  | "failed"
-  | "cancelled";
-
-export type CommandCenterRunTracePresenceState =
-  | "none"
-  | "trace present"
-  | "latest-turn trace present";
 
 export type CommandCenterCanonicalTaskEventType =
   | "task.created"
@@ -105,6 +241,7 @@ export interface CommandCenterEvent {
   queuedAt?: number | null;
   requestId: string | null;
   runId: string | null;
+  runKind?: CommandCenterRunKind | null;
   sourceMode?: string | null;
   taskType: string | null;
   sseType: string | null;
@@ -139,6 +276,7 @@ export interface CommandCenterRun {
   latestTurnMessageId?: string | null;
   requestId?: string | null;
   runId: string | null;
+  runKind?: CommandCenterRunKind | null;
   runType?: string | null;
   state?: CommandCenterRunLifecycleState | string | null;
   status: CommandCenterRunStatus;
@@ -173,7 +311,7 @@ export interface CommandCenterHealthItem {
   key: "core" | "llm" | "deps" | "vector" | "memory";
   label: string;
   raw: string | null;
-  status: CommandCenterHealthStatus;
+  status: CommandCenterHealthState;
 }
 
 export interface CommandCenterTaskEvent {
@@ -202,4 +340,188 @@ export interface CommandCenterRagTracePayload {
   memory: CommandCenterRagTraceItem[];
   resolvedThreadId: number;
   semantic: CommandCenterRagTraceItem[];
+}
+
+function normalizeCommandCenterToken(value: string | null | undefined): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[.\s-]+/g, "_")
+    .replace(/_+/g, "_");
+}
+
+function humanizeCommandCenterToken(value: string | null | undefined): string {
+  const normalized = String(value ?? "")
+    .trim()
+    .replace(/[._-]+/g, " ")
+    .replace(/\s+/g, " ");
+  if (!normalized) return "unknown";
+  if (normalized.toLowerCase() === "ok") return "OK";
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+}
+
+function fallbackPresentation(value: string | null | undefined): CommandCenterStatusPresentation {
+  const label = humanizeCommandCenterToken(value);
+  return {
+    isFallback: true,
+    label,
+    tone: "subtle",
+  };
+}
+
+export function describeCommandCenterHealthStatePresentation(
+  state: string | null | undefined
+): CommandCenterStatusPresentation {
+  const normalized = normalizeCommandCenterToken(state);
+  switch (normalized) {
+    case COMMAND_CENTER_HEALTH_STATES.OK:
+    case "healthy":
+    case "online":
+      return COMMAND_CENTER_HEALTH_STATE_PRESENTATIONS[COMMAND_CENTER_HEALTH_STATES.OK];
+    case COMMAND_CENTER_HEALTH_STATES.DEGRADED:
+    case "warning":
+    case "warn":
+      return COMMAND_CENTER_HEALTH_STATE_PRESENTATIONS[COMMAND_CENTER_HEALTH_STATES.DEGRADED];
+    case COMMAND_CENTER_HEALTH_STATES.DOWN:
+    case "fail":
+    case "failed":
+    case "error":
+    case "offline":
+    case "misconfigured":
+      return COMMAND_CENTER_HEALTH_STATE_PRESENTATIONS[COMMAND_CENTER_HEALTH_STATES.DOWN];
+    case COMMAND_CENTER_HEALTH_STATES.UNKNOWN:
+    case "":
+      return COMMAND_CENTER_HEALTH_STATE_PRESENTATIONS[COMMAND_CENTER_HEALTH_STATES.UNKNOWN];
+    default:
+      return fallbackPresentation(state);
+  }
+}
+
+export function normalizeCommandCenterRunStatus(
+  status: string | null | undefined
+): CommandCenterRunStatus {
+  const normalized = normalizeCommandCenterToken(status);
+  switch (normalized) {
+    case COMMAND_CENTER_RUN_STATUSES.RUNNING:
+    case "created":
+    case "chunk":
+    case "streaming":
+    case "processing":
+    case "started":
+      return COMMAND_CENTER_RUN_STATUSES.RUNNING;
+    case COMMAND_CENTER_RUN_STATUSES.COMPLETED:
+    case "succeeded":
+    case "success":
+    case "done":
+      return COMMAND_CENTER_RUN_STATUSES.COMPLETED;
+    case COMMAND_CENTER_RUN_STATUSES.FAILED:
+    case "error":
+    case "failure":
+      return COMMAND_CENTER_RUN_STATUSES.FAILED;
+    case COMMAND_CENTER_RUN_STATUSES.CANCELLED:
+    case "canceled":
+      return COMMAND_CENTER_RUN_STATUSES.CANCELLED;
+    case COMMAND_CENTER_RUN_STATUSES.NEEDS_ATTENTION:
+    case "attention":
+    case "blocked":
+    case "waiting":
+    case "approval":
+    case "clarification":
+    case "pending":
+      return COMMAND_CENTER_RUN_STATUSES.NEEDS_ATTENTION;
+    case COMMAND_CENTER_RUN_STATUSES.UNKNOWN:
+    default:
+      return COMMAND_CENTER_RUN_STATUSES.UNKNOWN;
+  }
+}
+
+export function describeCommandCenterRunStatusPresentation(
+  status: string | null | undefined
+): CommandCenterStatusPresentation {
+  const normalized = normalizeCommandCenterRunStatus(status);
+  return COMMAND_CENTER_RUN_STATUS_PRESENTATIONS[normalized];
+}
+
+export function normalizeCommandCenterTerminalOutcome(
+  outcome: string | null | undefined
+): CommandCenterRunTerminalOutcome | null {
+  const normalized = normalizeCommandCenterToken(outcome);
+  switch (normalized) {
+    case COMMAND_CENTER_RUN_TERMINAL_OUTCOMES.COMPLETED:
+    case "succeeded":
+    case "success":
+    case "done":
+      return COMMAND_CENTER_RUN_TERMINAL_OUTCOMES.COMPLETED;
+    case COMMAND_CENTER_RUN_TERMINAL_OUTCOMES.FAILED:
+      return COMMAND_CENTER_RUN_TERMINAL_OUTCOMES.FAILED;
+    case COMMAND_CENTER_RUN_TERMINAL_OUTCOMES.CANCELLED:
+    case "canceled":
+      return COMMAND_CENTER_RUN_TERMINAL_OUTCOMES.CANCELLED;
+    default:
+      return null;
+  }
+}
+
+export function describeCommandCenterRunTerminalOutcomePresentation(
+  outcome: string | null | undefined
+): CommandCenterStatusPresentation | null {
+  const normalized = normalizeCommandCenterTerminalOutcome(outcome);
+  if (!normalized) return null;
+  return COMMAND_CENTER_RUN_TERMINAL_OUTCOME_PRESENTATIONS[normalized];
+}
+
+export function normalizeCommandCenterTracePresenceState(
+  state: string | null | undefined
+): CommandCenterRunTracePresenceState {
+  const normalized = normalizeCommandCenterToken(state);
+  switch (normalized) {
+    case COMMAND_CENTER_TRACE_PRESENCE_STATES.NONE:
+    case "no_trace":
+      return COMMAND_CENTER_TRACE_PRESENCE_STATES.NONE;
+    case COMMAND_CENTER_TRACE_PRESENCE_STATES.TRACE_PRESENT:
+    case "tracepresent":
+    case "trace":
+      return COMMAND_CENTER_TRACE_PRESENCE_STATES.TRACE_PRESENT;
+    case COMMAND_CENTER_TRACE_PRESENCE_STATES.LATEST_TURN_TRACE_PRESENT:
+    case "latestturntracepresent":
+    case "latest_turn_trace":
+      return COMMAND_CENTER_TRACE_PRESENCE_STATES.LATEST_TURN_TRACE_PRESENT;
+    case "":
+    default:
+      return COMMAND_CENTER_TRACE_PRESENCE_STATES.NONE;
+  }
+}
+
+export function describeCommandCenterTracePresencePresentation(
+  state: string | null | undefined
+): CommandCenterStatusPresentation {
+  const normalized = normalizeCommandCenterTracePresenceState(state);
+  return COMMAND_CENTER_TRACE_PRESENCE_PRESENTATIONS[normalized];
+}
+
+export function normalizeCommandCenterRunKind(
+  kind: string | null | undefined
+): CommandCenterRunKind {
+  const normalized = normalizeCommandCenterToken(kind);
+  if (
+    normalized === COMMAND_CENTER_RUN_KINDS.CHAT_COMPLETION ||
+    normalized === "chatcompletion" ||
+    normalized === "chat_completion" ||
+    normalized === "chat.completion" ||
+    normalized === "chat" ||
+    normalized === "completion"
+  ) {
+    return COMMAND_CENTER_RUN_KINDS.CHAT_COMPLETION;
+  }
+  return COMMAND_CENTER_RUN_KINDS.UNKNOWN;
+}
+
+export function describeCommandCenterRunKindLabel(
+  kind: string | null | undefined
+): string | null {
+  const normalized = normalizeCommandCenterRunKind(kind);
+  if (normalized === COMMAND_CENTER_RUN_KINDS.CHAT_COMPLETION) {
+    return "chat completion";
+  }
+  return null;
 }

--- a/frontend/src/features/commandCenter/types.ts
+++ b/frontend/src/features/commandCenter/types.ts
@@ -35,6 +35,11 @@ export type CommandCenterRunTerminalOutcome =
   | "failed"
   | "cancelled";
 
+export type CommandCenterRunTracePresenceState =
+  | "none"
+  | "trace present"
+  | "latest-turn trace present";
+
 export type CommandCenterCanonicalTaskEventType =
   | "task.created"
   | "task.running"
@@ -66,14 +71,21 @@ export interface CommandCenterRunStreamingEvidence {
 }
 
 export interface CommandCenterRunTraceEvidence {
+  documentCount: number | null;
+  graphCount: number | null;
   latestTurnContentPresent: boolean;
+  latestTurnMessageId: string | null;
   latestTurnTracePresent: boolean;
+  memoryCount: number | null;
   retrievalQuery: string | null;
   retrievalQueryMatchesLatestTurn: boolean | null;
   retrievalQueryPresent: boolean;
   retrievalTarget: string | null;
+  sourceMode: string | null;
+  tracePresenceState: CommandCenterRunTracePresenceState;
   tracePresent: boolean;
   traceUrl: string | null;
+  widenReason: string | null;
 }
 
 export interface CommandCenterEvent {
@@ -82,21 +94,26 @@ export interface CommandCenterEvent {
   durationMs?: number | null;
   firstOutputAt?: number | null;
   firstTokenAt?: number | null;
+  graphCount?: number | null;
   json: CommandCenterJson;
   kind: string | null;
   lifecycleState?: string | null;
   latestTurnContent?: string | null;
+  memoryCount?: number | null;
   raw: string;
   receivedAt: number;
   queuedAt?: number | null;
   requestId: string | null;
   runId: string | null;
+  sourceMode?: string | null;
   taskType: string | null;
   sseType: string | null;
   status: string | null;
   retrievalQuery?: string | null;
   retrievalQueryMatchesLatestTurn?: boolean | null;
   retrievalTarget?: string | null;
+  documentCount?: number | null;
+  widenReason?: string | null;
   summary: string;
   taskId: string | null;
   latestTurnMessageId: string | null;

--- a/frontend/src/features/commandCenter/types.ts
+++ b/frontend/src/features/commandCenter/types.ts
@@ -28,6 +28,8 @@ export type CommandCenterRunLifecycleState =
   | "cancelled"
   | "unknown";
 
+export type CommandCenterRunLifecyclePath = string[];
+
 export type CommandCenterRunTerminalOutcome =
   | "succeeded"
   | "failed"
@@ -48,17 +50,53 @@ export type CommandCenterRagTraceUnavailableReason =
   | "no_thread"
   | "no_trace";
 
+export interface CommandCenterRunTimings {
+  completedAt: number | null;
+  firstOutputAt: number | null;
+  firstTokenAt: number | null;
+  queuedAt: number | null;
+  totalDurationMs: number | null;
+  warmupAt: number | null;
+}
+
+export interface CommandCenterRunStreamingEvidence {
+  chunkCount: number;
+  firstChunkAt: number | null;
+  hasStreamedContent: boolean;
+}
+
+export interface CommandCenterRunTraceEvidence {
+  latestTurnContentPresent: boolean;
+  latestTurnTracePresent: boolean;
+  retrievalQuery: string | null;
+  retrievalQueryMatchesLatestTurn: boolean | null;
+  retrievalQueryPresent: boolean;
+  retrievalTarget: string | null;
+  tracePresent: boolean;
+  traceUrl: string | null;
+}
+
 export interface CommandCenterEvent {
   eventId: string | null;
+  completedAt?: number | null;
+  durationMs?: number | null;
+  firstOutputAt?: number | null;
+  firstTokenAt?: number | null;
   json: CommandCenterJson;
   kind: string | null;
+  lifecycleState?: string | null;
+  latestTurnContent?: string | null;
   raw: string;
   receivedAt: number;
+  queuedAt?: number | null;
   requestId: string | null;
   runId: string | null;
   taskType: string | null;
   sseType: string | null;
   status: string | null;
+  retrievalQuery?: string | null;
+  retrievalQueryMatchesLatestTurn?: boolean | null;
+  retrievalTarget?: string | null;
   summary: string;
   taskId: string | null;
   latestTurnMessageId: string | null;
@@ -66,6 +104,8 @@ export interface CommandCenterEvent {
   terminalOutcome: CommandCenterRunTerminalOutcome | null;
   threadId: number | null;
   turnId: string | null;
+  traceUrl?: string | null;
+  warmupAt?: number | null;
   type: string | null;
 }
 
@@ -74,6 +114,7 @@ export interface CommandCenterRun {
   events?: CommandCenterEvent[];
   identityKind?: CommandCenterRunIdentityKind;
   key: string;
+  lifecycleStates?: CommandCenterRunLifecyclePath;
   lastEvent: CommandCenterEvent;
   lastEventAt: number;
   lastKind: string | null;
@@ -84,11 +125,14 @@ export interface CommandCenterRun {
   runType?: string | null;
   state?: CommandCenterRunLifecycleState | string | null;
   status: CommandCenterRunStatus;
+  streamingEvidence?: CommandCenterRunStreamingEvidence | null;
   summary: string;
   taskId: string | null;
   terminalOutcome?: CommandCenterRunTerminalOutcome | null;
+  timings?: CommandCenterRunTimings | null;
   turnId?: string | null;
   threadId?: number | null;
+  traceEvidence?: CommandCenterRunTraceEvidence | null;
   traceUrl?: string | null;
 }
 


### PR DESCRIPTION
## Summary
- Aggregate SSE task events into stable run records with canonical task, lifecycle, timing, streaming, and trace identity.
- Render semantic run summary and detail views with compact identity, lifecycle, retrieval, and trace coherence sections.
- Pass run context through to the trace panel so operators can follow one run across the detail and trace surfaces.
- Canonicalize observability tokens and health-state mapping to reduce label drift across Command Center.

## Testing
- `pnpm --dir frontend/src exec vitest run features/commandCenter/__tests__/RunDetailsPanel.test.tsx features/commandCenter/__tests__/RagTracePanel.test.tsx features/commandCenter/__tests__/CommandCenterPage.test.tsx`
- `pnpm --dir frontend/src exec vitest run features/commandCenter/__tests__/commandCenterRunAggregation.test.tsx`