### PR TITLE
fix(migrations): restore extension schema consistency

### DIFF
--- a/docs/architecture/00-current-state.md
+++ b/docs/architecture/00-current-state.md
@@ -27,14 +27,14 @@ Codexify is in local-beta hardening on `main`. The supported path is still the l
 - A retrieval posture explainer was added to the Command Center, rendering human-readable explanations for each posture field value with copy-to-clipboard support.
 - The retrieval-posture explainer UI surface was added to the Command Center with a standalone panel and per-thread posture history display.
 - Executable backend-seam evaluation suites continue to provide coverage for: identity-boundary proof (project scope containment, explicit widening, exclusion filters), supported-path golden tasks (completion acceptance, RAG trace isolation, Obsidian ingest→retrieve seam), and broker/source-mode matrix reconciliation.
-- Fresh live proof was re-run on the exact current `main` tip. Chat completion still works and the chat ownership seam normalizes a browser display label to `local`, but the live backend container is not in the supported local-only posture, document upload fails with `upload_failed` because the expected `agent_extension_*` tables are missing, and the bounded tool-loop cases regress instead of matching the claimed supported-path behavior.
+- Fresh live proof was re-run on the exact current `main` tip. Chat completion still works and the chat ownership seam normalizes a browser display label to `local`, and the supported local Compose migrator now reaches the merged extension/eval head cleanly so the expected `agent_extension_*` tables are present again. The live backend container still needs a separate supported-profile recheck, and the bounded tool-loop cases still regress instead of matching the claimed supported-path behavior.
 
 ## Current supported reality
 - Local Docker Compose remains the supported install path.
 - Supported beta posture is intended to be local-only, but the live backend container currently reports `CODEXIFY_BETA_CORE_ONLY=false`, `CODEXIFY_LOCAL_ONLY_MODE=false`, and `ALLOW_CLOUD_PROVIDERS=true`, so the running stack is not in the supported posture.
 - Chat acceptance, worker execution, and Postgres persistence still work for plain chat completion on the current live runtime.
 - Single-user ownership on the chat path normalizes browser display labels to `local`; that seam did not leak the display label into persisted thread ownership in this run.
-- Upload -> parse -> embed -> retrieve is not currently proven on the live runtime. Direct document upload returned `upload_failed` because backend schema consistency checks require missing `agent_extension_*` tables, so retrieval was not reached.
+- Upload -> parse -> embed -> retrieve is not currently proven on the live runtime. The schema-consistency gap that previously blocked document upload on missing `agent_extension_*` tables has been repaired on the supported local Compose path, but the full end-to-end upload -> embed -> retrieve proof still needs a fresh rerun on the current tip.
 - The bounded tool-loop slice is not currently behaving as claimed on the live runtime: the one-turn case fails with `tool_command_execution_failed`, and the hard-stop / blocked-result prompts collapse into plain answers instead of staying bounded.
 - Retrieval assembly now keeps user boundaries explicit in the broker and records widening reasons so trace output stays truthful.
 - Built-in system docs/help are seeded at startup and available to retrieval.
@@ -66,7 +66,7 @@ Codexify is in local-beta hardening on `main`. The supported path is still the l
 ## Active blockers
 - Live backend posture mismatch: the running backend container reports `CODEXIFY_BETA_CORE_ONLY=false`, `CODEXIFY_LOCAL_ONLY_MODE=false`, and `ALLOW_CLOUD_PROVIDERS=true`, while the catalog still exposes cloud inventory such as `groq` as enabled. Supported-path signoff is not satisfied until the live runtime is brought back into the local-only supported profile.
 - Retrieval-posture populated state not yet demonstrated: The completion-service seam has not yet been updated to emit `payload_summary["retrieval_posture"]`. The diagnostics route is live and returns correct empty-state shape, but the fast path (reading canonical snapshot) is a dead letter until that seam is updated. The fallback synthesis path also returns empty because historical task.completed events lack the required legacy trace fields.
-- Fresh live release evidence on the exact current `main` tip is still required before release signoff for the full beta evidence pack; this run proves chat acceptance and chat ownership normalization, but upload -> embed -> retrieve and bounded tool-loop behavior are still failing on the live runtime.
+- Fresh live release evidence on the exact current `main` tip is still required before release signoff for the full beta evidence pack; this run now proves chat acceptance, chat ownership normalization, and migration/schema consistency on the supported Compose stack, but upload -> embed -> retrieve and bounded tool-loop behavior still need fresh live proof.
 - Release signoff still depends on the supported-profile, provider registry, and health surfaces staying aligned.
 
 ## This week's priorities

