### PR TITLE
Add audit trap and ritual generators with review templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Codexify Makefile
 
-.PHONY: all install dev-install test clean lint lint-fix lint-fix-unsafe format check docs build check-pytest dossier-collab desktop-dev desktop-build daily-audit morning-audit evening-audit audit-risk audit-gates audit-gates-pre-merge audit-gates-pre-release audit-full
+.PHONY: all install dev-install test clean lint lint-fix lint-fix-unsafe format check docs build check-pytest dossier-collab desktop-dev desktop-build daily-audit morning-audit evening-audit audit-risk audit-gates audit-gates-pre-merge audit-gates-pre-release audit-full audit-traps audit-ritual-weekly audit-ritual-monthly audit-ritual-quarterly
 
 # Python executable
 PYTHON      ?= python
@@ -218,6 +218,31 @@ audit-full:
 	$(PYTHON) scripts/audit/risk_matrix.py --delta
 	$(PYTHON) scripts/audit/regression_gates.py
 	@echo "Audit complete. Reports in docs/audits/regression/"
+
+# ────────────────────────────────
+# Pass 2: Heuristic Intelligence
+#
+# Rationale:
+# - Trap detection for preventable patterns
+# - Ritual automation for recurring reviews
+# - All report-only by default
+# ────────────────────────────────
+
+# Detect preventable traps in changed files
+audit-traps:
+	$(PYTHON) scripts/audit/trap_detector.py
+
+# Generate weekly ritual agenda
+audit-ritual-weekly:
+	$(PYTHON) scripts/audit/ritual.py --cadence weekly
+
+# Generate monthly ritual agenda
+audit-ritual-monthly:
+	$(PYTHON) scripts/audit/ritual.py --cadence monthly
+
+# Generate quarterly ritual agenda
+audit-ritual-quarterly:
+	$(PYTHON) scripts/audit/ritual.py --cadence quarterly
 
 # Help target
 help:

