### PR TITLE
feat: add graph write idempotency and receipt semantics for inspectio…

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -40,6 +40,8 @@ If you are working on continuity governance, working-set decay, or import-aware 
 
 If you are working on the continuity control plane itself, including scope, intensity, decay, import treatment, exclusions, inspection, and reset semantics, continue with [`ADR-016: Continuity Governance Surface Contract`](./adr/016-continuity-governance-surface-contract.md) after ADR-015. That ADR defines the user-governed surface that configures continuity behavior without collapsing it into persona ownership or deep identity consent.
 
+If you are working on graph-write replay safety or receipt semantics for the inspection-only graph lane, continue with [`ADR-017: Graph Write Idempotency and Receipt Semantics`](./adr/017-graph-write-idempotency-and-receipt-semantics.md) after ADR-011. That ADR defines deterministic graph-write identity and ephemeral receipt claims without introducing graph truth.
+
 ## KB Validity and Diagram Source Sets
 
 Before generating architecture diagrams, read the [`KB Validity Matrix`](./kb-validity-matrix.md).
@@ -82,6 +84,7 @@ Before generating architecture diagrams, read the [`KB Validity Matrix`](./kb-va
 - [Account Export + Restore Contract](./account-export-restore-contract.md): provenance, lineage, and restore semantics for durable artifacts and imported state.
 - [Continuity Engine Working Set and Decay Contract](./adr/015-continuity-engine-working-set-and-decay-contract.md): user-governed continuity layer above thread-first chat, with working-set decay, provenance, and imported-history scaffolding.
 - [Continuity Governance Surface Contract](./adr/016-continuity-governance-surface-contract.md): user-governed continuity control plane for scope, intensity, decay, import treatment, exclusions, inspectability, and reset semantics.
+- [Graph Write Idempotency and Receipt Semantics](./adr/017-graph-write-idempotency-and-receipt-semantics.md): deterministic graph-write identity and ephemeral receipt claims for the inspection-only graph lane.
 - [Delegation Runtime Contract](./delegation-runtime.md): current delegation seam, runtime contract, and source-thread provenance rules.
 - [Delegation Operator Manual](./delegation-operator-manual.md): operator procedure for supervised delegation, recovery, and summary persistence.
 - [Chat Runtime Gap Analysis](./chat-runtime-gap-analysis.md): companion note explaining why the runtime contract exists and which ambiguity classes it is intended to shrink.

--- a/docs/architecture/adr/017-graph-write-idempotency-and-receipt-semantics.md
+++ b/docs/architecture/adr/017-graph-write-idempotency-and-receipt-semantics.md
@@ -1,0 +1,184 @@
+---
+tags:
+* architecture
+* adr
+* memory-graph
+* graph-write
+* idempotency
+* receipts
+  aliases:
+* ADR-017
+* Graph Write Idempotency and Receipt Semantics
+---
+
+# ADR-017: Graph Write Idempotency and Receipt Semantics
+
+## Status
+
+Accepted
+
+## Date
+
+2026-04-28
+
+## Context
+
+ADR-007 established the derived graph write hook.
+ADR-008 established the candidate_trace diagnostic surface.
+ADR-009 established the candidate_trace ingest worker scaffold.
+ADR-011 established the dedicated graph-write task seam and inspection-only
+worker scaffold.
+
+That topology is useful, but it still leaves one replay-safety gap: the graph
+lane had no explicit operational identity or receipt claim semantics. Without
+that seam, repeated graph-write tasks can only be treated as ad hoc duplicates,
+which is brittle even when no graph persistence exists yet.
+
+The purpose of this ADR is to close that gap before any Neo4j persistence is
+added.
+
+## Problem Statement
+
+The graph lane is derived, transient, and inspection-only in the current phase.
+Even so, it still needs a bounded replay contract so worker runs are stable
+when the same derived payload is replayed more than once.
+
+Without explicit identity and receipt semantics, the lane risks:
+
+- replaying the same derived task with no clear first-seen boundary
+- treating duplicate payloads as novel inspection work
+- leaking the illusion of canonical graph truth into an inspection-only path
+- making future persistence assumptions harder to reason about
+
+This matters even before graph writes exist because the identity seam will
+shape later persistence behavior.
+
+## Decision
+
+Codexify defines deterministic graph-write identity plus ephemeral receipt
+claims as the replay-safety contract for the inspection-only graph lane.
+
+The lane now behaves as follows:
+
+- candidate traces are normalized and mapped to graph candidates
+- graph-write identity is built from the candidate-trace boundary plus the
+  canonicalized graph payload
+- a `GraphWriteTask` carries that identity when it is enqueued
+- the graph-write worker claims an ephemeral receipt before inspection
+- first-seen tasks produce inspection summaries
+- repeated tasks within the receipt window degrade to duplicate/replay
+  handling and skip further graph-lane work
+
+This is an operational control-plane seam only. It does not create graph truth.
+
+## Canonical Terms
+
+| Term | Canonical meaning |
+|---|---|
+| Graph-write identity | The deterministic operational identity for a derived graph task. It is derived from the candidate-trace boundary and the canonicalized node/edge/warning payload. |
+| Graph-write fingerprint | The stable digest of a canonicalized graph payload. It is insensitive to payload ordering when the graph meaning is unchanged. |
+| Graph-write task identity | The combined identity fields carried on `GraphWriteTask`, including `graph_write_id` and `idempotency_key`. |
+| Receipt claim | An ephemeral Redis-backed claim that marks the first inspection of a graph-write idempotency key for the duration of the TTL. |
+| Duplicate/replay handling | The bounded worker path taken when a receipt already exists. Duplicate/replayed tasks are logged and skipped, not promoted to truth. |
+| Operational receipt state | Non-canonical state used only to make the inspection-only lane replay-safe. It is not exportable, restorable, or authoritative. |
+
+## Decision Details
+
+The graph lane must remain replay-safe without becoming a persistence layer.
+
+Required behavior:
+
+- identical graph payloads on the same candidate trace should produce the same
+  graph-write identity
+- different graph shapes should change the fingerprint and therefore the
+  idempotency key
+- distinct candidate traces must remain distinct even when payload shape is
+  similar
+- the worker must claim an ephemeral receipt before inspecting the task
+- duplicate claims must skip further graph-lane work
+- malformed tasks and receipt-claim failures must remain isolated from the
+  worker loop
+
+## Non-Negotiable Invariants
+
+- receipts are operational and ephemeral, not canonical truth
+- graph-write tasks remain derived artifacts
+- no Neo4j writes occur in this phase
+- no Postgres writes occur in this phase
+- no vector writes occur in this phase
+- no retrieval path may consume graph-write tasks or receipts in this phase
+- no export or restore payload may participate in graph-write receipt state
+- no chat completion behavior may depend on graph-write enqueue or receipt
+  success
+
+## Relationship to Existing Architecture
+
+This ADR is constrained by:
+
+- ADR-007 for derived graph write hook provenance
+- ADR-008 for candidate_trace diagnostic lineage
+- ADR-009 for candidate_trace ingest worker behavior
+- ADR-011 for the dedicated graph-write task seam and inspection-only worker
+- the account export/restore contract for provenance boundaries
+- the data and storage contract for canonical truth boundaries
+
+Current runtime truth remains unchanged: graph persistence is still deferred.
+
+## Implementation Boundaries
+
+This ADR does not implement:
+
+- real Neo4j writes
+- durable idempotent persistence semantics
+- graph retrieval consumption
+- Postgres receipts
+- vector receipts
+- export/restore participation
+- UI coupling
+- canonical graph truth claims
+
+The receipt seam exists only to make the inspection-only lane replay-safe.
+
+## Deferred Work
+
+The following are explicitly left for later tasks:
+
+- real graph persistence in Neo4j or a compatible projection
+- durable write idempotency for graph materialization
+- graph retrieval consumption
+- any export/restore support for graph-derived structures
+
+## Consequences
+
+### Positive
+
+- replay behavior is bounded before persistence exists
+- the worker can distinguish first-seen from duplicate inspection work
+- later persistence work has a stable identity seam to build on
+- graph tasks stay clearly derived and non-canonical
+
+### Negative
+
+- the graph lane now carries another explicit control-plane concept
+- later persistence work must honor the receipt and identity semantics instead
+  of inventing a new uniqueness story
+- the inspection-only path still needs careful docs so no one reads it as graph
+  truth
+
+## Links
+
+- [[ADR Index]]
+- [[007-Memory-Graph-Derived-Write-Hook|ADR-007 Memory Graph Derived Write Hook]]
+- [[008-Candidate-Trace-Surface|ADR-008 Candidate Trace Surface]]
+- [[009-Candidate-Trace-Ingest-Worker|ADR-009 Candidate Trace Ingest Worker Scaffold]]
+- [[011-Graph-Write-Task-Seam-and-Worker-Scaffold|ADR-011 Graph Write Task Seam and Worker Scaffold]]
+- [[candidate-ingest-pipeline|Candidate Trace Ingestion Pipeline]]
+- [[memory-graph-indexing-plan|Memory Graph Indexing Plan]]
+- [[account-export-restore-contract|Account Export + Restore Contract]]
+- [[data-and-storage|Data and Storage]]
+- [[00-current-state]]
+
+## Notes
+
+This ADR intentionally stops at replay safety. It does not introduce graph
+truth, graph retrieval, or durable persistence.

--- a/docs/architecture/adr/adr-index.md
+++ b/docs/architecture/adr/adr-index.md
@@ -50,6 +50,7 @@ Use this note as the local map for all ADRs.
 14. [[014-Flow-Builder-Thread-Draft-and-Receipts-Contract|ADR-014 Flow Builder Thread, Draft, and Receipts Contract]] — canonical contract for Guardian threads, flow drafts, Builder support lanes, and run receipts.
 15. [[015-Continuity-Engine-Working-Set-and-Decay-Contract|ADR-015 Continuity Engine Working Set and Decay Contract]] — user-governed continuity layer above thread-first chat, with working-set decay and provenance.
 16. [[016-Continuity-Governance-Surface-Contract|ADR-016 Continuity Governance Surface Contract]] — user-governed continuity control plane for scope, decay, import treatment, exclusions, inspection, and reset semantics.
+17. [[017-Graph-Write-Idempotency-and-Receipt-Semantics|ADR-017 Graph Write Idempotency and Receipt Semantics]] — deterministic graph-write identity and ephemeral receipt claims for the inspection-only graph lane.
 
 ---
 
@@ -205,6 +206,18 @@ Primary companion notes:
   * [[system-overview|System Overview]]
   * [[data-and-storage|Data and Storage]]
   * [[tech-debt-and-risks|Tech Debt and Risks]]
+  * [[00-current-state]]
+
+* [[017-Graph-Write-Idempotency-and-Receipt-Semantics|ADR-017 Graph Write Idempotency and Receipt Semantics]] links to:
+
+  * [[007-Memory-Graph-Derived-Write-Hook|Memory Graph Derived Write Hook]]
+  * [[008-Candidate-Trace-Surface|Candidate Trace Surface]]
+  * [[009-Candidate-Trace-Ingest-Worker|Candidate Trace Ingest Worker Scaffold]]
+  * [[011-Graph-Write-Task-Seam-and-Worker-Scaffold|Graph Write Task Seam and Worker Scaffold]]
+  * [[candidate-ingest-pipeline|Candidate Trace Ingestion Pipeline]]
+  * [[memory-graph-indexing-plan|Memory Graph Indexing Plan]]
+  * [[account-export-restore-contract|Account Export + Restore Contract]]
+  * [[data-and-storage|Data and Storage]]
   * [[00-current-state]]
 ---
 

--- a/docs/architecture/candidate-ingest-pipeline.md
+++ b/docs/architecture/candidate-ingest-pipeline.md
@@ -8,6 +8,8 @@ Source anchors:
 - guardian/workers/graph_write_worker.py
 - guardian/tasks/types.py
 - guardian/queue/redis_queue.py
+- guardian/queue/graph_write_receipts.py
+- guardian/memory_graph/graph_write_identity.py
 - docs/architecture/candidate-trace-surface.md
 - docs/architecture/chat-runtime-contract.md
 - docs/architecture/adr/009-candidate-trace-ingest-worker.md
@@ -100,6 +102,24 @@ Graph-write tasks remain deterministic derived artifacts and are not:
 - written to Neo4j in this phase
 
 Future graph persistence remains explicitly deferred.
+
+## Graph Identity and Receipt Semantics
+
+Graph-write tasks now carry deterministic graph-lane identity derived from the
+candidate trace boundary plus the canonicalized graph payload.
+
+Before the graph-write worker inspects a task, it claims an ephemeral receipt
+for the task's idempotency key. That receipt is Redis-backed operational dedupe
+only:
+
+- it is not exported
+- it is not restored
+- it is not persisted as canonical state
+- it is not used by retrieval
+- it is not written to Neo4j in this phase
+
+The receipt claim only makes the inspection-only lane replay-safe. It does not
+turn graph tasks into graph truth.
 
 ## Non-Canonical Constraint
 

--- a/docs/architecture/memory-graph-indexing-plan.md
+++ b/docs/architecture/memory-graph-indexing-plan.md
@@ -13,6 +13,8 @@ Source anchors:
 - docs/architecture/account-export-restore-contract.md
 - guardian/workers/graph_write_worker.py
 - guardian/tasks/types.py
+- guardian/memory_graph/graph_write_identity.py
+- guardian/queue/graph_write_receipts.py
 - docs/architecture/adr/011-graph-write-task-seam-and-worker-scaffold.md
 
 ## 1. Purpose and Scope
@@ -234,6 +236,20 @@ This worker is log-only and exists to stabilize topology before persistence:
 
 Actual graph persistence and idempotent write semantics remain deferred to a
 later task.
+
+### 5.6 Graph Replay Safety
+
+The current graph-lane implementation path now includes deterministic
+graph-write identity and ephemeral receipt claims before inspection.
+
+This is a provenance-preserving, replay-safe control-plane seam:
+
+- graph-write tasks remain derived artifacts
+- receipt state remains operational and ephemeral
+- no canonical graph truth is claimed here
+
+Real Neo4j writes, durable idempotent persistence, and graph retrieval
+consumption remain deferred to a later task.
 
 ## 6. Invariants
 

--- a/guardian/memory_graph/graph_write_identity.py
+++ b/guardian/memory_graph/graph_write_identity.py
@@ -1,0 +1,89 @@
+"""Deterministic identity helpers for derived graph-write tasks."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+def _canonicalize_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            str(key): _canonicalize_value(value[key])
+            for key in sorted(value, key=lambda item: str(item))
+        }
+    if isinstance(value, (list, tuple, set)):
+        canonical_items = [_canonicalize_value(item) for item in value]
+        return sorted(
+            canonical_items,
+            key=lambda item: json.dumps(
+                item,
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+                ensure_ascii=False,
+            ),
+        )
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(
+        _canonicalize_value(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+        ensure_ascii=False,
+    )
+
+
+def _stable_digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def compute_graph_write_fingerprint(
+    nodes: list[dict], edges: list[dict], warnings: list[str]
+) -> str:
+    canonical_payload = {
+        "nodes": sorted(
+            (_canonicalize_value(node) for node in nodes),
+            key=lambda item: _stable_json(item),
+        ),
+        "edges": sorted(
+            (_canonicalize_value(edge) for edge in edges),
+            key=lambda item: _stable_json(item),
+        ),
+        "warnings": sorted(
+            _canonicalize_value(warning) for warning in warnings
+        ),
+    }
+    return _stable_digest(_stable_json(canonical_payload))
+
+
+def build_graph_write_identity(
+    *,
+    request_id: str,
+    thread_id: str | int,
+    candidate_trace_id: str,
+    nodes: list[dict],
+    edges: list[dict],
+    warnings: list[str],
+) -> dict:
+    fingerprint = compute_graph_write_fingerprint(nodes, edges, warnings)
+    identity_seed = {
+        "candidate_trace_id": str(candidate_trace_id),
+        "graph_fingerprint": fingerprint,
+    }
+    graph_write_id = f"gwr_{_stable_digest(_stable_json(identity_seed))[:24]}"
+    idempotency_key = f"graph-write:{candidate_trace_id}:{fingerprint}"
+    return {
+        "request_id": str(request_id),
+        "thread_id": thread_id,
+        "candidate_trace_id": str(candidate_trace_id),
+        "graph_write_id": graph_write_id,
+        "idempotency_key": idempotency_key,
+        "graph_fingerprint": fingerprint,
+    }

--- a/guardian/queue/graph_write_receipts.py
+++ b/guardian/queue/graph_write_receipts.py
@@ -1,0 +1,30 @@
+"""Ephemeral receipt helpers for inspection-only graph-write tasks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from guardian.queue.redis_queue import set_if_absent_with_ttl
+
+GRAPH_WRITE_RECEIPT_KEY_PREFIX = "codexify:graph-write:receipt"
+GRAPH_WRITE_RECEIPT_TTL_SECONDS = 3600
+
+
+def build_graph_write_receipt_key(idempotency_key: str) -> str:
+    return f"{GRAPH_WRITE_RECEIPT_KEY_PREFIX}:{str(idempotency_key).strip()}"
+
+
+def claim_graph_write_receipt(
+    redis_client: Any,
+    idempotency_key: str,
+    ttl_seconds: int = GRAPH_WRITE_RECEIPT_TTL_SECONDS,
+) -> bool:
+    key = build_graph_write_receipt_key(idempotency_key)
+    return bool(
+        set_if_absent_with_ttl(
+            redis_client,
+            key,
+            "claimed",
+            ttl_seconds,
+        )
+    )

--- a/guardian/queue/redis_queue.py
+++ b/guardian/queue/redis_queue.py
@@ -531,6 +531,21 @@ def enqueue(task: Any, queue_name: str) -> None:
         raise
 
 
+def set_if_absent_with_ttl(
+    client: Any, key: str, value: str, ttl_seconds: int
+) -> bool:
+    """Set a Redis key if absent using EX + NX semantics."""
+
+    return bool(
+        client.set(
+            key,
+            value,
+            ex=int(ttl_seconds),
+            nx=True,
+        )
+    )
+
+
 class _QueueRedisFacade:
     """Blocking-safe Redis facade for queue consumers."""
 

--- a/guardian/tasks/types.py
+++ b/guardian/tasks/types.py
@@ -135,6 +135,8 @@ class GraphWriteTask(TypedDict):
     thread_id: str | int
     candidate_trace_id: str
     created_at: str
+    graph_write_id: str
+    idempotency_key: str
     nodes: list[dict[str, Any]]
     edges: list[dict[str, Any]]
     warnings: list[str]

--- a/guardian/workers/candidate_ingest_worker.py
+++ b/guardian/workers/candidate_ingest_worker.py
@@ -17,6 +17,9 @@ from guardian.core.candidate_normalizer import normalize_candidate_trace
 from guardian.memory_graph.graph_candidate_mapper import (
     map_to_graph_write_candidates,
 )
+from guardian.memory_graph.graph_write_identity import (
+    build_graph_write_identity,
+)
 from guardian.queue.redis_queue import (
     CANDIDATE_INGEST_QUEUE,
     GRAPH_WRITE_QUEUE,
@@ -91,11 +94,22 @@ def _build_graph_write_task(
         )
         return None
 
+    identity = build_graph_write_identity(
+        request_id=normalized_task["request_id"],
+        thread_id=normalized_task["thread_id"],
+        candidate_trace_id=normalized_task["candidate_trace_id"],
+        nodes=nodes,
+        edges=edges,
+        warnings=warnings,
+    )
+
     return {
         "request_id": normalized_task["request_id"],
         "thread_id": normalized_task["thread_id"],
         "candidate_trace_id": normalized_task["candidate_trace_id"],
         "created_at": normalized_task["created_at"],
+        "graph_write_id": identity["graph_write_id"],
+        "idempotency_key": identity["idempotency_key"],
         "nodes": nodes,
         "edges": edges,
         "warnings": warnings,

--- a/guardian/workers/graph_write_worker.py
+++ b/guardian/workers/graph_write_worker.py
@@ -13,12 +13,20 @@ import logging
 import time
 from typing import Any
 
+from guardian.memory_graph.graph_write_identity import (
+    build_graph_write_identity,
+)
+from guardian.queue.graph_write_receipts import claim_graph_write_receipt
 from guardian.queue.redis_queue import GRAPH_WRITE_QUEUE, get_redis_connection
 
 logger = logging.getLogger(__name__)
 
 GRAPH_WRITE_WORKER_SUMMARY_LOG = "graph_write_worker_inspected_task"
 GRAPH_WRITE_WORKER_WARNING_LOG = "graph_write_worker_task_warnings"
+GRAPH_WRITE_WORKER_DUPLICATE_LOG = "graph_write_worker_duplicate_task_skipped"
+GRAPH_WRITE_WORKER_RECEIPT_CLAIM_FAILED_LOG = (
+    "graph_write_worker_receipt_claim_failed"
+)
 
 
 def _coerce_mapping_list(raw: Any) -> list[dict[str, Any]]:
@@ -42,6 +50,34 @@ def _coerce_warning_list(raw: Any) -> list[str]:
     return result
 
 
+def _coerce_task_identity(
+    task: dict[str, Any],
+    *,
+    nodes: list[dict[str, Any]],
+    edges: list[dict[str, Any]],
+    warnings: list[str],
+) -> dict[str, Any]:
+    graph_write_id = str(task.get("graph_write_id") or "").strip()
+    idempotency_key = str(task.get("idempotency_key") or "").strip()
+    if graph_write_id and idempotency_key:
+        return {
+            "graph_write_id": graph_write_id,
+            "idempotency_key": idempotency_key,
+        }
+    fallback = build_graph_write_identity(
+        request_id=str(task.get("request_id") or ""),
+        thread_id=task.get("thread_id") or "",
+        candidate_trace_id=str(task.get("candidate_trace_id") or ""),
+        nodes=nodes,
+        edges=edges,
+        warnings=warnings,
+    )
+    return {
+        "graph_write_id": fallback["graph_write_id"],
+        "idempotency_key": fallback["idempotency_key"],
+    }
+
+
 def process_graph_write_task(task: dict) -> None:
     if not isinstance(task, dict):
         logger.warning(
@@ -56,6 +92,57 @@ def process_graph_write_task(task: dict) -> None:
     nodes = _coerce_mapping_list(task.get("nodes"))
     edges = _coerce_mapping_list(task.get("edges"))
     warnings = _coerce_warning_list(task.get("warnings"))
+    identity = _coerce_task_identity(
+        task,
+        nodes=nodes,
+        edges=edges,
+        warnings=warnings,
+    )
+    graph_write_id = identity["graph_write_id"]
+    idempotency_key = identity["idempotency_key"]
+
+    try:
+        redis = get_redis_connection()
+    except Exception:
+        logger.exception(
+            f"[graph-write] {GRAPH_WRITE_WORKER_RECEIPT_CLAIM_FAILED_LOG}",
+            extra={
+                "request_id": request_id,
+                "thread_id": thread_id,
+                "candidate_trace_id": candidate_trace_id,
+                "graph_write_id": graph_write_id,
+                "idempotency_key": idempotency_key,
+            },
+        )
+        return
+
+    try:
+        claimed = claim_graph_write_receipt(redis, idempotency_key)
+    except Exception:
+        logger.exception(
+            f"[graph-write] {GRAPH_WRITE_WORKER_RECEIPT_CLAIM_FAILED_LOG}",
+            extra={
+                "request_id": request_id,
+                "thread_id": thread_id,
+                "candidate_trace_id": candidate_trace_id,
+                "graph_write_id": graph_write_id,
+                "idempotency_key": idempotency_key,
+            },
+        )
+        return
+
+    if not claimed:
+        logger.info(
+            f"[graph-write] {GRAPH_WRITE_WORKER_DUPLICATE_LOG}",
+            extra={
+                "request_id": request_id,
+                "thread_id": thread_id,
+                "candidate_trace_id": candidate_trace_id,
+                "graph_write_id": graph_write_id,
+                "idempotency_key": idempotency_key,
+            },
+        )
+        return
 
     node_types = sorted(
         {
@@ -78,6 +165,8 @@ def process_graph_write_task(task: dict) -> None:
             "request_id": request_id,
             "thread_id": thread_id,
             "candidate_trace_id": candidate_trace_id,
+            "graph_write_id": graph_write_id,
+            "idempotency_key": idempotency_key,
             "node_count": len(nodes),
             "edge_count": len(edges),
             "warning_count": len(warnings),
@@ -129,6 +218,8 @@ if __name__ == "__main__":
 __all__ = [
     "GRAPH_WRITE_WORKER_SUMMARY_LOG",
     "GRAPH_WRITE_WORKER_WARNING_LOG",
+    "GRAPH_WRITE_WORKER_DUPLICATE_LOG",
+    "GRAPH_WRITE_WORKER_RECEIPT_CLAIM_FAILED_LOG",
     "process_graph_write_task",
     "run_graph_write_worker",
 ]

--- a/tests/memory_graph/test_graph_write_identity.py
+++ b/tests/memory_graph/test_graph_write_identity.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from guardian.memory_graph.graph_write_identity import (
+    build_graph_write_identity,
+    compute_graph_write_fingerprint,
+)
+
+
+def _graph_payload() -> tuple[list[dict], list[dict], list[str]]:
+    nodes = [
+        {
+            "node_key": "graph:document:2",
+            "node_type": "Document",
+            "source_type": "retrieval",
+            "source_id": "doc-2",
+            "content": "Project brief",
+            "metadata": {
+                "project_id": "project-1",
+                "thread_id": "thread-1",
+                "labels": ["b", "a"],
+            },
+        },
+        {
+            "node_key": "graph:message:1",
+            "node_type": "Message",
+            "source_type": "thread",
+            "source_id": "msg-1",
+            "content": "Source message",
+            "metadata": {
+                "thread_id": "thread-1",
+                "project_id": "project-1",
+            },
+        },
+    ]
+    edges = [
+        {
+            "edge_type": "PART_OF_THREAD",
+            "from_node_key": "graph:document:2",
+            "to_node_key": "graph:message:1",
+            "metadata": {"thread_id": "thread-1"},
+        }
+    ]
+    warnings = ["late", "early"]
+    return nodes, edges, warnings
+
+
+def test_graph_write_identity_is_deterministic_for_same_payload():
+    nodes, edges, warnings = _graph_payload()
+
+    first = build_graph_write_identity(
+        request_id="req-1",
+        thread_id=7,
+        candidate_trace_id="trace-1",
+        nodes=nodes,
+        edges=edges,
+        warnings=warnings,
+    )
+    second = build_graph_write_identity(
+        request_id="req-1",
+        thread_id=7,
+        candidate_trace_id="trace-1",
+        nodes=nodes,
+        edges=edges,
+        warnings=warnings,
+    )
+
+    assert first["graph_write_id"] == second["graph_write_id"]
+    assert first["idempotency_key"] == second["idempotency_key"]
+    assert first["graph_fingerprint"] == second["graph_fingerprint"]
+
+
+def test_graph_write_identity_is_order_insensitive_for_equivalent_graph_payload():
+    nodes, edges, warnings = _graph_payload()
+    reversed_nodes = list(reversed(nodes))
+    reversed_edges = list(reversed(edges))
+    reversed_warnings = list(reversed(warnings))
+
+    fingerprint_one = compute_graph_write_fingerprint(nodes, edges, warnings)
+    fingerprint_two = compute_graph_write_fingerprint(
+        reversed_nodes,
+        reversed_edges,
+        reversed_warnings,
+    )
+
+    identity_one = build_graph_write_identity(
+        request_id="req-1",
+        thread_id=7,
+        candidate_trace_id="trace-1",
+        nodes=nodes,
+        edges=edges,
+        warnings=warnings,
+    )
+    identity_two = build_graph_write_identity(
+        request_id="req-1",
+        thread_id=7,
+        candidate_trace_id="trace-1",
+        nodes=reversed_nodes,
+        edges=reversed_edges,
+        warnings=reversed_warnings,
+    )
+
+    assert fingerprint_one == fingerprint_two
+    assert identity_one["graph_write_id"] == identity_two["graph_write_id"]
+    assert identity_one["idempotency_key"] == identity_two["idempotency_key"]
+
+
+def test_graph_write_identity_changes_when_graph_shape_changes():
+    nodes, edges, warnings = _graph_payload()
+
+    baseline = build_graph_write_identity(
+        request_id="req-1",
+        thread_id=7,
+        candidate_trace_id="trace-1",
+        nodes=nodes,
+        edges=edges,
+        warnings=warnings,
+    )
+    changed = build_graph_write_identity(
+        request_id="req-1",
+        thread_id=7,
+        candidate_trace_id="trace-1",
+        nodes=nodes
+        + [
+            {
+                "node_key": "graph:fact:3",
+                "node_type": "MemoryFact",
+                "source_type": "memory",
+                "source_id": "fact-1",
+                "content": "New fact",
+                "metadata": {"thread_id": "thread-1"},
+            }
+        ],
+        edges=edges,
+        warnings=warnings,
+    )
+
+    assert baseline["graph_fingerprint"] != changed["graph_fingerprint"]
+    assert baseline["graph_write_id"] != changed["graph_write_id"]
+    assert baseline["idempotency_key"] != changed["idempotency_key"]
+
+
+def test_graph_write_identity_keeps_candidate_trace_boundary():
+    nodes, edges, warnings = _graph_payload()
+
+    first = build_graph_write_identity(
+        request_id="req-1",
+        thread_id=7,
+        candidate_trace_id="trace-1",
+        nodes=nodes,
+        edges=edges,
+        warnings=warnings,
+    )
+    second = build_graph_write_identity(
+        request_id="req-1",
+        thread_id=7,
+        candidate_trace_id="trace-2",
+        nodes=nodes,
+        edges=edges,
+        warnings=warnings,
+    )
+
+    assert first["graph_fingerprint"] == second["graph_fingerprint"]
+    assert first["graph_write_id"] != second["graph_write_id"]
+    assert first["idempotency_key"] != second["idempotency_key"]

--- a/tests/workers/test_candidate_ingest_worker.py
+++ b/tests/workers/test_candidate_ingest_worker.py
@@ -79,6 +79,10 @@ def test_candidate_ingest_worker_enqueues_graph_write_task_from_graph_candidates
     assert graph_write_task["thread_id"] == 7
     assert graph_write_task["candidate_trace_id"] == "trace-1"
     assert graph_write_task["created_at"] == "2026-01-01T00:00:00Z"
+    assert graph_write_task["graph_write_id"].startswith("gwr_")
+    assert graph_write_task["idempotency_key"].startswith(
+        "graph-write:trace-1:"
+    )
     assert len(graph_write_task["nodes"]) == 2
     assert len(graph_write_task["edges"]) == 1
     assert graph_write_task["warnings"] == []
@@ -215,6 +219,93 @@ def test_candidate_ingest_worker_contains_graph_write_enqueue_failure(
     assert summary.edge_count == 1
     assert summary.warning_count == 0
     enqueue_spy.assert_called_once()
+
+
+def test_candidate_ingest_worker_graph_write_identity_is_stable_for_same_payload(
+    monkeypatch,
+):
+    enqueue_spy = MagicMock(return_value=None)
+    monkeypatch.setattr(candidate_ingest_worker, "enqueue", enqueue_spy)
+
+    payload = {
+        "messages": [
+            {
+                "id": "msg-1",
+                "content": "Source message",
+            }
+        ],
+        "documents": [
+            {
+                "id": "doc-1",
+                "content": "Derived document",
+                "source_message_id": "msg-1",
+            }
+        ],
+    }
+
+    candidate_ingest_worker.process_candidate_ingest_task(
+        _task(payload=payload)
+    )
+    candidate_ingest_worker.process_candidate_ingest_task(
+        _task(payload=payload)
+    )
+
+    first_task = enqueue_spy.call_args_list[0].args[0]
+    second_task = enqueue_spy.call_args_list[1].args[0]
+
+    assert first_task["graph_write_id"] == second_task["graph_write_id"]
+    assert first_task["idempotency_key"] == second_task["idempotency_key"]
+
+
+def test_candidate_ingest_worker_graph_write_identity_changes_when_candidates_change(
+    monkeypatch,
+):
+    enqueue_spy = MagicMock(return_value=None)
+    monkeypatch.setattr(candidate_ingest_worker, "enqueue", enqueue_spy)
+
+    first_payload = {
+        "messages": [
+            {
+                "id": "msg-1",
+                "content": "Source message",
+            }
+        ],
+        "documents": [
+            {
+                "id": "doc-1",
+                "content": "Derived document",
+                "source_message_id": "msg-1",
+            }
+        ],
+    }
+    second_payload = {
+        "messages": [
+            {
+                "id": "msg-1",
+                "content": "Source message",
+            }
+        ],
+        "documents": [
+            {
+                "id": "doc-1",
+                "content": "Derived document v2",
+                "source_message_id": "msg-1",
+            }
+        ],
+    }
+
+    candidate_ingest_worker.process_candidate_ingest_task(
+        _task(payload=first_payload)
+    )
+    candidate_ingest_worker.process_candidate_ingest_task(
+        _task(payload=second_payload)
+    )
+
+    first_task = enqueue_spy.call_args_list[0].args[0]
+    second_task = enqueue_spy.call_args_list[1].args[0]
+
+    assert first_task["graph_write_id"] != second_task["graph_write_id"]
+    assert first_task["idempotency_key"] != second_task["idempotency_key"]
 
 
 def test_candidate_ingest_worker_does_not_persist_or_call_graph_backend(

--- a/tests/workers/test_graph_write_worker.py
+++ b/tests/workers/test_graph_write_worker.py
@@ -6,12 +6,31 @@ from unittest.mock import MagicMock
 from guardian.workers import graph_write_worker
 
 
+class _FakeReceiptRedis:
+    def __init__(
+        self, results: list[bool | None] | None = None, *, failure=None
+    ):
+        self.results = list(results or [])
+        self.failure = failure
+        self.calls: list[tuple[str, str, int | None, bool]] = []
+
+    def set(self, key, value, ex=None, nx=False):
+        self.calls.append((key, value, ex, nx))
+        if self.failure is not None:
+            raise self.failure
+        if self.results:
+            return self.results.pop(0)
+        return True
+
+
 def _task() -> dict[str, object]:
     return {
         "request_id": "req-1",
         "thread_id": 7,
         "candidate_trace_id": "trace-1",
         "created_at": "2026-01-01T00:00:00Z",
+        "graph_write_id": "gwr_test_identity",
+        "idempotency_key": "graph-write:trace-1:fingerprint-1",
         "nodes": [
             {
                 "node_key": "graph:document:1",
@@ -40,10 +59,29 @@ def _record_by_message(caplog, message: str):
     )
 
 
-def test_graph_write_worker_logs_summary_for_valid_task(caplog):
+def test_graph_write_worker_claims_receipt_and_logs_summary_for_first_seen_task(
+    caplog, monkeypatch
+):
     caplog.set_level(logging.INFO)
+    redis_client = _FakeReceiptRedis(results=[True])
+    get_redis_connection_spy = MagicMock(return_value=redis_client)
+    monkeypatch.setattr(
+        graph_write_worker,
+        "get_redis_connection",
+        get_redis_connection_spy,
+    )
 
     graph_write_worker.process_graph_write_task(_task())
+
+    get_redis_connection_spy.assert_called_once()
+    assert len(redis_client.calls) == 1
+    receipt_key, receipt_value, ttl, nx = redis_client.calls[0]
+    assert receipt_key == (
+        "codexify:graph-write:receipt:graph-write:trace-1:fingerprint-1"
+    )
+    assert receipt_value == "claimed"
+    assert ttl == 3600
+    assert nx is True
 
     summary = _record_by_message(
         caplog,
@@ -52,6 +90,8 @@ def test_graph_write_worker_logs_summary_for_valid_task(caplog):
     assert summary.request_id == "req-1"
     assert summary.thread_id == 7
     assert summary.candidate_trace_id == "trace-1"
+    assert summary.graph_write_id == "gwr_test_identity"
+    assert summary.idempotency_key == "graph-write:trace-1:fingerprint-1"
     assert summary.node_count == 1
     assert summary.edge_count == 1
     assert summary.warning_count == 0
@@ -59,56 +99,79 @@ def test_graph_write_worker_logs_summary_for_valid_task(caplog):
     assert summary.edge_types == ["PART_OF_THREAD"]
 
 
-def test_graph_write_worker_logs_warnings_when_present(caplog):
+def test_graph_write_worker_skips_duplicate_task_after_receipt_claim(
+    caplog, monkeypatch
+):
     caplog.set_level(logging.INFO)
+    redis_client = _FakeReceiptRedis(results=[True, False])
+    monkeypatch.setattr(
+        graph_write_worker,
+        "get_redis_connection",
+        MagicMock(return_value=redis_client),
+    )
 
     task = _task()
-    task["warnings"] = ["ambiguous_relationship"]
-
+    graph_write_worker.process_graph_write_task(task)
     graph_write_worker.process_graph_write_task(task)
 
-    warning = _record_by_message(
+    summary_records = [
+        record
+        for record in caplog.records
+        if record.getMessage()
+        == f"[graph-write] {graph_write_worker.GRAPH_WRITE_WORKER_SUMMARY_LOG}"
+    ]
+    duplicate_record = _record_by_message(
         caplog,
-        f"[graph-write] {graph_write_worker.GRAPH_WRITE_WORKER_WARNING_LOG}",
+        f"[graph-write] {graph_write_worker.GRAPH_WRITE_WORKER_DUPLICATE_LOG}",
     )
-    assert warning.warnings == ["ambiguous_relationship"]
+
+    assert len(summary_records) == 1
+    assert duplicate_record.request_id == "req-1"
+    assert duplicate_record.thread_id == 7
+    assert duplicate_record.candidate_trace_id == "trace-1"
+    assert duplicate_record.graph_write_id == "gwr_test_identity"
+    assert (
+        duplicate_record.idempotency_key == "graph-write:trace-1:fingerprint-1"
+    )
 
 
-def test_graph_write_worker_survives_malformed_task(caplog):
-    caplog.set_level(logging.WARNING)
+def test_graph_write_worker_contains_receipt_claim_failure(caplog, monkeypatch):
+    caplog.set_level(logging.INFO)
+    redis_client = _FakeReceiptRedis(failure=RuntimeError("redis down"))
+    monkeypatch.setattr(
+        graph_write_worker,
+        "get_redis_connection",
+        MagicMock(return_value=redis_client),
+    )
 
-    graph_write_worker.process_graph_write_task(None)
+    graph_write_worker.process_graph_write_task(_task())
 
     assert any(
-        "malformed task ignored" in record.getMessage()
+        record.levelno >= logging.ERROR
+        and graph_write_worker.GRAPH_WRITE_WORKER_RECEIPT_CLAIM_FAILED_LOG
+        in record.getMessage()
+        for record in caplog.records
+    )
+    assert not any(
+        record.getMessage()
+        == f"[graph-write] {graph_write_worker.GRAPH_WRITE_WORKER_SUMMARY_LOG}"
         for record in caplog.records
     )
 
 
-def test_graph_write_worker_does_not_persist_or_call_graph_backend(
+def test_graph_write_worker_still_does_not_persist_or_call_graph_backend(
     monkeypatch,
 ):
-    enqueue_spy = MagicMock(
-        side_effect=AssertionError("queue fan-out not expected")
-    )
-    redis_spy = MagicMock(
-        side_effect=AssertionError("redis client not expected")
+    redis_client = _FakeReceiptRedis(results=[True])
+    monkeypatch.setattr(
+        graph_write_worker,
+        "get_redis_connection",
+        MagicMock(return_value=redis_client),
     )
     graph_backend_spy = MagicMock(
         side_effect=AssertionError("graph backend not expected")
     )
 
-    monkeypatch.setattr(
-        graph_write_worker,
-        "enqueue",
-        enqueue_spy,
-        raising=False,
-    )
-    monkeypatch.setattr(
-        graph_write_worker,
-        "get_redis_connection",
-        redis_spy,
-    )
     monkeypatch.setattr(
         graph_write_worker,
         "write_graph_candidates",
@@ -118,6 +181,5 @@ def test_graph_write_worker_does_not_persist_or_call_graph_backend(
 
     graph_write_worker.process_graph_write_task(_task())
 
-    enqueue_spy.assert_not_called()
-    redis_spy.assert_not_called()
+    assert len(redis_client.calls) == 1
     graph_backend_spy.assert_not_called()


### PR DESCRIPTION
…n lane

## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
