### PR TITLE
Codex/fix desktop auth gate mismatch

### DIFF
--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -2490,6 +2490,44 @@ export function GuardianChat({
     releaseTurnLease,
   ]);
 
+  function extractThreadIdFromResponsePayload(payload: unknown): number | null {
+    if (typeof payload === "number" && Number.isFinite(payload)) {
+      return payload;
+    }
+    if (typeof payload === "string") {
+      const parsed = Number(payload.trim());
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+    if (!payload || typeof payload !== "object") {
+      return null;
+    }
+
+    const source = payload as Record<string, unknown>;
+    const thread =
+      source.thread && typeof source.thread === "object"
+        ? (source.thread as Record<string, unknown>)
+        : null;
+    const message =
+      source.message && typeof source.message === "object"
+        ? (source.message as Record<string, unknown>)
+        : null;
+    const rawId =
+      source.thread_id ??
+      source.threadId ??
+      source.created_thread_id ??
+      source.createdThreadId ??
+      thread?.id ??
+      thread?.thread_id ??
+      thread?.threadId ??
+      thread?.id_str ??
+      message?.thread_id ??
+      message?.threadId ??
+      source.id ??
+      source.id_str;
+    const numericId = Number(rawId);
+    return Number.isFinite(numericId) ? numericId : null;
+  }
+
   // Auto-thread creation handler
   const handleThreadCreated = (
     threadId: number,
@@ -2537,10 +2575,8 @@ export function GuardianChat({
         metadata,
       });
       const payload = (resp && resp.data) || {};
-      const newThreadId =
-        payload.id ?? payload.thread?.id ?? payload.thread_id ?? payload.id_str;
-      const numericThreadId = Number(newThreadId);
-      if (!Number.isFinite(numericThreadId)) {
+      const numericThreadId = extractThreadIdFromResponsePayload(payload);
+      if (numericThreadId == null) {
         throw new Error("Thread id missing from create thread response");
       }
 
@@ -2569,9 +2605,8 @@ export function GuardianChat({
       const payload = trimmedTitle ? { title: trimmedTitle } : {};
       const res = await api.post(`/chat/${effectiveThreadId}/branch`, payload);
       const data = res?.data ?? {};
-      const rawId = data?.id ?? data?.thread?.id ?? data?.thread_id ?? data?.id_str;
-      const newThreadId = Number(rawId);
-      if (!Number.isFinite(newThreadId)) {
+      const newThreadId = extractThreadIdFromResponsePayload(data);
+      if (newThreadId == null) {
         throw new Error("Branch response missing thread id");
       }
       const responseTitle = typeof data?.title === "string" && data.title.trim().length > 0 ? data.title : undefined;
@@ -2730,10 +2765,8 @@ export function GuardianChat({
           project_id: workspaceProjectId ?? undefined,
         });
         const th = (resp && resp.data) || {};
-        const newThreadId =
-          th.thread_id ?? th.thread?.id ?? th.message?.thread_id ?? th.id ?? th.id_str;
-        const numericNewId = Number(newThreadId);
-        if (!Number.isFinite(numericNewId)) {
+        const numericNewId = extractThreadIdFromResponsePayload(th);
+        if (numericNewId == null) {
           console.warn("Unexpected create-on-send response:", th);
           throw new Error("Thread id missing from response");
         }

--- a/frontend/src/features/chat/__tests__/GuardianChat.test.tsx
+++ b/frontend/src/features/chat/__tests__/GuardianChat.test.tsx
@@ -659,6 +659,50 @@ describe("GuardianChat inference rail", () => {
     ).toBe(false);
   });
 
+  it("accepts camelCase create-on-send thread ids without dropping the new thread", async () => {
+    renderChat("draft-thread", {
+      userName: "Resonant Jones",
+    });
+
+    apiMock.post.mockImplementation(async (url: string, body?: any) => {
+      if (url === "/chat/messages") {
+        expect(body).toEqual(
+          expect.objectContaining({
+            thread_id: null,
+            role: "user",
+            user_id: "local",
+          })
+        );
+        return {
+          data: {
+            created_thread: true,
+            createdThreadId: 123,
+            thread: {
+              id: 123,
+              title: "New Thread",
+            },
+          },
+        };
+      }
+      if (url === "/chat/123/complete") {
+        return { data: { task_id: "task-123" } };
+      }
+      return { data: {} };
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("composer-send"));
+    });
+
+    await waitFor(() => {
+      expect(apiMock.post).toHaveBeenCalledWith(
+        "/chat/123/complete",
+        expect.anything()
+      );
+    });
+    expect(screen.queryByText("Thread id missing from response")).not.toBeInTheDocument();
+  });
+
   it("switches profiles through the command bus invoke surface instead of the legacy tools shim", async () => {
     const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("local_mode");
     renderChat("1");

--- a/frontend/src/hooks/useRuntimeHealth.test.ts
+++ b/frontend/src/hooks/useRuntimeHealth.test.ts
@@ -37,10 +37,10 @@ const flushPromises = async () => {
 };
 
 function mockHealthResponses(overrides: {
-  embedder?: "ok" | "fail" | "missing" | "unreachable";
+  chat?: "ok" | "fail" | "missing" | "unreachable";
   llm?: "ok" | "fail" | "missing" | "unreachable";
 } = {}) {
-  const embedder = overrides.embedder ?? "ok";
+  const chat = overrides.chat ?? "ok";
   const llm = overrides.llm ?? "ok";
 
   apiGet.mockImplementation((path: string) => {
@@ -60,21 +60,40 @@ function mockHealthResponses(overrides: {
       }
       return Promise.resolve({ data: { ok: false, status: "offline" } });
     }
-    if (path === "/api/health/embedder") {
-      if (embedder === "ok") {
-        return Promise.resolve({ data: { status: "ok" } });
+    if (path === "/health/chat") {
+      if (chat === "ok") {
+        return Promise.resolve({
+          data: {
+            ok: true,
+            status: "healthy",
+            completion_service: {
+              ok: true,
+              status_reason: "ok",
+              redis_reachable: true,
+            },
+          },
+        });
       }
-      if (embedder === "missing") {
+      if (chat === "missing") {
         const error = new Error("not found") as Error & {
           response?: { status?: number };
         };
         error.response = { status: 404 };
         return Promise.reject(error);
       }
-      if (embedder === "unreachable") {
-        return Promise.reject(new Error("embedder unreachable"));
+      if (chat === "unreachable") {
+        return Promise.reject(new Error("chat unreachable"));
       }
-      return Promise.resolve({ data: { status: "error" } });
+      return Promise.resolve({
+        data: {
+          ok: false,
+          status: "degraded",
+          completion_service: {
+            ok: false,
+            status_reason: "worker_heartbeat_stale",
+          },
+        },
+      });
     }
     return Promise.reject(new Error("unknown endpoint"));
   });
@@ -108,7 +127,7 @@ describe("useRuntimeHealth", () => {
   });
 
   it("flags backend unreachable", async () => {
-    mockHealthResponses({ llm: "unreachable", embedder: "unreachable" });
+    mockHealthResponses({ llm: "unreachable", chat: "unreachable" });
     const { result } = renderHook(() => useRuntimeHealth());
     await act(async () => {
       await flushPromises();
@@ -135,8 +154,8 @@ describe("useRuntimeHealth", () => {
     });
   });
 
-  it("treats /api/health/embedder 404 as missing endpoint, not backend unreachable", async () => {
-    mockHealthResponses({ embedder: "missing" });
+  it("treats /health/chat 404 as missing endpoint, not backend unreachable", async () => {
+    mockHealthResponses({ chat: "missing" });
     const { result } = renderHook(() => useRuntimeHealth());
     await act(async () => {
       await flushPromises();
@@ -150,7 +169,7 @@ describe("useRuntimeHealth", () => {
   });
 
   it("flags chat unhealthy", async () => {
-    mockHealthResponses({ embedder: "fail" });
+    mockHealthResponses({ chat: "fail" });
     const { result } = renderHook(() => useRuntimeHealth());
     await act(async () => {
       await flushPromises();
@@ -171,9 +190,8 @@ describe("useRuntimeHealth", () => {
 
     const calledPaths = apiGet.mock.calls.map(([path]) => String(path));
     expect(calledPaths).toContain("/api/health/llm");
-    expect(calledPaths).toContain("/api/health/embedder");
+    expect(calledPaths).toContain("/health/chat");
     expect(calledPaths).not.toContain("/health");
-    expect(calledPaths).not.toContain("/health/chat");
     expect(calledPaths).not.toContain("/api/health");
     expect(calledPaths).not.toContain("/api/health/chat");
   });

--- a/frontend/src/hooks/useRuntimeHealth.ts
+++ b/frontend/src/hooks/useRuntimeHealth.ts
@@ -143,22 +143,21 @@ export function useRuntimeHealth(): RuntimeHealthStatus {
       firstCheckAtRef.current = startedAt;
     }
     try {
-      const [llmResult, embedderResult] =
+      const [llmResult, chatResult] =
         await Promise.allSettled([
           api.get("/api/health/llm"),
-          api.get("/api/health/embedder"),
+          api.get("/health/chat"),
         ]);
       const llmPayload =
         llmResult.status === "fulfilled" ? llmResult.value?.data : null;
-
       const llmHealth = parseHealthResult(llmResult);
-      const embedderHealth = parseHealthResult(embedderResult);
-      const backendReachable = llmHealth.reachable || embedderHealth.reachable;
-      const chatHealthy = embedderHealth.ok;
+      const chatHealth = parseHealthResult(chatResult);
+      const backendReachable = llmHealth.reachable || chatHealth.reachable;
+      const chatHealthy = chatHealth.ok;
       const llmHealthy = llmHealth.ok;
       const llmDetail = extractLlmDetail(llmPayload);
       const healthEndpointMissing =
-        llmHealth.missing || embedderHealth.missing;
+        llmHealth.missing || chatHealth.missing;
       const success =
         backendReachable && chatHealthy === true && llmHealthy === true;
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1193,13 +1193,10 @@ export async function fetchPersonalFactRevisions(
 }
 
 export async function fetchProviderState() {
-  const res = await fetch("/api/health/llm");
-
-  if (!res.ok) {
-    throw new Error(`Provider state fetch failed: ${res.status}`);
-  }
-
-  const json = await res.json();
+  // Use the authenticated runtime client so packaged desktop mode keeps the
+  // in-memory desktop API key attached to the provider health probe.
+  const res = await api.get("/health/llm");
+  const json = res?.data ?? {};
 
   console.log("[provider-state:raw]", json);
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -202,22 +202,19 @@ function applyAuthHeaders(
   const forceApiKey = options.forceApiKey ?? false;
   const token = getAuthToken();
   const runtimeApiKey = getRuntimeApiKey();
-  const devApiKey = resolveDevApiKey();
-  const apiKey = runtimeApiKey || devApiKey;
   const hasAuthorization = hasHeader(headers, "Authorization");
   const hasApiKey = hasHeader(headers, "X-API-Key");
 
+  if (runtimeApiKey && !hasApiKey) {
+    headers["X-API-Key"] = runtimeApiKey;
+  } else {
+    const devApiKey = resolveDevApiKey();
+    if ((forceApiKey || !token) && devApiKey && !hasApiKey) {
+      headers["X-API-Key"] = devApiKey;
+    }
+  }
+
   if (!forceApiKey && token && !hasAuthorization) {
-    headers.Authorization = `Bearer ${token}`;
-    return;
-  }
-
-  if (apiKey && !hasApiKey) {
-    headers["X-API-Key"] = apiKey;
-    return;
-  }
-
-  if (token && !hasAuthorization) {
     headers.Authorization = `Bearer ${token}`;
   }
 }
@@ -889,19 +886,16 @@ api.interceptors.request.use((config) => {
 
   const token = getAuthToken();
   const runtimeApiKey = getRuntimeApiKey();
+  if (runtimeApiKey && !existingApiKey) {
+    setHeader("X-API-Key", runtimeApiKey);
+  } else if (!token) {
+    const devApiKey = resolveDevApiKey();
+    if (devApiKey && !existingAuthorization && !existingApiKey) {
+      setHeader("X-API-Key", devApiKey);
+    }
+  }
   if (token && !existingAuthorization) {
     setHeader("Authorization", `Bearer ${token}`);
-  } else if (!token) {
-    if (runtimeApiKey && !existingAuthorization && !existingApiKey) {
-      setHeader("X-API-Key", runtimeApiKey);
-    } else {
-      const devApiKey = resolveDevApiKey();
-      if (devApiKey && !existingAuthorization && !existingApiKey) {
-        setHeader("X-API-Key", devApiKey);
-      }
-    }
-  } else if (runtimeApiKey && !existingApiKey) {
-    setHeader("X-API-Key", runtimeApiKey);
   }
   config.headers = headers;
 

--- a/frontend/src/test/api.desktop-auth.test.ts
+++ b/frontend/src/test/api.desktop-auth.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  default as api,
   buildAuthenticatedFetchInit,
   clearRuntimeApiKey,
   setAuthToken,
@@ -23,12 +24,15 @@ function normalizeHeaders(headers: RequestInit["headers"]): Record<string, strin
 }
 
 describe("desktop auth headers", () => {
+  const originalAdapter = api.defaults.adapter;
+
   afterEach(() => {
+    api.defaults.adapter = originalAdapter;
     setAuthToken(null);
     clearRuntimeApiKey();
   });
 
-  it("prefers bearer token when forceApiKey is not set", () => {
+  it("attaches the runtime desktop key alongside bearer token when available", () => {
     setAuthToken("bearer-token");
     setRuntimeApiKey("desktop-key");
 
@@ -38,7 +42,7 @@ describe("desktop auth headers", () => {
     expect(headers["Authorization"] ?? headers["authorization"]).toBe(
       "Bearer bearer-token"
     );
-    expect(headers["X-API-Key"] ?? headers["x-api-key"]).toBeUndefined();
+    expect(headers["X-API-Key"] ?? headers["x-api-key"]).toBe("desktop-key");
   });
 
   it("uses X-API-Key when forceApiKey is true", () => {
@@ -61,5 +65,31 @@ describe("desktop auth headers", () => {
 
     expect(headers["X-API-Key"] ?? headers["x-api-key"]).toBe("desktop-key");
     expect(headers["Authorization"] ?? headers["authorization"]).toBeUndefined();
+  });
+
+  it("sends the runtime desktop key through the axios client even when a bearer token exists", async () => {
+    setAuthToken("bearer-token");
+    setRuntimeApiKey("desktop-key");
+
+    let capturedHeaders: Record<string, string> = {};
+    api.defaults.adapter = async (config) => {
+      capturedHeaders = normalizeHeaders(config.headers);
+      return {
+        data: { ok: true },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config,
+      };
+    };
+
+    await api.get("/api/health/llm");
+
+    expect(capturedHeaders["Authorization"] ?? capturedHeaders["authorization"]).toBe(
+      "Bearer bearer-token"
+    );
+    expect(capturedHeaders["X-API-Key"] ?? capturedHeaders["x-api-key"]).toBe(
+      "desktop-key"
+    );
   });
 });

--- a/frontend/src/test/api.desktop-auth.test.ts
+++ b/frontend/src/test/api.desktop-auth.test.ts
@@ -4,6 +4,7 @@ import {
   default as api,
   buildAuthenticatedFetchInit,
   clearRuntimeApiKey,
+  fetchProviderState,
   setAuthToken,
   setRuntimeApiKey,
 } from "@/lib/api";
@@ -88,6 +89,30 @@ describe("desktop auth headers", () => {
     expect(capturedHeaders["Authorization"] ?? capturedHeaders["authorization"]).toBe(
       "Bearer bearer-token"
     );
+    expect(capturedHeaders["X-API-Key"] ?? capturedHeaders["x-api-key"]).toBe(
+      "desktop-key"
+    );
+  });
+
+  it("fetchProviderState uses the authenticated desktop runtime client", async () => {
+    setRuntimeApiKey("desktop-key");
+
+    let capturedHeaders: Record<string, string> = {};
+    api.defaults.adapter = async (config) => {
+      capturedHeaders = normalizeHeaders(config.headers);
+      return {
+        data: { ok: true, status: "online" },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config,
+      };
+    };
+
+    await expect(fetchProviderState()).resolves.toEqual({
+      ok: true,
+      status: "online",
+    });
     expect(capturedHeaders["X-API-Key"] ?? capturedHeaders["x-api-key"]).toBe(
       "desktop-key"
     );


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
