### PR TITLE
Fix settings panel clipping and align the sticky tab rail

### DIFF
--- a/frontend/src/features/settings/SettingsView.tsx
+++ b/frontend/src/features/settings/SettingsView.tsx
@@ -1188,9 +1188,9 @@ export function SettingsView({
   }
 
   return (
-    <div className="w-full" style={{ color: "var(--text)" }}>
-      <SettingsPanelShell>
-        <div className="flex h-full min-h-0 flex-col gap-[var(--shell-gap)]">
+    <div className="flex h-full min-h-0 w-full justify-center" style={{ color: "var(--text)" }}>
+      <SettingsPanelShell className="w-full">
+        <div className="flex h-full min-h-0 w-full flex-col gap-[var(--settings-edge-chrome)]">
           <SettingsPanelDock>
             {visibleTabs.map(renderTabButton)}
           </SettingsPanelDock>
@@ -1198,8 +1198,12 @@ export function SettingsView({
           <div
             ref={settingsScrollContainerRef}
             data-testid="settings-panel-scroll-body"
-            className="flex min-h-0 flex-1 flex-col gap-[var(--shell-gap)] overflow-x-visible overflow-y-auto"
+            className="flex min-h-0 flex-1 justify-center overflow-auto px-[var(--settings-edge-chrome)] pb-[var(--settings-edge-chrome)]"
           >
+            <div
+              data-testid="settings-panel-content"
+              className="flex w-full min-w-0 max-w-[72rem] flex-col gap-[var(--shell-gap)]"
+            >
             {tab === "system" && (
           <SettingsSectionCard
             data-testid="settings-system-surface"
@@ -1788,6 +1792,7 @@ export function SettingsView({
             <MemoryBrowser activeThreadId={activeThreadId} />
           </SettingsSectionCard>
         )}
+            </div>
           </div>
         </div>
       </SettingsPanelShell>

--- a/frontend/src/features/settings/__tests__/SettingsView.test.tsx
+++ b/frontend/src/features/settings/__tests__/SettingsView.test.tsx
@@ -124,9 +124,12 @@ describe("SettingsView", () => {
     expect(
       screen.getByRole("tablist", { name: "Settings tabs" })
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("tab", { name: "Personal Facts" })
-    ).toBeInTheDocument();
+    expect(screen.getByRole("tablist", { name: "Settings tabs" })).toHaveStyle({
+      position: "sticky",
+      top: "calc(var(--radius-micro) * 0.75)",
+      paddingInline: "calc(var(--radius-micro) * 0.75)",
+    });
+    expect(screen.getByRole("tab", { name: "Personal Facts" })).toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: "Imprint" }));
 
@@ -185,11 +188,15 @@ describe("SettingsView", () => {
     const scrollBody = screen.getByTestId(
       "settings-panel-scroll-body"
     ) as HTMLDivElement;
+    const content = screen.getByTestId(
+      "settings-panel-content"
+    ) as HTMLDivElement;
 
     expect(
       screen.queryByRole("button", { name: "Import ChatGPT history" })
     ).not.toBeInTheDocument();
-    expect(scrollBody).toHaveClass("overflow-y-auto", "overflow-x-visible");
+    expect(scrollBody).toHaveClass("overflow-auto", "justify-center");
+    expect(content).toHaveClass("max-w-[72rem]", "w-full", "min-w-0");
 
     await user.click(screen.getByRole("tab", { name: "Data" }));
     expect(

--- a/frontend/src/features/settings/components/SettingsPanelDock.tsx
+++ b/frontend/src/features/settings/components/SettingsPanelDock.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties, PropsWithChildren } from "react";
 
 import { cn } from "@/lib/utils";
+import { SETTINGS_DENSITY } from "../settingsDensityContract";
 
 type SettingsPanelDockProps = PropsWithChildren<{
   className?: string;
@@ -19,21 +20,22 @@ export default function SettingsPanelDock({
       aria-label="Settings tabs"
       aria-orientation="horizontal"
       className={cn(
-        "sticky top-[calc(var(--card-pad) + var(--board-edge))] z-30 flex w-full shrink-0 items-center justify-center",
+        "sticky z-30 flex w-full shrink-0 items-center justify-center",
         className
       )}
       style={{
         position: "sticky",
-        top: "calc(var(--card-pad) + var(--board-edge))",
+        top: SETTINGS_DENSITY.edgeChrome,
+        paddingInline: SETTINGS_DENSITY.edgeChrome,
       }}
     >
       <div
-        className="glass-pill flex w-full max-w-full min-w-0 flex-wrap items-center justify-center"
+        className="glass-pill isolate relative inline-flex w-fit max-w-full min-w-0 flex-wrap items-center justify-center overflow-x-auto"
         style={
           {
             "--pill-active-text": "var(--text-on-accent)",
-            "--pill-gap": "var(--radius-micro)",
-            "--pill-font": "0.84rem",
+            "--pill-gap": "calc(var(--radius-micro) / 2)",
+            "--pill-font": "0.8rem",
           } as CSSProperties
         }
       >

--- a/frontend/src/features/settings/components/SettingsPanelShell.tsx
+++ b/frontend/src/features/settings/components/SettingsPanelShell.tsx
@@ -1,6 +1,7 @@
 import type { PropsWithChildren } from "react";
 
 import { cn } from "@/lib/utils";
+import { SETTINGS_DENSITY } from "../settingsDensityContract";
 
 type SettingsPanelShellProps = PropsWithChildren<{
   className?: string;
@@ -23,7 +24,7 @@ export default function SettingsPanelShell({
         borderRadius: "calc(var(--card-radius) + var(--board-edge) / 2)",
         border: "1px solid color-mix(in srgb, var(--panel-bezel) 86%, transparent)",
         background: "color-mix(in srgb, var(--panel-bg) 80%, transparent)",
-        padding: "calc(var(--card-pad) + var(--board-edge))",
+        padding: SETTINGS_DENSITY.edgeChrome,
         boxShadow:
           "inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -1px 0 rgba(0,0,0,0.16)",
       }}

--- a/frontend/src/features/settings/components/__tests__/SettingsPanelDock.test.tsx
+++ b/frontend/src/features/settings/components/__tests__/SettingsPanelDock.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, test } from "vitest";
 
 import SettingsPanelDock from "@/features/settings/components/SettingsPanelDock";
+import { SETTINGS_DENSITY } from "@/features/settings/settingsDensityContract";
 
 describe("SettingsPanelDock", () => {
   test("keeps the tab rail sticky and labeled as a control surface", () => {
@@ -23,7 +24,8 @@ describe("SettingsPanelDock", () => {
     expect(dock).toHaveClass("sticky", "flex", "w-full", "justify-center");
     expect(dock).toHaveStyle({
       position: "sticky",
-      top: "calc(var(--card-pad) + var(--board-edge))",
+      top: SETTINGS_DENSITY.edgeChrome,
+      paddingInline: SETTINGS_DENSITY.edgeChrome,
     });
     expect(dock).toHaveAttribute("aria-orientation", "horizontal");
     expect(screen.getByRole("tab", { name: "Appearance" })).toBeInTheDocument();

--- a/frontend/src/features/settings/components/__tests__/SettingsPanelShell.test.tsx
+++ b/frontend/src/features/settings/components/__tests__/SettingsPanelShell.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, test } from "vitest";
 
 import SettingsPanelShell from "@/features/settings/components/SettingsPanelShell";
+import { SETTINGS_DENSITY } from "@/features/settings/settingsDensityContract";
 
 describe("SettingsPanelShell", () => {
   test("separates the inner settings shell from its content", () => {
@@ -21,7 +22,7 @@ describe("SettingsPanelShell", () => {
       "overflow-hidden"
     );
     expect(shell).toHaveStyle({
-      padding: "calc(var(--card-pad) + var(--board-edge))",
+      padding: SETTINGS_DENSITY.edgeChrome,
     });
     expect(shell).toHaveTextContent("Content");
     expect(screen.getByTestId("shell-content")).toBeInTheDocument();

--- a/frontend/src/features/settings/settingsDensityContract.ts
+++ b/frontend/src/features/settings/settingsDensityContract.ts
@@ -12,6 +12,12 @@
 
 export const SETTINGS_DENSITY = {
   /**
+   * Inset buffer used to keep interactive content clear of the frame edge.
+   * This is intentionally 6px so controls do not touch the shell border.
+   */
+  edgeChrome: "calc(var(--radius-micro) * 0.75)", // 6px
+
+  /**
    * Space between major sections within a SettingsSectionCard.
    * Corresponds to the outer shell gap rhythm (var(--shell-gap) = 16px).
    */


### PR DESCRIPTION
## Summary
- Center the Settings panel content within the frame card and add a dedicated 6px edge chrome inset so controls do not clip against the border
- Make the Settings tab rail match the main navigation pill styling more closely while staying sticky at the top of the panel
- Add regression coverage for the shell inset, sticky dock behavior, and centered scroll-body layout

## Testing
- TypeScript compile check passed
- Diff hygiene check passed
- Vitest was attempted for the updated Settings tests, but the local frontend workspace is missing Rollup's optional native package