### PR TITLE
Fix packaged desktop auth gate

### DIFF
--- a/docs/architecture/config-and-ops.md
+++ b/docs/architecture/config-and-ops.md
@@ -173,6 +173,7 @@ Source anchors:
 - The proof image is intentionally backend-only for now; workers and migrator still remain source-backed in the existing Docker path until they are proven separately.
 - The proof image still ships a small set of non-source runtime files needed by startup, including supported-profile YAML and bundled help content.
 - Packaged desktop auth handoff now flows through a Tauri command that returns a sanitized runtime auth/config payload for the local packaged runtime. The frontend consumes the handed-off `GUARDIAN_API_KEY` only in packaged mode, while diagnostics expose only presence and source metadata such as `envPath`, `runtimeRoot`, and `failureKind`.
+- The Guardian auth gate now derives from the same in-memory runtime API key that the desktop API client uses, so packaged desktop mode can satisfy local auth without `VITE_GUARDIAN_API_KEY`; the legacy Vite env key remains a dev-only fallback.
 
 ## Config Resolution Order and Defaults
 

--- a/frontend/src/components/persona/layout/__tests__/GuardianChatWithSidebar.stability.test.tsx
+++ b/frontend/src/components/persona/layout/__tests__/GuardianChatWithSidebar.stability.test.tsx
@@ -34,6 +34,18 @@ const authState = vi.hoisted(() => ({
   status: "authenticated" as const,
   token: "test-token",
 }));
