### PR TITLE
Update current-state release override for weekly audit

### DIFF
--- a/docs/architecture/00-current-state.md
+++ b/docs/architecture/00-current-state.md
@@ -1,13 +1,10 @@
 ## Purpose
-
-This file is the canonical short-form source of truth for Codexify's current operational and release state. If it conflicts with older architecture, planning, or roadmap language on short-horizon reality, this file wins.
+This file is Codexify's canonical short-form source of truth for current operational and release state. If it conflicts with older architecture, planning, or roadmap language on short-horizon reality, this file wins.
 
 ## Last updated
-
-2026-04-05
+2026-04-08
 
 ## Interpretation rule
-
 This file is authoritative for:
 - release readiness
 - supported install path
@@ -16,59 +13,49 @@ This file is authoritative for:
 - what is and is not part of the present release promise
 
 ## Current phase
-
-Codexify is in supported-local-beta hardening on `main`. The shipped baseline is still the local Docker Compose stack and supported-profile contract, but `main` now also carries a delegation backbone (draft/approve/cancel/event stream) that is stubbed at execution time. Treat the release as partial delegation plumbing plus the existing chat/ingestion runtime, not a finished autonomous coding-agent product.
+Codexify is in local-beta hardening on `main`. The supported path is still the local Docker Compose stack with a local-only provider policy, while recent merged work tightened startup ingestion and retrieval sharing. Quarantined surfaces remain outside the beta promise.
 
 ## What changed recently
-
-- Delegation runtime docs and operator manual landed on `main`, with validation updated for the new delegation slice.
-- Backend delegation backbone merged: packet draft/approve/cancel routes, persisted packet/job/summary rows, explicit delegation statuses, and task-event reuse for delegation runs.
-- Task lifecycle states and event metadata are now explicit in shared task/protocol tokens; terminal cancel visibility is emitted from the delegation path.
-- Unassigned threads now default to the `General` project, and frontend project controls were aligned with that scope.
-- The web runtime startup path now uses an explicit startup gate, and the ChatGPT import sweep moved off the critical path.
-- Delegation worker migration handling was reanchored so terminal jobs are guarded instead of being reprocessed.
+- Built-in help is now bundled and re-seeded into documents and RAG at backend startup.
+- API and worker retrieval now share one runtime vector store instead of drifting by path.
+- Personal-facts routes were wired into the Postgres chatlog adapter and covered by runtime route tests, but the supported profile still quarantines that surface.
+- Live import catch-up was re-proven on `main`: the embed backlog drained while chat stayed healthy.
+- Frontend-only chat/sidebar polish landed, but it does not change the release contract.
 
 ## Current supported reality
-
-- Local Docker Compose remains the supported install path on `main`.
-- The supported beta profile still uses `CODEXIFY_BETA_CORE_ONLY=true`, `CODEXIFY_LOCAL_ONLY_MODE=true`, and `ALLOW_CLOUD_PROVIDERS=false`.
-- `General` is now the default project for unassigned threads.
-- Delegation can draft, approve, queue, cancel, and stream run events, with packet/job/summary state persisted in Postgres.
-- Delegation execution is still stubbed, so the backbone does not yet prove a real external coding-agent loop.
-- `/health`, `/health/chat`, `/api/health/llm`, and `/api/health/retrieval` remain the main runtime evidence surfaces.
-- The clean-start, existing-instance upgrade, and archived-snapshot proof artifacts are still on `main` as historical evidence.
+- Local Docker Compose remains the supported install path.
+- Supported beta posture is still local-only: `LLM_PROVIDER=local`, `CODEXIFY_LOCAL_ONLY_MODE=true`, `ALLOW_CLOUD_PROVIDERS=false`.
+- Chat acceptance, worker execution, and Postgres persistence remain the core validated loop.
+- Upload -> parse -> embed -> retrieve remains supported, with one shared runtime vector store.
+- Built-in system docs/help are seeded at startup and available to retrieval.
+- The import embed worker can drain a live backlog without breaking chat or health surfaces.
+- `/health`, `/health/chat`, `/api/health/llm`, `/api/health/retrieval`, and `/api/llm/catalog?include=all` remain the primary runtime evidence surfaces.
 
 ## Not yet true / do not assume
