### PR TITLE
Expose packaged runtime health diagnostics in Guardian

### DIFF
--- a/docs/architecture/config-and-ops.md
+++ b/docs/architecture/config-and-ops.md
@@ -238,6 +238,8 @@ Unverified:
 - command bus run stream:
   - `GET /api/guardian/commands/runs/{run_id}/events`
 
+Packaged desktop runtime banners now expose sanitized health-poll diagnostics when degraded. Operators can read the banner's resolved API base URL, auth source, endpoint paths, HTTP status or transport error class, parsed status, parsed `ok` value, and poll timestamps without exposing raw credentials. Use those fields together with terminal probes when the packaged UI appears stale or disagrees with `/health/chat` and `/api/health/llm`.
+
 Primary anchors:
 - `guardian/routes/health.py`
 - `guardian/guardian_api.py`

--- a/frontend/src/components/persona/layout/AppShell.runtimeHealth.test.tsx
+++ b/frontend/src/components/persona/layout/AppShell.runtimeHealth.test.tsx
@@ -16,12 +16,37 @@ type RuntimeHealthMock = {
   failureKind: RuntimeHealthFailureKindToken | "unknown" | null;
   llmDetail: string | null;
   lastSuccessAt: number | null;
+  lastFailedAt: number | null;
   backendReachable: boolean | null;
   chatHealthy: boolean | null;
   llmHealthy: boolean | null;
   liveEventsStatus: LiveEventConnectionState;
   lastCheckedAt: number | null;
   stale: boolean;
+  diagnostics: {
+    resolvedApiBaseUrl: string | null;
+    apiKeyPresent: boolean;
+    authSource: string;
+    chat: {
+      endpoint: string;
+      httpStatus: number | null;
+      transportErrorClass: string | null;
+      parsedStatus: string | null;
+      parsedOk: boolean | null;
+    };
+    llm: {
+      endpoint: string;
+      httpStatus: number | null;
+      transportErrorClass: string | null;
+      parsedStatus: string | null;
+      parsedOk: boolean | null;
+    };
+    failureKind: RuntimeHealthFailureKindToken | "unknown" | null;
+    lastSuccessAt: number | null;
+    lastFailedAt: number | null;
+    lastCheckedAt: number | null;
+    currentComputedStateSource: string;
+  };
 };
 
 const runtimeHealthState: RuntimeHealthMock = {
@@ -29,12 +54,37 @@ const runtimeHealthState: RuntimeHealthMock = {
   failureKind: null,
   llmDetail: null,
   lastSuccessAt: Date.parse("2026-03-20T12:00:00Z"),
+  lastFailedAt: null,
   backendReachable: true,
   chatHealthy: true,
   llmHealthy: true,
   liveEventsStatus: LIVE_EVENT_CONNECTION_STATES.CONNECTED,
   lastCheckedAt: Date.parse("2026-03-20T12:00:00Z"),
   stale: false,
+  diagnostics: {
+    resolvedApiBaseUrl: "http://127.0.0.1:8888/api",
+    apiKeyPresent: true,
+    authSource: "runtime-desktop",
+    chat: {
+      endpoint: "/health/chat",
+      httpStatus: 200,
+      transportErrorClass: null,
+      parsedStatus: "healthy",
+      parsedOk: true,
+    },
+    llm: {
+      endpoint: "/api/health/llm",
+      httpStatus: 200,
+      transportErrorClass: null,
+      parsedStatus: "online",
+      parsedOk: true,
+    },
+    failureKind: null,
+    lastSuccessAt: Date.parse("2026-03-20T12:00:00Z"),
+    lastFailedAt: null,
+    lastCheckedAt: Date.parse("2026-03-20T12:00:00Z"),
+    currentComputedStateSource: "live-poll",
+  },
 };
 const routeCapabilityState = {
   ready: true,
@@ -43,6 +93,37 @@ const routeCapabilityState = {
 
 vi.mock("@/hooks/useRuntimeHealth", () => ({
   default: () => runtimeHealthState,
+  formatRuntimeHealthDiagnostics: (diagnostics: typeof runtimeHealthState.diagnostics) =>
+    [
+      `resolved api base url=${diagnostics.resolvedApiBaseUrl ?? "<unresolved>"}`,
+      `apiKeyPresent=${diagnostics.apiKeyPresent ? "true" : "false"}`,
+      `authSource=${diagnostics.authSource}`,
+      `chat endpoint called=${diagnostics.chat.endpoint}`,
+      `chat HTTP status=${diagnostics.chat.httpStatus ?? "<none>"}`,
+      `parsed chat health status=${diagnostics.chat.parsedStatus ?? "<none>"}`,
+      `parsed chat health ok=${
+        diagnostics.chat.parsedOk == null
+          ? "<unknown>"
+          : diagnostics.chat.parsedOk
+            ? "true"
+            : "false"
+      }`,
+      `llm endpoint called=${diagnostics.llm.endpoint}`,
+      `llm HTTP status=${diagnostics.llm.httpStatus ?? "<none>"}`,
+      `parsed llm health status=${diagnostics.llm.parsedStatus ?? "<none>"}`,
+      `parsed llm health ok=${
+        diagnostics.llm.parsedOk == null
+          ? "<unknown>"
+          : diagnostics.llm.parsedOk
+            ? "true"
+            : "false"
+      }`,
+      `failureKind=${diagnostics.failureKind ?? "none"}`,
+      `last successful health poll=${diagnostics.lastSuccessAt ?? "<none>"}`,
+      `last failed health poll=${diagnostics.lastFailedAt ?? "<none>"}`,
+      `current health poll=${diagnostics.lastCheckedAt ?? "<none>"}`,
+      `current computed state source=${diagnostics.currentComputedStateSource}`,
+    ],
 }));
 
 vi.mock("@/lib/runtimeRouteCapabilities", () => ({
@@ -191,13 +272,49 @@ vi.mock("@/theme", () => ({
 
 describe("AppShell runtime health banner", () => {
   beforeEach(() => {
+    Object.defineProperty(window, "localStorage", {
+      value: {
+        getItem: vi.fn(() => null),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+        key: vi.fn(() => null),
+        length: 0,
+      },
+      configurable: true,
+    });
     runtimeHealthState.status = RUNTIME_HEALTH_STATUSES.HEALTHY;
     runtimeHealthState.failureKind = null;
     runtimeHealthState.llmDetail = null;
     runtimeHealthState.backendReachable = true;
     runtimeHealthState.lastSuccessAt = Date.parse("2026-03-20T12:00:00Z");
+    runtimeHealthState.lastFailedAt = null;
     routeCapabilityState.ready = true;
     routeCapabilityState.state = "available";
+    runtimeHealthState.diagnostics = {
+      resolvedApiBaseUrl: "http://127.0.0.1:8888/api",
+      apiKeyPresent: true,
+      authSource: "runtime-desktop",
+      chat: {
+        endpoint: "/health/chat",
+        httpStatus: 200,
+        transportErrorClass: null,
+        parsedStatus: "healthy",
+        parsedOk: true,
+      },
+      llm: {
+        endpoint: "/api/health/llm",
+        httpStatus: 200,
+        transportErrorClass: null,
+        parsedStatus: "online",
+        parsedOk: true,
+      },
+      failureKind: null,
+      lastSuccessAt: Date.parse("2026-03-20T12:00:00Z"),
+      lastFailedAt: null,
+      lastCheckedAt: Date.parse("2026-03-20T12:00:00Z"),
+      currentComputedStateSource: "live-poll",
+    };
     if (!window.matchMedia) {
       window.matchMedia = ((query: string) => ({
         matches: false,
@@ -223,10 +340,35 @@ describe("AppShell runtime health banner", () => {
       RUNTIME_HEALTH_FAILURE_KINDS.BACKEND_UNREACHABLE;
     runtimeHealthState.backendReachable = false;
     runtimeHealthState.lastSuccessAt = Date.parse("2026-03-20T11:55:00Z");
+    runtimeHealthState.lastFailedAt = Date.parse("2026-03-20T11:54:30Z");
+    runtimeHealthState.diagnostics = {
+      resolvedApiBaseUrl: "http://127.0.0.1:8888/api",
+      apiKeyPresent: true,
+      authSource: "runtime-desktop",
+      chat: {
+        endpoint: "/health/chat",
+        httpStatus: 503,
+        transportErrorClass: null,
+        parsedStatus: "degraded",
+        parsedOk: false,
+      },
+      llm: {
+        endpoint: "/api/health/llm",
+        httpStatus: 200,
+        transportErrorClass: null,
+        parsedStatus: "online",
+        parsedOk: true,
+      },
+      failureKind: RUNTIME_HEALTH_FAILURE_KINDS.BACKEND_UNREACHABLE,
+      lastSuccessAt: Date.parse("2026-03-20T11:55:00Z"),
+      lastFailedAt: Date.parse("2026-03-20T11:54:30Z"),
+      lastCheckedAt: Date.parse("2026-03-20T12:00:00Z"),
+      currentComputedStateSource: "live-poll",
+    };
 
     render(<AppShell />);
 
-    expect(screen.getByText(/Runtime offline/i)).toBeInTheDocument();
+    expect(screen.getByText(/Provider offline/i)).toBeInTheDocument();
     expect(
       screen.getByText(/failure:\s*backend_unreachable/i)
     ).toBeInTheDocument();
@@ -238,6 +380,8 @@ describe("AppShell runtime health banner", () => {
     runtimeHealthState.failureKind =
       RUNTIME_HEALTH_FAILURE_KINDS.HEALTH_ENDPOINT_MISSING;
     runtimeHealthState.lastSuccessAt = Date.parse("2026-03-20T11:55:00Z");
+    runtimeHealthState.diagnostics.failureKind =
+      RUNTIME_HEALTH_FAILURE_KINDS.HEALTH_ENDPOINT_MISSING;
 
     render(<AppShell />);
 
@@ -251,15 +395,68 @@ describe("AppShell runtime health banner", () => {
     runtimeHealthState.llmDetail =
       "MiniMax live discovery unavailable using documented model list";
     runtimeHealthState.lastSuccessAt = Date.parse("2026-03-20T11:55:00Z");
+    runtimeHealthState.diagnostics.failureKind =
+      RUNTIME_HEALTH_FAILURE_KINDS.LLM_UNHEALTHY;
+    runtimeHealthState.diagnostics.llm = {
+      endpoint: "/api/health/llm",
+      httpStatus: 200,
+      transportErrorClass: null,
+      parsedStatus: "offline",
+      parsedOk: false,
+    };
 
     render(<AppShell />);
 
-    expect(screen.getByText(/Response delayed/i)).toBeInTheDocument();
+    expect(screen.getByText(/Provider degraded/i)).toBeInTheDocument();
     expect(
       screen.getByText(/failure:\s*llm_unhealthy/i)
     ).toBeInTheDocument();
     expect(
       screen.getByText(/MiniMax live discovery unavailable/i)
     ).toBeInTheDocument();
+  });
+
+  it("renders sanitized technical details when runtime health is degraded", () => {
+    runtimeHealthState.status = RUNTIME_HEALTH_STATUSES.DEGRADED;
+    runtimeHealthState.failureKind =
+      RUNTIME_HEALTH_FAILURE_KINDS.CHAT_UNHEALTHY;
+    runtimeHealthState.lastFailedAt = Date.parse("2026-03-20T11:54:30Z");
+    runtimeHealthState.diagnostics = {
+      resolvedApiBaseUrl: "http://127.0.0.1:8888/api",
+      apiKeyPresent: true,
+      authSource: "runtime-desktop",
+      chat: {
+        endpoint: "/health/chat",
+        httpStatus: 200,
+        transportErrorClass: null,
+        parsedStatus: "healthy",
+        parsedOk: true,
+      },
+      llm: {
+        endpoint: "/api/health/llm",
+        httpStatus: 200,
+        transportErrorClass: null,
+        parsedStatus: "online",
+        parsedOk: true,
+      },
+      failureKind: RUNTIME_HEALTH_FAILURE_KINDS.CHAT_UNHEALTHY,
+      lastSuccessAt: Date.parse("2026-03-20T11:55:00Z"),
+      lastFailedAt: Date.parse("2026-03-20T11:54:30Z"),
+      lastCheckedAt: Date.parse("2026-03-20T12:00:00Z"),
+      currentComputedStateSource: "live-poll",
+    };
+
+    render(<AppShell />);
+
+    expect(screen.getByText(/Technical details/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/resolved api base url=http:\/\/127\.0\.0\.1:8888\/api/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/apiKeyPresent=true/i)).toBeInTheDocument();
+    expect(screen.getByText(/authSource=runtime-desktop/i)).toBeInTheDocument();
+    expect(screen.getByText(/chat endpoint called=\/health\/chat/i)).toBeInTheDocument();
+    expect(screen.getByText(/llm endpoint called=\/api\/health\/llm/i)).toBeInTheDocument();
+    expect(screen.getByText(/failureKind=chat_unhealthy/i)).toBeInTheDocument();
+    expect(screen.queryByText("desktop-secret-key")).toBeNull();
   });
 });

--- a/frontend/src/components/persona/layout/AppShell.tsx
+++ b/frontend/src/components/persona/layout/AppShell.tsx
@@ -50,7 +50,9 @@ import { useShellViewportProfile } from "./shellBreakpointContract";
 import { getMobileShellProfile } from "./mobileShellProfile";
 import { useWallpaperUrl } from "@/hooks/useWallpaperUrl";
 import { useLiveEvents } from "@/hooks/useLiveEvents";
-import useRuntimeHealth from "@/hooks/useRuntimeHealth";
+import useRuntimeHealth, {
+  formatRuntimeHealthDiagnostics,
+} from "@/hooks/useRuntimeHealth";
 import { useViewportInsets } from "@/hooks/useViewportInsets";
 import {
   describeProviderState,
@@ -2432,6 +2434,10 @@ export default function AppShell({
     runtimeFailureKind === RUNTIME_HEALTH_FAILURE_KINDS.LLM_UNHEALTHY
       ? runtimeHealth.llmDetail
       : null;
+  const runtimeDiagnosticLines =
+    runtimeHealth.status === RUNTIME_HEALTH_STATUSES.DEGRADED
+      ? formatRuntimeHealthDiagnostics(runtimeHealth.diagnostics)
+      : [];
 
   const providerRuntimeState: ProviderRuntimeState =
     runtimeHealth.backendReachable === false
@@ -2864,6 +2870,18 @@ export default function AppShell({
                 {runtimePresentation.detail}
               </div>
             )}
+            {runtimeDiagnosticLines.length > 0 ? (
+              <details className="mt-1 rounded-md border border-dashed border-[color:var(--panel-border)] px-2 py-1 text-[11px]">
+                <summary className="cursor-pointer select-none opacity-80">
+                  Technical details
+                </summary>
+                <div className="mt-2 flex flex-col gap-1 font-mono text-[10px] leading-4 opacity-85">
+                  {runtimeDiagnosticLines.map((line) => (
+                    <div key={line}>{line}</div>
+                  ))}
+                </div>
+              </details>
+            ) : null}
           </div>
         </div>
       )}
@@ -3209,6 +3227,7 @@ export default function AppShell({
                         onWorkspaceToggle={toggleWorkspaceDrawer}
                         workspaceOpen={workspaceDrawerOpen}
                         providerRuntimeState={providerRuntimeState}
+                        runtimeHealth={runtimeHealth}
                         activeWorkspaceDoc={null}
                         onWorkspaceClose={closeWorkspaceDrawer}
                       />

--- a/frontend/src/components/persona/layout/GuardianChatWithSidebar.tsx
+++ b/frontend/src/components/persona/layout/GuardianChatWithSidebar.tsx
@@ -27,6 +27,9 @@ import {
 import { SessionSpine } from "@/state/session/SessionSpine";
 import { SUPPORTED_PROFILE_ROUTE_LABELS } from "@/contracts/supportedProfileRoutes";
 import { useRuntimeRouteCapabilities } from "@/lib/runtimeRouteCapabilities";
+import type {
+  RuntimeHealthStatus,
+} from "@/hooks/useRuntimeHealth";
 import {
   useSessionActiveDraft,
   useSessionActiveInferenceMode,
@@ -239,6 +242,7 @@ type GuardianChatWithSidebarProps = {
   onWorkspaceClose?: () => void;
   onWorkspaceOpenInThread?: (doc: DocumentLike | null) => void;
   providerRuntimeState?: ProviderRuntimeState | null;
+  runtimeHealth?: RuntimeHealthStatus | null;
 };
 
 export default function GuardianChatWithSidebar({
@@ -255,6 +259,7 @@ export default function GuardianChatWithSidebar({
   onWorkspaceClose,
   onWorkspaceOpenInThread,
   providerRuntimeState = null,
+  runtimeHealth = null,
 }: GuardianChatWithSidebarProps) {
   const auth = useAuthState();
   const [isSidebarVisible, setIsSidebarVisible] = React.useState(() => {
@@ -1739,6 +1744,7 @@ export default function GuardianChatWithSidebar({
                   onWorkspaceToggle={onWorkspaceToggle}
                   workspaceOpen={workspaceOpen}
                   providerRuntimeState={providerRuntimeState}
+                  runtimeHealth={runtimeHealth}
                   activeThread={activeThread}
                   workspaceProjectId={selectedProjectId}
                   onSendMessage={handleSendMessage}

--- a/frontend/src/components/persona/layout/__tests__/GuardianChatWithSidebar.stability.test.tsx
+++ b/frontend/src/components/persona/layout/__tests__/GuardianChatWithSidebar.stability.test.tsx
@@ -46,6 +46,35 @@ const runtimeAuthState = vi.hoisted(() => ({
         failureKind: string | null;
       },
 }));
+const runtimeHealthState = vi.hoisted(() => ({
+  status: "healthy" as const,
+  diagnostics: null as
+    | null
+    | {
+        resolvedApiBaseUrl: string | null;
+        apiKeyPresent: boolean;
+        authSource: string;
+        chat: {
+          endpoint: string;
+          httpStatus: number | null;
+          transportErrorClass: string | null;
+          parsedStatus: string | null;
+          parsedOk: boolean | null;
+        };
+        llm: {
+          endpoint: string;
+          httpStatus: number | null;
+          transportErrorClass: string | null;
+          parsedStatus: string | null;
+          parsedOk: boolean | null;
+        };
+        failureKind: string | null;
+        lastSuccessAt: number | null;
+        lastFailedAt: number | null;
+        lastCheckedAt: number | null;
+        currentComputedStateSource: string;
+      },
+}));
 const routeCapabilityStates = vi.hoisted(
   () =>
     ({
@@ -62,6 +91,20 @@ vi.mock("@/features/chat/GuardianChat", () => ({
         <div data-testid="active-thread-id">{String(props?.activeThread?.id ?? "none")}</div>
         <div data-testid="active-thread-title">{String(props?.activeThread?.title ?? "")}</div>
         <div data-testid="active-thread-messages">{String(props?.activeThread?.messages?.length ?? 0)}</div>
+        {props?.runtimeHealth?.diagnostics ? (
+          <div data-testid="runtime-health-diagnostics">
+            {[
+              `resolvedApiBaseUrl=${String(props.runtimeHealth.diagnostics.resolvedApiBaseUrl ?? "")}`,
+              `apiKeyPresent=${props.runtimeHealth.diagnostics.apiKeyPresent ? "true" : "false"}`,
+              `authSource=${String(props.runtimeHealth.diagnostics.authSource ?? "")}`,
+              `chatEndpoint=${String(props.runtimeHealth.diagnostics.chat.endpoint ?? "")}`,
+              `chatStatus=${String(props.runtimeHealth.diagnostics.chat.parsedStatus ?? "")}`,
+              `llmEndpoint=${String(props.runtimeHealth.diagnostics.llm.endpoint ?? "")}`,
+              `llmStatus=${String(props.runtimeHealth.diagnostics.llm.parsedStatus ?? "")}`,
+              `failureKind=${String(props.runtimeHealth.diagnostics.failureKind ?? "")}`,
+            ].join(" | ")}
+          </div>
+        ) : null}
       </div>
     );
   },
@@ -100,6 +143,39 @@ vi.mock("@/hooks/useLiveEvents", () => ({
   useLiveEvents: () => ({
     subscribe: () => () => {},
   }),
+}));
+
+vi.mock("@/hooks/useRuntimeHealth", () => ({
+  __esModule: true,
+  default: () => runtimeHealthState,
+  formatRuntimeHealthDiagnostics: (diagnostics: any) => [
+    `resolved api base url=${diagnostics.resolvedApiBaseUrl ?? "<unresolved>"}`,
+    `apiKeyPresent=${diagnostics.apiKeyPresent ? "true" : "false"}`,
+    `authSource=${diagnostics.authSource}`,
+    `chat endpoint called=${diagnostics.chat.endpoint}`,
+    `parsed chat health status=${diagnostics.chat.parsedStatus ?? "<none>"}`,
+    `parsed chat health ok=${
+      diagnostics.chat.parsedOk == null
+        ? "<unknown>"
+        : diagnostics.chat.parsedOk
+          ? "true"
+          : "false"
+    }`,
+    `llm endpoint called=${diagnostics.llm.endpoint}`,
+    `parsed llm health status=${diagnostics.llm.parsedStatus ?? "<none>"}`,
+    `parsed llm health ok=${
+      diagnostics.llm.parsedOk == null
+        ? "<unknown>"
+        : diagnostics.llm.parsedOk
+          ? "true"
+          : "false"
+    }`,
+    `failureKind=${diagnostics.failureKind ?? "none"}`,
+    `last successful health poll=${diagnostics.lastSuccessAt ?? "<none>"}`,
+    `last failed health poll=${diagnostics.lastFailedAt ?? "<none>"}`,
+    `current health poll=${diagnostics.lastCheckedAt ?? "<none>"}`,
+    `current computed state source=${diagnostics.currentComputedStateSource}`,
+  ],
 }));
 
 vi.mock("@/hooks/useWallpaperUrl", () => ({
@@ -380,7 +456,13 @@ describe("GuardianChatWithSidebar stability contract", () => {
       },
     });
 
-    render(<GuardianChatWithSidebar guardianName="Guardian" userName="User" />);
+    render(
+      <GuardianChatWithSidebar
+        guardianName="Guardian"
+        userName="User"
+        runtimeHealth={runtimeHealthState as any}
+      />
+    );
 
     await screen.findByTestId("thread-1");
 
@@ -410,7 +492,13 @@ describe("GuardianChatWithSidebar stability contract", () => {
     });
 
     const user = userEvent.setup();
-    render(<GuardianChatWithSidebar guardianName="Guardian" userName="User" />);
+    render(
+      <GuardianChatWithSidebar
+        guardianName="Guardian"
+        userName="User"
+        runtimeHealth={runtimeHealthState as any}
+      />
+    );
 
     await screen.findByTestId("thread-1");
     await user.click(screen.getByTestId("thread-2"));
@@ -443,7 +531,13 @@ describe("GuardianChatWithSidebar stability contract", () => {
     });
 
     const user = userEvent.setup();
-    render(<GuardianChatWithSidebar guardianName="Guardian" userName="User" />);
+    render(
+      <GuardianChatWithSidebar
+        guardianName="Guardian"
+        userName="User"
+        runtimeHealth={runtimeHealthState as any}
+      />
+    );
 
     await screen.findByTestId("thread-2");
     await user.click(screen.getByTestId("thread-2"));
@@ -467,7 +561,13 @@ describe("GuardianChatWithSidebar stability contract", () => {
     });
 
     const user = userEvent.setup();
-    render(<GuardianChatWithSidebar guardianName="Guardian" userName="User" />);
+    render(
+      <GuardianChatWithSidebar
+        guardianName="Guardian"
+        userName="User"
+        runtimeHealth={runtimeHealthState as any}
+      />
+    );
 
     await screen.findByTestId("thread-1");
     await user.click(screen.getByTestId("sidebar-set-project-2"));
@@ -925,6 +1025,8 @@ describe("GuardianChatWithSidebar auth banner", () => {
     authState.token = "test-token";
     runtimeAuthState.isTauri = false;
     runtimeAuthState.desktopAuthConfig = null;
+    runtimeHealthState.status = "healthy";
+    runtimeHealthState.diagnostics = null;
     const storage = new Map<string, string>();
     Object.defineProperty(window, "localStorage", {
       value: {
@@ -992,5 +1094,69 @@ describe("GuardianChatWithSidebar auth banner", () => {
     expect(screen.getByText("failureKind=config_incomplete")).toBeInTheDocument();
     expect(screen.queryByText("desktop-secret-key")).toBeNull();
     expect(screen.queryByText("Sign in or provide a dev key in local development.")).toBeNull();
+  });
+
+  it("forwards sanitized runtime-health diagnostics to the provider banner path", () => {
+    runtimeHealthState.status = "degraded";
+    runtimeHealthState.diagnostics = {
+      resolvedApiBaseUrl: "http://127.0.0.1:8888/api",
+      apiKeyPresent: true,
+      authSource: "runtime-desktop",
+      chat: {
+        endpoint: "/health/chat",
+        httpStatus: 200,
+        transportErrorClass: null,
+        parsedStatus: "healthy",
+        parsedOk: true,
+      },
+      llm: {
+        endpoint: "/api/health/llm",
+        httpStatus: 200,
+        transportErrorClass: null,
+        parsedStatus: "online",
+        parsedOk: true,
+      },
+      failureKind: "chat_unhealthy",
+      lastSuccessAt: Date.parse("2026-03-20T12:00:00.000Z"),
+      lastFailedAt: Date.parse("2026-03-20T11:59:00.000Z"),
+      lastCheckedAt: Date.parse("2026-03-20T12:00:00.000Z"),
+      currentComputedStateSource: "live-poll",
+    };
+    runtimeAuthState.isTauri = true;
+    runtimeAuthState.desktopAuthConfig = {
+      apiKeyPresent: true,
+      apiKey: "desktop-secret-key",
+      envPath: "/Users/chriscastillo/Codexify/.env",
+      runtimeRoot: "/Users/chriscastillo/Codexify",
+      failureKind: null,
+    };
+
+    render(
+      <GuardianChatWithSidebar
+        guardianName="Guardian"
+        userName="User"
+        runtimeHealth={runtimeHealthState as any}
+      />
+    );
+
+    expect(screen.getByTestId("runtime-health-diagnostics")).toHaveTextContent(
+      "resolvedApiBaseUrl=http://127.0.0.1:8888/api"
+    );
+    expect(screen.getByTestId("runtime-health-diagnostics")).toHaveTextContent(
+      "apiKeyPresent=true"
+    );
+    expect(screen.getByTestId("runtime-health-diagnostics")).toHaveTextContent(
+      "authSource=runtime-desktop"
+    );
+    expect(screen.getByTestId("runtime-health-diagnostics")).toHaveTextContent(
+      "chatEndpoint=/health/chat"
+    );
+    expect(screen.getByTestId("runtime-health-diagnostics")).toHaveTextContent(
+      "llmEndpoint=/api/health/llm"
+    );
+    expect(screen.getByTestId("runtime-health-diagnostics")).toHaveTextContent(
+      "failureKind=chat_unhealthy"
+    );
+    expect(screen.queryByText("desktop-secret-key")).toBeNull();
   });
 });

--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -72,6 +72,10 @@ import {
   useInferenceRequestState,
 } from "@/features/chat/hooks/useInferenceRequestState";
 import {
+  formatRuntimeHealthDiagnostics,
+  type RuntimeHealthStatus,
+} from "@/hooks/useRuntimeHealth";
+import {
   createIdleInferenceRequestState,
   DEFAULT_COMPOSER_INFERENCE_MODE,
   isActiveInferencePhase,
@@ -662,6 +666,7 @@ export function GuardianChat({
   activeInferenceMode = DEFAULT_COMPOSER_INFERENCE_MODE,
   activeDraft = "",
   providerRuntimeState = null,
+  runtimeHealth = null,
   onSessionTabActivate,
   onSessionTabClose,
   onSessionTabOpen,
@@ -701,6 +706,7 @@ export function GuardianChat({
   activeInferenceMode?: ComposerInferenceMode;
   activeDraft?: string;
   providerRuntimeState?: ProviderRuntimeState | null;
+  runtimeHealth?: RuntimeHealthStatus | null;
   onSessionTabActivate?: (tabId: TabId) => void;
   onSessionTabClose?: (tabId: TabId) => void;
   onSessionTabOpen?: () => void;
@@ -1198,6 +1204,13 @@ export function GuardianChat({
   const llmStatusMessage =
     llmHealth.error
     || "Guardian cannot reach the model endpoint. Check connectivity and model service availability.";
+  const runtimeHealthDiagnosticLines = useMemo(
+    () =>
+      runtimeHealth?.status === "degraded"
+        ? formatRuntimeHealthDiagnostics(runtimeHealth.diagnostics)
+        : [],
+    [runtimeHealth]
+  );
   const mobileShellProfile = useMobileShellProfile();
   const mobileGestureState = useMobileGestureState(mobileShellProfile.active);
   const applePlatform = useMemo(() => isApplePlatform(), []);
@@ -3288,6 +3301,18 @@ export function GuardianChat({
           </div>
           {cloudProvidersDisabled ? (
             <div className="mt-1 opacity-80">Cloud providers disabled by config.</div>
+          ) : null}
+          {runtimeHealthDiagnosticLines.length > 0 ? (
+            <details className="mt-2 rounded-md border border-dashed border-[color:var(--panel-border)] px-2 py-1 text-[11px]">
+              <summary className="cursor-pointer select-none opacity-80">
+                Technical details
+              </summary>
+              <div className="mt-2 flex flex-col gap-1 font-mono text-[10px] leading-4 opacity-85">
+                {runtimeHealthDiagnosticLines.map((line) => (
+                  <div key={line}>{line}</div>
+                ))}
+              </div>
+            </details>
           ) : null}
         </div>
       )}

--- a/frontend/src/hooks/useRuntimeHealth.test.ts
+++ b/frontend/src/hooks/useRuntimeHealth.test.ts
@@ -15,6 +15,30 @@ type LiveEventsStatus = {
 };
 
 const apiGet = vi.fn();
+const runtimeState = vi.hoisted(() => ({
+  isTauri: true,
+  apiBaseUrl: "http://127.0.0.1:8888/api",
+  desktopAuthConfig: {
+    apiKeyPresent: true,
+    apiKey: "packaged-runtime-key",
+    envPath: "/Users/chriscastillo/Codexify/.env",
+    runtimeRoot: "/Users/chriscastillo/Codexify",
+    failureKind: null,
+    runtimeContext: "packaged",
+  } as
+    | null
+    | {
+        apiKeyPresent: boolean;
+        apiKey: string | null;
+        envPath: string | null;
+        runtimeRoot: string | null;
+        failureKind: string | null;
+        runtimeContext: string | null;
+      },
+  runtimeApiKey: "packaged-runtime-key" as string | null,
+  authToken: null as string | null,
+  devApiKey: "" as string,
+}));
 let liveEventsStatus: LiveEventsStatus = {
   connected: true,
   connectionStatus: LIVE_EVENT_CONNECTION_STATES.CONNECTED,
@@ -25,6 +49,22 @@ vi.mock("@/lib/api", () => ({
   default: {
     get: (...args: unknown[]) => apiGet(...args),
   },
+  getAuthToken: () => runtimeState.authToken,
+  getDevApiKey: () => runtimeState.devApiKey,
+  readRuntimeApiKey: () => runtimeState.runtimeApiKey,
+}));
+
+vi.mock("@/lib/runtimeConfig", () => ({
+  getDesktopRuntimeAuthConfig: () => runtimeState.desktopAuthConfig,
+  getRuntimeConfigSync: () => ({
+    mode: runtimeState.isTauri ? "tauri" : "web",
+    backendBaseUrl: "http://127.0.0.1:8888",
+    apiBaseUrl: runtimeState.apiBaseUrl,
+    sseUrl: "http://127.0.0.1:8888/api/events",
+    sharePublicBaseUrl: "http://127.0.0.1:5173",
+    authMode: "local",
+  }),
+  isTauriRuntime: () => runtimeState.isTauri,
 }));
 
 vi.mock("@/hooks/useLiveEvents", () => ({
@@ -104,6 +144,19 @@ describe("useRuntimeHealth", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-20T12:00:00.000Z"));
     apiGet.mockReset();
+    runtimeState.isTauri = true;
+    runtimeState.apiBaseUrl = "http://127.0.0.1:8888/api";
+    runtimeState.desktopAuthConfig = {
+      apiKeyPresent: true,
+      apiKey: "packaged-runtime-key",
+      envPath: "/Users/chriscastillo/Codexify/.env",
+      runtimeRoot: "/Users/chriscastillo/Codexify",
+      failureKind: null,
+      runtimeContext: "packaged",
+    };
+    runtimeState.runtimeApiKey = "packaged-runtime-key";
+    runtimeState.authToken = null;
+    runtimeState.devApiKey = "";
     liveEventsStatus = {
       connected: true,
       connectionStatus: LIVE_EVENT_CONNECTION_STATES.CONNECTED,
@@ -123,6 +176,29 @@ describe("useRuntimeHealth", () => {
     });
     await waitFor(() => {
       expect(result.current.status).toBe(RUNTIME_HEALTH_STATUSES.HEALTHY);
+      expect(result.current.failureKind).toBeNull();
+      expect(result.current.chatHealthy).toBe(true);
+      expect(result.current.llmHealthy).toBe(true);
+      expect(result.current.lastCheckedAt).toBe(Date.parse("2026-03-20T12:00:00.000Z"));
+      expect(result.current.lastSuccessAt).toBe(Date.parse("2026-03-20T12:00:00.000Z"));
+      expect(result.current.lastFailedAt).toBeNull();
+      expect(result.current.diagnostics.resolvedApiBaseUrl).toBe(
+        "http://127.0.0.1:8888/api"
+      );
+      expect(result.current.diagnostics.apiKeyPresent).toBe(true);
+      expect(result.current.diagnostics.authSource).toBe("runtime-desktop");
+      expect(result.current.diagnostics.chat.endpoint).toBe("/health/chat");
+      expect(result.current.diagnostics.chat.httpStatus).toBe(200);
+      expect(result.current.diagnostics.chat.parsedStatus).toBe("healthy");
+      expect(result.current.diagnostics.chat.parsedOk).toBe(true);
+      expect(result.current.diagnostics.llm.endpoint).toBe("/api/health/llm");
+      expect(result.current.diagnostics.llm.httpStatus).toBe(200);
+      expect(result.current.diagnostics.llm.parsedStatus).toBe("online");
+      expect(result.current.diagnostics.llm.parsedOk).toBe(true);
+      expect(result.current.diagnostics.failureKind).toBeNull();
+      expect(result.current.diagnostics.currentComputedStateSource).toBe(
+        "live-poll"
+      );
     });
   });
 
@@ -168,6 +244,46 @@ describe("useRuntimeHealth", () => {
     });
   });
 
+  it("clears chat_unhealthy when /health/chat becomes healthy", async () => {
+    mockHealthResponses({ chat: "fail" });
+    const { result } = renderHook(() => useRuntimeHealth());
+    await act(async () => {
+      await flushPromises();
+    });
+    await waitFor(() => {
+      expect(result.current.failureKind).toBe(
+        RUNTIME_HEALTH_FAILURE_KINDS.CHAT_UNHEALTHY
+      );
+      expect(result.current.diagnostics.chat.parsedStatus).toBe("degraded");
+      expect(result.current.diagnostics.chat.parsedOk).toBe(false);
+      expect(result.current.diagnostics.currentComputedStateSource).toBe(
+        "live-poll"
+      );
+    });
+
+    expect(result.current.status).toBe(RUNTIME_HEALTH_STATUSES.DEGRADED);
+
+    mockHealthResponses({ chat: "ok" });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+      await flushPromises();
+    });
+
+    await waitFor(() => {
+      expect(result.current.failureKind).toBeNull();
+      expect(result.current.chatHealthy).toBe(true);
+      expect(result.current.status).toBe(RUNTIME_HEALTH_STATUSES.HEALTHY);
+      expect(result.current.diagnostics.chat.parsedStatus).toBe("healthy");
+      expect(result.current.diagnostics.chat.parsedOk).toBe(true);
+      expect(result.current.diagnostics.lastSuccessAt).toBe(
+        Date.parse("2026-03-20T12:00:15.000Z")
+      );
+      expect(result.current.diagnostics.lastFailedAt).toBe(
+        Date.parse("2026-03-20T12:00:00.000Z")
+      );
+    });
+  });
+
   it("flags chat unhealthy", async () => {
     mockHealthResponses({ chat: "fail" });
     const { result } = renderHook(() => useRuntimeHealth());
@@ -177,6 +293,47 @@ describe("useRuntimeHealth", () => {
     await waitFor(() => {
       expect(result.current.failureKind).toBe(
         RUNTIME_HEALTH_FAILURE_KINDS.CHAT_UNHEALTHY
+      );
+    });
+  });
+
+  it("records endpoint and auth diagnostics for a degraded health poll", async () => {
+    runtimeState.desktopAuthConfig = {
+      apiKeyPresent: true,
+      apiKey: "packaged-runtime-key",
+      envPath: "/Users/chriscastillo/Codexify/.env",
+      runtimeRoot: "/Users/chriscastillo/Codexify",
+      failureKind: null,
+      runtimeContext: "packaged",
+    };
+    runtimeState.runtimeApiKey = "packaged-runtime-key";
+    mockHealthResponses({ llm: "fail", chat: "ok" });
+
+    const { result } = renderHook(() => useRuntimeHealth());
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe(RUNTIME_HEALTH_STATUSES.DEGRADED);
+      expect(result.current.failureKind).toBe(
+        RUNTIME_HEALTH_FAILURE_KINDS.LLM_UNHEALTHY
+      );
+      expect(result.current.diagnostics.apiKeyPresent).toBe(true);
+      expect(result.current.diagnostics.authSource).toBe("runtime-desktop");
+      expect(result.current.diagnostics.llm.endpoint).toBe("/api/health/llm");
+      expect(result.current.diagnostics.llm.httpStatus).toBe(200);
+      expect(result.current.diagnostics.llm.parsedStatus).toBe("offline");
+      expect(result.current.diagnostics.llm.parsedOk).toBe(false);
+      expect(result.current.diagnostics.chat.endpoint).toBe("/health/chat");
+      expect(result.current.diagnostics.chat.httpStatus).toBe(200);
+      expect(result.current.diagnostics.chat.parsedStatus).toBe("healthy");
+      expect(result.current.diagnostics.chat.parsedOk).toBe(true);
+      expect(result.current.diagnostics.lastCheckedAt).toBe(
+        Date.parse("2026-03-20T12:00:00.000Z")
+      );
+      expect(result.current.diagnostics.currentComputedStateSource).toBe(
+        "live-poll"
       );
     });
   });

--- a/frontend/src/hooks/useRuntimeHealth.ts
+++ b/frontend/src/hooks/useRuntimeHealth.ts
@@ -1,6 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import api from "@/lib/api";
+import api, {
+  getAuthToken,
+  getDevApiKey,
+  readRuntimeApiKey,
+} from "@/lib/api";
 import { useLiveEvents } from "@/hooks/useLiveEvents";
+import {
+  getDesktopRuntimeAuthConfig,
+  getRuntimeConfigSync,
+  isTauriRuntime,
+} from "@/lib/runtimeConfig";
 import {
   LIVE_EVENT_CONNECTION_STATES,
   LiveEventConnectionState,
@@ -12,8 +21,43 @@ import {
 
 const POLL_INTERVAL_MS = 15000;
 const STALE_THRESHOLD_MS = 45000;
+const CHAT_HEALTH_ENDPOINT = "/health/chat";
+const LLM_HEALTH_ENDPOINT = "/api/health/llm";
 
 export type RuntimeFailureKind = RuntimeHealthFailureKindToken;
+export type RuntimeHealthAuthSource =
+  | "runtime-desktop"
+  | "vite-dev"
+  | "bearer-only"
+  | "none"
+  | "unknown";
+
+export type RuntimeHealthStateSource =
+  | "live-poll"
+  | "cached"
+  | "fallback"
+  | "unknown";
+
+export type RuntimeHealthEndpointObservation = {
+  endpoint: string;
+  httpStatus: number | null;
+  transportErrorClass: string | null;
+  parsedStatus: string | null;
+  parsedOk: boolean | null;
+};
+
+export type RuntimeHealthDiagnostics = {
+  resolvedApiBaseUrl: string | null;
+  apiKeyPresent: boolean;
+  authSource: RuntimeHealthAuthSource;
+  chat: RuntimeHealthEndpointObservation;
+  llm: RuntimeHealthEndpointObservation;
+  failureKind: RuntimeFailureKind | null;
+  lastSuccessAt: number | null;
+  lastFailedAt: number | null;
+  lastCheckedAt: number | null;
+  currentComputedStateSource: RuntimeHealthStateSource;
+};
 
 export type RuntimeHealthStatus = {
   status: RuntimeHealthStatusToken;
@@ -25,34 +69,67 @@ export type RuntimeHealthStatus = {
   liveEventsStatus: LiveEventConnectionState;
   lastSuccessAt: number | null;
   lastCheckedAt: number | null;
+  lastFailedAt: number | null;
   stale: boolean;
+  diagnostics: RuntimeHealthDiagnostics;
 };
 
 type HealthSnapshot = {
   backendReachable: boolean | null;
   healthEndpointMissing: boolean | null;
-  chatHealthy: boolean | null;
-  llmHealthy: boolean | null;
+  chat: RuntimeHealthEndpointObservation & {
+    derivedHealthy: boolean | null;
+    reachable: boolean;
+    missing: boolean;
+    payload: unknown | null;
+  };
+  llm: RuntimeHealthEndpointObservation & {
+    derivedHealthy: boolean | null;
+    reachable: boolean;
+    missing: boolean;
+    payload: unknown | null;
+  };
   llmDetail: string | null;
   lastSuccessAt: number | null;
+  lastFailedAt: number | null;
   lastCheckedAt: number | null;
 };
 
 const INITIAL_SNAPSHOT: HealthSnapshot = {
   backendReachable: null,
   healthEndpointMissing: null,
-  chatHealthy: null,
-  llmHealthy: null,
+  chat: {
+    endpoint: CHAT_HEALTH_ENDPOINT,
+    httpStatus: null,
+    transportErrorClass: null,
+    parsedStatus: null,
+    parsedOk: null,
+    derivedHealthy: null,
+    reachable: false,
+    missing: false,
+    payload: null,
+  },
+  llm: {
+    endpoint: LLM_HEALTH_ENDPOINT,
+    httpStatus: null,
+    transportErrorClass: null,
+    parsedStatus: null,
+    parsedOk: null,
+    derivedHealthy: null,
+    reachable: false,
+    missing: false,
+    payload: null,
+  },
   llmDetail: null,
   lastSuccessAt: null,
+  lastFailedAt: null,
   lastCheckedAt: null,
 };
 
-function isHealthOk(payload: unknown): boolean {
-  if (!payload || typeof payload !== "object") return false;
-  const candidate = payload as { ok?: unknown; status?: unknown };
-  if (typeof candidate.ok === "boolean") return candidate.ok;
-  return String(candidate.status ?? "").toLowerCase() === "ok";
+function isHealthStatusToken(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().toLowerCase();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 type HealthResult = {
@@ -70,24 +147,155 @@ function responseStatusFromResult(
   return typeof status === "number" ? status : null;
 }
 
-function parseHealthResult(
+function getTransportErrorClass(error: unknown): string | null {
+  if (!error || typeof error !== "object") return null;
+  const candidate = error as { name?: unknown; code?: unknown };
+  const name =
+    typeof candidate.name === "string" && candidate.name.trim()
+      ? candidate.name.trim()
+      : null;
+  if (name) return name;
+  const code =
+    typeof candidate.code === "string" && candidate.code.trim()
+      ? candidate.code.trim()
+      : null;
+  return code;
+}
+
+function readParsedStatus(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const candidate = payload as { status?: unknown };
+  return isHealthStatusToken(candidate.status);
+}
+
+function readParsedOk(payload: unknown): boolean | null {
+  if (!payload || typeof payload !== "object") return null;
+  const candidate = payload as { ok?: unknown };
+  return typeof candidate.ok === "boolean" ? candidate.ok : null;
+}
+
+function deriveHealthySignal(payload: unknown, httpStatus: number | null): boolean | null {
+  const parsedOk = readParsedOk(payload);
+  if (parsedOk !== null) return parsedOk;
+  const parsedStatus = readParsedStatus(payload);
+  if (parsedStatus) {
+    return ["ok", "healthy", "online"].includes(parsedStatus);
+  }
+  if (httpStatus == null) return null;
+  return httpStatus >= 200 && httpStatus < 300;
+}
+
+function summarizeHealthResult(
+  endpoint: string,
   result: PromiseSettledResult<{ data?: unknown }>
-): HealthResult {
+): HealthResult & RuntimeHealthEndpointObservation & {
+  derivedHealthy: boolean | null;
+  payload: unknown | null;
+} {
   if (result.status === "fulfilled") {
+    const payload = result.value?.data ?? null;
+    const derivedHealthy = deriveHealthySignal(payload, 200);
     return {
+      endpoint,
       reachable: true,
-      ok: isHealthOk(result.value?.data),
+      ok: derivedHealthy,
+      derivedHealthy,
       missing: false,
+      httpStatus: 200,
+      transportErrorClass: null,
+      parsedStatus: readParsedStatus(payload),
+      parsedOk: readParsedOk(payload),
+      payload,
     };
   }
+
   const status = responseStatusFromResult(result);
-  if (status === 404) {
-    return { reachable: true, ok: null, missing: true };
+  const payload =
+    (result.reason as { response?: { data?: unknown } } | null)?.response?.data ??
+    null;
+  const missing = status === 404;
+  const reachable = status != null;
+  return {
+    endpoint,
+    reachable,
+    ok: missing ? false : deriveHealthySignal(payload, status),
+    derivedHealthy: missing ? false : deriveHealthySignal(payload, status),
+    missing,
+    httpStatus: status,
+    transportErrorClass: status == null ? getTransportErrorClass(result.reason) : null,
+    parsedStatus: readParsedStatus(payload),
+    parsedOk: readParsedOk(payload),
+    payload,
+  };
+}
+
+function resolveRuntimeHealthAuthSource(): RuntimeHealthAuthSource {
+  const desktopAuthConfig = getDesktopRuntimeAuthConfig();
+  const runtimeDesktopKeyPresent = Boolean(
+    desktopAuthConfig?.apiKeyPresent || readRuntimeApiKey()
+  );
+  const devKeyPresent = Boolean(getDevApiKey().trim());
+  const bearerPresent = Boolean(getAuthToken());
+
+  if (isTauriRuntime() && runtimeDesktopKeyPresent) {
+    return "runtime-desktop";
   }
-  if (status != null) {
-    return { reachable: true, ok: false, missing: false };
+  if (!isTauriRuntime() && devKeyPresent) {
+    return "vite-dev";
   }
-  return { reachable: false, ok: null, missing: false };
+  if (bearerPresent) {
+    return "bearer-only";
+  }
+  if (isTauriRuntime()) {
+    return desktopAuthConfig ? "none" : "unknown";
+  }
+  if (devKeyPresent) {
+    return "vite-dev";
+  }
+  return "none";
+}
+
+function formatTimestamp(value: number | null): string {
+  return value == null ? "<none>" : new Date(value).toISOString();
+}
+
+export function formatRuntimeHealthDiagnostics(
+  diagnostics: RuntimeHealthDiagnostics
+): string[] {
+  return [
+    `resolved api base url=${diagnostics.resolvedApiBaseUrl ?? "<unresolved>"}`,
+    `apiKeyPresent=${diagnostics.apiKeyPresent ? "true" : "false"}`,
+    `authSource=${diagnostics.authSource}`,
+    `chat endpoint called=${diagnostics.chat.endpoint}`,
+    diagnostics.chat.httpStatus != null
+      ? `chat HTTP status=${diagnostics.chat.httpStatus}`
+      : `chat transport error class=${diagnostics.chat.transportErrorClass ?? "<none>"}`,
+    `parsed chat health status=${diagnostics.chat.parsedStatus ?? "<none>"}`,
+    `parsed chat health ok=${
+      diagnostics.chat.parsedOk == null
+        ? "<unknown>"
+        : diagnostics.chat.parsedOk
+          ? "true"
+          : "false"
+    }`,
+    `llm endpoint called=${diagnostics.llm.endpoint}`,
+    diagnostics.llm.httpStatus != null
+      ? `llm HTTP status=${diagnostics.llm.httpStatus}`
+      : `llm transport error class=${diagnostics.llm.transportErrorClass ?? "<none>"}`,
+    `parsed llm health status=${diagnostics.llm.parsedStatus ?? "<none>"}`,
+    `parsed llm health ok=${
+      diagnostics.llm.parsedOk == null
+        ? "<unknown>"
+        : diagnostics.llm.parsedOk
+          ? "true"
+          : "false"
+    }`,
+    `failureKind=${diagnostics.failureKind ?? "none"}`,
+    `last successful health poll=${formatTimestamp(diagnostics.lastSuccessAt)}`,
+    `last failed health poll=${formatTimestamp(diagnostics.lastFailedAt)}`,
+    `current health poll=${formatTimestamp(diagnostics.lastCheckedAt)}`,
+    `current computed state source=${diagnostics.currentComputedStateSource}`,
+  ];
 }
 
 function normalizeDetail(value: unknown): string | null {
@@ -148,26 +356,24 @@ export function useRuntimeHealth(): RuntimeHealthStatus {
           api.get("/api/health/llm"),
           api.get("/health/chat"),
         ]);
-      const llmPayload =
-        llmResult.status === "fulfilled" ? llmResult.value?.data : null;
-      const llmHealth = parseHealthResult(llmResult);
-      const chatHealth = parseHealthResult(chatResult);
+      const llmHealth = summarizeHealthResult(LLM_HEALTH_ENDPOINT, llmResult);
+      const chatHealth = summarizeHealthResult(CHAT_HEALTH_ENDPOINT, chatResult);
       const backendReachable = llmHealth.reachable || chatHealth.reachable;
       const chatHealthy = chatHealth.ok;
       const llmHealthy = llmHealth.ok;
-      const llmDetail = extractLlmDetail(llmPayload);
-      const healthEndpointMissing =
-        llmHealth.missing || chatHealth.missing;
+      const llmDetail = extractLlmDetail(llmHealth.payload);
+      const healthEndpointMissing = llmHealth.missing || chatHealth.missing;
       const success =
         backendReachable && chatHealthy === true && llmHealthy === true;
 
       setSnapshot((prev) => ({
         backendReachable,
         healthEndpointMissing,
-        chatHealthy,
-        llmHealthy,
+        chat: chatHealth,
+        llm: llmHealth,
         llmDetail,
         lastCheckedAt: startedAt,
+        lastFailedAt: success ? prev.lastFailedAt : startedAt,
         lastSuccessAt: success ? startedAt : prev.lastSuccessAt,
       }));
     } finally {
@@ -186,6 +392,7 @@ export function useRuntimeHealth(): RuntimeHealthStatus {
   const now = Date.now();
   const hasChecked = snapshot.lastCheckedAt != null;
   const lastSuccessAt = snapshot.lastSuccessAt;
+  const lastFailedAt = snapshot.lastFailedAt;
   const firstCheckAt = firstCheckAtRef.current;
   const stale =
     lastSuccessAt != null
@@ -203,9 +410,9 @@ export function useRuntimeHealth(): RuntimeHealthStatus {
     failureKind = RUNTIME_HEALTH_FAILURE_KINDS.BACKEND_UNREACHABLE;
   } else if (hasChecked && snapshot.healthEndpointMissing) {
     failureKind = RUNTIME_HEALTH_FAILURE_KINDS.HEALTH_ENDPOINT_MISSING;
-  } else if (hasChecked && snapshot.chatHealthy === false) {
+  } else if (hasChecked && snapshot.chat.derivedHealthy === false) {
     failureKind = RUNTIME_HEALTH_FAILURE_KINDS.CHAT_UNHEALTHY;
-  } else if (hasChecked && snapshot.llmHealthy === false) {
+  } else if (hasChecked && snapshot.llm.derivedHealthy === false) {
     failureKind = RUNTIME_HEALTH_FAILURE_KINDS.LLM_UNHEALTHY;
   } else if (liveEventsDisconnected) {
     failureKind = RUNTIME_HEALTH_FAILURE_KINDS.LIVE_EVENTS_DISCONNECTED;
@@ -213,19 +420,58 @@ export function useRuntimeHealth(): RuntimeHealthStatus {
     failureKind = RUNTIME_HEALTH_FAILURE_KINDS.STALE;
   }
 
+  const currentComputedStateSource: RuntimeHealthStateSource = hasChecked
+    ? stale
+      ? "cached"
+      : "live-poll"
+    : "fallback";
+  const desktopRuntimeAuthConfig = getDesktopRuntimeAuthConfig();
+  const resolvedApiBaseUrl = getRuntimeConfigSync().apiBaseUrl || null;
+  const runtimeDesktopKeyPresent = Boolean(
+    desktopRuntimeAuthConfig?.apiKeyPresent || readRuntimeApiKey()
+  );
+  const authSource = resolveRuntimeHealthAuthSource();
+  const apiKeyPresent = runtimeDesktopKeyPresent;
+  const diagnostics: RuntimeHealthDiagnostics = {
+    resolvedApiBaseUrl,
+    apiKeyPresent,
+    authSource,
+    chat: {
+      endpoint: snapshot.chat.endpoint,
+      httpStatus: snapshot.chat.httpStatus,
+      transportErrorClass: snapshot.chat.transportErrorClass,
+      parsedStatus: snapshot.chat.parsedStatus,
+      parsedOk: snapshot.chat.parsedOk,
+    },
+    llm: {
+      endpoint: snapshot.llm.endpoint,
+      httpStatus: snapshot.llm.httpStatus,
+      transportErrorClass: snapshot.llm.transportErrorClass,
+      parsedStatus: snapshot.llm.parsedStatus,
+      parsedOk: snapshot.llm.parsedOk,
+    },
+    failureKind,
+    lastSuccessAt,
+    lastFailedAt,
+    lastCheckedAt: snapshot.lastCheckedAt,
+    currentComputedStateSource,
+  };
+
   return {
     status: failureKind
       ? RUNTIME_HEALTH_STATUSES.DEGRADED
       : RUNTIME_HEALTH_STATUSES.HEALTHY,
     failureKind,
     backendReachable: snapshot.backendReachable,
-    chatHealthy: snapshot.chatHealthy,
-    llmHealthy: snapshot.llmHealthy,
+    chatHealthy: snapshot.chat.derivedHealthy,
+    llmHealthy: snapshot.llm.derivedHealthy,
     llmDetail: snapshot.llmDetail,
     liveEventsStatus: connectionStatus,
     lastSuccessAt,
+    lastFailedAt,
     lastCheckedAt: snapshot.lastCheckedAt,
     stale,
+    diagnostics,
   };
 }
 

--- a/frontend/src/test/api.desktop-auth.test.ts
+++ b/frontend/src/test/api.desktop-auth.test.ts
@@ -94,6 +94,32 @@ describe("desktop auth headers", () => {
     );
   });
 
+  it("keeps the runtime desktop key on the health poll path even when a bearer token is stale", async () => {
+    setAuthToken("stale-bearer-token");
+    setRuntimeApiKey("desktop-key");
+
+    let capturedHeaders: Record<string, string> = {};
+    api.defaults.adapter = async (config) => {
+      capturedHeaders = normalizeHeaders(config.headers);
+      return {
+        data: { ok: true, status: "healthy" },
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config,
+      };
+    };
+
+    await api.get("/health/chat");
+
+    expect(capturedHeaders["Authorization"] ?? capturedHeaders["authorization"]).toBe(
+      "Bearer stale-bearer-token"
+    );
+    expect(capturedHeaders["X-API-Key"] ?? capturedHeaders["x-api-key"]).toBe(
+      "desktop-key"
+    );
+  });
+
   it("fetchProviderState uses the authenticated desktop runtime client", async () => {
     setRuntimeApiKey("desktop-key");
 


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
