### PR TITLE
feat(delegation): bind codex executor to worker lane

### DIFF
--- a/guardian/core/config.py
+++ b/guardian/core/config.py
@@ -191,6 +191,16 @@ class Settings(BaseSettings):
             "Docker Compose path remains the supported default posture."
         ),
     )
+    CODEXIFY_CODEX_BIN: str = Field(
+        default="codex",
+        description=(
+            "Path or command name for the Codex CLI used by delegation worker execution."
+        ),
+    )
+    CODEXIFY_CODEX_TIMEOUT_SECONDS: int = Field(
+        default=900,
+        description=("Timeout budget for a Codex delegation run in seconds."),
+    )
     LOCAL_COMPAT_FIRST: bool = Field(
         default=False,
         description=(

--- a/guardian/core/delegation_service.py
+++ b/guardian/core/delegation_service.py
@@ -2,15 +2,23 @@
 
 from __future__ import annotations
 
+import json
 import os
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
+from guardian.core.executors.base import (
+    CodeExecutor,
+    ExecutorFailure,
+    ExecutorResult,
+)
 from guardian.db import models as db_models
 from guardian.protocol_tokens import (
+    DELEGATION_SUMMARY_OUTCOME_TYPE,
     DELEGATION_TERMINAL_STATUSES,
+    DelegationExecutorName,
     DelegationJobStatus,
 )
 from guardian.tasks.types import (
@@ -60,8 +68,195 @@ def _normalize_text(value: Any) -> str:
     return str(value or "").strip()
 
 
+def _preserve_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
 def _normalize_context(value: Any) -> dict[str, Any]:
     return dict(value) if isinstance(value, dict) else {}
+
+
+def _dedupe_text_list(raw: Any) -> list[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, (list, tuple, set)):
+        items = raw
+    elif isinstance(raw, str):
+        items = [part.strip() for part in raw.split(",")]
+    else:
+        items = [raw]
+    result: list[str] = []
+    for item in items:
+        value = _normalize_text(item)
+        if value and value not in result:
+            result.append(value)
+    return result
+
+
+_SUMMARY_SECTION_HEADERS: dict[str, str] = {
+    "title": "title",
+    "summary": "summary",
+    "files changed": "files_changed",
+    "files_changed": "files_changed",
+    "commands run": "commands_run",
+    "commands_run": "commands_run",
+    "key changes": "key_changes",
+    "key_changes": "key_changes",
+    "unresolved questions": "unresolved_questions",
+    "unresolved_questions": "unresolved_questions",
+    "tags": "tags",
+    "outcome type": "outcome_type",
+    "outcome_type": "outcome_type",
+}
+
+
+def _flatten_summary_list(raw: Any) -> list[str]:
+    values = _dedupe_text_list(raw)
+    result: list[str] = []
+    for value in values:
+        if value.lower() in {"none", "n/a", "na"}:
+            continue
+        if value not in result:
+            result.append(value)
+    return result
+
+
+def _parse_structured_summary_text(
+    text: str | None,
+) -> dict[str, Any]:
+    stripped = _normalize_text(text)
+    parsed: dict[str, Any] = {
+        "title": None,
+        "summary": None,
+        "files_changed": [],
+        "commands_run": [],
+        "key_changes": [],
+        "unresolved_questions": [],
+        "tags": [],
+        "outcome_type": DELEGATION_SUMMARY_OUTCOME_TYPE,
+    }
+    if not stripped:
+        return parsed
+
+    try:
+        decoded = json.loads(stripped)
+    except Exception:
+        decoded = None
+
+    if isinstance(decoded, dict):
+        parsed["title"] = (
+            _normalize_text(decoded.get("title") or decoded.get("name")) or None
+        )
+        parsed["summary"] = (
+            _normalize_text(
+                decoded.get("summary")
+                or decoded.get("final_text")
+                or decoded.get("text")
+            )
+            or None
+        )
+        parsed["files_changed"] = _flatten_summary_list(
+            decoded.get("files_changed") or decoded.get("filesChanged")
+        )
+        parsed["commands_run"] = _flatten_summary_list(
+            decoded.get("commands_run") or decoded.get("commandsRun")
+        )
+        parsed["key_changes"] = _flatten_summary_list(
+            decoded.get("key_changes") or decoded.get("keyChanges")
+        )
+        parsed["unresolved_questions"] = _flatten_summary_list(
+            decoded.get("unresolved_questions")
+            or decoded.get("unresolvedQuestions")
+        )
+        parsed["tags"] = _flatten_summary_list(decoded.get("tags"))
+        parsed["outcome_type"] = (
+            _normalize_text(
+                decoded.get("outcome_type") or decoded.get("outcomeType")
+            )
+            or DELEGATION_SUMMARY_OUTCOME_TYPE
+        )
+        return parsed
+
+    sections: dict[str, list[str]] = {
+        "files_changed": [],
+        "commands_run": [],
+        "key_changes": [],
+        "unresolved_questions": [],
+        "tags": [],
+    }
+    current: str | None = None
+    summary_lines: list[str] = []
+
+    for raw_line in stripped.splitlines():
+        line = raw_line.rstrip()
+        normalized = line.strip().lower()
+        header = None
+        if ":" in normalized:
+            candidate = normalized.split(":", 1)[0].strip()
+            header = _SUMMARY_SECTION_HEADERS.get(candidate)
+
+        if header:
+            current = header
+            remainder = line.split(":", 1)[1].strip() if ":" in line else ""
+            if remainder:
+                if header == "title":
+                    parsed["title"] = _normalize_text(remainder) or None
+                elif header == "summary":
+                    summary_lines.append(remainder)
+                elif header == "outcome_type":
+                    parsed["outcome_type"] = (
+                        _normalize_text(remainder)
+                        or DELEGATION_SUMMARY_OUTCOME_TYPE
+                    )
+                else:
+                    sections[header].append(remainder)
+            continue
+
+        if current == "summary":
+            summary_lines.append(line)
+        elif current in sections:
+            sections[current].append(line)
+
+    def _flatten(values: list[str]) -> list[str]:
+        items: list[str] = []
+        for line in values:
+            candidate = line.strip().lstrip("-*• ").strip()
+            if not candidate:
+                continue
+            parts = [candidate]
+            if "," in candidate and "\n" not in candidate:
+                parts = [part.strip() for part in candidate.split(",")]
+            for part in parts:
+                value = _normalize_text(part)
+                if not value or value.lower() in {"none", "n/a", "na"}:
+                    continue
+                if value not in items:
+                    items.append(value)
+        return items
+
+    parsed["files_changed"] = _flatten(sections["files_changed"])
+    parsed["commands_run"] = _flatten(sections["commands_run"])
+    parsed["key_changes"] = _flatten(sections["key_changes"])
+    parsed["unresolved_questions"] = _flatten(sections["unresolved_questions"])
+    parsed["tags"] = _flatten(sections["tags"])
+    if summary_lines:
+        parsed["summary"] = (
+            "\n".join(line for line in summary_lines if line).strip() or None
+        )
+    if parsed["summary"] is None:
+        parsed["summary"] = stripped
+    return parsed
+
+
+def _merge_text_lists(*values: Any) -> list[str]:
+    merged: list[str] = []
+    for raw in values:
+        for value in _dedupe_text_list(raw):
+            if value not in merged:
+                merged.append(value)
+    return merged
 
 
 def _packet_from_row(row: Any) -> DelegationPacket:
@@ -330,6 +525,16 @@ class DelegationService:
             )
         return job
 
+    def resolve_executor(self, executor_name: str) -> CodeExecutor:
+        normalized = _normalize_text(executor_name).lower()
+        if normalized == DelegationExecutorName.CODEX.value:
+            from guardian.core.executors.codex_executor import CodexExecutor
+
+            return CodexExecutor()
+        raise DelegationConflictError(
+            f"unsupported_executor:{normalized or '<missing>'}"
+        )
+
     # ------------------------------------------------------------------
     # Approval / enqueue payloads
     # ------------------------------------------------------------------
@@ -341,6 +546,8 @@ class DelegationService:
             raise DelegationConflictError(
                 f"packet_not_approvable:{packet.packet_id}:{packet_status}"
             )
+        # Validate the executor choice before creating durable queue state.
+        self.resolve_executor(packet.executor)
 
         now_iso = _now_iso()
         existing_job = self.get_job_by_packet(packet.packet_id)
@@ -443,13 +650,22 @@ class DelegationService:
         delegation_id: str,
         *,
         error_message: str,
+        summary: DelegationSummary | None = None,
     ) -> DelegationJobRecord:
-        return self._transition_job(
+        job = self._transition_job(
             delegation_id,
             DelegationJobStatus.FAILED.value,
             completed=True,
             error_message=error_message,
         )
+        summary_packet = summary or self.build_summary_packet(
+            job,
+            status=DelegationJobStatus.FAILED.value,
+            error_message=error_message,
+            result={"failure": {"message": error_message}},
+        )
+        self.record_summary(summary_packet)
+        return job
 
     def cancel_delegation(self, delegation_id: str) -> DelegationCancelResult:
         job = self._require_job(delegation_id)
@@ -485,19 +701,211 @@ class DelegationService:
         status: str | None = None,
         error_message: str | None = None,
     ) -> DelegationSummary:
+        result_payload = dict(result or {})
+        metadata_payload = dict(metadata or {})
+        parsed = _parse_structured_summary_text(
+            summary
+            or result_payload.get("summary")
+            or result_payload.get("final_text")
+            or result_payload.get("raw_transcript")
+        )
+        title = (
+            _normalize_text(
+                result_payload.get("title")
+                or metadata_payload.get("title")
+                or job.task_prompt
+            )
+            or job.task_prompt
+        )
+        normalized_status = (
+            _normalize_text(
+                status
+                or result_payload.get("status")
+                or DelegationJobStatus.COMPLETED.value
+            )
+            or DelegationJobStatus.COMPLETED.value
+        )
+        files_changed = _merge_text_lists(
+            result_payload.get("files_changed"),
+            result_payload.get("filesChanged"),
+            parsed.get("files_changed"),
+        )
+        commands_run = _merge_text_lists(
+            result_payload.get("commands_run"),
+            result_payload.get("commandsRun"),
+            parsed.get("commands_run"),
+        )
+        key_changes = _merge_text_lists(
+            result_payload.get("key_changes"),
+            result_payload.get("keyChanges"),
+            parsed.get("key_changes"),
+        )
+        unresolved_questions = _merge_text_lists(
+            result_payload.get("unresolved_questions"),
+            result_payload.get("unresolvedQuestions"),
+            parsed.get("unresolved_questions"),
+        )
+        packet_tags = _normalize_tags(job.tags)
+        result_tags = _merge_text_lists(
+            result_payload.get("tags"),
+            metadata_payload.get("tags"),
+            parsed.get("tags"),
+        )
+        tags = _normalize_tags([*packet_tags, *result_tags])
+        outcome_type = DELEGATION_SUMMARY_OUTCOME_TYPE
+        raw_transcript = _preserve_text(
+            result_payload.get("raw_transcript")
+            or result_payload.get("rawTranscript")
+            or metadata_payload.get("raw_transcript")
+            or metadata_payload.get("rawTranscript")
+        )
+        transcript = (
+            _normalize_text(
+                result_payload.get("transcript")
+                or result_payload.get("stdout")
+                or parsed.get("summary")
+                or summary
+            )
+            or None
+        )
+        canonical_summary = (
+            _normalize_text(
+                parsed.get("summary")
+                or summary
+                or result_payload.get("summary")
+                or result_payload.get("final_text")
+                or transcript
+            )
+            or None
+        )
+        failure_payload = result_payload.get("failure")
+        if failure_payload is None:
+            failure_payload = metadata_payload.get("failure")
+        if failure_payload is None and error_message:
+            failure_payload = {"message": error_message}
+        if isinstance(failure_payload, ExecutorFailure):
+            failure_payload = failure_payload.to_dict()
+        normalized_failure = (
+            dict(failure_payload) if isinstance(failure_payload, dict) else None
+        )
+        normalized_error_message = (
+            _normalize_text(
+                error_message
+                or (normalized_failure or {}).get("message")
+                or result_payload.get("error_message")
+            )
+            or None
+        )
+        enrich_payload = bool(
+            result_payload
+            or metadata_payload
+            or summary
+            or status
+            or error_message
+        )
+        if enrich_payload:
+            result_payload.update(
+                {
+                    "title": title,
+                    "summary": canonical_summary,
+                    "status": normalized_status,
+                    "outcome_type": outcome_type,
+                    "outcomeType": outcome_type,
+                    "files_changed": files_changed,
+                    "commands_run": commands_run,
+                    "key_changes": key_changes,
+                    "unresolved_questions": unresolved_questions,
+                    "tags": tags,
+                    "raw_transcript": raw_transcript,
+                    "transcript": transcript,
+                    "failure": normalized_failure,
+                    "error_message": normalized_error_message,
+                }
+            )
+            metadata_payload.update(
+                {
+                    "title": title,
+                    "status": normalized_status,
+                    "outcome_type": outcome_type,
+                    "tags": tags,
+                    "error_message": normalized_error_message,
+                }
+            )
         return DelegationSummary(
             delegation_id=job.delegation_id,
             task_id=job.task_id,
-            status=_normalize_text(
-                status or DelegationJobStatus.COMPLETED.value
-            )
-            or DelegationJobStatus.COMPLETED.value,
-            summary=summary,
-            result=dict(result or {}),
-            metadata=dict(metadata or {}),
-            error_message=error_message,
+            status=normalized_status,
+            outcome_type=outcome_type,
+            title=title,
+            summary=canonical_summary,
+            files_changed=files_changed,
+            commands_run=commands_run,
+            key_changes=key_changes,
+            unresolved_questions=unresolved_questions,
+            tags=tags,
+            result=result_payload,
+            metadata=metadata_payload,
+            raw_transcript=raw_transcript,
+            transcript=transcript,
+            failure=normalized_failure,
+            error_message=normalized_error_message,
             created_at=_now_iso(),
             completed_at=_now_iso(),
+        )
+
+    def normalize_executor_result(
+        self,
+        job: DelegationJobRecord,
+        executor_result: ExecutorResult,
+        *,
+        packet: DelegationPacket | None = None,
+    ) -> DelegationSummary:
+        packet = packet or self.get_packet(job.packet_id)
+        result_payload = dict(executor_result.result or {})
+        result_payload.update(
+            {
+                "final_text": executor_result.final_text,
+                "summary": executor_result.summary,
+                "stdout": executor_result.stdout,
+                "stderr": executor_result.stderr,
+                "raw_transcript": executor_result.raw_transcript,
+                "files_changed": list(executor_result.files_changed),
+                "commands_run": list(executor_result.commands_run),
+                "output_chunks": [
+                    chunk.to_dict() for chunk in executor_result.output_chunks
+                ],
+                "failure": (
+                    executor_result.failure.to_dict()
+                    if executor_result.failure is not None
+                    else None
+                ),
+                "status": executor_result.status,
+            }
+        )
+        metadata_payload = dict(executor_result.metadata or {})
+        metadata_payload.setdefault("executor", job.executor)
+        metadata_payload.setdefault("repo_path", job.repo_path)
+        metadata_payload.setdefault("task_id", job.task_id)
+        metadata_payload.setdefault("delegation_id", job.delegation_id)
+        if packet is not None:
+            metadata_payload.setdefault("packet_id", packet.packet_id)
+            metadata_payload.setdefault("title", packet.task_prompt)
+        if executor_result.failure is not None:
+            metadata_payload.setdefault(
+                "failure", executor_result.failure.to_dict()
+            )
+        return self.build_summary_packet(
+            job,
+            summary=executor_result.summary or executor_result.final_text,
+            result=result_payload,
+            metadata=metadata_payload,
+            status=executor_result.status,
+            error_message=executor_result.error_message
+            or (
+                executor_result.failure.message
+                if executor_result.failure is not None
+                else None
+            ),
         )
 
     def record_summary(self, summary: DelegationSummary) -> DelegationSummary:

--- a/guardian/core/executors/__init__.py
+++ b/guardian/core/executors/__init__.py
@@ -2,8 +2,18 @@
 
 from guardian.core.executors.base import (
     CodeExecutor,
+    ExecutorFailure,
     ExecutorRequest,
     ExecutorResult,
+    ExecutorStreamChunk,
 )
+from guardian.core.executors.codex_executor import CodexExecutor
 
-__all__ = ["CodeExecutor", "ExecutorRequest", "ExecutorResult"]
+__all__ = [
+    "CodeExecutor",
+    "CodexExecutor",
+    "ExecutorFailure",
+    "ExecutorRequest",
+    "ExecutorResult",
+    "ExecutorStreamChunk",
+]

--- a/guardian/core/executors/base.py
+++ b/guardian/core/executors/base.py
@@ -4,11 +4,46 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Callable, Protocol, runtime_checkable
 
 
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass(slots=True)
+class ExecutorStreamChunk:
+    """One streamed chunk from a delegation executor."""
+
+    stream: str
+    text: str
+    sequence: int | None = None
+    created_at: str = field(default_factory=_utc_now_iso)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ExecutorFailure:
+    """Structured executor failure metadata."""
+
+    error_code: str
+    failure_class: str
+    message: str
+    binary: str | None = None
+    command: list[str] = field(default_factory=list)
+    returncode: int | None = None
+    signal: int | None = None
+    timeout_seconds: float | None = None
+    timed_out: bool = False
+    spawn_failed: bool = False
+    stdout: str = ""
+    stderr: str = ""
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
 
 
 @dataclass(slots=True)
@@ -22,6 +57,7 @@ class ExecutorRequest:
     tags: list[str] = field(default_factory=list)
     thread_id: int | None = None
     project_id: int | None = None
+    timeout_seconds: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -33,11 +69,29 @@ class ExecutorResult:
     task_id: str
     status: str
     summary: str | None = None
+    final_text: str | None = None
+    stdout: str = ""
+    stderr: str = ""
+    raw_transcript: str = ""
+    files_changed: list[str] = field(default_factory=list)
+    commands_run: list[str] = field(default_factory=list)
+    output_chunks: list[ExecutorStreamChunk] = field(default_factory=list)
     result: dict[str, Any] = field(default_factory=dict)
     metadata: dict[str, Any] = field(default_factory=dict)
+    failure: ExecutorFailure | None = None
     error_message: str | None = None
     created_at: str = field(default_factory=_utc_now_iso)
     completed_at: str = field(default_factory=_utc_now_iso)
+
+    def __post_init__(self) -> None:
+        if self.final_text is None and self.summary is not None:
+            self.final_text = self.summary
+        if self.summary is None and self.final_text is not None:
+            self.summary = self.final_text
+        if not self.raw_transcript and self.stdout:
+            self.raw_transcript = self.stdout
+        if not self.raw_transcript and self.stderr:
+            self.raw_transcript = self.stderr
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -45,9 +99,20 @@ class ExecutorResult:
 
 @runtime_checkable
 class CodeExecutor(Protocol):
-    def execute(self, request: ExecutorRequest) -> ExecutorResult:
+    def execute(
+        self,
+        request: ExecutorRequest,
+        *,
+        on_output: Callable[[ExecutorStreamChunk], None] | None = None,
+        should_stop: Callable[[], bool] | None = None,
+    ) -> ExecutorResult:
         """Execute a code task and return a structured result."""
-        ...
 
 
-__all__ = ["ExecutorRequest", "ExecutorResult", "CodeExecutor"]
+__all__ = [
+    "CodeExecutor",
+    "ExecutorFailure",
+    "ExecutorRequest",
+    "ExecutorResult",
+    "ExecutorStreamChunk",
+]

--- a/guardian/core/executors/codex_executor.py
+++ b/guardian/core/executors/codex_executor.py
@@ -1,0 +1,604 @@
+"""Real Codex CLI executor binding for delegation tasks."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from guardian.core.config import get_settings
+from guardian.core.executors.base import (
+    CodeExecutor,
+    ExecutorFailure,
+    ExecutorRequest,
+    ExecutorResult,
+    ExecutorStreamChunk,
+)
+from guardian.protocol_tokens import (
+    DELEGATION_SUMMARY_OUTCOME_TYPE,
+    DelegationJobStatus,
+    ErrorCode,
+)
+
+logger = logging.getLogger(__name__)
+
+_PROCESS_POLL_SECONDS = 0.1
+_TERMINATION_GRACE_SECONDS = 5.0
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalize_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _normalize_text_list(raw: Any) -> list[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, (list, tuple, set)):
+        items = raw
+    elif isinstance(raw, str):
+        items = raw.split(",") if "," in raw else [raw]
+    else:
+        items = [raw]
+    result: list[str] = []
+    for item in items:
+        text = _normalize_text(item)
+        if text and text not in result:
+            result.append(text)
+    return result
+
+
+def _command_prefix(spec: str) -> list[str]:
+    command = shlex.split(spec.strip()) if spec and spec.strip() else []
+    return command or ["codex"]
+
+
+def _binary_exists(binary: str) -> bool:
+    if not binary:
+        return False
+    path = Path(binary)
+    if path.exists() and os.access(path, os.X_OK):
+        return True
+    return shutil.which(binary) is not None
+
+
+def _split_structured_lines(text: str) -> dict[str, list[str] | str | None]:
+    stripped = text.strip()
+    parsed: dict[str, list[str] | str | None] = {
+        "title": None,
+        "summary": None,
+        "files_changed": [],
+        "commands_run": [],
+        "key_changes": [],
+        "unresolved_questions": [],
+        "tags": [],
+        "outcome_type": DELEGATION_SUMMARY_OUTCOME_TYPE,
+    }
+    if not stripped:
+        return parsed
+
+    try:
+        decoded = json.loads(stripped)
+    except Exception:
+        decoded = None
+
+    if isinstance(decoded, dict):
+        parsed["title"] = (
+            _normalize_text(decoded.get("title") or decoded.get("name")) or None
+        )
+        parsed["summary"] = (
+            _normalize_text(
+                decoded.get("summary")
+                or decoded.get("final_text")
+                or decoded.get("text")
+            )
+            or None
+        )
+        parsed["files_changed"] = _normalize_text_list(
+            decoded.get("files_changed") or decoded.get("filesChanged")
+        )
+        parsed["commands_run"] = _normalize_text_list(
+            decoded.get("commands_run") or decoded.get("commandsRun")
+        )
+        parsed["key_changes"] = _normalize_text_list(
+            decoded.get("key_changes") or decoded.get("keyChanges")
+        )
+        parsed["unresolved_questions"] = _normalize_text_list(
+            decoded.get("unresolved_questions")
+            or decoded.get("unresolvedQuestions")
+        )
+        parsed["tags"] = _normalize_text_list(decoded.get("tags"))
+        parsed["outcome_type"] = (
+            _normalize_text(
+                decoded.get("outcome_type")
+                or decoded.get("outcomeType")
+                or DELEGATION_SUMMARY_OUTCOME_TYPE
+            )
+            or DELEGATION_SUMMARY_OUTCOME_TYPE
+        )
+        return parsed
+
+    section_map = {
+        "title": "title",
+        "summary": "summary",
+        "files changed": "files_changed",
+        "files_changed": "files_changed",
+        "commands run": "commands_run",
+        "commands_run": "commands_run",
+        "key changes": "key_changes",
+        "key_changes": "key_changes",
+        "unresolved questions": "unresolved_questions",
+        "unresolved_questions": "unresolved_questions",
+        "tags": "tags",
+        "outcome type": "outcome_type",
+        "outcome_type": "outcome_type",
+    }
+    sections: dict[str, list[str]] = {
+        "files_changed": [],
+        "commands_run": [],
+        "key_changes": [],
+        "unresolved_questions": [],
+        "tags": [],
+    }
+    current: str | None = None
+    summary_lines: list[str] = []
+
+    for raw_line in stripped.splitlines():
+        line = raw_line.rstrip()
+        normalized = line.strip().lower()
+        header = None
+        if ":" in normalized:
+            candidate = normalized.split(":", 1)[0].strip()
+            header = section_map.get(candidate)
+        if header:
+            current = header
+            remainder = line.split(":", 1)[1].strip() if ":" in line else ""
+            if remainder:
+                if header == "title":
+                    parsed["title"] = _normalize_text(remainder) or None
+                elif header == "summary":
+                    summary_lines.append(remainder)
+                elif header == "outcome_type":
+                    parsed["outcome_type"] = (
+                        _normalize_text(remainder)
+                        or DELEGATION_SUMMARY_OUTCOME_TYPE
+                    )
+                else:
+                    sections[header].append(remainder)
+            continue
+
+        if current == "summary":
+            summary_lines.append(line)
+        elif current in sections:
+            sections[current].append(line)
+
+    def _flatten_section(values: list[str]) -> list[str]:
+        items: list[str] = []
+        for line in values:
+            candidate = line.strip()
+            if not candidate:
+                continue
+            candidate = candidate.lstrip("-*• ").strip()
+            if not candidate:
+                continue
+            if "," in candidate and "\n" not in candidate:
+                candidates = [part.strip() for part in candidate.split(",")]
+            else:
+                candidates = [candidate]
+            for item in candidates:
+                normalized_item = _normalize_text(item)
+                if not normalized_item:
+                    continue
+                if normalized_item.lower() in {"none", "n/a", "na"}:
+                    continue
+                if normalized_item not in items:
+                    items.append(normalized_item)
+        return items
+
+    parsed["files_changed"] = _flatten_section(sections["files_changed"])
+    parsed["commands_run"] = _flatten_section(sections["commands_run"])
+    parsed["key_changes"] = _flatten_section(sections["key_changes"])
+    parsed["unresolved_questions"] = _flatten_section(
+        sections["unresolved_questions"]
+    )
+    parsed["tags"] = _flatten_section(sections["tags"])
+    if summary_lines:
+        parsed["summary"] = (
+            "\n".join(line for line in summary_lines if line).strip() or None
+        )
+    if parsed["summary"] is None:
+        parsed["summary"] = stripped
+    if parsed["title"] is None:
+        parsed["title"] = None
+    return parsed
+
+
+class CodexExecutor(CodeExecutor):
+    """Execute the configured Codex CLI and stream output incrementally."""
+
+    def __init__(
+        self,
+        *,
+        codex_bin: str | None = None,
+        timeout_seconds: float | int | None = None,
+    ) -> None:
+        settings = get_settings()
+        self._codex_bin = (
+            _normalize_text(codex_bin or settings.CODEXIFY_CODEX_BIN) or "codex"
+        )
+        self._timeout_seconds = (
+            float(timeout_seconds)
+            if timeout_seconds is not None
+            else float(settings.CODEXIFY_CODEX_TIMEOUT_SECONDS)
+        )
+
+    def execute(
+        self,
+        request: ExecutorRequest,
+        *,
+        on_output: Callable[[ExecutorStreamChunk], None] | None = None,
+        should_stop: Callable[[], bool] | None = None,
+    ) -> ExecutorResult:
+        timeout_seconds = (
+            float(request.timeout_seconds)
+            if request.timeout_seconds is not None
+            else self._timeout_seconds
+        )
+        command_prefix = _command_prefix(self._codex_bin)
+        executable = command_prefix[0]
+        command = [*command_prefix, "exec", request.task_prompt]
+        base_metadata = {
+            "binary": executable,
+            "command": command,
+            "cwd": request.repo_path,
+            "timeout_seconds": timeout_seconds,
+            "executor": request.executor,
+        }
+
+        if not _binary_exists(executable):
+            failure = ExecutorFailure(
+                error_code=ErrorCode.DELEGATION_EXECUTOR_NOT_FOUND.value,
+                failure_class="FileNotFoundError",
+                message=f"Codex binary not found: {executable}",
+                binary=executable,
+                command=command,
+                timeout_seconds=timeout_seconds,
+                stdout="",
+                stderr="",
+                details={"cwd": request.repo_path},
+            )
+            return ExecutorResult(
+                delegation_id=request.delegation_id,
+                task_id=request.task_id,
+                status=DelegationJobStatus.FAILED.value,
+                summary=failure.message,
+                final_text="",
+                result={
+                    **base_metadata,
+                    "files_changed": [],
+                    "commands_run": [],
+                    "raw_transcript": "",
+                    "parsed_output": {},
+                    "failure": failure.to_dict(),
+                    "timed_out": False,
+                    "cancelled": False,
+                },
+                metadata={**base_metadata, "missing_binary": True},
+                failure=failure,
+                error_message=failure.message,
+            )
+
+        stdout_chunks: list[str] = []
+        stderr_chunks: list[str] = []
+        transcript_chunks: list[str] = []
+        stream_events: list[ExecutorStreamChunk] = []
+        sequence = 0
+        lock = threading.Lock()
+
+        proc: subprocess.Popen[str] | None = None
+        try:
+            proc = subprocess.Popen(
+                command,
+                cwd=request.repo_path or None,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.DEVNULL,
+                text=True,
+                bufsize=1,
+            )
+        except Exception as exc:
+            failure = ExecutorFailure(
+                error_code=ErrorCode.DELEGATION_EXECUTOR_SPAWN_FAILED.value,
+                failure_class=exc.__class__.__name__,
+                message=str(exc),
+                binary=executable,
+                command=command,
+                timeout_seconds=timeout_seconds,
+                spawn_failed=True,
+                stdout="",
+                stderr="",
+                details={"cwd": request.repo_path},
+            )
+            return ExecutorResult(
+                delegation_id=request.delegation_id,
+                task_id=request.task_id,
+                status=DelegationJobStatus.FAILED.value,
+                summary=failure.message,
+                final_text="",
+                result={
+                    **base_metadata,
+                    "files_changed": [],
+                    "commands_run": [],
+                    "raw_transcript": "",
+                    "parsed_output": {},
+                    "failure": failure.to_dict(),
+                    "timed_out": False,
+                    "cancelled": False,
+                },
+                metadata={**base_metadata, "spawn_failed": True},
+                failure=failure,
+                error_message=failure.message,
+            )
+
+        assert proc.stdout is not None
+        assert proc.stderr is not None
+
+        def _record_chunk(stream: str, raw_line: str) -> None:
+            nonlocal sequence
+            text = raw_line.rstrip("\r\n")
+            if not text:
+                return
+            with lock:
+                chunk = ExecutorStreamChunk(
+                    stream=stream,
+                    text=text,
+                    sequence=sequence,
+                )
+                sequence += 1
+                stream_events.append(chunk)
+                if stream == "stdout":
+                    stdout_chunks.append(raw_line)
+                else:
+                    stderr_chunks.append(raw_line)
+                transcript_chunks.append(f"[{stream}] {raw_line}")
+            if on_output is not None:
+                try:
+                    on_output(chunk)
+                except Exception:
+                    logger.exception("[codex-executor] output callback failed")
+
+        def _read_stream(stream: Any, stream_name: str) -> None:
+            try:
+                while True:
+                    raw_line = stream.readline()
+                    if raw_line == "":
+                        break
+                    _record_chunk(stream_name, raw_line)
+            finally:
+                try:
+                    stream.close()
+                except Exception:
+                    pass
+
+        stdout_thread = threading.Thread(
+            target=_read_stream,
+            args=(proc.stdout, "stdout"),
+            daemon=True,
+        )
+        stderr_thread = threading.Thread(
+            target=_read_stream,
+            args=(proc.stderr, "stderr"),
+            daemon=True,
+        )
+        stdout_thread.start()
+        stderr_thread.start()
+
+        cancelled = False
+        timed_out = False
+        returncode: int | None = None
+        deadline = (
+            time.monotonic() + timeout_seconds
+            if timeout_seconds is not None
+            else None
+        )
+
+        try:
+            while True:
+                if should_stop is not None and should_stop():
+                    cancelled = True
+                    self._terminate_process(proc)
+                    break
+                try:
+                    returncode = proc.wait(timeout=_PROCESS_POLL_SECONDS)
+                    break
+                except subprocess.TimeoutExpired:
+                    if deadline is not None and time.monotonic() >= deadline:
+                        timed_out = True
+                        self._terminate_process(proc)
+                        break
+
+            if returncode is None:
+                try:
+                    returncode = proc.wait(timeout=_TERMINATION_GRACE_SECONDS)
+                except subprocess.TimeoutExpired:
+                    timed_out = True
+                    self._kill_process(proc)
+                    returncode = proc.poll()
+
+            stdout_thread.join(timeout=_TERMINATION_GRACE_SECONDS)
+            stderr_thread.join(timeout=_TERMINATION_GRACE_SECONDS)
+        except Exception as exc:
+            self._kill_process(proc)
+            stdout_thread.join(timeout=_TERMINATION_GRACE_SECONDS)
+            stderr_thread.join(timeout=_TERMINATION_GRACE_SECONDS)
+            failure = ExecutorFailure(
+                error_code=ErrorCode.DELEGATION_EXECUTOR_SPAWN_FAILED.value,
+                failure_class=exc.__class__.__name__,
+                message=str(exc),
+                binary=executable,
+                command=command,
+                timeout_seconds=timeout_seconds,
+                spawn_failed=True,
+                stdout="".join(stdout_chunks),
+                stderr="".join(stderr_chunks),
+                details={"cwd": request.repo_path},
+            )
+            return ExecutorResult(
+                delegation_id=request.delegation_id,
+                task_id=request.task_id,
+                status=DelegationJobStatus.FAILED.value,
+                summary=failure.message,
+                final_text="".join(stdout_chunks).strip(),
+                stdout="".join(stdout_chunks),
+                stderr="".join(stderr_chunks),
+                raw_transcript="".join(transcript_chunks),
+                result={
+                    **base_metadata,
+                    "files_changed": [],
+                    "commands_run": [],
+                    "raw_transcript": "".join(transcript_chunks),
+                    "parsed_output": {},
+                    "failure": failure.to_dict(),
+                    "timed_out": False,
+                    "cancelled": False,
+                },
+                metadata={**base_metadata, "spawn_failed": True},
+                failure=failure,
+                error_message=failure.message,
+            )
+
+        stdout_text = "".join(stdout_chunks)
+        stderr_text = "".join(stderr_chunks)
+        raw_transcript = "".join(transcript_chunks)
+        final_text = (
+            _normalize_text(stdout_text)
+            or _normalize_text(stderr_text)
+            or _normalize_text(raw_transcript)
+        )
+        parsed = _split_structured_lines(final_text or raw_transcript)
+        files_changed = _normalize_text_list(parsed.get("files_changed"))
+        commands_run = _normalize_text_list(parsed.get("commands_run"))
+        signal = (
+            abs(returncode)
+            if isinstance(returncode, int) and returncode < 0
+            else None
+        )
+
+        failure: ExecutorFailure | None = None
+        status = DelegationJobStatus.COMPLETED.value
+        error_message: str | None = None
+        if cancelled:
+            status = DelegationJobStatus.CANCELLED.value
+            error_message = "codex execution cancelled"
+        elif timed_out:
+            status = DelegationJobStatus.FAILED.value
+            error_message = (
+                f"Codex execution timed out after {timeout_seconds}s"
+            )
+            failure = ExecutorFailure(
+                error_code=ErrorCode.DELEGATION_EXECUTOR_TIMEOUT.value,
+                failure_class="TimeoutExpired",
+                message=error_message,
+                binary=executable,
+                command=command,
+                returncode=returncode,
+                signal=signal,
+                timeout_seconds=timeout_seconds,
+                timed_out=True,
+                stdout=stdout_text,
+                stderr=stderr_text,
+                details={"cwd": request.repo_path},
+            )
+        elif returncode not in (None, 0):
+            status = DelegationJobStatus.FAILED.value
+            error_message = f"Codex exited with code {returncode}"
+            failure = ExecutorFailure(
+                error_code=ErrorCode.DELEGATION_EXECUTOR_NONZERO_EXIT.value,
+                failure_class="NonZeroExit",
+                message=error_message,
+                binary=executable,
+                command=command,
+                returncode=returncode,
+                signal=signal,
+                timeout_seconds=timeout_seconds,
+                stdout=stdout_text,
+                stderr=stderr_text,
+                details={"cwd": request.repo_path},
+            )
+
+        result_payload = {
+            **base_metadata,
+            "returncode": returncode,
+            "signal": signal,
+            "timed_out": timed_out,
+            "cancelled": cancelled,
+            "files_changed": files_changed,
+            "commands_run": commands_run,
+            "final_text": final_text,
+            "stdout": stdout_text,
+            "stderr": stderr_text,
+            "raw_transcript": raw_transcript,
+            "parsed_output": parsed,
+            "output_chunks": [chunk.to_dict() for chunk in stream_events],
+            "failure": failure.to_dict() if failure is not None else None,
+        }
+        metadata = {
+            **base_metadata,
+            "returncode": returncode,
+            "signal": signal,
+            "timed_out": timed_out,
+            "cancelled": cancelled,
+            "stdout_line_count": len(stdout_chunks),
+            "stderr_line_count": len(stderr_chunks),
+            "raw_transcript_length": len(raw_transcript),
+        }
+        if failure is not None:
+            metadata["failure"] = failure.to_dict()
+
+        return ExecutorResult(
+            delegation_id=request.delegation_id,
+            task_id=request.task_id,
+            status=status,
+            summary=final_text or error_message,
+            final_text=final_text,
+            stdout=stdout_text,
+            stderr=stderr_text,
+            raw_transcript=raw_transcript,
+            files_changed=files_changed,
+            commands_run=commands_run,
+            output_chunks=stream_events,
+            result=result_payload,
+            metadata=metadata,
+            failure=failure,
+            error_message=error_message,
+            created_at=_utc_now_iso(),
+            completed_at=_utc_now_iso(),
+        )
+
+    @staticmethod
+    def _terminate_process(proc: subprocess.Popen[str]) -> None:
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+
+    @staticmethod
+    def _kill_process(proc: subprocess.Popen[str]) -> None:
+        try:
+            proc.kill()
+        except Exception:
+            pass
+
+
+__all__ = ["CodexExecutor"]

--- a/guardian/protocol_tokens.py
+++ b/guardian/protocol_tokens.py
@@ -29,6 +29,13 @@ class DelegationJobStatus(str, Enum):
     CANCELLED = "cancelled"
 
 
+DELEGATION_SUMMARY_OUTCOME_TYPE = "task_summary"
+
+
+class DelegationExecutorName(str, Enum):
+    CODEX = "codex"
+
+
 class DelegationEventType(str, Enum):
     CREATED = "delegation.created"
     RUNNING = "delegation.running"
@@ -45,6 +52,10 @@ class ErrorCode(str, Enum):
     CHAT_COMPLETE_TASK_CREATED_EVENT_FAILED = (
         "CHAT_COMPLETE_TASK_CREATED_EVENT_FAILED"
     )
+    DELEGATION_EXECUTOR_NOT_FOUND = "DELEGATION_EXECUTOR_NOT_FOUND"
+    DELEGATION_EXECUTOR_TIMEOUT = "DELEGATION_EXECUTOR_TIMEOUT"
+    DELEGATION_EXECUTOR_NONZERO_EXIT = "DELEGATION_EXECUTOR_NONZERO_EXIT"
+    DELEGATION_EXECUTOR_SPAWN_FAILED = "DELEGATION_EXECUTOR_SPAWN_FAILED"
 
 
 class EmbeddingLifecycleStatus(str, Enum):
@@ -62,6 +73,9 @@ TASK_EVENT_TYPES: frozenset[str] = frozenset(
 )
 DELEGATION_JOB_STATUSES: frozenset[str] = frozenset(
     {status.value for status in DelegationJobStatus}
+)
+DELEGATION_EXECUTOR_NAMES: frozenset[str] = frozenset(
+    {executor.value for executor in DelegationExecutorName}
 )
 DELEGATION_EVENT_TYPES: frozenset[str] = frozenset(
     {event_type.value for event_type in DelegationEventType}
@@ -91,12 +105,15 @@ __all__ = [
     "AcceptanceStatus",
     "TaskEventType",
     "DelegationJobStatus",
+    "DELEGATION_SUMMARY_OUTCOME_TYPE",
+    "DelegationExecutorName",
     "DelegationEventType",
     "ErrorCode",
     "EmbeddingLifecycleStatus",
     "ACCEPTANCE_STATUSES",
     "TASK_EVENT_TYPES",
     "DELEGATION_JOB_STATUSES",
+    "DELEGATION_EXECUTOR_NAMES",
     "DELEGATION_EVENT_TYPES",
     "DELEGATION_TERMINAL_STATUSES",
     "DELEGATION_TERMINAL_EVENT_TYPES",

--- a/guardian/tasks/types.py
+++ b/guardian/tasks/types.py
@@ -8,7 +8,10 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Type
 
-from guardian.protocol_tokens import DelegationJobStatus
+from guardian.protocol_tokens import (
+    DELEGATION_SUMMARY_OUTCOME_TYPE,
+    DelegationJobStatus,
+)
 
 
 def _utc_now_iso() -> str:
@@ -55,6 +58,12 @@ def _coerce_optional_text(raw: Any) -> str | None:
     return value or None
 
 
+def _coerce_optional_raw_text(raw: Any) -> str | None:
+    if raw is None:
+        return None
+    return str(raw)
+
+
 def _coerce_text_list(raw: Any) -> list[str]:
     if raw is None:
         return []
@@ -67,6 +76,14 @@ def _coerce_text_list(raw: Any) -> list[str]:
         return result
     value = str(raw).strip()
     return [value] if value else []
+
+
+def _coerce_deduped_text_list(raw: Any) -> list[str]:
+    result: list[str] = []
+    for item in _coerce_text_list(raw):
+        if item not in result:
+            result.append(item)
+    return result
 
 
 def _coerce_mapping(raw: Any) -> dict[str, Any]:
@@ -108,7 +125,7 @@ class DelegationDraftRequest:
             user_intent=str(
                 payload.get("user_intent") or payload.get("task_prompt") or ""
             ).strip(),
-            tags=_coerce_text_list(payload.get("tags")),
+            tags=_coerce_deduped_text_list(payload.get("tags")),
             context=_coerce_mapping(
                 payload.get("context")
                 or payload.get("thread_context")
@@ -157,7 +174,7 @@ class DelegationPacket:
             task_prompt=str(
                 payload.get("task_prompt") or payload.get("user_intent") or ""
             ).strip(),
-            tags=_coerce_text_list(payload.get("tags")),
+            tags=_coerce_deduped_text_list(payload.get("tags")),
             context=_coerce_mapping(
                 payload.get("context")
                 or payload.get("thread_context")
@@ -175,32 +192,112 @@ class DelegationSummary:
     delegation_id: str = ""
     task_id: str = ""
     status: str = DelegationJobStatus.COMPLETED.value
+    outcome_type: str = DELEGATION_SUMMARY_OUTCOME_TYPE
+    title: str | None = None
     summary: str | None = None
+    files_changed: list[str] = field(default_factory=list)
+    commands_run: list[str] = field(default_factory=list)
+    key_changes: list[str] = field(default_factory=list)
+    unresolved_questions: list[str] = field(default_factory=list)
+    tags: list[str] = field(default_factory=list)
     result: dict[str, Any] = field(default_factory=dict)
     metadata: dict[str, Any] = field(default_factory=dict)
+    raw_transcript: str | None = None
+    transcript: str | None = None
+    failure: dict[str, Any] | None = None
     error_message: str | None = None
     created_at: str = field(default_factory=_utc_now_iso)
     completed_at: str = field(default_factory=_utc_now_iso)
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        payload = asdict(self)
+        payload["files_changed"] = _coerce_deduped_text_list(
+            payload.get("files_changed")
+        )
+        payload["commands_run"] = _coerce_deduped_text_list(
+            payload.get("commands_run")
+        )
+        payload["key_changes"] = _coerce_deduped_text_list(
+            payload.get("key_changes")
+        )
+        payload["unresolved_questions"] = _coerce_deduped_text_list(
+            payload.get("unresolved_questions")
+        )
+        payload["tags"] = _coerce_deduped_text_list(payload.get("tags"))
+        payload["delegationId"] = self.delegation_id
+        payload["taskId"] = self.task_id
+        payload["outcomeType"] = self.outcome_type
+        payload["filesChanged"] = list(self.files_changed)
+        payload["commandsRun"] = list(self.commands_run)
+        payload["keyChanges"] = list(self.key_changes)
+        payload["unresolvedQuestions"] = list(self.unresolved_questions)
+        payload["rawTranscript"] = self.raw_transcript
+        payload["errorMessage"] = self.error_message
+        payload["createdAt"] = self.created_at
+        payload["completedAt"] = self.completed_at
+        return payload
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> DelegationSummary:
         payload = payload or {}
+        files_changed = _coerce_deduped_text_list(
+            payload.get("files_changed") or payload.get("filesChanged")
+        )
+        commands_run = _coerce_deduped_text_list(
+            payload.get("commands_run") or payload.get("commandsRun")
+        )
+        key_changes = _coerce_deduped_text_list(
+            payload.get("key_changes") or payload.get("keyChanges")
+        )
+        unresolved_questions = _coerce_deduped_text_list(
+            payload.get("unresolved_questions")
+            or payload.get("unresolvedQuestions")
+        )
+        tags = _coerce_deduped_text_list(payload.get("tags"))
         return cls(
-            delegation_id=str(payload.get("delegation_id") or "").strip(),
-            task_id=str(payload.get("task_id") or "").strip(),
+            delegation_id=str(
+                payload.get("delegation_id")
+                or payload.get("delegationId")
+                or ""
+            ).strip(),
+            task_id=str(
+                payload.get("task_id") or payload.get("taskId") or ""
+            ).strip(),
             status=_status_text(
                 payload.get("status"),
                 DelegationJobStatus.COMPLETED.value,
             ),
+            outcome_type=_status_text(
+                payload.get("outcome_type") or payload.get("outcomeType"),
+                DELEGATION_SUMMARY_OUTCOME_TYPE,
+            ),
+            title=_coerce_optional_text(payload.get("title")),
             summary=_coerce_optional_text(payload.get("summary")),
+            files_changed=files_changed,
+            commands_run=commands_run,
+            key_changes=key_changes,
+            unresolved_questions=unresolved_questions,
+            tags=tags,
             result=_coerce_mapping(payload.get("result")),
             metadata=_coerce_mapping(payload.get("metadata")),
+            raw_transcript=_coerce_optional_raw_text(
+                payload.get("raw_transcript") or payload.get("rawTranscript")
+            ),
+            transcript=_coerce_optional_text(payload.get("transcript")),
+            failure=_coerce_mapping(payload.get("failure"))
+            if payload.get("failure") is not None
+            else None,
             error_message=_coerce_optional_text(payload.get("error_message")),
-            created_at=str(payload.get("created_at") or _utc_now_iso()),
-            completed_at=str(payload.get("completed_at") or _utc_now_iso()),
+            created_at=str(
+                payload.get("created_at")
+                or payload.get("createdAt")
+                or _utc_now_iso()
+            ),
+            completed_at=str(
+                payload.get("completed_at")
+                or payload.get("completedAt")
+                or _utc_now_iso()
+            ),
         )
 
 
@@ -383,7 +480,7 @@ class DelegationTask(BaseTask):
             task_prompt=str(
                 payload.get("task_prompt") or payload.get("user_intent") or ""
             ).strip(),
-            tags=_coerce_text_list(payload.get("tags")),
+            tags=_coerce_deduped_text_list(payload.get("tags")),
             context=_coerce_mapping(
                 payload.get("context")
                 or payload.get("thread_context")

--- a/guardian/workers/delegation_worker.py
+++ b/guardian/workers/delegation_worker.py
@@ -1,4 +1,4 @@
-"""Stub worker for queued delegation tasks."""
+"""Worker for queued delegation tasks."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ from guardian.core.delegation_service import (
     DelegationNotFoundError,
     DelegationService,
 )