-
-- Do not assume delegation can run real external coding-agent work yet; the worker still returns a stub result.
-- Do not assume delegation result injection back into the source thread exists.
-- Do not assume this tip of `main` has a fresh live end-to-end proof after the latest runtime changes.
-- Do not assume older proof docs alone represent the current runtime tip after later merges.
-- Do not assume internal-only or dev-only surfaces are part of the supported beta surface unless this file says so.
+- Do not assume the current tip has been re-proven end-to-end after the latest runtime-adjacent merges.
+- Do not assume `personal_facts` is part of the supported beta surface; the supported profile quarantines it.
+- Do not assume delegation or autonomous coding-agent execution is shipped; the current release promise still excludes that loop.
+- Do not assume internal operator surfaces or quarantined routes represent the supported beta contract.
+- Do not assume older proof docs alone describe the current tip if a newer merge changed runtime wiring.
 
 ## Active blockers
+- Fresh live release evidence on the exact current `main` tip is stale and needs to be rerun.
+- Release signoff still depends on the supported-profile, provider registry, and health surfaces staying aligned.
 
-- Fresh live beta proof on the current `main` tip is still missing after the latest runtime changes.
-- Any release milestone that includes autonomous delegation is blocked; the executor is stubbed and the return path is not shipped.
-- Release signoff still depends on the supported-profile / provider / health contract staying aligned.
-
-## This week's priorities
-
-1. Re-run the supported local Compose beta proof on current `main` and refresh the evidence pack.
-2. Decide whether delegation stays a stubbed internal backbone or needs a real executor and source-thread return path for the next milestone.
-3. Keep the supported-profile, provider registry, and health surfaces aligned before widening any release claim.
-4. Update the KB again only after the next merged proof or runtime change, not local intent.
+## This week’s priorities
+1. Re-run the supported local Compose beta proof on the current `main` tip.
+2. Keep the supported-profile contract, catalog, and health surfaces aligned with the local-only provider posture.
+3. Leave `personal_facts` out of the beta claim unless the supported profile is explicitly changed.
+4. Keep delegation excluded from the shipped promise unless the executor/result-return path is made explicit and proven.
 
 ## Release definition right now
-
 - [ ] Supported-profile flags and mounted routes still match the beta contract.
-- [ ] Fresh live evidence exists on current `main` for clean start, assistant completion, upload -> embed -> retrieve, and health surfaces.
-- [ ] Delegation is either explicitly excluded from the shipped promise or implemented with a real executor plus source-thread result return.
+- [ ] Fresh live evidence exists on the current `main` tip for clean start, assistant completion, upload -> embed -> retrieve, and health surfaces.
+- [ ] The release promise does not include `personal_facts` unless the supported profile is updated.
+- [ ] Delegation is either explicitly excluded or implemented with a real executor plus source-thread result return.
 - [ ] No internal-only or quarantined surface is part of the release claim.
-- [ ] The blockers above are closed or consciously deferred.
 
 ## How to read the rest of the KB
-
 - `system-overview.md` explains structure, not release readiness.
 - `flows.md` explains runtime behavior.
 - `data-and-storage.md` explains persistence/invariants.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,5 +1,5 @@
 Purpose: Provide a KB-first entry point into Codexify's current architecture so humans and AI can orient quickly, find the right source files, and plan changes with an accurate map.
-Last updated: 2026-04-05
+Last updated: 2026-04-08
 Source anchors:
 - docs/architecture/
 - guardian/guardian_api.py


### PR DESCRIPTION
## Summary
- Refresh the canonical current-state doc to reflect the latest `main` reality
- Reframe the release view around the local-only beta path, recent startup/retrieval improvements, and current exclusions
- Update the architecture README timestamp so the KB entry point stays current

## Testing
- Not run (not requested)