### PR TITLE
Prototype compiled backend runtime image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -55,6 +55,8 @@ venv
 /data
 /docker
 /docs
+!docs/builtin-help/
+!docs/builtin-help/**
 /frontend
 /models
 /src-tauri

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -186,3 +186,45 @@ FROM runtime AS tts-runtime
 
 # Copy the site-packages tree with pinned TTS dependency graph.
 COPY --from=builder-tts /opt/python/lib/python3.11/site-packages /opt/python/lib/python3.11/site-packages
+
+# === Compiled backend proof stage: build a frozen artifact for the API entrypoint ===
+FROM builder AS compiled-builder
+
+WORKDIR /src
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends binutils && \
+    rm -rf /var/lib/apt/lists/*
+COPY guardian /src/guardian
+COPY backend /src/backend
+COPY config /src/config
+COPY docs/builtin-help /src/docs/builtin-help
+COPY packaging/pyinstaller /src/packaging/pyinstaller
+
+RUN mkdir -p /src/guardian/contracts && \
+    cp /src/guardian/contracts.py /src/guardian/contracts/__init__.py
+
+RUN python -m pip install pyinstaller
+RUN pyinstaller /src/packaging/pyinstaller/codexify_backend.spec --noconfirm --clean --distpath /src/build/dist --workpath /src/build/work
+
+# === Compiled backend runtime proof image ===
+FROM dhi.io/python:3.11.14-debian13-dev AS compiled-runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONPATH=/app \
+    PORT=8888 \
+    HOME=/home/codexify \
+    CODEXIFY_APP_ROOT=/app
+
+WORKDIR /app
+
+RUN mkdir -p /home/codexify
+
+COPY --from=compiled-builder /src/build/dist/codexify-backend /app/runtime
+COPY config /app/config
+COPY docs/builtin-help /app/docs/builtin-help
+
+EXPOSE 8888
+
+ENTRYPOINT ["/app/runtime/codexify-backend"]

--- a/backend/compiled_backend_entry.py
+++ b/backend/compiled_backend_entry.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import uvicorn
+
+
+def _bootstrap_contract_modules() -> None:
+    base = Path(getattr(sys, "_MEIPASS", Path(__file__).resolve().parent)) / "bootstrap" / "guardian"
+    module_specs = [
+        ("guardian.contracts", base / "contracts.py"),
+        ("guardian.contracts.imprint_snapshot", base / "contracts" / "imprint_snapshot.py"),
+        ("guardian.contracts.imprint_proposal", base / "contracts" / "imprint_proposal.py"),
+    ]
+
+    for module_name, module_path in module_specs:
+        if module_name in sys.modules:
+            continue
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"Unable to load {module_name} from {module_path}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+
+
+def main() -> None:
+    _bootstrap_contract_modules()
+    from guardian.guardian_api import app
+
+    port = int(os.getenv("PORT", "8888"))
+    uvicorn.run(app, host="0.0.0.0", port=port, log_level="info")
+
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.compiled.yml
+++ b/docker-compose.compiled.yml
@@ -1,0 +1,7 @@
+name: codexify
+
+services:
+  backend:
+    image: codexify-runtime-compiled:local
+    entrypoint: ["/app/runtime/codexify-backend"]
+    command: []

--- a/docs/architecture/config-and-ops.md
+++ b/docs/architecture/config-and-ops.md
@@ -168,6 +168,10 @@ Source anchors:
 - Source/dev installs may still use the repository Compose path and local build workflow.
 - The launcher/wizard is responsible for creating local config, validating Compose, pulling the registry-backed runtime images, and starting services in the packaged path.
 - Packaged first-run users should not need Rust, pnpm, Python dev tooling, or a source checkout to reach a usable local runtime.
+- The backend registry image now has a compiled/frozen proof target built with PyInstaller at `backend/compiled_backend_entry.py`.
+- The proof target lives in `backend/Dockerfile` as `compiled-runtime` and keeps the source-backed runtime stage intact for dev and legacy Compose paths.
+- The proof image is intentionally backend-only for now; workers and migrator still remain source-backed in the existing Docker path until they are proven separately.
+- The proof image still ships a small set of non-source runtime files needed by startup, including supported-profile YAML and bundled help content.
 
 ## Config Resolution Order and Defaults
 

--- a/guardian/services/builtin_help_ingest.py
+++ b/guardian/services/builtin_help_ingest.py
@@ -30,6 +30,9 @@ BUILTIN_HELP_DOCUMENT_ID = str(
 
 
 def _repo_root() -> Path:
+    cwd = Path.cwd()
+    if (cwd / BUILTIN_HELP_REL_PATH).exists():
+        return cwd
     return Path(__file__).resolve().parents[2]
 
 

--- a/packaging/pyinstaller/codexify_backend.spec
+++ b/packaging/pyinstaller/codexify_backend.spec
@@ -1,0 +1,73 @@
+# -*- mode: python ; coding: utf-8 -*-
+from pathlib import Path
+
+from PyInstaller.building.build_main import Analysis, COLLECT, EXE, PYZ
+from PyInstaller.utils.hooks import collect_submodules
+
+repo_root = Path.cwd()
+
+datas = [
+    (str(repo_root / "config" / "public_routes.yaml"), "config"),
+    (str(repo_root / "docs" / "builtin-help" / "codexify-guide.md"), "docs/builtin-help"),
+    (str(repo_root / "guardian" / "contracts.py"), "bootstrap/guardian"),
+    (str(repo_root / "guardian" / "contracts" / "imprint_snapshot.py"), "bootstrap/guardian/contracts"),
+    (str(repo_root / "guardian" / "contracts" / "imprint_proposal.py"), "bootstrap/guardian/contracts"),
+]
+datas.extend(
+    (
+        str(path),
+        "config/supported_profiles",
+    )
+    for path in sorted((repo_root / "config" / "supported_profiles").glob("*.yaml"))
+)
+hiddenimports = [
+    "backend.rag.chatgpt_migration",
+    "chromadb.api.rust",
+    "chromadb.telemetry.product",
+    "chromadb.telemetry.product.posthog",
+    "guardian.contracts",
+    "guardian.contracts.imprint_proposal",
+    "guardian.contracts.imprint_snapshot",
+    *collect_submodules("guardian.contracts"),
+]
+
+a = Analysis(
+    [str(repo_root / "backend" / "compiled_backend_entry.py")],
+    pathex=[str(repo_root)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+pyz = PYZ(a.pure)
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="codexify-backend",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name="codexify-backend",
+)

--- a/scripts/verification/check_compiled_runtime_image.sh
+++ b/scripts/verification/check_compiled_runtime_image.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_NAME="${1:-codexify-runtime-compiled:local}"
+
+docker run --rm --entrypoint sh "${IMAGE_NAME}" -lc '
+  set -eu
+  test -x /app/runtime/codexify-backend
+  test -d /app/runtime/_internal
+  test -d /app/config
+  test -d /app/docs/builtin-help
+  test ! -d /app/backend
+  test ! -d /app/tests
+  test ! -d /app/guardian
+'

--- a/tests/ops/test_compiled_runtime_contract.py
+++ b/tests/ops/test_compiled_runtime_contract.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+def test_compiled_backend_docker_target_and_overlay_exist() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+
+    dockerfile = (repo_root / "backend" / "Dockerfile").read_text(
+        encoding="utf-8"
+    )
+    overlay = (repo_root / "docker-compose.compiled.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "FROM builder AS compiled-builder" in dockerfile
+    assert (
+        "FROM dhi.io/python:3.11.14-debian13-dev AS compiled-runtime"
+        in dockerfile
+    )
+    assert (
+        "pyinstaller /src/packaging/pyinstaller/codexify_backend.spec"
+        in dockerfile
+    )
+    assert "ENTRYPOINT [\"/app/runtime/codexify-backend\"]" in dockerfile
+    assert "image: codexify-runtime-compiled:local" in overlay
+    assert "command: []" in overlay


### PR DESCRIPTION
## Summary
- Add a PyInstaller-based proof target for the backend API and wire it into a new compiled runtime Docker stage.
- Preserve the existing source-backed dev/runtime path while adding a small compose overlay for the compiled image.
- Document the current beta posture in the architecture ops notes and keep bundled help content available in the frozen image.
- Add a filesystem sanity check and a focused contract test for the compiled-runtime build shape.

## Testing
- `git diff --check` passed.
- Docker Compose config validation passed for both source and runtime overlays.
- Built the compiled runtime image successfully and verified the final image excludes raw backend/guardian/tests source directories.
- Started the compiled backend in local Compose and verified `/ping` and `/health` respond successfully.
- Focused contract test passed for the compiled runtime packaging slice.