### PR TITLE
Fix packaged desktop auth handoff

### DIFF
--- a/docs/architecture/config-and-ops.md
+++ b/docs/architecture/config-and-ops.md
@@ -1,5 +1,5 @@
 Purpose: Give senior engineers the operational truth needed to run, debug, and change Codexify safely, with special attention to config precedence, worker dependencies, and failure signatures.
-Last updated: 2026-04-26
+Last updated: 2026-04-28
 Source anchors:
 - Makefile
 - package.json
@@ -172,6 +172,7 @@ Source anchors:
 - The proof target lives in `backend/Dockerfile` as `compiled-runtime` and keeps the source-backed runtime stage intact for dev and legacy Compose paths.
 - The proof image is intentionally backend-only for now; workers and migrator still remain source-backed in the existing Docker path until they are proven separately.
 - The proof image still ships a small set of non-source runtime files needed by startup, including supported-profile YAML and bundled help content.
+- Packaged desktop auth handoff now flows through a Tauri command that returns a sanitized runtime auth/config payload for the local packaged runtime. The frontend consumes the handed-off `GUARDIAN_API_KEY` only in packaged mode, while diagnostics expose only presence and source metadata such as `envPath`, `runtimeRoot`, and `failureKind`.
 
 ## Config Resolution Order and Defaults
 

--- a/frontend/src/components/persona/layout/GuardianChatWithSidebar.tsx
+++ b/frontend/src/components/persona/layout/GuardianChatWithSidebar.tsx
@@ -51,6 +51,7 @@ import {
   requireAuthReady,
   useAuthState,
 } from "@/lib/authState";
