### PR TITLE
Explain retrieval posture changes in command center

### DIFF
--- a/frontend/src/features/commandCenter/CommandCenterPage.tsx
+++ b/frontend/src/features/commandCenter/CommandCenterPage.tsx
@@ -402,14 +402,15 @@ export default function CommandCenterPage({ enabled }: CommandCenterPageProps) {
         <div className="min-h-0 flex-1">
           {activeThreadId !== null ? (
             <div className="mb-4">
-              <RetrievalPosturePanel
-                compact
-                testId="command-center-thread-posture-panel"
-                threadId={activeThreadId}
-                title="Thread retrieval posture"
-              />
-            </div>
-          ) : null}
+            <RetrievalPosturePanel
+              compact
+              testId="command-center-thread-posture-panel"
+              threadId={activeThreadId}
+              title="Thread retrieval posture"
+              showComparisonStrip
+            />
+          </div>
+        ) : null}
           <TraceWorkbench
             allRuns={runs}
             filters={traceFilters}

--- a/frontend/src/features/commandCenter/__tests__/CommandCenterPage.test.tsx
+++ b/frontend/src/features/commandCenter/__tests__/CommandCenterPage.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
 import CommandCenterPage from "../CommandCenterPage";
 import { describeRuntimeStatusPresentation } from "@/contracts/runtimeTokens";
@@ -650,13 +650,66 @@ const mockedRuns: CommandCenterRun[] = [
   },
 ];
 
+const mockedComparisonRuns: CommandCenterRun[] = [
+  makeComparisonRun({
+    eventId: "evt-12",
+    key: "task-source-mode",
+    receivedAt: "2026-04-01T15:57:00Z",
+    threadId: 800,
+  }),
+  makeComparisonRun({
+    eventId: "evt-13",
+    key: "task-boundary-label",
+    receivedAt: "2026-04-01T15:56:50Z",
+    threadId: 810,
+  }),
+  makeComparisonRun({
+    eventId: "evt-14",
+    key: "task-override-mode",
+    receivedAt: "2026-04-01T15:56:40Z",
+    threadId: 820,
+  }),
+  makeComparisonRun({
+    eventId: "evt-15",
+    key: "task-widen-reason",
+    receivedAt: "2026-04-01T15:56:30Z",
+    threadId: 830,
+  }),
+  makeComparisonRun({
+    eventId: "evt-16",
+    key: "task-conversation-only",
+    receivedAt: "2026-04-01T15:56:20Z",
+    threadId: 840,
+  }),
+  makeComparisonRun({
+    eventId: "evt-17",
+    key: "task-multi-change",
+    receivedAt: "2026-04-01T15:56:10Z",
+    threadId: 850,
+  }),
+  makeComparisonRun({
+    eventId: "evt-18",
+    key: "task-unsupported-change",
+    receivedAt: "2026-04-01T15:56:00Z",
+    threadId: 860,
+  }),
+  makeComparisonRun({
+    eventId: "evt-19",
+    key: "task-unchanged",
+    receivedAt: "2026-04-01T15:55:50Z",
+    threadId: 870,
+  }),
+];
+
+const allMockedRuns = [...mockedRuns, ...mockedComparisonRuns];
+
 vi.mock("../hooks/useCommandCenterEvents", () => ({
   default: () => ({
     connectionDetail: "Listening to /api/events",
     connectionState: "open",
     events: mockedEvents,
     lastEventAt: Date.parse("2026-04-01T15:58:45Z"),
-    runs: mockedRuns,
+    runs: allMockedRuns,
     unauthorized: false,
   }),
 }));
@@ -747,6 +800,60 @@ const mockedPartialPosture = {
   conversation_only: true,
 } as unknown as CommandCenterRetrievalPosture;
 
