### PR TITLE
Refine mobile nav and workspace summon behavior

### DIFF
--- a/frontend/src/components/persona/layout/AppShell.tsx
+++ b/frontend/src/components/persona/layout/AppShell.tsx
@@ -79,6 +79,11 @@ import {
   createDocumentContextTile,
   type DocumentContextTile,
 } from "@/lib/documentContext";
+import {
+  getMobileTopNavDockStyle,
+  getMobileTopNavRailStyle,
+  getMobileWorkspaceSummonCopy,
+} from "./mobileNavigationContract";
 
 // TEMPORARY: inject static design tokens until full migration is done.
 import { injectCssVars } from "@/theme";
@@ -1440,6 +1445,14 @@ export default function AppShell({
     [shellViewportProfile]
   );
   const isPhoneShell = mobileShellProfile.active;
+  const mobileTopNavDockStyle = useMemo<React.CSSProperties>(
+    () => getMobileTopNavDockStyle(mobileShellProfile),
+    [mobileShellProfile]
+  );
+  const mobileTopNavRailStyle = useMemo<React.CSSProperties>(
+    () => getMobileTopNavRailStyle(mobileShellProfile),
+    [mobileShellProfile]
+  );
 
   /* ─────────────────────────────────────────────────────────────────────────────
      🏗️ SECTION: Modular Design Token Setup
@@ -1979,11 +1992,13 @@ export default function AppShell({
   const workspaceDrawerPaneStyle: React.CSSProperties = isPhoneShell
     ? {
         padding: "var(--board-edge)",
-        flex: "1 1 0%",
-        width: "100%",
-        minWidth: 0,
-        minHeight: 0,
+        flex: "0 0 auto",
+        width: mobileShellProfile.workspace.drawerWidth,
+        minWidth: mobileShellProfile.workspace.drawerWidth,
+        height: "100%",
+        minHeight: "100%",
         maxHeight: "100%",
+        alignSelf: "stretch",
         borderRadius: "var(--card-radius)",
         boxShadow:
           workspaceLayoutMode === "workspace_focus"
@@ -2018,34 +2033,80 @@ export default function AppShell({
       }
     : {};
   const sharedWorkspaceDrawer = showWorkspaceDrawer ? (
-    <div
-      data-testid="workspace-drawer-pane"
-      data-pane-basis={isPhoneShell ? "100.00%" : workspacePaneBasis}
-      data-pane-min-width={isPhoneShell ? "0px" : workspacePaneMinWidth}
-      data-shell-workspace-arrangement={shellViewportProfile.workspaceArrangement}
-      className="min-h-0 min-w-0 overflow-visible rounded-[var(--radius)]"
-      style={workspaceDrawerPaneStyle}
-    >
-      <WorkspaceDrawer
-        routeContext={workspaceRouteContext}
-        isOpen={workspaceDrawerOpen}
-        activeTab={workspaceDrawerTab}
-        layoutMode={workspaceLayoutMode}
-        paneRatio={workspacePaneRatio}
-        minPaneRatio={minWorkspacePaneRatio}
-        maxPaneRatio={maxWorkspacePaneRatio}
-        onOpenChange={(nextOpen) => {
-          if (nextOpen) {
-            openWorkspaceDrawer();
-            return;
-          }
-          closeWorkspaceDrawer();
-        }}
-        onActiveTabChange={handleWorkspaceDrawerTabChange}
-        onLayoutModeChange={setWorkspaceLayoutMode}
-        projectId={effectiveDocumentsProjectId}
-      />
-    </div>
+    isPhoneShell ? (
+      <div
+        data-testid="workspace-drawer-overlay"
+        data-overlay-mode="mobile"
+        className="absolute inset-0 z-20 flex items-stretch justify-end bg-black/35 backdrop-blur-sm"
+      >
+        <button
+          type="button"
+          aria-label="Close workspace drawer"
+          className="absolute inset-0 border-0 bg-transparent p-0"
+          onClick={closeWorkspaceDrawer}
+        />
+        <div
+          data-testid="workspace-drawer-pane"
+          data-overlay="true"
+          data-pane-basis={mobileShellProfile.workspace.drawerWidth}
+          data-pane-min-width="0px"
+          data-shell-workspace-arrangement={shellViewportProfile.workspaceArrangement}
+          className="relative z-10 h-full min-h-0 min-w-0 overflow-visible rounded-[var(--radius)]"
+          style={workspaceDrawerPaneStyle}
+          onClick={(event) => event.stopPropagation()}
+          onPointerDown={(event) => event.stopPropagation()}
+        >
+          <WorkspaceDrawer
+            routeContext={workspaceRouteContext}
+            isOpen={workspaceDrawerOpen}
+            activeTab={workspaceDrawerTab}
+            layoutMode={workspaceLayoutMode}
+            paneRatio={workspacePaneRatio}
+            minPaneRatio={minWorkspacePaneRatio}
+            maxPaneRatio={maxWorkspacePaneRatio}
+            onOpenChange={(nextOpen) => {
+              if (nextOpen) {
+                openWorkspaceDrawer();
+                return;
+              }
+              closeWorkspaceDrawer();
+            }}
+            onActiveTabChange={handleWorkspaceDrawerTabChange}
+            onLayoutModeChange={setWorkspaceLayoutMode}
+            projectId={effectiveDocumentsProjectId}
+          />
+        </div>
+      </div>
+    ) : (
+      <div
+        data-testid="workspace-drawer-pane"
+        data-pane-basis={workspacePaneBasis}
+        data-pane-min-width={workspacePaneMinWidth}
+        data-shell-workspace-arrangement={shellViewportProfile.workspaceArrangement}
+        className="min-h-0 min-w-0 overflow-visible rounded-[var(--radius)]"
+        style={workspaceDrawerPaneStyle}
+      >
+        <WorkspaceDrawer
+          routeContext={workspaceRouteContext}
+          isOpen={workspaceDrawerOpen}
+          activeTab={workspaceDrawerTab}
+          layoutMode={workspaceLayoutMode}
+          paneRatio={workspacePaneRatio}
+          minPaneRatio={minWorkspacePaneRatio}
+          maxPaneRatio={maxWorkspacePaneRatio}
+          onOpenChange={(nextOpen) => {
+            if (nextOpen) {
+              openWorkspaceDrawer();
+              return;
+            }
+            closeWorkspaceDrawer();
+          }}
+          onActiveTabChange={handleWorkspaceDrawerTabChange}
+          onLayoutModeChange={setWorkspaceLayoutMode}
+          projectId={effectiveDocumentsProjectId}
+        />
+      </div>
+    )
   ) : null;
   const workspaceShellLaneClassName = isPhoneShell
     ? "flex h-full min-h-0 w-full flex-col gap-[var(--gutter)]"
@@ -2075,71 +2136,74 @@ export default function AppShell({
   const runtimeLastHealthy = runtimeHealth.lastSuccessAt
     ? new Date(runtimeHealth.lastSuccessAt).toLocaleString()
     : "never";
-  const topNavDockStyle = useMemo<React.CSSProperties>(
-    () => ({
-      paddingTop: "var(--pill-pad-y)",
-      paddingBottom: "var(--pill-pad-y)",
-      width: mobileShellProfile.topNav.width,
-      maxWidth: "100%",
-      minWidth: 0,
-      display: mobileShellProfile.topNav.scrollable ? "flex" : undefined,
-      flexWrap: "nowrap",
-      overflowX: mobileShellProfile.topNav.scrollable ? "auto" : undefined,
-      overflowY: mobileShellProfile.topNav.scrollable ? "hidden" : undefined,
-      overscrollBehaviorX: mobileShellProfile.topNav.scrollable
-        ? "contain"
-        : undefined,
-      scrollbarWidth: mobileShellProfile.topNav.scrollable ? "none" : undefined,
-      WebkitOverflowScrolling: mobileShellProfile.topNav.scrollable
-        ? "touch"
-        : undefined,
-      whiteSpace: "nowrap",
-    }),
-    [mobileShellProfile.topNav.scrollable, mobileShellProfile.topNav.width]
+  const workspaceSummonCopy = getMobileWorkspaceSummonCopy(workspaceDrawerOpen);
+  const workspaceDrawerToggle = workspaceShellEnabled ? (
+    <button
+      type="button"
+      className="pill-tab shrink-0 whitespace-nowrap"
+      data-state={workspaceDrawerOpen ? "active" : "inactive"}
+      data-testid="workspace-drawer-toggle"
+      aria-pressed={workspaceDrawerOpen}
+      aria-label={
+        isPhoneShell
+          ? workspaceSummonCopy.ariaLabel
+          : "Toggle workspace drawer"
+      }
+      title={
+        isPhoneShell
+          ? workspaceSummonCopy.title
+          : workspaceDrawerOpen
+            ? "Close workspace drawer"
+            : "Open workspace drawer"
+      }
+      onClick={toggleWorkspaceDrawer}
+    >
+      {isPhoneShell ? workspaceSummonCopy.label : "Workspace"}
+    </button>
+  ) : null;
+  const settingsUtilityAction = (
+    <button
+      type="button"
+      className="pill-tab h-9 w-9 shrink-0 p-0"
+      data-state={view === "settings" ? "active" : "inactive"}
+      data-testid="settings-utility-toggle"
+      aria-label="Settings"
+      title="Settings"
+      onClick={openSettings}
+    >
+      <Settings2 className="h-4 w-4" aria-hidden="true" />
+    </button>
   );
-  const headerUtilityActions = (
+  const shareUtilityAction = activeRouteThreadId != null ? (
+    <ShareButton
+      targetType="thread"
+      targetId={activeRouteThreadId}
+      className="pill-tab shrink-0 whitespace-nowrap"
+      dataState="inactive"
+      style={{
+        borderRadius: 999,
+        border: "1px solid var(--chip-border)",
+        background: "var(--chip-bg)",
+        color: "var(--text)",
+        fontSize: "0.78rem",
+        fontWeight: 500,
+        boxShadow:
+          "inset 0 1px 0 rgba(255,255,255,0.22), 0 3px 10px rgba(0,0,0,0.18)",
+      }}
+    />
+  ) : null;
+  const desktopHeaderUtilityActions = (
     <>
-      <button
-        type="button"
-        className="pill-tab h-9 w-9 shrink-0 p-0"
-        data-state={view === "settings" ? "active" : "inactive"}
-        data-testid="settings-utility-toggle"
-        aria-label="Settings"
-        title="Settings"
-        onClick={openSettings}
-      >
-        <Settings2 className="h-4 w-4" aria-hidden="true" />
-      </button>
-      {workspaceShellEnabled && (
-        <button
-          type="button"
-          className="pill-tab shrink-0 whitespace-nowrap"
-          data-state={workspaceDrawerOpen ? "active" : "inactive"}
-          data-testid="workspace-drawer-toggle"
-          aria-pressed={workspaceDrawerOpen}
-          onClick={toggleWorkspaceDrawer}
-        >
-          Workspace
-        </button>
-      )}
-      {activeRouteThreadId != null && (
-        <ShareButton
-          targetType="thread"
-          targetId={activeRouteThreadId}
-          className="pill-tab shrink-0 whitespace-nowrap"
-          dataState="inactive"
-          style={{
-            borderRadius: 999,
-            border: "1px solid var(--chip-border)",
-            background: "var(--chip-bg)",
-            color: "var(--text)",
-            fontSize: "0.78rem",
-            fontWeight: 500,
-            boxShadow:
-              "inset 0 1px 0 rgba(255,255,255,0.22), 0 3px 10px rgba(0,0,0,0.18)",
-          }}
-        />
-      )}
+      {settingsUtilityAction}
+      {workspaceDrawerToggle}
+      {shareUtilityAction}
+    </>
+  );
+  const mobileHeaderUtilityActions = (
+    <>
+      {workspaceDrawerToggle}
+      {settingsUtilityAction}
+      {shareUtilityAction}
     </>
   );
 
@@ -2241,103 +2305,107 @@ export default function AppShell({
       )} */}
       {/* Glass Pill Menu Bar + Header Actions */}
       <div