--- a/docs/audit-templates/monthly-review.md
+++ b/docs/audit-templates/monthly-review.md
@@ -1,0 +1,220 @@
+# Monthly Architecture Audit
+
+Use this template for the monthly deep-dive architecture audit ritual.
+
+---
+
+## Meeting Info
+
+**Date:** <!-- YYYY-MM-DD -->
+
+**Attendees:**
+
+- <!-- Name (Role) -->
+
+**Duration:** 90 minutes
+
+---
+
+## 1. Risk Matrix Re-scoring (15 min)
+
+### Current Distribution
+<!-- Before scoring -->
+
+| Band | Count |
+|------|-------|
+| Critical | <!-- count --> |
+| High | <!-- count --> |
+| Moderate | <!-- count --> |
+| Low | <!-- count --> |
+| **Total** | <!-- total --> |
+
+### Score Changes This Month
+<!-- List any scores that changed -->
+
+| Risk ID | Old Score | New Score | Delta | Reason |
+|---------|-----------|-----------|-------|--------|
+| <!-- id --> | <!-- old --> | <!-- new --> | <!-- +/- --> | <!-- why --> |
+
+### New Risks Identified
+<!-- Any risks added this month -->
+
+| Risk ID | Area | Initial Score | Source |
+|---------|------|---------------|--------|
+| <!-- id --> | <!-- area --> | <!-- score --> | <!-- incident/discovery --> |
+
+### Risks Deprecated
+<!-- Any risks no longer relevant -->
+
+| Risk ID | Reason for Deprecation |
+|---------|------------------------|
+| <!-- id --> | <!-- why --> |
+
+---
+
+## 2. "Temporary" Shim Review (10 min)
+
+### Shims Still in Place
+<!-- Controls marked as "temporary" or "shim" -->
+
+| Risk ID | Current Control | Age | Decision |
+|---------|-----------------|-----|----------|
+| <!-- id --> | <!-- control --> | <!-- weeks --> | <!-- Keep/Remove/Replace --> |
+
+### Shim Conversion Plan
+<!-- Which shims need to become permanent? -->
+
+- [ ] <!-- Risk ID -->: <!-- action -->
+
+---
+
+## 3. Provider Dependency Drift (10 min)
+
+### Single-Provider Dependencies
+<!-- Check for increasing coupling to one provider -->
+
+| Provider | Components Using | Risk Level |
+|----------|------------------|------------|
+| Anthropic | <!-- count/areas --> | <!-- High/Med/Low --> |
+| OpenAI | <!-- count/areas --> | <!-- High/Med/Low --> |
+| Google | <!-- count/areas --> | <!-- High/Med/Low --> |
+| Local | <!-- count/areas --> | <!-- High/Med/Low --> |
+
+### Adapter Coverage
+<!-- Are all provider-specific patterns covered by adapters? -->
+
+- [ ] All provider code in adapters
+- [ ] Provider-specific error handling centralized
+- [ ] Cross-provider tests passing
+
+---
+
+## 4. Memory Portability Check (10 min)
+
+### Export Path Verification
+<!-- Can we still export all user context? -->
+
+| Data Type | Exportable? | Test Date | Notes |
+|-----------|-------------|-----------|-------|
+| Threads | Y/N | <!-- date --> | <!-- notes --> |
+| Documents | Y/N | <!-- date --> | <!-- notes --> |
+| Embeddings | Y/N | <!-- date --> | <!-- notes --> |
+| Events | Y/N | <!-- date --> | <!-- notes --> |
+
+### Schema Compatibility
+<!-- Any breaking schema changes? -->
+
+- [ ] No breaking changes
+- [ ] Migration provided for: <!-- what -->
+
+---
+
+## 5. Orchestration Debt Review (10 min)
+
+### Retry Pattern Consistency
+<!-- Check for TRAP-8 findings -->
+
+| Subsystem | Retry Strategy | Consistent with Others? |
+|-----------|----------------|-------------------------|
+| <!-- name --> | <!-- strategy --> | Y/N |
+
+### Error Handling Patterns
+<!-- Are error handling patterns consistent? -->
+
+- [ ] Consistent exception hierarchy
+- [ ] Consistent logging patterns
+- [ ] Consistent fallback behavior
+
+### State Machine Formalization
+<!-- Any ad-hoc orchestration that should be formalized? -->
+
+| Flow | Current State | Needs Formalization? |
+|------|---------------|----------------------|
+| <!-- flow name --> | <!-- ad-hoc/formal --> | Y/N |
+
+---
+
+## 6. Observability Gaps (10 min)
+
+### Recent Failures Analysis
+<!-- Can we explain recent failures? -->
+
+| Incident | Root Cause Explained? | Observability Gap? |
+|----------|----------------------|--------------------|
+| <!-- INC-... --> | Y/N | <!-- what was missing --> |
+
+### Trace Coverage
+<!-- End-to-end traces available for key flows? -->
+
+| Flow | Trace ID Present? | Correlation Works? |
+|------|-------------------|--------------------|
+| Chat completion | Y/N | Y/N |
+| Document ingestion | Y/N | Y/N |
+| Tool execution | Y/N | Y/N |
+| Sync/federation | Y/N | Y/N |
+
+---
+
+## 7. Subsystem Count Review (15 min)
+
+### Current Subsystems
+<!-- List all subsystems and their sizes -->
+
+| Subsystem | Files | Complexity | Justified? |
+|-----------|-------|------------|------------|
+| <!-- name --> | <!-- count --> | <!-- High/Med/Low --> | Y/N - explain |
+
+### Merger Candidates
+<!-- Subsystems that could be combined -->
+
+| Candidate 1 | Candidate 2 | Rationale | Effort |
+|-------------|-------------|-----------|--------|
+| <!-- name --> | <!-- name --> | <!-- why --> | <!-- estimate --> |
+
+### Removal Candidates
+<!-- Subsystems that could be removed -->
+
+| Subsystem | Usage | Removal Impact | Effort |
+|-----------|-------|----------------|--------|
+| <!-- name --> | <!-- how used --> | <!-- impact --> | <!-- estimate --> |
+
+### Decision
+<!-- At least one simplification should be identified -->
+
+**Selected simplification:** <!-- what -->
+
+**Owner:** <!-- who -->
+
+**Target completion:** <!-- date -->
+
+---
+
+## Action Items
+
+### This Month
+- [ ] <!-- task --> (Owner: <!-- name -->)
+
+### Next Month
+- [ ] <!-- task --> (Owner: <!-- name -->)
+
+### Next Quarter
+- [ ] Plan migration drill (Owner: <!-- name -->)
+
+---
+
+## Sign-off
+
+| Role | Name | Date |
+|------|------|------|
+| Facilitator | | |
+| Architecture Lead | | |
+| Platform Lead | | |
+| Risk Owners (highest risks) | | |
+
+---
+
+## Appendix: Risk Matrix Snapshot
+
+<!-- Include full risk matrix or link to generated report -->
+
+See: `docs/audits/regression/risk-matrix-*.md`