+from guardian.core.executors.base import ExecutorRequest, ExecutorResult
 from guardian.protocol_tokens import DelegationEventType, DelegationJobStatus
 from guardian.queue import task_events
 from guardian.queue.redis_queue import clear_cancelled, dequeue, is_cancelled
@@ -68,7 +69,7 @@ def process_delegation_task(
     *,
     service: DelegationService | None = None,
 ) -> dict[str, Any]:
-    """Process a queued delegation task with a stub executor result."""
+    """Process a queued delegation task through the Codex executor."""
 
     svc = service or _service
     job = svc.get_job(task.delegation_id)
@@ -84,8 +85,10 @@ def process_delegation_task(
                 cancellation_payload = {
                     "delegation_id": task.delegation_id,
                     "task_id": task.task_id,
+                    "packet_id": job.packet_id,
                     "status": DelegationJobStatus.CANCELLED.value,
                     "reason": "cancelled_before_execution",
+                    "event_name": DelegationEventType.CANCELLED.value,
                 }
                 _safe_publish(
                     task.task_id,
@@ -96,11 +99,18 @@ def process_delegation_task(
                 cancelled.job,
                 status=DelegationJobStatus.CANCELLED.value,
                 summary="Delegation cancelled before execution.",
-                result={"mode": "stub", "cancelled": True},
+                result={
+                    "cancelled": True,
+                    "reason": "cancelled_before_execution",
+                    "packet_id": job.packet_id,
+                    "task_id": task.task_id,
+                },
                 metadata={
                     "delegation_id": task.delegation_id,
                     "task_id": task.task_id,
-                    "executor": task.executor,
+                    "executor": job.executor,
+                    "repo_path": job.repo_path,
+                    "tags": list(job.tags),
                 },
                 error_message="cancelled_before_execution",
             )
@@ -115,12 +125,15 @@ def process_delegation_task(
                 running_job.status,
             )
             return running_job.to_dict()
+
         running_payload = {
             "delegation_id": task.delegation_id,
             "task_id": task.task_id,
+            "packet_id": job.packet_id,
             "status": DelegationJobStatus.RUNNING.value,
-            "executor": task.executor,
-            "repo_path": task.repo_path,
+            "executor": job.executor,
+            "repo_path": job.repo_path,
+            "event_name": DelegationEventType.RUNNING.value,
         }
         _safe_publish(
             task.task_id,
@@ -128,27 +141,56 @@ def process_delegation_task(
             running_payload,
         )
 
-        progress_payload = {
-            "delegation_id": task.delegation_id,
-            "task_id": task.task_id,
-            "status": DelegationJobStatus.RUNNING.value,
-            "progress": 50,
-            "message": "Delegation worker stub in progress.",
-        }
-        _safe_publish(
-            task.task_id,
-            DelegationEventType.PROGRESS.value,
-            progress_payload,
+        executor = svc.resolve_executor(job.executor)
+        request = ExecutorRequest(
+            delegation_id=task.delegation_id,
+            task_id=task.task_id,
+            repo_path=job.repo_path,
+            executor=job.executor,
+            task_prompt=job.task_prompt,
+            context=dict(job.context),
+            tags=list(job.tags),
+            thread_id=job.thread_id,
+            project_id=job.project_id,
         )
 
-        if is_cancelled(task.task_id):
+        def _publish_progress(chunk: Any) -> None:
+            if not getattr(chunk, "text", "").strip():
+                return
+            progress_payload = {
+                "delegation_id": task.delegation_id,
+                "task_id": task.task_id,
+                "packet_id": job.packet_id,
+                "status": DelegationJobStatus.RUNNING.value,
+                "event_name": DelegationEventType.PROGRESS.value,
+                "stream": getattr(chunk, "stream", "stdout"),
+                "sequence": getattr(chunk, "sequence", None),
+                "message": chunk.text,
+                "text": chunk.text,
+            }
+            _safe_publish(
+                task.task_id,
+                DelegationEventType.PROGRESS.value,
+                progress_payload,
+            )
+
+        executor_result: ExecutorResult = executor.execute(
+            request,
+            on_output=_publish_progress,
+            should_stop=lambda: is_cancelled(task.task_id),
+        )
+
+        if executor_result.status == DelegationJobStatus.CANCELLED.value:
             cancelled = svc.cancel_delegation(task.delegation_id)
             if cancelled.changed:
                 cancellation_payload = {
                     "delegation_id": task.delegation_id,
                     "task_id": task.task_id,
+                    "packet_id": job.packet_id,
                     "status": DelegationJobStatus.CANCELLED.value,
-                    "reason": "cancelled_during_execution",
+                    "reason": executor_result.error_message
+                    or "cancelled_during_execution",
+                    "event_name": DelegationEventType.CANCELLED.value,
                 }
                 _safe_publish(
                     task.task_id,
@@ -158,33 +200,47 @@ def process_delegation_task(
             summary = svc.build_summary_packet(
                 cancelled.job,
                 status=DelegationJobStatus.CANCELLED.value,
-                summary="Delegation cancelled during execution.",
-                result={"mode": "stub", "cancelled": True},
+                summary=executor_result.summary
+                or "Delegation cancelled during execution.",
+                result=executor_result.to_dict(),
                 metadata={
                     "delegation_id": task.delegation_id,
                     "task_id": task.task_id,
-                    "executor": task.executor,
+                    "executor": job.executor,
+                    "repo_path": job.repo_path,
+                    "tags": list(job.tags),
+                    "executor_failure": (
+                        executor_result.failure.to_dict()
+                        if executor_result.failure is not None
+                        else None
+                    ),
                 },
-                error_message="cancelled_during_execution",
+                error_message=executor_result.error_message
+                or "cancelled_during_execution",
             )
             return summary.to_dict()
 
-        summary = svc.build_summary_packet(
+        summary = svc.normalize_executor_result(
             running_job,
-            status=DelegationJobStatus.COMPLETED.value,
-            summary="Delegation worker stub completed.",
-            result={
-                "mode": "stub",
-                "delegation_id": task.delegation_id,
-                "task_id": task.task_id,
-                "packet_id": task.packet_id,
-            },
-            metadata={
-                "executor": task.executor,
-                "repo_path": task.repo_path,
-                "tags": list(task.tags),
-            },
+            executor_result,
+            packet=svc.get_packet(job.packet_id),
         )
+        if executor_result.status == DelegationJobStatus.FAILED.value:
+            svc.mark_job_failed(
+                task.delegation_id,
+                error_message=summary.error_message
+                or executor_result.error_message
+                or "delegation_failed",
+                summary=summary,
+            )
+            failed_payload = summary.to_dict()
+            _safe_publish(
+                task.task_id,
+                DelegationEventType.FAILED.value,
+                failed_payload,
+            )
+            return failed_payload
+
         svc.mark_job_completed(task.delegation_id, summary=summary)
         completed_payload = summary.to_dict()
         _safe_publish(
@@ -193,6 +249,47 @@ def process_delegation_task(
             completed_payload,
         )
         return completed_payload
+    except Exception as exc:
+        logger.exception(
+            "[delegation-worker] unexpected executor failure delegation_id=%s task_id=%s",
+            task.delegation_id,
+            task.task_id,
+        )
+        summary = svc.build_summary_packet(
+            job,
+            status=DelegationJobStatus.FAILED.value,
+            summary=str(exc),
+            result={
+                "failure": {
+                    "error_code": "DELEGATION_EXECUTOR_SPAWN_FAILED",
+                    "failure_class": exc.__class__.__name__,
+                    "message": str(exc),
+                },
+                "task_id": task.task_id,
+                "packet_id": job.packet_id,
+                "executor": job.executor,
+            },
+            metadata={
+                "delegation_id": task.delegation_id,
+                "task_id": task.task_id,
+                "executor": job.executor,
+                "repo_path": job.repo_path,
+                "tags": list(job.tags),
+            },
+            error_message=str(exc),
+        )
+        svc.mark_job_failed(
+            task.delegation_id,
+            error_message=str(exc),
+            summary=summary,
+        )
+        failed_payload = summary.to_dict()
+        _safe_publish(
+            task.task_id,
+            DelegationEventType.FAILED.value,
+            failed_payload,
+        )
+        return failed_payload
     finally:
         clear_cancelled(task.task_id)
 

--- a/tests/contracts/test_protocol_tokens.py
+++ b/tests/contracts/test_protocol_tokens.py
@@ -1,7 +1,9 @@
 from guardian.protocol_tokens import (
     ACCEPTANCE_STATUSES,
     DELEGATION_EVENT_TYPES,
+    DELEGATION_EXECUTOR_NAMES,
     DELEGATION_JOB_STATUSES,
+    DELEGATION_SUMMARY_OUTCOME_TYPE,
     DELEGATION_TERMINAL_EVENT_TYPES,
     DELEGATION_TERMINAL_STATUSES,
     EMBEDDING_LIFECYCLE_STATUSES,
@@ -9,6 +11,7 @@ from guardian.protocol_tokens import (
     TASK_EVENT_TYPES,
     AcceptanceStatus,
     DelegationEventType,
+    DelegationExecutorName,
     DelegationJobStatus,
     EmbeddingLifecycleStatus,
     ErrorCode,
@@ -51,6 +54,11 @@ def test_delegation_status_tokens() -> None:
     }
 
 
+def test_delegation_executor_tokens() -> None:
+    assert DelegationExecutorName.CODEX.value == "codex"
+    assert DELEGATION_EXECUTOR_NAMES == {"codex"}
+
+
 def test_delegation_event_tokens() -> None:
     assert DelegationEventType.CREATED.value == "delegation.created"
     assert DelegationEventType.RUNNING.value == "delegation.running"
@@ -79,12 +87,36 @@ def test_error_code_tokens() -> None:
         ErrorCode.CHAT_COMPLETE_TASK_CREATED_EVENT_FAILED.value
         == "CHAT_COMPLETE_TASK_CREATED_EVENT_FAILED"
     )
+    assert (
+        ErrorCode.DELEGATION_EXECUTOR_NOT_FOUND.value
+        == "DELEGATION_EXECUTOR_NOT_FOUND"
+    )
+    assert (
+        ErrorCode.DELEGATION_EXECUTOR_TIMEOUT.value
+        == "DELEGATION_EXECUTOR_TIMEOUT"
+    )
+    assert (
+        ErrorCode.DELEGATION_EXECUTOR_NONZERO_EXIT.value
+        == "DELEGATION_EXECUTOR_NONZERO_EXIT"
+    )
+    assert (
+        ErrorCode.DELEGATION_EXECUTOR_SPAWN_FAILED.value
+        == "DELEGATION_EXECUTOR_SPAWN_FAILED"
+    )
     assert ERROR_CODES == {
         "QUEUE_ENQUEUE_FAILED",
         "CHAT_COMPLETE_ENQUEUE_FAILED",
         "TASK_EVENT_PUBLISH_FAILED",
         "CHAT_COMPLETE_TASK_CREATED_EVENT_FAILED",
+        "DELEGATION_EXECUTOR_NOT_FOUND",
+        "DELEGATION_EXECUTOR_TIMEOUT",
+        "DELEGATION_EXECUTOR_NONZERO_EXIT",
+        "DELEGATION_EXECUTOR_SPAWN_FAILED",
     }
+
+
+def test_delegation_summary_outcome_token() -> None:
+    assert DELEGATION_SUMMARY_OUTCOME_TYPE == "task_summary"
 
 
 def test_embedding_lifecycle_tokens() -> None:

--- a/tests/core/test_codex_executor.py
+++ b/tests/core/test_codex_executor.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+from dataclasses import dataclass
+from typing import Any
+
+from guardian.core.executors.base import ExecutorRequest
+from guardian.core.executors.codex_executor import CodexExecutor
+from guardian.protocol_tokens import DelegationJobStatus, ErrorCode
+
+
+@dataclass
+class FakeProcess:
+    stdout_text: str = ""
+    stderr_text: str = ""
+    configured_returncode: int = 0
+    raise_timeout: bool = False
+
+    def __post_init__(self) -> None:
+        self.stdout = io.StringIO(self.stdout_text)
+        self.stderr = io.StringIO(self.stderr_text)
+        self.returncode: int | None = None
+        self.terminated = False
+        self.killed = False
+        self.command: list[str] | None = None
+
+    def wait(self, timeout: float | None = None) -> int:
+        _ = timeout
+        if self.raise_timeout and not self.terminated and not self.killed:
+            raise subprocess.TimeoutExpired(
+                cmd=self.command or ["codex"],
+                timeout=timeout,
+            )
+        if self.returncode is None:
+            self.returncode = self.configured_returncode
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminated = True
+        if self.returncode is None:
+            self.returncode = -15
+
+    def kill(self) -> None:
+        self.killed = True
+        if self.returncode is None:
+            self.returncode = -9
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+
+def _request() -> ExecutorRequest:
+    return ExecutorRequest(
+        delegation_id="delegation-1",
+        task_id="task-1",
+        repo_path="/workspace/codexify",
+        executor="codex",
+        task_prompt="Return a structured task summary.",
+        context={"thread_id": 42},
+        tags=["backend", "delegation"],
+        thread_id=42,
+        project_id=9,
+    )
+
+
+def test_codex_executor_success_returns_structured_result(monkeypatch) -> None:
+    stdout_payload = json.dumps(
+        {
+            "outcomeType": "task_summary",
+            "summary": "Codex normalized the delegation lane.",
+            "files_changed": ["guardian/core/delegation_service.py"],
+            "commands_run": ["pytest -v tests/core/test_codex_executor.py"],
+        }
+    )
+    fake_process = FakeProcess(
+        stdout_text=f"{stdout_payload}\n",
+        stderr_text="codex: using local workspace\n",
+        configured_returncode=0,
+    )
+    popen_calls: list[tuple[list[str], dict[str, Any]]] = []
+
+    monkeypatch.setattr(
+        "guardian.core.executors.codex_executor.shutil.which",
+        lambda _binary: "/usr/bin/codex",
+    )
+
+    def fake_popen(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        popen_calls.append((list(cmd), dict(kwargs)))
+        fake_process.command = list(cmd)
+        return fake_process
+
+    monkeypatch.setattr(
+        "guardian.core.executors.codex_executor.subprocess.Popen",
+        fake_popen,
+    )
+
+    executor = CodexExecutor(timeout_seconds=30)
+    chunks: list[Any] = []
+    result = executor.execute(_request(), on_output=chunks.append)
+
+    assert popen_calls
+    assert popen_calls[0][0] == [
+        "codex",
+        "exec",
+        "Return a structured task summary.",
+    ]
+    assert result.status == DelegationJobStatus.COMPLETED.value
+    assert result.summary == stdout_payload
+    assert result.final_text == stdout_payload
+    assert result.files_changed == ["guardian/core/delegation_service.py"]
+    assert result.commands_run == [
+        "pytest -v tests/core/test_codex_executor.py"
+    ]
+    assert result.raw_transcript
+    assert "[stdout]" in result.raw_transcript
+    assert "[stderr]" in result.raw_transcript
+    assert chunks and chunks[0].stream == "stdout"
+    assert result.result["parsed_output"]["summary"] == (
+        "Codex normalized the delegation lane."
+    )
+
+
+def test_codex_executor_missing_binary_becomes_not_found(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "guardian.core.executors.codex_executor.shutil.which",
+        lambda _binary: None,
+    )
+
+    executor = CodexExecutor(timeout_seconds=30)
+    result = executor.execute(_request())
+
+    assert result.status == DelegationJobStatus.FAILED.value
+    assert result.failure is not None
+    assert (
+        result.failure.error_code
+        == ErrorCode.DELEGATION_EXECUTOR_NOT_FOUND.value
+    )
+    assert result.failure.failure_class == "FileNotFoundError"
+    assert result.error_message == "Codex binary not found: codex"
+
+
+def test_codex_executor_timeout_becomes_timeout_failure(monkeypatch) -> None:
+    fake_process = FakeProcess(
+        stdout_text="working\n",
+        configured_returncode=0,
+        raise_timeout=True,
+    )
+    monotonic_values = iter([0.0, 0.2, 0.4, 0.6, 0.8])
+
+    monkeypatch.setattr(
+        "guardian.core.executors.codex_executor.shutil.which",
+        lambda _binary: "/usr/bin/codex",
+    )
+    monkeypatch.setattr(
+        "guardian.core.executors.codex_executor.time.monotonic",
+        lambda: next(monotonic_values),
+    )
+
+    def fake_popen(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        fake_process.command = list(cmd)
+        return fake_process
+
+    monkeypatch.setattr(
+        "guardian.core.executors.codex_executor.subprocess.Popen",
+        fake_popen,
+    )
+
+    executor = CodexExecutor(timeout_seconds=0.1)
+    result = executor.execute(_request())
+
+    assert result.status == DelegationJobStatus.FAILED.value
+    assert result.failure is not None
+    assert (
+        result.failure.error_code == ErrorCode.DELEGATION_EXECUTOR_TIMEOUT.value
+    )
+    assert result.failure.timed_out is True
+    assert result.error_message == "Codex execution timed out after 0.1s"
+
+
+def test_codex_executor_nonzero_exit_becomes_failure(monkeypatch) -> None:
+    fake_process = FakeProcess(
+        stdout_text="partial output\n",
+        stderr_text="codex exited\n",
+        configured_returncode=17,
+    )
+    monkeypatch.setattr(
+        "guardian.core.executors.codex_executor.shutil.which",
+        lambda _binary: "/usr/bin/codex",
+    )
+
+    def fake_popen(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        fake_process.command = list(cmd)
+        return fake_process
+
+    monkeypatch.setattr(
+        "guardian.core.executors.codex_executor.subprocess.Popen",
+        fake_popen,
+    )
+
+    executor = CodexExecutor(timeout_seconds=30)
+    result = executor.execute(_request())
+
+    assert result.status == DelegationJobStatus.FAILED.value
+    assert result.failure is not None
+    assert (
+        result.failure.error_code
+        == ErrorCode.DELEGATION_EXECUTOR_NONZERO_EXIT.value
+    )
+    assert result.failure.returncode == 17
+    assert result.error_message == "Codex exited with code 17"
+
+
+def test_codex_executor_spawn_failure_becomes_spawn_failure(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "guardian.core.executors.codex_executor.shutil.which",
+        lambda _binary: "/usr/bin/codex",
+    )
+
+    def fake_popen(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        raise OSError("boom")
+
+    monkeypatch.setattr(
+        "guardian.core.executors.codex_executor.subprocess.Popen",
+        fake_popen,
+    )
+
+    executor = CodexExecutor(timeout_seconds=30)
+    result = executor.execute(_request())
+
+    assert result.status == DelegationJobStatus.FAILED.value
+    assert result.failure is not None
+    assert (
+        result.failure.error_code
+        == ErrorCode.DELEGATION_EXECUTOR_SPAWN_FAILED.value
+    )
+    assert result.failure.failure_class == "OSError"
+    assert result.error_message == "boom"

--- a/tests/core/test_delegation_service.py
+++ b/tests/core/test_delegation_service.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
+import json
+
 from guardian.core.delegation_service import DelegationService
-from guardian.protocol_tokens import DelegationJobStatus
+from guardian.core.executors.base import ExecutorResult
+from guardian.core.executors.codex_executor import CodexExecutor
+from guardian.protocol_tokens import (
+    DELEGATION_SUMMARY_OUTCOME_TYPE,
+    DelegationExecutorName,
+    DelegationJobStatus,
+)
 from guardian.tasks.types import DelegationDraftRequest
 
 
@@ -11,9 +19,9 @@ def _request() -> DelegationDraftRequest:
         conversation_id="conversation-7",
         project_id=9,
         repo_path="/workspace/codexify",
-        executor="stub",
+        executor=DelegationExecutorName.CODEX.value,
         user_intent="Map the delegation lane end-to-end.",
-        tags=["backend", "delegation"],
+        tags=["backend", "backend", "delegation"],
         context={"thread_subject": "delegation slice"},
     )
 
@@ -29,7 +37,7 @@ def test_draft_packet_construction() -> None:
     assert packet.conversation_id == "conversation-7"
     assert packet.project_id == 9
     assert packet.repo_path == "/workspace/codexify"
-    assert packet.executor == "stub"
+    assert packet.executor == DelegationExecutorName.CODEX.value
     assert packet.task_prompt == "Map the delegation lane end-to-end."
     assert packet.tags == ["backend", "delegation"]
     assert packet.context == {"thread_subject": "delegation slice"}
@@ -46,6 +54,7 @@ def test_approval_creates_job_and_enqueue_payload() -> None:
     assert approval.job.packet_id == packet.packet_id
     assert approval.job.delegation_id
     assert approval.job.status == DelegationJobStatus.APPROVED.value
+    assert approval.job.executor == DelegationExecutorName.CODEX.value
     assert approval.job.approved_at is not None
     assert approval.task.type == "delegation.task"
     assert approval.task.task_id == approval.job.task_id
@@ -55,9 +64,117 @@ def test_approval_creates_job_and_enqueue_payload() -> None:
     assert approval.task.task_prompt == packet.task_prompt
     assert approval.task.context == packet.context
 
+    executor = service.resolve_executor(approval.job.executor)
+    assert isinstance(executor, CodexExecutor)
+
     queued_job = service.mark_job_queued(approval.job.delegation_id)
     assert queued_job.status == DelegationJobStatus.QUEUED.value
     assert queued_job.queued_at is not None
+
+
+def test_canonical_summary_normalization_from_expected_final_format() -> None:
+    service = DelegationService()
+    packet = service.draft_packet(_request())
+    approval = service.approve_packet(packet.packet_id)
+    service.mark_job_queued(approval.job.delegation_id)
+
+    final_text = json.dumps(
+        {
+            "outcomeType": "task_summary",
+            "title": "Ignored in favor of packet prompt",
+            "summary": "Codex completed the delegation lane.",
+            "files_changed": [
+                "guardian/core/delegation_service.py",
+                "guardian/workers/delegation_worker.py",
+            ],
+            "commands_run": [
+                "pytest -v tests/core/test_codex_executor.py",
+            ],
+            "key_changes": [
+                "streamed Codex output",
+                "normalized terminal summary",
+            ],
+            "unresolved_questions": [],
+            "tags": ["backend", "backend", "codex"],
+        }
+    )
+    executor_result = ExecutorResult(
+        delegation_id=approval.job.delegation_id,
+        task_id=approval.job.task_id,
+        status=DelegationJobStatus.COMPLETED.value,
+        summary=final_text,
+        final_text=final_text,
+        stdout=final_text,
+        raw_transcript=f"[stdout] {final_text}\n",
+        result={
+            "tags": ["delegation", "backend", "delegation"],
+            "raw_transcript": f"[stdout] {final_text}\n",
+        },
+        metadata={
+            "executor": DelegationExecutorName.CODEX.value,
+            "repo_path": packet.repo_path,
+            "tags": ["backend", "delegation", "delegation"],
+        },
+    )
+
+    summary = service.normalize_executor_result(
+        approval.job,
+        executor_result,
+        packet=packet,
+    )
+
+    assert summary.outcome_type == DELEGATION_SUMMARY_OUTCOME_TYPE
+    assert summary.title == approval.job.task_prompt
+    assert summary.summary == "Codex completed the delegation lane."
+    assert summary.files_changed == [
+        "guardian/core/delegation_service.py",
+        "guardian/workers/delegation_worker.py",
+    ]
+    assert summary.commands_run == [
+        "pytest -v tests/core/test_codex_executor.py"
+    ]
+    assert summary.key_changes == [
+        "streamed Codex output",
+        "normalized terminal summary",
+    ]
+    assert summary.unresolved_questions == []
+    assert summary.tags == ["backend", "delegation", "codex"]
+    assert summary.raw_transcript == f"[stdout] {final_text}\n"
+    assert summary.result["failure"] is None
+    assert summary.metadata["executor"] == DelegationExecutorName.CODEX.value
+
+
+def test_summary_normalization_falls_back_to_raw_final_text() -> None:
+    service = DelegationService()
+    packet = service.draft_packet(_request())
+    approval = service.approve_packet(packet.packet_id)
+
+    final_text = "Codex output without structure"
+    executor_result = ExecutorResult(
+        delegation_id=approval.job.delegation_id,
+        task_id=approval.job.task_id,
+        status=DelegationJobStatus.COMPLETED.value,
+        summary=final_text,
+        final_text=final_text,
+        stdout=final_text,
+        raw_transcript=final_text,
+        metadata={"tags": ["delegation", "delegation"]},
+    )
+
+    summary = service.normalize_executor_result(
+        approval.job,
+        executor_result,
+        packet=packet,
+    )
+
+    assert summary.title == approval.job.task_prompt
+    assert summary.summary == final_text
+    assert summary.files_changed == []
+    assert summary.commands_run == []
+    assert summary.key_changes == []
+    assert summary.unresolved_questions == []
+    assert summary.tags == ["backend", "delegation"]
+    assert summary.outcome_type == DELEGATION_SUMMARY_OUTCOME_TYPE
 
 
 def test_canonical_summary_shape_defaults() -> None:
@@ -71,7 +188,14 @@ def test_canonical_summary_shape_defaults() -> None:
     assert summary.delegation_id == approval.job.delegation_id
     assert summary.task_id == approval.job.task_id
     assert summary.status == DelegationJobStatus.COMPLETED.value
+    assert summary.outcome_type == DELEGATION_SUMMARY_OUTCOME_TYPE
+    assert summary.title == approval.job.task_prompt
     assert summary.summary is None
+    assert summary.files_changed == []
+    assert summary.commands_run == []
+    assert summary.key_changes == []
+    assert summary.unresolved_questions == []
+    assert summary.tags == ["backend", "delegation"]
     assert summary.result == {}
     assert summary.metadata == {}
     assert summary.error_message is None

--- a/tests/routes/test_delegations_routes.py
+++ b/tests/routes/test_delegations_routes.py
@@ -4,7 +4,11 @@ from typing import Any
 
 import pytest
 
-from guardian.protocol_tokens import DelegationEventType, DelegationJobStatus
+from guardian.protocol_tokens import (
+    DelegationEventType,
+    DelegationExecutorName,
+    DelegationJobStatus,
+)
 from guardian.routes import delegations
 
 
@@ -21,7 +25,7 @@ def _draft_payload() -> dict[str, Any]:
         "conversation_id": "thread-17",
         "project_id": 3,
         "repo_path": "/workspace/codexify",
-        "executor": "stub",
+        "executor": DelegationExecutorName.CODEX.value,
         "user_intent": "Build the delegation lane backend slice.",
         "tags": ["backend", "delegation"],
         "context": {"thread_title": "Delegation slice"},
@@ -39,6 +43,7 @@ def test_delegation_draft_creation(test_client) -> None:
     assert packet["thread_id"] == 17
     assert packet["task_prompt"] == "Build the delegation lane backend slice."
     assert packet["tags"] == ["backend", "delegation"]
+    assert packet["executor"] == DelegationExecutorName.CODEX.value
 
 
 def test_delegation_approve_creates_queued_task_and_returns_ids(
@@ -107,6 +112,7 @@ def test_delegation_approve_creates_queued_task_and_returns_ids(
     assert job is not None
     assert job.status == DelegationJobStatus.QUEUED.value
     assert job.task_id == body["task_id"]
+    assert job.executor == DelegationExecutorName.CODEX.value
 
 
 def test_delegation_cancel_marks_terminal_state(

--- a/tests/workers/test_delegation_worker.py
+++ b/tests/workers/test_delegation_worker.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 from typing import Any
 
 from guardian.core.delegation_service import DelegationService
-from guardian.protocol_tokens import DelegationEventType, DelegationJobStatus
+from guardian.core.executors.base import (
+    ExecutorFailure,
+    ExecutorResult,
+    ExecutorStreamChunk,
+)
+from guardian.protocol_tokens import (
+    DelegationEventType,
+    DelegationExecutorName,
+    DelegationJobStatus,
+    ErrorCode,
+)
 from guardian.tasks.types import DelegationDraftRequest
 from guardian.workers import delegation_worker
 
@@ -14,8 +24,8 @@ def _request() -> DelegationDraftRequest:
         conversation_id="conversation-11",
         project_id=4,
         repo_path="/workspace/codexify",
-        executor="stub",
-        user_intent="Validate the delegation worker stub.",
+        executor=DelegationExecutorName.CODEX.value,
+        user_intent="Validate the delegation worker Codex path.",
         tags=["worker", "delegation"],
         context={"source": "test"},
     )
@@ -29,29 +39,70 @@ def _make_service() -> tuple[DelegationService, Any]:
     return service, approval
 
 
-def test_worker_publishes_running_completed_lifecycle(monkeypatch) -> None:
+def test_worker_publishes_running_progress_completed_lifecycle(
+    monkeypatch,
+) -> None:
     service, approval = _make_service()
 
     published: list[tuple[str, str, dict[str, Any]]] = []
 
-    def fake_publish(task_id, event_type, data):
-        published.append((task_id, event_type, dict(data or {})))
-        return {
-            "ok": True,
-            "task_id": task_id,
-            "event_type": event_type,
-            "visibility_scope": "progress",
-            "terminal_visibility": False,
-            "execution_continued": True,
-            "event_id": f"evt-{len(published)}",
-        }
+    class FakeExecutor:
+        def execute(self, request, *, on_output=None, should_stop=None):  # type: ignore[no-untyped-def]
+            if on_output is not None:
+                on_output(
+                    ExecutorStreamChunk(
+                        stream="stdout",
+                        text="Analyzing workspace",
+                        sequence=0,
+                    )
+                )
+                on_output(
+                    ExecutorStreamChunk(
+                        stream="stdout",
+                        text="Files changed: guardian/workers/delegation_worker.py",
+                        sequence=1,
+                    )
+                )
+            return ExecutorResult(
+                delegation_id=request.delegation_id,
+                task_id=request.task_id,
+                status=DelegationJobStatus.COMPLETED.value,
+                summary="Codex completed delegation.",
+                final_text="Codex completed delegation.",
+                stdout="Analyzing workspace\nFiles changed: guardian/workers/delegation_worker.py\n",
+                raw_transcript=(
+                    "[stdout] Analyzing workspace\n"
+                    "[stdout] Files changed: guardian/workers/delegation_worker.py\n"
+                ),
+                files_changed=["guardian/workers/delegation_worker.py"],
+                commands_run=[
+                    "pytest -v tests/workers/test_delegation_worker.py"
+                ],
+                metadata={"executor": DelegationExecutorName.CODEX.value},
+            )
 
     monkeypatch.setattr(delegation_worker, "is_cancelled", lambda *_: False)
     monkeypatch.setattr(delegation_worker, "clear_cancelled", lambda *_: None)
     monkeypatch.setattr(
         delegation_worker.task_events,
         "publish_with_visibility",
-        fake_publish,
+        lambda task_id, event_type, data: (
+            published.append((task_id, event_type, dict(data or {})))
+            or {
+                "ok": True,
+                "task_id": task_id,
+                "event_type": event_type,
+                "visibility_scope": "progress",
+                "terminal_visibility": False,
+                "execution_continued": True,
+                "event_id": f"evt-{len(published)}",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        service,
+        "resolve_executor",
+        lambda _name: FakeExecutor(),
     )
 
     result = delegation_worker.process_delegation_task(
@@ -60,39 +111,14 @@ def test_worker_publishes_running_completed_lifecycle(monkeypatch) -> None:
     )
 
     event_types = [event_type for _task_id, event_type, _payload in published]
-    assert event_types == [
-        DelegationEventType.RUNNING.value,
-        DelegationEventType.PROGRESS.value,
-        DelegationEventType.COMPLETED.value,
-    ]
+    assert event_types[0] == DelegationEventType.RUNNING.value
+    assert DelegationEventType.PROGRESS.value in event_types
+    assert event_types[-1] == DelegationEventType.COMPLETED.value
     assert result["status"] == DelegationJobStatus.COMPLETED.value
+    assert result["outcome_type"] == "task_summary"
     assert result["delegation_id"] == approval.job.delegation_id
     assert result["task_id"] == approval.task.task_id
-
-
-def test_worker_stub_result_persists_terminal_state(monkeypatch) -> None:
-    service, approval = _make_service()
-
-    monkeypatch.setattr(delegation_worker, "is_cancelled", lambda *_: False)
-    monkeypatch.setattr(delegation_worker, "clear_cancelled", lambda *_: None)
-    monkeypatch.setattr(
-        delegation_worker.task_events,
-        "publish_with_visibility",
-        lambda task_id, event_type, data: {
-            "ok": True,
-            "task_id": task_id,
-            "event_type": event_type,
-            "visibility_scope": "progress",
-            "terminal_visibility": False,
-            "execution_continued": True,
-            "event_id": "evt",
-        },
-    )
-
-    result = delegation_worker.process_delegation_task(
-        approval.task,
-        service=service,
-    )
+    assert result["files_changed"] == ["guardian/workers/delegation_worker.py"]
 
     job = service.get_job(approval.job.delegation_id)
     summary = service.get_summary(approval.job.delegation_id)
@@ -104,11 +130,98 @@ def test_worker_stub_result_persists_terminal_state(monkeypatch) -> None:
 
     assert summary is not None
     assert summary.status == DelegationJobStatus.COMPLETED.value
-    assert summary.summary == "Delegation worker stub completed."
-    assert summary.result["mode"] == "stub"
-    assert summary.result["packet_id"] == approval.packet.packet_id
-    assert summary.metadata["executor"] == "stub"
-    assert result["status"] == DelegationJobStatus.COMPLETED.value
+    assert summary.summary == "Codex completed delegation."
+    assert summary.files_changed == ["guardian/workers/delegation_worker.py"]
+    assert summary.commands_run == [
+        "pytest -v tests/workers/test_delegation_worker.py"
+    ]
+    assert summary.metadata["executor"] == DelegationExecutorName.CODEX.value
+
+
+def test_worker_publishes_terminal_failed_state_on_executor_failure(
+    monkeypatch,
+) -> None:
+    service, approval = _make_service()
+
+    published: list[tuple[str, str, dict[str, Any]]] = []
+
+    class FailingExecutor:
+        def execute(self, request, *, on_output=None, should_stop=None):  # type: ignore[no-untyped-def]
+            return ExecutorResult(
+                delegation_id=request.delegation_id,
+                task_id=request.task_id,
+                status=DelegationJobStatus.FAILED.value,
+                summary="Codex binary not found: codex",
+                final_text="",
+                stdout="",
+                raw_transcript="",
+                failure=ExecutorFailure(
+                    error_code=ErrorCode.DELEGATION_EXECUTOR_NOT_FOUND.value,
+                    failure_class="FileNotFoundError",
+                    message="Codex binary not found: codex",
+                    binary="codex",
+                    command=["codex", "exec", request.task_prompt],
+                    timeout_seconds=900,
+                    details={"cwd": request.repo_path},
+                ),
+                error_message="Codex binary not found: codex",
+                metadata={"executor": DelegationExecutorName.CODEX.value},
+            )
+
+    monkeypatch.setattr(delegation_worker, "is_cancelled", lambda *_: False)
+    monkeypatch.setattr(delegation_worker, "clear_cancelled", lambda *_: None)
+    monkeypatch.setattr(
+        delegation_worker.task_events,
+        "publish_with_visibility",
+        lambda task_id, event_type, data: (
+            published.append((task_id, event_type, dict(data or {})))
+            or {
+                "ok": True,
+                "task_id": task_id,
+                "event_type": event_type,
+                "visibility_scope": "progress",
+                "terminal_visibility": False,
+                "execution_continued": True,
+                "event_id": f"evt-{len(published)}",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        service,
+        "resolve_executor",
+        lambda _name: FailingExecutor(),
+    )
+
+    result = delegation_worker.process_delegation_task(
+        approval.task,
+        service=service,
+    )
+
+    event_types = [event_type for _task_id, event_type, _payload in published]
+    assert DelegationEventType.FAILED.value in event_types
+    assert result["status"] == DelegationJobStatus.FAILED.value
+    assert (
+        result["failure"]["error_code"]
+        == ErrorCode.DELEGATION_EXECUTOR_NOT_FOUND.value
+    )
+
+    job = service.get_job(approval.job.delegation_id)
+    summary = service.get_summary(approval.job.delegation_id)
+
+    assert job is not None
+    assert job.status == DelegationJobStatus.FAILED.value
+    assert job.completed_at is not None
+    assert job.error_message == "Codex binary not found: codex"
+
+    assert summary is not None
+    assert summary.status == DelegationJobStatus.FAILED.value
+    assert summary.summary == "Codex binary not found: codex"
+    assert summary.failure is not None
+    assert (
+        summary.failure["error_code"]
+        == ErrorCode.DELEGATION_EXECUTOR_NOT_FOUND.value
+    )
+    assert summary.error_message == "Codex binary not found: codex"
 
 
 def test_worker_short_circuits_when_job_is_already_terminal(
@@ -119,24 +232,23 @@ def test_worker_short_circuits_when_job_is_already_terminal(
 
     published: list[tuple[str, str, dict[str, Any]]] = []
 
-    def fake_publish(task_id, event_type, data):
-        published.append((task_id, event_type, dict(data or {})))
-        return {
-            "ok": True,
-            "task_id": task_id,
-            "event_type": event_type,
-            "visibility_scope": "progress",
-            "terminal_visibility": False,
-            "execution_continued": True,
-            "event_id": f"evt-{len(published)}",
-        }
-
     monkeypatch.setattr(delegation_worker, "is_cancelled", lambda *_: False)
     monkeypatch.setattr(delegation_worker, "clear_cancelled", lambda *_: None)
     monkeypatch.setattr(
         delegation_worker.task_events,
         "publish_with_visibility",
-        fake_publish,
+        lambda task_id, event_type, data: (
+            published.append((task_id, event_type, dict(data or {})))
+            or {
+                "ok": True,
+                "task_id": task_id,
+                "event_type": event_type,
+                "visibility_scope": "progress",
+                "terminal_visibility": False,
+                "execution_continued": True,
+                "event_id": f"evt-{len(published)}",
+            }
+        ),
     )
 
     result = delegation_worker.process_delegation_task(


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
