### PR TITLE
Document personal-facts runtime proof gap in architecture notes

### DIFF
--- a/docs/architecture/2026-04-07-personal-facts-route-runtime-proof.md
+++ b/docs/architecture/2026-04-07-personal-facts-route-runtime-proof.md
@@ -148,7 +148,7 @@ Observed consequence:
 
 ## Verdict
 
-`mounted but blocked by auth/config`
+`inconclusive`
 
 ## Blocker Classification
 

--- a/frontend/src/features/chat/ChatView.tsx
+++ b/frontend/src/features/chat/ChatView.tsx
@@ -22,7 +22,6 @@ import type {
   StreamingDraft,
 } from "@/features/chat/useChat";
 import { cn } from "@/lib/utils";
-import { useChatAutoScroll } from "@/features/chat/hooks/useChatAutoScroll";
 import { parseDocumentContextContent } from "@/lib/documentContext";
 import {
   createIdleInferenceRequestState,

--- a/guardian/core/pgdb.py
+++ b/guardian/core/pgdb.py
@@ -25,9 +25,14 @@ from psycopg import errors as pg_errors
 from psycopg.rows import dict_row
 from psycopg.types.json import Json
 from sqlalchemy import create_engine, inspect
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 
-from guardian.db.models import EventOutbox
+from guardian.db.models import (
+    EventOutbox,
+    PersonalFact,
+    PersonalFactEvidence,
+    PersonalFactRevision,
+)
 
 from .chat_db import ChatDB
 from .default_project import (
@@ -1659,6 +1664,267 @@ class PgDB(ChatDB):
                 cur.execute(query, params)
                 rows = cur.fetchall()
                 return [dict(row) for row in rows]
+
+    # ---- personal facts --------------------------------------------------
+    def _fact_to_dict(self, fact: PersonalFact) -> dict[str, Any]:
+        return {
+            "id": fact.id,
+            "user_id": fact.user_id,
+            "key": fact.key,
+            "value": fact.value,
+            "status": fact.status,
+            "confidence": fact.confidence,
+            "is_active": fact.is_active,
+            "last_confirmed_at": (
+                fact.last_confirmed_at.isoformat()
+                if fact.last_confirmed_at
+                else None
+            ),
+            "created_at": (
+                fact.created_at.isoformat() if fact.created_at else None
+            ),
+            "updated_at": (
+                fact.updated_at.isoformat() if fact.updated_at else None
+            ),
+        }
+
+    def _evidence_to_dict(
+        self, evidence: PersonalFactEvidence
+    ) -> dict[str, Any]:
+        return {
+            "id": evidence.id,
+            "fact_id": evidence.fact_id,
+            "source_message_id": evidence.source_message_id,
+            "excerpt": evidence.excerpt,
+            "modality": evidence.modality,
+            "confidence": evidence.confidence,
+            "source_type": evidence.source_type,
+            "evidence_meta": evidence.evidence_meta,
+            "created_at": (
+                evidence.created_at.isoformat() if evidence.created_at else None
+            ),
+        }
+
+    def _revision_to_dict(
+        self, revision: PersonalFactRevision
+    ) -> dict[str, Any]:
+        return {
+            "id": revision.id,
+            "fact_id": revision.fact_id,
+            "actor": revision.actor,
+            "action": revision.action,
+            "field_changed": revision.field_changed,
+            "old_value": revision.old_value,
+            "new_value": revision.new_value,
+            "reason": revision.reason,
+            "created_at": (
+                revision.created_at.isoformat() if revision.created_at else None
+            ),
+        }
+
+    def list_facts(
+        self,
+        user_id: str,
+        status: str | None = None,
+        active_only: bool = True,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        with self._sa_session() as session:
+            query = session.query(PersonalFact).filter_by(user_id=user_id)
+            if status:
+                query = query.filter_by(status=status)
+            if active_only:
+                query = query.filter_by(is_active=True)
+            facts = (
+                query.order_by(PersonalFact.updated_at.desc())
+                .limit(limit)
+                .all()
+            )
+            return [self._fact_to_dict(fact) for fact in facts]
+
+    def create_fact(
+        self,
+        user_id: str,
+        key: str,
+        value: str,
+        status: str = "candidate",
+        confidence: float = 0.5,
+    ) -> int:
+        with self._sa_session() as session:
+            fact = PersonalFact(
+                user_id=user_id,
+                key=key,
+                value=value,
+                status=status,
+                confidence=confidence,
+                is_active=True,
+            )
+            session.add(fact)
+            session.flush()
+            return int(fact.id)
+
+    def get_fact(self, fact_id: int) -> dict[str, Any] | None:
+        with self._sa_session() as session:
+            fact = session.query(PersonalFact).filter_by(id=fact_id).first()
+            if not fact:
+                return None
+            return self._fact_to_dict(fact)
+
+    def _add_fact_revision(
+        self,
+        session: Session,
+        *,
+        fact_id: int,
+        actor: str,
+        action: str,
+        field_changed: str | None = None,
+        old_value: str | None = None,
+        new_value: str | None = None,
+        reason: str | None = None,
+    ) -> None:
+        revision = PersonalFactRevision(
+            fact_id=fact_id,
+            actor=actor,
+            action=action,
+            field_changed=field_changed,
+            old_value=old_value,
+            new_value=new_value,
+            reason=reason,
+        )
+        session.add(revision)
+
+    def update_fact(
+        self,
+        fact_id: int,
+        *,
+        value: str | None = None,
+        status: str | None = None,
+        confidence: float | None = None,
+        actor: str = "system",
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        with self._sa_session() as session:
+            fact = session.query(PersonalFact).filter_by(id=fact_id).first()
+            if not fact:
+                raise ValueError(f"Fact {fact_id} not found")
+
+            if value is not None and value != fact.value:
+                self._add_fact_revision(
+                    session,
+                    fact_id=fact.id,
+                    actor=actor,
+                    action="value_updated",
+                    field_changed="value",
+                    old_value=fact.value,
+                    new_value=value,
+                    reason=reason,
+                )
+                fact.value = value
+
+            if status is not None and status != fact.status:
+                self._add_fact_revision(
+                    session,
+                    fact_id=fact.id,
+                    actor=actor,
+                    action="status_updated",
+                    field_changed="status",
+                    old_value=fact.status,
+                    new_value=status,
+                    reason=reason,
+                )
+                fact.status = status
+                if status == "verified":
+                    fact.last_confirmed_at = datetime.now(timezone.utc)
+
+            if confidence is not None and confidence != fact.confidence:
+                self._add_fact_revision(
+                    session,
+                    fact_id=fact.id,
+                    actor=actor,
+                    action="confidence_updated",
+                    field_changed="confidence",
+                    old_value=str(fact.confidence),
+                    new_value=str(confidence),
+                    reason=reason,
+                )
+                fact.confidence = confidence
+
+            fact.updated_at = datetime.now(timezone.utc)
+            session.add(fact)
+            return self._fact_to_dict(fact)
+
+    def confirm_fact(
+        self,
+        fact_id: int,
+        *,
+        actor: str = "system",
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        return self.update_fact(
+            fact_id,
+            status="verified",
+            actor=actor,
+            reason=reason,
+        )
+
+    def dispute_fact(
+        self,
+        fact_id: int,
+        *,
+        actor: str = "system",
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        return self.update_fact(
+            fact_id,
+            status="disputed",
+            actor=actor,
+            reason=reason,
+        )
+
+    def list_fact_evidence(self, fact_id: int) -> list[dict[str, Any]]:
+        with self._sa_session() as session:
+            evidence = (
+                session.query(PersonalFactEvidence)
+                .filter_by(fact_id=fact_id)
+                .order_by(PersonalFactEvidence.created_at.asc())
+                .all()
+            )
+            return [self._evidence_to_dict(row) for row in evidence]
+
+    def add_fact_evidence(
+        self,
+        fact_id: int,
+        source_message_id: int | None,
+        excerpt: str | None,
+        *,
+        modality: str = "text",
+        confidence: float = 0.5,
+        source_type: str = "runtime_extraction",
+        evidence_meta: dict[str, Any] | None = None,
+    ) -> int:
+        with self._sa_session() as session:
+            evidence = PersonalFactEvidence(
+                fact_id=fact_id,
+                source_message_id=source_message_id,
+                excerpt=excerpt,
+                modality=modality,
+                confidence=confidence,
+                source_type=source_type,
+                evidence_meta=evidence_meta or {},
+            )
+            session.add(evidence)
+            session.flush()
+            return int(evidence.id)
+
+    def get_fact_revisions(self, fact_id: int) -> list[dict[str, Any]]:
+        with self._sa_session() as session:
+            revisions = (
+                session.query(PersonalFactRevision)
+                .filter_by(fact_id=fact_id)
+                .order_by(PersonalFactRevision.created_at.desc())
+                .all()
+            )
+            return [self._revision_to_dict(row) for row in revisions]
 
     # ---- connector sync jobs ---------------------------------------------
     def ensure_sync_job_support(self) -> None:

--- a/guardian/tests/test_personal_facts_runtime_routes.py
+++ b/guardian/tests/test_personal_facts_runtime_routes.py
@@ -1,0 +1,191 @@
+"""Runtime checks for the mounted personal-facts routes."""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.engine import make_url
+
+import guardian.guardian_api as guardian_api
+import guardian.routes.personal_facts as personal_facts
+from guardian.core import dependencies
+from guardian.core.chatlog_postgres import PostgresChatLogDB
+
+
+def _resolve_api_key() -> str:
+    api_key = (
+        getattr(dependencies, "API_KEY", "")
+        or os.getenv("GUARDIAN_API_KEY")
+        or ""
+    ).strip()
+    if not api_key:
+        pytest.skip(
+            "GUARDIAN_API_KEY is not configured for runtime route tests"
+        )
+    return api_key
+
+
+def _resolve_runtime_db_url() -> str:
+    for env_name in (
+        "TEST_DATABASE_URL",
+        "GUARDIAN_DATABASE_URL",
+        "DATABASE_URL",
+    ):
+        db_url = (os.getenv(env_name) or "").strip()
+        if db_url:
+            return db_url
+
+    runtime_db = getattr(guardian_api, "chatlog_db", None) or getattr(
+        dependencies, "chatlog_db", None
+    )
+    db_url = (
+        getattr(runtime_db, "dsn", None)
+        or getattr(runtime_db, "db_url", None)
+        or ""
+    ).strip()
+    if not db_url:
+        pytest.skip("No Postgres runtime DSN is available for route tests")
+
+    try:
+        parsed = make_url(db_url)
+        if parsed.host == "db":
+            parsed = parsed.set(host="127.0.0.1", port=5433)
+        return parsed.render_as_string(hide_password=False)
+    except Exception:
+        return db_url
+
+
+@pytest.fixture
+def runtime_personal_facts_client(monkeypatch):
+    api_key = _resolve_api_key()
+    db_url = _resolve_runtime_db_url()
+    runtime_db = PostgresChatLogDB(db_url)
+    user_id = f"runtime-personal-facts-{uuid4().hex}"
+
+    monkeypatch.setenv("GUARDIAN_API_KEY", api_key)
+    monkeypatch.setenv("GUARDIAN_AUTH_MODE", "local")
+    monkeypatch.setenv("GUARDIAN_EXPOSURE_MODE", "local_safe")
+    monkeypatch.setenv("CODEXIFY_SINGLE_USER_ID", user_id)
+    monkeypatch.setattr(dependencies, "chatlog_db", runtime_db, raising=False)
+    monkeypatch.setattr(dependencies, "init_database", lambda: runtime_db)
+    monkeypatch.setattr(guardian_api, "chatlog_db", runtime_db, raising=False)
+    monkeypatch.setattr(personal_facts, "chatlog_db", runtime_db, raising=False)
+
+    client = TestClient(
+        guardian_api.app,
+        raise_server_exceptions=False,
+    )
+    headers = {"X-API-Key": api_key}
+    try:
+        yield client, headers, user_id
+    finally:
+        client.close()
+
+
+def _create_runtime_fact(
+    client: TestClient, headers: dict[str, str]
+) -> dict[str, object]:
+    suffix = uuid4().hex
+    payload = {
+        "key": f"runtime-fact-{suffix}",
+        "value": f"runtime-value-{suffix}",
+        "status": "candidate",
+        "confidence": 0.5,
+    }
+    response = client.post("/personal-facts", headers=headers, json=payload)
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["ok"] is True
+    assert isinstance(data["id"], int)
+    return {"id": data["id"], "payload": payload}
+
+
+def test_runtime_personal_facts_list_create_and_get(
+    runtime_personal_facts_client,
+):
+    client, headers, user_id = runtime_personal_facts_client
+    created = _create_runtime_fact(client, headers)
+    fact_id = int(created["id"])
+    payload = created["payload"]
+
+    list_response = client.get("/personal-facts", headers=headers)
+    assert list_response.status_code == 200, list_response.text
+    list_data = list_response.json()
+    assert list_data["ok"] is True
+    assert any(fact["id"] == fact_id for fact in list_data["facts"])
+
+    detail_response = client.get(f"/personal-facts/{fact_id}", headers=headers)
+    assert detail_response.status_code == 200, detail_response.text
+    detail_data = detail_response.json()
+    assert detail_data["ok"] is True
+    assert detail_data["fact"]["id"] == fact_id
+    assert detail_data["fact"]["user_id"] == user_id
+    assert detail_data["fact"]["key"] == payload["key"]
+    assert detail_data["fact"]["value"] == payload["value"]
+
+
+def test_runtime_personal_fact_confirm_dispute_evidence_and_revisions(
+    runtime_personal_facts_client,
+):
+    client, headers, _user_id = runtime_personal_facts_client
+    created = _create_runtime_fact(client, headers)
+    fact_id = int(created["id"])
+
+    confirm_response = client.post(
+        f"/personal-facts/{fact_id}/confirm",
+        headers=headers,
+        json={"reason": "runtime seam verification"},
+    )
+    assert confirm_response.status_code == 200, confirm_response.text
+    confirm_data = confirm_response.json()
+    assert confirm_data["ok"] is True
+    assert confirm_data["fact"]["status"] == "verified"
+
+    dispute_response = client.post(
+        f"/personal-facts/{fact_id}/dispute",
+        headers=headers,
+        json={"reason": "runtime seam verification"},
+    )
+    assert dispute_response.status_code == 200, dispute_response.text
+    dispute_data = dispute_response.json()
+    assert dispute_data["ok"] is True
+    assert dispute_data["fact"]["status"] == "disputed"
+
+    evidence_response = client.post(
+        f"/personal-facts/{fact_id}/evidence",
+        headers=headers,
+        json={
+            "excerpt": "runtime evidence",
+            "source_type": "user_stated",
+        },
+    )
+    assert evidence_response.status_code == 200, evidence_response.text
+    evidence_data = evidence_response.json()
+    assert evidence_data["ok"] is True
+    assert isinstance(evidence_data["id"], int)
+
+    list_evidence_response = client.get(
+        f"/personal-facts/{fact_id}/evidence",
+        headers=headers,
+    )
+    assert (
+        list_evidence_response.status_code == 200
+    ), list_evidence_response.text
+    list_evidence_data = list_evidence_response.json()
+    assert list_evidence_data["ok"] is True
+    assert any(
+        evidence["id"] == evidence_data["id"]
+        for evidence in list_evidence_data["evidence"]
+    )
+
+    revisions_response = client.get(
+        f"/personal-facts/{fact_id}/revisions",
+        headers=headers,
+    )
+    assert revisions_response.status_code == 200, revisions_response.text
+    revisions_data = revisions_response.json()
+    assert revisions_data["ok"] is True
+    assert len(revisions_data["revisions"]) >= 2


### PR DESCRIPTION
## Summary
- Add an architecture proof note for the `personal_facts` route/runtime seam
- Document the exact runtime environment, route exposure, and request outcomes observed in the local stack
- Capture the concrete blocker: the live Postgres chatlog adapter lacks the personal-facts methods the route calls

## Testing
- `docker compose ps`
- `sed -n '1,260p' guardian/routes/personal_facts.py`
- `sed -n '1,220p' guardian/core/chatlog_postgres.py`
- `sed -n '1,220p' guardian/core/db.py`
- `docker compose exec -T backend python -c "from guardian.guardian_api import app; ..."`
- `docker compose exec -T backend python -c "from guardian.guardian_api import app; import json; schema=app.openapi(); ..."`
- `docker compose exec -T backend python - <<'PY' ... PY`
- `docker compose logs --tail=200 backend`