-        className={`relative z-10 w-full ${isPhoneShell ? "flex items-center gap-2" : "flex items-center justify-between gap-3"}`}
+        className={`relative z-10 w-full ${isPhoneShell ? "flex items-center gap-[var(--shell-gap)]" : "flex items-center justify-between gap-3"}`}
       >
-        <div className={isPhoneShell ? "min-w-0 flex-1" : undefined}>
+        <div className="min-w-0 flex-1">
+          <div
+            className="glass-pill isolate relative min-w-0"
+            data-testid="app-shell-top-nav"
+            data-shell-nav-mode={
+              mobileShellProfile.topNav.scrollable ? "scroll_rail" : "docked"
+            }
+            style={mobileTopNavDockStyle}
+          >
+            {/* glass backdrop */}
+            <div className="absolute inset-0 -z-10 overflow-hidden rounded-full pointer-events-none">
+              <RefractiveGlassCard
+                wallpaperUrl={activeWallpaper}
+                className="w-full h-full rounded-full"
+                style={{ background: "transparent", border: "none" }}
+                intensity={0.006}
+                aberration={0.006}
+              />
+            </div>
+
+            <div
+              className="flex min-w-0 flex-1 items-center"
+              style={mobileTopNavRailStyle}
+            >
+              {/* brand badge — doubles as layout mode toggle */}
+              <button
+                type="button"
+                className="pill-tab brand-tab shrink-0 whitespace-nowrap"
+                style={{ color: "var(--text-on-accent)" }}
+                title={
+                  layoutMode === "zen"
+                    ? "Zen layout — click to switch to Focus"
+                    : "Focus layout — click to switch to Zen"
+                }
+                onClick={() =>
+                  setLayoutMode((prev) => (prev === "focus" ? "zen" : "focus"))
+                }
+              >
+                Codexify
+              </button>
+
+              {/* beta release indicator — persistent across navigation */}
+              <span
+                className="inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase whitespace-nowrap"
+                style={{
+                  background: "var(--accent)",
+                  color: "var(--text-on-accent)",
+                  opacity: 0.85,
+                  letterSpacing: "0.05em",
+                }}
+                title="Beta release — feedback welcome"
+              >
+                Beta
+              </span>
+
+              {/* nav tabs */}
+              <button
+                className="pill-tab shrink-0 whitespace-nowrap"
+                data-state={view === "guardian" ? "active" : "inactive"}
+                onClick={() => navigateToView("guardian")}
+              >
+                Guardian
+              </button>
+              <button
+                className="pill-tab shrink-0 whitespace-nowrap"
+                data-state={view === "dashboard" ? "active" : "inactive"}
+                onClick={() => navigateToView("dashboard")}
+              >
+                Dashboard
+              </button>
+              <button
+                className="pill-tab shrink-0 whitespace-nowrap"
+                data-state={view === "documents" ? "active" : "inactive"}
+                onClick={() => navigateToView("documents")}
+              >
+                Documents
+              </button>
+              <button
+                className="pill-tab shrink-0 whitespace-nowrap"
+                data-state={view === "gallery" ? "active" : "inactive"}
+                onClick={() => navigateToView("gallery")}
+              >
+                Gallery
+              </button>
+              <button
+                className="pill-tab shrink-0 whitespace-nowrap"
+                data-state={view === "personaStudio" ? "active" : "inactive"}
+                onClick={() => navigateToView("personaStudio")}
+              >
+                Persona Studio
+              </button>
+            </div>
+          </div>
+        </div>
         <div
