### PR TITLE
feat: add capability activation dispatch contract seam

### DIFF
--- a/docs/architecture/self-extending-agent-plugin-system.md
+++ b/docs/architecture/self-extending-agent-plugin-system.md
@@ -2,7 +2,7 @@
 
 This note is the companion architecture reference for ADR-010. It explains the governed shape of Codexify's self-extending model without claiming runtime implementation.
 
-Implementation status: extension proposal persistence, manual install-gate decisions, capability registry entries, scoped install binding persistence, and backend read-time effective capability resolution exist on the backend; sandbox execution, runtime activation/dispatch, and plugin execution do not. Resolution precedence is profile > project > account.
+Implementation status: extension proposal persistence, manual install-gate decisions, capability registry entries, scoped install binding persistence, backend read-time effective capability resolution, and a pure capability activation / dispatch contract seam exist on the backend; it returns explicit allow/deny outcomes plus command-bus-shaped dispatch envelopes. Sandbox execution, runtime activation, autonomous dispatch, and plugin execution still do not exist. Resolution precedence is profile > project > account.
 
 ## Purpose
 

--- a/guardian/extensions/activation.py
+++ b/guardian/extensions/activation.py
@@ -1,0 +1,475 @@
+"""Read-time activation helpers for effective extension capabilities."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from guardian.extensions.contracts import (
+    CapabilityActivationConflictDetail,
+    CapabilityActivationDecision,
+    CapabilityActivationMatch,
+    CapabilityActivationOutcomeToken,
+    CapabilityActivationRequest,
+    CapabilityDispatchEnvelope,
+    CapabilityExposedCommand,
+    EffectiveCapabilityRecord,
+    ExtensionRequestedPermission,
+)
+from guardian.extensions.resolver import (
+    EffectiveCapabilityResolutionError,
+    EffectiveCapabilityResolver,
+)
+from guardian.extensions.store import ExtensionProposalStore
+from guardian.extensions.tokens import (
+    CapabilityActivationConflictClassToken,
+    CapabilityActivationContextToken,
+    CapabilityActivationDenyReasonToken,
+)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _permission_key(
+    permission: ExtensionRequestedPermission,
+) -> tuple[str, str]:
+    return permission.permission, permission.resource or ""
+
+
+def _coerce_permissions(
+    value: Sequence[ExtensionRequestedPermission | Mapping[str, Any]] | None,
+) -> tuple[ExtensionRequestedPermission, ...]:
+    if value is None:
+        return ()
+    normalized: list[ExtensionRequestedPermission] = []
+    for item in value:
+        if isinstance(item, ExtensionRequestedPermission):
+            normalized.append(item)
+        elif isinstance(item, Mapping):
+            normalized.append(ExtensionRequestedPermission.from_payload(item))
+        else:
+            raise ValueError(
+                "requested permissions must be extension permission records or mappings"
+            )
+    return tuple(normalized)
+
+
+def _requested_permission_subset(
+    *,
+    requested: tuple[ExtensionRequestedPermission, ...],
+    approved: tuple[ExtensionRequestedPermission, ...],
+) -> bool:
+    requested_keys = {_permission_key(permission) for permission in requested}
+    approved_keys = {_permission_key(permission) for permission in approved}
+    return requested_keys.issubset(approved_keys)
+
+
+def _build_request(
+    *,
+    account_id: str,
+    requested_command_id: str,
+    activation_context_token: str,
+    project_id: int | None = None,
+    profile_id: str | None = None,
+    requested_permissions: Sequence[
+        ExtensionRequestedPermission | Mapping[str, Any]
+    ]
+    | None = None,
+    request_metadata: Mapping[str, Any] | None = None,
+    source_thread_id: int | None = None,
+    source_message_id: int | None = None,
+    requested_at: datetime | None = None,
+) -> CapabilityActivationRequest:
+    return CapabilityActivationRequest(
+        account_id=account_id,
+        requested_command_id=requested_command_id,
+        activation_context_token=activation_context_token,
+        project_id=project_id,
+        profile_id=profile_id,
+        requested_permissions=_coerce_permissions(requested_permissions),
+        request_metadata=dict(request_metadata or {}),
+        source_thread_id=source_thread_id,
+        source_message_id=source_message_id,
+        requested_at=requested_at or _utc_now(),
+    )
+
+
+def _get_resolver(
+    *,
+    resolver: EffectiveCapabilityResolver | None = None,
+    store: ExtensionProposalStore | None = None,
+) -> EffectiveCapabilityResolver:
+    if resolver is not None:
+        return resolver
+    return EffectiveCapabilityResolver(store)
+
+
+def _resolve_snapshot(
+    *,
+    request: CapabilityActivationRequest,
+    resolver: EffectiveCapabilityResolver,
+):
+    if (
+        request.activation_context_token
+        == CapabilityActivationContextToken.OWNER_ONLY.value
+    ):
+        return resolver.resolve_effective_capabilities_for_owner(
+            account_id=request.account_id
+        )
+    if (
+        request.activation_context_token
+        == CapabilityActivationContextToken.OWNER_PROJECT.value
+    ):
+        return resolver.resolve_effective_capabilities_for_owner_and_project(
+            account_id=request.account_id,
+            project_id=request.project_id
+            if request.project_id is not None
+            else 0,
+        )
+    if (
+        request.activation_context_token
+        == CapabilityActivationContextToken.OWNER_PROFILE.value
+    ):
+        return resolver.resolve_effective_capabilities_for_owner_and_profile(
+            account_id=request.account_id,
+            profile_id=request.profile_id or "",
+        )
+    return resolver.resolve_effective_capabilities_for_owner_project_profile(
+        account_id=request.account_id,
+        project_id=request.project_id if request.project_id is not None else 0,
+        profile_id=request.profile_id or "",
+    )
+
+
+def _match_exposed_command(
+    *,
+    record: EffectiveCapabilityRecord,
+    requested_command_id: str,
+) -> tuple[CapabilityExposedCommand, str | None] | None:
+    for exposed_command in record.manifest_snapshot.exposed_commands:
+        if exposed_command.command_id == requested_command_id:
+            return exposed_command, None
+        if requested_command_id in exposed_command.tool_aliases:
+            return exposed_command, requested_command_id
+    return None
+
+
+def _build_match(
+    *,
+    record: EffectiveCapabilityRecord,
+    exposed_command: CapabilityExposedCommand,
+    matched_alias: str | None,
+) -> CapabilityActivationMatch:
+    return CapabilityActivationMatch(
+        account_id=record.account_id,
+        registry_entry_id=record.registry_entry_id,
+        proposal_id=record.proposal_id,
+        binding_id=record.binding_id,
+        resolved_from_scope_token=record.resolved_from_scope_token,
+        manifest_snapshot=record.manifest_snapshot,
+        approved_permissions=record.approved_permissions,
+        exposed_command=exposed_command,
+        matched_alias=matched_alias,
+        source_thread_id=record.source_thread_id,
+        source_message_id=record.source_message_id,
+        target_surface_token=record.target_surface_token,
+        match_metadata={
+            "registry_status_token": record.registry_status_token,
+            "binding_status_token": record.binding_status_token,
+        },
+    )
+
+
+def _deny(
+    *,
+    request: CapabilityActivationRequest,
+    reason_token: str,
+    candidate_matches: tuple[CapabilityActivationMatch, ...] = (),
+    evaluated_at: datetime | None = None,
+) -> CapabilityActivationDecision:
+    return CapabilityActivationDecision(
+        request=request,
+        outcome_token=CapabilityActivationOutcomeToken.DENIED.value,
+        candidate_matches=candidate_matches,
+        denial_reason_token=reason_token,
+        evaluated_at=evaluated_at or _utc_now(),
+        decision_metadata={
+            "requested_command_id": request.requested_command_id,
+            "activation_context_token": request.activation_context_token,
+        },
+    )
+
+
+def _conflict(
+    *,
+    request: CapabilityActivationRequest,
+    conflict_class_token: str,
+    candidate_matches: tuple[CapabilityActivationMatch, ...],
+    summary: str,
+    evaluated_at: datetime | None = None,
+    conflict_metadata: Mapping[str, Any] | None = None,
+) -> CapabilityActivationDecision:
+    return CapabilityActivationDecision(
+        request=request,
+        outcome_token=CapabilityActivationOutcomeToken.CONFLICT.value,
+        candidate_matches=candidate_matches,
+        conflict_details=(
+            CapabilityActivationConflictDetail(
+                conflict_class_token=conflict_class_token,
+                requested_command_id=request.requested_command_id,
+                candidate_matches=candidate_matches,
+                summary=summary,
+                conflict_metadata=dict(conflict_metadata or {}),
+            ),
+        ),
+        conflict_class_token=conflict_class_token,
+        evaluated_at=evaluated_at or _utc_now(),
+        decision_metadata={
+            "requested_command_id": request.requested_command_id,
+            "activation_context_token": request.activation_context_token,
+        },
+    )
+
+
+def _allowed(
+    *,
+    request: CapabilityActivationRequest,
+    match: CapabilityActivationMatch,
+    evaluated_at: datetime | None = None,
+) -> CapabilityActivationDecision:
+    envelope = CapabilityDispatchEnvelope(
+        owner_account_id=request.account_id,
+        requested_command_id=request.requested_command_id,
+        command_id=match.exposed_command.command_id,
+        activation_context_token=request.activation_context_token,
+        proposal_id=match.proposal_id,
+        registry_entry_id=match.registry_entry_id,
+        binding_id=match.binding_id,
+        resolved_from_scope_token=match.resolved_from_scope_token,
+        manifest_snapshot=match.manifest_snapshot,
+        approved_permissions=match.approved_permissions,
+        requested_permissions=request.requested_permissions,
+        matched_alias=match.matched_alias,
+        actor_id=request.account_id,
+        actor_session_id=None,
+        delegated_by=None,
+        arguments={},
+        requested_at=request.requested_at,
+        envelope_metadata={
+            "source_thread_id": match.source_thread_id,
+            "source_message_id": match.source_message_id,
+            "requested_command_id": request.requested_command_id,
+        },
+    )
+    return CapabilityActivationDecision(
+        request=request,
+        outcome_token=CapabilityActivationOutcomeToken.ALLOWED.value,
+        candidate_matches=(match,),
+        dispatch_envelope=envelope,
+        evaluated_at=evaluated_at or _utc_now(),
+        decision_metadata={
+            "requested_command_id": request.requested_command_id,
+            "activation_context_token": request.activation_context_token,
+        },
+    )
+
+
+def _activate(
+    *,
+    request: CapabilityActivationRequest,
+    resolver: EffectiveCapabilityResolver | None = None,
+    store: ExtensionProposalStore | None = None,
+) -> CapabilityActivationDecision:
+    resolved = _get_resolver(resolver=resolver, store=store)
+    try:
+        snapshot = _resolve_snapshot(request=request, resolver=resolved)
+    except EffectiveCapabilityResolutionError as exc:
+        return _conflict(
+            request=request,
+            conflict_class_token=CapabilityActivationConflictClassToken.RESOLUTION_AMBIGUITY.value,
+            candidate_matches=(),
+            summary=str(exc),
+            conflict_metadata={"resolution_error": str(exc)},
+        )
+
+    candidate_matches: list[CapabilityActivationMatch] = []
+    for record in snapshot.records:
+        exposure = _match_exposed_command(
+            record=record, requested_command_id=request.requested_command_id
+        )
+        if exposure is None:
+            continue
+        exposed_command, matched_alias = exposure
+        candidate_matches.append(
+            _build_match(
+                record=record,
+                exposed_command=exposed_command,
+                matched_alias=matched_alias,
+            )
+        )
+
+    if not candidate_matches:
+        return _deny(
+            request=request,
+            reason_token=CapabilityActivationDenyReasonToken.NO_MATCHING_EXPOSURE.value,
+            evaluated_at=_utc_now(),
+        )
+
+    if len(candidate_matches) > 1:
+        summary = (
+            "multiple effective capabilities expose "
+            f"{request.requested_command_id!r}"
+        )
+        return _conflict(
+            request=request,
+            conflict_class_token=CapabilityActivationConflictClassToken.SAME_COMMAND_EXPOSURE.value,
+            candidate_matches=tuple(candidate_matches),
+            summary=summary,
+            conflict_metadata={
+                "candidate_count": len(candidate_matches),
+                "requested_command_id": request.requested_command_id,
+            },
+        )
+
+    match = candidate_matches[0]
+    if not _requested_permission_subset(
+        requested=request.requested_permissions,
+        approved=match.approved_permissions,
+    ):
+        return _deny(
+            request=request,
+            reason_token=CapabilityActivationDenyReasonToken.INSUFFICIENT_PERMISSIONS.value,
+            candidate_matches=(match,),
+        )
+
+    return _allowed(request=request, match=match)
+
+
+def activate_capability_for_owner_only(
+    *,
+    account_id: str,
+    requested_command_id: str,
+    requested_permissions: Sequence[
+        ExtensionRequestedPermission | Mapping[str, Any]
+    ]
+    | None = None,
+    resolver: EffectiveCapabilityResolver | None = None,
+    store: ExtensionProposalStore | None = None,
+    request_metadata: Mapping[str, Any] | None = None,
+    source_thread_id: int | None = None,
+    source_message_id: int | None = None,
+    requested_at: datetime | None = None,
+) -> CapabilityActivationDecision:
+    request = _build_request(
+        account_id=account_id,
+        requested_command_id=requested_command_id,
+        activation_context_token=CapabilityActivationContextToken.OWNER_ONLY.value,
+        requested_permissions=requested_permissions,
+        request_metadata=request_metadata,
+        source_thread_id=source_thread_id,
+        source_message_id=source_message_id,
+        requested_at=requested_at,
+    )
+    return _activate(request=request, resolver=resolver, store=store)
+
+
+def activate_capability_for_owner_and_project(
+    *,
+    account_id: str,
+    project_id: int,
+    requested_command_id: str,
+    requested_permissions: Sequence[
+        ExtensionRequestedPermission | Mapping[str, Any]
+    ]
+    | None = None,
+    resolver: EffectiveCapabilityResolver | None = None,
+    store: ExtensionProposalStore | None = None,
+    request_metadata: Mapping[str, Any] | None = None,
+    source_thread_id: int | None = None,
+    source_message_id: int | None = None,
+    requested_at: datetime | None = None,
+) -> CapabilityActivationDecision:
+    request = _build_request(
+        account_id=account_id,
+        requested_command_id=requested_command_id,
+        activation_context_token=CapabilityActivationContextToken.OWNER_PROJECT.value,
+        project_id=project_id,
+        requested_permissions=requested_permissions,
+        request_metadata=request_metadata,
+        source_thread_id=source_thread_id,
+        source_message_id=source_message_id,
+        requested_at=requested_at,
+    )
+    return _activate(request=request, resolver=resolver, store=store)
+
+
+def activate_capability_for_owner_and_profile(
+    *,
+    account_id: str,
+    profile_id: str,
+    requested_command_id: str,
+    requested_permissions: Sequence[
+        ExtensionRequestedPermission | Mapping[str, Any]
+    ]
+    | None = None,
+    resolver: EffectiveCapabilityResolver | None = None,
+    store: ExtensionProposalStore | None = None,
+    request_metadata: Mapping[str, Any] | None = None,
+    source_thread_id: int | None = None,
+    source_message_id: int | None = None,
+    requested_at: datetime | None = None,
+) -> CapabilityActivationDecision:
+    request = _build_request(
+        account_id=account_id,
+        requested_command_id=requested_command_id,
+        activation_context_token=CapabilityActivationContextToken.OWNER_PROFILE.value,
+        profile_id=profile_id,
+        requested_permissions=requested_permissions,
+        request_metadata=request_metadata,
+        source_thread_id=source_thread_id,
+        source_message_id=source_message_id,
+        requested_at=requested_at,
+    )
+    return _activate(request=request, resolver=resolver, store=store)
+
+
+def activate_capability_for_owner_project_profile(
+    *,
+    account_id: str,
+    project_id: int,
+    profile_id: str,
+    requested_command_id: str,
+    requested_permissions: Sequence[
+        ExtensionRequestedPermission | Mapping[str, Any]
+    ]
+    | None = None,
+    resolver: EffectiveCapabilityResolver | None = None,
+    store: ExtensionProposalStore | None = None,
+    request_metadata: Mapping[str, Any] | None = None,
+    source_thread_id: int | None = None,
+    source_message_id: int | None = None,
+    requested_at: datetime | None = None,
+) -> CapabilityActivationDecision:
+    request = _build_request(
+        account_id=account_id,
+        requested_command_id=requested_command_id,
+        activation_context_token=CapabilityActivationContextToken.OWNER_PROJECT_PROFILE.value,
+        project_id=project_id,
+        profile_id=profile_id,
+        requested_permissions=requested_permissions,
+        request_metadata=request_metadata,
+        source_thread_id=source_thread_id,
+        source_message_id=source_message_id,
+        requested_at=requested_at,
+    )
+    return _activate(request=request, resolver=resolver, store=store)
+
+
+__all__ = [
+    "activate_capability_for_owner_only",
+    "activate_capability_for_owner_and_project",
+    "activate_capability_for_owner_and_profile",
+    "activate_capability_for_owner_project_profile",
+]

--- a/guardian/extensions/contracts.py
+++ b/guardian/extensions/contracts.py
@@ -4,14 +4,25 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
+from guardian.command_bus.contracts import INVOKE_VERSION
 from guardian.extensions.tokens import (
+    CapabilityActivationConflictClassToken,
+    CapabilityActivationContextToken,
+    CapabilityActivationDenyReasonToken,
+    CapabilityActivationOutcomeToken,
+    CapabilityDispatchSourceToken,
     CapabilityEntryProvenanceClass,
     CapabilityRegistryStatus,
     ExtensionInstallBindingScope,
     ExtensionInstallBindingStatus,
     InstallGateDecisionToken,
+    normalize_capability_activation_conflict_class_token,
+    normalize_capability_activation_context_token,
+    normalize_capability_activation_deny_reason_token,
+    normalize_capability_activation_outcome_token,
+    normalize_capability_dispatch_source_token,
     normalize_capability_entry_provenance_class,
     normalize_capability_registry_status,
     normalize_extension_install_binding_scope,
@@ -36,6 +47,20 @@ def _clean_mapping(value: Mapping[str, Any] | None) -> dict[str, Any]:
     if not value:
         return {}
     return {str(key): item for key, item in dict(value).items()}
+
+
+def _clean_text_sequence(value: Sequence[Any] | None) -> tuple[str, ...]:
+    if not value:
+        return ()
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        text = str(item).strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        cleaned.append(text)
+    return tuple(cleaned)
 
 
 @dataclass(frozen=True, slots=True)
@@ -230,6 +255,48 @@ class ExtensionTestEvidenceMetadata:
 
 
 @dataclass(frozen=True, slots=True)
+class CapabilityExposedCommand:
+    """Manifest-declared command exposure plus bounded tool aliases."""
+
+    command_id: str
+    tool_aliases: tuple[str, ...] = ()
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        command_id = _clean_optional_text(self.command_id)
+        if not command_id:
+            raise ValueError("command_id is required")
+        object.__setattr__(self, "command_id", command_id)
+        object.__setattr__(
+            self, "tool_aliases", _clean_text_sequence(self.tool_aliases)
+        )
+        object.__setattr__(self, "metadata", _clean_mapping(self.metadata))
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "command_id": self.command_id,
+            "tool_aliases": list(self.tool_aliases),
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_payload(
+        cls, payload: Mapping[str, Any] | None
+    ) -> CapabilityExposedCommand:
+        data = dict(payload or {})
+        metadata = data.get("metadata")
+        return cls(
+            command_id=data.get("command_id") or data.get("tool_id") or "",
+            tool_aliases=tuple(
+                str(item) for item in data.get("tool_aliases") or []
+            ),
+            metadata=_clean_mapping(metadata)
+            if isinstance(metadata, Mapping)
+            else {},
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class ExtensionProposalManifest:
     """Manifest draft persisted for a proposed extension."""
 
@@ -237,6 +304,7 @@ class ExtensionProposalManifest:
     scope: str
     requested_permissions: tuple[ExtensionRequestedPermission, ...] = ()
     declared_dependencies: tuple[ExtensionDeclaredDependency, ...] = ()
+    exposed_commands: tuple[CapabilityExposedCommand, ...] = ()
     rollback_metadata: ExtensionRollbackMetadata | None = None
     test_evidence_metadata: ExtensionTestEvidenceMetadata | None = None
     source_thread_id: int | None = None
@@ -267,6 +335,11 @@ class ExtensionProposalManifest:
             self,
             "declared_dependencies",
             tuple(self.declared_dependencies or ()),
+        )
+        object.__setattr__(
+            self,
+            "exposed_commands",
+            tuple(self.exposed_commands or ()),
         )
         object.__setattr__(
             self, "profile_id", _clean_optional_text(self.profile_id)
@@ -300,6 +373,9 @@ class ExtensionProposalManifest:
                 dependency.to_payload()
                 for dependency in self.declared_dependencies
             ],
+            "exposed_commands": [
+                command.to_payload() for command in self.exposed_commands
+            ],
             "rollback_metadata": (
                 self.rollback_metadata.to_payload()
                 if self.rollback_metadata is not None
@@ -325,6 +401,10 @@ class ExtensionProposalManifest:
             ExtensionDeclaredDependency.from_payload(item)
             for item in data.get("declared_dependencies") or []
         )
+        exposed_commands = tuple(
+            CapabilityExposedCommand.from_payload(item)
+            for item in data.get("exposed_commands") or []
+        )
         rollback_metadata = ExtensionRollbackMetadata.from_payload(
             data.get("rollback_metadata")
         )
@@ -336,6 +416,7 @@ class ExtensionProposalManifest:
             scope=data.get("scope") or "",
             requested_permissions=requested_permissions,
             declared_dependencies=declared_dependencies,
+            exposed_commands=exposed_commands,
             rollback_metadata=rollback_metadata,
             test_evidence_metadata=test_evidence_metadata,
             source_thread_id=data.get("source_thread_id"),
@@ -1306,12 +1387,747 @@ class EffectiveCapabilitySnapshot:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class CapabilityActivationRequest:
+    """Read-time request for capability activation."""
+
+    account_id: str
+    requested_command_id: str
+    activation_context_token: str
+    project_id: int | None = None
+    profile_id: str | None = None
+    requested_permissions: tuple[ExtensionRequestedPermission, ...] = ()
+    request_metadata: dict[str, Any] = field(default_factory=dict)
+    source_thread_id: int | None = None
+    source_message_id: int | None = None
+    requested_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "account_id", _clean_optional_text(self.account_id) or ""
+        )
+        object.__setattr__(
+            self,
+            "requested_command_id",
+            _clean_optional_text(self.requested_command_id) or "",
+        )
+        object.__setattr__(
+            self,
+            "activation_context_token",
+            normalize_capability_activation_context_token(
+                self.activation_context_token
+            ),
+        )
+        object.__setattr__(
+            self,
+            "project_id",
+            None if self.project_id is None else int(self.project_id),
+        )
+        object.__setattr__(
+            self, "profile_id", _clean_optional_text(self.profile_id)
+        )
+        object.__setattr__(
+            self,
+            "requested_permissions",
+            tuple(self.requested_permissions or ()),
+        )
+        object.__setattr__(
+            self, "request_metadata", _clean_mapping(self.request_metadata)
+        )
+        if not self.account_id:
+            raise ValueError("account_id is required")
+        if not self.requested_command_id:
+            raise ValueError("requested_command_id is required")
+        if (
+            self.activation_context_token
+            == CapabilityActivationContextToken.OWNER_ONLY.value
+        ):
+            if self.project_id is not None or self.profile_id is not None:
+                raise ValueError(
+                    "owner-only activation must not carry project or profile context"
+                )
+        elif (
+            self.activation_context_token
+            == CapabilityActivationContextToken.OWNER_PROJECT.value
+        ):
+            if self.project_id is None or self.profile_id is not None:
+                raise ValueError(
+                    "owner+project activation requires project context and excludes profile context"
+                )
+        elif (
+            self.activation_context_token
+            == CapabilityActivationContextToken.OWNER_PROFILE.value
+        ):
+            if self.profile_id is None or self.project_id is not None:
+                raise ValueError(
+                    "owner+profile activation requires profile context and excludes project context"
+                )
+        elif (
+            self.activation_context_token
+            == CapabilityActivationContextToken.OWNER_PROJECT_PROFILE.value
+        ):
+            if self.project_id is None or self.profile_id is None:
+                raise ValueError(
+                    "owner+project+profile activation requires both project and profile context"
+                )
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "account_id": self.account_id,
+            "requested_command_id": self.requested_command_id,
+            "activation_context_token": self.activation_context_token,
+            "project_id": self.project_id,
+            "profile_id": self.profile_id,
+            "requested_permissions_json": [
+                permission.to_payload()
+                for permission in self.requested_permissions
+            ],
+            "request_metadata_json": dict(self.request_metadata),
+            "source_thread_id": self.source_thread_id,
+            "source_message_id": self.source_message_id,
+            "requested_at": self.requested_at,
+        }
+
+    @classmethod
+    def from_payload(
+        cls, payload: Mapping[str, Any]
+    ) -> CapabilityActivationRequest:
+        data = dict(payload)
+        return cls(
+            account_id=data.get("account_id") or "",
+            requested_command_id=data.get("requested_command_id")
+            or data.get("command_id")
+            or "",
+            activation_context_token=data.get("activation_context_token") or "",
+            project_id=data.get("project_id"),
+            profile_id=data.get("profile_id"),
+            requested_permissions=tuple(
+                ExtensionRequestedPermission.from_payload(item)
+                for item in data.get("requested_permissions_json") or []
+            ),
+            request_metadata=_clean_mapping(
+                data.get("request_metadata_json")
+                if isinstance(data.get("request_metadata_json"), Mapping)
+                else {}
+            ),
+            source_thread_id=data.get("source_thread_id"),
+            source_message_id=data.get("source_message_id"),
+            requested_at=data.get("requested_at"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityActivationMatch:
+    """A unique effective capability that matched a requested command."""
+
+    account_id: str
+    registry_entry_id: str
+    proposal_id: str
+    binding_id: str
+    resolved_from_scope_token: str
+    manifest_snapshot: ExtensionProposalManifest
+    approved_permissions: tuple[ExtensionRequestedPermission, ...] = ()
+    exposed_command: CapabilityExposedCommand | None = None
+    matched_alias: str | None = None
+    source_thread_id: int | None = None
+    source_message_id: int | None = None
+    target_surface_token: str | None = None
+    match_metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "account_id", _clean_optional_text(self.account_id) or ""
+        )
+        object.__setattr__(
+            self,
+            "registry_entry_id",
+            _clean_optional_text(self.registry_entry_id) or "",
+        )
+        object.__setattr__(
+            self, "proposal_id", _clean_optional_text(self.proposal_id) or ""
+        )
+        object.__setattr__(
+            self, "binding_id", _clean_optional_text(self.binding_id) or ""
+        )
+        object.__setattr__(
+            self,
+            "resolved_from_scope_token",
+            normalize_extension_install_binding_scope(
+                self.resolved_from_scope_token
+            ),
+        )
+        object.__setattr__(
+            self,
+            "approved_permissions",
+            tuple(self.approved_permissions or ()),
+        )
+        object.__setattr__(
+            self,
+            "matched_alias",
+            _clean_optional_text(self.matched_alias),
+        )
+        object.__setattr__(
+            self,
+            "target_surface_token",
+            _clean_optional_text(self.target_surface_token)
+            or self.manifest_snapshot.target_surface,
+        )
+        object.__setattr__(
+            self, "match_metadata", _clean_mapping(self.match_metadata)
+        )
+        if self.exposed_command is None:
+            raise ValueError("exposed_command is required")
+        if not self.account_id:
+            raise ValueError("account_id is required")
+        if not self.registry_entry_id:
+            raise ValueError("registry_entry_id is required")
+        if not self.proposal_id:
+            raise ValueError("proposal_id is required")
+        if not self.binding_id:
+            raise ValueError("binding_id is required")
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "account_id": self.account_id,
+            "registry_entry_id": self.registry_entry_id,
+            "proposal_id": self.proposal_id,
+            "binding_id": self.binding_id,
+            "resolved_from_scope_token": self.resolved_from_scope_token,
+            "manifest_snapshot_json": self.manifest_snapshot.to_payload(),
+            "approved_permissions_json": [
+                permission.to_payload()
+                for permission in self.approved_permissions
+            ],
+            "exposed_command_json": self.exposed_command.to_payload(),
+            "matched_alias": self.matched_alias,
+            "source_thread_id": self.source_thread_id,
+            "source_message_id": self.source_message_id,
+            "target_surface_token": self.target_surface_token,
+            "match_metadata_json": dict(self.match_metadata),
+        }
+
+    @classmethod
+    def from_payload(
+        cls, payload: Mapping[str, Any]
+    ) -> CapabilityActivationMatch:
+        data = dict(payload)
+        manifest_payload = data.get("manifest_snapshot_json")
+        if not isinstance(manifest_payload, Mapping):
+            manifest_payload = {}
+        exposed_payload = data.get("exposed_command_json")
+        if not isinstance(exposed_payload, Mapping):
+            exposed_payload = {}
+        match_metadata = data.get("match_metadata_json")
+        return cls(
+            account_id=data.get("account_id") or "",
+            registry_entry_id=data.get("registry_entry_id") or "",
+            proposal_id=data.get("proposal_id") or "",
+            binding_id=data.get("binding_id") or "",
+            resolved_from_scope_token=data.get("resolved_from_scope_token")
+            or "",
+            manifest_snapshot=ExtensionProposalManifest.from_payload(
+                manifest_payload
+            ),
+            approved_permissions=tuple(
+                ExtensionRequestedPermission.from_payload(item)
+                for item in data.get("approved_permissions_json") or []
+            ),
+            exposed_command=CapabilityExposedCommand.from_payload(
+                exposed_payload
+            )
+            if exposed_payload
+            else None,
+            matched_alias=data.get("matched_alias"),
+            source_thread_id=data.get("source_thread_id"),
+            source_message_id=data.get("source_message_id"),
+            target_surface_token=data.get("target_surface_token"),
+            match_metadata=_clean_mapping(match_metadata)
+            if isinstance(match_metadata, Mapping)
+            else {},
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityActivationConflictDetail:
+    """Structured conflict metadata for a denied activation."""
+
+    conflict_class_token: str
+    requested_command_id: str
+    candidate_matches: tuple[CapabilityActivationMatch, ...] = ()
+    summary: str | None = None
+    conflict_metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "conflict_class_token",
+            normalize_capability_activation_conflict_class_token(
+                self.conflict_class_token
+            ),
+        )
+        object.__setattr__(
+            self,
+            "requested_command_id",
+            _clean_optional_text(self.requested_command_id) or "",
+        )
+        object.__setattr__(
+            self,
+            "candidate_matches",
+            tuple(self.candidate_matches or ()),
+        )
+        object.__setattr__(self, "summary", _clean_optional_text(self.summary))
+        object.__setattr__(
+            self,
+            "conflict_metadata",
+            _clean_mapping(self.conflict_metadata),
+        )
+        if not self.requested_command_id:
+            raise ValueError("requested_command_id is required")
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "conflict_class_token": self.conflict_class_token,
+            "requested_command_id": self.requested_command_id,
+            "candidate_matches_json": [
+                match.to_payload() for match in self.candidate_matches
+            ],
+            "summary": self.summary,
+            "conflict_metadata_json": dict(self.conflict_metadata),
+        }
+
+    @classmethod
+    def from_payload(
+        cls, payload: Mapping[str, Any]
+    ) -> CapabilityActivationConflictDetail:
+        data = dict(payload)
+        conflict_metadata = data.get("conflict_metadata_json")
+        return cls(
+            conflict_class_token=data.get("conflict_class_token") or "",
+            requested_command_id=data.get("requested_command_id") or "",
+            candidate_matches=tuple(
+                CapabilityActivationMatch.from_payload(item)
+                for item in data.get("candidate_matches_json") or []
+            ),
+            summary=data.get("summary"),
+            conflict_metadata=_clean_mapping(conflict_metadata)
+            if isinstance(conflict_metadata, Mapping)
+            else {},
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityDispatchEnvelope:
+    """Command-bus-shaped envelope prepared for later invocation."""
+
+    owner_account_id: str
+    requested_command_id: str
+    command_id: str
+    activation_context_token: str
+    proposal_id: str
+    registry_entry_id: str
+    binding_id: str
+    resolved_from_scope_token: str
+    manifest_snapshot: ExtensionProposalManifest
+    approved_permissions: tuple[ExtensionRequestedPermission, ...] = ()
+    requested_permissions: tuple[ExtensionRequestedPermission, ...] = ()
+    dispatch_source_token: str = (
+        CapabilityDispatchSourceToken.CAPABILITY_ACTIVATION.value
+    )
+    matched_alias: str | None = None
+    actor_kind: str = "human"
+    actor_id: str | None = None
+    actor_session_id: str | None = None
+    delegated_by: str | None = None
+    arguments: dict[str, Any] = field(default_factory=dict)
+    idempotency_key: str | None = None
+    invoke_version: str = INVOKE_VERSION
+    envelope_metadata: dict[str, Any] = field(default_factory=dict)
+    requested_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "owner_account_id",
+            _clean_optional_text(self.owner_account_id) or "",
+        )
+        object.__setattr__(
+            self,
+            "requested_command_id",
+            _clean_optional_text(self.requested_command_id) or "",
+        )
+        object.__setattr__(
+            self, "command_id", _clean_optional_text(self.command_id) or ""
+        )
+        object.__setattr__(
+            self,
+            "activation_context_token",
+            normalize_capability_activation_context_token(
+                self.activation_context_token
+            ),
+        )
+        object.__setattr__(
+            self, "proposal_id", _clean_optional_text(self.proposal_id) or ""
+        )
+        object.__setattr__(
+            self,
+            "registry_entry_id",
+            _clean_optional_text(self.registry_entry_id) or "",
+        )
+        object.__setattr__(
+            self, "binding_id", _clean_optional_text(self.binding_id) or ""
+        )
+        object.__setattr__(
+            self,
+            "resolved_from_scope_token",
+            normalize_extension_install_binding_scope(
+                self.resolved_from_scope_token
+            ),
+        )
+        object.__setattr__(
+            self,
+            "approved_permissions",
+            tuple(self.approved_permissions or ()),
+        )
+        object.__setattr__(
+            self,
+            "requested_permissions",
+            tuple(self.requested_permissions or ()),
+        )
+        object.__setattr__(
+            self,
+            "dispatch_source_token",
+            normalize_capability_dispatch_source_token(
+                self.dispatch_source_token
+            ),
+        )
+        object.__setattr__(
+            self, "matched_alias", _clean_optional_text(self.matched_alias)
+        )
+        object.__setattr__(
+            self, "actor_kind", _clean_optional_text(self.actor_kind) or "human"
+        )
+        object.__setattr__(
+            self,
+            "actor_id",
+            _clean_optional_text(self.actor_id) or self.owner_account_id,
+        )
+        object.__setattr__(
+            self,
+            "actor_session_id",
+            _clean_optional_text(self.actor_session_id),
+        )
+        object.__setattr__(
+            self, "delegated_by", _clean_optional_text(self.delegated_by)
+        )
+        object.__setattr__(self, "arguments", _clean_mapping(self.arguments))
+        object.__setattr__(
+            self,
+            "idempotency_key",
+            _clean_optional_text(self.idempotency_key),
+        )
+        object.__setattr__(
+            self,
+            "invoke_version",
+            _clean_optional_text(self.invoke_version) or INVOKE_VERSION,
+        )
+        object.__setattr__(
+            self,
+            "envelope_metadata",
+            _clean_mapping(self.envelope_metadata),
+        )
+        if not self.owner_account_id:
+            raise ValueError("owner_account_id is required")
+        if not self.requested_command_id:
+            raise ValueError("requested_command_id is required")
+        if not self.command_id:
+            raise ValueError("command_id is required")
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "owner_account_id": self.owner_account_id,
+            "requested_command_id": self.requested_command_id,
+            "command_id": self.command_id,
+            "activation_context_token": self.activation_context_token,
+            "proposal_id": self.proposal_id,
+            "registry_entry_id": self.registry_entry_id,
+            "binding_id": self.binding_id,
+            "resolved_from_scope_token": self.resolved_from_scope_token,
+            "manifest_snapshot_json": self.manifest_snapshot.to_payload(),
+            "approved_permissions_json": [
+                permission.to_payload()
+                for permission in self.approved_permissions
+            ],
+            "requested_permissions_json": [
+                permission.to_payload()
+                for permission in self.requested_permissions
+            ],
+            "dispatch_source_token": self.dispatch_source_token,
+            "matched_alias": self.matched_alias,
+            "actor_kind": self.actor_kind,
+            "actor_id": self.actor_id,
+            "actor_session_id": self.actor_session_id,
+            "delegated_by": self.delegated_by,
+            "arguments_json": dict(self.arguments),
+            "idempotency_key": self.idempotency_key,
+            "invoke_version": self.invoke_version,
+            "envelope_metadata_json": dict(self.envelope_metadata),
+            "requested_at": self.requested_at,
+        }
+
+    @classmethod
+    def from_payload(
+        cls, payload: Mapping[str, Any]
+    ) -> CapabilityDispatchEnvelope:
+        data = dict(payload)
+        manifest_payload = data.get("manifest_snapshot_json")
+        if not isinstance(manifest_payload, Mapping):
+            manifest_payload = {}
+        envelope_metadata = data.get("envelope_metadata_json")
+        arguments = data.get("arguments_json")
+        return cls(
+            owner_account_id=data.get("owner_account_id") or "",
+            requested_command_id=data.get("requested_command_id") or "",
+            command_id=data.get("command_id") or "",
+            activation_context_token=data.get("activation_context_token") or "",
+            proposal_id=data.get("proposal_id") or "",
+            registry_entry_id=data.get("registry_entry_id") or "",
+            binding_id=data.get("binding_id") or "",
+            resolved_from_scope_token=data.get("resolved_from_scope_token")
+            or "",
+            manifest_snapshot=ExtensionProposalManifest.from_payload(
+                manifest_payload
+            ),
+            approved_permissions=tuple(
+                ExtensionRequestedPermission.from_payload(item)
+                for item in data.get("approved_permissions_json") or []
+            ),
+            requested_permissions=tuple(
+                ExtensionRequestedPermission.from_payload(item)
+                for item in data.get("requested_permissions_json") or []
+            ),
+            dispatch_source_token=data.get("dispatch_source_token") or "",
+            matched_alias=data.get("matched_alias"),
+            actor_kind=data.get("actor_kind") or "human",
+            actor_id=data.get("actor_id"),
+            actor_session_id=data.get("actor_session_id"),
+            delegated_by=data.get("delegated_by"),
+            arguments=_clean_mapping(arguments)
+            if isinstance(arguments, Mapping)
+            else {},
+            idempotency_key=data.get("idempotency_key"),
+            invoke_version=data.get("invoke_version") or INVOKE_VERSION,
+            envelope_metadata=_clean_mapping(envelope_metadata)
+            if isinstance(envelope_metadata, Mapping)
+            else {},
+            requested_at=data.get("requested_at"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityActivationDecision:
+    """Outcome for a read-time activation decision."""
+
+    request: CapabilityActivationRequest
+    outcome_token: str
+    candidate_matches: tuple[CapabilityActivationMatch, ...] = ()
+    conflict_details: tuple[CapabilityActivationConflictDetail, ...] = ()
+    denial_reason_token: str | None = None
+    conflict_class_token: str | None = None
+    dispatch_envelope: CapabilityDispatchEnvelope | None = None
+    evaluated_at: datetime | None = None
+    decision_metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "outcome_token",
+            normalize_capability_activation_outcome_token(self.outcome_token),
+        )
+        object.__setattr__(
+            self,
+            "candidate_matches",
+            tuple(self.candidate_matches or ()),
+        )
+        object.__setattr__(
+            self,
+            "conflict_details",
+            tuple(self.conflict_details or ()),
+        )
+        object.__setattr__(
+            self,
+            "denial_reason_token",
+            (
+                normalize_capability_activation_deny_reason_token(
+                    self.denial_reason_token
+                )
+                if self.denial_reason_token is not None
+                else None
+            ),
+        )
+        object.__setattr__(
+            self,
+            "conflict_class_token",
+            (
+                normalize_capability_activation_conflict_class_token(
+                    self.conflict_class_token
+                )
+                if self.conflict_class_token is not None
+                else None
+            ),
+        )
+        object.__setattr__(
+            self,
+            "decision_metadata",
+            _clean_mapping(self.decision_metadata),
+        )
+        if self.outcome_token == CapabilityActivationOutcomeToken.ALLOWED.value:
+            if self.dispatch_envelope is None:
+                raise ValueError(
+                    "allowed activation requires a dispatch envelope"
+                )
+            if self.denial_reason_token is not None:
+                raise ValueError(
+                    "allowed activation must not carry a denial reason"
+                )
+            if self.conflict_class_token is not None:
+                raise ValueError(
+                    "allowed activation must not carry conflict metadata"
+                )
+            if self.conflict_details:
+                raise ValueError(
+                    "allowed activation must not carry conflict details"
+                )
+            if len(self.candidate_matches) != 1:
+                raise ValueError(
+                    "allowed activation requires one matched capability"
+                )
+        elif (
+            self.outcome_token == CapabilityActivationOutcomeToken.DENIED.value
+        ):
+            if self.dispatch_envelope is not None:
+                raise ValueError(
+                    "denied activation must not carry a dispatch envelope"
+                )
+            if self.denial_reason_token is None:
+                raise ValueError("denied activation requires a denial reason")
+            if self.conflict_class_token is not None:
+                raise ValueError(
+                    "denied activation must not carry conflict class metadata"
+                )
+            if self.conflict_details:
+                raise ValueError(
+                    "denied activation must not carry conflict details"
+                )
+        elif (
+            self.outcome_token
+            == CapabilityActivationOutcomeToken.CONFLICT.value
+        ):
+            if self.dispatch_envelope is not None:
+                raise ValueError(
+                    "conflict activation must not carry a dispatch envelope"
+                )
+            if self.conflict_class_token is None:
+                raise ValueError(
+                    "conflict activation requires a conflict class"
+                )
+            if not self.conflict_details:
+                raise ValueError(
+                    "conflict activation requires conflict details"
+                )
+            if self.denial_reason_token is not None:
+                raise ValueError(
+                    "conflict activation must not carry a denial reason"
+                )
+
+    @property
+    def is_allowed(self) -> bool:
+        return (
+            self.outcome_token == CapabilityActivationOutcomeToken.ALLOWED.value
+        )
+
+    @property
+    def is_denied(self) -> bool:
+        return (
+            self.outcome_token == CapabilityActivationOutcomeToken.DENIED.value
+        )
+
+    @property
+    def is_conflict(self) -> bool:
+        return (
+            self.outcome_token
+            == CapabilityActivationOutcomeToken.CONFLICT.value
+        )
+
+    @property
+    def selected_match(self) -> CapabilityActivationMatch | None:
+        return self.candidate_matches[0] if self.candidate_matches else None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "request_json": self.request.to_payload(),
+            "outcome_token": self.outcome_token,
+            "candidate_matches_json": [
+                match.to_payload() for match in self.candidate_matches
+            ],
+            "conflict_details_json": [
+                detail.to_payload() for detail in self.conflict_details
+            ],
+            "denial_reason_token": self.denial_reason_token,
+            "conflict_class_token": self.conflict_class_token,
+            "dispatch_envelope_json": (
+                self.dispatch_envelope.to_payload()
+                if self.dispatch_envelope is not None
+                else None
+            ),
+            "evaluated_at": self.evaluated_at,
+            "decision_metadata_json": dict(self.decision_metadata),
+        }
+
+    @classmethod
+    def from_payload(
+        cls, payload: Mapping[str, Any]
+    ) -> CapabilityActivationDecision:
+        data = dict(payload)
+        request_payload = data.get("request_json")
+        if not isinstance(request_payload, Mapping):
+            request_payload = {}
+        envelope_payload = data.get("dispatch_envelope_json")
+        if not isinstance(envelope_payload, Mapping):
+            envelope_payload = None
+        return cls(
+            request=CapabilityActivationRequest.from_payload(request_payload),
+            outcome_token=data.get("outcome_token") or "",
+            candidate_matches=tuple(
+                CapabilityActivationMatch.from_payload(item)
+                for item in data.get("candidate_matches_json") or []
+            ),
+            conflict_details=tuple(
+                CapabilityActivationConflictDetail.from_payload(item)
+                for item in data.get("conflict_details_json") or []
+            ),
+            denial_reason_token=data.get("denial_reason_token"),
+            conflict_class_token=data.get("conflict_class_token"),
+            dispatch_envelope=(
+                CapabilityDispatchEnvelope.from_payload(envelope_payload)
+                if envelope_payload is not None
+                else None
+            ),
+            evaluated_at=data.get("evaluated_at"),
+            decision_metadata=_clean_mapping(
+                data.get("decision_metadata_json")
+                if isinstance(data.get("decision_metadata_json"), Mapping)
+                else {}
+            ),
+        )
+
+
 __all__ = [
     "MANIFEST_VERSION",
     "ExtensionRequestedPermission",
     "ExtensionDeclaredDependency",
     "ExtensionRollbackMetadata",
     "ExtensionTestEvidenceMetadata",
+    "CapabilityExposedCommand",
     "ExtensionProposalManifest",
     "ExtensionProposalRecord",
     "InstallGateDecisionRecord",
@@ -1320,4 +2136,9 @@ __all__ = [
     "ExtensionBindingRecord",
     "EffectiveCapabilityRecord",
     "EffectiveCapabilitySnapshot",
+    "CapabilityActivationRequest",
+    "CapabilityActivationMatch",
+    "CapabilityActivationConflictDetail",
+    "CapabilityDispatchEnvelope",
+    "CapabilityActivationDecision",
 ]

--- a/guardian/extensions/tokens.py
+++ b/guardian/extensions/tokens.py
@@ -71,6 +71,44 @@ class ExtensionInstallBindingStatus(str, Enum):
     ARCHIVED = "archived"
 
 
+class CapabilityActivationContextToken(str, Enum):
+    """Canonical activation contexts for read-time capability checks."""
+
+    OWNER_ONLY = "owner_only"
+    OWNER_PROJECT = "owner_project"
+    OWNER_PROFILE = "owner_profile"
+    OWNER_PROJECT_PROFILE = "owner_project_profile"
+
+
+class CapabilityActivationOutcomeToken(str, Enum):
+    """Canonical activation outcomes."""
+
+    ALLOWED = "allowed"
+    DENIED = "denied"
+    CONFLICT = "conflict"
+
+
+class CapabilityActivationDenyReasonToken(str, Enum):
+    """Canonical activation denial reasons."""
+
+    MISSING_IDENTITY = "missing_identity"
+    NO_MATCHING_EXPOSURE = "no_matching_exposure"
+    INSUFFICIENT_PERMISSIONS = "insufficient_permissions"
+
+
+class CapabilityActivationConflictClassToken(str, Enum):
+    """Canonical activation conflict classes."""
+
+    SAME_COMMAND_EXPOSURE = "same_command_exposure"
+    RESOLUTION_AMBIGUITY = "resolution_ambiguity"
+
+
+class CapabilityDispatchSourceToken(str, Enum):
+    """Canonical dispatch source tags for prepared activation envelopes."""
+
+    CAPABILITY_ACTIVATION = "capability_activation"
+
+
 EXTENSION_TARGET_SURFACES: frozenset[str] = frozenset(
     surface.value for surface in ExtensionTargetSurface
 )
@@ -94,6 +132,21 @@ EXTENSION_INSTALL_BINDING_SCOPES: frozenset[str] = frozenset(
 )
 EXTENSION_INSTALL_BINDING_STATUSES: frozenset[str] = frozenset(
     status.value for status in ExtensionInstallBindingStatus
+)
+CAPABILITY_ACTIVATION_CONTEXT_TOKENS: frozenset[str] = frozenset(
+    token.value for token in CapabilityActivationContextToken
+)
+CAPABILITY_ACTIVATION_OUTCOME_TOKENS: frozenset[str] = frozenset(
+    token.value for token in CapabilityActivationOutcomeToken
+)
+CAPABILITY_ACTIVATION_DENY_REASON_TOKENS: frozenset[str] = frozenset(
+    token.value for token in CapabilityActivationDenyReasonToken
+)
+CAPABILITY_ACTIVATION_CONFLICT_CLASS_TOKENS: frozenset[str] = frozenset(
+    token.value for token in CapabilityActivationConflictClassToken
+)
+CAPABILITY_DISPATCH_SOURCE_TOKENS: frozenset[str] = frozenset(
+    token.value for token in CapabilityDispatchSourceToken
 )
 
 
@@ -168,6 +221,50 @@ def normalize_extension_install_binding_status(value: str | None) -> str:
     )
 
 
+def normalize_capability_activation_context_token(value: str | None) -> str:
+    return _normalize_token(
+        value,
+        allowed=CAPABILITY_ACTIVATION_CONTEXT_TOKENS,
+        kind="capability_activation_context",
+    )
+
+
+def normalize_capability_activation_outcome_token(value: str | None) -> str:
+    return _normalize_token(
+        value,
+        allowed=CAPABILITY_ACTIVATION_OUTCOME_TOKENS,
+        kind="capability_activation_outcome",
+    )
+
+
+def normalize_capability_activation_deny_reason_token(
+    value: str | None,
+) -> str:
+    return _normalize_token(
+        value,
+        allowed=CAPABILITY_ACTIVATION_DENY_REASON_TOKENS,
+        kind="capability_activation_deny_reason",
+    )
+
+
+def normalize_capability_activation_conflict_class_token(
+    value: str | None,
+) -> str:
+    return _normalize_token(
+        value,
+        allowed=CAPABILITY_ACTIVATION_CONFLICT_CLASS_TOKENS,
+        kind="capability_activation_conflict_class",
+    )
+
+
+def normalize_capability_dispatch_source_token(value: str | None) -> str:
+    return _normalize_token(
+        value,
+        allowed=CAPABILITY_DISPATCH_SOURCE_TOKENS,
+        kind="capability_dispatch_source",
+    )
+
+
 __all__ = [
     "ExtensionTargetSurface",
     "ExtensionProposalScope",
@@ -177,6 +274,11 @@ __all__ = [
     "CapabilityEntryProvenanceClass",
     "ExtensionInstallBindingScope",
     "ExtensionInstallBindingStatus",
+    "CapabilityActivationContextToken",
+    "CapabilityActivationOutcomeToken",
+    "CapabilityActivationDenyReasonToken",
+    "CapabilityActivationConflictClassToken",
+    "CapabilityDispatchSourceToken",
     "ExtensionTokenError",
     "EXTENSION_TARGET_SURFACES",
     "EXTENSION_PROPOSAL_SCOPES",
@@ -186,6 +288,11 @@ __all__ = [
     "CAPABILITY_ENTRY_PROVENANCE_CLASSES",
     "EXTENSION_INSTALL_BINDING_SCOPES",
     "EXTENSION_INSTALL_BINDING_STATUSES",
+    "CAPABILITY_ACTIVATION_CONTEXT_TOKENS",
+    "CAPABILITY_ACTIVATION_OUTCOME_TOKENS",
+    "CAPABILITY_ACTIVATION_DENY_REASON_TOKENS",
+    "CAPABILITY_ACTIVATION_CONFLICT_CLASS_TOKENS",
+    "CAPABILITY_DISPATCH_SOURCE_TOKENS",
     "normalize_extension_target_surface",
     "normalize_extension_proposal_scope",
     "normalize_extension_proposal_status",
@@ -194,4 +301,9 @@ __all__ = [
     "normalize_capability_entry_provenance_class",
     "normalize_extension_install_binding_scope",
     "normalize_extension_install_binding_status",
+    "normalize_capability_activation_context_token",
+    "normalize_capability_activation_outcome_token",
+    "normalize_capability_activation_deny_reason_token",
+    "normalize_capability_activation_conflict_class_token",
+    "normalize_capability_dispatch_source_token",
 ]

--- a/tests/extensions/test_capability_activation_contract.py
+++ b/tests/extensions/test_capability_activation_contract.py
@@ -1,0 +1,789 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from guardian.db.models import (
+    AgentExtensionInstallBinding,
+    AgentExtensionInstallGateDecision,
+    AgentExtensionProposal,
+    AgentExtensionRegistryEntry,
+    Base,
+)
+from guardian.extensions.activation import (
+    activate_capability_for_owner_and_profile,
+    activate_capability_for_owner_and_project,
+    activate_capability_for_owner_only,
+    activate_capability_for_owner_project_profile,
+)
+from guardian.extensions.bindings import ExtensionInstallBindings
+from guardian.extensions.contracts import (
+    CapabilityActivationConflictClassToken,
+    CapabilityActivationDenyReasonToken,
+    CapabilityActivationOutcomeToken,
+    CapabilityExposedCommand,
+    CapabilityRegistryEntry,
+    EffectiveCapabilityRecord,
+    ExtensionDeclaredDependency,
+    ExtensionInstallBinding,
+    ExtensionProposalManifest,
+    ExtensionRequestedPermission,
+    ExtensionRollbackMetadata,
+    ExtensionTestEvidenceMetadata,
+)
+from guardian.extensions.install_gate import InstallGate
+from guardian.extensions.registry import CapabilityRegistry
+from guardian.extensions.resolver import EffectiveCapabilityResolver
+from guardian.extensions.store import ExtensionProposalStore
+from guardian.extensions.tokens import (
+    CapabilityRegistryStatus,
+    ExtensionInstallBindingScope,
+    ExtensionProposalScope,
+    ExtensionTargetSurface,
+)
+
+COMMAND_ID = "command::activate-alpha"
+COMMAND_ALIAS = "command::activate-alpha-alias"
+OTHER_COMMAND_ID = "command::activate-beta"
+
+
+@pytest.fixture()
+def activation_store():
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(
+        bind=engine,
+        tables=[
+            AgentExtensionProposal.__table__,
+            AgentExtensionInstallGateDecision.__table__,
+            AgentExtensionRegistryEntry.__table__,
+            AgentExtensionInstallBinding.__table__,
+        ],
+    )
+    Session = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False, future=True
+    )
+
+    class _DB:
+        def get_session(self):
+            return Session()
+
+    store = ExtensionProposalStore(_DB())
+    registry = CapabilityRegistry(store)
+    gate = InstallGate(store, registry)
+    bindings = ExtensionInstallBindings(store, registry)
+    resolver = EffectiveCapabilityResolver(store)
+    return store, gate, registry, bindings, resolver
+
+
+def _manifest(
+    *,
+    target_surface: str,
+    scope: str,
+    project_id: int | None = None,
+    profile_id: str | None = None,
+    source_thread_id: int | None = 41,
+    source_message_id: int | None = 42,
+    exposed_command_ids: tuple[str, ...] = (COMMAND_ID,),
+    requested_permissions: tuple[ExtensionRequestedPermission, ...]
+    | None = None,
+) -> ExtensionProposalManifest:
+    return ExtensionProposalManifest(
+        target_surface=target_surface,
+        scope=scope,
+        project_id=project_id,
+        profile_id=profile_id,
+        source_thread_id=source_thread_id,
+        source_message_id=source_message_id,
+        summary="Generate a bounded tool plugin",
+        description="Draft a tool proposal without executing it.",
+        requested_permissions=requested_permissions
+        or (
+            ExtensionRequestedPermission(
+                permission="command.run",
+                resource="command_bus",
+                reason="bounded command execution",
+            ),
+        ),
+        declared_dependencies=(
+            ExtensionDeclaredDependency(
+                name="httpx",
+                version_spec=">=0.28",
+                source="pypi",
+            ),
+        ),
+        exposed_commands=tuple(
+            CapabilityExposedCommand(
+                command_id=command_id,
+                tool_aliases=(
+                    (COMMAND_ALIAS,) if command_id == COMMAND_ID else ()
+                ),
+            )
+            for command_id in exposed_command_ids
+        ),
+        rollback_metadata=ExtensionRollbackMetadata(
+            strategy="disable_and_revert",
+            rollback_ref="ticket-123",
+        ),
+        test_evidence_metadata=ExtensionTestEvidenceMetadata(
+            status="passing",
+            summary="activation contract coverage",
+            artifacts=(
+                "tests/extensions/test_capability_activation_contract.py",
+            ),
+        ),
+    )
+
+
+def _approved_registry_entry(
+    store: ExtensionProposalStore,
+    gate: InstallGate,
+    *,
+    account_id: str,
+    manifest: ExtensionProposalManifest,
+):
+    proposal = store.create_proposal(account_id=account_id, manifest=manifest)
+    decision, registry_entry = gate.approve_proposal(
+        account_id=account_id,
+        proposal_id=proposal.proposal_id,
+        reason="manual approval",
+        notes={"reviewer": "alice"},
+    )
+    return proposal, decision, registry_entry
+
+
+def _bind_scope(
+    bindings: ExtensionInstallBindings,
+    registry_entry,
+    *,
+    account_id: str,
+    scope_token: str,
+    project_id: int | None = None,
+    profile_id: str | None = None,
+    account_scope_target_id: str | None = "account-target-1",
+):
+    return bindings.bind_registry_entry_to_scope(
+        binding=ExtensionInstallBinding(
+            account_id=account_id,
+            registry_entry_id=registry_entry.registry_id,
+            scope_token=scope_token,
+            project_id=project_id,
+            profile_id=profile_id,
+            account_scope_target_id=account_scope_target_id,
+        )
+    )
+
+
+def _bind_all_scopes(
+    bindings: ExtensionInstallBindings,
+    registry_entry,
+    *,
+    account_id: str,
+    project_id: int | None = None,
+    profile_id: str | None = None,
+):
+    bound = {}
+    if project_id is not None:
+        bound["project"] = _bind_scope(
+            bindings,
+            registry_entry,
+            account_id=account_id,
+            scope_token=ExtensionInstallBindingScope.PROJECT.value,
+            project_id=project_id,
+            account_scope_target_id=None,
+        )
+    if profile_id is not None:
+        bound["profile"] = _bind_scope(
+            bindings,
+            registry_entry,
+            account_id=account_id,
+            scope_token=ExtensionInstallBindingScope.PROFILE.value,
+            profile_id=profile_id,
+            account_scope_target_id=None,
+        )
+    bound["account"] = _bind_scope(
+        bindings,
+        registry_entry,
+        account_id=account_id,
+        scope_token=ExtensionInstallBindingScope.ACCOUNT.value,
+        account_scope_target_id=f"{account_id}-target",
+    )
+    return bound
+
+
+def test_account_context_activation_succeeds_for_account_scoped_capability(
+    activation_store,
+):
+    store, gate, registry, bindings, resolver = activation_store
+    _proposal, _decision, registry_entry = _approved_registry_entry(
+        store,
+        gate,
+        account_id="acct-1",
+        manifest=_manifest(
+            target_surface=ExtensionTargetSurface.COMMAND_BUS.value,
+            scope=ExtensionProposalScope.ACCOUNT.value,
+        ),
+    )
+    account_binding = _bind_scope(
+        bindings,
+        registry_entry,
+        account_id="acct-1",
+        scope_token=ExtensionInstallBindingScope.ACCOUNT.value,
+        account_scope_target_id="account-target-1",
+    )
+
+    decision = activate_capability_for_owner_only(
+        account_id="acct-1",
+        requested_command_id=COMMAND_ID,
+        resolver=resolver,
+    )
+
+    assert (
+        decision.outcome_token == CapabilityActivationOutcomeToken.ALLOWED.value
+    )
+    assert decision.dispatch_envelope is not None
+    assert decision.selected_match is not None
+    assert decision.selected_match.binding_id == account_binding.binding_id
+    assert decision.dispatch_envelope.owner_account_id == "acct-1"
+    assert decision.dispatch_envelope.requested_command_id == COMMAND_ID
+    assert decision.dispatch_envelope.command_id == COMMAND_ID
+    assert decision.dispatch_envelope.proposal_id == _proposal.proposal_id
+    assert (
+        decision.dispatch_envelope.registry_entry_id
+        == registry_entry.registry_id
+    )
+    assert decision.dispatch_envelope.binding_id == account_binding.binding_id
+    assert decision.dispatch_envelope.resolved_from_scope_token == (
+        ExtensionInstallBindingScope.ACCOUNT.value
+    )
+
+
+def test_project_context_activation_prefers_project_effective_over_account_effective(
+    activation_store,
+):
+    store, gate, registry, bindings, resolver = activation_store
+    _proposal, _decision, registry_entry = _approved_registry_entry(
+        store,
+        gate,
+        account_id="acct-1",
+        manifest=_manifest(
+            target_surface=ExtensionTargetSurface.COMMAND_BUS.value,
+            scope=ExtensionProposalScope.PROJECT.value,
+            project_id=17,
+        ),
+    )
+    scoped = _bind_all_scopes(
+        bindings,
+        registry_entry,
+        account_id="acct-1",
+        project_id=17,
+    )
+
+    decision = activate_capability_for_owner_and_project(
+        account_id="acct-1",
+        project_id=17,
+        requested_command_id=COMMAND_ID,
+        resolver=resolver,
+    )
+
+    assert (
+        decision.outcome_token == CapabilityActivationOutcomeToken.ALLOWED.value
+    )
+    assert decision.selected_match is not None
+    assert decision.selected_match.binding_id == scoped["project"].binding_id
+    assert decision.selected_match.resolved_from_scope_token == (
+        ExtensionInstallBindingScope.PROJECT.value
+    )
+    assert decision.dispatch_envelope is not None
+    assert decision.dispatch_envelope.binding_id == scoped["project"].binding_id
+
+
+def test_profile_context_activation_prefers_profile_effective_over_project_account(
+    activation_store,
+):
+    store, gate, registry, bindings, resolver = activation_store
+    _proposal, _decision, registry_entry = _approved_registry_entry(
+        store,
+        gate,
+        account_id="acct-1",
+        manifest=_manifest(
+            target_surface=ExtensionTargetSurface.PERSONA_STUDIO.value,
+            scope=ExtensionProposalScope.PROFILE.value,
+            profile_id="profile-alpha",
+        ),
+    )
+    scoped = _bind_all_scopes(
+        bindings,
+        registry_entry,
+        account_id="acct-1",
+        project_id=17,
+        profile_id="profile-alpha",
+    )
+
+    decision = activate_capability_for_owner_and_profile(
+        account_id="acct-1",
+        profile_id="profile-alpha",
+        requested_command_id=COMMAND_ID,
+        resolver=resolver,
+    )
+
+    assert (
+        decision.outcome_token == CapabilityActivationOutcomeToken.ALLOWED.value
+    )
+    assert decision.selected_match is not None
+    assert decision.selected_match.binding_id == scoped["profile"].binding_id
+    assert decision.selected_match.resolved_from_scope_token == (
+        ExtensionInstallBindingScope.PROFILE.value
+    )
+
+
+def test_combined_project_profile_context_respects_profile_over_project_account(
+    activation_store,
+):
+    store, gate, registry, bindings, resolver = activation_store
+    _proposal, _decision, registry_entry = _approved_registry_entry(
+        store,
+        gate,
+        account_id="acct-1",
+        manifest=_manifest(
+            target_surface=ExtensionTargetSurface.COMMAND_BUS.value,
+            scope=ExtensionProposalScope.PROJECT.value,
+            project_id=17,
+        ),
+    )
+    scoped = _bind_all_scopes(
+        bindings,
+        registry_entry,
+        account_id="acct-1",
+        project_id=17,
+        profile_id="profile-alpha",
+    )
+
+    decision = activate_capability_for_owner_project_profile(
+        account_id="acct-1",
+        project_id=17,
+        profile_id="profile-alpha",
+        requested_command_id=COMMAND_ID,
+        resolver=resolver,
+    )
+
+    assert (
+        decision.outcome_token == CapabilityActivationOutcomeToken.ALLOWED.value
+    )
+    assert decision.selected_match is not None
+    assert decision.selected_match.binding_id == scoped["profile"].binding_id
+    assert decision.selected_match.resolved_from_scope_token == (
+        ExtensionInstallBindingScope.PROFILE.value
+    )
+
+
+def test_missing_project_profile_context_does_not_widen_into_scoped_bindings(
+    activation_store,
+):
+    store, gate, registry, bindings, resolver = activation_store
+    project_registry = _approved_registry_entry(
+        store,
+        gate,
+        account_id="acct-1",
+        manifest=_manifest(
+            target_surface=ExtensionTargetSurface.COMMAND_BUS.value,
+            scope=ExtensionProposalScope.PROJECT.value,
+            project_id=17,
+        ),
+    )[2]
+    profile_registry = _approved_registry_entry(
+        store,
+        gate,
+        account_id="acct-1",
+        manifest=_manifest(
+            target_surface=ExtensionTargetSurface.PERSONA_STUDIO.value,
+            scope=ExtensionProposalScope.PROFILE.value,
+            profile_id="profile-alpha",
+        ),
+    )[2]
+
+    _bind_scope(
+        bindings,
+        project_registry,
+        account_id="acct-1",
+        scope_token=ExtensionInstallBindingScope.PROJECT.value,
+        project_id=17,
+        account_scope_target_id=None,
+    )
+    _bind_scope(
+        bindings,
+        profile_registry,
+        account_id="acct-1",
+        scope_token=ExtensionInstallBindingScope.PROFILE.value,
+        profile_id="profile-alpha",
+        account_scope_target_id=None,
+    )
+
+    decision = activate_capability_for_owner_only(
+        account_id="acct-1",
+        requested_command_id=COMMAND_ID,
+        resolver=resolver,
+    )
+
+    assert (
+        decision.outcome_token == CapabilityActivationOutcomeToken.DENIED.value
+    )
+    assert decision.denial_reason_token == (
+        CapabilityActivationDenyReasonToken.NO_MATCHING_EXPOSURE.value
+    )
+
+
+def test_denied_when_no_effective_capability_exposes_requested_command(
+    activation_store,
+):
+    store, gate, registry, bindings, resolver = activation_store
+    _proposal, _decision, registry_entry = _approved_registry_entry(
+        store,
+        gate,
+        account_id="acct-1",
+        manifest=_manifest(
+            target_surface=ExtensionTargetSurface.COMMAND_BUS.value,
+            scope=ExtensionProposalScope.ACCOUNT.value,
+            exposed_command_ids=(OTHER_COMMAND_ID,),
+        ),
+    )
+    _bind_scope(
+        bindings,
+        registry_entry,
+        account_id="acct-1",
+        scope_token=ExtensionInstallBindingScope.ACCOUNT.value,
+        account_scope_target_id="account-target-1",
+    )
+
+    decision = activate_capability_for_owner_only(
+        account_id="acct-1",
+        requested_command_id=COMMAND_ID,
+        resolver=resolver,
+    )
+
+    assert (
+        decision.outcome_token == CapabilityActivationOutcomeToken.DENIED.value
+    )
+    assert decision.denial_reason_token == (
+        CapabilityActivationDenyReasonToken.NO_MATCHING_EXPOSURE.value
+    )
+    assert decision.dispatch_envelope is None
+
+
+def test_denied_when_approved_permissions_are_insufficient(
+    activation_store,
+):
+    store, gate, registry, bindings, resolver = activation_store
+    _proposal, _decision, registry_entry = _approved_registry_entry(
+        store,
+        gate,
+        account_id="acct-1",
+        manifest=_manifest(
+            target_surface=ExtensionTargetSurface.COMMAND_BUS.value,
+            scope=ExtensionProposalScope.ACCOUNT.value,
+            requested_permissions=(
+                ExtensionRequestedPermission(
+                    permission="command.run",
+                    resource="command_bus",
+                    reason="bounded command execution",
+                ),
+            ),
+        ),
+    )
+    _bind_scope(
+        bindings,
+        registry_entry,
+        account_id="acct-1",
+        scope_token=ExtensionInstallBindingScope.ACCOUNT.value,
+        account_scope_target_id="account-target-1",
+    )
+
+    decision = activate_capability_for_owner_only(
+        account_id="acct-1",
+        requested_command_id=COMMAND_ID,
+        requested_permissions=(
+            ExtensionRequestedPermission(
+                permission="command.admin",
+                resource="command_bus",
+                reason="requires elevated permission",
+            ),
+        ),
+        resolver=resolver,
+    )
+
+    assert (
+        decision.outcome_token == CapabilityActivationOutcomeToken.DENIED.value
+    )
+    assert decision.denial_reason_token == (
+        CapabilityActivationDenyReasonToken.INSUFFICIENT_PERMISSIONS.value
+    )
+    assert decision.candidate_matches
+    assert decision.dispatch_envelope is None
+
+
+def test_owner_account_isolation_blocks_other_accounts(
+    activation_store,
+):
+    store, gate, registry, bindings, resolver = activation_store
+    _proposal, _decision, registry_entry = _approved_registry_entry(
+        store,
+        gate,
+        account_id="acct-1",
+        manifest=_manifest(
+            target_surface=ExtensionTargetSurface.COMMAND_BUS.value,
+            scope=ExtensionProposalScope.ACCOUNT.value,
+        ),
+    )
+    _bind_scope(
+        bindings,
+        registry_entry,
+        account_id="acct-1",
+        scope_token=ExtensionInstallBindingScope.ACCOUNT.value,
+        account_scope_target_id="account-target-1",
+    )
+
+    decision = activate_capability_for_owner_only(
+        account_id="acct-2",
+        requested_command_id=COMMAND_ID,
+        resolver=resolver,
+    )
+
+    assert (
+        decision.outcome_token == CapabilityActivationOutcomeToken.DENIED.value
+    )
+    assert decision.denial_reason_token == (
+        CapabilityActivationDenyReasonToken.NO_MATCHING_EXPOSURE.value
+    )
+
+
+def test_activation_preserves_lineage_in_decision_and_dispatch_envelope(
+    activation_store,
+):
+    store, gate, registry, bindings, resolver = activation_store
+    proposal, decision_row, registry_entry = _approved_registry_entry(
+        store,
+        gate,
+        account_id="acct-1",
+        manifest=_manifest(
+            target_surface=ExtensionTargetSurface.COMMAND_BUS.value,
+            scope=ExtensionProposalScope.ACCOUNT.value,
+        ),
+    )
+    account_binding = _bind_scope(
+        bindings,
+        registry_entry,
+        account_id="acct-1",
+        scope_token=ExtensionInstallBindingScope.ACCOUNT.value,
+        account_scope_target_id="account-target-1",
+    )
+
+    decision = activate_capability_for_owner_only(
+        account_id="acct-1",
+        requested_command_id=COMMAND_ID,
+        resolver=resolver,
+    )
+
+    assert decision.request.account_id == "acct-1"
+    assert decision.selected_match is not None
+    assert decision.selected_match.proposal_id == proposal.proposal_id
+    assert (
+        decision.selected_match.registry_entry_id == registry_entry.registry_id
+    )
+    assert decision.selected_match.binding_id == account_binding.binding_id
+    assert (
+        decision.selected_match.manifest_snapshot
+        == registry_entry.manifest_snapshot
+    )
+    assert (
+        decision.selected_match.approved_permissions
+        == registry_entry.approved_permissions
+    )
+    assert decision.dispatch_envelope is not None
+    assert decision.dispatch_envelope.proposal_id == proposal.proposal_id
+    assert (
+        decision.dispatch_envelope.registry_entry_id
+        == registry_entry.registry_id
+    )
+    assert decision.dispatch_envelope.binding_id == account_binding.binding_id
+    assert (
+        decision.dispatch_envelope.manifest_snapshot
+        == registry_entry.manifest_snapshot
+    )
+    assert (
+        decision.dispatch_envelope.approved_permissions
+        == registry_entry.approved_permissions
+    )
+
+
+def test_activation_deterministic_ordering_for_conflicts(
+    activation_store,
+):
+    store, gate, registry, bindings, resolver = activation_store
+    first_registry = _approved_registry_entry(
+        store,
+        gate,
+        account_id="acct-1",
+        manifest=_manifest(
+            target_surface=ExtensionTargetSurface.COMMAND_BUS.value,
+            scope=ExtensionProposalScope.ACCOUNT.value,
+            exposed_command_ids=(COMMAND_ID,),
+        ),
+    )[2]
+    second_registry = _approved_registry_entry(
+        store,
+        gate,
+        account_id="acct-1",
+        manifest=_manifest(
+            target_surface=ExtensionTargetSurface.PERSONA_STUDIO.value,
+            scope=ExtensionProposalScope.ACCOUNT.value,
+            exposed_command_ids=(COMMAND_ID,),
+        ),
+    )[2]
+
+    first_binding = _bind_scope(
+        bindings,
+        first_registry,
+        account_id="acct-1",
+        scope_token=ExtensionInstallBindingScope.ACCOUNT.value,
+        account_scope_target_id="account-target-1",
+    )
+    second_binding = _bind_scope(
+        bindings,
+        second_registry,
+        account_id="acct-1",
+        scope_token=ExtensionInstallBindingScope.ACCOUNT.value,
+        account_scope_target_id="account-target-2",
+    )
+
+    decision = activate_capability_for_owner_only(
+        account_id="acct-1",
+        requested_command_id=COMMAND_ID,
+        resolver=resolver,
+    )
+
+    assert (
+        decision.outcome_token
+        == CapabilityActivationOutcomeToken.CONFLICT.value
+    )
+    assert decision.conflict_details
+    assert [
+        match.binding_id
+        for match in decision.conflict_details[0].candidate_matches
+    ] == [
+        first_binding.binding_id,
+        second_binding.binding_id,
+    ]
+    assert [
+        match.target_surface_token
+        for match in decision.conflict_details[0].candidate_matches
+    ] == [
+        ExtensionTargetSurface.COMMAND_BUS.value,
+        ExtensionTargetSurface.PERSONA_STUDIO.value,
+    ]
+
+
+def test_ambiguous_same_command_exposure_fails_closed_with_conflict(
+    activation_store,
+):
+    store, gate, registry, bindings, resolver = activation_store
+    first_registry = _approved_registry_entry(
+        store,
+        gate,
+        account_id="acct-1",
+        manifest=_manifest(
+            target_surface=ExtensionTargetSurface.COMMAND_BUS.value,
+            scope=ExtensionProposalScope.ACCOUNT.value,
+        ),
+    )[2]
+    second_registry = _approved_registry_entry(
+        store,
+        gate,
+        account_id="acct-1",
+        manifest=_manifest(
+            target_surface=ExtensionTargetSurface.PERSONA_STUDIO.value,
+            scope=ExtensionProposalScope.ACCOUNT.value,
+        ),
+    )[2]
+
+    _bind_scope(
+        bindings,
+        first_registry,
+        account_id="acct-1",
+        scope_token=ExtensionInstallBindingScope.ACCOUNT.value,
+        account_scope_target_id="account-target-1",
+    )
+    _bind_scope(
+        bindings,
+        second_registry,
+        account_id="acct-1",
+        scope_token=ExtensionInstallBindingScope.ACCOUNT.value,
+        account_scope_target_id="account-target-2",
+    )
+
+    decision = activate_capability_for_owner_only(
+        account_id="acct-1",
+        requested_command_id=COMMAND_ID,
+        resolver=resolver,
+    )
+
+    assert (
+        decision.outcome_token
+        == CapabilityActivationOutcomeToken.CONFLICT.value
+    )
+    assert decision.conflict_class_token == (
+        CapabilityActivationConflictClassToken.SAME_COMMAND_EXPOSURE.value
+    )
+    assert decision.dispatch_envelope is None
+    assert decision.conflict_details[0].candidate_matches
+
+
+def test_activation_is_side_effect_free(
+    activation_store,
+):
+    store, gate, registry, bindings, resolver = activation_store
+    _proposal, _decision, registry_entry = _approved_registry_entry(
+        store,
+        gate,
+        account_id="acct-1",
+        manifest=_manifest(
+            target_surface=ExtensionTargetSurface.COMMAND_BUS.value,
+            scope=ExtensionProposalScope.ACCOUNT.value,
+        ),
+    )
+    _bind_scope(
+        bindings,
+        registry_entry,
+        account_id="acct-1",
+        scope_token=ExtensionInstallBindingScope.ACCOUNT.value,
+        account_scope_target_id="account-target-1",
+    )
+
+    registry_before = store.list_registry_entries(account_id="acct-1")
+    bindings_before = store.list_bindings(account_id="acct-1")
+
+    decision = activate_capability_for_owner_only(
+        account_id="acct-1",
+        requested_command_id=COMMAND_ID,
+        resolver=resolver,
+    )
+
+    registry_after = store.list_registry_entries(account_id="acct-1")
+    bindings_after = store.list_bindings(account_id="acct-1")
+
+    assert (
+        decision.outcome_token == CapabilityActivationOutcomeToken.ALLOWED.value
+    )
+    assert registry_after == registry_before
+    assert bindings_after == bindings_before
+    assert (
+        store.get_registry_entry_by_id(
+            account_id="acct-1", registry_id=registry_entry.registry_id
+        )
+        == registry_entry
+    )


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
