### PR TITLE
Show retrieval posture history in command center

### DIFF
--- a/frontend/src/features/commandCenter/CommandCenterPage.tsx
+++ b/frontend/src/features/commandCenter/CommandCenterPage.tsx
@@ -7,9 +7,11 @@ import EventConsole from "@/features/commandCenter/components/EventConsole";
 import HealthOverview from "@/features/commandCenter/components/HealthOverview";
 import TraceWorkbench, {
   RetrievalPosturePanel,
+  RetrievalPostureSummaryRow,
 } from "@/features/commandCenter/components/TraceWorkbench";
 import useCommandCenterEvents from "@/features/commandCenter/hooks/useCommandCenterEvents";
 import useHealthSummary from "@/features/commandCenter/hooks/useHealthSummary";
+import useRetrievalPostureHistory from "@/features/commandCenter/hooks/useRetrievalPostureHistory";
 import {
   buildCommandCenterEventConsoleRows,
   countCommandCenterUnknownItems,
@@ -271,6 +273,62 @@ function DashboardSummary({
   );
 }
 
+function RecentRetrievalPosturePanel({
+  threadId,
+}: {
+  threadId: number | null;
+}) {
+  const { error, items, loading, status } = useRetrievalPostureHistory(threadId);
+
+  if (threadId === null) return null;
+
+  return (
+    <Card
+      className="bezel-none border"
+      data-testid="command-center-retrieval-posture-history-panel"
+      style={{
+        background: "color-mix(in oklab, var(--panel-bg) 96%, transparent)",
+        borderColor: "var(--panel-border)",
+      }}
+    >
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base" style={{ color: "var(--text)" }}>
+          Recent retrieval posture
+        </CardTitle>
+        <p className="text-sm" style={{ color: "var(--muted)" }}>
+          Newest-first thread history from completed debug evidence only.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {loading ? (
+          <div className="rounded-[var(--tile-radius)] border p-3 text-sm" style={{ background: "var(--surface-soft)", borderColor: "var(--panel-border)", color: "var(--muted)" }}>
+            Loading recent retrieval posture history…
+          </div>
+        ) : error ? (
+          <div className="rounded-[var(--tile-radius)] border p-3 text-sm" style={{ background: "var(--surface-soft)", borderColor: "var(--danger-border)", color: "var(--danger-text)" }}>
+            {error}
+          </div>
+        ) : status === "empty" || items.length === 0 ? (
+          <div className="rounded-[var(--tile-radius)] border p-3 text-sm" style={{ background: "var(--surface-soft)", borderColor: "var(--panel-border)", color: "var(--muted)" }}>
+            No recent retrieval posture history for this thread.
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {items.map((item) => (
+              <RetrievalPostureSummaryRow
+                key={`${item.task_id}:${item.created_at}`}
+                createdAt={item.created_at}
+                posture={item.retrieval_posture}
+                taskId={item.task_id}
+              />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 export default function CommandCenterPage({ enabled }: CommandCenterPageProps) {
   const {
     connectionDetail,
@@ -401,7 +459,8 @@ export default function CommandCenterPage({ enabled }: CommandCenterPageProps) {
 
         <div className="min-h-0 flex-1">
           {activeThreadId !== null ? (
-            <div className="mb-4">
+            <div className="mb-4 space-y-4">
+              <RecentRetrievalPosturePanel threadId={activeThreadId} />
               <RetrievalPosturePanel
                 compact
                 testId="command-center-thread-posture-panel"

--- a/frontend/src/features/commandCenter/__tests__/CommandCenterPage.test.tsx
+++ b/frontend/src/features/commandCenter/__tests__/CommandCenterPage.test.tsx
@@ -9,6 +9,7 @@ import type {
   CommandCenterEvent,
   CommandCenterHealthItem,
   CommandCenterRagTracePayload,
+  CommandCenterRetrievalPostureHistoryItem,
   CommandCenterRetrievalPosture,
   CommandCenterRun,
 } from "@/features/commandCenter/types";
@@ -787,6 +788,69 @@ const mockedPartialPosture = {
   conversation_only: true,
 } as unknown as CommandCenterRetrievalPosture;
 
+const mockedConversationHistoryItem: CommandCenterRetrievalPostureHistoryItem = {
+  created_at: "2026-04-01T15:58:30Z",
+  retrieval_posture: mockedRetrievalPosture,
+  task_id: "task-alpha",
+};
+
+const mockedProjectHistoryItem: CommandCenterRetrievalPostureHistoryItem = {
+  created_at: "2026-04-01T15:57:30Z",
+  retrieval_posture: mockedProjectPosture,
+  task_id: "task-bravo",
+};
+
+const mockedPersonalKnowledgeHistoryItem: CommandCenterRetrievalPostureHistoryItem = {
+  created_at: "2026-04-01T15:56:30Z",
+  retrieval_posture: mockedPersonalKnowledgePosture,
+  task_id: "task-charlie",
+};
+
+function cloneHistoryState<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+const defaultRetrievalPostureHistoryState = {
+  42: {
+    error: null,
+    items: [
+      mockedConversationHistoryItem,
+      mockedProjectHistoryItem,
+      mockedPersonalKnowledgeHistoryItem,
+    ],
+    loading: false,
+    status: "ok" as const,
+  },
+  84: {
+    error: null,
+    items: [],
+    loading: false,
+    status: "empty" as const,
+  },
+  500: {
+    error: null,
+    items: [],
+    loading: true,
+    status: null,
+  },
+  600: {
+    error: "Retrieval posture history unavailable",
+    items: [],
+    loading: false,
+    status: null,
+  },
+  700: {
+    error: null,
+    items: [],
+    loading: false,
+    status: "empty" as const,
+  },
+};
+
+let mockedRetrievalPostureHistoryStateByThreadId = cloneHistoryState(
+  defaultRetrievalPostureHistoryState
+);
+
 vi.mock("../hooks/useRetrievalPosture", () => ({
   default: (threadId: number | null) => {
     if (threadId === 42) {
@@ -870,9 +934,34 @@ vi.mock("../hooks/useRetrievalPosture", () => ({
   },
 }));
 
+vi.mock("../hooks/useRetrievalPostureHistory", () => ({
+  default: (threadId: number | null) => {
+    if (threadId === null) {
+      return {
+        error: null,
+        items: [],
+        loading: false,
+        status: null,
+      };
+    }
+
+    return (
+      mockedRetrievalPostureHistoryStateByThreadId[threadId] ?? {
+        error: null,
+        items: [],
+        loading: false,
+        status: null,
+      }
+    );
+  },
+}));
+
 beforeEach(() => {
   mockRefresh.mockClear();
   mockClipboardWriteText.mockReset();
+  mockedRetrievalPostureHistoryStateByThreadId = cloneHistoryState(
+    defaultRetrievalPostureHistoryState
+  );
   Object.defineProperty(navigator, "clipboard", {
     configurable: true,
     value: {
@@ -933,6 +1022,9 @@ describe("CommandCenterPage", () => {
     expect(screen.getByTestId("command-center-health-overview")).toBeInTheDocument();
     expect(screen.getByTestId("command-center-trace-workbench")).toBeInTheDocument();
     expect(screen.getByTestId("command-center-event-console")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("command-center-retrieval-posture-history-panel")
+    ).toBeInTheDocument();
 
     expect(screen.getAllByLabelText(/transport state open/i)).toHaveLength(2);
     expect(screen.getAllByText(/last event: .*2026/i)).toHaveLength(2);
@@ -944,6 +1036,19 @@ describe("CommandCenterPage", () => {
     expect(within(healthOverview).getByText("Deps")).toBeInTheDocument();
     expect(within(healthOverview).getByText("Vector")).toBeInTheDocument();
     expect(within(healthOverview).getByText("Memory")).toBeInTheDocument();
+
+    const historyPanel = screen.getByTestId("command-center-retrieval-posture-history-panel");
+    expect(within(historyPanel).getByText("Recent retrieval posture")).toBeInTheDocument();
+    expect(
+      within(historyPanel).getByText(
+        /Newest-first thread history from completed debug evidence only\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      within(historyPanel).getByText(
+        /no recent retrieval posture history for this thread/i
+      )
+    ).toBeInTheDocument();
 
     fireEvent.click(within(healthOverview).getByRole("button", { name: /core/i }));
     expect(screen.getByText("Health detail: Core")).toBeInTheDocument();
@@ -982,6 +1087,9 @@ describe("CommandCenterPage", () => {
     fireEvent.click(within(workbench).getByRole("button", { name: /task-bravo/i }));
     expect(within(workbench).getByText("Selected: task-bravo")).toBeInTheDocument();
     expect(within(workbench).getByText(/trace: unavailable/i)).toBeInTheDocument();
+    expect(
+      within(historyPanel).getByText(/no recent retrieval posture history for this thread/i)
+    ).toBeInTheDocument();
 
     const console = screen.getByTestId("command-center-event-console");
     expect(within(console).getByText("Event console")).toBeInTheDocument();
@@ -1008,6 +1116,22 @@ describe("CommandCenterPage", () => {
 
     const workbench = screen.getByTestId("command-center-trace-workbench");
     fireEvent.click(within(workbench).getByRole("button", { name: /task-alpha/i }));
+
+    const historyPanel = screen.getByTestId("command-center-retrieval-posture-history-panel");
+    const historyItems = within(historyPanel).getAllByTestId(
+      "command-center-retrieval-posture-history-item"
+    );
+    expect(historyItems).toHaveLength(3);
+    expect(historyItems[0]).toHaveTextContent(/task-alpha/i);
+    expect(historyItems[0]).toHaveTextContent(/source: conversation/i);
+    expect(historyItems[0]).toHaveTextContent(/boundary: active_conversation_only/i);
+    expect(historyItems[0]).toHaveTextContent(/widen: none/i);
+    expect(historyItems[0]).toHaveTextContent(/This run stayed inside the active conversation\./i);
+    expect(historyItems[1]).toHaveTextContent(/task-bravo/i);
+    expect(historyItems[1]).toHaveTextContent(/source: project/i);
+    expect(historyItems[1]).toHaveTextContent(/widen: insufficient_thread_hits/i);
+    expect(historyItems[2]).toHaveTextContent(/task-charlie/i);
+    expect(historyItems[2]).toHaveTextContent(/source: personal_knowledge/i);
 
     expect(within(threadPanel).getByText(/source: conversation/i)).toBeInTheDocument();
     expect(within(threadPanel).getByText(/boundary: active_conversation_only/i)).toBeInTheDocument();
@@ -1253,8 +1377,11 @@ describe("CommandCenterPage", () => {
     fireEvent.click(within(workbench).getByRole("button", { name: /task-golf/i }));
 
     const threadPanel = screen.getByTestId("command-center-thread-posture-panel");
+    const historyPanel = screen.getByTestId("command-center-retrieval-posture-history-panel");
     expect(within(threadPanel).getByText("Thread retrieval posture")).toBeInTheDocument();
     expect(within(threadPanel).getByText(/loading retrieval posture/i)).toBeInTheDocument();
+    expect(within(historyPanel).getByText("Recent retrieval posture")).toBeInTheDocument();
+    expect(within(historyPanel).getByText(/loading recent retrieval posture history/i)).toBeInTheDocument();
     expect(
       within(threadPanel).queryByRole("button", { name: /^copy posture$/i })
     ).not.toBeInTheDocument();
@@ -1273,8 +1400,13 @@ describe("CommandCenterPage", () => {
     fireEvent.click(within(workbench).getByRole("button", { name: /task-hotel/i }));
 
     const threadPanel = screen.getByTestId("command-center-thread-posture-panel");
+    const historyPanel = screen.getByTestId("command-center-retrieval-posture-history-panel");
     expect(within(threadPanel).getByText("Thread retrieval posture")).toBeInTheDocument();
     expect(within(threadPanel).getByText(/retrieval posture unavailable/i)).toBeInTheDocument();
+    expect(within(historyPanel).getByText("Recent retrieval posture")).toBeInTheDocument();
+    expect(
+      within(historyPanel).getByText(/retrieval posture history unavailable/i)
+    ).toBeInTheDocument();
     expect(
       within(threadPanel).queryByRole("button", { name: /^copy posture$/i })
     ).not.toBeInTheDocument();
@@ -1293,8 +1425,13 @@ describe("CommandCenterPage", () => {
     fireEvent.click(within(workbench).getByRole("button", { name: /task-india/i }));
 
     const threadPanel = screen.getByTestId("command-center-thread-posture-panel");
+    const historyPanel = screen.getByTestId("command-center-retrieval-posture-history-panel");
     expect(within(threadPanel).getByText("Thread retrieval posture")).toBeInTheDocument();
     expect(within(threadPanel).getByText(/no retrieval posture evidence for this thread/i)).toBeInTheDocument();
+    expect(within(historyPanel).getByText("Recent retrieval posture")).toBeInTheDocument();
+    expect(
+      within(historyPanel).getByText(/no recent retrieval posture history for this thread/i)
+    ).toBeInTheDocument();
     expect(
       within(threadPanel).queryByRole("button", { name: /^copy posture$/i })
     ).not.toBeInTheDocument();

--- a/frontend/src/features/commandCenter/components/TraceWorkbench.tsx
+++ b/frontend/src/features/commandCenter/components/TraceWorkbench.tsx
@@ -331,6 +331,79 @@ type RetrievalPostureCopyFeedback =
   | { action: "bundle"; status: "copied" | "failed" }
   | null;
 
+function renderRetrievalPostureBadges(
+  posture: CommandCenterRetrievalPosture
+): React.ReactNode[] {
+  return [
+    <Badge
+      key="source_mode"
+      className="border text-[11px] font-medium leading-none"
+      style={{
+        background: "var(--surface-soft)",
+        borderColor: "var(--panel-border)",
+        color: "var(--text)",
+      }}
+    >
+      source: {posture.source_mode}
+    </Badge>,
+    <Badge
+      key="boundary_label"
+      className="border text-[11px] font-medium leading-none"
+      style={{
+        background: "var(--surface-soft)",
+        borderColor: "var(--panel-border)",
+        color: "var(--text)",
+      }}
+    >
+      boundary: {posture.boundary_label}
+    </Badge>,
+    posture.retrieval_override_mode ? (
+      <Badge
+        key="retrieval_override_mode"
+        className="border text-[11px] font-medium leading-none"
+        style={{
+          background: "var(--surface-soft)",
+          borderColor: "var(--panel-border)",
+          color: "var(--text)",
+        }}
+      >
+        override: {posture.retrieval_override_mode}
+      </Badge>
+    ) : null,
+    <Badge
+      key="widen_reason"
+      className="border text-[11px] font-medium leading-none"
+      style={{
+        background: "var(--surface-soft)",
+        borderColor: "var(--panel-border)",
+        color: "var(--text)",
+      }}
+    >
+      widen: {posture.widen_reason}
+    </Badge>,
+    posture.conversation_only ? (
+      <Badge
+        key="conversation_only"
+        className="border text-[11px] font-medium leading-none"
+        style={{
+          background: "color-mix(in oklab, var(--accent-weak) 60%, transparent)",
+          borderColor: "var(--panel-border)",
+          color: "var(--text-on-accent)",
+        }}
+      >
+        conversation-only
+      </Badge>
+    ) : null,
+  ].filter((value): value is React.ReactNode => Boolean(value));
+}
+
+function formatRetrievalPostureHistoryTimestamp(value: string | null): string {
+  if (!value) return "Not yet";
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return value;
+  return new Date(parsed).toLocaleString();
+}
+
 function RetrievalPostureDetails({
   retrievalPosture,
   onCopyPosture,
@@ -519,6 +592,51 @@ function RetrievalPostureDetails({
         ) : null}
       </div>
     </>
+  );
+}
+
+export function RetrievalPostureSummaryRow({
+  createdAt,
+  posture,
+  taskId,
+}: {
+  createdAt: string | null;
+  posture: CommandCenterRetrievalPosture;
+  taskId: string;
+}) {
+  const summaryLines = describeRetrievalPosture(posture);
+  const summary = summaryLines[0] ?? "Retrieval posture metadata is present.";
+
+  return (
+    <div
+      className="space-y-2 rounded-[var(--tile-radius)] border px-3 py-2"
+      data-testid="command-center-retrieval-posture-history-item"
+      style={{
+        background: "var(--surface-soft)",
+        borderColor: "var(--panel-border)",
+      }}
+    >
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        <span
+          className="rounded-full border px-2 py-1"
+          style={{ borderColor: "var(--panel-border)", color: "var(--muted)" }}
+        >
+          {formatRetrievalPostureHistoryTimestamp(createdAt)}
+        </span>
+        <span
+          className="rounded-full border px-2 py-1"
+          style={{ borderColor: "var(--panel-border)", color: "var(--muted)" }}
+        >
+          Task: {taskId}
+        </span>
+      </div>
+
+      <div className="flex flex-wrap gap-2">{renderRetrievalPostureBadges(posture)}</div>
+
+      <div className="text-sm leading-5" style={{ color: "var(--text)" }}>
+        {summary}
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/features/commandCenter/hooks/useRetrievalPostureHistory.ts
+++ b/frontend/src/features/commandCenter/hooks/useRetrievalPostureHistory.ts
@@ -1,0 +1,158 @@
+import * as React from "react";
+
+import { fetchRetrievalPostureHistory } from "@/lib/api";
+
+import type {
+  CommandCenterRetrievalPosture,
+  CommandCenterRetrievalPostureHistoryItem,
+  CommandCenterRetrievalPostureHistoryResponse,
+} from "@/features/commandCenter/types";
+
+type UseRetrievalPostureHistoryResult = {
+  error: string | null;
+  items: CommandCenterRetrievalPostureHistoryItem[];
+  loading: boolean;
+  status: "ok" | "empty" | null;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function asBool(value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  return null;
+}
+
+function parseStatus(
+  value: unknown
+): CommandCenterRetrievalPostureHistoryResponse["status"] | null {
+  if (value === "ok" || value === "empty") return value;
+  return null;
+}
+
+function normalizeRetrievalPosture(
+  raw: Record<string, unknown> | null
+): CommandCenterRetrievalPosture | null {
+  if (!raw) return null;
+
+  const source_mode = asString(raw.source_mode);
+  const boundary_label = asString(raw.boundary_label);
+  const widen_reason = asString(raw.widen_reason);
+  if (!source_mode || !boundary_label || !widen_reason) return null;
+
+  return {
+    source_mode,
+    boundary_label,
+    retrieval_override_mode: asString(raw.retrieval_override_mode),
+    widen_reason,
+    conversation_only:
+      asBool(raw.conversation_only) ?? source_mode === "conversation",
+  };
+}
+
+function normalizeHistoryItems(
+  rawItems: unknown
+): CommandCenterRetrievalPostureHistoryItem[] {
+  if (!Array.isArray(rawItems)) return [];
+
+  const items: CommandCenterRetrievalPostureHistoryItem[] = [];
+  for (const rawItem of rawItems) {
+    const item = asRecord(rawItem);
+    if (!item) continue;
+
+    const task_id = asString(item.task_id);
+    const created_at = asString(item.created_at);
+    const retrievalPosture = normalizeRetrievalPosture(
+      asRecord(item.retrieval_posture)
+    );
+    if (!task_id || !created_at || !retrievalPosture) continue;
+
+    items.push({
+      task_id,
+      created_at,
+      retrieval_posture: retrievalPosture,
+    });
+  }
+
+  return items;
+}
+
+function formatError(error: unknown): string {
+  const candidate = error as any;
+  const detail =
+    candidate?.response?.data?.detail ??
+    candidate?.response?.data?.error ??
+    candidate?.message ??
+    "Failed to load retrieval posture history";
+  return String(detail);
+}
+
+export default function useRetrievalPostureHistory(
+  threadId: number | null
+): UseRetrievalPostureHistoryResult {
+  const [state, setState] = React.useState<UseRetrievalPostureHistoryResult>({
+    error: null,
+    items: [],
+    loading: false,
+    status: null,
+  });
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    if (threadId === null) {
+      setState({
+        error: null,
+        items: [],
+        loading: false,
+        status: null,
+      });
+      return;
+    }
+
+    setState({
+      error: null,
+      items: [],
+      loading: true,
+      status: null,
+    });
+
+    void fetchRetrievalPostureHistory(threadId)
+      .then((raw) => {
+        if (cancelled) return;
+        const record = asRecord(raw);
+        const status = parseStatus(record?.status);
+        setState({
+          error: null,
+          items: normalizeHistoryItems(record?.items),
+          loading: false,
+          status: status ?? null,
+        });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setState({
+          error: formatError(error),
+          items: [],
+          loading: false,
+          status: null,
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [threadId]);
+
+  return state;
+}

--- a/frontend/src/features/commandCenter/types.ts
+++ b/frontend/src/features/commandCenter/types.ts
@@ -383,6 +383,18 @@ export interface CommandCenterRetrievalPostureResponse {
   retrieval_posture: CommandCenterRetrievalPosture | null;
 }
 
+export interface CommandCenterRetrievalPostureHistoryItem {
+  created_at: string;
+  retrieval_posture: CommandCenterRetrievalPosture;
+  task_id: string;
+}
+
+export interface CommandCenterRetrievalPostureHistoryResponse {
+  items: CommandCenterRetrievalPostureHistoryItem[];
+  status: "ok" | "empty";
+  thread_id: number;
+}
+
 function normalizeCommandCenterToken(value: string | null | undefined): string {
   return String(value ?? "")
     .trim()

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -275,6 +275,21 @@ export async function fetchLatestRetrievalPosture(
   return response.data;
 }
 
+export function buildRetrievalPostureHistoryPath(
+  threadId: string | number
+): string {
+  return `/api/chat/${normalizePathSegment(threadId)}/debug/retrieval-posture/history`;
+}
+
+export async function fetchRetrievalPostureHistory(
+  threadId: number
+): Promise<Record<string, unknown>> {
+  const response = await api.get<Record<string, unknown>>(
+    buildRetrievalPostureHistoryPath(threadId)
+  );
+  return response.data;
+}
+
 export type ThreadConfigUpdate = {
   providerId?: string;
   modelId?: string;


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