-          className="glass-pill isolate relative min-w-0"
-          data-testid="app-shell-top-nav"
-          data-shell-nav-mode={
-            mobileShellProfile.topNav.scrollable ? "scroll_rail" : "docked"
-          }
-          style={topNavDockStyle}
+          className={`flex shrink-0 items-center ${isPhoneShell ? "gap-[var(--pill-gap)]" : "justify-end gap-2"}`}
         >
-          {/* glass backdrop */}
-          <div className="absolute inset-0 -z-10 overflow-hidden rounded-full pointer-events-none">
-            <RefractiveGlassCard
-              wallpaperUrl={activeWallpaper}
-              className="w-full h-full rounded-full"
-              style={{ background: "transparent", border: "none" }}
-              intensity={0.006}
-              aberration={0.006}
-            />
-          </div>
-
-          {/* brand badge — doubles as layout mode toggle */}
-          <button
-            type="button"
-            className="pill-tab brand-tab shrink-0 whitespace-nowrap"
-            style={{ color: "var(--text-on-accent)" }}
-            title={
-              layoutMode === "zen"
-                ? "Zen layout — click to switch to Focus"
-                : "Focus layout — click to switch to Zen"
-            }
-            onClick={() =>
-              setLayoutMode((prev) => (prev === "focus" ? "zen" : "focus"))
-            }
-          >
-            Codexify
-          </button>
-
-          {/* beta release indicator — persistent across navigation */}
-          <span
-            className="inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase whitespace-nowrap"
-            style={{
-              background: "var(--accent)",
-              color: "var(--text-on-accent)",
-              opacity: 0.85,
-              letterSpacing: "0.05em",
-            }}
-            title="Beta release — feedback welcome"
-          >
-            Beta
-          </span>
-
-          {/* nav tabs */}
-          <button
-            className="pill-tab shrink-0 whitespace-nowrap"
-            data-state={view === "guardian" ? "active" : "inactive"}
-            onClick={() => navigateToView("guardian")}
-          >
-            Guardian
-          </button>
-          <button
-            className="pill-tab shrink-0 whitespace-nowrap"
-            data-state={view === "dashboard" ? "active" : "inactive"}
-            onClick={() => navigateToView("dashboard")}
-          >
-            Dashboard
-          </button>
-          <button
-            className="pill-tab shrink-0 whitespace-nowrap"
-            data-state={view === "documents" ? "active" : "inactive"}
-            onClick={() => navigateToView("documents")}
-          >
-            Documents
-          </button>
-          <button
-            className="pill-tab shrink-0 whitespace-nowrap"
-            data-state={view === "gallery" ? "active" : "inactive"}
-            onClick={() => navigateToView("gallery")}
-          >
-            Gallery
-          </button>
-          <button
-            className="pill-tab shrink-0 whitespace-nowrap"
-            data-state={view === "personaStudio" ? "active" : "inactive"}
-            onClick={() => navigateToView("personaStudio")}
-          >
-            Persona Studio
-          </button>
-          {isPhoneShell && headerUtilityActions}
+          {isPhoneShell ? mobileHeaderUtilityActions : desktopHeaderUtilityActions}
         </div>
