### PR TITLE
fix(auth): remove predictable local bootstrap credential

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ PORT=8888
 GUARDIAN_AUTH_MODE=local
 # Backend auth secret. Use a long random value and rotate frequently.
 GUARDIAN_API_KEY=58e96127c5131719d9a040eda0681be0c9891be30dd27305cce2fd1bea4d46b1
+# Optional bootstrap secret for the canonical local owner account.
+# When unset, startup still creates the local owner row but no guessable login
+# credential is seeded.
+GUARDIAN_BOOTSTRAP_PASSWORD=
 # Local-only browser key injection. Mirror the backend key ONLY when running
 # on localhost/trusted dev builds; leave empty for anything public or hosted.
 # Example: VITE_GUARDIAN_API_KEY=${GUARDIAN_API_KEY}

--- a/guardian/core/user_manager.py
+++ b/guardian/core/user_manager.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import os
+import secrets
 from datetime import datetime, timezone
 from typing import Any
 
@@ -13,11 +15,20 @@ from guardian.db.models import User
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_BOOTSTRAP_PASSWORD = "local"
+BOOTSTRAP_PASSWORD_ENV = "GUARDIAN_BOOTSTRAP_PASSWORD"
 
 
 def _resolve_default_user_id() -> str:
     return "local"
+
+
+def _bootstrap_password_hash() -> str:
+    bootstrap_password = (os.getenv(BOOTSTRAP_PASSWORD_ENV) or "").strip()
+    if not bootstrap_password:
+        # Fail closed: the canonical local owner still exists, but it is not
+        # issued a guessable password on fresh instances.
+        bootstrap_password = secrets.token_urlsafe(32)
+    return hash_password(bootstrap_password)
 
 
 def get_or_create_default_user(
@@ -35,7 +46,7 @@ def get_or_create_default_user(
         return {
             "id": user_id,
             "username": user_id,
-            "password_hash": hash_password(DEFAULT_BOOTSTRAP_PASSWORD),
+            "password_hash": _bootstrap_password_hash(),
             "created_at": None,
         }
 
@@ -45,7 +56,7 @@ def get_or_create_default_user(
             user = User(
                 id=user_id,
                 username=user_id,
-                password_hash=hash_password(DEFAULT_BOOTSTRAP_PASSWORD),
+                password_hash=_bootstrap_password_hash(),
                 created_at=datetime.now(timezone.utc),
             )
             session.add(user)

--- a/guardian/db/migrations/versions/f2b3c4d5e6f9_add_user_password_hash.py
+++ b/guardian/db/migrations/versions/f2b3c4d5e6f9_add_user_password_hash.py
@@ -7,24 +7,16 @@ Create Date: 2026-04-20 00:00:00.000000
 
 from typing import Sequence, Union
 
-import bcrypt
 import sqlalchemy as sa
 from alembic import op
+
+from guardian.core.user_manager import _bootstrap_password_hash
 
 # revision identifiers, used by Alembic.
 revision: str = "f2b3c4d5e6f9"
 down_revision: Union[str, Sequence[str], None] = "f2b3c4d5e6f8"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
-
-DEFAULT_BOOTSTRAP_PASSWORD = "local"
-
-
-def _bootstrap_password_hash() -> str:
-    return bcrypt.hashpw(
-        DEFAULT_BOOTSTRAP_PASSWORD.encode("utf-8"),
-        bcrypt.gensalt(),
-    ).decode("utf-8")
 
 
 def upgrade() -> None:

--- a/tests/auth/test_auth_flow.py
+++ b/tests/auth/test_auth_flow.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
+from guardian.core.passwords import verify_password
+from guardian.core.user_manager import get_or_create_default_user
 from guardian.db.models import User
 
 
@@ -114,3 +117,61 @@ def test_login_and_authenticated_request(monkeypatch):
             mock_chatlog_db.create_project.call_args.kwargs["user_id"]
             == expected_user_id
         )
+
+
+def test_default_local_bootstrap_is_canonical_but_not_guessable(monkeypatch):
+    monkeypatch.delenv("GUARDIAN_BOOTSTRAP_PASSWORD", raising=False)
+    monkeypatch.setenv("GUARDIAN_API_KEY", "test-api-key")
+    monkeypatch.setenv("GUARDIAN_SESSION_SECRET", "auth-flow-session-secret")
+    monkeypatch.setenv("CODEXIFY_DISABLE_DOTENV", "1")
+
+    auth_db = _AuthDb()
+
+    from guardian.routes import auth as auth_routes
+
+    with patch.object(auth_routes, "load_guardian_db_from_env", return_value=auth_db):
+        seeded_user = get_or_create_default_user(auth_db)
+
+        assert seeded_user["id"] == "local"
+        assert seeded_user["username"] == "local"
+        assert verify_password("local", seeded_user["password_hash"]) is False
+
+        app = FastAPI()
+        app.include_router(auth_routes.router)
+        client = TestClient(app)
+        login_response = client.post(
+            "/auth/login",
+            json={"username": "local", "password": "local"},
+        )
+
+    assert login_response.status_code == 401
+
+
+def test_local_bootstrap_uses_operator_secret_when_provided(monkeypatch):
+    monkeypatch.setenv("GUARDIAN_BOOTSTRAP_PASSWORD", "operator-secret")
+    monkeypatch.setenv("GUARDIAN_API_KEY", "test-api-key")
+    monkeypatch.setenv("GUARDIAN_SESSION_SECRET", "auth-flow-session-secret")
+    monkeypatch.setenv("CODEXIFY_DISABLE_DOTENV", "1")
+
+    auth_db = _AuthDb()
+
+    from guardian import guardian_api
+    from guardian.routes import auth as auth_routes
+
+    with patch.object(auth_routes, "load_guardian_db_from_env", return_value=auth_db):
+        seeded_user = get_or_create_default_user(auth_db)
+
+        assert seeded_user["id"] == "local"
+        assert seeded_user["username"] == "local"
+        assert verify_password(
+            "operator-secret", seeded_user["password_hash"]
+        )
+
+        client = TestClient(guardian_api.app)
+        login_response = client.post(
+            "/auth/login",
+            json={"username": "local", "password": "operator-secret"},
+        )
+
+    assert login_response.status_code == 200
+    assert login_response.json()["user_id"] == "local"


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