--- a/guardian/db/migrations/versions/b3c4d5e6f7a8_merge_extension_and_eval_heads.py
+++ b/guardian/db/migrations/versions/b3c4d5e6f7a8_merge_extension_and_eval_heads.py
@@ -1,0 +1,32 @@
+"""merge extension and eval heads
+
+Revision ID: b3c4d5e6f7a8
+Revises: a2b3c4d5e6f7, e4f5a6b7c8d9
+Create Date: 2026-04-22 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import sqlalchemy as sa  # noqa: F401
+from alembic import op  # noqa: F401
+
+# revision identifiers, used by Alembic.
+revision: str = "b3c4d5e6f7a8"
+down_revision: str | Sequence[str] | None = (
+    "a2b3c4d5e6f7",
+    "e4f5a6b7c8d9",
+)
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Merge the extension and eval branches without changing schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade the merge point without altering branch contents."""
+    pass

--- a/tests/migration/test_agent_extension_schema_consistency.py
+++ b/tests/migration/test_agent_extension_schema_consistency.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+from urllib.parse import urlparse, urlunparse
+
+import pytest
+
+try:
+    import psycopg  # type: ignore
+except ImportError:  # pragma: no cover
+    psycopg = None
+
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine, inspect
+
+MERGE_HEAD_REVISION = "b3c4d5e6f7a8"
+
+
+def _build_database_url(base_url: str, database_name: str) -> str:
+    parsed = urlparse(base_url)
+    return urlunparse(parsed._replace(path=f"/{database_name}"))
+
+
+def _admin_database_url(base_url: str) -> str:
+    parsed = urlparse(base_url)
+    return urlunparse(parsed._replace(path="/postgres"))
+
+
+@pytest.mark.integration
+def test_agent_extension_schema_chain_merges_and_tables_exist(
+    tmp_path, monkeypatch
+):
+    if psycopg is None:
+        pytest.skip("psycopg not installed")
+
+    base_url = os.getenv("TEST_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if not base_url:
+        pytest.skip(
+            "TEST_DATABASE_URL or DATABASE_URL environment variable required"
+        )
+
+    admin_url = _admin_database_url(base_url)
+    db_name = f"codexify_extension_schema_{uuid.uuid4().hex[:12]}"
+    temp_url = _build_database_url(base_url, db_name)
+
+    try:
+        admin_conn = psycopg.connect(admin_url, autocommit=True)
+    except Exception as exc:  # pragma: no cover - env specific
+        pytest.skip(f"Unable to connect to admin database: {exc}")
+    try:
+        with admin_conn.cursor() as cur:
+            cur.execute(f"CREATE DATABASE {db_name}")
+    except psycopg.Error as exc:  # pragma: no cover - environment specific
+        admin_conn.close()
+        pytest.skip(f"Unable to create test database: {exc.pgcode}")
+    finally:
+        admin_conn.close()
+
+    cfg_path = tmp_path / "alembic.ini"
+    cfg_path.write_text(Path("backend/alembic.ini").read_text())
+    cfg = Config(str(cfg_path))
+    cfg.set_main_option("sqlalchemy.url", temp_url)
+    repo_root = Path(__file__).resolve().parents[2]
+    migrations_dir = repo_root / "backend" / "migrations"
+    cfg.set_main_option("script_location", str(migrations_dir))
+    monkeypatch.setenv("DATABASE_URL", temp_url)
+
+    engine = None
+    try:
+        script = ScriptDirectory.from_config(cfg)
+        assert set(script.get_heads()) == {MERGE_HEAD_REVISION}
+
+        command.upgrade(cfg, "heads")
+
+        engine = create_engine(temp_url)
+        inspector = inspect(engine)
+        existing_tables = set(inspector.get_table_names())
+
+        expected_tables = {
+            "agent_extension_proposals",
+            "agent_extension_install_gate_decisions",
+            "agent_extension_registry_entries",
+            "agent_extension_install_bindings",
+            "eval_trace_snapshots",
+            "eval_verdicts",
+        }
+        assert expected_tables <= existing_tables
+
+        with engine.connect() as connection:
+            version_rows = connection.execute(
+                sa.text("SELECT version_num FROM alembic_version")
+            ).scalars()
+            assert list(version_rows) == [MERGE_HEAD_REVISION]
+    finally:
+        if engine is not None:
+            engine.dispose()
+
+        cleanup_conn = psycopg.connect(admin_url, autocommit=True)
+        try:
+            with cleanup_conn.cursor() as cur:
+                cur.execute(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = %s",
+                    (db_name,),
+                )
+            drop_conn = psycopg.connect(admin_url, autocommit=True)
+            try:
+                with drop_conn.cursor() as cur:
+                    cur.execute(f"DROP DATABASE IF EXISTS {db_name}")
+            finally:
+                drop_conn.close()
+        finally:
+            cleanup_conn.close()

--- a/tests/migration/test_extension_install_bindings_migration.py
+++ b/tests/migration/test_extension_install_bindings_migration.py
@@ -179,11 +179,13 @@ def test_extension_install_bindings_migration_round_trip(tmp_path, monkeypatch):
                 },
             )
             session.add(proposal)
