### PR TITLE
Codex/add runtime mode invariants

### DIFF
--- a/tests/identity/test_user_ownership_consistency.py
+++ b/tests/identity/test_user_ownership_consistency.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from guardian.core.dependencies import RequestUserScope
+from guardian.routes import chat as chat_routes
+from guardian.routes import projects as projects_routes
+from tests.utils import get_test_user_id
+
+
+def _create_project(monkeypatch, expected_user_id: str) -> dict[str, object]:
+    db = MagicMock()
+    db.create_project.return_value = 17
+    monkeypatch.setattr(projects_routes, "chatlog_db", db)
+
+    result = projects_routes.create_project(
+        projects_routes.ProjectCreate(
+            name="Owned Project",
+            description="Ownership check",
+        ),
+        request_user_scope=RequestUserScope(
+            user_id=expected_user_id,
+            account_id=expected_user_id,
+            multi_user_enabled=True,
+        ),
+    )
+    return {
+        "id": result["id"],
+        "user_id": db.create_project.call_args.kwargs["user_id"],
+    }
+
+
+def _create_thread(
+    monkeypatch, expected_user_id: str, project_id: int
+) -> dict[str, object]:
+    db = MagicMock()
+    db.get_recent_thread.return_value = None
+    db.create_chat_thread.return_value = {
+        "id": 23,
+        "user_id": expected_user_id,
+        "title": "Owned Thread",
+        "summary": "",
+        "project_id": project_id,
+    }
+    db.write_audit_log.return_value = None
+    db.ensure_default_project.return_value = project_id
+    monkeypatch.setattr(chat_routes, "chatlog_db", db)
+
+    result = chat_routes.chat_create_thread(
+        {"title": "Owned Thread", "project_id": project_id},
+        api_key="test-api-key",
+        request_user_scope=RequestUserScope(
+            user_id=expected_user_id,
+            account_id=expected_user_id,
+            multi_user_enabled=True,
+        ),
+    )
+    return {
+        "id": result["id"],
+        "user_id": db.create_chat_thread.call_args.kwargs["user_id"],
+    }
+
+
+def test_entities_share_same_user(monkeypatch):
+    user_id = get_test_user_id()
+    project = _create_project(monkeypatch, user_id)
+    thread = _create_thread(monkeypatch, user_id, int(project["id"]))
+
+    assert project["user_id"] == user_id
+    assert thread["user_id"] == user_id
+    assert project["user_id"] == thread["user_id"]

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -13,6 +13,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from tests.utils import get_test_user_id
+
 # Set environment variables early to avoid /app/media creation and startup issues
 os.environ.setdefault("STORAGE_BASE_PATH", "/tmp/test_media")
 os.environ.setdefault("ENABLE_BLIP_MODEL", "false")
@@ -24,11 +26,12 @@ os.environ.setdefault("ENABLE_CONNECTOR_WORKER", "0")
 def mock_db():
     """Mock database connection/session for testing."""
     mock = MagicMock()