--- a/docs/audit-templates/weekly-review.md
+++ b/docs/audit-templates/weekly-review.md
@@ -1,0 +1,142 @@
+# Weekly Regression Review
+
+Use this template for the 30-minute weekly regression review ritual.
+
+---
+
+## Meeting Info
+
+**Date:** <!-- YYYY-MM-DD -->
+
+**Attendees:**
+
+- <!-- Name (Role) -->
+
+**Time:** 30 minutes
+
+---
+
+## 1. New Incidents or Near-Misses (5 min)
+
+### Incidents Since Last Week
+<!-- List any incidents or near-misses -->
+
+| Incident ID | Subsystem | Severity | Status |
+|-------------|-----------|----------|--------|
+| <!-- INC-... --> | <!-- name --> | <!-- Critical/High/Med/Low --> | <!-- Open/Closed --> |
+
+### Risk Matrix Updates Required
+<!-- Did any incidents require risk score adjustments? -->
+
+- [ ] No updates needed
+- [ ] Updated: <!-- Risk ID -->
+
+---
+
+## 2. Highest Score Risks (5 min)
+
+### Top 3 Risks Needing Attention
+<!-- From risk matrix -->
+
+1. **<!-- Risk Area -->** (`<!-- ID -->`)
+   - Score: <!-- score -->
+   - Owner: <!-- owner -->
+   - Action needed: <!-- what -->
+
+2. **<!-- Risk Area -->** (`<!-- ID -->`)
+   - Score: <!-- score -->
+   - Owner: <!-- owner -->
+   - Action needed: <!-- what -->
+
+3. **<!-- Risk Area -->** (`<!-- ID -->`)
+   - Score: <!-- score -->
+   - Owner: <!-- owner -->
+   - Action needed: <!-- what -->
+
+---
+
+## 3. Stale Entries (5 min)
+
+### Risks Past Review Interval
+<!-- Risks not reviewed in their interval_days -->
+
+| Risk ID | Area | Days Stale | Owner |
+|---------|------|------------|-------|
+| <!-- id --> | <!-- area --> | <!-- days --> | <!-- owner --> |
+
+### Decisions
+- [ ] Updated review dates
+- [ ] Assigned new owners
+- [ ] Deprecated obsolete risks
+
+---
+
+## 4. Subsystem Complexity Changes (5 min)
+
+### Changes This Week
+<!-- Did any subsystems grow unexpectedly? -->
+
+| Subsystem | Files Changed | Complexity Concern? |
+|-----------|---------------|---------------------|
+| <!-- name --> | <!-- count --> | <!-- Y/N - explain --> |
+
+### Simplification Opportunities
+<!-- Any subsystems that could be merged or reduced? -->
+
+---
+
+## 5. Changes Without Eval Coverage (5 min)
+
+### High-Blast-Radius Changes
+<!-- Any changes that skipped evaluation? -->
+
+| Change | Blast Radius | Eval Coverage | Risk |
+|--------|--------------|---------------|------|
+| <!-- description --> | <!-- radius --> | <!-- coverage --> | <!-- trap? --> |
+
+### Trap Detection Findings
+<!-- Review trap-detector output -->
+
+- [ ] No new traps
+- [ ] Traps detected (see `docs/audits/regression/traps-*.md`)
+
+---
+
+## 6. Simplification Candidate (5 min)
+
+### This Week's Candidate
+<!-- One thing that could be removed or simplified -->
+
+**What:** <!-- description -->
+
+**Why:** <!-- justification -->
+
+**Effort:** <!-- estimate -->
+
+**Owner:** <!-- who would do it -->
+
+---
+
+## Action Items
+
+### Immediate (This Week)
+- [ ] <!-- task --> (Owner: <!-- name -->)
+
+### This Sprint
+- [ ] <!-- task --> (Owner: <!-- name -->)
+
+---
+
+## Sign-off
+
+| Role | Name | Date |
+|------|------|------|
+| Facilitator | | |
+| Risk Owner (highest risk) | | |
+| Architecture Rep | | |
+
+---
+
+## Notes
+
+<!-- Free-form notes from the review -->