+function makeComparisonRun({
+  eventId,
+  key,
+  receivedAt,
+  threadId,
+}: {
+  eventId: string;
+  key: string;
+  receivedAt: string;
+  threadId: number;
+}): CommandCenterRun {
+  const timestamp = Date.parse(receivedAt);
+
+  return {
+    eventCount: 1,
+    identityKind: "task",
+    key,
+    lastEvent: makeEvent({
+      eventId,
+      json: { thread_id: threadId, type: "chat.completion" },
+      kind: null,
+      raw: `{"thread_id":${threadId},"type":"chat.completion"}`,
+      receivedAt: timestamp,
+      runId: `run-${key}`,
+      sseType: "task.completed",
+      state: "completed",
+      status: null,
+      summary: "chat completion completed",
+      taskId: key,
+      taskType: "chat.completion",
+      terminalOutcome: COMMAND_CENTER_RUN_TERMINAL_OUTCOMES.COMPLETED,
+      threadId,
+      turnId: `turn-${key}`,
+      type: "task.completed",
+    }),
+    lastEventAt: timestamp,
+    lastKind: null,
+    lastType: "task.completed",
+    requestId: null,
+    runId: `run-${key}`,
+    runKind: "chat_completion",
+    runType: "chat completion",
+    state: "completed",
+    status: COMMAND_CENTER_RUN_STATUSES.COMPLETED,
+    summary: "chat completion · completed",
+    taskId: key,
+    terminalOutcome: COMMAND_CENTER_RUN_TERMINAL_OUTCOMES.COMPLETED,
+    threadId,
+    traceEvidence: null,
+    traceUrl: null,
+    turnId: `turn-${key}`,
+  };
+}
+
 vi.mock("../hooks/useRetrievalPosture", () => ({
   default: (threadId: number | null) => {
     if (threadId === 42) {
@@ -819,6 +926,112 @@ vi.mock("../hooks/useRetrievalPosture", () => ({
         loading: false,
         retrievalPosture: null,
         status: "empty",
+      };
+    }
+    if (threadId === 800) {
+      return {
+        error: null,
+        loading: false,
+        retrievalPosture: {
+          source_mode: "project",
+          boundary_label: "active_conversation_only",
+          retrieval_override_mode: "conversation",
+          widen_reason: "none",
+          conversation_only: true,
+        },
+        status: "ok",
+      };
+    }
+    if (threadId === 810) {
+      return {
+        error: null,
+        loading: false,
+        retrievalPosture: {
+          source_mode: "conversation",
+          boundary_label: "same_user_same_project",
+          retrieval_override_mode: "conversation",
+          widen_reason: "none",
+          conversation_only: true,
+        },
+        status: "ok",
+      };
+    }
+    if (threadId === 820) {
+      return {
+        error: null,
+        loading: false,
+        retrievalPosture: {
+          source_mode: "conversation",
+          boundary_label: "active_conversation_only",
+          retrieval_override_mode: null,
+          widen_reason: "none",
+          conversation_only: true,
+        },
+        status: "ok",
+      };
+    }
+    if (threadId === 830) {
+      return {
+        error: null,
+        loading: false,
+        retrievalPosture: {
+          source_mode: "conversation",
+          boundary_label: "active_conversation_only",
+          retrieval_override_mode: "conversation",
+          widen_reason: "insufficient_thread_hits",
+          conversation_only: true,
+        },
+        status: "ok",
+      };
+    }
+    if (threadId === 840) {
+      return {
+        error: null,
+        loading: false,
+        retrievalPosture: {
+          source_mode: "conversation",
+          boundary_label: "active_conversation_only",
+          retrieval_override_mode: "conversation",
+          widen_reason: "none",
+          conversation_only: false,
+        },
+        status: "ok",
+      };
+    }
+    if (threadId === 850) {
+      return {
+        error: null,
+        loading: false,
+        retrievalPosture: {
+          source_mode: "project",
+          boundary_label: "active_conversation_only",
+          retrieval_override_mode: "conversation",
+          widen_reason: "insufficient_thread_hits",
+          conversation_only: true,
+        },
+        status: "ok",
+      };
+    }
+    if (threadId === 860) {
+      return {
+        error: null,
+        loading: false,
+        retrievalPosture: {
+          source_mode: "project",
+          boundary_label: "same_user_same_project",
+          retrieval_override_mode: null,
+          widen_reason: "insufficient_thread_hits",
+          conversation_only: false,
+        },
+        status: "ok",
+      };
+    }
+    if (threadId === 870) {
+      return {
+        error: null,
+        loading: false,
+        retrievalPosture: mockedRetrievalPosture,
+        status: "ok",
       };
     }
     return {
@@ -960,7 +1173,7 @@ describe("CommandCenterPage", () => {
     expect(within(threadPanel).getByText(/boundary: active_conversation_only/i)).toBeInTheDocument();
     expect(within(threadPanel).getByText(/override: conversation/i)).toBeInTheDocument();
     expect(within(threadPanel).getByText(/widen: none/i)).toBeInTheDocument();
-    expect(within(threadPanel).getByText(/conversation-only/i)).toBeInTheDocument();
+    expect(within(threadPanel).getByText(/^conversation-only$/i)).toBeInTheDocument();
     expect(within(threadPanel).getByText(/This run stayed inside the active conversation\./i)).toBeInTheDocument();
     expect(within(threadPanel).getByText(/No widening occurred\./i)).toBeInTheDocument();
     expect(within(threadPanel).getByText("What these fields mean")).toBeInTheDocument();
@@ -980,6 +1193,148 @@ describe("CommandCenterPage", () => {
     expect(within(threadPanel).getByText(/Retrieval did not widen\./i)).toBeInTheDocument();
   });
 
+  it.each([
+    [
+      "source_mode",
+      "task-source-mode",
+      "The retrieval scope changed.",
+    ],
+    [
+      "boundary_label",
+      "task-boundary-label",
+      "The retrieval boundary changed.",
+    ],
+    [
+      "retrieval_override_mode",
+      "task-override-mode",
+      "An explicit retrieval override changed the posture.",
+    ],
+    [
+      "widen_reason",
+      "task-widen-reason",
+      "The reason for widening changed.",
+    ],
+    [
+      "conversation_only",
+      "task-conversation-only",
+      "Conversation-only retrieval changed.",
+    ],
+  ] as const)(
+    "renders a bounded explanation when %s changes",
+    async (field, taskKey, expectedLine) => {
+      render(<CommandCenterPage enabled />);
+
+      const workbench = screen.getByTestId("command-center-trace-workbench");
+      const threadPanel = screen.getByTestId("command-center-thread-posture-panel");
+
+      fireEvent.click(within(workbench).getByRole("button", { name: /task-alpha/i }));
+      await waitFor(() =>
+        expect(within(threadPanel).getByText("No previous posture to compare")).toBeInTheDocument()
+      );
+
+      fireEvent.click(within(workbench).getByRole("button", { name: new RegExp(taskKey, "i") }));
+
+      await waitFor(() =>
+        expect(within(threadPanel).getByText("Posture changed since previous run")).toBeInTheDocument()
+      );
+
+      expect(within(threadPanel).getByText(`Changed: ${field}`)).toBeInTheDocument();
+      expect(within(threadPanel).getByText(expectedLine)).toBeInTheDocument();
+      expect(
+        within(threadPanel).queryByText(
+          /Retrieval posture changed, but this combination does not yet have a tailored explanation\./i
+        )
+      ).not.toBeInTheDocument();
+    }
+  );
+
+  it("renders multiple bounded explanation lines when multiple fields change", async () => {
+    render(<CommandCenterPage enabled />);
+
+    const workbench = screen.getByTestId("command-center-trace-workbench");
+    const threadPanel = screen.getByTestId("command-center-thread-posture-panel");
+
+    fireEvent.click(within(workbench).getByRole("button", { name: /task-alpha/i }));
+    await waitFor(() =>
+      expect(within(threadPanel).getByText("No previous posture to compare")).toBeInTheDocument()
+    );
+
+    fireEvent.click(within(workbench).getByRole("button", { name: /task-multi-change/i }));
+
+    await waitFor(() =>
+      expect(within(threadPanel).getByText("Posture changed since previous run")).toBeInTheDocument()
+    );
+
+    expect(within(threadPanel).getByText("Changed: source_mode, widen_reason")).toBeInTheDocument();
+    expect(within(threadPanel).getByText("The retrieval scope changed.")).toBeInTheDocument();
+    expect(within(threadPanel).getByText("The reason for widening changed.")).toBeInTheDocument();
+    expect(
+      within(threadPanel).queryByText(
+        /Retrieval posture changed, but this combination does not yet have a tailored explanation\./i
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  it("falls back when the changed-field combination is unsupported", async () => {
+    render(<CommandCenterPage enabled />);
+
+    const workbench = screen.getByTestId("command-center-trace-workbench");
+    const threadPanel = screen.getByTestId("command-center-thread-posture-panel");
+
+    fireEvent.click(within(workbench).getByRole("button", { name: /task-alpha/i }));
+    await waitFor(() =>
+      expect(within(threadPanel).getByText("No previous posture to compare")).toBeInTheDocument()
+    );
+
+    fireEvent.click(within(workbench).getByRole("button", { name: /task-unsupported-change/i }));
+
+    await waitFor(() =>
+      expect(within(threadPanel).getByText("Posture changed since previous run")).toBeInTheDocument()
+    );
+
+    expect(
+      within(threadPanel).getByText(
+        "Changed: source_mode, boundary_label, retrieval_override_mode, widen_reason, conversation_only"
+      )
+    ).toBeInTheDocument();
+    expect(
+      within(threadPanel).getByText(
+        /Retrieval posture changed, but this combination does not yet have a tailored explanation\./i
+      )
+    ).toBeInTheDocument();
+    expect(within(threadPanel).queryByText("The retrieval scope changed.")).not.toBeInTheDocument();
+    expect(within(threadPanel).queryByText("The retrieval boundary changed.")).not.toBeInTheDocument();
+  });
+
+  it("does not render the explainer for unchanged and no-previous states", async () => {
+    render(<CommandCenterPage enabled />);
+
+    const workbench = screen.getByTestId("command-center-trace-workbench");
+    const threadPanel = screen.getByTestId("command-center-thread-posture-panel");
+
+    expect(within(threadPanel).queryByText(/The retrieval scope changed\./i)).not.toBeInTheDocument();
+    expect(
+      within(threadPanel).queryByText(
+        /Retrieval posture changed, but this combination does not yet have a tailored explanation\./i
+      )
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(within(workbench).getByRole("button", { name: /task-alpha/i }));
+    await waitFor(() =>
+      expect(within(threadPanel).getByText("No previous posture to compare")).toBeInTheDocument()
+    );
+    expect(within(threadPanel).queryByText("The retrieval scope changed.")).not.toBeInTheDocument();
+    expect(within(threadPanel).queryByText("Changed: source_mode")).not.toBeInTheDocument();
+
+    fireEvent.click(within(workbench).getByRole("button", { name: /task-unchanged/i }));
+
+    await waitFor(() =>
+      expect(within(threadPanel).getByText("Posture unchanged since previous run")).toBeInTheDocument()
+    );
+    expect(within(threadPanel).queryByText(/^Changed:/i)).not.toBeInTheDocument();
+    expect(within(threadPanel).queryByText("The retrieval scope changed.")).not.toBeInTheDocument();
+  });
+
   it("renders retrieval posture section for active thread with status ok", () => {
     render(<CommandCenterPage enabled />);
 
@@ -997,7 +1352,7 @@ describe("CommandCenterPage", () => {
     expect(within(workbench).getByText(/boundary: active_conversation_only/i)).toBeInTheDocument();
     expect(within(workbench).getByText(/override: conversation/i)).toBeInTheDocument();
     expect(within(workbench).getByText(/widen: none/i)).toBeInTheDocument();
-    expect(within(workbench).getByText(/conversation-only/i)).toBeInTheDocument();
+    expect(within(workbench).getByText(/^conversation-only$/i)).toBeInTheDocument();
 
     // Verify explainer text is also present
     expect(within(workbench).getByText(/This run stayed inside the active conversation\./i)).toBeInTheDocument();

--- a/frontend/src/features/commandCenter/components/TraceWorkbench.tsx
+++ b/frontend/src/features/commandCenter/components/TraceWorkbench.tsx
@@ -140,6 +140,78 @@ function firstNumber(...values: unknown[]): number | null {
   return null;
 }
 
+export const RETRIEVAL_POSTURE_DIFF_FIELDS = [
+  "source_mode",
+  "boundary_label",
+  "retrieval_override_mode",
+  "widen_reason",
+  "conversation_only",
+] as const;
+
+export type RetrievalPostureDiffField =
+  (typeof RETRIEVAL_POSTURE_DIFF_FIELDS)[number];
+
+export type RetrievalPostureDiff = {
+  changed: boolean;
+  changedFields: RetrievalPostureDiffField[];
+};
+
+export function diffRetrievalPosture(
+  current: CommandCenterRetrievalPosture,
+  previous: CommandCenterRetrievalPosture | null
+): RetrievalPostureDiff {
+  if (!previous) {
+    return { changed: false, changedFields: [] };
+  }
+
+  const changedFields = RETRIEVAL_POSTURE_DIFF_FIELDS.filter(
+    (field) => current[field] !== previous[field]
+  );
+
+  return {
+    changed: changedFields.length > 0,
+    changedFields,
+  };
+}
+
+export type RetrievalPostureChangeExplanation = {
+  lines: string[];
+};
+
+const RETRIEVAL_POSTURE_CHANGE_EXPLANATIONS: Record<
+  RetrievalPostureDiffField,
+  string
+> = {
+  source_mode: "The retrieval scope changed.",
+  boundary_label: "The retrieval boundary changed.",
+  retrieval_override_mode: "An explicit retrieval override changed the posture.",
+  widen_reason: "The reason for widening changed.",
+  conversation_only: "Conversation-only retrieval changed.",
+};
+
+const RETRIEVAL_POSTURE_CHANGE_FALLBACK =
+  "Retrieval posture changed, but this combination does not yet have a tailored explanation.";
+
+export function describeRetrievalPostureChange(
+  diff: RetrievalPostureDiff,
+  current: CommandCenterRetrievalPosture | null,
+  previous: CommandCenterRetrievalPosture | null
+): RetrievalPostureChangeExplanation {
+  if (!diff.changed || !current || !previous) {
+    return { lines: [] };
+  }
+
+  if (diff.changedFields.length === 0 || diff.changedFields.length > 2) {
+    return { lines: [RETRIEVAL_POSTURE_CHANGE_FALLBACK] };
+  }
+
+  const lines = diff.changedFields.map(
+    (field) => RETRIEVAL_POSTURE_CHANGE_EXPLANATIONS[field]
+  );
+
+  return lines.length > 0 ? { lines } : { lines: [RETRIEVAL_POSTURE_CHANGE_FALLBACK] };
+}
+
 /**
  * Derives a brief human-readable explanation of the retrieval posture from
  * canonical backend fields. Presentation-only — does not infer or classify.
@@ -269,10 +341,58 @@ function describeRetrievalPostureToken(
   }
 }
 
+type RetrievalPostureComparisonState = "changed" | "unchanged" | "no-previous" | "none";
+
+type RetrievalPostureComparison = {
+  changedFields: RetrievalPostureDiffField[] | null;
+  explanationLines: string[] | null;
+  label: string | null;
+  state: RetrievalPostureComparisonState;
+};
+
+function latestRetrievalPostureComparison(
+  current: CommandCenterRetrievalPosture | null,
+  previous: CommandCenterRetrievalPosture | null
+): RetrievalPostureComparison {
+  if (!current) {
+    return {
+      changedFields: null,
+      explanationLines: null,
+      label: null,
+      state: "none",
+    };
+  }
+
+  if (!previous) {
+    return {
+      changedFields: null,
+      explanationLines: null,
+      label: "No previous posture to compare",
+      state: "no-previous",
+    };
+  }
+
+  const comparison = diffRetrievalPosture(current, previous);
+  const explanation = describeRetrievalPostureChange(comparison, current, previous);
+
+  return {
+    changedFields: comparison.changed ? comparison.changedFields : null,
+    explanationLines: comparison.changed ? explanation.lines : null,
+    label: comparison.changed
+      ? "Posture changed since previous run"
+      : "Posture unchanged since previous run",
+    state: comparison.changed ? "changed" : "unchanged",
+  };
+}
+
 function RetrievalPostureDetails({
+  comparison,
   retrievalPosture,
+  showComparisonStrip,
 }: {
+  comparison: RetrievalPostureComparison | null;
   retrievalPosture: CommandCenterRetrievalPosture;
+  showComparisonStrip: boolean;
 }) {
   const glossaryRows: Array<{
     field: RetrievalPostureTokenField;
@@ -303,6 +423,41 @@ function RetrievalPostureDetails({
 
   return (
     <>
+      {showComparisonStrip && comparison?.label ? (
+        <div
+          className="mt-2 rounded-[var(--tile-radius)] border px-3 py-2 text-xs leading-5"
+          style={{
+            background: "var(--surface-soft)",
+            borderColor: "var(--panel-border)",
+            color: "var(--muted)",
+          }}
+        >
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge
+              className="border text-[11px] font-medium leading-none"
+              style={{
+                background: "var(--surface-soft)",
+                borderColor: "var(--panel-border)",
+                color: "var(--text)",
+              }}
+            >
+              {comparison.label}
+            </Badge>
+            {comparison.changedFields ? (
+              <div className="space-y-1">
+                <span>Changed: {comparison.changedFields.join(", ")}</span>
+                {comparison.explanationLines ? (
+                  <div className="space-y-0.5 leading-5" style={{ color: "var(--text)" }}>
+                    {comparison.explanationLines.map((line) => (
+                      <p key={line}>{line}</p>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
       <div className="mt-2 flex flex-wrap gap-2">
         <Badge
           className="border text-[11px] font-medium leading-none"
@@ -404,15 +559,47 @@ export function RetrievalPosturePanel({
   threadId,
   title = "Retrieval posture",
   testId,
+  showComparisonStrip = false,
 }: {
   className?: string;
   compact?: boolean;
   threadId: number | null;
   title?: string;
   testId?: string;
+  showComparisonStrip?: boolean;
 }) {
   const { error: postureError, loading: postureLoading, retrievalPosture, status: postureStatus } =
     useRetrievalPosture(threadId);
+  const previousRetrievalPostureRef = React.useRef<CommandCenterRetrievalPosture | null>(null);
+  const [comparison, setComparison] = React.useState<RetrievalPostureComparison>({
+    changedFields: null,
+    explanationLines: null,
+    label: null,
+    state: "none",
+  });
+  const comparisonSnapshot = retrievalPosture
+    ? [
+        retrievalPosture.source_mode,
+        retrievalPosture.boundary_label,
+        retrievalPosture.retrieval_override_mode ?? "null",
+        retrievalPosture.widen_reason,
+        String(retrievalPosture.conversation_only),
+      ].join("\u241f")
+    : null;
+
+  React.useEffect(() => {
+    if (postureLoading || postureError || postureStatus !== "ok" || !retrievalPosture) {
+      return;
+    }
+
+    const nextComparison = latestRetrievalPostureComparison(
+      retrievalPosture,
+      previousRetrievalPostureRef.current
+    );
+
+    setComparison(nextComparison);
+    previousRetrievalPostureRef.current = retrievalPosture;
+  }, [comparisonSnapshot, postureError, postureLoading, postureStatus, threadId]);
 
   const rootClassName = [
     compact ? "rounded-[var(--tile-radius)] border p-2.5" : "rounded-[var(--tile-radius)] border p-3",
@@ -449,7 +636,11 @@ export function RetrievalPosturePanel({
           No retrieval posture evidence for this thread.
         </div>
       ) : retrievalPosture ? (
-        <RetrievalPostureDetails retrievalPosture={retrievalPosture} />
+        <RetrievalPostureDetails
+          comparison={comparison}
+          retrievalPosture={retrievalPosture}
+          showComparisonStrip={showComparisonStrip}
+        />
       ) : null}
     </div>
   );


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