+import { getDesktopRuntimeAuthConfig, isTauriRuntime } from "@/lib/runtimeConfig";
 import type {
   ChatRequestState,
   ProviderRuntimeState,
@@ -89,6 +90,18 @@ function PanelShell({ className, surfaceStyle, disabled, children }: PanelShellP
       {children}
     </FrameCard>
   );
+}
+
+function formatDesktopAuthDiagnostics(): string[] {
+  if (!isTauriRuntime()) return [];
+  const snapshot = getDesktopRuntimeAuthConfig();
+  if (!snapshot) return [];
+  return [
+    `apiKeyPresent=${snapshot.apiKeyPresent ? "true" : "false"}`,
+    `envPath=${snapshot.envPath ?? "<unavailable>"}`,
+    `runtimeRoot=${snapshot.runtimeRoot ?? "<unavailable>"}`,
+    snapshot.failureKind ? `failureKind=${snapshot.failureKind}` : null,
+  ].filter((line): line is string => Boolean(line));
 }
 
 const sameThreadSnapshot = (a: Thread, b: Thread): boolean => {
@@ -1679,7 +1692,18 @@ export default function GuardianChatWithSidebar({
                   className="mx-4 mt-3 rounded-lg border px-3 py-2 text-xs"
                   style={{ borderColor: "var(--panel-border)", color: "var(--text)" }}
                 >
-                  Authentication required. Please sign in or set a dev key.
+                  <div>Authentication required.</div>
+                  {formatDesktopAuthDiagnostics().length ? (
+                    <div className="mt-1 space-y-0.5 text-[11px] leading-5 text-[color:var(--muted)]">
+                      {formatDesktopAuthDiagnostics().map((line) => (
+                        <div key={line}>{line}</div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="mt-1 text-[11px] leading-5 text-[color:var(--muted)]">
+                      Sign in or provide a dev key in local development.
+                    </div>
+                  )}
                 </div>
               )}
               {showWorkspacePreview && (

--- a/frontend/src/lib/runtimeConfig.ts
+++ b/frontend/src/lib/runtimeConfig.ts
@@ -14,6 +14,15 @@ export interface RuntimeConfig {
 
 type TauriRuntimeConfig = Partial<RuntimeConfig>;
 
+export type DesktopRuntimeAuthConfig = RuntimeConfig & {
+  apiKeyPresent: boolean;
+  apiKey: string | null;
+  envPath: string | null;
+  runtimeRoot: string | null;
+  failureKind: string | null;
+  runtimeContext: string | null;
+};
+
 export type LauncherStartupHandoff = {
   shouldRunWizard: boolean;
   setupComplete: boolean;
@@ -51,6 +60,7 @@ const DESKTOP_SHARE_STORAGE_KEY = "cfy.desktop.sharePublicBaseUrl";
 
 let runtimeConfigCache: RuntimeConfig | null = null;
 let runtimeConfigPromise: Promise<RuntimeConfig> | null = null;
+let desktopRuntimeAuthConfigCache: DesktopRuntimeAuthConfig | null = null;
 
 type TauriCoreApi = {
   invoke: <T = unknown>(
@@ -242,6 +252,39 @@ function normalizeLauncherStartupHandoff(
   };
 }
 
+function normalizeDesktopRuntimeAuthConfig(
+  payload: unknown
+): DesktopRuntimeAuthConfig | null {
+  if (!payload || typeof payload !== "object") return null;
+  const source = payload as Record<string, unknown>;
+  const backendBaseUrl = normalizeNullableText(source.backendBaseUrl);
+  const apiBaseUrl = normalizeNullableText(source.apiBaseUrl);
+  const sseUrl = normalizeNullableText(source.sseUrl);
+  const sharePublicBaseUrl = normalizeNullableText(source.sharePublicBaseUrl);
+  const authMode = coerceAuthMode(
+    normalizeNullableText(source.authMode) ?? "local"
+  );
+
+  if (!backendBaseUrl || !apiBaseUrl || !sseUrl || !sharePublicBaseUrl) {
+    return null;
+  }
+
+  return {
+    mode: "tauri",
+    backendBaseUrl,
+    apiBaseUrl,
+    sseUrl,
+    sharePublicBaseUrl,
+    authMode,
+    apiKeyPresent: asBoolean(source.apiKeyPresent),
+    apiKey: normalizeNullableText(source.apiKey),
+    envPath: normalizeNullableText(source.envPath),
+    runtimeRoot: normalizeNullableText(source.runtimeRoot),
+    failureKind: normalizeNullableText(source.failureKind),
+    runtimeContext: normalizeNullableText(source.runtimeContext),
+  };
+}
+
 export async function readDesktopLauncherStartupHandoff(): Promise<LauncherStartupHandoff | null> {
   if (!isTauriRuntime()) return null;
   try {
@@ -390,22 +433,91 @@ function defaultSharePublicBaseUrl(mode: RuntimeMode): string {
 }
 
 async function readTauriRuntimeConfig(): Promise<TauriRuntimeConfig | null> {
-  if (!isTauriRuntime()) return null;
+  if (!isTauriRuntime()) {
+    desktopRuntimeAuthConfigCache = null;
+    try {
+      const { clearRuntimeApiKey } = await import("@/lib/runtimeAuth");
+      clearRuntimeApiKey();
+    } catch {
+      // Ignore cache wiring failures; the web runtime can still proceed.
+    }
+    return null;
+  }
   try {
     const core = await loadTauriCore();
-    const payload = await core.invoke<any>("desktop_get_runtime_config");
-    if (!payload || typeof payload !== "object") return null;
+    const payload = await core.invoke<unknown>(
+      "desktop_get_runtime_auth_config"
+    );
+    const authConfig = normalizeDesktopRuntimeAuthConfig(payload);
+    desktopRuntimeAuthConfigCache = authConfig;
+    if (authConfig?.apiKey) {
+      try {
+        const { setRuntimeApiKey } = await import("@/lib/runtimeAuth");
+        setRuntimeApiKey(authConfig.apiKey);
+      } catch {
+        // Ignore auth cache wiring failures; the runtime config itself still resolves.
+      }
+    } else if (authConfig) {
+      try {
+        const { clearRuntimeApiKey } = await import("@/lib/runtimeAuth");
+        clearRuntimeApiKey();
+      } catch {
+        // Ignore cache wiring failures; the runtime config itself still resolves.
+      }
+    }
+    if (authConfig) {
+      return {
+        mode: authConfig.mode,
+        backendBaseUrl: authConfig.backendBaseUrl,
+        apiBaseUrl: authConfig.apiBaseUrl,
+        sseUrl: authConfig.sseUrl,
+        sharePublicBaseUrl: authConfig.sharePublicBaseUrl,
+        authMode: authConfig.authMode,
+      };
+    }
+
+    const legacyPayload = await core.invoke<any>("desktop_get_runtime_config");
+    if (!legacyPayload || typeof legacyPayload !== "object") return null;
+    desktopRuntimeAuthConfigCache = {
+      mode: "tauri",
+      backendBaseUrl: String(legacyPayload.backendBaseUrl ?? "").trim(),
+      apiBaseUrl: String(legacyPayload.apiBaseUrl ?? "").trim(),
+      sseUrl: String(legacyPayload.sseUrl ?? "").trim(),
+      sharePublicBaseUrl: String(legacyPayload.sharePublicBaseUrl ?? "").trim(),
+      authMode:
+        String(legacyPayload.authMode ?? "")
+          .trim()
+          .toLowerCase() === "remote"
+          ? "remote"
+          : "local",
+      apiKeyPresent: false,
+      apiKey: null,
+      envPath: null,
+      runtimeRoot: null,
+      failureKind: null,
+      runtimeContext: "packaged",
+    };
+    try {
+      const { clearRuntimeApiKey } = await import("@/lib/runtimeAuth");
+      clearRuntimeApiKey();
+    } catch {
+      // Ignore cache wiring failures; the runtime config itself still resolves.
+    }
     return {
       mode: "tauri",
-      backendBaseUrl: String(payload.backendBaseUrl ?? "").trim(),
-      apiBaseUrl: String(payload.apiBaseUrl ?? "").trim(),
-      sseUrl: String(payload.sseUrl ?? "").trim(),
-      sharePublicBaseUrl: String(payload.sharePublicBaseUrl ?? "").trim(),
-      authMode: String(payload.authMode ?? "").trim().toLowerCase() === "remote" ? "remote" : "local",
+      backendBaseUrl: desktopRuntimeAuthConfigCache.backendBaseUrl,
+      apiBaseUrl: desktopRuntimeAuthConfigCache.apiBaseUrl,
+      sseUrl: desktopRuntimeAuthConfigCache.sseUrl,
+      sharePublicBaseUrl: desktopRuntimeAuthConfigCache.sharePublicBaseUrl,
+      authMode: desktopRuntimeAuthConfigCache.authMode,
     };
   } catch {
     return null;
   }
+}
+
+export function getDesktopRuntimeAuthConfig(): DesktopRuntimeAuthConfig | null {
+  return desktopRuntimeAuthConfigCache;
 }
 
 function buildRuntimeConfig(

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,12 +5,17 @@ import ReactDOM from "react-dom/client";
 
 import App from "./App";
 import { configureGC } from "./dcw-services/gc";
-import { refreshApiBaseUrl, setRuntimeApiKey } from "./lib/api";
+import {
+  refreshApiBaseUrl,
+  readRuntimeApiKey,
+  setRuntimeApiKey,
+} from "./lib/api";
 import { resolveAuthStateOnBoot } from "./lib/authState";
 import { GuardianAPI } from "./lib/guardianApi";
 import {
   getRuntimeConfigSync,
   initRuntimeConfig,
+  getDesktopRuntimeAuthConfig,
   invokeTauriCommand,
   isTauriRuntime,
 } from "./lib/runtimeConfig";
@@ -46,6 +51,7 @@ function readDevApiKey(): string {
 
 async function hydrateDesktopApiKey(): Promise<void> {
   if (!isTauriRuntime()) return;
+  if (readRuntimeApiKey()) return;
   try {
     const value = await invokeTauriCommand<string | null>("desktop_get_api_key");
     setRuntimeApiKey(typeof value === "string" ? value : null);
@@ -71,15 +77,21 @@ function renderApp(): void {
 async function bootstrap(): Promise<void> {
   try {
     const runtimeConfig = await initRuntimeConfig();
+    const runtimeAuthConfig = getDesktopRuntimeAuthConfig();
     refreshApiBaseUrl();
 
     const devApiKey = readDevApiKey();
+    const runtimeApiKey = readRuntimeApiKey();
     configureGC({
       base: runtimeConfig.apiBaseUrl,
-      token: devApiKey || undefined,
+      token: runtimeApiKey || devApiKey || undefined,
     });
 
     await hydrateDesktopApiKey();
+    configureGC({
+      base: runtimeConfig.apiBaseUrl,
+      token: readRuntimeApiKey() || devApiKey || undefined,
+    });
     resolveAuthStateOnBoot();
 
     (window as any).__GC_ENV__ = {
@@ -88,8 +100,11 @@ async function bootstrap(): Promise<void> {
       base: runtimeConfig.apiBaseUrl,
       backendBase: runtimeConfig.backendBaseUrl,
       sse: runtimeConfig.sseUrl,
-      keyPresent: !!devApiKey,
-      guardianDevKeyPresent: !!(import.meta.env as any).VITE_GUARDIAN_DEV_API_KEY,
+      keyPresent: !!(readRuntimeApiKey() || devApiKey),
+      apiKeyPresent: !!runtimeAuthConfig?.apiKeyPresent,
+      envPath: runtimeAuthConfig?.envPath ?? null,
+      runtimeRoot: runtimeAuthConfig?.runtimeRoot ?? null,
+      failureKind: runtimeAuthConfig?.failureKind ?? null,
     };
     console.info("[gc] env snapshot", {
       mode: (window as any).__GC_ENV__?.mode,
@@ -97,7 +112,10 @@ async function bootstrap(): Promise<void> {
       base: (window as any).__GC_ENV__?.base,
       backendBase: (window as any).__GC_ENV__?.backendBase,
       keyPresent: (window as any).__GC_ENV__?.keyPresent,
-      guardianDevKeyPresent: (window as any).__GC_ENV__?.guardianDevKeyPresent,
+      apiKeyPresent: (window as any).__GC_ENV__?.apiKeyPresent,
+      envPath: (window as any).__GC_ENV__?.envPath,
+      runtimeRoot: (window as any).__GC_ENV__?.runtimeRoot,
+      failureKind: (window as any).__GC_ENV__?.failureKind,
     });
 
     if (!devApiKey && import.meta.env.DEV) {
@@ -120,7 +138,7 @@ async function bootstrap(): Promise<void> {
 const initialRuntimeConfig = getRuntimeConfigSync();
 configureGC({
   base: initialRuntimeConfig.apiBaseUrl,
-  token: readDevApiKey() || undefined,
+  token: readRuntimeApiKey() || readDevApiKey() || undefined,
 });
 resolveAuthStateOnBoot();
 renderApp();

--- a/frontend/src/test/runtime-config.test.ts
+++ b/frontend/src/test/runtime-config.test.ts
@@ -3,9 +3,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   initRuntimeConfig,
   readDesktopStartupRoutingDecision,
+  getDesktopRuntimeAuthConfig,
   resolveApiUrl,
   resolveSseEndpoint,
 } from "@/lib/runtimeConfig";
+import {
+  buildAuthenticatedFetchInit,
+  clearRuntimeApiKey,
+  readRuntimeApiKey,
+} from "@/lib/api";
 
 const invokeMock = vi.fn();
 
@@ -13,6 +19,7 @@ describe("runtime config", () => {
   beforeEach(() => {
     vi.unstubAllEnvs();
     invokeMock.mockReset();
+    clearRuntimeApiKey();
     const storage = new Map<string, string>();
     Object.defineProperty(window, "localStorage", {
       value: {
@@ -57,6 +64,12 @@ describe("runtime config", () => {
       sseUrl: "http://127.0.0.1:9999/api/events",
       sharePublicBaseUrl: "https://share.example",
       authMode: "local",
+      apiKeyPresent: true,
+      apiKey: "packaged-runtime-key",
+      envPath: "/Users/chriscastillo/Codexify/.env",
+      runtimeRoot: "/Users/chriscastillo/Codexify",
+      failureKind: null,
+      runtimeContext: "packaged",
     });
 
     const config = await initRuntimeConfig({ force: true });
@@ -64,10 +77,19 @@ describe("runtime config", () => {
     expect(config.mode).toBe("tauri");
     expect(config.backendBaseUrl).toBe("http://127.0.0.1:9999");
     expect(config.apiBaseUrl).toBe("http://127.0.0.1:9999/api");
+    expect(readRuntimeApiKey()).toBe("packaged-runtime-key");
+    expect(getDesktopRuntimeAuthConfig()?.apiKeyPresent).toBe(true);
+    expect(getDesktopRuntimeAuthConfig()?.envPath).toBe(
+      "/Users/chriscastillo/Codexify/.env"
+    );
     expect(resolveApiUrl("/api/share", config)).toBe(
       "http://127.0.0.1:9999/api/share"
     );
     expect(resolveSseEndpoint(config)).toBe("http://127.0.0.1:9999/api/events");
+    const headers = buildAuthenticatedFetchInit().headers as Record<string, string>;
+    expect(headers["X-API-Key"] ?? headers["x-api-key"]).toBe(
+      "packaged-runtime-key"
+    );
   });
 
   it("prioritizes persisted desktop connection overrides", async () => {
@@ -117,6 +139,33 @@ describe("runtime config", () => {
     expect(decision?.setupReadiness?.recommendedAction).toBe(
       "Open Docker Desktop, then retry."
     );
+  });
+
+  it("captures packaged auth diagnostics without exposing the secret", async () => {
+    (window as any).__TAURI_IPC__ = {};
+    (window as any).__CFY_TAURI_CORE__ = { invoke: invokeMock };
+    invokeMock.mockResolvedValue({
+      mode: "tauri",
+      backendBaseUrl: "http://127.0.0.1:8888",
+      apiBaseUrl: "http://127.0.0.1:8888/api",
+      sseUrl: "http://127.0.0.1:8888/api/events",
+      sharePublicBaseUrl: "http://127.0.0.1:5173",
+      authMode: "local",
+      apiKeyPresent: false,
+      apiKey: null,
+      envPath: "/Users/chriscastillo/Codexify/.env",
+      runtimeRoot: "/Users/chriscastillo/Codexify",
+      failureKind: "config_incomplete",
+      runtimeContext: "packaged",
+    });
+
+    await initRuntimeConfig({ force: true });
+
+    const snapshot = getDesktopRuntimeAuthConfig();
+
+    expect(snapshot?.apiKeyPresent).toBe(false);
+    expect(snapshot?.failureKind).toBe("config_incomplete");
+    expect(JSON.stringify(snapshot)).not.toContain("packaged-runtime-key");
   });
 
   it("refreshes launcher setup readiness when the first handoff is incomplete", async () => {

--- a/frontend/src/tests/playwright/desktop-media-contract.spec.ts
+++ b/frontend/src/tests/playwright/desktop-media-contract.spec.ts
@@ -13,6 +13,22 @@ test.describe("desktop media contract", () => {
       (window as any).__CFY_TAURI_CORE__ = {
         invoke: async (command: string, payload?: Record<string, unknown>) => {
           invokeCalls.push({ command, payload: payload ?? null });
+          if (command === "desktop_get_runtime_auth_config") {
+            return {
+              mode: "tauri",
+              backendBaseUrl: "http://backend.test",
+              apiBaseUrl: "http://backend.test/api",
+              sseUrl: "http://backend.test/api/events",
+              sharePublicBaseUrl: "http://share.test",
+              authMode: "local",
+              apiKeyPresent: true,
+              apiKey: "desktop-test-key",
+              envPath: "/Users/chriscastillo/Codexify/.env",
+              runtimeRoot: "/Users/chriscastillo/Codexify",
+              failureKind: null,
+              runtimeContext: "packaged",
+            };
+          }
           if (command === "desktop_get_runtime_config") {
             return {
               mode: "tauri",
@@ -65,9 +81,6 @@ test.describe("desktop media contract", () => {
               llmReady: true,
               checks: [],
             };
-          }
-          if (command === "desktop_get_api_key") {
-            return null;
           }
           return null;
         },

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -101,6 +101,28 @@ pub struct DesktopRuntimeConfig {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct DesktopRuntimeAuthConfig {
+    pub mode: String,
+    pub backend_base_url: String,
+    pub api_base_url: String,
+    pub sse_url: String,
+    pub share_public_base_url: String,
+    pub auth_mode: String,
+    pub api_key_present: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_root: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_context: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LauncherStartupHandoff {
     pub should_run_wizard: bool,
     pub setup_complete: bool,
@@ -3975,6 +3997,76 @@ pub fn desktop_get_runtime_config() -> DesktopRuntimeConfig {
     }
 }
 
+fn desktop_runtime_auth_config(runtime: &BootstrapRuntime) -> DesktopRuntimeAuthConfig {
+    let backend_base_url = desktop_backend_base_url();
+    let api_base_url = resolve_api_base_url(&backend_base_url);
+    let sse_url = combine_url(&api_base_url, "/events");
+    let share_public_base_url = resolve_share_public_base_url(&backend_base_url);
+    let auth_mode = env_first(&["GUARDIAN_AUTH_MODE"], "local");
+    let runtime_root = runtime.runtime_root_display();
+    let env_path = runtime
+        .runtime_root_path()
+        .map(runtime_env_file_path)
+        .map(|path| path.display().to_string());
+
+    let mut api_key_present = false;
+    let mut api_key = None;
+    let mut failure_kind = None;
+
+    if let Some(runtime_root_path) = runtime.runtime_root_path() {
+        let env_path_buf = runtime_env_file_path(runtime_root_path);
+        if !env_path_buf.is_file() {
+            failure_kind = Some("missing_config".to_string());
+        } else {
+            match read_env_file_ordered(&env_path_buf) {
+                Ok((_order, values)) => {
+                    let candidate = values
+                        .get("GUARDIAN_API_KEY")
+                        .map(|value| value.trim().to_string())
+                        .filter(|value| !is_placeholder_config_value(Some(value)));
+                    api_key_present = candidate.is_some();
+                    api_key = candidate;
+                    if !api_key_present {
+                        failure_kind = Some("config_incomplete".to_string());
+                    }
+                }
+                Err(err) => {
+                    failure_kind = Some("config_incomplete".to_string());
+                    log::warn!(
+                        "packaged runtime auth config could not read env file: env_path={} error={}",
+                        env_path_buf.display(),
+                        err
+                    );
+                }
+            }
+        }
+    } else {
+        failure_kind = Some(FAILURE_KIND_RUNTIME_ROOT_UNAVAILABLE.to_string());
+    }
+
+    DesktopRuntimeAuthConfig {
+        mode: RUNTIME_CONTEXT_PACKAGED.to_string(),
+        backend_base_url,
+        api_base_url,
+        sse_url,
+        share_public_base_url,
+        auth_mode,
+        api_key_present,
+        api_key,
+        env_path,
+        runtime_root,
+        failure_kind,
+        runtime_context: Some(runtime.runtime_context.clone()),
+    }
+}
+
+#[tauri::command]
+pub fn desktop_get_runtime_auth_config(
+    runtime: tauri::State<'_, BootstrapRuntime>,
+) -> DesktopRuntimeAuthConfig {
+    desktop_runtime_auth_config(&runtime)
+}
+
 #[tauri::command]
 pub fn desktop_get_launcher_startup_handoff(
     runtime: tauri::State<'_, BootstrapRuntime>,
@@ -5584,6 +5676,49 @@ mod tests {
                 .expect("failed to read migrated model data"),
             "legacy-models"
         );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn packaged_runtime_auth_config_reads_env_without_leaking_secret() {
+        let root = unique_temp_dir("codexify-packaged-auth-config");
+        let runtime_home = root.join("Application Support").join("Codexify");
+        let runtime_root = root.join("Codexify");
+        fs::create_dir_all(&runtime_home).expect("failed to create runtime home");
+        fs::create_dir_all(&runtime_root).expect("failed to create runtime root");
+
+        let env_path = runtime_env_file_path(&runtime_root);
+        fs::write(
+            &env_path,
+            [
+                "GUARDIAN_API_KEY=packaged-runtime-secret",
+                "GUARDIAN_AUTH_MODE=local",
+                "CODEXIFY_DESKTOP_BACKEND_URL=http://127.0.0.1:8888",
+                "",
+            ]
+            .join("\n"),
+        )
+        .expect("failed to seed packaged env");
+
+        let runtime = test_runtime(true, runtime_root.clone(), Some(runtime_home));
+        let config = desktop_runtime_auth_config(&runtime);
+        let env_path_display = env_path.display().to_string();
+        let runtime_root_display = runtime_root.display().to_string();
+
+        assert!(config.api_key_present);
+        assert_eq!(
+            config.api_key.as_deref(),
+            Some("packaged-runtime-secret")
+        );
+        assert_eq!(config.env_path.as_deref(), Some(env_path_display.as_str()));
+        assert_eq!(config.runtime_root.as_deref(), Some(runtime_root_display.as_str()));
+        assert_eq!(config.failure_kind, None);
+        let diagnostics = redact_setup_diagnostics(
+            "GUARDIAN_API_KEY=packaged-runtime-secret\nruntimeRoot=/tmp/Codexify",
+        );
+        assert!(!diagnostics.contains("packaged-runtime-secret"));
+        assert!(diagnostics.contains("GUARDIAN_API_KEY=<redacted>"));
 
         fs::remove_dir_all(&root).ok();
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,6 +25,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             commands::desktop_get_runtime_config,
+            commands::desktop_get_runtime_auth_config,
             commands::desktop_get_launcher_startup_handoff,
             commands::desktop_fetch_media,
             commands::desktop_get_api_key,


### PR DESCRIPTION
## Summary
- Add a Tauri-backed packaged runtime auth/config payload so the desktop frontend can read the local `GUARDIAN_API_KEY` without relying on bundle-time `VITE_GUARDIAN_API_KEY`.
- Wire the frontend runtime loader and API client to use the handed-off key in packaged mode, while keeping diagnostics redacted to presence/source metadata only.
- Update the packaged auth banner and architecture docs to reflect the new local desktop handoff behavior.
- Add focused tests covering the packaged auth config path, API-key header attachment, and secret redaction.

## Testing
- Frontend Vitest coverage for runtime config and auth header behavior passed.
- Rust `cargo check` passed for the Tauri command surface.
- `git diff --check` passed.