--- a/docs/audits/regression/ritual-monthly-20260407-162205.json
+++ b/docs/audits/regression/ritual-monthly-20260407-162205.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e112174473dee7d1b983f99d2b84eeb8e438055d831437625d00c54a5417f728
+size 2313

--- a/docs/audits/regression/ritual-monthly-20260407-162205.md
+++ b/docs/audits/regression/ritual-monthly-20260407-162205.md
@@ -1,0 +1,73 @@
+# Monthly Architecture Audit
+
+**Generated:** 2026-04-07T16:22:05.655819
+
+## Current Metrics
+
+- **Critical Risks:** 16
+- **High Risks:** 2
+- **Total Risks:** 18
+
+## Agenda
+
+### Re-score Risk Matrix (15 min)
+
+**Prompt:** Review and update all 18 risk scores based on current state
+
+**Action:** Update scripts/audit/data/risk_matrix_baseline.json
+
+**Current Band Distribution:**
+- Critical: 16
+- High: 2
+- Moderate: 0
+- Low: 0
+
+### Review 'Temporary' Shims (10 min)
+
+**Prompt:** 0 risks have temporary controls that may be permanent
+
+**Potential Shims:**
+
+**Action:** Convert or document permanent shims
+
+### Provider Dependency Drift (10 min)
+
+**Prompt:** Has dependency on any single provider increased?
+
+**Action:** Check for provider-specific code outside adapters
+
+### Memory Portability Check (10 min)
+
+**Prompt:** Can we still export all user context?
+
+**Action:** Verify export path works for new data types
+
+### Orchestration Debt Review (10 min)
+
+**Prompt:** Have retry/error handling patterns become inconsistent?
+
+**Action:** Review scripts/audit/traps-*.md for TRAP-8 findings
+
+### Observability Gaps (10 min)
+
+**Prompt:** Can we explain recent failures?
+
+**Action:** Review incident log for unexplained issues
+
+### Subsystem Count Review (15 min)
+
+**Prompt:** Are there subsystems that could be merged or removed?
+
+**Action:** Propose at least one simplification
+
+## Action Items
+
+### This Month
+
+- [ ] **Update risk matrix scores** (Owner: Architecture)
+- [ ] **Document or remove temporary shims** (Owner: Platform)
+- [ ] **Verify memory export path** (Owner: Memory)
+
+### Next Month
+
+- [ ] **Plan quarterly migration drill** (Owner: Runtime)

--- a/docs/audits/regression/ritual-weekly-20260407-162205.json
+++ b/docs/audits/regression/ritual-weekly-20260407-162205.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1cc14ca58cc0bf2df3cf6867e8b01d0e8ee30dbf4584dadd3a8ba43407022b73
+size 2155

--- a/docs/audits/regression/ritual-weekly-20260407-162205.md
+++ b/docs/audits/regression/ritual-weekly-20260407-162205.md
@@ -1,0 +1,60 @@
+# Weekly Regression Review (30 minutes)
+
+**Generated:** 2026-04-07T16:22:05.486628
+
+## Summary
+
+- **Total Risks:** 18
+- **Stale Risks:** 0
+- **Critical/High Risks:** 18
+
+## Agenda
+
+### New Incidents or Near-Misses (5 min)
+
+**Prompt:** Review any incidents since last week. Update risk matrix if needed.
+
+**Action:** File incident entries in docs/audits/regression/incidents/
+
+### Highest Score Risks (5 min)
+
+**Prompt:** Review 3 highest risks needing attention
+
+**Risks to Review:**
+- `observability`: Observability (300)
+- `persona-boundaries`: Persona Boundaries (240)
+- `orchestration`: Orchestration (240)
+
+### Stale Entries (5 min)
+
+**Prompt:** 0 risks haven't been reviewed in their interval
+
+**Risks to Review:**
+
+### Subsystem Complexity Changes (5 min)
+
+**Prompt:** Did any subsystems grow unexpectedly this week?
+
+**Action:** Review recent changes for complexity-creep indicators
+
+### Changes Without Full Eval Coverage (5 min)
+
+**Prompt:** Any high-blast-radius changes skip evaluation?
+
+**Action:** Check docs/audits/regression/traps-*.md for findings
+
+### Simplification Candidates (5 min)
+
+**Prompt:** What can be removed or simplified?
+
+**Action:** Identify at least one removal/simplification candidate
+
+## Action Items
+
+### Immediate
+
+
+### This Week
+
+- [ ] **Update controls for Model Routing** (Owner: Platform)
+- [ ] **Update controls for Retrieval** (Owner: Memory)

