### PR TITLE
Add default-off multi-user auth mode gate

### DIFF
--- a/guardian/core/config.py
+++ b/guardian/core/config.py
@@ -98,6 +98,12 @@ class Settings(BaseSettings):
             "Fail-closed egress guard. When true, all outbound non-local egress is blocked."
         ),
     )
+    CODEXIFY_MULTI_USER_ENABLED: bool = Field(
+        default=False,
+        description=(
+            "Backend auth gate for multi-user deployments. When false, Guardian keeps the single-user fallback path."
+        ),
+    )
     CODEXIFY_EGRESS_ALLOWLIST: str = Field(
         default="",
         description=(

--- a/guardian/core/dependencies.py
+++ b/guardian/core/dependencies.py
@@ -30,6 +30,7 @@ from guardian.core import event_bus
 from guardian.core.auth import verify_session_token
 from guardian.core.chat_db import ChatDB
 from guardian.core.chatlog_postgres import PostgresChatLogDB
+from guardian.core.config import get_settings as get_core_settings
 from guardian.core.egress import EgressDeniedError, assert_egress_allowed
 from guardian.memory.query_memory import memory_store as _memory_store
 from guardian.sensors.state import Sensors
@@ -209,15 +210,98 @@ def get_single_user_id() -> str:
     return configured or _DEFAULT_SINGLE_USER_ID
 
 
+def _multi_user_mode_enabled() -> bool:
+    try:
+        settings = get_core_settings()
+        return bool(getattr(settings, "CODEXIFY_MULTI_USER_ENABLED", False))
+    except Exception:
+        return False
+
+
+def _coerce_text(value: object) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    return ""
+
+
+def _resolve_authenticated_subject(
+    authorization: object = None,
+    gc_session: object = None,
+) -> str | None:
+    """
+    Resolve an authenticated subject from bearer/session credentials.
+
+    Returns None when no session/JWT subject can be extracted.
+    """
+
+    def _subject_from_token(token: str) -> str | None:
+        raw = token.strip()
+        if not raw:
+            return None
+
+        ok, subject = verify_session_token(raw)
+        if ok:
+            cleaned = (subject or "").strip()
+            if cleaned:
+                return cleaned
+
+        if jwt is None:
+            return None
+
+        for secret in _remote_token_secrets():
+            try:
+                payload = jwt.decode(
+                    raw,
+                    secret,
+                    algorithms=["HS256"],
+                    options={"verify_aud": False},
+                )
+            except Exception:
+                continue
+            cleaned = str(payload.get("sub") or "").strip()
+            if cleaned:
+                return cleaned
+        return None
+
+    for candidate in (_coerce_text(authorization), _coerce_text(gc_session)):
+        if not candidate:
+            continue
+        if candidate.lower().startswith("bearer "):
+            candidate = candidate[7:].strip()
+        subject = _subject_from_token(candidate)
+        if subject:
+            return subject
+    return None
+
+
 def get_request_user_id(
     x_user_id: Optional[str] = Header(default=None, alias="X-User-Id"),
+    authorization: Optional[str] = Header(default=None, alias="Authorization"),
+    gc_session: Optional[str] = Cookie(None, alias="gc_session"),
 ) -> str:
     """
-    Resolve request user identity from server-side single-user configuration.
+    Resolve request user identity.
 
-    `X-User-Id` is only honored when explicit local debug flags are enabled.
+    In default single-user mode, `X-User-Id` is only honored when explicit
+    local debug flags are enabled and otherwise falls back to the configured
+    single-user identity.
+
+    When CODEXIFY_MULTI_USER_ENABLED=true, the request must carry an
+    authenticated subject from the existing session/JWT path.
     """
-    candidate = (x_user_id or "").strip()
+    if _multi_user_mode_enabled():
+        subject = _resolve_authenticated_subject(authorization, gc_session)
+        if subject:
+            return subject
+        logger.warning(
+            "Rejected request without authenticated subject in multi-user mode"
+        )
+        raise HTTPException(
+            status_code=401,
+            detail="Multi-user mode requires an authenticated session/JWT subject",
+        )
+
+    candidate = _coerce_text(x_user_id)
     allow_override = _allow_user_header_override()
     if candidate and allow_override:
         logger.debug(
@@ -446,12 +530,14 @@ def require_api_key(api_key: str = Depends(verify_api_key)) -> str:
 def get_current_user(
     api_key: str = Depends(require_api_key),
     x_user_id: Optional[str] = Header(default=None, alias="X-User-Id"),
+    authorization: Optional[str] = Header(default=None, alias="Authorization"),
+    gc_session: Optional[str] = Cookie(None, alias="gc_session"),
 ) -> str:
     """
     Resolve current user from server-side single-user identity.
     """
     _ = api_key
-    return get_request_user_id(x_user_id)
+    return get_request_user_id(x_user_id, authorization, gc_session)
 
 
 # =========================

--- a/tests/core/test_multi_user_auth_mode.py
+++ b/tests/core/test_multi_user_auth_mode.py
@@ -1,0 +1,94 @@
+import importlib
+
+import pytest
+from fastapi import HTTPException
+
+from guardian.core.auth import issue_session_token
+
+
+def _reload_auth_modules(monkeypatch, **env_overrides):
+    monkeypatch.setenv("CODEXIFY_DISABLE_DOTENV", "1")
+    for key, value in env_overrides.items():
+        if value is None:
+            monkeypatch.delenv(key, raising=False)
+        else:
+            monkeypatch.setenv(key, value)
+
+    import guardian.core.config as core_config
+    import guardian.core.dependencies as dependencies
+
+    core_config = importlib.reload(core_config)
+    dependencies = importlib.reload(dependencies)
+    return core_config, dependencies
+
+
+def test_multi_user_mode_default_off_preserves_single_user_fallback(
+    monkeypatch,
+):
+    core_config, dependencies = _reload_auth_modules(
+        monkeypatch,
+        CODEXIFY_SINGLE_USER_ID="single-user",
+        CODEXIFY_MULTI_USER_ENABLED="false",
+    )
+
+    assert core_config.get_settings().CODEXIFY_MULTI_USER_ENABLED is False
+
+    current_user = dependencies.get_current_user(api_key="api-key")
+
+    assert current_user == "single-user"
+
+
+def test_multi_user_mode_enabled_rejects_missing_authenticated_subject(
+    monkeypatch,
+):
+    core_config, dependencies = _reload_auth_modules(
+        monkeypatch,
+        CODEXIFY_SINGLE_USER_ID="single-user",
+        CODEXIFY_MULTI_USER_ENABLED="true",
+    )
+
+    assert core_config.get_settings().CODEXIFY_MULTI_USER_ENABLED is True
+
+    with pytest.raises(HTTPException) as exc_info:
+        dependencies.get_current_user(api_key="api-key")
+
+    assert exc_info.value.status_code == 401
+    assert "multi-user" in str(exc_info.value.detail).lower()
+    assert "session/jwt" in str(exc_info.value.detail).lower()
+
+
+def test_multi_user_mode_enabled_accepts_resolved_authenticated_subject(
+    monkeypatch,
+):
+    core_config, dependencies = _reload_auth_modules(
+        monkeypatch,
+        CODEXIFY_SINGLE_USER_ID="single-user",
+        CODEXIFY_MULTI_USER_ENABLED="true",
+        GUARDIAN_SESSION_SECRET="multi-user-session-secret",
+        GUARDIAN_AUTH_MODE="remote",
+    )
+
+    assert core_config.get_settings().CODEXIFY_MULTI_USER_ENABLED is True
+
+    session_token, _expires = issue_session_token(
+        subject="resolved-user",
+        ttl_seconds=60,
+    )
+
+    assert (
+        dependencies._resolve_authenticated_subject(
+            f"Bearer {session_token}",
+            None,
+        )
+        == "resolved-user"
+    )
+
+    monkeypatch.setattr(
+        dependencies,
+        "_resolve_authenticated_subject",
+        lambda *_args, **_kwargs: "resolved-user",
+    )
+
+    current_user = dependencies.get_current_user(api_key="api-key")
+
+    assert current_user == "resolved-user"


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