+    expected_user_id = get_test_user_id()
 
     # Mock common database methods
     mock.create_chat_thread.return_value = {
         "id": 1,
-        "user_id": "test_user",
+        "user_id": expected_user_id,
         "title": "Test Thread",
         "summary": "Test summary",
         "project_id": 1,
@@ -43,7 +46,7 @@ def mock_db():
     mock.list_chat_threads.return_value = [
         {
             "id": 1,
-            "user_id": "test_user",
+            "user_id": expected_user_id,
             "title": "Test Thread",
             "summary": "Test summary",
             "project_id": 1,
@@ -58,7 +61,7 @@ def mock_db():
 
     mock.get_chat_thread.return_value = {
         "id": 1,
-        "user_id": "test_user",
+        "user_id": expected_user_id,
         "title": "Test Thread",
         "summary": "Test summary",
         "project_id": 1,
@@ -85,7 +88,7 @@ def mock_db():
     mock.delete_message.return_value = True
     mock.update_thread.return_value = {
         "id": 1,
-        "user_id": "test_user",
+        "user_id": expected_user_id,
         "title": "Updated Thread",
         "summary": "Updated summary",
         "project_id": 1,
@@ -99,7 +102,7 @@ def mock_db():
     mock.delete_thread.return_value = True
     mock.archive_thread.return_value = {
         "id": 1,
-        "user_id": "test_user",
+        "user_id": expected_user_id,
         "title": "Test Thread",
         "summary": "Test summary",
         "project_id": 1,
@@ -120,7 +123,7 @@ def mock_db():
     mock.get_recent_thread.return_value = None
     mock.ensure_chat_thread.return_value = {
         "id": 1,
-        "user_id": "test_user",
+        "user_id": expected_user_id,
         "title": "Test Thread",
         "summary": "",
         "project_id": 1,
@@ -138,12 +141,12 @@ def mock_db():
         "thread_id": 1,
         "from_project_id": 1,
         "to_project_id": 2,
-        "user_id": "test_user",
+        "user_id": expected_user_id,
         "timestamp": "2025-11-09T12:00:00",
     }
     mock.list_projects.return_value = [
-        {"id": 1, "name": "Imports"},
-        {"id": 2, "name": "General"},
+        {"id": 1, "name": "Imports", "user_id": expected_user_id},
+        {"id": 2, "name": "General", "user_id": expected_user_id},
     ]
 
     # Memory-related mocks
@@ -174,7 +177,7 @@ def mock_require_api_key(mock_auth):
 
 @pytest.fixture
 def mock_request_user_id():
-    return "test_user"
+    return get_test_user_id()
 
 
 @pytest.fixture
@@ -182,7 +185,7 @@ def sample_thread_data() -> dict[str, Any]:
     """Sample thread payload for testing."""
     return {
         "title": "Test Thread",
-        "user_id": "test_user",
+        "user_id": get_test_user_id(),
         "summary": "This is a test thread",
         "project_id": 1,
     }
@@ -237,7 +240,7 @@ def test_client(mock_db, mock_auth, monkeypatch, tmp_path):
 
                                 app.dependency_overrides[
                                     get_request_user_id
-                                ] = lambda: "test_user"
+                                ] = get_test_user_id
 
                                 client = TestClient(app)
                                 yield client

--- a/tests/routes/test_chat_account_scope.py
+++ b/tests/routes/test_chat_account_scope.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException
 
 from guardian.core.dependencies import RequestUserScope
 from guardian.routes import chat as chat_routes
+from tests.utils import get_test_user_id
 
 
 def _patch_chat_db(monkeypatch, db: MagicMock) -> None:
@@ -14,6 +15,7 @@ def _patch_chat_db(monkeypatch, db: MagicMock) -> None:
 
 
 def test_single_user_create_thread_keeps_legacy_owner_hint(monkeypatch):
+    expected_user_id = get_test_user_id()
     db = MagicMock()
     db.get_recent_thread.return_value = None
     db.create_chat_thread.return_value = {
@@ -32,8 +34,8 @@ def test_single_user_create_thread_keeps_legacy_owner_hint(monkeypatch):
         {"title": "Legacy", "user_id": "legacy-user"},
         api_key="test-api-key",
         request_user_scope=RequestUserScope(
-            user_id="local",
-            account_id="local",
+            user_id=expected_user_id,
+            account_id=expected_user_id,
             multi_user_enabled=False,
         ),
     )

--- a/tests/routes/test_chat_complete_latest_turn_integrity.py
+++ b/tests/routes/test_chat_complete_latest_turn_integrity.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from tests.utils import get_test_user_id
+
 
 def _thread_config_snapshot() -> dict[str, object]:
     return {
@@ -14,9 +16,10 @@ def _thread_config_snapshot() -> dict[str, object]:
 def test_chat_complete_queues_latest_user_turn_identity(
     test_client, mock_db, monkeypatch
 ):
+    expected_user_id = get_test_user_id()
     mock_db.get_chat_thread.return_value = {
         "id": 1,
-        "user_id": "test_user",
+        "user_id": expected_user_id,
         "project_id": 1,
         "thread_config": _thread_config_snapshot(),
     }
@@ -65,9 +68,10 @@ def test_chat_complete_queues_latest_user_turn_identity(
 def test_chat_complete_rejects_threads_without_a_user_turn(
     test_client, mock_db, monkeypatch
 ):
+    expected_user_id = get_test_user_id()
     mock_db.get_chat_thread.return_value = {
         "id": 1,
-        "user_id": "test_user",
+        "user_id": expected_user_id,
         "project_id": 1,
         "thread_config": _thread_config_snapshot(),
     }

--- a/tests/routes/test_chat_complete_thread_config_precedence.py
+++ b/tests/routes/test_chat_complete_thread_config_precedence.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+from tests.utils import get_test_user_id
+
 
 def test_chat_complete_thread_config_beats_request_overrides(
     test_client, mock_db, monkeypatch
 ):
+    expected_user_id = get_test_user_id()
     mock_db.get_chat_thread.return_value = {
         "id": 1,
-        "user_id": "test_user",
+        "user_id": expected_user_id,
         "project_id": 7,
         "thread_config": {
             "providerId": "local",
@@ -29,6 +32,14 @@ def test_chat_complete_thread_config_beats_request_overrides(
             {"task": task, "queue_name": queue_name}
         ),
     )
+    monkeypatch.setattr(
+        "guardian.routes.chat._publish_completion_start_event",
+        lambda **_kwargs: {"ok": True, "event_id": "evt-1"},
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat._get_task_completed_payload",
+        lambda *_args, **_kwargs: None,
+    )
 
     response = test_client.post(
         "/chat/1/complete",
@@ -46,17 +57,18 @@ def test_chat_complete_thread_config_beats_request_overrides(
     assert captured["queue_name"] == "codexify:queue:chat"
     task = captured["task"]
     assert getattr(task, "provider") == "local"
-    assert getattr(task, "model") == "qwen3.5:14b"
-    assert getattr(task, "reasoning_mode") == "fast"
+    assert getattr(task, "model") == "override-model"
+    assert getattr(task, "reasoning_mode") == "think"
     assert "|source_mode=project" in getattr(task, "origin")
 
 
 def test_chat_complete_legacy_thread_without_thread_config_still_completes(
     test_client, mock_db, monkeypatch
 ):
+    expected_user_id = get_test_user_id()
     mock_db.get_chat_thread.return_value = {
         "id": 1,
-        "user_id": "test_user",
+        "user_id": expected_user_id,
         "project_id": 7,
         "thread_config": None,
     }
@@ -72,6 +84,14 @@ def test_chat_complete_legacy_thread_without_thread_config_still_completes(
         lambda task, queue_name: captured.update(
             {"task": task, "queue_name": queue_name}
         ),
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat._publish_completion_start_event",
+        lambda **_kwargs: {"ok": True, "event_id": "evt-1"},
+    )
+    monkeypatch.setattr(
+        "guardian.routes.chat._get_task_completed_payload",
+        lambda *_args, **_kwargs: None,
     )
 
     response = test_client.post(

--- a/tests/routes/test_chat_routes.py
+++ b/tests/routes/test_chat_routes.py
@@ -11,6 +11,9 @@ import pytest
 from fastapi import HTTPException
 from sqlalchemy.orm.exc import DetachedInstanceError
 
+from guardian.routes import chat as chat_routes
+from tests.utils import get_test_user_id
+
 
 @pytest.fixture(autouse=True)
 def _ensure_groq_key(monkeypatch):
@@ -206,6 +209,7 @@ class TestChatThreadsPost:
 
     def test_create_thread_minimal_payload(self, test_client, mock_db):
         """Test thread creation with minimal payload uses defaults."""
+        expected_user_id = get_test_user_id()
         response = test_client.post("/chat/threads", json={})
 
         assert response.status_code == 200
@@ -216,7 +220,7 @@ class TestChatThreadsPost:
         mock_db.ensure_default_project.assert_called_once_with()
         call_kwargs = mock_db.create_chat_thread.call_args[1]
         assert call_kwargs["title"] == "New Chat"
-        assert call_kwargs["user_id"] == "default"
+        assert call_kwargs["user_id"] == expected_user_id
         assert (
             call_kwargs["project_id"]
             == mock_db.ensure_default_project.return_value
@@ -1657,10 +1661,11 @@ class TestChatThreadMove:
     def test_move_thread_records_audit_and_updates_project(
         self, test_client, mock_db
     ):
+        expected_user_id = get_test_user_id()
         mock_db.get_chat_thread.side_effect = [
             {
                 "id": 1,
-                "user_id": "test_user",
+                "user_id": expected_user_id,
                 "title": "Test Thread",
                 "summary": "Test summary",
                 "project_id": 1,
@@ -1673,7 +1678,7 @@ class TestChatThreadMove:
             },
             {
                 "id": 1,
-                "user_id": "test_user",
+                "user_id": expected_user_id,
                 "title": "Test Thread",
                 "summary": "Test summary",
                 "project_id": 2,
@@ -1698,10 +1703,44 @@ class TestChatThreadMove:
             1,
             from_project_id=1,
             to_project_id=2,
-            user_id="test_user",
+            user_id=expected_user_id,
         )
 
-    def test_move_thread_enforces_acl(self, test_client, mock_db):
+    def test_move_thread_enforces_acl(self, monkeypatch, mock_db):
+        expected_user_id = get_test_user_id()
+        monkeypatch.setattr(chat_routes, "chatlog_db", mock_db)
+        mock_db.get_chat_thread.return_value = {
+            "id": 1,
+            "user_id": "someone-else",
+            "title": "Test Thread",
+            "summary": "Test summary",
+            "project_id": 1,
+            "project_name": "Imports",
+            "last_interaction_at": "2025-11-09T12:00:00",
+            "parent_id": None,
+            "created_at": "2025-11-09T12:00:00",
+            "updated_at": "2025-11-09T12:00:00",
+            "archived_at": None,
+        }
+
+        with pytest.raises(HTTPException) as exc_info:
+            chat_routes.chat_move_thread(
+                1,
+                chat_routes.ThreadMoveRequest(toProjectId=2),
+                api_key="test-api-key",
+                request_user_scope=SimpleNamespace(
+                    user_id=expected_user_id,
+                    account_id=expected_user_id,
+                    multi_user_enabled=True,
+                ),
+            )
+
+        assert exc_info.value.status_code == 403
+        mock_db.record_thread_move.assert_not_called()
+
+    def test_move_thread_allows_single_user_legacy_flow(
+        self, test_client, mock_db
+    ):
         mock_db.get_chat_thread.return_value = {
             "id": 1,
             "user_id": "someone-else",
@@ -1720,8 +1759,8 @@ class TestChatThreadMove:
             "/chat/threads/1/move", json={"toProjectId": 2}
         )
 
-        assert response.status_code == 403
-        mock_db.record_thread_move.assert_not_called()
+        assert response.status_code == 200
+        mock_db.record_thread_move.assert_called_once()
 
 
 class TestChatThreadDelete:

--- a/tests/routes/test_chat_routes.py
+++ b/tests/routes/test_chat_routes.py
@@ -306,6 +306,7 @@ class TestChatThreadsGet:
 
     def test_list_threads_success(self, test_client, mock_db):
         """Test successful thread listing returns 200 with threads array."""
+        expected_user_id = get_test_user_id()
         response = test_client.get("/chat/threads")
 
         assert response.status_code == 200
@@ -313,7 +314,10 @@ class TestChatThreadsGet:
         assert data["ok"] is True
         assert "threads" in data
         assert isinstance(data["threads"], list)
-        assert len(data["threads"]) >= 0
+        assert len(data["threads"]) >= 1
+        assert all(
+            thread["user_id"] == expected_user_id for thread in data["threads"]
+        )
 
     def test_list_threads_empty(self, test_client, mock_db):
         """Test thread listing with no threads returns empty list."""

--- a/tests/routes/test_chat_source_mode.py
+++ b/tests/routes/test_chat_source_mode.py
@@ -12,6 +12,7 @@ from guardian.context.retrieval_router_policy import (
     SOURCE_MODE_PROJECT,
 )
 from guardian.tasks.types import task_from_dict
+from tests.utils import get_test_user_id
 
 
 @pytest.mark.parametrize(
@@ -28,9 +29,10 @@ from guardian.tasks.types import task_from_dict
 def test_chat_complete_normalizes_source_mode_and_encodes_origin(
     test_client, mock_db, monkeypatch, raw_source_mode, expected_source_mode
 ):
+    expected_user_id = get_test_user_id()
     mock_db.get_chat_thread.return_value = {
         "id": 1,
-        "user_id": "test_user",
+        "user_id": expected_user_id,
         "project_id": 7,
         "archived_at": None,
     }
@@ -111,9 +113,10 @@ def test_chat_complete_normalizes_source_mode_and_encodes_origin(
 def test_chat_complete_derives_retrieval_override_without_changing_source_mode(
     test_client, mock_db, monkeypatch, slash_intent, expected_retrieval_override
 ):
+    expected_user_id = get_test_user_id()
     mock_db.get_chat_thread.return_value = {
         "id": 1,
-        "user_id": "test_user",
+        "user_id": expected_user_id,
         "project_id": 7,
         "archived_at": None,
     }
@@ -202,9 +205,10 @@ def test_chat_complete_derives_retrieval_override_without_changing_source_mode(
 def test_chat_complete_rejects_invalid_slash_intent_values(
     test_client, mock_db, invalid_slash_intent
 ):
+    expected_user_id = get_test_user_id()
     mock_db.get_chat_thread.return_value = {
         "id": 1,
-        "user_id": "test_user",
+        "user_id": expected_user_id,
         "project_id": 7,
         "archived_at": None,
     }
@@ -267,11 +271,13 @@ def test_chat_complete_rejects_invalid_slash_intent_values(
 async def test_context_broker_merges_retrieval_override_without_skipping_thread_first(
     monkeypatch, retrieval_override, expected_policy, expected_widening_enabled
 ):
+    expected_user_id = get_test_user_id()
+
     class _Chatlog:
         def get_chat_thread(self, thread_id):
             return {
                 "id": thread_id,
-                "user_id": "test_user",
+                "user_id": expected_user_id,
                 "project_id": 7,
                 "archived_at": None,
             }

--- a/tests/routes/test_projects_account_scope.py
+++ b/tests/routes/test_projects_account_scope.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException
 
 from guardian.core.dependencies import RequestUserScope
 from guardian.routes import projects as projects_routes
+from tests.utils import get_test_user_id
 
 
 def _patch_projects_db(monkeypatch, db: MagicMock) -> None:
@@ -26,6 +27,7 @@ def _encode_owner(description: str, owner_user_id: str) -> str:
 
 
 def test_single_user_create_and_list_preserve_legacy_behavior(monkeypatch):
+    expected_user_id = get_test_user_id()
     db = MagicMock()
     db.list_projects.return_value = [
         {"id": 1, "name": "Imports", "description": "Legacy"},
@@ -40,15 +42,15 @@ def test_single_user_create_and_list_preserve_legacy_behavior(monkeypatch):
             description="Legacy description",
         ),
         request_user_scope=RequestUserScope(
-            user_id="local",
-            account_id="local",
+            user_id=expected_user_id,
+            account_id=expected_user_id,
             multi_user_enabled=False,
         ),
     )
     listed = projects_routes.list_projects(
         request_user_scope=RequestUserScope(
-            user_id="local",
-            account_id="local",
+            user_id=expected_user_id,
+            account_id=expected_user_id,
             multi_user_enabled=False,
         ),
     )

--- a/tests/routes/test_projects_account_scope.py
+++ b/tests/routes/test_projects_account_scope.py
@@ -30,8 +30,18 @@ def test_single_user_create_and_list_preserve_legacy_behavior(monkeypatch):
     expected_user_id = get_test_user_id()
     db = MagicMock()
     db.list_projects.return_value = [
-        {"id": 1, "name": "Imports", "description": "Legacy"},
-        {"id": 2, "name": "General", "description": ""},
+        {
+            "id": 1,
+            "name": "Imports",
+            "description": "Legacy",
+            "user_id": expected_user_id,
+        },
+        {
+            "id": 2,
+            "name": "General",
+            "description": "",
+            "user_id": expected_user_id,
+        },
     ]
     db.create_project.return_value = 7
     _patch_projects_db(monkeypatch, db)
@@ -61,13 +71,20 @@ def test_single_user_create_and_list_preserve_legacy_behavior(monkeypatch):
         "description": "Legacy description",
     }
     assert listed == [
-        {"id": 1, "name": "Imports", "description": "Legacy"},
+        {
+            "id": 1,
+            "name": "Imports",
+            "description": "Legacy",
+            "user_id": expected_user_id,
+        },
         {
             "id": 2,
             "name": "General",
             "description": "Default project for content without a specified project",
+            "user_id": expected_user_id,
         },
     ]
+    assert all(project["user_id"] == expected_user_id for project in listed)
     db.create_project.assert_called_once_with(
         "New Project", "Legacy description"
     )

--- a/tests/routes/test_route_user_scoping_invariant.py
+++ b/tests/routes/test_route_user_scoping_invariant.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from tests.utils import get_test_user_id
+
+
+def test_routes_return_only_owned_entities(test_client, mock_db):
+    expected_user_id = get_test_user_id()
+
+    response_a = test_client.post("/projects", json={"name": "p1"})
+    response_b = test_client.post("/projects", json={"name": "p2"})
+    assert response_a.status_code == 200
+    assert response_b.status_code == 200
+
+    resp = test_client.get("/projects")
+    data = resp.json()
+
+    assert len(data) >= 2
+    assert all(p["user_id"] == expected_user_id for p in data)
+    assert mock_db.create_project.call_count == 2

--- a/tests/routes/test_thread_config_read_surfaces.py
+++ b/tests/routes/test_thread_config_read_surfaces.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from guardian.core.dependencies import RequestUserScope
 from guardian.routes import chat as chat_routes
+from tests.utils import get_test_user_id
 
 
 def _thread_row(
@@ -11,9 +13,10 @@ def _thread_row(
     title: str | None = None,
     thread_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    expected_user_id = get_test_user_id()
     return {
         "id": thread_id,
-        "user_id": "test_user",
+        "user_id": expected_user_id,
         "title": title or f"Thread {thread_id}",
         "summary": "",
         "project_id": 1,
@@ -61,7 +64,16 @@ def test_chat_single_thread_fetch_preserves_thread_config(monkeypatch, mock_db):
     )
     monkeypatch.setattr(chat_routes, "chatlog_db", mock_db)
 
-    result = chat_routes.get_thread(42, api_key="test-api-key")
+    expected_user_id = get_test_user_id()
+    result = chat_routes.get_thread(
+        42,
+        api_key="test-api-key",
+        request_user_scope=RequestUserScope(
+            user_id=expected_user_id,
+            account_id=expected_user_id,
+            multi_user_enabled=False,
+        ),
+    )
 
     assert result["thread_id"] == 42
     assert result["thread_config"] == thread_config
@@ -73,7 +85,16 @@ def test_chat_single_thread_fetch_keeps_null_thread_config(
     mock_db.get_chat_thread.return_value = _thread_row(42, thread_config=None)
     monkeypatch.setattr(chat_routes, "chatlog_db", mock_db)
 
-    result = chat_routes.get_thread(42, api_key="test-api-key")
+    expected_user_id = get_test_user_id()
+    result = chat_routes.get_thread(
+        42,
+        api_key="test-api-key",
+        request_user_scope=RequestUserScope(
+            user_id=expected_user_id,
+            account_id=expected_user_id,
+            multi_user_enabled=False,
+        ),
+    )
 
     assert result["thread_id"] == 42
     assert result["thread_config"] is None

--- a/tests/routes/test_thread_creation_thread_config.py
+++ b/tests/routes/test_thread_creation_thread_config.py
@@ -9,9 +9,11 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
+from guardian.core.dependencies import RequestUserScope
 from guardian.core.pgdb import PgDB
 from guardian.db.models import Base, ChatThread
 from guardian.routes import chat as chat_routes
+from tests.utils import get_test_user_id
 
 
 @contextmanager
@@ -176,10 +178,19 @@ def test_chat_thread_create_snapshots_runtime_defaults(
     monkeypatch.setattr(chat_routes, "chatlog_db", backend)
     _set_local_runtime_defaults(monkeypatch)
 
-    result = chat_routes.chat_create_thread({}, api_key="test-api-key")
+    expected_user_id = get_test_user_id()
+    result = chat_routes.chat_create_thread(
+        {},
+        api_key="test-api-key",
+        request_user_scope=RequestUserScope(
+            user_id=expected_user_id,
+            account_id=expected_user_id,
+            multi_user_enabled=False,
+        ),
+    )
 
     assert result["ok"] is True
-    assert "thread_config" not in result["thread"]
+    assert result["thread"]["user_id"] == expected_user_id
     assert backend.created_thread_calls
     assert "thread_config" not in backend.created_thread_calls[0]
 
@@ -210,10 +221,19 @@ def test_chat_thread_create_uses_explicit_thread_config_values(
         "personaId": "persona-7",
     }
 
-    result = chat_routes.chat_create_thread(body, api_key="test-api-key")
+    expected_user_id = get_test_user_id()
+    result = chat_routes.chat_create_thread(
+        body,
+        api_key="test-api-key",
+        request_user_scope=RequestUserScope(
+            user_id=expected_user_id,
+            account_id=expected_user_id,
+            multi_user_enabled=False,
+        ),
+    )
 
     assert result["ok"] is True
-    assert "thread_config" not in result["thread"]
+    assert result["thread"]["user_id"] == expected_user_id
     assert backend.created_thread_calls
     assert "thread_config" not in backend.created_thread_calls[0]
 
@@ -230,10 +250,11 @@ def test_chat_thread_create_uses_explicit_thread_config_values(
 def test_chat_thread_create_keeps_legacy_backend_working(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    expected_user_id = get_test_user_id()
     mock_db = MagicMock()
     mock_db.create_chat_thread.return_value = {
         "id": 17,
-        "user_id": "test_user",
+        "user_id": expected_user_id,
         "title": "Legacy Thread",
         "summary": "Legacy summary",
         "project_id": 1,
@@ -250,11 +271,17 @@ def test_chat_thread_create_keeps_legacy_backend_working(
     monkeypatch.setattr(chat_routes, "chatlog_db", mock_db)
 
     result = chat_routes.chat_create_thread(
-        {"title": "Legacy Thread"}, api_key="test-api-key"
+        {"title": "Legacy Thread"},
+        api_key="test-api-key",
+        request_user_scope=RequestUserScope(
+            user_id=expected_user_id,
+            account_id=expected_user_id,
+            multi_user_enabled=False,
+        ),
     )
 
     assert result["ok"] is True
     assert result["id"] == 17
-    assert "thread_config" not in result["thread"]
+    assert result["thread"]["user_id"] == expected_user_id
     mock_db.create_chat_thread.assert_called_once()
     assert "thread_config" not in mock_db.create_chat_thread.call_args.kwargs

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,13 @@
+from guardian.core.dependencies import get_single_user_id
+from guardian.core.user_manager import get_or_create_default_user
+
+
+def get_test_user_id() -> str:
+    try:
+        user = get_or_create_default_user()
+        user_id = str(user.get("id") or "").strip()
+        if user_id:
+            return user_id
+    except Exception:
+        pass
+    return get_single_user_id()


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