--- a/docs/audits/regression/ritual-weekly-20260407-163531.json
+++ b/docs/audits/regression/ritual-weekly-20260407-163531.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6aa95c3bf47587487be59292664f50e87a992fa0889e97c605cdd2a9b2b94444
+size 2155

--- a/docs/audits/regression/ritual-weekly-20260407-163531.md
+++ b/docs/audits/regression/ritual-weekly-20260407-163531.md
@@ -1,0 +1,60 @@
+# Weekly Regression Review (30 minutes)
+
+**Generated:** 2026-04-07T16:35:31.199239
+
+## Summary
+
+- **Total Risks:** 18
+- **Stale Risks:** 0
+- **Critical/High Risks:** 18
+
+## Agenda
+
+### New Incidents or Near-Misses (5 min)
+
+**Prompt:** Review any incidents since last week. Update risk matrix if needed.
+
+**Action:** File incident entries in docs/audits/regression/incidents/
+
+### Highest Score Risks (5 min)
+
+**Prompt:** Review 3 highest risks needing attention
+
+**Risks to Review:**
+- `observability`: Observability (300)
+- `persona-boundaries`: Persona Boundaries (240)
+- `orchestration`: Orchestration (240)
+
+### Stale Entries (5 min)
+
+**Prompt:** 0 risks haven't been reviewed in their interval
+
+**Risks to Review:**
+
+### Subsystem Complexity Changes (5 min)
+
+**Prompt:** Did any subsystems grow unexpectedly this week?
+
+**Action:** Review recent changes for complexity-creep indicators
+
+### Changes Without Full Eval Coverage (5 min)
+
+**Prompt:** Any high-blast-radius changes skip evaluation?
+
+**Action:** Check docs/audits/regression/traps-*.md for findings
+
+### Simplification Candidates (5 min)
+
+**Prompt:** What can be removed or simplified?
+
+**Action:** Identify at least one removal/simplification candidate
+
+## Action Items
+
+### Immediate
+
+
+### This Week
+
+- [ ] **Update controls for Model Routing** (Owner: Platform)
+- [ ] **Update controls for Retrieval** (Owner: Memory)

--- a/docs/audits/regression/traps-20260407-162154.json
+++ b/docs/audits/regression/traps-20260407-162154.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0212f7b1d7a23f525fae940f6d6b7cbd10105aafc61664815d28fba31672a7a5
+size 164

--- a/docs/audits/regression/traps-20260407-162154.md
+++ b/docs/audits/regression/traps-20260407-162154.md
@@ -1,0 +1,11 @@
+# Trap Detection Report
+
+**Generated:** 2026-04-07T16:21:54.624406
+
+## Summary
+
+- **Warnings:** 0
+- **Reviews:** 0
+- **Critical Reviews:** 0
+
+✅ No traps detected.

--- a/docs/audits/regression/traps-20260407-163524.json
+++ b/docs/audits/regression/traps-20260407-163524.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63b3ffe7dcb96388f11dd1445d4646a8f89d30fafb79b41c2aad5fd3ab08a705
+size 164

--- a/docs/audits/regression/traps-20260407-163524.md
+++ b/docs/audits/regression/traps-20260407-163524.md
@@ -1,0 +1,11 @@
+# Trap Detection Report
+
+**Generated:** 2026-04-07T16:35:24.153867
+
+## Summary
+
+- **Warnings:** 0
+- **Reviews:** 0
+- **Critical Reviews:** 0
+
+✅ No traps detected.


### PR DESCRIPTION
## Summary
- Added new Makefile targets for trap detection and weekly/monthly/quarterly ritual generation.
- Added reusable weekly and monthly audit review templates under `docs/audit-templates/`.
- Added generated regression audit artifacts for the new ritual and trap runs under `docs/audits/regression/`.

## Testing
- Not run (not requested)