### PR TITLE
Codex/trace imprint prompt path

### DIFF
--- a/frontend/src/features/chat/components/ChatBubble.tsx
+++ b/frontend/src/features/chat/components/ChatBubble.tsx
@@ -231,6 +231,35 @@ const normalizeLanguageLabel = (className?: string) => {
   return raw.toUpperCase();
 };
 
+type MarkdownNode = {
+  type?: string;
+  value?: unknown;
+  children?: MarkdownNode[];
+};
+
+const normalizeAssistantProse = (value: string) => {
+  return value
+    .replace(/\$\s*\\rightarrow\s*\$/g, "→")
+    .replace(/\$\s*\\leftarrow\s*\$/g, "←")
+    .replace(/\$\s*\\leftrightarrow\s*\$/g, "↔")
+    .replace(/\$\s*\\to\s*\$/g, "→")
+    .replace(/\\rightarrow/g, "→")
+    .replace(/\\leftarrow/g, "←")
+    .replace(/\\leftrightarrow/g, "↔")
+    .replace(/\\to/g, "→");
+};
+
+const remarkNormalizeAssistantProse = () => (tree: MarkdownNode) => {
+  const walk = (node: MarkdownNode) => {
+    if (node.type === "text" && typeof node.value === "string") {
+      node.value = normalizeAssistantProse(node.value);
+    }
+    node.children?.forEach(walk);
+  };
+
+  walk(tree);
+};
+
 const OVERSIZED_USER_MESSAGE_CHAR_LIMIT = 1200;
 const OVERSIZED_USER_MESSAGE_LINE_LIMIT = 18;
 const COLLAPSED_USER_MESSAGE_MAX_HEIGHT = 224;
@@ -556,7 +585,10 @@ export function ChatBubble({
           wordWrap: "break-word",
         }}
       >
-        <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm, remarkNormalizeAssistantProse]}
+          components={markdownComponents}
+        >
           {assistantContent}
         </ReactMarkdown>
       </div>

--- a/frontend/src/features/chat/components/__tests__/ChatBubble.test.tsx
+++ b/frontend/src/features/chat/components/__tests__/ChatBubble.test.tsx
@@ -200,6 +200,52 @@ describe("ChatBubble", () => {
     expect(screen.getByText("const total = 1;")).toBeInTheDocument();
   });
 
