### PR TITLE
Codex/fix desktop auth gate mismatch

### DIFF
--- a/docs/architecture/config-and-ops.md
+++ b/docs/architecture/config-and-ops.md
@@ -174,6 +174,7 @@ Source anchors:
 - The proof image still ships a small set of non-source runtime files needed by startup, including supported-profile YAML and bundled help content.
 - Packaged desktop auth handoff now flows through a Tauri command that returns a sanitized runtime auth/config payload for the local packaged runtime. The frontend consumes the handed-off `GUARDIAN_API_KEY` only in packaged mode, while diagnostics expose only presence and source metadata such as `envPath`, `runtimeRoot`, and `failureKind`.
 - The Guardian auth gate now derives from the same in-memory runtime API key that the desktop API client uses, so packaged desktop mode can satisfy local auth without `VITE_GUARDIAN_API_KEY`; the legacy Vite env key remains a dev-only fallback.
+- Packaged desktop live updates use the same authenticated SSE request path as the rest of the runtime client. If the event stream disconnects while `/health/chat` and `/api/health/llm` are still green, the shell should surface that as a separate live-update transport warning rather than a provider-health degradation, and the technical details should show the observed endpoint, auth source, HTTP status or transport error class, and polling timestamps without revealing raw credentials.
 
 ## Config Resolution Order and Defaults
 

--- a/docs/architecture/flows.md
+++ b/docs/architecture/flows.md
@@ -20,6 +20,7 @@ Source anchors:
 
 Trigger:
 - Frontend posts `POST /api/chat/{thread_id}/complete` after a user message exists in the thread.
+- When the composer starts a brand-new conversation, the frontend first creates a backend thread, resolves the durable thread id from the response, selects that id, and only then posts the first user message to `POST /api/chat/{thread_id}/messages`.
 
 Sequence:
 1. `guardian/routes/chat.py` validates the thread, turn state, and effective identity depth.

--- a/docs/architecture/flows.md
+++ b/docs/architecture/flows.md
@@ -20,7 +20,7 @@ Source anchors:
 
 Trigger:
 - Frontend posts `POST /api/chat/{thread_id}/complete` after a user message exists in the thread.
-- When the composer starts a brand-new conversation, the frontend first creates a backend thread, resolves the durable thread id from the response, selects that id, and only then posts the first user message to `POST /api/chat/{thread_id}/messages`.
+- When the composer starts a brand-new conversation, the frontend first creates a backend thread with `POST /api/chat/threads`, resolves the durable thread id from the response, selects that id, and only then posts the first user message to `POST /api/chat/{thread_id}/messages`.
 
 Sequence:
 1. `guardian/routes/chat.py` validates the thread, turn state, and effective identity depth.

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -102,7 +102,7 @@ The configured provider is not the same thing as discovered provider inventory. 
 ### Chat completion path
 
 - Trigger: `POST /api/chat/{thread_id}/complete`
-- For first-send flows, the frontend now creates a backend thread first, resolves the returned durable thread id, and only then posts the first user message to `POST /api/chat/{thread_id}/messages` before queuing completion.
+- For first-send flows, the frontend now creates a backend thread first with `POST /api/chat/threads`, resolves the returned durable thread id, and only then posts the first user message to `POST /api/chat/{thread_id}/messages` before queuing completion.
 - Core sequence:
   - validate thread and depth context
   - acquire Redis turn lock

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -102,6 +102,7 @@ The configured provider is not the same thing as discovered provider inventory. 
 ### Chat completion path
 
 - Trigger: `POST /api/chat/{thread_id}/complete`
+- For first-send flows, the frontend now creates a backend thread first, resolves the returned durable thread id, and only then posts the first user message to `POST /api/chat/{thread_id}/messages` before queuing completion.
 - Core sequence:
   - validate thread and depth context
   - acquire Redis turn lock