+            session.commit()
+            session.refresh(proposal)
 
             decision = AgentExtensionInstallGateDecision(
                 decision_id="decision-1",
                 account_id="user-123",
-                proposal_id="proposal-1",
+                proposal_id=proposal.proposal_id,
                 decision_token=InstallGateDecisionToken.APPROVED.value,
                 reason="manual approval",
                 notes_json={},
@@ -205,12 +207,14 @@ def test_extension_install_bindings_migration_round_trip(tmp_path, monkeypatch):
                 ],
             )
             session.add(decision)
+            session.commit()
+            session.refresh(decision)
 
             registry = AgentExtensionRegistryEntry(
                 registry_id="registry-1",
                 account_id="user-123",
-                proposal_id="proposal-1",
-                decision_id="decision-1",
+                proposal_id=proposal.proposal_id,
+                decision_id=decision.decision_id,
                 project_id=17,
                 profile_id=None,
                 source_thread_id=21,
@@ -247,12 +251,14 @@ def test_extension_install_bindings_migration_round_trip(tmp_path, monkeypatch):
                 },
             )
             session.add(registry)
+            session.commit()
+            session.refresh(registry)
 
             binding = AgentExtensionInstallBinding(
                 binding_id="binding-1",
                 account_id="user-123",
-                registry_entry_id="registry-1",
-                proposal_id="proposal-1",
+                registry_entry_id=registry.registry_id,
+                proposal_id=proposal.proposal_id,
                 scope_token=ExtensionInstallBindingScope.PROJECT.value,
                 project_id=17,
                 profile_id=None,

--- a/tests/migration/test_extension_registry_migration.py
+++ b/tests/migration/test_extension_registry_migration.py
@@ -244,11 +244,13 @@ def test_extension_registry_migration_round_trip(tmp_path, monkeypatch):
                 },
             )
             session.add(proposal)
+            session.commit()
+            session.refresh(proposal)
 
             decision = AgentExtensionInstallGateDecision(
                 decision_id="decision-1",
                 account_id="user-123",
-                proposal_id="proposal-1",
+                proposal_id=proposal.proposal_id,
                 decision_token="approved",
                 reason="manual approval",
                 notes_json={
@@ -273,12 +275,14 @@ def test_extension_registry_migration_round_trip(tmp_path, monkeypatch):
                 ],
             )
             session.add(decision)
+            session.commit()
+            session.refresh(decision)
 
             registry = AgentExtensionRegistryEntry(
                 registry_id="registry-1",
                 account_id="user-123",
-                proposal_id="proposal-1",
-                decision_id="decision-1",
+                proposal_id=proposal.proposal_id,
+                decision_id=decision.decision_id,
                 project_id=17,
                 profile_id="profile-alpha",
                 source_thread_id=21,
@@ -329,21 +333,21 @@ def test_extension_registry_migration_round_trip(tmp_path, monkeypatch):
                     ],
                 },
                 registration_metadata_json={
-                    "decision_id": "decision-1",
+                    "decision_id": decision.decision_id,
                     "decision_token": "approved",
                     "decision_reason": "manual approval",
                     "decision_notes": {
                         "reviewer": "alice",
                         "note": "approved for testing",
                     },
-                    "proposal_id": "proposal-1",
+                    "proposal_id": proposal.proposal_id,
                     "account_id": "user-123",
                 },
                 provenance_class_token="proposal_approval",
                 provenance_json={
                     "provenance_class": "proposal_approval",
-                    "proposal_id": "proposal-1",
-                    "decision_id": "decision-1",
+                    "proposal_id": proposal.proposal_id,
+                    "decision_id": decision.decision_id,
                     "source_thread_id": 21,
                     "source_message_id": 22,
                     "target_surface": "command_bus",
@@ -351,8 +355,6 @@ def test_extension_registry_migration_round_trip(tmp_path, monkeypatch):
             )
             session.add(registry)
             session.commit()
-            session.refresh(proposal)
-            session.refresh(decision)
             session.refresh(registry)
 
         with Session() as session:


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