+  it("normalizes TeX-style arrows in assistant prose without breaking markdown", () => {
+    render(
+      <ChatBubble
+        isGuardian
+        message={{
+          id: "msg-6b",
+          authorId: "bot",
+          authorName: "Guardian",
+          content:
+            "**Bold intro**\n\n- First item\n- Second item\n\nUser engages with Persona $\\rightarrow$ User transforms $\\rightarrow$ Project advances",
+          createdAt: Date.now(),
+        }}
+      />
+    );
+
+    expect(screen.getByText("Bold intro")).toBeInTheDocument();
+    expect(screen.getByText("First item")).toBeInTheDocument();
+    expect(screen.getByText("Second item")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "User engages with Persona → User transforms → Project advances"
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/\\rightarrow/)).not.toBeInTheDocument();
+  });
+
+  it("leaves inline and fenced code untouched while normalizing prose arrows", () => {
+    render(
+      <ChatBubble
+        isGuardian
+        message={{
+          id: "msg-6c",
+          authorId: "bot",
+          authorName: "Guardian",
+          content:
+            "Normal prose: $\\rightarrow$\n\nInline code: `$\\rightarrow$`\n\n```txt\nconst arrow = \"$\\rightarrow$\";\n```",
+          createdAt: Date.now(),
+        }}
+      />
+    );
+
+    expect(screen.getByText("Normal prose: →")).toBeInTheDocument();
+    expect(screen.getByText("$\\rightarrow$", { selector: "code" })).toBeInTheDocument();
+    expect(screen.getByText('const arrow = "$\\rightarrow$";')).toBeInTheDocument();
+  });
+
   it("renders user multiline code as plaintext without copy affordances", () => {
     const pastedCode = "function demo() {\n  const total = 1;\n  return total;\n}";
 

--- a/frontend/src/features/settings/api/__tests__/systemPrompt.test.ts
+++ b/frontend/src/features/settings/api/__tests__/systemPrompt.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import api from "@/lib/api";
+
+import { fetchSystemPromptInspectorSnapshot } from "@/features/settings/api/systemPrompt";
+
+vi.mock("@/lib/api", () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+const apiGetMock = vi.mocked(api.get);
+
+describe("fetchSystemPromptInspectorSnapshot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("reads the persisted status and resolved summary surfaces only", async () => {
+    apiGetMock.mockImplementation(async (url: string) => {
+      if (url === "/api/imprint/status") {
+        return {
+          data: {
+            imprint: {
+              id: 12,
+              status: "active",
+              heat_score: 0.7,
+              preferred_name: "Harbor",
+              created_at: "2026-03-08T18:00:00Z",
+            },
+            persona: {
+              id: 8,
+              source: "user",
+              snippet: "Calm and technical.",
+              created_at: "2026-03-08T18:05:00Z",
+            },
+            system_prompt_meta: {
+              estimated_tokens: 1320,
+              docs_count: 2,
+              segments_present: {
+                base: true,
+                imprint: true,
+                persona: true,
+                system_docs: true,
+              },
+              segments: [
+                {
+                  name: "base",
+                  chars: 1200,
+                  estimated_tokens: 300,
+                  truncated: false,
+                },
+                {
+                  name: "imprint",
+                  chars: 220,
+                  estimated_tokens: 55,
+                  truncated: false,
+                },
+                {
+                  name: "persona",
+                  chars: 180,
+                  estimated_tokens: 45,
+                  truncated: false,
+                },
+                {
+                  name: "system_docs",
+                  chars: 1400,
+                  estimated_tokens: 350,
+                  truncated: true,
+                },
+              ],
+            },
+          },
+        } as any;
+      }
+
+      if (url === "/api/system_prompt/summary") {
+        return {
+          data: {
+            estimated_tokens_total: 1320,
+            threshold: {
+              warn_tokens: 6000,
+              hard_tokens: 8000,
+              status: "warn",
+            },
+            segments: [
+              {
+                name: "base",
+                chars: 1200,
+                estimated_tokens: 300,
+                truncated: false,
+              },
+              {
+                name: "system_docs",
+                chars: 1400,
+                estimated_tokens: 350,
+                truncated: true,
+              },
+            ],
+            docs_count: 2,
+            generated_at: "2026-03-09T04:12:00Z",
+            estimated_tokens: 1320,
+            cap_tokens: 8000,
+            docs_truncated: true,
+            overflow: false,
+            warnings: ["System docs truncated due to token budget."],
+          },
+        } as any;
+      }
+
+      throw new Error(`unexpected endpoint: ${url}`);
+    });
+
+    const snapshot = await fetchSystemPromptInspectorSnapshot({
+      projectId: 77,
+      threadId: 5,
+    });
+
+    expect(apiGetMock).toHaveBeenCalledTimes(2);
+    expect(apiGetMock).toHaveBeenNthCalledWith(1, "/api/imprint/status", {
+      params: { project_id: 77, thread_id: 5 },
+    });
+    expect(apiGetMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/system_prompt/summary",
+      { params: { project_id: 77, thread_id: 5 } }
+    );
+    expect(snapshot.imprint?.status).toBe("active");
+    expect(snapshot.persona?.source).toBe("user");
+    expect(snapshot.threshold.status).toBe("warn");
+    expect(snapshot.docsCount).toBe(2);
+    expect(snapshot.segmentsPresent.imprint).toBe(true);
+    expect(snapshot.segmentsPresent.persona).toBe(true);
+  });
+});

--- a/frontend/src/vite.config.ts
+++ b/frontend/src/vite.config.ts
@@ -18,6 +18,19 @@ const PROXY_TARGET =
   process.env.VITE_BACKEND_URL ||
   'http://localhost:8888';
 