-        </div>
-        {!isPhoneShell && (
-          <div className="flex items-center justify-end gap-2">
-            {headerUtilityActions}
-          </div>
-        )}
       </div>
 
       {showRuntimeBanner && (
@@ -2589,7 +2657,7 @@ export default function AppShell({
                           setPendingComposerDocumentTiles([])
                         }
                         onWorkspaceToggle={toggleWorkspaceDrawer}
-                        workspaceOpen={false}
+                        workspaceOpen={workspaceDrawerOpen}
                         activeWorkspaceDoc={null}
                         onWorkspaceClose={closeWorkspaceDrawer}
                       />

--- a/frontend/src/components/persona/layout/GuardianChatWithSidebar.tsx
+++ b/frontend/src/components/persona/layout/GuardianChatWithSidebar.tsx
@@ -1467,6 +1467,7 @@ export default function GuardianChatWithSidebar({
   );
 
   const chatDisabled = !isDesktopLayout && isSidebarOpen;
+  const showWorkspacePreview = workspaceOpen && activeWorkspaceDoc != null;
 
   const sidebarWrapperClass = "relative flex h-full min-h-0 shrink-0 basis-[clamp(300px,24vw,360px)]";
   const stopDrawerEvent = React.useCallback((event: React.SyntheticEvent) => {
@@ -1636,7 +1637,7 @@ export default function GuardianChatWithSidebar({
                   Authentication required. Please sign in or set a dev key.
                 </div>
               )}
-              {workspaceOpen && (
+              {showWorkspacePreview && (
                 <div className="absolute inset-0 z-[110] pointer-events-auto">
                   <div className="absolute right-0 top-0 h-full w-[min(420px,90vw)] bg-black/50 backdrop-blur-md border-l border-white/10 shadow-2xl overflow-hidden">
                     <div className="flex items-center justify-between px-4 py-2 border-b border-white/10">

--- a/frontend/src/components/persona/layout/__tests__/AppShell.test.tsx
+++ b/frontend/src/components/persona/layout/__tests__/AppShell.test.tsx
@@ -286,6 +286,19 @@ function readPaneBasis(element: HTMLElement): number {
   return Number.parseFloat(element.getAttribute("data-pane-basis") ?? "0");
 }
 
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+  window.dispatchEvent(new Event("resize"));
+}
+
+beforeEach(() => {
+  setViewportWidth(1280);
+});
+
 describe("AppShell logo wordmark color contract", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -659,6 +672,37 @@ describe("AppShell workspace drawer shell", () => {
       expect(screen.queryByTestId("workspace-drawer")).not.toBeInTheDocument();
     }
   );
+
+  it("keeps the mobile workspace summon explicit and opens the drawer as an overlay", async () => {
+    const user = userEvent.setup();
+    setViewportWidth(390);
+    localStorage.setItem("cfy.lastView", "guardian");
+    setRouteThread(null);
+
+    render(<AppShell />);
+
+    expect(screen.getByTestId("app-shell-top-nav")).toHaveAttribute(
+      "data-shell-nav-mode",
+      "scroll_rail"
+    );
+    expect(
+      screen.getByRole("button", { name: "Open Workspace" })
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Open Workspace" }));
+
+    expect(
+      await screen.findByRole("button", { name: "Close Workspace" })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("workspace-drawer-overlay")).toHaveAttribute(
+      "data-overlay-mode",
+      "mobile"
+    );
+    expect(screen.getByTestId("workspace-drawer-pane")).toHaveAttribute(
+      "data-overlay",
+      "true"
+    );
+  });
 
   it("resolves supported views to chat_focus while the workspace is closed", () => {
     localStorage.setItem("cfy.lastView", "dashboard");

--- a/frontend/src/components/persona/layout/mobileNavigationContract.ts
+++ b/frontend/src/components/persona/layout/mobileNavigationContract.ts
@@ -1,0 +1,69 @@
+import type { CSSProperties } from "react";
+
+import type { MobileShellProfile } from "./mobileShellProfile";
+
+export type MobileWorkspaceSummonCopy = {
+  label: string;
+  ariaLabel: string;
+  title: string;
+};
+
+export function getMobileTopNavDockStyle(
+  mobileShellProfile: Pick<MobileShellProfile, "topNav">
+): CSSProperties {
+  return {
+    paddingTop: "var(--pill-pad-y)",
+    paddingBottom: "var(--pill-pad-y)",
+    width: mobileShellProfile.topNav.width,
+    maxWidth: "100%",
+    minWidth: 0,
+    display: "flex",
+    alignItems: "center",
+    overflow: "hidden",
+    boxSizing: "border-box",
+  };
+}
+
+export function getMobileTopNavRailStyle(
+  mobileShellProfile: Pick<MobileShellProfile, "topNav">
+): CSSProperties {
+  return {
+    flex: "1 1 auto",
+    minWidth: 0,
+    display: "flex",
+    alignItems: "center",
+    flexWrap: "nowrap",
+    gap: mobileShellProfile.topNav.railGap,
+    paddingInline: mobileShellProfile.topNav.railEdgePadding,
+    overflowX: mobileShellProfile.topNav.scrollable ? "auto" : undefined,
+    overflowY: mobileShellProfile.topNav.scrollable ? "hidden" : undefined,
+    overscrollBehaviorX: mobileShellProfile.topNav.scrollable
+      ? "contain"
+      : undefined,
+    scrollPaddingInline: mobileShellProfile.topNav.scrollable
+      ? mobileShellProfile.topNav.railEdgePadding
+      : undefined,
+    scrollbarWidth: mobileShellProfile.topNav.scrollable ? "none" : undefined,
+    WebkitOverflowScrolling: mobileShellProfile.topNav.scrollable
+      ? "touch"
+      : undefined,
+    whiteSpace: "nowrap",
+    boxSizing: "border-box",
+  };
+}
+
+export function getMobileWorkspaceSummonCopy(
+  isOpen: boolean
+): MobileWorkspaceSummonCopy {
+  return isOpen
+    ? {
+        label: "Close Workspace",
+        ariaLabel: "Close Workspace",
+        title: "Hide the Workspace drawer",
+      }
+    : {
+        label: "Open Workspace",
+        ariaLabel: "Open Workspace",
+        title: "Open the Workspace drawer",
+      };
+}

--- a/frontend/src/components/persona/layout/mobileShellProfile.ts
+++ b/frontend/src/components/persona/layout/mobileShellProfile.ts
@@ -13,6 +13,8 @@ export type MobileShellProfile = {
   topNav: {
     scrollable: boolean;
     width: string;
+    railEdgePadding: string;
+    railGap: string;
   };
   guardian: {
     singleLane: boolean;
@@ -41,6 +43,8 @@ const DESKTOP_SHELL_PROFILE = {
   topNav: {
     scrollable: false,
     width: "auto",
+    railEdgePadding: "0px",
+    railGap: "var(--pill-gap)",
   },
   guardian: {
     singleLane: false,
@@ -69,6 +73,8 @@ const PHONE_SHELL_PROFILE = {
   topNav: {
     scrollable: true,
     width: "100%",
+    railEdgePadding: "10px",
+    railGap: "var(--pill-gap)",
   },
   guardian: {
     singleLane: true,

--- a/frontend/src/features/workspace/__tests__/WorkspaceInvocation.test.tsx
+++ b/frontend/src/features/workspace/__tests__/WorkspaceInvocation.test.tsx
@@ -146,6 +146,19 @@ function WorkspaceProbe() {
   );
 }
 
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+  window.dispatchEvent(new Event("resize"));
+}
+
+beforeEach(() => {
+  setViewportWidth(1280);
+});
+
 describe("workspace invocation contract", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -225,6 +238,43 @@ describe("workspace invocation contract", () => {
       );
       expect(screen.getByTestId("workspace-probe")).toHaveTextContent(
         "Thread Attachment"
+      );
+    });
+  });
+
+  it("keeps Workspace collapsed by default on phone widths after a document open request", async () => {
+    setViewportWidth(390);
+    render(<WorkspaceProbe />);
+
+    let didOpen = false;
+    await act(async () => {
+      didOpen = forwardLegacyDocumentOpenToWorkspace(
+        {
+          doc: {
+            id: "phone-1",
+            title: "Phone Notes",
+            name: "Phone Notes",
+            ext: "md",
+            type: "file",
+            src_url: "/media/documents/phone-notes.md",
+          },
+        },
+        {
+          source: "documents",
+          targetView: "documents",
+        }
+      );
+    });
+
+    expect(didOpen).toBe(true);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workspace-probe")).toHaveAttribute(
+        "data-open",
+        "false"
+      );
+      expect(screen.getByTestId("workspace-probe")).toHaveTextContent(
+        "Phone Notes"
       );
     });
   });

--- a/frontend/src/features/workspace/state/useWorkspaceState.ts
+++ b/frontend/src/features/workspace/state/useWorkspaceState.ts
@@ -274,7 +274,13 @@ export function useWorkspaceState({
       const nextRequest = { ...request, doc: nextDoc };
 
       setActiveDoc(nextDoc);
-      setWorkspaceOpen((previous) => (isPhoneShell ? previous : true));
+      // Phone shells keep Workspace collapsed until the user explicitly summons it.
+      setWorkspaceOpen((previous) => {
+        if (isPhoneShell) {
+          return previous;
+        }
+        return true;
+      });
       onOpenRequest?.(nextRequest);
       return true;
     },


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