--- a/frontend/src/components/persona/layout/AppShell.runtimeHealth.test.tsx
+++ b/frontend/src/components/persona/layout/AppShell.runtimeHealth.test.tsx
@@ -25,7 +25,11 @@ type RuntimeHealthMock = {
   stale: boolean;
   diagnostics: {
     resolvedApiBaseUrl: string | null;
+    resolvedApiBaseUrlSource: string;
     apiKeyPresent: boolean;
+    apiKeySource: string;
+    hydrationState: "pending" | "ready" | "failed";
+    nativeCommandStatus: string | null;
     authSource: string;
     chat: {
       endpoint: string;
@@ -51,6 +55,8 @@ type RuntimeHealthMock = {
       transportErrorClass: string | null;
       authSource: string;
       apiKeyPresent: boolean;
+      hydrationState: "pending" | "ready" | "failed";
+      nativeCommandStatus: string | null;
       reconnectAttempts: number;
       retryMs: number;
       subscribers: number;
@@ -80,7 +86,11 @@ const runtimeHealthState: RuntimeHealthMock = {
   stale: false,
   diagnostics: {
     resolvedApiBaseUrl: "http://127.0.0.1:8888/api",
+    resolvedApiBaseUrlSource: "runtime-desktop",
     apiKeyPresent: true,
+    apiKeySource: "runtime-desktop",
+    hydrationState: "ready",
+    nativeCommandStatus: "ready",
     authSource: "runtime-desktop",
     chat: {
       endpoint: "/health/chat",
@@ -106,6 +116,8 @@ const runtimeHealthState: RuntimeHealthMock = {
       transportErrorClass: null,
       authSource: "runtime-desktop",
       apiKeyPresent: true,
+      hydrationState: "ready",
+      nativeCommandStatus: "ready",
       reconnectAttempts: 0,
       retryMs: 1000,
       subscribers: 1,
@@ -130,7 +142,11 @@ vi.mock("@/hooks/useRuntimeHealth", () => ({
   formatRuntimeHealthDiagnostics: (diagnostics: typeof runtimeHealthState.diagnostics) =>
     [
       `resolved api base url=${diagnostics.resolvedApiBaseUrl ?? "<unresolved>"}`,
+      `resolved api base url source=${diagnostics.resolvedApiBaseUrlSource}`,
       `apiKeyPresent=${diagnostics.apiKeyPresent ? "true" : "false"}`,
+      `api key source=${diagnostics.apiKeySource}`,
+      `hydration state=${diagnostics.hydrationState}`,
+      `native command status=${diagnostics.nativeCommandStatus ?? "<unknown>"}`,
       `authSource=${diagnostics.authSource}`,
       `chat endpoint called=${diagnostics.chat.endpoint}`,
       `chat HTTP status=${diagnostics.chat.httpStatus ?? "<none>"}`,
@@ -160,6 +176,8 @@ vi.mock("@/hooks/useRuntimeHealth", () => ({
       `live events transport error class=${diagnostics.liveEvents.transportErrorClass ?? "<none>"}`,
       `live events authSource=${diagnostics.liveEvents.authSource}`,
       `live events apiKeyPresent=${diagnostics.liveEvents.apiKeyPresent ? "true" : "false"}`,
+      `live events hydration state=${diagnostics.liveEvents.hydrationState}`,
+      `live events native command status=${diagnostics.liveEvents.nativeCommandStatus ?? "<unknown>"}`,
       `live events reconnect attempts=${diagnostics.liveEvents.reconnectAttempts}`,
       `live events status updated=${diagnostics.liveEvents.statusUpdatedAt ?? "<none>"}`,
       `failureKind=${diagnostics.failureKind ?? "none"}`,
@@ -337,7 +355,11 @@ describe("AppShell runtime health banner", () => {
     routeCapabilityState.state = "available";
     runtimeHealthState.diagnostics = {
       resolvedApiBaseUrl: "http://127.0.0.1:8888/api",
+      resolvedApiBaseUrlSource: "runtime-desktop",
       apiKeyPresent: true,
+      apiKeySource: "runtime-desktop",
+      hydrationState: "ready",
+      nativeCommandStatus: "ready",
       authSource: "runtime-desktop",
       chat: {
         endpoint: "/health/chat",
@@ -363,6 +385,8 @@ describe("AppShell runtime health banner", () => {
         transportErrorClass: null,
         authSource: "runtime-desktop",
         apiKeyPresent: true,
+        hydrationState: "ready",
+        nativeCommandStatus: "ready",
         reconnectAttempts: 0,
         retryMs: 1000,
         subscribers: 1,
@@ -404,7 +428,11 @@ describe("AppShell runtime health banner", () => {
     runtimeHealthState.lastFailedAt = Date.parse("2026-03-20T11:54:30Z");
     runtimeHealthState.diagnostics = {
       resolvedApiBaseUrl: "http://127.0.0.1:8888/api",
+      resolvedApiBaseUrlSource: "runtime-desktop",
       apiKeyPresent: true,
+      apiKeySource: "runtime-desktop",
+      hydrationState: "ready",
+      nativeCommandStatus: "ready",
       authSource: "runtime-desktop",
       chat: {
         endpoint: "/health/chat",
@@ -430,6 +458,8 @@ describe("AppShell runtime health banner", () => {
         transportErrorClass: null,
         authSource: "runtime-desktop",
         apiKeyPresent: true,
+        hydrationState: "ready",
+        nativeCommandStatus: "ready",
         reconnectAttempts: 0,
         retryMs: 1000,
         subscribers: 1,
@@ -492,6 +522,8 @@ describe("AppShell runtime health banner", () => {
       transportErrorClass: null,
       authSource: "runtime-desktop",
       apiKeyPresent: true,
+      hydrationState: "ready",
+      nativeCommandStatus: "ready",
       reconnectAttempts: 0,
       retryMs: 1000,
       subscribers: 1,
@@ -525,6 +557,8 @@ describe("AppShell runtime health banner", () => {
       transportErrorClass: null,
       authSource: "runtime-desktop",
       apiKeyPresent: true,
+      hydrationState: "ready",
+      nativeCommandStatus: "ready",
       reconnectAttempts: 3,
       retryMs: 5000,
       subscribers: 1,
@@ -549,7 +583,11 @@ describe("AppShell runtime health banner", () => {
     runtimeHealthState.lastFailedAt = Date.parse("2026-03-20T11:54:30Z");
     runtimeHealthState.diagnostics = {
       resolvedApiBaseUrl: "http://127.0.0.1:8888/api",
+      resolvedApiBaseUrlSource: "runtime-desktop",
       apiKeyPresent: true,
+      apiKeySource: "runtime-desktop",
+      hydrationState: "ready",
+      nativeCommandStatus: "ready",
       authSource: "runtime-desktop",
       chat: {
         endpoint: "/health/chat",
@@ -575,6 +613,8 @@ describe("AppShell runtime health banner", () => {
         transportErrorClass: null,
         authSource: "runtime-desktop",
         apiKeyPresent: true,
+        hydrationState: "ready",
+        nativeCommandStatus: "ready",
         reconnectAttempts: 0,
         retryMs: 1000,
         subscribers: 1,

--- a/frontend/src/components/persona/layout/AppShell.runtimeHealth.test.tsx
+++ b/frontend/src/components/persona/layout/AppShell.runtimeHealth.test.tsx
@@ -41,6 +41,23 @@ type RuntimeHealthMock = {
       parsedStatus: string | null;
       parsedOk: boolean | null;
     };
+    liveEvents: {
+      endpoint: string | null;
+      connectionState: LiveEventConnectionState;
+      lastEventAt: number | null;
+      lastPingAt: number | null;
+      statusUpdatedAt: number | null;
+      lastHttpStatus: number | null;
+      transportErrorClass: string | null;
+      authSource: string;
+      apiKeyPresent: boolean;
+      reconnectAttempts: number;
+      retryMs: number;
+      subscribers: number;
+      readyState: 0 | 1 | 2;
+      lastErrorAt: number | null;
+      lastEventId: string | null;
+    };
     failureKind: RuntimeHealthFailureKindToken | "unknown" | null;
     lastSuccessAt: number | null;
     lastFailedAt: number | null;
@@ -79,6 +96,23 @@ const runtimeHealthState: RuntimeHealthMock = {
       parsedStatus: "online",
       parsedOk: true,
     },
+    liveEvents: {
+      endpoint: "http://127.0.0.1:8888/api/events",
+      connectionState: LIVE_EVENT_CONNECTION_STATES.CONNECTED,
+      lastEventAt: Date.parse("2026-03-20T11:59:58Z"),
+      lastPingAt: Date.parse("2026-03-20T11:59:58Z"),
+      statusUpdatedAt: Date.parse("2026-03-20T12:00:00Z"),
+      lastHttpStatus: 200,
+      transportErrorClass: null,
+      authSource: "runtime-desktop",
+      apiKeyPresent: true,
+      reconnectAttempts: 0,
+      retryMs: 1000,
+      subscribers: 1,
+      readyState: 1,
+      lastErrorAt: null,
+      lastEventId: "evt-1",
+    },
     failureKind: null,
     lastSuccessAt: Date.parse("2026-03-20T12:00:00Z"),
     lastFailedAt: null,
@@ -115,9 +149,19 @@ vi.mock("@/hooks/useRuntimeHealth", () => ({
         diagnostics.llm.parsedOk == null
           ? "<unknown>"
           : diagnostics.llm.parsedOk
-            ? "true"
-            : "false"
+          ? "true"
+          : "false"
       }`,
+      `live events endpoint called=${diagnostics.liveEvents.endpoint ?? "<unresolved>"}`,
+      `live events connection state=${diagnostics.liveEvents.connectionState}`,
+      `live events last event=${diagnostics.liveEvents.lastEventAt ?? "<none>"}`,
+      `live events last ping=${diagnostics.liveEvents.lastPingAt ?? "<none>"}`,
+      `live events HTTP status=${diagnostics.liveEvents.lastHttpStatus ?? "<none>"}`,
+      `live events transport error class=${diagnostics.liveEvents.transportErrorClass ?? "<none>"}`,
+      `live events authSource=${diagnostics.liveEvents.authSource}`,
+      `live events apiKeyPresent=${diagnostics.liveEvents.apiKeyPresent ? "true" : "false"}`,
+      `live events reconnect attempts=${diagnostics.liveEvents.reconnectAttempts}`,
+      `live events status updated=${diagnostics.liveEvents.statusUpdatedAt ?? "<none>"}`,
       `failureKind=${diagnostics.failureKind ?? "none"}`,
       `last successful health poll=${diagnostics.lastSuccessAt ?? "<none>"}`,
       `last failed health poll=${diagnostics.lastFailedAt ?? "<none>"}`,
@@ -309,6 +353,23 @@ describe("AppShell runtime health banner", () => {
         parsedStatus: "online",
         parsedOk: true,
       },
+      liveEvents: {
+        endpoint: "http://127.0.0.1:8888/api/events",
+        connectionState: LIVE_EVENT_CONNECTION_STATES.CONNECTED,
+        lastEventAt: Date.parse("2026-03-20T11:59:58Z"),
+        lastPingAt: Date.parse("2026-03-20T11:59:58Z"),
+        statusUpdatedAt: Date.parse("2026-03-20T12:00:00Z"),
+        lastHttpStatus: 200,
+        transportErrorClass: null,
+        authSource: "runtime-desktop",
+        apiKeyPresent: true,
+        reconnectAttempts: 0,
+        retryMs: 1000,
+        subscribers: 1,
+        readyState: 1,
+        lastErrorAt: null,
+        lastEventId: "evt-1",
+      },
       failureKind: null,
       lastSuccessAt: Date.parse("2026-03-20T12:00:00Z"),
       lastFailedAt: null,
@@ -359,6 +420,23 @@ describe("AppShell runtime health banner", () => {
         parsedStatus: "online",
         parsedOk: true,
       },
+      liveEvents: {
+        endpoint: "http://127.0.0.1:8888/api/events",
+        connectionState: LIVE_EVENT_CONNECTION_STATES.CONNECTED,
+        lastEventAt: Date.parse("2026-03-20T11:59:58Z"),
+        lastPingAt: Date.parse("2026-03-20T11:59:58Z"),
+        statusUpdatedAt: Date.parse("2026-03-20T12:00:00Z"),
+        lastHttpStatus: 200,
+        transportErrorClass: null,
+        authSource: "runtime-desktop",
+        apiKeyPresent: true,
+        reconnectAttempts: 0,
+        retryMs: 1000,
+        subscribers: 1,
+        readyState: 1,
+        lastErrorAt: null,
+        lastEventId: "evt-1",
+      },
       failureKind: RUNTIME_HEALTH_FAILURE_KINDS.BACKEND_UNREACHABLE,
       lastSuccessAt: Date.parse("2026-03-20T11:55:00Z"),
       lastFailedAt: Date.parse("2026-03-20T11:54:30Z"),
@@ -404,6 +482,23 @@ describe("AppShell runtime health banner", () => {
       parsedStatus: "offline",
       parsedOk: false,
     };
+    runtimeHealthState.diagnostics.liveEvents = {
+      endpoint: "http://127.0.0.1:8888/api/events",
+      connectionState: LIVE_EVENT_CONNECTION_STATES.CONNECTED,
+      lastEventAt: Date.parse("2026-03-20T11:59:58Z"),
+      lastPingAt: Date.parse("2026-03-20T11:59:58Z"),
+      statusUpdatedAt: Date.parse("2026-03-20T12:00:00Z"),
+      lastHttpStatus: 200,
+      transportErrorClass: null,
+      authSource: "runtime-desktop",
+      apiKeyPresent: true,
+      reconnectAttempts: 0,
+      retryMs: 1000,
+      subscribers: 1,
+      readyState: 1,
+      lastErrorAt: null,
+      lastEventId: "evt-1",
+    };
 
     render(<AppShell />);
 
@@ -413,6 +508,37 @@ describe("AppShell runtime health banner", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(/MiniMax live discovery unavailable/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders a live updates warning without calling the provider degraded when chat and llm are healthy", () => {
+    runtimeHealthState.status = RUNTIME_HEALTH_STATUSES.HEALTHY;
+    runtimeHealthState.failureKind = null;
+    runtimeHealthState.diagnostics.failureKind = null;
+    runtimeHealthState.diagnostics.liveEvents = {
+      endpoint: "http://127.0.0.1:8888/api/events",
+      connectionState: LIVE_EVENT_CONNECTION_STATES.DISCONNECTED,
+      lastEventAt: Date.parse("2026-03-20T11:45:00Z"),
+      lastPingAt: Date.parse("2026-03-20T11:45:00Z"),
+      statusUpdatedAt: Date.parse("2026-03-20T11:45:00Z"),
+      lastHttpStatus: 200,
+      transportErrorClass: null,
+      authSource: "runtime-desktop",
+      apiKeyPresent: true,
+      reconnectAttempts: 3,
+      retryMs: 5000,
+      subscribers: 1,
+      readyState: 2,
+      lastErrorAt: Date.parse("2026-03-20T11:46:00Z"),
+      lastEventId: "evt-2",
+    };
+
+    render(<AppShell />);
+
+    expect(screen.getByText(/Live updates disconnected/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Provider degraded/i)).toBeNull();
+    expect(
+      screen.getByText(/live events connection state=disconnected/i)
     ).toBeInTheDocument();
   });
 
@@ -439,6 +565,23 @@ describe("AppShell runtime health banner", () => {
         parsedStatus: "online",
         parsedOk: true,
       },
+      liveEvents: {
+        endpoint: "http://127.0.0.1:8888/api/events",
+        connectionState: LIVE_EVENT_CONNECTION_STATES.CONNECTED,
+        lastEventAt: Date.parse("2026-03-20T11:59:58Z"),
+        lastPingAt: Date.parse("2026-03-20T11:59:58Z"),
+        statusUpdatedAt: Date.parse("2026-03-20T12:00:00Z"),
+        lastHttpStatus: 200,
+        transportErrorClass: null,
+        authSource: "runtime-desktop",
+        apiKeyPresent: true,
+        reconnectAttempts: 0,
+        retryMs: 1000,
+        subscribers: 1,
+        readyState: 1,
+        lastErrorAt: null,
+        lastEventId: "evt-1",
+      },
       failureKind: RUNTIME_HEALTH_FAILURE_KINDS.CHAT_UNHEALTHY,
       lastSuccessAt: Date.parse("2026-03-20T11:55:00Z"),
       lastFailedAt: Date.parse("2026-03-20T11:54:30Z"),
@@ -452,8 +595,10 @@ describe("AppShell runtime health banner", () => {
     expect(
       screen.getByText(/resolved api base url=http:\/\/127\.0\.0\.1:8888\/api/i)
     ).toBeInTheDocument();
-    expect(screen.getByText(/apiKeyPresent=true/i)).toBeInTheDocument();
-    expect(screen.getByText(/authSource=runtime-desktop/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/^apiKeyPresent=true$/i)[0]).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/^authSource=runtime-desktop$/i)[0]
+    ).toBeInTheDocument();
     expect(screen.getByText(/chat endpoint called=\/health\/chat/i)).toBeInTheDocument();
     expect(screen.getByText(/llm endpoint called=\/api\/health\/llm/i)).toBeInTheDocument();
     expect(screen.getByText(/failureKind=chat_unhealthy/i)).toBeInTheDocument();

--- a/frontend/src/components/persona/layout/AppShell.tsx
+++ b/frontend/src/components/persona/layout/AppShell.tsx
@@ -56,6 +56,7 @@ import useRuntimeHealth, {
 import { useViewportInsets } from "@/hooks/useViewportInsets";
 import {
   describeProviderState,
+  LIVE_EVENT_CONNECTION_STATES,
   PROVIDER_RUNTIME_STATES,
   RUNTIME_HEALTH_FAILURE_KINDS,
   RUNTIME_HEALTH_STATUSES,
@@ -2427,6 +2428,7 @@ export default function AppShell({
   const runtimeDegraded =
     runtimeHealth.status === RUNTIME_HEALTH_STATUSES.DEGRADED;
   const runtimeFailureKind = runtimeHealth.failureKind ?? "unknown";
+  const now = Date.now();
   const runtimeDetail =
     typeof process !== "undefined" &&
     process.env &&
@@ -2436,6 +2438,15 @@ export default function AppShell({
       : null;
   const runtimeDiagnosticLines =
     runtimeHealth.status === RUNTIME_HEALTH_STATUSES.DEGRADED
+      ? formatRuntimeHealthDiagnostics(runtimeHealth.diagnostics)
+      : [];
+  const liveUpdatesDisconnected =
+    runtimeHealth.diagnostics.liveEvents.connectionState ===
+      LIVE_EVENT_CONNECTION_STATES.DISCONNECTED &&
+    typeof runtimeHealth.diagnostics.liveEvents.statusUpdatedAt === "number" &&
+    now - runtimeHealth.diagnostics.liveEvents.statusUpdatedAt > 45_000;
+  const liveUpdateDiagnosticLines =
+    !runtimeDegraded && liveUpdatesDisconnected
       ? formatRuntimeHealthDiagnostics(runtimeHealth.diagnostics)
       : [];
 
@@ -2885,6 +2896,43 @@ export default function AppShell({
           </div>
         </div>
       )}
+      {liveUpdatesDisconnected && !runtimeDegraded ? (
+        <div className="relative z-10 w-full mt-3">
+          <div
+            className="flex w-full flex-col gap-1 rounded-[14px] border px-4 py-2 text-xs sm:text-sm"
+            style={{
+              borderColor: "var(--panel-border)",
+              background:
+                "color-mix(in oklab, var(--panel-bg) 92%, transparent)",
+              color: "var(--text)",
+            }}
+          >
+            <div className="flex items-center justify-between gap-3">
+              <span className="font-semibold tracking-wide">
+                Live updates disconnected
+              </span>
+              <span className="opacity-80">
+                state: {runtimeHealth.diagnostics.liveEvents.connectionState}
+              </span>
+            </div>
+            <div className="text-[11px] opacity-75" style={{ color: "var(--muted)" }}>
+              Guardian is healthy, but the live event stream has not stayed connected.
+            </div>
+            {liveUpdateDiagnosticLines.length > 0 ? (
+              <details className="mt-1 rounded-md border border-dashed border-[color:var(--panel-border)] px-2 py-1 text-[11px]">
+                <summary className="cursor-pointer select-none opacity-80">
+                  Technical details
+                </summary>
+                <div className="mt-2 flex flex-col gap-1 font-mono text-[10px] leading-4 opacity-85">
+                  {liveUpdateDiagnosticLines.map((line) => (
+                    <div key={line}>{line}</div>
+                  ))}
+                </div>
+              </details>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
 
       {/* ─────────────────────────────────────────────────────────────────────────────
           📺 SECTION: Main Content Area

--- a/frontend/src/components/persona/layout/AppShell.tsx
+++ b/frontend/src/components/persona/layout/AppShell.tsx
@@ -2426,8 +2426,10 @@ export default function AppShell({
     : "flex h-full min-h-0 w-full items-stretch gap-[var(--gutter)]";
 
   const runtimeDegraded =
-    runtimeHealth.status === RUNTIME_HEALTH_STATUSES.DEGRADED;
+    runtimeHealth.status === RUNTIME_HEALTH_STATUSES.DEGRADED &&
+    runtimeHealth.diagnostics.hydrationState !== "pending";
   const runtimeFailureKind = runtimeHealth.failureKind ?? "unknown";
+  const runtimeHydrationState = runtimeHealth.diagnostics.hydrationState;
   const now = Date.now();
   const runtimeDetail =
     typeof process !== "undefined" &&
@@ -2451,7 +2453,9 @@ export default function AppShell({
       : [];
 
   const providerRuntimeState: ProviderRuntimeState =
-    runtimeHealth.backendReachable === false
+    runtimeHydrationState === "pending"
+      ? PROVIDER_RUNTIME_STATES.ONLINE
+      : runtimeHealth.backendReachable === false
       ? PROVIDER_RUNTIME_STATES.OFFLINE
       : PROVIDER_RUNTIME_STATES.DEGRADED;
 

--- a/frontend/src/components/persona/layout/__tests__/GuardianChatWithSidebar.stability.test.tsx
+++ b/frontend/src/components/persona/layout/__tests__/GuardianChatWithSidebar.stability.test.tsx
@@ -48,11 +48,15 @@ const runtimeAuthState = vi.hoisted(() => ({
 }));
 const runtimeHealthState = vi.hoisted(() => ({
   status: "healthy" as const,
-  diagnostics: null as
+    diagnostics: null as
     | null
     | {
         resolvedApiBaseUrl: string | null;
+        resolvedApiBaseUrlSource: string;
         apiKeyPresent: boolean;
+        apiKeySource: string;
+        hydrationState: "pending" | "ready" | "failed";
+        nativeCommandStatus: string | null;
         authSource: string;
         chat: {
           endpoint: string;
@@ -67,6 +71,25 @@ const runtimeHealthState = vi.hoisted(() => ({
           transportErrorClass: string | null;
           parsedStatus: string | null;
           parsedOk: boolean | null;
+        };
+        liveEvents: {
+          endpoint: string | null;
+          connectionState: string;
+          lastEventAt: number | null;
+          lastPingAt: number | null;
+          statusUpdatedAt: number | null;
+          lastHttpStatus: number | null;
+          transportErrorClass: string | null;
+          authSource: string;
+          apiKeyPresent: boolean;
+          hydrationState: "pending" | "ready" | "failed";
+          nativeCommandStatus: string | null;
+          reconnectAttempts: number;
+          retryMs: number;
+          subscribers: number;
+          readyState: 0 | 1 | 2;
+          lastErrorAt: number | null;
+          lastEventId: string | null;
         };
         failureKind: string | null;
         lastSuccessAt: number | null;
@@ -95,7 +118,11 @@ vi.mock("@/features/chat/GuardianChat", () => ({
           <div data-testid="runtime-health-diagnostics">
             {[
               `resolvedApiBaseUrl=${String(props.runtimeHealth.diagnostics.resolvedApiBaseUrl ?? "")}`,
+              `resolvedApiBaseUrlSource=${String(props.runtimeHealth.diagnostics.resolvedApiBaseUrlSource ?? "")}`,
               `apiKeyPresent=${props.runtimeHealth.diagnostics.apiKeyPresent ? "true" : "false"}`,
+              `apiKeySource=${String(props.runtimeHealth.diagnostics.apiKeySource ?? "")}`,
+              `hydrationState=${String(props.runtimeHealth.diagnostics.hydrationState ?? "")}`,
+              `nativeCommandStatus=${String(props.runtimeHealth.diagnostics.nativeCommandStatus ?? "")}`,
               `authSource=${String(props.runtimeHealth.diagnostics.authSource ?? "")}`,
               `chatEndpoint=${String(props.runtimeHealth.diagnostics.chat.endpoint ?? "")}`,
               `chatStatus=${String(props.runtimeHealth.diagnostics.chat.parsedStatus ?? "")}`,
@@ -150,7 +177,11 @@ vi.mock("@/hooks/useRuntimeHealth", () => ({
   default: () => runtimeHealthState,
   formatRuntimeHealthDiagnostics: (diagnostics: any) => [
     `resolved api base url=${diagnostics.resolvedApiBaseUrl ?? "<unresolved>"}`,
+    `resolved api base url source=${diagnostics.resolvedApiBaseUrlSource ?? "<unknown>"}`,
     `apiKeyPresent=${diagnostics.apiKeyPresent ? "true" : "false"}`,
+    `api key source=${diagnostics.apiKeySource ?? "<unknown>"}`,
+    `hydration state=${diagnostics.hydrationState ?? "<unknown>"}`,
+    `native command status=${diagnostics.nativeCommandStatus ?? "<unknown>"}`,
     `authSource=${diagnostics.authSource}`,
     `chat endpoint called=${diagnostics.chat.endpoint}`,
     `parsed chat health status=${diagnostics.chat.parsedStatus ?? "<none>"}`,
@@ -1100,7 +1131,11 @@ describe("GuardianChatWithSidebar auth banner", () => {
     runtimeHealthState.status = "degraded";
     runtimeHealthState.diagnostics = {
       resolvedApiBaseUrl: "http://127.0.0.1:8888/api",
+      resolvedApiBaseUrlSource: "runtime-desktop",
       apiKeyPresent: true,
+      apiKeySource: "runtime-desktop",
+      hydrationState: "ready",
+      nativeCommandStatus: "ready",
       authSource: "runtime-desktop",
       chat: {
         endpoint: "/health/chat",
@@ -1115,6 +1150,25 @@ describe("GuardianChatWithSidebar auth banner", () => {
         transportErrorClass: null,
         parsedStatus: "online",
         parsedOk: true,
+      },
+      liveEvents: {
+        endpoint: "http://127.0.0.1:8888/api/events",
+        connectionState: "connected",
+        lastEventAt: Date.parse("2026-03-20T11:59:58.000Z"),
+        lastPingAt: Date.parse("2026-03-20T11:59:58.000Z"),
+        statusUpdatedAt: Date.parse("2026-03-20T12:00:00.000Z"),
+        lastHttpStatus: 200,
+        transportErrorClass: null,
+        authSource: "runtime-desktop",
+        apiKeyPresent: true,
+        hydrationState: "ready",
+        nativeCommandStatus: "ready",
+        reconnectAttempts: 0,
+        retryMs: 1000,
+        subscribers: 1,
+        readyState: 1,
+        lastErrorAt: null,
+        lastEventId: "evt-1",
       },
       failureKind: "chat_unhealthy",
       lastSuccessAt: Date.parse("2026-03-20T12:00:00.000Z"),

--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -67,6 +67,8 @@ import type { SessionTab, TabId } from "@/state/session/types";
 import type { RagTraceResponse } from "@/types/rag";
 import { fetchSystemPromptSummary, type PromptCostStatus, type SystemPromptSummary } from "@/imprint/api";
 import { logOnce } from "@/lib/logging/logOnce";
+import { useAuthState } from "@/lib/authState";
+import { getRuntimeConfigHydrationState } from "@/lib/runtimeConfig";
 import {
   describeModelCapability,
   isChatSelectableModel,
@@ -720,6 +722,7 @@ export function GuardianChat({
   onSessionInferenceModeChange?: (mode: ComposerInferenceMode) => void;
   onSessionDraftChange?: (text: string) => void;
 }) {
+  const auth = useAuthState();
   // RAG depth selector: User's control of perceptual awareness
   const [depth, setDepth] = useState<DepthMode>("normal");
   const [sourceMode, setSourceMode] = useState<SourceMode>(() =>
@@ -2555,6 +2558,21 @@ export function GuardianChat({
       bodyText: string,
       options?: { tabId?: TabId | null }
     ): Promise<number | null> => {
+      const hydrationState = getRuntimeConfigHydrationState();
+      if (hydrationState === "pending") {
+        showToast("Local runtime is still hydrating. Try again in a moment.");
+        return null;
+      }
+      if (hydrationState === "failed") {
+        showToast(
+          "Local runtime handoff failed. Open desktop diagnostics and retry."
+        );
+        return null;
+      }
+      if (!auth.ready) {
+        showToast("Authentication is not ready yet.");
+        return null;
+      }
       if (effectiveThreadId != null) {
         return effectiveThreadId;
       }
@@ -2613,13 +2631,13 @@ export function GuardianChat({
           tabId: originTabId,
         });
         return resolution.threadId;
-      } catch (error) {
-        console.error("[guardian] thread creation failed", error);
-        showToast("Failed to create thread.");
-        return null;
-      }
+    } catch (error) {
+      console.error("[guardian] thread creation failed", error);
+      showToast("Failed to create thread.");
+      return null;
+    }
     },
-    [effectiveThreadId, handleThreadCreated, showToast]
+    [auth.ready, effectiveThreadId, handleThreadCreated, showToast]
   );
 
   const ensureThreadIdForAttachments = useCallback(
@@ -2729,6 +2747,21 @@ export function GuardianChat({
      * title becomes the thread's identity in the distributed awareness network.
      */
     const normalizedUserId = CANONICAL_SINGLE_USER_ID;
+    const hydrationState = getRuntimeConfigHydrationState();
+    if (hydrationState === "pending") {
+      showToast("Local runtime is still hydrating. Try again in a moment.");
+      return;
+    }
+    if (hydrationState === "failed") {
+      showToast(
+        "Local runtime handoff failed. Open desktop diagnostics and retry."
+      );
+      return;
+    }
+    if (!auth.ready) {
+      showToast("Authentication is not ready yet.");
+      return;
+    }
     const targetThreadId = options?.threadIdOverride ?? effectiveThreadId;
     const requestedProfileId = resolveProfileIdFromCommand(text);
     const isProfileCommand =

--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -34,6 +34,7 @@ import {
 import ChatView from "@/features/chat/ChatView";
 import useChat from "@/features/chat/useChat";
 import api, {
+  buildChatThreadsPath,
   buildChatCompletePath,
   clearInFlightCompletionTurnId,
   formatThreadIdResolutionDiagnostics,
@@ -2565,16 +2566,17 @@ export function GuardianChat({
       const metadata = originTabId
         ? { draft_tab_id: originTabId }
         : undefined;
+      const createThreadEndpoint = buildChatThreadsPath();
 
       try {
-        const resp = await api.post("/chat/threads", {
+        const resp = await api.post(createThreadEndpoint, {
           title: provisionalTitle,
           user_id: normalizedUserId,
           metadata,
         });
         const response = resp ?? {};
         const resolution = resolveBackendThreadIdFromResponse(response, {
-          endpoint: "POST /chat/threads",
+          endpoint: `POST ${createThreadEndpoint}`,
           method: "POST",
           status:
             typeof response?.status === "number" &&

--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -36,9 +36,13 @@ import useChat from "@/features/chat/useChat";
 import api, {
   buildChatCompletePath,
   clearInFlightCompletionTurnId,
+  formatThreadIdResolutionDiagnostics,
   getInFlightCompletionTurnId,
+  hasRequestAuthCredential,
   invokeCommandBus,
   moveChatThread,
+  resolveBackendThreadIdFromResponse,
+  type ThreadIdResolutionDiagnostics,
   updateThreadConfig,
   OptionalSurfaceError,
 } from "@/lib/api";
@@ -846,6 +850,7 @@ export function GuardianChat({
     return () => window.removeEventListener("cfy:composer:prefill", onPrefill as EventListener);
   }, []);
   const [currentThreadId, setCurrentThreadId] = useState<number | null>(null);
+  const [threadCreationIssue, setThreadCreationIssue] = useState<ThreadIdResolutionDiagnostics | null>(null);
   const [chatReloadVersion, setChatReloadVersion] = useState(0);
   const [composerShellReserve, setComposerShellReserve] = useState(160);
   const [threadTitle, setThreadTitle] = useState<string>(activeThread?.title ?? NEW_THREAD_TITLE);
@@ -1682,6 +1687,20 @@ export function GuardianChat({
     effectiveThreadIdRef.current = effectiveThreadId;
   }, [effectiveThreadId]);
 
+  useEffect(() => {
+    if (effectiveThreadId != null && threadCreationIssue) {
+      setThreadCreationIssue(null);
+    }
+  }, [effectiveThreadId, threadCreationIssue]);
+
+  const threadCreationIssueLines = useMemo(
+    () =>
+      threadCreationIssue
+        ? formatThreadIdResolutionDiagnostics(threadCreationIssue)
+        : [],
+    [threadCreationIssue]
+  );
+
   useLayoutEffect(() => {
     sourceScopeKeyRef.current = sourceScopeKey;
     if (persistedThreadConfig) {
@@ -2503,44 +2522,6 @@ export function GuardianChat({
     releaseTurnLease,
   ]);
 
-  function extractThreadIdFromResponsePayload(payload: unknown): number | null {
-    if (typeof payload === "number" && Number.isFinite(payload)) {
-      return payload;
-    }
-    if (typeof payload === "string") {
-      const parsed = Number(payload.trim());
-      return Number.isFinite(parsed) ? parsed : null;
-    }
-    if (!payload || typeof payload !== "object") {
-      return null;
-    }
-
-    const source = payload as Record<string, unknown>;
-    const thread =
-      source.thread && typeof source.thread === "object"
-        ? (source.thread as Record<string, unknown>)
-        : null;
-    const message =
-      source.message && typeof source.message === "object"
-        ? (source.message as Record<string, unknown>)
-        : null;
-    const rawId =
-      source.thread_id ??
-      source.threadId ??
-      source.created_thread_id ??
-      source.createdThreadId ??
-      thread?.id ??
-      thread?.thread_id ??
-      thread?.threadId ??
-      thread?.id_str ??
-      message?.thread_id ??
-      message?.threadId ??
-      source.id ??
-      source.id_str;
-    const numericId = Number(rawId);
-    return Number.isFinite(numericId) ? numericId : null;
-  }
-
   // Auto-thread creation handler
   const handleThreadCreated = (
     threadId: number,
@@ -2568,41 +2549,80 @@ export function GuardianChat({
     }
   };
 
-  const ensureThreadIdForAttachments = useCallback(
-    async (bodyText: string) => {
+  const createThreadFromComposer = useCallback(
+    async (
+      bodyText: string,
+      options?: { tabId?: TabId | null }
+    ): Promise<number | null> => {
       if (effectiveThreadId != null) {
         return effectiveThreadId;
       }
 
       const normalizedUserId = CANONICAL_SINGLE_USER_ID;
-      const originTabId = activeSessionTabIdRef.current;
+      const originTabId = options?.tabId ?? activeSessionTabIdRef.current;
       const firstLine = bodyText.trim().split(/\n+/)[0] ?? "";
       const provisionalTitle = firstLine.slice(0, 60) || NEW_THREAD_TITLE;
       const metadata = originTabId
         ? { draft_tab_id: originTabId }
         : undefined;
 
-      const resp = await api.post("/chat/threads", {
-        title: provisionalTitle,
-        user_id: normalizedUserId,
-        metadata,
-      });
-      const payload = (resp && resp.data) || {};
-      const numericThreadId = extractThreadIdFromResponsePayload(payload);
-      if (numericThreadId == null) {
-        throw new Error("Thread id missing from create thread response");
-      }
+      try {
+        const resp = await api.post("/chat/threads", {
+          title: provisionalTitle,
+          user_id: normalizedUserId,
+          metadata,
+        });
+        const response = resp ?? {};
+        const resolution = resolveBackendThreadIdFromResponse(response, {
+          endpoint: "POST /chat/threads",
+          method: "POST",
+          status:
+            typeof response?.status === "number" &&
+            Number.isFinite(response.status)
+              ? response.status
+              : null,
+          authPresent: hasRequestAuthCredential(),
+        });
+        if (resolution.threadId == null) {
+          setThreadCreationIssue(resolution.diagnostics);
+          console.warn(
+            "[guardian] thread creation response missing thread id",
+            resolution.diagnostics
+          );
+          showToast("Thread id missing from response");
+          return null;
+        }
 
-      const derivedTitle = payload.thread?.title ?? provisionalTitle;
-      handleThreadCreated(numericThreadId, derivedTitle, {
-        tabId: originTabId,
-      });
-      onThreadPersisted?.(numericThreadId, derivedTitle, {
-        tabId: originTabId,
-      });
-      return numericThreadId;
+        setThreadCreationIssue(null);
+        const payload =
+          response?.data && typeof response.data === "object" && !Array.isArray(response.data)
+            ? (response.data as Record<string, unknown>)
+            : {};
+        const thread =
+          payload.thread && typeof payload.thread === "object"
+            ? (payload.thread as Record<string, unknown>)
+            : null;
+        const derivedTitle =
+          typeof thread?.title === "string" && thread.title.trim().length > 0
+            ? thread.title.trim()
+            : provisionalTitle;
+
+        handleThreadCreated(resolution.threadId, derivedTitle, {
+          tabId: originTabId,
+        });
+        return resolution.threadId;
+      } catch (error) {
+        console.error("[guardian] thread creation failed", error);
+        showToast("Failed to create thread.");
+        return null;
+      }
     },
-    [effectiveThreadId, onThreadPersisted]
+    [effectiveThreadId, handleThreadCreated, showToast]
+  );
+
+  const ensureThreadIdForAttachments = useCallback(
+    async (bodyText: string) => createThreadFromComposer(bodyText),
+    [createThreadFromComposer]
   );
 
   const handleBranchThread = async () => {
@@ -2618,7 +2638,16 @@ export function GuardianChat({
       const payload = trimmedTitle ? { title: trimmedTitle } : {};
       const res = await api.post(`/chat/${effectiveThreadId}/branch`, payload);
       const data = res?.data ?? {};
-      const newThreadId = extractThreadIdFromResponsePayload(data);
+      const resolution = resolveBackendThreadIdFromResponse(data, {
+        endpoint: `POST /chat/${effectiveThreadId}/branch`,
+        method: "POST",
+        status:
+          typeof res?.status === "number" && Number.isFinite(res.status)
+            ? res.status
+            : null,
+        authPresent: hasRequestAuthCredential(),
+      });
+      const newThreadId = resolution.threadId;
       if (newThreadId == null) {
         throw new Error("Branch response missing thread id");
       }
@@ -2698,7 +2727,6 @@ export function GuardianChat({
      * title becomes the thread's identity in the distributed awareness network.
      */
     const normalizedUserId = CANONICAL_SINGLE_USER_ID;
-    const originTabId = activeSessionTabIdRef.current;
     const targetThreadId = options?.threadIdOverride ?? effectiveThreadId;
     const requestedProfileId = resolveProfileIdFromCommand(text);
     const isProfileCommand =
@@ -2763,50 +2791,43 @@ export function GuardianChat({
       activeDocumentTiles
     );
     if (!targetThreadId) {
-      const firstLine = text.trim().split(/\n+/)[0] ?? "";
-      const provisionalTitle = firstLine.slice(0, 60) || NEW_THREAD_TITLE;
       let createdThreadId: number | null = null;
       setPendingTurnLock(true);
       try {
-        const resp = await api.post("/chat/messages", {
-          thread_id: null,
-          draft_tab_id: originTabId ?? undefined,
+        createdThreadId = await createThreadFromComposer(contentForSend);
+        if (createdThreadId == null) {
+          setPendingTurnLock(false);
+          return;
+        }
+        await activateThread(createdThreadId);
+
+        await api.post(`/chat/${createdThreadId}/messages`, {
           role: "user",
           content: contentForSend,
           user_id: normalizedUserId,
-          title: provisionalTitle,
           project_id: workspaceProjectId ?? undefined,
         });
-        const th = (resp && resp.data) || {};
-        const numericNewId = extractThreadIdFromResponsePayload(th);
-        if (numericNewId == null) {
-          console.warn("Unexpected create-on-send response:", th);
-          throw new Error("Thread id missing from response");
-        }
-        createdThreadId = numericNewId;
-        const derivedTitle = th.thread?.title ?? provisionalTitle;
-        handleThreadCreated(numericNewId, derivedTitle, {
-          tabId: originTabId,
+
+        emitThreadsRefresh("refresh", {
+          reason: "message",
+          id: String(createdThreadId),
         });
-        await activateThread(numericNewId);
-        onThreadPersisted?.(numericNewId, derivedTitle, {
-          tabId: originTabId,
-        });
+        setChatReloadVersion((v) => v + 1);
 
         // Lock the new thread before requesting assistant completion.
-        setTurnLockForThread(numericNewId, true);
+        setTurnLockForThread(createdThreadId, true);
         setPendingTurnLock(false);
 
         // Remove draft only after successful commit.
         if (typeof window !== "undefined") {
-          sessionStorage.removeItem(`${DRAFT_KEY_PREFIX}${numericNewId}`);
+          sessionStorage.removeItem(`${DRAFT_KEY_PREFIX}${createdThreadId}`);
         }
 
         // Complete the thread and refresh.
-        startInferenceForThread(numericNewId);
-        const completionOutcome = await completeThread(numericNewId, options);
+        startInferenceForThread(createdThreadId);
+        const completionOutcome = await completeThread(createdThreadId, options);
         if (completionOutcome !== "ok" && completionOutcome !== "inflight") {
-          setTurnLockForThread(numericNewId, false);
+          setTurnLockForThread(createdThreadId, false);
           if (completionOutcome === "failed") {
             throw new Error("Assistant response failed.");
           }
@@ -3316,6 +3337,34 @@ export function GuardianChat({
           ) : null}
         </div>
       )}
+
+      {threadCreationIssue ? (
+        <div
+          data-testid="thread-id-resolution-banner"
+          className={`mt-2 rounded-lg border px-3 py-2 text-xs ${CHAT_LANE_STAGE_GUTTER_CLASS}`}
+          style={{
+            borderColor: "var(--panel-border)",
+            color: "var(--text)",
+            background:
+              "color-mix(in oklab, var(--panel-bg) 88%, #f59e0b 12%)",
+          }}
+        >
+          <div className="font-semibold">Thread id missing from response</div>
+          <div className="mt-1 opacity-90">
+            Guardian could not resolve a durable thread id from the backend response.
+          </div>
+          <details className="mt-2 rounded-md border border-dashed border-[color:var(--panel-border)] px-2 py-1 text-[11px]">
+            <summary className="cursor-pointer select-none opacity-80">
+              Technical details
+            </summary>
+            <div className="mt-2 flex flex-col gap-1 font-mono text-[10px] leading-4 opacity-85">
+              {threadCreationIssueLines.map((line) => (
+                <div key={line}>{line}</div>
+              ))}
+            </div>
+          </details>
+        </div>
+      ) : null}
 
       {/* Messages region - Flex 1, scrolls independently */}
       <div className="relative flex flex-col flex-1 min-h-0 overflow-hidden">

--- a/frontend/src/features/chat/__tests__/GuardianChat.test.tsx
+++ b/frontend/src/features/chat/__tests__/GuardianChat.test.tsx
@@ -40,6 +40,12 @@ const composerState = vi.hoisted(() => ({
     | null,
 }));
 
+const authState = vi.hoisted(() => ({
+  ready: true,
+  status: "authenticated" as const,
+  token: "test-token",
+}));
+
 type MockGuardianEventSource = EventTarget & {
   url: string;
   options: Record<string, unknown>;
@@ -238,6 +244,10 @@ vi.mock("@/lib/runtimeRouteCapabilities", () => ({
     mounted: [],
     declared: {},
   }),
+}));
+
+vi.mock("@/lib/authState", () => ({
+  useAuthState: () => authState,
 }));
 
 vi.mock("@/components/ui/dropdown-menu", () => ({

--- a/frontend/src/features/chat/__tests__/GuardianChat.test.tsx
+++ b/frontend/src/features/chat/__tests__/GuardianChat.test.tsx
@@ -52,38 +52,57 @@ type MockGuardianEventSource = EventTarget & {
   emitError: () => void;
 };
 
-vi.mock("@/lib/api", () => ({
-  default: apiSpies,
-  buildChatCompletePath: (threadId: string | number) => `/chat/${threadId}/complete`,
-  clearInFlightCompletionTurnId: vi.fn(),
-  getAuthToken: vi.fn(() => null),
-  getBackendOutageRemainingMs: vi.fn(() => 0),
-  getDevApiKey: vi.fn(() => null),
-  getInFlightCompletionTurnId: vi.fn(() => null),
-  readRuntimeApiKey: vi.fn(() => null),
-  invokeCommandBus: async (payload: Record<string, unknown>) => {
-    const response = await apiSpies.post(
-      "/api/guardian/commands/invoke",
-      payload,
-      {
-        headers: {
-          "X-User-Id": String((payload as any)?.actor?.id ?? ""),
-        },
-      }
-    );
-    return response?.data ?? {};
-  },
-  updateThreadConfig: async (
-    threadId: string | number,
-    patch: Record<string, unknown>
-  ) => {
-    const response = await apiSpies.patch(
-      `/chat/threads/${threadId}/config`,
-      patch
-    );
-    return response?.data ?? {};
-  },
-}));
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>(
+    "@/lib/api"
+  );
+
+  return {
+    ...actual,
+    default: apiSpies,
+    buildChatCompletePath: (threadId: string | number) =>
+      `/chat/${threadId}/complete`,
+    clearInFlightCompletionTurnId: vi.fn(),
+    getAuthToken: vi.fn(() => null),
+    getBackendOutageRemainingMs: vi.fn(() => 0),
+    getDevApiKey: vi.fn(() => null),
+    getInFlightCompletionTurnId: vi.fn(() => null),
+    hasRequestAuthCredential: vi.fn(() => true),
+    readRuntimeApiKey: vi.fn(() => null),
+    invokeCommandBus: async (payload: Record<string, unknown>) => {
+      const response = await apiSpies.post(
+        "/api/guardian/commands/invoke",
+        payload,
+        {
+          headers: {
+            "X-User-Id": String((payload as any)?.actor?.id ?? ""),
+          },
+        }
+      );
+      return response?.data ?? {};
+    },
+    moveChatThread: async (
+      threadId: string | number,
+      toProjectId: string | number
+    ) => {
+      const response = await apiSpies.post(
+        `/chat/threads/${threadId}/move`,
+        { toProjectId }
+      );
+      return response?.data ?? {};
+    },
+    updateThreadConfig: async (
+      threadId: string | number,
+      patch: Record<string, unknown>
+    ) => {
+      const response = await apiSpies.patch(
+        `/chat/threads/${threadId}/config`,
+        patch
+      );
+      return response?.data ?? {};
+    },
+  };
+});
 
 vi.mock("@/lib/guardianEventSource", () => {
   class MockGuardianEventSource extends EventTarget {
@@ -354,6 +373,25 @@ function renderChat(
   };
 }
 
+function createApiResponse(
+  data: Record<string, unknown>,
+  status = 201
+): {
+  data: Record<string, unknown>;
+  status: number;
+  statusText: string;
+  headers: Record<string, unknown>;
+  config: Record<string, unknown>;
+} {
+  return {
+    data,
+    status,
+    statusText: status === 201 ? "Created" : "OK",
+    headers: {},
+    config: {},
+  };
+}
+
 async function advanceTimers(ms: number) {
   await act(async () => {
     vi.advanceTimersByTime(ms);
@@ -607,100 +645,165 @@ describe("GuardianChat inference rail", () => {
     });
   });
 
-  it("uses canonical local ownership when creating a chat thread from a display label", async () => {
-    renderChat("draft-thread", {
-      userName: "Resonant Jones",
-    });
+  it.each([
+    [
+      "thread_id",
+      { thread_id: 123, thread: { id: 123, title: "New Thread" } },
+    ],
+    [
+      "threadId",
+      { threadId: 123, thread: { id: 123, title: "New Thread" } },
+    ],
+    [
+      "id",
+      { id: 123, thread: { id: 123, title: "New Thread" } },
+    ],
+    [
+      "thread.id",
+      { thread: { id: 123, title: "New Thread" } },
+    ],
+    [
+      "Axios wrapper data.thread_id",
+      { thread_id: 123, thread: { id: 123, title: "New Thread" } },
+    ],
+  ])(
+    "creates and sends a new thread when the response shape supports %s",
+    async (_label, threadResponse) => {
+      renderChat("draft-thread", {
+        userName: "Resonant Jones",
+      });
 
-    apiMock.post.mockImplementation(async (url: string, body?: any) => {
-      if (url === "/chat/messages") {
-        expect(body).toEqual(
-          expect.objectContaining({
-            thread_id: null,
-            role: "user",
-            user_id: "local",
-          })
-        );
-        return {
-          data: {
-            thread_id: 123,
-            thread: {
-              id: 123,
-              title: "New Thread",
+      apiMock.post.mockImplementation(async (url: string, body?: any) => {
+        if (url === "/chat/threads") {
+          expect(body).toEqual(
+            expect.objectContaining({
+              title: "hello",
+              user_id: "local",
+            })
+          );
+          return createApiResponse(threadResponse as Record<string, unknown>, 201);
+        }
+        if (url === "/chat/123/messages") {
+          expect(body).toEqual(
+            expect.objectContaining({
+              role: "user",
+              content: "hello",
+              user_id: "local",
+            })
+          );
+          return createApiResponse(
+            {
+              ok: true,
+              thread: { id: 123, title: "New Thread" },
+              message: { id: 456, thread_id: 123 },
             },
-          },
-        };
-      }
-      if (url === "/chat/123/complete") {
-        return { data: { task_id: "task-123" } };
-      }
-      return { data: {} };
-    });
+            200
+          );
+        }
+        if (url === "/chat/123/complete") {
+          return createApiResponse({ task_id: "task-123" }, 200);
+        }
+        return createApiResponse({}, 200);
+      });
 
-    await act(async () => {
-      fireEvent.click(screen.getByTestId("composer-send"));
-    });
-    await advanceTimers(100);
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("composer-send"));
+      });
+      await advanceTimers(100);
 
-    await waitFor(() => {
-      expect(apiMock.post).toHaveBeenCalledWith(
-        "/chat/messages",
-        expect.objectContaining({
-          user_id: "local",
-        })
-      );
-    });
-    expect(
-      apiMock.post.mock.calls.some(
-        ([url, body]) =>
-          url === "/chat/messages" &&
-          (body as Record<string, unknown>)?.user_id === "Resonant Jones"
-      )
-    ).toBe(false);
-  });
-
-  it("accepts camelCase create-on-send thread ids without dropping the new thread", async () => {
-    renderChat("draft-thread", {
-      userName: "Resonant Jones",
-    });
-
-    apiMock.post.mockImplementation(async (url: string, body?: any) => {
-      if (url === "/chat/messages") {
-        expect(body).toEqual(
-          expect.objectContaining({
-            thread_id: null,
-            role: "user",
-            user_id: "local",
-          })
+      await waitFor(() => {
+        expect(apiMock.post).toHaveBeenCalledWith(
+          "/chat/123/complete",
+          expect.anything()
         );
-        return {
-          data: {
-            created_thread: true,
-            createdThreadId: 123,
-            thread: {
-              id: 123,
-              title: "New Thread",
-            },
-          },
-        };
-      }
-      if (url === "/chat/123/complete") {
-        return { data: { task_id: "task-123" } };
-      }
-      return { data: {} };
-    });
+      });
 
-    await act(async () => {
-      fireEvent.click(screen.getByTestId("composer-send"));
-    });
-
-    await waitFor(() => {
-      expect(apiMock.post).toHaveBeenCalledWith(
+      const postUrls = apiMock.post.mock.calls
+        .map(([url]) => url as string)
+        .filter((url) => url === "/chat/threads" || url === "/chat/123/messages" || url === "/chat/123/complete");
+      expect(postUrls).toEqual([
+        "/chat/threads",
+        "/chat/123/messages",
         "/chat/123/complete",
-        expect.anything()
-      );
+      ]);
+      expect(
+        screen.queryByTestId("thread-id-resolution-banner")
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Thread id missing from response")
+      ).not.toBeInTheDocument();
+    }
+  );
+
+  it("surfaces sanitized diagnostics when the create-thread response lacks a thread id", async () => {
+    renderChat("draft-thread", {
+      userName: "Resonant Jones",
     });
-    expect(screen.queryByText("Thread id missing from response")).not.toBeInTheDocument();
+
+    apiMock.post.mockImplementation(async (url: string, body?: any) => {
+      if (url === "/chat/threads") {
+        expect(body).toEqual(
+          expect.objectContaining({
+            title: "hello",
+            user_id: "local",
+          })
+        );
+        return createApiResponse(
+          {
+            ok: true,
+            created_thread: true,
+            thread: {
+              title: "Top secret thread",
+              content: "secret body",
+            },
+            apiKey: "desktop-key",
+            cookie: "sid=abc123",
+          },
+          200
+        );
+      }
+      return createApiResponse({}, 200);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("composer-send"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("thread-id-resolution-banner")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("Thread id missing from response")
+    ).toBeInTheDocument();
+    expect(screen.getByText("endpoint=POST /chat/threads")).toBeInTheDocument();
+    expect(screen.getByText("method=POST")).toBeInTheDocument();
+    expect(screen.getByText("status=200")).toBeInTheDocument();
+    expect(screen.getByText("authPresent=true")).toBeInTheDocument();
+    expect(screen.getByText(/responseKeys=/)).toHaveTextContent(
+      "responseKeys=data,status,statusText,headers,config"
+    );
+    expect(screen.getByText(/dataKeys=/)).toHaveTextContent(
+      "dataKeys=ok,created_thread,thread,apiKey,cookie"
+    );
+    expect(screen.getByText(/threadKeys=/)).toHaveTextContent(
+      "threadKeys=title,content"
+    );
+    expect(screen.getByText(/parserBranch=/)).toHaveTextContent(
+      "response.thread_id -> response.threadId -> response.id"
+    );
+    expect(screen.getByText(/parserFailureReason=/)).toHaveTextContent(
+      "parserFailureReason=thread_id_missing"
+    );
+    expect(
+      screen.queryByText(/Top secret thread|secret body|desktop-key|sid=abc123/)
+    ).not.toBeInTheDocument();
+    expect(
+      apiMock.post.mock.calls.some(([url]) => url === "/chat/123/messages")
+    ).toBe(false);
+    expect(
+      apiMock.post.mock.calls.some(([url]) => url === "/chat/123/complete")
+    ).toBe(false);
   });
 
   it("switches profiles through the command bus invoke surface instead of the legacy tools shim", async () => {

--- a/frontend/src/features/chat/__tests__/GuardianChat.test.tsx
+++ b/frontend/src/features/chat/__tests__/GuardianChat.test.tsx
@@ -648,23 +648,23 @@ describe("GuardianChat inference rail", () => {
   it.each([
     [
       "thread_id",
-      { thread_id: 123, thread: { id: 123, title: "New Thread" } },
+      { thread_id: 2, thread: { id: 2, title: "New Thread" } },
     ],
     [
       "threadId",
-      { threadId: 123, thread: { id: 123, title: "New Thread" } },
+      { threadId: 2, thread: { id: 2, title: "New Thread" } },
     ],
     [
       "id",
-      { id: 123, thread: { id: 123, title: "New Thread" } },
+      { id: 2, thread: { id: 2, title: "New Thread" } },
     ],
     [
       "thread.id",
-      { thread: { id: 123, title: "New Thread" } },
+      { thread: { id: 2, title: "New Thread" } },
     ],
     [
       "Axios wrapper data.thread_id",
-      { thread_id: 123, thread: { id: 123, title: "New Thread" } },
+      { thread_id: 2, thread: { id: 2, title: "New Thread" } },
     ],
   ])(
     "creates and sends a new thread when the response shape supports %s",
@@ -674,7 +674,7 @@ describe("GuardianChat inference rail", () => {
       });
 
       apiMock.post.mockImplementation(async (url: string, body?: any) => {
-        if (url === "/chat/threads") {
+        if (url === "/api/chat/threads") {
           expect(body).toEqual(
             expect.objectContaining({
               title: "hello",
@@ -683,7 +683,7 @@ describe("GuardianChat inference rail", () => {
           );
           return createApiResponse(threadResponse as Record<string, unknown>, 201);
         }
-        if (url === "/chat/123/messages") {
+        if (url === "/chat/2/messages") {
           expect(body).toEqual(
             expect.objectContaining({
               role: "user",
@@ -694,13 +694,13 @@ describe("GuardianChat inference rail", () => {
           return createApiResponse(
             {
               ok: true,
-              thread: { id: 123, title: "New Thread" },
-              message: { id: 456, thread_id: 123 },
+              thread: { id: 2, title: "New Thread" },
+              message: { id: 456, thread_id: 2 },
             },
             200
           );
         }
-        if (url === "/chat/123/complete") {
+        if (url === "/chat/2/complete") {
           return createApiResponse({ task_id: "task-123" }, 200);
         }
         return createApiResponse({}, 200);
@@ -713,19 +713,22 @@ describe("GuardianChat inference rail", () => {
 
       await waitFor(() => {
         expect(apiMock.post).toHaveBeenCalledWith(
-          "/chat/123/complete",
+          "/chat/2/complete",
           expect.anything()
         );
       });
 
       const postUrls = apiMock.post.mock.calls
         .map(([url]) => url as string)
-        .filter((url) => url === "/chat/threads" || url === "/chat/123/messages" || url === "/chat/123/complete");
+        .filter((url) => url === "/api/chat/threads" || url === "/chat/2/messages" || url === "/chat/2/complete");
       expect(postUrls).toEqual([
-        "/chat/threads",
-        "/chat/123/messages",
-        "/chat/123/complete",
+        "/api/chat/threads",
+        "/chat/2/messages",
+        "/chat/2/complete",
       ]);
+      expect(
+        apiMock.post.mock.calls.some(([url]) => url === "/chat/threads")
+      ).toBe(false);
       expect(
         screen.queryByTestId("thread-id-resolution-banner")
       ).not.toBeInTheDocument();
@@ -741,7 +744,7 @@ describe("GuardianChat inference rail", () => {
     });
 
     apiMock.post.mockImplementation(async (url: string, body?: any) => {
-      if (url === "/chat/threads") {
+      if (url === "/api/chat/threads") {
         expect(body).toEqual(
           expect.objectContaining({
             title: "hello",
@@ -776,7 +779,7 @@ describe("GuardianChat inference rail", () => {
     expect(
       screen.getByText("Thread id missing from response")
     ).toBeInTheDocument();
-    expect(screen.getByText("endpoint=POST /chat/threads")).toBeInTheDocument();
+    expect(screen.getByText("endpoint=POST /api/chat/threads")).toBeInTheDocument();
     expect(screen.getByText("method=POST")).toBeInTheDocument();
     expect(screen.getByText("status=200")).toBeInTheDocument();
     expect(screen.getByText("authPresent=true")).toBeInTheDocument();
@@ -799,10 +802,66 @@ describe("GuardianChat inference rail", () => {
       screen.queryByText(/Top secret thread|secret body|desktop-key|sid=abc123/)
     ).not.toBeInTheDocument();
     expect(
-      apiMock.post.mock.calls.some(([url]) => url === "/chat/123/messages")
+      apiMock.post.mock.calls.some(([url]) => url === "/chat/2/messages")
     ).toBe(false);
     expect(
-      apiMock.post.mock.calls.some(([url]) => url === "/chat/123/complete")
+      apiMock.post.mock.calls.some(([url]) => url === "/chat/2/complete")
+    ).toBe(false);
+  });
+
+  it("surfaces wrong-endpoint diagnostics for non-object create-thread responses", async () => {
+    renderChat("draft-thread", {
+      userName: "Resonant Jones",
+    });
+
+    apiMock.post.mockImplementation(async (url: string, body?: any) => {
+      if (url === "/api/chat/threads") {
+        expect(body).toEqual(
+          expect.objectContaining({
+            title: "hello",
+            user_id: "local",
+          })
+        );
+        return {
+          data: "<html>Guardian shell</html>",
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          config: {},
+        };
+      }
+      return createApiResponse({}, 200);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("composer-send"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("thread-id-resolution-banner")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("Thread id missing from response")
+    ).toBeInTheDocument();
+    expect(screen.getByText("endpoint=POST /api/chat/threads")).toBeInTheDocument();
+    expect(screen.getByText("status=200")).toBeInTheDocument();
+    expect(screen.getByText("authPresent=true")).toBeInTheDocument();
+    expect(screen.getByText(/responseKeys=/)).toHaveTextContent(
+      "responseKeys=data,status,statusText,headers,config"
+    );
+    expect(screen.getByText(/dataKeys=/)).toHaveTextContent("dataKeys=<none>");
+    expect(screen.getByText(/threadKeys=/)).toHaveTextContent("threadKeys=<none>");
+    expect(screen.getByText("parserFailureReason=wrong_endpoint_or_non_json_response")).toBeInTheDocument();
+    expect(screen.queryByText(/Guardian shell/)).not.toBeInTheDocument();
+    expect(
+      apiMock.post.mock.calls.some(([url]) => url === "/api/chat/threads")
+    ).toBe(true);
+    expect(
+      apiMock.post.mock.calls.some(([url]) => url === "/chat/2/messages")
+    ).toBe(false);
+    expect(
+      apiMock.post.mock.calls.some(([url]) => url === "/chat/2/complete")
     ).toBe(false);
   });
 

--- a/frontend/src/features/chat/hooks/useInferenceRequestState.ts
+++ b/frontend/src/features/chat/hooks/useInferenceRequestState.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { GuardianEventSource } from "@/lib/guardianEventSource";
-import api, { getAuthToken, getDevApiKey, readRuntimeApiKey } from "@/lib/api";
+import api, { buildAuthenticatedFetchInit } from "@/lib/api";
 import {
   createIdleInferenceRequestState,
   isActiveInferencePhase,
@@ -543,15 +543,13 @@ function buildLifecyclePatch(
 }
 
 function buildEventHeaders(): Record<string, string> {
-  const headers: Record<string, string> = {};
-  const authToken = getAuthToken();
-  const apiKey = readRuntimeApiKey() || getDevApiKey();
-  if (authToken) {
-    headers.Authorization = `Bearer ${authToken}`;
-  } else if (apiKey) {
-    headers["X-API-Key"] = apiKey;
-  }
-  return headers;
+  const init = buildAuthenticatedFetchInit({
+    headers: {
+      Accept: "text/event-stream",
+      "Cache-Control": "no-cache",
+    },
+  });
+  return (init.headers as Record<string, string>) ?? {};
 }
 
 function buildStatePatch(

--- a/frontend/src/hooks/useLiveEvents.ts
+++ b/frontend/src/hooks/useLiveEvents.ts
@@ -13,8 +13,10 @@ import { buildAuthenticatedFetchInit } from "@/lib/api";
 import type { LiveEvent } from "@/lib/events/types";
 import {
   getDesktopRuntimeAuthConfig,
+  getRuntimeConfigHydrationFailureKind,
   getRuntimeConfigSync,
   getRuntimeConfigVersion,
+  getRuntimeConfigHydrationState,
   isTauriRuntime,
   resolveSseEndpoint,
   subscribeRuntimeConfigState,
@@ -76,6 +78,8 @@ export type LiveEventsDiagnostics = {
   transportErrorClass: string | null;
   authSource: RuntimeAuthSource;
   apiKeyPresent: boolean;
+  hydrationState: "pending" | "ready" | "failed";
+  nativeCommandStatus: string | null;
   reconnectAttempts: number;
   retryMs: number;
   subscribers: number;
@@ -85,6 +89,10 @@ export type LiveEventsDiagnostics = {
 };
 
 function resolveLiveEventsAuthSource(): RuntimeAuthSource {
+  const hydrationState = getRuntimeConfigHydrationState();
+  if (hydrationState === "pending") {
+    return "unknown";
+  }
   const desktopAuthConfig = getDesktopRuntimeAuthConfig();
   const runtimeDesktopKeyPresent = Boolean(
     desktopAuthConfig?.apiKeyPresent || readRuntimeApiKey()
@@ -112,6 +120,11 @@ export function useLiveEvents(options: { passive?: boolean } = {}): UseLiveEvent
     subscribeRuntimeConfigState,
     getRuntimeConfigVersion,
     getRuntimeConfigVersion
+  );
+  const runtimeConfigHydrationState = useSyncExternalStore(
+    subscribeRuntimeConfigState,
+    getRuntimeConfigHydrationState,
+    getRuntimeConfigHydrationState
   );
   const [connected, setConnected] = useState(false);
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>(
@@ -253,6 +266,32 @@ export function useLiveEvents(options: { passive?: boolean } = {}): UseLiveEvent
       return;
     }
 
+    if (runtimeConfigHydrationState === "pending") {
+      if (connectedTimerRef.current) {
+        clearTimeout(connectedTimerRef.current);
+        connectedTimerRef.current = null;
+      }
+      pendingConnectedRef.current = null;
+      connectedRef.current = false;
+      setConnected(false);
+      setConnectionStatus(LIVE_EVENT_CONNECTION_STATES.CONNECTING);
+      setStatusUpdatedAt(Date.now());
+      return;
+    }
+
+    if (runtimeConfigHydrationState === "failed") {
+      if (connectedTimerRef.current) {
+        clearTimeout(connectedTimerRef.current);
+        connectedTimerRef.current = null;
+      }
+      pendingConnectedRef.current = null;
+      connectedRef.current = false;
+      setConnected(false);
+      setConnectionStatus(LIVE_EVENT_CONNECTION_STATES.DISCONNECTED);
+      setStatusUpdatedAt(Date.now());
+      return;
+    }
+
     if (!checkAuthGate(auth, "SSE connect")) {
       if (connectedTimerRef.current) {
         clearTimeout(connectedTimerRef.current);
@@ -325,6 +364,7 @@ export function useLiveEvents(options: { passive?: boolean } = {}): UseLiveEvent
     auth.token,
     handleHubEvent,
     runtimeAuthVersion,
+    runtimeConfigHydrationState,
     streamUrl,
     updateConnected,
   ]);
@@ -340,6 +380,11 @@ export function useLiveEvents(options: { passive?: boolean } = {}): UseLiveEvent
       transportErrorClass: hubStatus.transportErrorClass,
       authSource: hubStatus.authSource,
       apiKeyPresent: hubStatus.apiKeyPresent,
+      hydrationState: runtimeConfigHydrationState,
+      nativeCommandStatus:
+        runtimeConfigHydrationState === "failed"
+          ? getRuntimeConfigHydrationFailureKind() ?? "failed"
+          : runtimeConfigHydrationState,
       reconnectAttempts: hubStatus.connectAttempt,
       retryMs: hubStatus.retryMs,
       subscribers: hubStatus.subscribers,
@@ -363,6 +408,7 @@ export function useLiveEvents(options: { passive?: boolean } = {}): UseLiveEvent
       hubStatus.subscribers,
       hubStatus.transportErrorClass,
       statusUpdatedAt,
+      runtimeConfigHydrationState,
       streamUrl,
     ]
   );

--- a/frontend/src/hooks/useLiveEvents.ts
+++ b/frontend/src/hooks/useLiveEvents.ts
@@ -1,10 +1,24 @@
 /**
  * useLiveEvents - shared SSE hook backed by a per-tab singleton hub.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { buildAuthenticatedFetchInit } from "@/lib/api";
 import type { LiveEvent } from "@/lib/events/types";
-import { getRuntimeConfigSync, resolveSseEndpoint } from "@/lib/runtimeConfig";
+import {
+  getDesktopRuntimeAuthConfig,
+  getRuntimeConfigSync,
+  getRuntimeConfigVersion,
+  isTauriRuntime,
+  resolveSseEndpoint,
+  subscribeRuntimeConfigState,
+} from "@/lib/runtimeConfig";
 import {
   checkAuthGate,
   markAuthUnauthenticatedFrom401,
@@ -13,13 +27,28 @@ import {
 import { SessionSpine } from "@/state/session/SessionSpine";
 import {
   LiveEventsHubEvent,
+  getLiveEventsHubStatus,
   subscribeLiveEventsHub,
   subscribeLiveEventsHubStatus,
+  type LiveEventsHubStatus,
 } from "@/lib/liveEventsHub";
 import {
   LIVE_EVENT_CONNECTION_STATES,
   LiveEventConnectionState,
 } from "@/contracts/runtimeTokens";
+import {
+  getAuthToken,
+  getDevApiKey,
+  readRuntimeApiKey,
+} from "@/lib/api";
+import {
+  resolveRuntimeAuthSource,
+  type RuntimeAuthSource,
+} from "@/lib/runtimeAuth";
+import {
+  getRuntimeAuthVersion,
+  subscribeRuntimeAuthState,
+} from "@/lib/runtimeAuth";
 
 const LAST_EVENT_DEBOUNCE_MS = 50;
 const CONNECTED_DEBOUNCE_MS = 200;
@@ -33,18 +62,66 @@ export interface UseLiveEventsResult {
   connectionStatus: ConnectionStatus;
   statusUpdatedAt: number | null;
   lastEvent: LiveEvent | null;
+  diagnostics: LiveEventsDiagnostics;
   subscribe: (eventType: string, handler: (event: LiveEvent) => void) => () => void;
+}
+
+export type LiveEventsDiagnostics = {
+  endpoint: string | null;
+  connectionState: ConnectionStatus;
+  lastEventAt: number | null;
+  lastPingAt: number | null;
+  statusUpdatedAt: number | null;
+  lastHttpStatus: number | null;
+  transportErrorClass: string | null;
+  authSource: RuntimeAuthSource;
+  apiKeyPresent: boolean;
+  reconnectAttempts: number;
+  retryMs: number;
+  subscribers: number;
+  readyState: 0 | 1 | 2;
+  lastErrorAt: number | null;
+  lastEventId: string | null;
+};
+
+function resolveLiveEventsAuthSource(): RuntimeAuthSource {
+  const desktopAuthConfig = getDesktopRuntimeAuthConfig();
+  const runtimeDesktopKeyPresent = Boolean(
+    desktopAuthConfig?.apiKeyPresent || readRuntimeApiKey()
+  );
+  const devKeyPresent = Boolean(getDevApiKey().trim());
+  const bearerPresent = Boolean(getAuthToken());
+  return resolveRuntimeAuthSource({
+    isTauriRuntime: isTauriRuntime(),
+    runtimeDesktopKeyPresent,
+    devKeyPresent,
+    bearerPresent,
+    desktopAuthConfigKnown: Boolean(desktopAuthConfig),
+  });
 }
 
 export function useLiveEvents(options: { passive?: boolean } = {}): UseLiveEventsResult {
   const { passive = false } = options;
   const auth = useAuthState();
+  const runtimeAuthVersion = useSyncExternalStore(
+    subscribeRuntimeAuthState,
+    getRuntimeAuthVersion,
+    getRuntimeAuthVersion
+  );
+  const runtimeConfigVersion = useSyncExternalStore(
+    subscribeRuntimeConfigState,
+    getRuntimeConfigVersion,
+    getRuntimeConfigVersion
+  );
   const [connected, setConnected] = useState(false);
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>(
     LIVE_EVENT_CONNECTION_STATES.DISCONNECTED
   );
   const [statusUpdatedAt, setStatusUpdatedAt] = useState<number>(() => Date.now());
   const [lastEvent, setLastEvent] = useState<LiveEvent | null>(null);
+  const [hubStatus, setHubStatus] = useState<LiveEventsHubStatus>(
+    () => getLiveEventsHubStatus()
+  );
   const listenersRef = useRef<Map<string, Set<(event: LiveEvent) => void>>>(
     new Map()
   );
@@ -56,7 +133,10 @@ export function useLiveEvents(options: { passive?: boolean } = {}): UseLiveEvent
   const pendingLastEventRef = useRef<LiveEvent | null>(null);
   const lastEventTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const streamUrl = useMemo(() => resolveSseEndpoint(getRuntimeConfigSync()), []);
+  const streamUrl = useMemo(
+    () => resolveSseEndpoint(getRuntimeConfigSync()),
+    [runtimeConfigVersion]
+  );
 
   const isSameEvent = useCallback((prev: LiveEvent | null, next: LiveEvent) => {
     if (!prev) return false;
@@ -196,10 +276,16 @@ export function useLiveEvents(options: { passive?: boolean } = {}): UseLiveEvent
       Accept: "text/event-stream",
       "Cache-Control": "no-cache",
     };
+    const apiKeyPresent = Boolean(
+      getDesktopRuntimeAuthConfig()?.apiKeyPresent ||
+        readRuntimeApiKey() ||
+        getDevApiKey().trim()
+    );
 
     let cancelled = false;
     const unsubscribeStatus = subscribeLiveEventsHubStatus((status) => {
       if (cancelled || isUnmountedRef.current) return;
+      setHubStatus(status);
       setConnectionStatus((prev) => {
         if (prev === status.connectionStatus) return prev;
         setStatusUpdatedAt(Date.now());
@@ -216,6 +302,8 @@ export function useLiveEvents(options: { passive?: boolean } = {}): UseLiveEvent
         url: streamUrl,
         headers,
         withCredentials: authInit.credentials === "include",
+        authSource: resolveLiveEventsAuthSource(),
+        apiKeyPresent,
         onUnauthorized: () => {
           markAuthUnauthenticatedFrom401();
         },
@@ -236,9 +324,48 @@ export function useLiveEvents(options: { passive?: boolean } = {}): UseLiveEvent
     auth.status,
     auth.token,
     handleHubEvent,
+    runtimeAuthVersion,
     streamUrl,
     updateConnected,
   ]);
+
+  const diagnostics = useMemo<LiveEventsDiagnostics>(
+    () => ({
+      endpoint: hubStatus.endpoint ?? streamUrl,
+      connectionState: connectionStatus,
+      lastEventAt: hubStatus.lastEventAt,
+      lastPingAt: hubStatus.lastPingAt,
+      statusUpdatedAt,
+      lastHttpStatus: hubStatus.lastHttpStatus,
+      transportErrorClass: hubStatus.transportErrorClass,
+      authSource: hubStatus.authSource,
+      apiKeyPresent: hubStatus.apiKeyPresent,
+      reconnectAttempts: hubStatus.connectAttempt,
+      retryMs: hubStatus.retryMs,
+      subscribers: hubStatus.subscribers,
+      readyState: hubStatus.readyState,
+      lastErrorAt: hubStatus.lastErrorAt,
+      lastEventId: hubStatus.lastEventId,
+    }),
+    [
+      connectionStatus,
+      hubStatus.apiKeyPresent,
+      hubStatus.authSource,
+      hubStatus.connectAttempt,
+      hubStatus.endpoint,
+      hubStatus.lastErrorAt,
+      hubStatus.lastEventAt,
+      hubStatus.lastEventId,
+      hubStatus.lastHttpStatus,
+      hubStatus.lastPingAt,
+      hubStatus.readyState,
+      hubStatus.retryMs,
+      hubStatus.subscribers,
+      hubStatus.transportErrorClass,
+      statusUpdatedAt,
+      streamUrl,
+    ]
+  );
 
   const subscribe = useCallback(
     (eventType: string, handler: (event: LiveEvent) => void) => {
@@ -263,6 +390,7 @@ export function useLiveEvents(options: { passive?: boolean } = {}): UseLiveEvent
     connectionStatus,
     statusUpdatedAt,
     lastEvent: passive ? lastEventRef.current : lastEvent,
+    diagnostics,
     subscribe,
   };
 }

--- a/frontend/src/hooks/useRuntimeHealth.test.ts
+++ b/frontend/src/hooks/useRuntimeHealth.test.ts
@@ -12,7 +12,45 @@ type LiveEventsStatus = {
   connected: boolean;
   connectionStatus: LiveEventConnectionState;
   statusUpdatedAt: number | null;
+  diagnostics: {
+    endpoint: string | null;
+    connectionState: LiveEventConnectionState;
+    lastEventAt: number | null;
+    lastPingAt: number | null;
+    statusUpdatedAt: number | null;
+    lastHttpStatus: number | null;
+    transportErrorClass: string | null;
+    authSource: string;
+    apiKeyPresent: boolean;
+    reconnectAttempts: number;
+    retryMs: number;
+    subscribers: number;
+    readyState: 0 | 1 | 2;
+    lastErrorAt: number | null;
+    lastEventId: string | null;
+  };
 };
+
+function makeLiveEventsDiagnostics(overrides: Partial<LiveEventsStatus["diagnostics"]> = {}): LiveEventsStatus["diagnostics"] {
+  return {
+    endpoint: "http://127.0.0.1:8888/api/events",
+    connectionState: LIVE_EVENT_CONNECTION_STATES.CONNECTED,
+    lastEventAt: Date.parse("2026-03-20T11:59:58.000Z"),
+    lastPingAt: Date.parse("2026-03-20T11:59:58.000Z"),
+    statusUpdatedAt: Date.parse("2026-03-20T12:00:00.000Z"),
+    lastHttpStatus: 200,
+    transportErrorClass: null,
+    authSource: "runtime-desktop",
+    apiKeyPresent: true,
+    reconnectAttempts: 0,
+    retryMs: 1000,
+    subscribers: 1,
+    readyState: 1,
+    lastErrorAt: null,
+    lastEventId: "evt-1",
+    ...overrides,
+  };
+}
 
 const apiGet = vi.fn();
 const runtimeState = vi.hoisted(() => ({
@@ -43,6 +81,7 @@ let liveEventsStatus: LiveEventsStatus = {
   connected: true,
   connectionStatus: LIVE_EVENT_CONNECTION_STATES.CONNECTED,
   statusUpdatedAt: Date.now(),
+  diagnostics: makeLiveEventsDiagnostics(),
 };
 
 vi.mock("@/lib/api", () => ({
@@ -161,6 +200,7 @@ describe("useRuntimeHealth", () => {
       connected: true,
       connectionStatus: LIVE_EVENT_CONNECTION_STATES.CONNECTED,
       statusUpdatedAt: Date.now(),
+      diagnostics: makeLiveEventsDiagnostics(),
     };
   });
 
@@ -384,22 +424,37 @@ describe("useRuntimeHealth", () => {
     expect(result.current.status).toBe(RUNTIME_HEALTH_STATUSES.DEGRADED);
   });
 
-  it("flags live events disconnected after the threshold", async () => {
+  it("exposes live events disconnect diagnostics without degrading provider health", async () => {
     mockHealthResponses();
     liveEventsStatus = {
       connected: false,
       connectionStatus: LIVE_EVENT_CONNECTION_STATES.DISCONNECTED,
       statusUpdatedAt: Date.now() - 46_000,
+      diagnostics: makeLiveEventsDiagnostics({
+        connectionState: LIVE_EVENT_CONNECTION_STATES.DISCONNECTED,
+        statusUpdatedAt: Date.now() - 46_000,
+        lastHttpStatus: 200,
+        lastErrorAt: Date.now() - 46_000,
+        reconnectAttempts: 3,
+        retryMs: 5000,
+      }),
     };
     const { result } = renderHook(() => useRuntimeHealth());
     await act(async () => {
       await flushPromises();
     });
     await waitFor(() => {
-      expect(result.current.failureKind).toBe(
-        RUNTIME_HEALTH_FAILURE_KINDS.LIVE_EVENTS_DISCONNECTED
+      expect(result.current.failureKind).toBeNull();
+      expect(result.current.status).toBe(RUNTIME_HEALTH_STATUSES.HEALTHY);
+      expect(result.current.diagnostics.liveEvents.connectionState).toBe(
+        LIVE_EVENT_CONNECTION_STATES.DISCONNECTED
       );
-      expect(result.current.status).toBe(RUNTIME_HEALTH_STATUSES.DEGRADED);
+      expect(result.current.diagnostics.liveEvents.lastHttpStatus).toBe(200);
+      expect(result.current.diagnostics.liveEvents.transportErrorClass).toBeNull();
+      expect(result.current.diagnostics.liveEvents.apiKeyPresent).toBe(true);
+      expect(result.current.diagnostics.liveEvents.statusUpdatedAt).toBe(
+        Date.now() - 46_000
+      );
     });
   });
 

--- a/frontend/src/hooks/useRuntimeHealth.test.ts
+++ b/frontend/src/hooks/useRuntimeHealth.test.ts
@@ -22,6 +22,8 @@ type LiveEventsStatus = {
     transportErrorClass: string | null;
     authSource: string;
     apiKeyPresent: boolean;
+    hydrationState: "pending" | "ready" | "failed";
+    nativeCommandStatus: string | null;
     reconnectAttempts: number;
     retryMs: number;
     subscribers: number;
@@ -42,6 +44,8 @@ function makeLiveEventsDiagnostics(overrides: Partial<LiveEventsStatus["diagnost
     transportErrorClass: null,
     authSource: "runtime-desktop",
     apiKeyPresent: true,
+    hydrationState: "ready",
+    nativeCommandStatus: "ready",
     reconnectAttempts: 0,
     retryMs: 1000,
     subscribers: 1,
@@ -56,6 +60,7 @@ const apiGet = vi.fn();
 const runtimeState = vi.hoisted(() => ({
   isTauri: true,
   apiBaseUrl: "http://127.0.0.1:8888/api",
+  hydrationState: "ready" as "pending" | "ready" | "failed",
   desktopAuthConfig: {
     apiKeyPresent: true,
     apiKey: "packaged-runtime-key",
@@ -95,6 +100,8 @@ vi.mock("@/lib/api", () => ({
 
 vi.mock("@/lib/runtimeConfig", () => ({
   getDesktopRuntimeAuthConfig: () => runtimeState.desktopAuthConfig,
+  getRuntimeConfigHydrationState: () => runtimeState.hydrationState,
+  getRuntimeConfigVersion: () => 0,
   getRuntimeConfigSync: () => ({
     mode: runtimeState.isTauri ? "tauri" : "web",
     backendBaseUrl: "http://127.0.0.1:8888",
@@ -104,6 +111,7 @@ vi.mock("@/lib/runtimeConfig", () => ({
     authMode: "local",
   }),
   isTauriRuntime: () => runtimeState.isTauri,
+  subscribeRuntimeConfigState: () => () => {},
 }));
 
 vi.mock("@/hooks/useLiveEvents", () => ({
@@ -185,6 +193,7 @@ describe("useRuntimeHealth", () => {
     apiGet.mockReset();
     runtimeState.isTauri = true;
     runtimeState.apiBaseUrl = "http://127.0.0.1:8888/api";
+    runtimeState.hydrationState = "ready";
     runtimeState.desktopAuthConfig = {
       apiKeyPresent: true,
       apiKey: "packaged-runtime-key",
@@ -225,7 +234,13 @@ describe("useRuntimeHealth", () => {
       expect(result.current.diagnostics.resolvedApiBaseUrl).toBe(
         "http://127.0.0.1:8888/api"
       );
+      expect(result.current.diagnostics.resolvedApiBaseUrlSource).toBe(
+        "runtime-desktop"
+      );
       expect(result.current.diagnostics.apiKeyPresent).toBe(true);
+      expect(result.current.diagnostics.apiKeySource).toBe("runtime-desktop");
+      expect(result.current.diagnostics.hydrationState).toBe("ready");
+      expect(result.current.diagnostics.nativeCommandStatus).toBe("ready");
       expect(result.current.diagnostics.authSource).toBe("runtime-desktop");
       expect(result.current.diagnostics.chat.endpoint).toBe("/health/chat");
       expect(result.current.diagnostics.chat.httpStatus).toBe(200);
@@ -360,6 +375,8 @@ describe("useRuntimeHealth", () => {
         RUNTIME_HEALTH_FAILURE_KINDS.LLM_UNHEALTHY
       );
       expect(result.current.diagnostics.apiKeyPresent).toBe(true);
+      expect(result.current.diagnostics.apiKeySource).toBe("runtime-desktop");
+      expect(result.current.diagnostics.hydrationState).toBe("ready");
       expect(result.current.diagnostics.authSource).toBe("runtime-desktop");
       expect(result.current.diagnostics.llm.endpoint).toBe("/api/health/llm");
       expect(result.current.diagnostics.llm.httpStatus).toBe(200);
@@ -452,9 +469,39 @@ describe("useRuntimeHealth", () => {
       expect(result.current.diagnostics.liveEvents.lastHttpStatus).toBe(200);
       expect(result.current.diagnostics.liveEvents.transportErrorClass).toBeNull();
       expect(result.current.diagnostics.liveEvents.apiKeyPresent).toBe(true);
+      expect(result.current.diagnostics.liveEvents.hydrationState).toBe("ready");
       expect(result.current.diagnostics.liveEvents.statusUpdatedAt).toBe(
         Date.now() - 46_000
       );
+    });
+  });
+
+  it("waits for desktop runtime hydration before polling health", async () => {
+    runtimeState.hydrationState = "pending";
+    mockHealthResponses();
+    const { result, rerender } = renderHook(() => useRuntimeHealth());
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(apiGet).not.toHaveBeenCalled();
+    expect(result.current.diagnostics.hydrationState).toBe("pending");
+    expect(result.current.diagnostics.nativeCommandStatus).toBe("pending");
+
+    runtimeState.hydrationState = "ready";
+    rerender();
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await waitFor(() => {
+      expect(apiGet).toHaveBeenCalledWith("/api/health/llm");
+      expect(apiGet).toHaveBeenCalledWith("/health/chat");
+      expect(result.current.diagnostics.hydrationState).toBe("ready");
+      expect(result.current.diagnostics.authSource).toBe("runtime-desktop");
+      expect(result.current.diagnostics.apiKeyPresent).toBe(true);
     });
   });
 

--- a/frontend/src/hooks/useRuntimeHealth.ts
+++ b/frontend/src/hooks/useRuntimeHealth.ts
@@ -3,9 +3,14 @@ import api, { getAuthToken, getDevApiKey, readRuntimeApiKey } from "@/lib/api";
 import { useLiveEvents } from "@/hooks/useLiveEvents";
 import {
   getDesktopRuntimeAuthConfig,
+  getRuntimeConfigHydrationFailureKind,
+  getRuntimeConfigHydrationState,
+  getRuntimeConfigVersion,
   getRuntimeConfigSync,
   isTauriRuntime,
+  subscribeRuntimeConfigState,
 } from "@/lib/runtimeConfig";
+import { useSyncExternalStore } from "react";
 import {
   resolveRuntimeAuthSource,
   type RuntimeAuthSource,
@@ -49,7 +54,16 @@ export type RuntimeHealthEndpointObservation = {
 
 export type RuntimeHealthDiagnostics = {
   resolvedApiBaseUrl: string | null;
+  resolvedApiBaseUrlSource:
+    | "runtime-desktop"
+    | "vite-dev"
+    | "local-storage-override"
+    | "fallback"
+    | "unknown";
   apiKeyPresent: boolean;
+  apiKeySource: RuntimeHealthAuthSource;
+  hydrationState: "pending" | "ready" | "failed";
+  nativeCommandStatus: string | null;
   authSource: RuntimeHealthAuthSource;
   chat: RuntimeHealthEndpointObservation;
   llm: RuntimeHealthEndpointObservation;
@@ -247,6 +261,36 @@ function resolveRuntimeHealthAuthSource(): RuntimeHealthAuthSource {
   });
 }
 
+function resolveRuntimeBaseUrlSource(
+  hydrationState: "pending" | "ready" | "failed",
+  runtimeConfigMode: "web" | "tauri",
+  desktopAuthConfig: ReturnType<typeof getDesktopRuntimeAuthConfig>
+): RuntimeHealthDiagnostics["resolvedApiBaseUrlSource"] {
+  if (hydrationState === "pending" || hydrationState === "failed") {
+    return "fallback";
+  }
+  if (desktopAuthConfig && runtimeConfigMode === "tauri") {
+    try {
+      if (
+        typeof window !== "undefined" &&
+        window.localStorage.getItem("cfy.desktop.backendBaseUrl")
+      ) {
+        return "local-storage-override";
+      }
+    } catch {
+      // Ignore localStorage access failures and fall back to the native source.
+    }
+    return "runtime-desktop";
+  }
+  if (runtimeConfigMode === "tauri") {
+    return "fallback";
+  }
+  if (getDevApiKey().trim()) {
+    return "vite-dev";
+  }
+  return "unknown";
+}
+
 function formatTimestamp(value: number | null): string {
   return value == null ? "<none>" : new Date(value).toISOString();
 }
@@ -256,7 +300,11 @@ export function formatRuntimeHealthDiagnostics(
 ): string[] {
   return [
     `resolved api base url=${diagnostics.resolvedApiBaseUrl ?? "<unresolved>"}`,
+    `resolved api base url source=${diagnostics.resolvedApiBaseUrlSource}`,
     `apiKeyPresent=${diagnostics.apiKeyPresent ? "true" : "false"}`,
+    `api key source=${diagnostics.apiKeySource}`,
+    `hydration state=${diagnostics.hydrationState}`,
+    `native command status=${diagnostics.nativeCommandStatus ?? "<unknown>"}`,
     `authSource=${diagnostics.authSource}`,
     `chat endpoint called=${diagnostics.chat.endpoint}`,
     diagnostics.chat.httpStatus != null
@@ -343,6 +391,16 @@ export function useRuntimeHealth(): RuntimeHealthStatus {
     liveEvents.connectionStatus ?? LIVE_EVENT_CONNECTION_STATES.DISCONNECTED;
   const statusUpdatedAt = liveEvents.statusUpdatedAt ?? null;
   const liveEventsDiagnostics = liveEvents.diagnostics;
+  const runtimeConfigVersion = useSyncExternalStore(
+    subscribeRuntimeConfigState,
+    getRuntimeConfigVersion,
+    getRuntimeConfigVersion
+  );
+  const runtimeConfigHydrationState = useSyncExternalStore(
+    subscribeRuntimeConfigState,
+    getRuntimeConfigHydrationState,
+    getRuntimeConfigHydrationState
+  );
   const [snapshot, setSnapshot] = useState<HealthSnapshot>(INITIAL_SNAPSHOT);
   const inFlightRef = useRef(false);
   const firstCheckAtRef = useRef<number | null>(null);
@@ -383,15 +441,21 @@ export function useRuntimeHealth(): RuntimeHealthStatus {
     } finally {
       inFlightRef.current = false;
     }
-  }, []);
+  }, [runtimeConfigVersion]);
 
   useEffect(() => {
+    if (runtimeConfigHydrationState === "pending") {
+      return;
+    }
+    if (runtimeConfigHydrationState === "failed") {
+      return;
+    }
     void poll();
     const timer = setInterval(() => {
       void poll();
     }, POLL_INTERVAL_MS);
     return () => clearInterval(timer);
-  }, [poll]);
+  }, [poll, runtimeConfigHydrationState, runtimeConfigVersion]);
 
   const now = Date.now();
   const hasChecked = snapshot.lastCheckedAt != null;
@@ -423,15 +487,31 @@ export function useRuntimeHealth(): RuntimeHealthStatus {
       : "live-poll"
     : "fallback";
   const desktopRuntimeAuthConfig = getDesktopRuntimeAuthConfig();
-  const resolvedApiBaseUrl = getRuntimeConfigSync().apiBaseUrl || null;
+  const runtimeConfig = getRuntimeConfigSync();
+  const resolvedApiBaseUrl = runtimeConfig.apiBaseUrl || null;
+  const hydrationState = runtimeConfigHydrationState;
+  const nativeCommandStatus =
+    hydrationState === "failed"
+      ? getRuntimeConfigHydrationFailureKind() ?? "failed"
+      : hydrationState;
   const runtimeDesktopKeyPresent = Boolean(
     desktopRuntimeAuthConfig?.apiKeyPresent || readRuntimeApiKey()
   );
   const apiKeyPresent = Boolean(runtimeDesktopKeyPresent || getDevApiKey().trim());
   const authSource = resolveRuntimeHealthAuthSource();
+  const resolvedApiBaseUrlSource = resolveRuntimeBaseUrlSource(
+    hydrationState,
+    runtimeConfig.mode,
+    desktopRuntimeAuthConfig
+  );
+  const apiKeySource = authSource;
   const diagnostics: RuntimeHealthDiagnostics = {
     resolvedApiBaseUrl,
+    resolvedApiBaseUrlSource,
     apiKeyPresent,
+    apiKeySource,
+    hydrationState,
+    nativeCommandStatus,
     authSource,
     chat: {
       endpoint: snapshot.chat.endpoint,
@@ -457,6 +537,8 @@ export function useRuntimeHealth(): RuntimeHealthStatus {
       transportErrorClass: liveEventsDiagnostics.transportErrorClass,
       authSource: liveEventsDiagnostics.authSource,
       apiKeyPresent: liveEventsDiagnostics.apiKeyPresent,
+      hydrationState: liveEventsDiagnostics.hydrationState,
+      nativeCommandStatus: liveEventsDiagnostics.nativeCommandStatus,
       reconnectAttempts: liveEventsDiagnostics.reconnectAttempts,
       retryMs: liveEventsDiagnostics.retryMs,
       subscribers: liveEventsDiagnostics.subscribers,

--- a/frontend/src/hooks/useRuntimeHealth.ts
+++ b/frontend/src/hooks/useRuntimeHealth.ts
@@ -1,15 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import api, {
-  getAuthToken,
-  getDevApiKey,
-  readRuntimeApiKey,
-} from "@/lib/api";
+import api, { getAuthToken, getDevApiKey, readRuntimeApiKey } from "@/lib/api";
 import { useLiveEvents } from "@/hooks/useLiveEvents";
 import {
   getDesktopRuntimeAuthConfig,
   getRuntimeConfigSync,
   isTauriRuntime,
 } from "@/lib/runtimeConfig";
+import {
+  resolveRuntimeAuthSource,
+  type RuntimeAuthSource,
+} from "@/lib/runtimeAuth";
 import {
   LIVE_EVENT_CONNECTION_STATES,
   LiveEventConnectionState,
@@ -18,6 +18,7 @@ import {
   RuntimeHealthFailureKindToken,
   RuntimeHealthStatusToken,
 } from "@/contracts/runtimeTokens";
+import type { LiveEventsDiagnostics } from "@/hooks/useLiveEvents";
 
 const POLL_INTERVAL_MS = 15000;
 const STALE_THRESHOLD_MS = 45000;
@@ -52,6 +53,7 @@ export type RuntimeHealthDiagnostics = {
   authSource: RuntimeHealthAuthSource;
   chat: RuntimeHealthEndpointObservation;
   llm: RuntimeHealthEndpointObservation;
+  liveEvents: LiveEventsDiagnostics;
   failureKind: RuntimeFailureKind | null;
   lastSuccessAt: number | null;
   lastFailedAt: number | null;
@@ -236,23 +238,13 @@ function resolveRuntimeHealthAuthSource(): RuntimeHealthAuthSource {
   );
   const devKeyPresent = Boolean(getDevApiKey().trim());
   const bearerPresent = Boolean(getAuthToken());
-
-  if (isTauriRuntime() && runtimeDesktopKeyPresent) {
-    return "runtime-desktop";
-  }
-  if (!isTauriRuntime() && devKeyPresent) {
-    return "vite-dev";
-  }
-  if (bearerPresent) {
-    return "bearer-only";
-  }
-  if (isTauriRuntime()) {
-    return desktopAuthConfig ? "none" : "unknown";
-  }
-  if (devKeyPresent) {
-    return "vite-dev";
-  }
-  return "none";
+  return resolveRuntimeAuthSource({
+    isTauriRuntime: isTauriRuntime(),
+    runtimeDesktopKeyPresent,
+    devKeyPresent,
+    bearerPresent,
+    desktopAuthConfigKnown: Boolean(desktopAuthConfig),
+  });
 }
 
 function formatTimestamp(value: number | null): string {
@@ -290,6 +282,17 @@ export function formatRuntimeHealthDiagnostics(
           ? "true"
           : "false"
     }`,
+    `live events endpoint called=${diagnostics.liveEvents.endpoint ?? "<unresolved>"}`,
+    `live events connection state=${diagnostics.liveEvents.connectionState}`,
+    `live events last event=${formatTimestamp(diagnostics.liveEvents.lastEventAt)}`,
+    `live events last ping=${formatTimestamp(diagnostics.liveEvents.lastPingAt)}`,
+    diagnostics.liveEvents.lastHttpStatus != null
+      ? `live events HTTP status=${diagnostics.liveEvents.lastHttpStatus}`
+      : `live events transport error class=${diagnostics.liveEvents.transportErrorClass ?? "<none>"}`,
+    `live events authSource=${diagnostics.liveEvents.authSource}`,
+    `live events apiKeyPresent=${diagnostics.liveEvents.apiKeyPresent ? "true" : "false"}`,
+    `live events reconnect attempts=${diagnostics.liveEvents.reconnectAttempts}`,
+    `live events status updated=${formatTimestamp(diagnostics.liveEvents.statusUpdatedAt)}`,
     `failureKind=${diagnostics.failureKind ?? "none"}`,
     `last successful health poll=${formatTimestamp(diagnostics.lastSuccessAt)}`,
     `last failed health poll=${formatTimestamp(diagnostics.lastFailedAt)}`,
@@ -339,6 +342,7 @@ export function useRuntimeHealth(): RuntimeHealthStatus {
   const connectionStatus =
     liveEvents.connectionStatus ?? LIVE_EVENT_CONNECTION_STATES.DISCONNECTED;
   const statusUpdatedAt = liveEvents.statusUpdatedAt ?? null;
+  const liveEventsDiagnostics = liveEvents.diagnostics;
   const [snapshot, setSnapshot] = useState<HealthSnapshot>(INITIAL_SNAPSHOT);
   const inFlightRef = useRef(false);
   const firstCheckAtRef = useRef<number | null>(null);
@@ -400,11 +404,6 @@ export function useRuntimeHealth(): RuntimeHealthStatus {
       : firstCheckAt != null
         ? now - firstCheckAt > STALE_THRESHOLD_MS
         : false;
-  const liveEventsDisconnected =
-    connectionStatus === LIVE_EVENT_CONNECTION_STATES.DISCONNECTED &&
-    typeof statusUpdatedAt === "number" &&
-    now - statusUpdatedAt > STALE_THRESHOLD_MS;
-
   let failureKind: RuntimeFailureKind | null = null;
   if (hasChecked && snapshot.backendReachable === false) {
     failureKind = RUNTIME_HEALTH_FAILURE_KINDS.BACKEND_UNREACHABLE;
@@ -414,8 +413,6 @@ export function useRuntimeHealth(): RuntimeHealthStatus {
     failureKind = RUNTIME_HEALTH_FAILURE_KINDS.CHAT_UNHEALTHY;
   } else if (hasChecked && snapshot.llm.derivedHealthy === false) {
     failureKind = RUNTIME_HEALTH_FAILURE_KINDS.LLM_UNHEALTHY;
-  } else if (liveEventsDisconnected) {
-    failureKind = RUNTIME_HEALTH_FAILURE_KINDS.LIVE_EVENTS_DISCONNECTED;
   } else if (stale) {
     failureKind = RUNTIME_HEALTH_FAILURE_KINDS.STALE;
   }
@@ -430,8 +427,8 @@ export function useRuntimeHealth(): RuntimeHealthStatus {
   const runtimeDesktopKeyPresent = Boolean(
     desktopRuntimeAuthConfig?.apiKeyPresent || readRuntimeApiKey()
   );
+  const apiKeyPresent = Boolean(runtimeDesktopKeyPresent || getDevApiKey().trim());
   const authSource = resolveRuntimeHealthAuthSource();
-  const apiKeyPresent = runtimeDesktopKeyPresent;
   const diagnostics: RuntimeHealthDiagnostics = {
     resolvedApiBaseUrl,
     apiKeyPresent,
@@ -449,6 +446,23 @@ export function useRuntimeHealth(): RuntimeHealthStatus {
       transportErrorClass: snapshot.llm.transportErrorClass,
       parsedStatus: snapshot.llm.parsedStatus,
       parsedOk: snapshot.llm.parsedOk,
+    },
+    liveEvents: {
+      endpoint: liveEventsDiagnostics.endpoint,
+      connectionState: liveEventsDiagnostics.connectionState,
+      lastEventAt: liveEventsDiagnostics.lastEventAt,
+      lastPingAt: liveEventsDiagnostics.lastPingAt,
+      statusUpdatedAt,
+      lastHttpStatus: liveEventsDiagnostics.lastHttpStatus,
+      transportErrorClass: liveEventsDiagnostics.transportErrorClass,
+      authSource: liveEventsDiagnostics.authSource,
+      apiKeyPresent: liveEventsDiagnostics.apiKeyPresent,
+      reconnectAttempts: liveEventsDiagnostics.reconnectAttempts,
+      retryMs: liveEventsDiagnostics.retryMs,
+      subscribers: liveEventsDiagnostics.subscribers,
+      readyState: liveEventsDiagnostics.readyState,
+      lastErrorAt: liveEventsDiagnostics.lastErrorAt,
+      lastEventId: liveEventsDiagnostics.lastEventId,
     },
     failureKind,
     lastSuccessAt,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -352,6 +352,26 @@ export type ThreadMoveResponse = {
   move?: Record<string, unknown>;
 };
 
+export type ThreadIdResolutionContext = {
+  endpoint: string;
+  method: string;
+  status: number | null;
+  authPresent: boolean;
+};
+
+export type ThreadIdResolutionDiagnostics = ThreadIdResolutionContext & {
+  responseKeys: string[];
+  responseDataKeys: string[];
+  responseThreadKeys: string[];
+  parserBranch: string;
+  parserFailureReason: string;
+};
+
+export type ThreadIdResolution = {
+  threadId: number | null;
+  diagnostics: ThreadIdResolutionDiagnostics;
+};
+
 export type CommandBusActor = {
   kind: "human" | "agent" | "system";
   id: string;
@@ -430,6 +450,115 @@ export async function moveChatThread(
     { toProjectId }
   );
   return response?.data ?? {};
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function summarizeObjectKeys(value: unknown, limit = 12): string[] {
+  if (!isPlainObject(value)) return [];
+  const keys = Object.keys(value).filter((key) => key !== "__proto__");
+  return keys.slice(0, limit);
+}
+
+function coerceThreadIdCandidate(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value.trim());
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function summarizeThreadIdParserBranches(): string {
+  return [
+    "response.thread_id",
+    "response.threadId",
+    "response.id",
+    "response.thread.id",
+    "response.data.thread_id",
+    "response.data.threadId",
+    "response.data.id",
+    "response.data.thread.id",
+  ].join(" -> ");
+}
+
+export function hasRequestAuthCredential(): boolean {
+  return Boolean(getRuntimeApiKey() || getAuthToken() || resolveDevApiKey());
+}
+
+export function resolveBackendThreadIdFromResponse(
+  responseLike: unknown,
+  context: ThreadIdResolutionContext
+): ThreadIdResolution {
+  const response = isPlainObject(responseLike) ? responseLike : null;
+  const responseData = response && isPlainObject(response.data) ? response.data : null;
+  const responseThread = response && isPlainObject(response.thread)
+    ? response.thread
+    : responseData && isPlainObject(responseData.thread)
+      ? responseData.thread
+      : null;
+
+  const diagnostics: ThreadIdResolutionDiagnostics = {
+    endpoint: context.endpoint,
+    method: context.method,
+    status: Number.isFinite(context.status as number) ? Number(context.status) : null,
+    authPresent: Boolean(context.authPresent),
+    responseKeys: summarizeObjectKeys(response),
+    responseDataKeys: summarizeObjectKeys(responseData),
+    responseThreadKeys: summarizeObjectKeys(responseThread),
+    parserBranch: summarizeThreadIdParserBranches(),
+    parserFailureReason: "thread_id_missing",
+  };
+
+  const candidates: Array<[string, unknown]> = [
+    ["response.thread_id", response?.thread_id],
+    ["response.threadId", response?.threadId],
+    ["response.id", response?.id],
+    ["response.thread.id", responseThread?.id],
+    ["response.data.thread_id", responseData?.thread_id],
+    ["response.data.threadId", responseData?.threadId],
+    ["response.data.id", responseData?.id],
+    ["response.data.thread.id", responseData?.thread?.id],
+  ];
+
+  for (const [branch, rawValue] of candidates) {
+    const threadId = coerceThreadIdCandidate(rawValue);
+    if (threadId != null) {
+      return {
+        threadId,
+        diagnostics: {
+          ...diagnostics,
+          parserBranch: branch,
+          parserFailureReason: "resolved",
+        },
+      };
+    }
+  }
+
+  return {
+    threadId: null,
+    diagnostics,
+  };
+}
+
+export function formatThreadIdResolutionDiagnostics(
+  diagnostics: ThreadIdResolutionDiagnostics
+): string[] {
+  return [
+    `endpoint=${diagnostics.endpoint}`,
+    `method=${diagnostics.method}`,
+    `status=${diagnostics.status ?? "<unknown>"}`,
+    `authPresent=${diagnostics.authPresent ? "true" : "false"}`,
+    `responseKeys=${diagnostics.responseKeys.length > 0 ? diagnostics.responseKeys.join(",") : "<none>"}`,
+    `dataKeys=${diagnostics.responseDataKeys.length > 0 ? diagnostics.responseDataKeys.join(",") : "<none>"}`,
+    `threadKeys=${diagnostics.responseThreadKeys.length > 0 ? diagnostics.responseThreadKeys.join(",") : "<none>"}`,
+    `parserBranch=${diagnostics.parserBranch}`,
+    `parserFailureReason=${diagnostics.parserFailureReason}`,
+  ];
 }
 
 function isAbsoluteUrl(value: string): boolean {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -277,6 +277,10 @@ export function buildLlmCatalogPath(): string {
   return "/llm/catalog";
 }
 
+export function buildChatThreadsPath(): string {
+  return "/api/chat/threads";
+}
+
 export function buildChatCompletePath(threadId: string | number): string {
   return `/chat/${normalizePathSegment(threadId)}/complete`;
 }
@@ -359,12 +363,17 @@ export type ThreadIdResolutionContext = {
   authPresent: boolean;
 };
 
+export type ThreadIdParserFailureReason =
+  | "resolved"
+  | "thread_id_missing"
+  | "wrong_endpoint_or_non_json_response";
+
 export type ThreadIdResolutionDiagnostics = ThreadIdResolutionContext & {
   responseKeys: string[];
   responseDataKeys: string[];
   responseThreadKeys: string[];
   parserBranch: string;
-  parserFailureReason: string;
+  parserFailureReason: ThreadIdParserFailureReason;
 };
 
 export type ThreadIdResolution = {
@@ -486,6 +495,13 @@ function summarizeThreadIdParserBranches(): string {
   ].join(" -> ");
 }
 
+function isAxiosResponseLike(value: unknown): value is Record<string, unknown> {
+  if (!isPlainObject(value)) return false;
+  return ["data", "status", "statusText", "headers", "config", "request"].some(
+    (key) => key in value
+  );
+}
+
 export function hasRequestAuthCredential(): boolean {
   return Boolean(getRuntimeApiKey() || getAuthToken() || resolveDevApiKey());
 }
@@ -495,12 +511,22 @@ export function resolveBackendThreadIdFromResponse(
   context: ThreadIdResolutionContext
 ): ThreadIdResolution {
   const response = isPlainObject(responseLike) ? responseLike : null;
-  const responseData = response && isPlainObject(response.data) ? response.data : null;
+  const responseHasDataProp =
+    Boolean(response) && Object.prototype.hasOwnProperty.call(response, "data");
+  const responseDataValue = responseHasDataProp ? response?.data : undefined;
+  const responseData = isPlainObject(responseDataValue) ? responseDataValue : null;
   const responseThread = response && isPlainObject(response.thread)
     ? response.thread
     : responseData && isPlainObject(responseData.thread)
       ? responseData.thread
       : null;
+  const parserFailureReason: ThreadIdParserFailureReason =
+    response != null &&
+    responseHasDataProp &&
+    !isPlainObject(responseDataValue) &&
+    isAxiosResponseLike(response)
+      ? "wrong_endpoint_or_non_json_response"
+      : "thread_id_missing";
 
   const diagnostics: ThreadIdResolutionDiagnostics = {
     endpoint: context.endpoint,
@@ -511,7 +537,7 @@ export function resolveBackendThreadIdFromResponse(
     responseDataKeys: summarizeObjectKeys(responseData),
     responseThreadKeys: summarizeObjectKeys(responseThread),
     parserBranch: summarizeThreadIdParserBranches(),
-    parserFailureReason: "thread_id_missing",
+    parserFailureReason,
   };
 
   const candidates: Array<[string, unknown]> = [

--- a/frontend/src/lib/liveEventsHub.ts
+++ b/frontend/src/lib/liveEventsHub.ts
@@ -1,4 +1,5 @@
 import { GuardianEventSource } from "@/lib/guardianEventSource";
+import type { RuntimeAuthSource } from "@/lib/runtimeAuth";
 import { getBackendOutageRemainingMs } from "@/lib/api";
 import type { LiveEvent, LiveEventEntity } from "@/lib/events/types";
 
@@ -20,16 +21,25 @@ export type LiveEventsHubConfig = {
   url: string;
   headers: Record<string, string>;
   withCredentials: boolean;
+  authSource: RuntimeAuthSource;
+  apiKeyPresent: boolean;
   onUnauthorized?: () => void;
 };
 
 export type LiveEventsHubEvent = LiveEvent;
 
 export type LiveEventsHubStatus = {
+  endpoint: string | null;
   readyState: 0 | 1 | 2;
   subscribers: number;
   lastEventId: string | null;
+  lastEventAt: number | null;
+  lastPingAt: number | null;
   lastErrorAt: number | null;
+  lastHttpStatus: number | null;
+  transportErrorClass: string | null;
+  authSource: RuntimeAuthSource;
+  apiKeyPresent: boolean;
   connectAttempt: number;
   retryMs: number;
   connectionStatus: HubConnectionStatus;
@@ -97,7 +107,11 @@ let connectionStatus: HubConnectionStatus = "disconnected";
 let connectAttempt = 0;
 let retryMs = INITIAL_RETRY_MS;
 let lastEventId: string | null = readStoredLastEventId();
+let lastEventAt: number | null = null;
+let lastPingAt: number | null = null;
 let lastErrorAt: number | null = null;
+let lastHttpStatus: number | null = null;
+let transportErrorClass: string | null = null;
 
 const seenEventIds = new Set<string>();
 const seenEventIdQueue: string[] = [];
@@ -160,10 +174,17 @@ function buildConfigKey(config: LiveEventsHubConfig): string {
 
 function statusSnapshot(): LiveEventsHubStatus {
   return {
+    endpoint: activeConfig?.url ?? null,
     readyState,
     subscribers: subscribers.size,
     lastEventId,
+    lastEventAt,
+    lastPingAt,
     lastErrorAt,
+    lastHttpStatus,
+    transportErrorClass,
+    authSource: activeConfig?.authSource ?? "unknown",
+    apiKeyPresent: Boolean(activeConfig?.apiKeyPresent),
     connectAttempt,
     retryMs,
     connectionStatus,
@@ -710,7 +731,11 @@ function hardReset(): void {
   activeConfig = null;
   activeConfigKey = "";
   lastEventId = readStoredLastEventId();
+  lastEventAt = null;
+  lastPingAt = null;
   lastErrorAt = null;
+  lastHttpStatus = null;
+  transportErrorClass = null;
   connectAttempt = 0;
   retryMs = INITIAL_RETRY_MS;
   connectionStatus = "disconnected";
@@ -778,7 +803,11 @@ function connect(config: LiveEventsHubConfig, reconnecting: boolean): void {
   const next = new GuardianEventSource(buildSourceUrl(config.url), {
     headers: config.headers,
     withCredentials: config.withCredentials,
-    onUnauthorized: config.onUnauthorized,
+    onUnauthorized: () => {
+      lastHttpStatus = 401;
+      transportErrorClass = null;
+      config.onUnauthorized?.();
+    },
     autoReconnect: false,
   });
   source = next;
@@ -787,6 +816,8 @@ function connect(config: LiveEventsHubConfig, reconnecting: boolean): void {
     if (abortSignal.aborted) return;
     readyState = GuardianEventSource.OPEN;
     connectionStatus = "connected";
+    lastHttpStatus = 200;
+    transportErrorClass = null;
     connectAttempt = 0;
     retryMs = INITIAL_RETRY_MS;
     notifyStatus();
@@ -795,6 +826,11 @@ function connect(config: LiveEventsHubConfig, reconnecting: boolean): void {
 
   sourceMessageListener = (evt: MessageEvent) => {
     if (abortSignal.aborted) return;
+    const now = Date.now();
+    lastEventAt = now;
+    if (evt.type === "ping") {
+      lastPingAt = now;
+    }
     const payload: LiveEventsHubRawEvent = {
       id: evt.lastEventId || null,
       type: evt.type || "message",
@@ -805,6 +841,7 @@ function connect(config: LiveEventsHubConfig, reconnecting: boolean): void {
       persistLastEventId(payload.id);
     }
     if (shouldDropEvent(payload)) return;
+    notifyStatus();
     publishEvent(payload);
   };
 
@@ -813,6 +850,7 @@ function connect(config: LiveEventsHubConfig, reconnecting: boolean): void {
     lastErrorAt = Date.now();
     readyState = GuardianEventSource.CLOSED;
     connectionStatus = "reconnecting";
+    transportErrorClass = "stream_error";
     notifyStatus();
     closeSource();
     scheduleReconnect();

--- a/frontend/src/lib/runtimeAuth.ts
+++ b/frontend/src/lib/runtimeAuth.ts
@@ -6,10 +6,52 @@ function normalizeApiKey(value: string | null | undefined): string | null {
 
 let runtimeApiKey: string | null = null;
 let runtimeApiKeyResolved = false;
+let runtimeAuthVersion = 0;
+const runtimeAuthListeners = new Set<() => void>();
+
+export type RuntimeAuthSource =
+  | "runtime-desktop"
+  | "vite-dev"
+  | "bearer-only"
+  | "none"
+  | "unknown";
+
+export function resolveRuntimeAuthSource(options: {
+  isTauriRuntime: boolean;
+  runtimeDesktopKeyPresent: boolean;
+  devKeyPresent: boolean;
+  bearerPresent: boolean;
+  desktopAuthConfigKnown: boolean;
+}): RuntimeAuthSource {
+  if (options.isTauriRuntime && options.runtimeDesktopKeyPresent) {
+    return "runtime-desktop";
+  }
+  if (!options.isTauriRuntime && options.devKeyPresent) {
+    return "vite-dev";
+  }
+  if (options.bearerPresent) {
+    return "bearer-only";
+  }
+  if (options.isTauriRuntime) {
+    return options.desktopAuthConfigKnown ? "none" : "unknown";
+  }
+  if (options.devKeyPresent) {
+    return "vite-dev";
+  }
+  return "none";
+}
+
+function emitRuntimeAuthChange(): void {
+  runtimeAuthVersion += 1;
+  for (const listener of runtimeAuthListeners) {
+    listener();
+  }
+}
 
 export function setRuntimeApiKey(value: string | null | undefined): void {
   runtimeApiKey = normalizeApiKey(value);
   runtimeApiKeyResolved = true;
+  emitRuntimeAuthChange();
 }
 
 export function getRuntimeApiKey(): string | null {
@@ -27,14 +69,28 @@ export function hasResolvedRuntimeApiKey(): boolean {
 export function clearRuntimeApiKey(): void {
   runtimeApiKey = null;
   runtimeApiKeyResolved = true;
+  emitRuntimeAuthChange();
 }
 
 export function __setRuntimeApiKeyForTests(value: string | null): void {
   runtimeApiKey = normalizeApiKey(value);
   runtimeApiKeyResolved = true;
+  emitRuntimeAuthChange();
 }
 
 export function __resetRuntimeApiKeyForTests(): void {
   runtimeApiKey = null;
   runtimeApiKeyResolved = false;
+  emitRuntimeAuthChange();
+}
+
+export function getRuntimeAuthVersion(): number {
+  return runtimeAuthVersion;
+}
+
+export function subscribeRuntimeAuthState(listener: () => void): () => void {
+  runtimeAuthListeners.add(listener);
+  return () => {
+    runtimeAuthListeners.delete(listener);
+  };
 }

--- a/frontend/src/lib/runtimeConfig.ts
+++ b/frontend/src/lib/runtimeConfig.ts
@@ -2,6 +2,7 @@ import { combineBaseAndPath } from "@/lib/urlJoin";
 
 export type RuntimeMode = "web" | "tauri";
 export type AuthMode = "local" | "remote";
+export type RuntimeConfigHydrationState = "pending" | "ready" | "failed";
 
 export interface RuntimeConfig {
   mode: RuntimeMode;
@@ -61,6 +62,8 @@ const DESKTOP_SHARE_STORAGE_KEY = "cfy.desktop.sharePublicBaseUrl";
 let runtimeConfigCache: RuntimeConfig | null = null;
 let runtimeConfigPromise: Promise<RuntimeConfig> | null = null;
 let desktopRuntimeAuthConfigCache: DesktopRuntimeAuthConfig | null = null;
+let runtimeConfigHydrationState: RuntimeConfigHydrationState = defaultMode() === "tauri" ? "pending" : "ready";
+let runtimeConfigHydrationFailureKind: string | null = null;
 let runtimeConfigVersion = 0;
 const runtimeConfigListeners = new Set<() => void>();
 
@@ -87,6 +90,14 @@ function emitRuntimeConfigChange(): void {
   for (const listener of runtimeConfigListeners) {
     listener();
   }
+}
+
+function setRuntimeConfigHydrationState(
+  state: RuntimeConfigHydrationState,
+  failureKind: string | null = null
+): void {
+  runtimeConfigHydrationState = state;
+  runtimeConfigHydrationFailureKind = failureKind;
 }
 
 function readRuntimeEnv(name: string, fallback = ""): string {
@@ -383,7 +394,7 @@ function resolveDesktopBackendBaseUrl(
     return normalizeBase(tauriBackend, mode === "tauri" ? "" : defaultBackendBaseUrl(mode));
   }
 
-  return mode === "tauri" ? "" : defaultBackendBaseUrl(mode);
+  return mode === "tauri" ? defaultBackendBaseUrl(mode) : defaultBackendBaseUrl(mode);
 }
 
 function resolveApiBaseUrl(mode: RuntimeMode, backendBaseUrl: string, explicit: string): string {
@@ -391,17 +402,17 @@ function resolveApiBaseUrl(mode: RuntimeMode, backendBaseUrl: string, explicit: 
   if (isAbsoluteUrl(candidate)) {
     return normalizeBase(candidate, combineBaseAndPath(backendBaseUrl, "/api"));
   }
+  if (mode === "tauri") {
+    return normalizeBase(
+      combineBaseAndPath(backendBaseUrl, "/api"),
+      "http://127.0.0.1:8888/api"
+    );
+  }
   if (candidate.startsWith("/")) {
     return normalizeBase(candidate, "/api");
   }
   if (candidate) {
     return normalizeBase(`/${candidate}`, "/api");
-  }
-  if (mode === "tauri" && !backendBaseUrl) {
-    return "/api";
-  }
-  if (mode === "tauri") {
-    return normalizeBase(combineBaseAndPath(backendBaseUrl, "/api"), "http://127.0.0.1:8888/api");
   }
   return "/api";
 }
@@ -529,6 +540,17 @@ export function getDesktopRuntimeAuthConfig(): DesktopRuntimeAuthConfig | null {
   return desktopRuntimeAuthConfigCache;
 }
 
+export function getRuntimeConfigHydrationState(): RuntimeConfigHydrationState {
+  if (runtimeConfigHydrationState === "pending" && !isTauriRuntime()) {
+    return "ready";
+  }
+  return runtimeConfigHydrationState;
+}
+
+export function getRuntimeConfigHydrationFailureKind(): string | null {
+  return runtimeConfigHydrationFailureKind;
+}
+
 export function getRuntimeConfigVersion(): number {
   return runtimeConfigVersion;
 }
@@ -602,16 +624,40 @@ export async function initRuntimeConfig(options: { force?: boolean } = {}): Prom
   }
 
   const mode = defaultMode();
+  if (mode === "tauri") {
+    setRuntimeConfigHydrationState("pending");
+  } else {
+    setRuntimeConfigHydrationState("ready");
+  }
   runtimeConfigPromise = (async () => {
-    const [launcherStartup, tauriConfig] = await Promise.all([
-      readDesktopLauncherStartupHandoff(),
-      readTauriRuntimeConfig(),
-    ]);
-    const config = buildRuntimeConfig(mode, tauriConfig, launcherStartup);
-    runtimeConfigCache = config;
-    emitRuntimeConfigChange();
-    runtimeConfigPromise = null;
-    return config;
+    try {
+      const [launcherStartup, tauriConfig] = await Promise.all([
+        readDesktopLauncherStartupHandoff(),
+        readTauriRuntimeConfig(),
+      ]);
+      const config = buildRuntimeConfig(mode, tauriConfig, launcherStartup);
+      runtimeConfigCache = config;
+      if (mode === "tauri") {
+        setRuntimeConfigHydrationState(
+          tauriConfig ? "ready" : "failed",
+          tauriConfig ? null : (desktopRuntimeAuthConfigCache?.failureKind ?? null)
+        );
+      } else {
+        setRuntimeConfigHydrationState("ready");
+      }
+      emitRuntimeConfigChange();
+      return config;
+    } catch (error) {
+      const failureKind =
+        error instanceof NativeBridgeUnavailableError
+          ? error.code
+          : "runtime-config-hydration-failed";
+      setRuntimeConfigHydrationState("failed", failureKind);
+      emitRuntimeConfigChange();
+      throw error;
+    } finally {
+      runtimeConfigPromise = null;
+    }
   })();
 
   return runtimeConfigPromise;

--- a/frontend/src/lib/runtimeConfig.ts
+++ b/frontend/src/lib/runtimeConfig.ts
@@ -61,6 +61,8 @@ const DESKTOP_SHARE_STORAGE_KEY = "cfy.desktop.sharePublicBaseUrl";
 let runtimeConfigCache: RuntimeConfig | null = null;
 let runtimeConfigPromise: Promise<RuntimeConfig> | null = null;
 let desktopRuntimeAuthConfigCache: DesktopRuntimeAuthConfig | null = null;
+let runtimeConfigVersion = 0;
+const runtimeConfigListeners = new Set<() => void>();
 
 type TauriCoreApi = {
   invoke: <T = unknown>(
@@ -77,6 +79,13 @@ export class NativeBridgeUnavailableError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "NativeBridgeUnavailableError";
+  }
+}
+
+function emitRuntimeConfigChange(): void {
+  runtimeConfigVersion += 1;
+  for (const listener of runtimeConfigListeners) {
+    listener();
   }
 }
 
@@ -520,6 +529,17 @@ export function getDesktopRuntimeAuthConfig(): DesktopRuntimeAuthConfig | null {
   return desktopRuntimeAuthConfigCache;
 }
 
+export function getRuntimeConfigVersion(): number {
+  return runtimeConfigVersion;
+}
+
+export function subscribeRuntimeConfigState(listener: () => void): () => void {
+  runtimeConfigListeners.add(listener);
+  return () => {
+    runtimeConfigListeners.delete(listener);
+  };
+}
+
 function buildRuntimeConfig(
   mode: RuntimeMode,
   tauriConfig: TauriRuntimeConfig | null,
@@ -589,6 +609,7 @@ export async function initRuntimeConfig(options: { force?: boolean } = {}): Prom
     ]);
     const config = buildRuntimeConfig(mode, tauriConfig, launcherStartup);
     runtimeConfigCache = config;
+    emitRuntimeConfigChange();
     runtimeConfigPromise = null;
     return config;
   })();

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -141,6 +141,5 @@ configureGC({
   token: readRuntimeApiKey() || readDevApiKey() || undefined,
 });
 resolveAuthStateOnBoot();
-renderApp();
-
 void bootstrap();
+renderApp();

--- a/frontend/src/test/api.desktop-auth.test.ts
+++ b/frontend/src/test/api.desktop-auth.test.ts
@@ -120,6 +120,31 @@ describe("desktop auth headers", () => {
     );
   });
 
+  it("attaches the runtime desktop key to create-thread requests", async () => {
+    setRuntimeApiKey("desktop-key");
+
+    let capturedHeaders: Record<string, string> = {};
+    api.defaults.adapter = async (config) => {
+      capturedHeaders = normalizeHeaders(config.headers);
+      return {
+        data: { thread_id: 123, thread: { id: 123, title: "New Thread" } },
+        status: 201,
+        statusText: "Created",
+        headers: {},
+        config,
+      };
+    };
+
+    await api.post("/chat/threads", {
+      title: "New Thread",
+      user_id: "local",
+    });
+
+    expect(capturedHeaders["X-API-Key"] ?? capturedHeaders["x-api-key"]).toBe(
+      "desktop-key"
+    );
+  });
+
   it("fetchProviderState uses the authenticated desktop runtime client", async () => {
     setRuntimeApiKey("desktop-key");
 

--- a/frontend/src/test/api.desktop-auth.test.ts
+++ b/frontend/src/test/api.desktop-auth.test.ts
@@ -135,7 +135,7 @@ describe("desktop auth headers", () => {
       };
     };
 
-    await api.post("/chat/threads", {
+    await api.post("/api/chat/threads", {
       title: "New Thread",
       user_id: "local",
     });

--- a/frontend/src/test/live-events-auth-gate.test.tsx
+++ b/frontend/src/test/live-events-auth-gate.test.tsx
@@ -23,6 +23,9 @@ type MockSource = {
 };
 
 const createdSources: MockSource[] = [];
+const runtimeState = vi.hoisted(() => ({
+  hydrationState: "ready" as "pending" | "ready" | "failed",
+}));
 
 vi.mock("@/lib/guardianEventSource", () => {
   class MockGuardianEventSource {
@@ -50,20 +53,25 @@ vi.mock("@/lib/guardianEventSource", () => {
 });
 
 vi.mock("@/lib/runtimeConfig", () => ({
-  getDesktopRuntimeAuthConfig: () => ({
-    mode: "tauri",
-    backendBaseUrl: "http://127.0.0.1:8888",
-    apiBaseUrl: "http://127.0.0.1:8888/api",
-    sseUrl: "http://127.0.0.1:8888/api/events",
-    sharePublicBaseUrl: "http://127.0.0.1:5173",
-    authMode: "local",
-    apiKeyPresent: true,
-    apiKey: "desktop-key",
-    envPath: "/Users/chriscastillo/Codexify/.env",
-    runtimeRoot: "/Users/chriscastillo/Codexify",
-    failureKind: null,
-    runtimeContext: "packaged",
-  }),
+  getDesktopRuntimeAuthConfig: () =>
+    runtimeState.hydrationState === "failed"
+      ? null
+      : {
+          mode: "tauri",
+          backendBaseUrl: "http://127.0.0.1:8888",
+          apiBaseUrl: "http://127.0.0.1:8888/api",
+          sseUrl: "http://127.0.0.1:8888/api/events",
+          sharePublicBaseUrl: "http://127.0.0.1:5173",
+          authMode: "local",
+          apiKeyPresent: true,
+          apiKey: "desktop-key",
+          envPath: "/Users/chriscastillo/Codexify/.env",
+          runtimeRoot: "/Users/chriscastillo/Codexify",
+          failureKind: null,
+          runtimeContext: "packaged",
+        },
+  getRuntimeConfigHydrationState: () => runtimeState.hydrationState,
+  getRuntimeConfigVersion: () => 0,
   getRuntimeConfigSync: () => ({
     mode: "tauri",
     backendBaseUrl: "http://127.0.0.1:8888",
@@ -72,7 +80,6 @@ vi.mock("@/lib/runtimeConfig", () => ({
     sharePublicBaseUrl: "http://127.0.0.1:5173",
     authMode: "local",
   }),
-  getRuntimeConfigVersion: () => 0,
   subscribeRuntimeConfigState: () => () => {},
   isTauriRuntime: () => true,
   resolveSseEndpoint: () => "http://127.0.0.1:8888/api/events",
@@ -81,6 +88,7 @@ vi.mock("@/lib/runtimeConfig", () => ({
 describe("useLiveEvents auth gating", () => {
   beforeEach(() => {
     createdSources.length = 0;
+    runtimeState.hydrationState = "ready";
     __resetAuthStateForTests();
     __resetLiveEventsHubForTests();
     clearRuntimeApiKey();
@@ -152,5 +160,32 @@ describe("useLiveEvents auth gating", () => {
     expect(JSON.stringify(result.current.diagnostics)).not.toContain(
       "stale-bearer-token"
     );
+  });
+
+  it("waits for runtime hydration before connecting live events", async () => {
+    runtimeState.hydrationState = "pending";
+    __setAuthStateForTests({
+      status: "authenticated",
+      ready: true,
+      token: "token-1",
+    });
+
+    const { result, rerender } = renderHook(() => useLiveEvents({ passive: true }));
+
+    expect(createdSources).toHaveLength(0);
+    expect(result.current.diagnostics.hydrationState).toBe("pending");
+    await waitFor(() => {
+      expect(result.current.connectionStatus).toBe("connecting");
+    });
+
+    runtimeState.hydrationState = "ready";
+    rerender();
+
+    await waitFor(() => {
+      expect(createdSources).toHaveLength(1);
+      expect(result.current.diagnostics.hydrationState).toBe("ready");
+      expect(result.current.diagnostics.authSource).toBe("runtime-desktop");
+      expect(result.current.diagnostics.apiKeyPresent).toBe(true);
+    });
   });
 });

--- a/frontend/src/test/live-events-auth-gate.test.tsx
+++ b/frontend/src/test/live-events-auth-gate.test.tsx
@@ -2,6 +2,11 @@ import { renderHook, waitFor, act } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useLiveEvents } from "@/hooks/useLiveEvents";
 import {
+  clearRuntimeApiKey,
+  setAuthToken,
+  setRuntimeApiKey,
+} from "@/lib/api";
+import {
   __resetAuthStateForTests,
   __setAuthStateForTests,
 } from "@/lib/authState";
@@ -44,11 +49,42 @@ vi.mock("@/lib/guardianEventSource", () => {
   return { GuardianEventSource: MockGuardianEventSource };
 });
 
+vi.mock("@/lib/runtimeConfig", () => ({
+  getDesktopRuntimeAuthConfig: () => ({
+    mode: "tauri",
+    backendBaseUrl: "http://127.0.0.1:8888",
+    apiBaseUrl: "http://127.0.0.1:8888/api",
+    sseUrl: "http://127.0.0.1:8888/api/events",
+    sharePublicBaseUrl: "http://127.0.0.1:5173",
+    authMode: "local",
+    apiKeyPresent: true,
+    apiKey: "desktop-key",
+    envPath: "/Users/chriscastillo/Codexify/.env",
+    runtimeRoot: "/Users/chriscastillo/Codexify",
+    failureKind: null,
+    runtimeContext: "packaged",
+  }),
+  getRuntimeConfigSync: () => ({
+    mode: "tauri",
+    backendBaseUrl: "http://127.0.0.1:8888",
+    apiBaseUrl: "http://127.0.0.1:8888/api",
+    sseUrl: "http://127.0.0.1:8888/api/events",
+    sharePublicBaseUrl: "http://127.0.0.1:5173",
+    authMode: "local",
+  }),
+  getRuntimeConfigVersion: () => 0,
+  subscribeRuntimeConfigState: () => () => {},
+  isTauriRuntime: () => true,
+  resolveSseEndpoint: () => "http://127.0.0.1:8888/api/events",
+}));
+
 describe("useLiveEvents auth gating", () => {
   beforeEach(() => {
     createdSources.length = 0;
     __resetAuthStateForTests();
     __resetLiveEventsHubForTests();
+    clearRuntimeApiKey();
+    setAuthToken(null);
     vi.spyOn(console, "debug").mockImplementation(() => {});
     vi.spyOn(console, "info").mockImplementation(() => {});
   });
@@ -84,5 +120,37 @@ describe("useLiveEvents auth gating", () => {
     await waitFor(() => {
       expect(source.close).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("attaches the packaged runtime API key without letting a stale bearer shadow it", async () => {
+    __setAuthStateForTests({
+      status: "authenticated",
+      ready: true,
+      token: "stale-bearer-token",
+    });
+    setAuthToken("stale-bearer-token");
+    setRuntimeApiKey("desktop-key");
+
+    const { result } = renderHook(() => useLiveEvents({ passive: true }));
+
+    await waitFor(() => {
+      expect(createdSources).toHaveLength(1);
+    });
+
+    const source = createdSources[0];
+    const headers = source.options.headers as Record<string, string>;
+
+    expect(result.current.diagnostics.authSource).toBe("runtime-desktop");
+    expect(result.current.diagnostics.apiKeyPresent).toBe(true);
+    expect(headers["X-API-Key"] ?? headers["x-api-key"]).toBe("desktop-key");
+    expect(headers["Authorization"] ?? headers["authorization"]).toBe(
+      "Bearer stale-bearer-token"
+    );
+    expect(JSON.stringify(result.current.diagnostics)).not.toContain(
+      "desktop-key"
+    );
+    expect(JSON.stringify(result.current.diagnostics)).not.toContain(
+      "stale-bearer-token"
+    );
   });
 });

--- a/frontend/src/test/live-events-singleton.test.tsx
+++ b/frontend/src/test/live-events-singleton.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type MockSource = {
   addEventListener: ReturnType<typeof vi.fn>;
+  emitOpen: () => void;
   emitError: () => void;
   emitEvent: (type: string, data: unknown, lastEventId?: string) => void;
   close: ReturnType<typeof vi.fn>;
@@ -57,6 +58,13 @@ vi.mock("@/lib/guardianEventSource", () => {
       const event = new Event("error");
       this.onerror?.(event);
       this.emit("error", event);
+    }
+
+    emitOpen(): void {
+      this.readyState = MockGuardianEventSource.OPEN;
+      const event = new Event("open");
+      this.onopen?.(event);
+      this.emit("open", event);
     }
 
     emitEvent(type: string, data: unknown, lastEventId?: string): void {
@@ -213,6 +221,33 @@ describe("live events singleton hub", () => {
         "browser.approval.decided",
       ])
     );
+
+    unmount();
+  });
+
+  it("marks a 200 text/event-stream connection as connected rather than failed", async () => {
+    const { result, unmount } = renderHook(() => useLiveEvents({ passive: true }));
+
+    await waitFor(() => {
+      expect(mockState.createdSources).toHaveLength(1);
+    });
+
+    expect(result.current.connectionStatus).toBe("connecting");
+
+    act(() => {
+      mockState.createdSources[0].emitOpen();
+    });
+
+    await waitFor(() => {
+      expect(result.current.connectionStatus).toBe("connected");
+      expect(result.current.connected).toBe(true);
+    });
+
+    const status = getLiveEventsHubStatus();
+    expect(status.connectionStatus).toBe("connected");
+    expect(status.readyState).toBe(1);
+    expect(status.lastHttpStatus).toBe(200);
+    expect(status.transportErrorClass).toBeNull();
 
     unmount();
   });

--- a/frontend/src/test/new-thread-route-invariant.test.ts
+++ b/frontend/src/test/new-thread-route-invariant.test.ts
@@ -14,6 +14,19 @@ describe("Draft thread route invariants", () => {
     expect(source).toContain("thread_id: null");
   });
 
+  it("routes Guardian create-thread calls through the canonical API prefix", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "features/chat/GuardianChat.tsx"),
+      "utf8"
+    );
+    const start = source.indexOf("const createThreadFromComposer");
+    const end = source.indexOf("const ensureThreadIdForAttachments");
+    const slice = start >= 0 && end > start ? source.slice(start, end) : source;
+
+    expect(slice).toContain("buildChatThreadsPath()");
+    expect(slice).not.toContain('api.post("/chat/threads"');
+  });
+
   it("does not create threads from dashboard new-thread flow", () => {
     const source = readFileSync(
       resolve(process.cwd(), "components/persona/layout/AppShell.tsx"),

--- a/frontend/src/test/runtime-config.test.ts
+++ b/frontend/src/test/runtime-config.test.ts
@@ -4,6 +4,7 @@ import {
   initRuntimeConfig,
   readDesktopStartupRoutingDecision,
   getDesktopRuntimeAuthConfig,
+  getRuntimeConfigHydrationState,
   resolveApiUrl,
   resolveSseEndpoint,
 } from "@/lib/runtimeConfig";
@@ -54,14 +55,41 @@ describe("runtime config", () => {
     expect(resolveSseEndpoint(config)).toBe("/api/events");
   });
 
+  it("ignores relative packaged API base overrides in tauri mode", async () => {
+    (window as any).__TAURI_IPC__ = {};
+    (window as any).__CFY_TAURI_CORE__ = { invoke: invokeMock };
+    vi.stubEnv("VITE_API_BASE_URL", "/api");
+    invokeMock.mockResolvedValue({
+      mode: "tauri",
+      backendBaseUrl: "http://127.0.0.1:8888",
+      apiBaseUrl: "http://127.0.0.1:8888/api",
+      sseUrl: "http://127.0.0.1:8888/api/events",
+      sharePublicBaseUrl: "http://127.0.0.1:5173",
+      authMode: "local",
+      apiKeyPresent: true,
+      apiKey: "packaged-runtime-key",
+      envPath: "/Users/chriscastillo/Codexify/.env",
+      runtimeRoot: "/Users/chriscastillo/Codexify",
+      failureKind: null,
+      runtimeContext: "packaged",
+    });
+
+    const config = await initRuntimeConfig({ force: true });
+
+    expect(config.apiBaseUrl).toBe("http://127.0.0.1:8888/api");
+    expect(resolveApiUrl("/api/share", config)).toBe(
+      "http://127.0.0.1:8888/api/share"
+    );
+  });
+
   it("hydrates tauri runtime config via desktop command", async () => {
     (window as any).__TAURI_IPC__ = {};
     (window as any).__CFY_TAURI_CORE__ = { invoke: invokeMock };
     invokeMock.mockResolvedValue({
       mode: "tauri",
-      backendBaseUrl: "http://127.0.0.1:9999",
-      apiBaseUrl: "http://127.0.0.1:9999/api",
-      sseUrl: "http://127.0.0.1:9999/api/events",
+      backendBaseUrl: "http://127.0.0.1:8888",
+      apiBaseUrl: "http://127.0.0.1:8888/api",
+      sseUrl: "http://127.0.0.1:8888/api/events",
       sharePublicBaseUrl: "https://share.example",
       authMode: "local",
       apiKeyPresent: true,
@@ -75,17 +103,18 @@ describe("runtime config", () => {
     const config = await initRuntimeConfig({ force: true });
 
     expect(config.mode).toBe("tauri");
-    expect(config.backendBaseUrl).toBe("http://127.0.0.1:9999");
-    expect(config.apiBaseUrl).toBe("http://127.0.0.1:9999/api");
+    expect(config.backendBaseUrl).toBe("http://127.0.0.1:8888");
+    expect(config.apiBaseUrl).toBe("http://127.0.0.1:8888/api");
     expect(readRuntimeApiKey()).toBe("packaged-runtime-key");
     expect(getDesktopRuntimeAuthConfig()?.apiKeyPresent).toBe(true);
     expect(getDesktopRuntimeAuthConfig()?.envPath).toBe(
       "/Users/chriscastillo/Codexify/.env"
     );
+    expect(getRuntimeConfigHydrationState()).toBe("ready");
     expect(resolveApiUrl("/api/share", config)).toBe(
-      "http://127.0.0.1:9999/api/share"
+      "http://127.0.0.1:8888/api/share"
     );
-    expect(resolveSseEndpoint(config)).toBe("http://127.0.0.1:9999/api/events");
+    expect(resolveSseEndpoint(config)).toBe("http://127.0.0.1:8888/api/events");
     const headers = buildAuthenticatedFetchInit().headers as Record<string, string>;
     expect(headers["X-API-Key"] ?? headers["x-api-key"]).toBe(
       "packaged-runtime-key"


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