+const ADDITIONAL_ALLOWED_HOSTS = (
+  process.env.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS ?? ''
+)
+  .split(',')
+  .map((host) => host.trim())
+  .filter(Boolean);
+const DEV_ALLOWED_HOSTS = Array.from(
+  new Set([
+    'axisnode',
+    ...ADDITIONAL_ALLOWED_HOSTS,
+  ])
+);
+
 export default defineConfig({
   root: resolve(__dirname),
 
@@ -85,6 +98,7 @@ export default defineConfig({
   server: {
     port: Number(process.env.VITE_DEV_SERVER_PORT ?? 5173),
     host: true,
+    allowedHosts: DEV_ALLOWED_HOSTS,
     strictPort: false,
     proxy: {
       // SSE: proxy to backend without rewriting path; backend supports /api/events

--- a/tests/core/test_chat_completion_service_identity_wiring.py
+++ b/tests/core/test_chat_completion_service_identity_wiring.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from guardian.cognition.imprints import store as imprint_store
+from guardian.cognition.personas import store as persona_store
+from guardian.core import chat_completion_service
+from guardian.core.chat_completion_service import (
+    build_sanitized_payload_summary,
+)
+from guardian.db.models import Base, Imprint, Persona
+from guardian.tasks.types import ChatCompletionTask
+
+
+def _setup_session_factory():
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(
+        bind=engine,
+        tables=[Imprint.__table__, Persona.__table__],
+    )
+    return sessionmaker(
+        bind=engine, autoflush=False, autocommit=False, future=True
+    )
+
+
+def _fake_retrieval_plan():
+    return SimpleNamespace(
+        intent=SimpleNamespace(value="identity"),
+        effective_depth=SimpleNamespace(value="normal"),
+        default_scope=SimpleNamespace(value="thread"),
+        time_mode=SimpleNamespace(value="current"),
+        graph_allowance=SimpleNamespace(value="allowed"),
+        retrieval_needed=False,
+        allow_global_fallback=False,
+        escalation_order=[],
+        reasons=[],
+    )
+
+
+@pytest.fixture
+def _runtime_prompt_setup(monkeypatch: pytest.MonkeyPatch):
+    Session = _setup_session_factory()
+    imprint_store._set_session_factory(Session)
+    persona_store._set_session_factory(Session)
+
+    monkeypatch.setattr(
+        "guardian.cognition.system_prompt_builder.get_docs_for",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        "guardian.cognition.system_prompt_builder.estimate_token_cost_for_docs",
+        lambda _docs: 0,
+    )
+    monkeypatch.setattr(
+        chat_completion_service, "resolve_thread_system_profile", None
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "validate_llm_config",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "resolve_retrieval_plan",
+        lambda *args, **kwargs: _fake_retrieval_plan(),
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "get_settings",
+        lambda: SimpleNamespace(
+            LLM_PROVIDER="groq",
+            LOCAL_LLM_MODEL="runtime-local-model",
+            DEFAULT_LOCAL_MODEL="runtime-local-model",
+            LLM_MODEL="runtime-local-model",
+        ),
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "CHAT_PROVIDER",
+        "groq",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "DEFAULT_MODEL",
+        "runtime-default-model",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_vector_store",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_memory_store",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_sensors",
+        None,
+        raising=False,
+    )
+
+    class _FakeBroker:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def assemble(
+            self,
+            thread_id,
+            query,
+            depth_mode,
+            user_id,
+            project_id=None,
+            source_mode="project",
+        ):
+            return {"semantic": [], "graph": []}, {
+                "documents": [],
+                "graph": [],
+                "source_mode": source_mode,
+            }
+
+    monkeypatch.setattr(chat_completion_service, "ContextBroker", _FakeBroker)
+
+    mock_chatlog_db = SimpleNamespace(
+        get_chat_thread=lambda thread_id: {
+            "id": thread_id,
+            "user_id": "u1",
+            "project_id": 7,
+            "thread_config": None,
+            "active_profile_id": None,
+        },
+        list_messages=lambda thread_id, limit, offset: [
+            {"id": 1, "role": "user", "content": "What changed?"}
+        ],
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "chatlog_db",
+        mock_chatlog_db,
+        raising=False,
+    )
+    return Session
+
+
+@pytest.mark.asyncio
+async def test_build_messages_for_llm_uses_persisted_active_imprint_and_persona(
+    _runtime_prompt_setup,
+):
+    imprint = imprint_store.save_imprint(
+        "u1",
+        7,
+        status="draft",
+        guardian_name="Auri",
+        preferred_name="Friend",
+        style="playful-dry",
+        metrics={"persona_draft": "Speak like a calm guide."},
+    )
+    imprint_store.activate_imprint(imprint.id)
+    persona = persona_store.set_persona(
+        "u1",
+        7,
+        body="Speak like a calm guide.",
+        source="imprint_zero_seed",
+    )
+
+    task = ChatCompletionTask(thread_id=1, max_context=50, depth_mode="normal")
+
+    (
+        messages_for_llm,
+        provider,
+        model,
+        bundle,
+        trace,
+    ) = await chat_completion_service.build_messages_for_llm(task)
+
+    system_content = messages_for_llm[0]["content"]
+    assert "=== IMPRINT_ZERO ===" in system_content
+    assert "=== PERSONA ===" in system_content
+    assert "Auri" in system_content
+    assert "Speak like a calm guide." in system_content
+
+    prompt_meta = bundle["_prompt_meta"]
+    assert prompt_meta["resolved_imprint_source"] == "active_scope"
+    assert prompt_meta["resolved_persona_source"] == "active_scope"
+    assert prompt_meta["resolved_persona_id"] == persona.id
+    assert prompt_meta["persona_has_body"] is True
+
+    summary = build_sanitized_payload_summary(
+        messages_for_llm,
+        bundle,
+        provider=provider,
+        model=model,
+    )
+    assert summary["has_system_prompt"] is True
+    assert summary["persona_or_imprint_present"] is True
+    assert summary["message_count"] >= 2
+    assert trace is not None

--- a/tests/routes/test_imprint_runtime_wiring.py
+++ b/tests/routes/test_imprint_runtime_wiring.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from guardian.cognition.imprints import store as imprint_store
+from guardian.cognition.personas import store as persona_store
+from guardian.cognition.system_prompt_builder import (
+    build_guardian_system_prompt,
+)
+from guardian.db.models import Base, Imprint, Persona, UserSettings
+from guardian.routes import imprint as imprint_routes
+from guardian.services import iddb_settings_service
+
+AUTH_HEADERS = {"X-API-Key": "test-api-key", "X-User-Id": "u1"}
+
+
+@pytest.fixture(autouse=True)
+def _auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GUARDIAN_API_KEY", "test-api-key")
+    monkeypatch.setenv("DEBUG", "1")
+
+
+@pytest.fixture(autouse=True)
+def _settings_db(monkeypatch: pytest.MonkeyPatch):
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(
+        bind=engine,
+        tables=[
+            UserSettings.__table__,
+            Imprint.__table__,
+            Persona.__table__,
+        ],
+    )
+    Session = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False, future=True
+    )
+    iddb_settings_service._set_session_factory(Session)
+    imprint_store._set_session_factory(Session)
+    persona_store._set_session_factory(Session)
+    monkeypatch.setattr(
+        imprint_routes,
+        "chatlog_db",
+        SimpleNamespace(get_project_identity_depth=lambda _project_id: "deep"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "guardian.cognition.system_prompt_builder.get_docs_for",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        "guardian.cognition.system_prompt_builder.estimate_token_cost_for_docs",
+        lambda _docs: 0,
+    )
+    yield
+
+
+def make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(imprint_routes.router)
+    app.include_router(imprint_routes.system_prompt_router)
+    app.include_router(imprint_routes.system_docs_router)
+    return app
+
+
+def test_accept_imprint_promotes_active_records_and_prompt_layers():
+    app = make_app()
+    client = TestClient(app)
+
+    draft = imprint_store.save_imprint(
+        "u1",
+        7,
+        status="draft",
+        guardian_name="Auri",
+        preferred_name="Friend",
+        style="playful-dry",
+        metrics={"persona_draft": "Write with short sentences."},
+    )
+
+    response = client.post(
+        "/api/imprint/accept",
+        json={"imprint_id": draft.id},
+        headers=AUTH_HEADERS,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["imprint"]["status"] == "active"
+    assert payload["persona"]["source"] == "imprint_zero_seed"
+
+    active_imprint = imprint_store.get_active_imprint("u1", 7)
+    active_persona = persona_store.get_active_persona("u1", 7)
+
+    assert active_imprint is not None
+    assert active_imprint.id == draft.id
+    assert active_imprint.status == "active"
+    assert active_persona is not None
+    assert active_persona.body == "Write with short sentences."
+    assert active_persona.is_active is True
+    assert active_persona.source == "imprint_zero_seed"
+
+    prompt, meta = build_guardian_system_prompt(
+        user_id="u1",
+        project_id=7,
+        depth="normal",
+        bundle={},
+    )
+    assert "=== IMPRINT_ZERO ===" in prompt
+    assert "=== PERSONA ===" in prompt
+    assert prompt.index("=== IMPRINT_ZERO ===") < prompt.index(
+        "=== PERSONA ==="
+    )
+    assert "Auri" in prompt
+    assert "Write with short sentences." in prompt
+    assert meta["resolved_imprint_source"] == "active_scope"
+    assert meta["resolved_persona_source"] == "active_scope"
+    assert meta["persona_has_body"] is True
+
+    status = client.get(
+        "/api/imprint/status",
+        headers=AUTH_HEADERS,
+        params={"project_id": 7},
+    )
+    assert status.status_code == 200
+    status_body = status.json()
+    assert status_body["imprint"]["status"] == "active"
+    assert status_body["persona"]["source"] == "imprint_zero_seed"
+    assert (
+        status_body["system_prompt_meta"]["segments_present"]["imprint"] is True
+    )
+    assert (
+        status_body["system_prompt_meta"]["segments_present"]["persona"] is True
+    )
+
+
+def test_update_persona_persists_project_scoped_active_persona_and_prompt_layers():
+    app = make_app()
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/imprint/persona",
+        json={"body": "Speak plainly and directly.", "project_id": 11},
+        headers=AUTH_HEADERS,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["source"] == "user"
+    assert payload["is_active"] is True
+
+    active_persona = persona_store.get_active_persona("u1", 11)
+    assert active_persona is not None
+    assert active_persona.body == "Speak plainly and directly."
+    assert active_persona.is_active is True
+    assert persona_store.get_active_persona("u1", None) is None
+
+    prompt, meta = build_guardian_system_prompt(
+        user_id="u1",
+        project_id=11,
+        depth="normal",
+        bundle={},
+    )
+    assert "=== PERSONA ===" in prompt
+    assert "Speak plainly and directly." in prompt
+    assert "=== IMPRINT_ZERO ===" not in prompt
+    assert meta["resolved_persona_source"] == "active_scope"
+    assert meta["resolved_imprint_source"] == "system_default"
+    assert meta["persona_has_body"] is True
+
+    status = client.get(
+        "/api/imprint/status",
+        headers=AUTH_HEADERS,
+        params={"project_id": 11},
+    )
+    assert status.status_code == 200
+    status_body = status.json()
+    assert status_body["imprint"] is None
+    assert status_body["persona"]["source"] == "user"
+    assert (
+        status_body["system_prompt_meta"]["segments_present"]["persona"] is True
+    )
+    assert (
+        status_body["system_prompt_meta"]["segments_present"]["imprint"]
+        is False
+    )


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