+const runtimeAuthState = vi.hoisted(() => ({
+  isTauri: false,
+  desktopAuthConfig: null as
+    | null
+    | {
+        apiKeyPresent: boolean;
+        apiKey: string | null;
+        envPath: string | null;
+        runtimeRoot: string | null;
+        failureKind: string | null;
+      },
+}));
 const routeCapabilityStates = vi.hoisted(
   () =>
     ({
@@ -127,6 +139,11 @@ vi.mock("@/lib/authState", () => ({
   useAuthState: () => authState,
   checkAuthGate: () => true,
   requireAuthReady: () => true,
+}));
+
+vi.mock("@/lib/runtimeConfig", () => ({
+  isTauriRuntime: () => runtimeAuthState.isTauri,
+  getDesktopRuntimeAuthConfig: () => runtimeAuthState.desktopAuthConfig,
 }));
 
 vi.mock("@/lib/runtimeRouteCapabilities", () => ({
@@ -313,7 +330,31 @@ describe("GuardianChatWithSidebar stability contract", () => {
     routeCapabilityStates[SUPPORTED_PROFILE_ROUTE_LABELS.IMPRINT] = "available";
     routeCapabilityStates[SUPPORTED_PROFILE_ROUTE_LABELS.UI_SESSION] =
       "available";
-    localStorage.clear();
+    const storage = new Map<string, string>();
+    Object.defineProperty(window, "localStorage", {
+      value: {
+        getItem: vi.fn((key: string) => storage.get(key) ?? null),
+        setItem: vi.fn((key: string, value: string) => {
+          storage.set(key, value);
+        }),
+        removeItem: vi.fn((key: string) => {
+          storage.delete(key);
+        }),
+        clear: vi.fn(() => {
+          storage.clear();
+        }),
+      },
+      configurable: true,
+    });
+    Object.defineProperty(window, "sessionStorage", {
+      value: {
+        getItem: vi.fn(() => null),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+      },
+      configurable: true,
+    });
     window.history.pushState({}, "", "/chat");
     Object.defineProperty(window, "matchMedia", {
       writable: true,
@@ -876,3 +917,80 @@ describe("GuardianChatWithSidebar stability contract", () => {
 
     global.fetch = originalFetch;
   });
+
+describe("GuardianChatWithSidebar auth banner", () => {
+  beforeEach(() => {
+    authState.ready = true;
+    authState.status = "authenticated";
+    authState.token = "test-token";
+    runtimeAuthState.isTauri = false;
+    runtimeAuthState.desktopAuthConfig = null;
+    const storage = new Map<string, string>();
+    Object.defineProperty(window, "localStorage", {
+      value: {
+        getItem: vi.fn((key: string) => storage.get(key) ?? null),
+        setItem: vi.fn((key: string, value: string) => {
+          storage.set(key, value);
+        }),
+        removeItem: vi.fn((key: string) => {
+          storage.delete(key);
+        }),
+        clear: vi.fn(() => {
+          storage.clear();
+        }),
+      },
+      configurable: true,
+    });
+    Object.defineProperty(window, "sessionStorage", {
+      value: {
+        getItem: vi.fn(() => null),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+      },
+      configurable: true,
+    });
+  });
+
+  it("does not render the auth banner when the runtime auth key is already unified into auth state", () => {
+    authState.ready = true;
+    authState.status = "authenticated";
+    authState.token = undefined;
+    runtimeAuthState.isTauri = true;
+    runtimeAuthState.desktopAuthConfig = {
+      apiKeyPresent: true,
+      apiKey: "desktop-secret-key",
+      envPath: "/Users/chriscastillo/Codexify/.env",
+      runtimeRoot: "/Users/chriscastillo/Codexify",
+      failureKind: null,
+    };
+
+    render(<GuardianChatWithSidebar guardianName="Guardian" userName="User" />);
+
+    expect(screen.queryByText("Authentication required.")).toBeNull();
+  });
+
+  it("renders sanitized desktop diagnostics without exposing the raw key", () => {
+    authState.ready = true;
+    authState.status = "unauthenticated";
+    authState.token = undefined;
+    runtimeAuthState.isTauri = true;
+    runtimeAuthState.desktopAuthConfig = {
+      apiKeyPresent: true,
+      apiKey: "desktop-secret-key",
+      envPath: "/Users/chriscastillo/Codexify/.env",
+      runtimeRoot: "/Users/chriscastillo/Codexify",
+      failureKind: "config_incomplete",
+    };
+
+    render(<GuardianChatWithSidebar guardianName="Guardian" userName="User" />);
+
+    expect(screen.getByText("Authentication required.")).toBeInTheDocument();
+    expect(screen.getByText("apiKeyPresent=true")).toBeInTheDocument();
+    expect(screen.getByText("envPath=/Users/chriscastillo/Codexify/.env")).toBeInTheDocument();
+    expect(screen.getByText("runtimeRoot=/Users/chriscastillo/Codexify")).toBeInTheDocument();
+    expect(screen.getByText("failureKind=config_incomplete")).toBeInTheDocument();
+    expect(screen.queryByText("desktop-secret-key")).toBeNull();
+    expect(screen.queryByText("Sign in or provide a dev key in local development.")).toBeNull();
+  });
+});

--- a/frontend/src/lib/authState.ts
+++ b/frontend/src/lib/authState.ts
@@ -1,5 +1,8 @@
 import { useSyncExternalStore } from "react";
-import { hasRuntimeApiKey } from "@/lib/runtimeAuth";
+import {
+  hasResolvedRuntimeApiKey,
+  hasRuntimeApiKey,
+} from "@/lib/runtimeAuth";
 
 export type AuthStatus = "unknown" | "authenticated" | "unauthenticated";
 
@@ -35,6 +38,14 @@ function readRuntimeEnv(name: string, fallback = ""): string {
     typeof process !== "undefined" ? ((process as any).env ?? {}) : {};
   const raw = viteEnv[name] ?? nodeEnv[name] ?? fallback;
   return String(raw ?? "");
+}
+
+function isDesktopRuntime(): boolean {
+  if (typeof window === "undefined") return false;
+  return (
+    typeof (window as any).__TAURI_IPC__ !== "undefined" ||
+    typeof (window as any).__TAURI_INTERNALS__ !== "undefined"
+  );
 }
 
 function isDevRuntime(): boolean {
@@ -73,6 +84,9 @@ function deriveAuthState(): AuthState {
       ready: true,
       token: token ?? undefined,
     };
+  }
+  if (isDesktopRuntime() && !hasResolvedRuntimeApiKey()) {
+    return { status: "unknown", ready: false };
   }
   return { status: "unauthenticated", ready: true };
 }

--- a/frontend/src/lib/runtimeAuth.ts
+++ b/frontend/src/lib/runtimeAuth.ts
@@ -5,9 +5,11 @@ function normalizeApiKey(value: string | null | undefined): string | null {
 }
 
 let runtimeApiKey: string | null = null;
+let runtimeApiKeyResolved = false;
 
 export function setRuntimeApiKey(value: string | null | undefined): void {
   runtimeApiKey = normalizeApiKey(value);
+  runtimeApiKeyResolved = true;
 }
 
 export function getRuntimeApiKey(): string | null {
@@ -18,10 +20,21 @@ export function hasRuntimeApiKey(): boolean {
   return !!runtimeApiKey;
 }
 
+export function hasResolvedRuntimeApiKey(): boolean {
+  return runtimeApiKeyResolved;
+}
+
 export function clearRuntimeApiKey(): void {
   runtimeApiKey = null;
+  runtimeApiKeyResolved = true;
 }
 
 export function __setRuntimeApiKeyForTests(value: string | null): void {
   runtimeApiKey = normalizeApiKey(value);
+  runtimeApiKeyResolved = true;
+}
+
+export function __resetRuntimeApiKeyForTests(): void {
+  runtimeApiKey = null;
+  runtimeApiKeyResolved = false;
 }

--- a/frontend/src/test/authState.test.ts
+++ b/frontend/src/test/authState.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  __resetAuthStateForTests,
+  resolveAuthStateOnBoot,
+  syncAuthStateFromCredentials,
+  getAuthState,
+} from "@/lib/authState";
+import {
+  clearRuntimeApiKey,
+  __resetRuntimeApiKeyForTests,
+  __setRuntimeApiKeyForTests,
+} from "@/lib/runtimeAuth";
+
+describe("auth state", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    __resetAuthStateForTests();
+    __resetRuntimeApiKeyForTests();
+    delete (window as any).__TAURI_IPC__;
+    delete (window as any).__TAURI_INTERNALS__;
+    window.sessionStorage.clear();
+  });
+
+  it("treats the packaged desktop runtime key as authenticated", () => {
+    (window as any).__TAURI_IPC__ = {};
+    __setRuntimeApiKeyForTests("desktop-runtime-key");
+
+    const state = resolveAuthStateOnBoot();
+
+    expect(state.status).toBe("authenticated");
+    expect(state.ready).toBe(true);
+    expect(getAuthState().status).toBe("authenticated");
+  });
+
+  it("falls back to the legacy VITE_GUARDIAN_API_KEY in local development", () => {
+    vi.stubEnv("VITE_GUARDIAN_API_KEY", "legacy-dev-key");
+
+    const state = resolveAuthStateOnBoot();
+
+    expect(state.status).toBe("authenticated");
+    expect(state.ready).toBe(true);
+  });
+
+  it("stays pending while desktop runtime auth is still hydrating", () => {
+    (window as any).__TAURI_IPC__ = {};
+
+    const state = resolveAuthStateOnBoot();
+
+    expect(state.status).toBe("unknown");
+    expect(state.ready).toBe(false);
+  });
+
+  it("becomes unauthenticated once hydration resolves and no key is present", () => {
+    clearRuntimeApiKey();
+
+    const state = syncAuthStateFromCredentials();
+
+    expect(state.status).toBe("unauthenticated");
+    expect(state.ready).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
