### PR TITLE
Codex/fix desktop auth gate mismatch

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -187,7 +187,7 @@ FROM runtime AS tts-runtime
 # Copy the site-packages tree with pinned TTS dependency graph.
 COPY --from=builder-tts /opt/python/lib/python3.11/site-packages /opt/python/lib/python3.11/site-packages
 
-# === Compiled backend proof stage: build a frozen artifact for the API entrypoint ===
+# === Compiled runtime proof stage: build a frozen dispatcher artifact ===
 FROM builder AS compiled-builder
 
 WORKDIR /src
@@ -204,9 +204,9 @@ RUN mkdir -p /src/guardian/contracts && \
     cp /src/guardian/contracts.py /src/guardian/contracts/__init__.py
 
 RUN python -m pip install pyinstaller
-RUN pyinstaller /src/packaging/pyinstaller/codexify_backend.spec --noconfirm --clean --distpath /src/build/dist --workpath /src/build/work
+RUN pyinstaller /src/packaging/pyinstaller/codexify_runtime.spec --noconfirm --clean --distpath /src/build/dist --workpath /src/build/work
 
-# === Compiled backend runtime proof image ===
+# === Compiled runtime proof image ===
 FROM dhi.io/python:3.11.14-debian13-dev AS compiled-runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -215,16 +215,35 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONPATH=/app \
     PORT=8888 \
     HOME=/home/codexify \
-    CODEXIFY_APP_ROOT=/app
+    CODEXIFY_APP_ROOT=/app \
+    ALEMBIC_CONFIG=/app/runtime/alembic.ini
 
 WORKDIR /app
 
 RUN mkdir -p /home/codexify
 
-COPY --from=compiled-builder /src/build/dist/codexify-backend /app/runtime
+COPY --from=compiled-builder /src/build/dist/codexify-runtime /app/runtime
 COPY config /app/config
 COPY docs/builtin-help /app/docs/builtin-help
+COPY backend/alembic.ini /app/runtime/alembic.ini
+COPY backend/migrations /app/runtime/migrations
+RUN python - <<'PY'
+from pathlib import Path
+
+path = Path("/app/runtime/alembic.ini")
+text = path.read_text(encoding="utf-8")
+text = text.replace(
+    "script_location = %(here)s/../guardian/db/migrations",
+    "script_location = %(here)s/migrations",
+)
+text = text.replace(
+    "prepend_sys_path = %(here)s/..",
+    "prepend_sys_path = %(here)s",
+)
+path.write_text(text, encoding="utf-8")
+PY
 
 EXPOSE 8888
 
-ENTRYPOINT ["/app/runtime/codexify-backend"]
+ENTRYPOINT ["/app/runtime/codexify-runtime"]
+CMD ["backend"]

--- a/backend/compiled_runtime_entry.py
+++ b/backend/compiled_runtime_entry.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+
+from backend.compiled_backend_entry import main as backend_main
+from backend.scripts.seed_defaults import main as seed_defaults_main
+from guardian.scripts.ensure_embed_model import main as ensure_embed_model_main
+
+
+def _run_backend() -> None:
+    required = (
+        os.getenv("LOCAL_EMBEDDINGS_REQUIRED", "0").strip().lower()
+        in {"1", "true", "yes", "on"}
+    )
+    model_dir = Path(
+        os.getenv("LOCAL_EMBED_MODEL", "/models/bge-large-en-v1.5")
+    )
+    if required and not model_dir.exists():
+        print(
+            "[backend] ERROR: LOCAL_EMBEDDINGS_REQUIRED=1 but model directory is missing: "
+            f"{model_dir}",
+            file=sys.stderr,
+        )
+        print(
+            "[backend] Run `docker compose run --rm model-prep` or mount a pre-provisioned model.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    backend_main()
+
+
+def _resolve_database_dsn() -> str | None:
+    return (
+        os.environ.get("DATABASE_URL")
+        or os.environ.get("GUARDIAN_DATABASE_URL")
+        or os.environ.get("GUARDIAN_DB_DSN")
+    )
+
+
+def _wait_for_db() -> str:
+    dsn = _resolve_database_dsn()
+    if not dsn:
+        raise SystemExit(
+            "[runtime] DATABASE_URL, GUARDIAN_DATABASE_URL, or GUARDIAN_DB_DSN is required"
+        )
+
+    try:
+        import psycopg  # type: ignore[import]
+
+        connect = psycopg.connect
+    except Exception:
+        import psycopg2  # type: ignore[import]
+
+        connect = psycopg2.connect
+
+    deadline = float(os.getenv("MIGRATOR_DB_TIMEOUT_SECONDS", "120"))
+    delay = 1.0
+    start = time.monotonic()
+    while True:
+        try:
+            conn = connect(dsn)
+            conn.close()
+            return dsn
+        except Exception as exc:
+            if time.monotonic() - start >= deadline:
+                raise SystemExit(f"[runtime] database unavailable: {exc}") from exc
+            time.sleep(delay)
+
+
+def _run_migrator() -> None:
+    cfg_path = Path(os.getenv("ALEMBIC_CONFIG", "/app/runtime/alembic.ini"))
+    if not cfg_path.is_file():
+        raise SystemExit(f"[runtime] missing Alembic config: {cfg_path}")
+
+    config = Config(str(cfg_path))
+    config.set_main_option("script_location", "/app/runtime/migrations")
+
+    _wait_for_db()
+    command.upgrade(config, "heads")
+
+    rc = seed_defaults_main()
+    if rc:
+        raise SystemExit(rc)
+
+
+def _run_model_prep() -> None:
+    raise SystemExit(ensure_embed_model_main())
+
+
+def _configure_worker_logging() -> None:
+    import logging
+
+    logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+
+
+def _run_worker(module: str) -> None:
+    _configure_worker_logging()
+    if module == "guardian.workers.chat_worker":
+        from guardian.workers.chat_worker import run_forever
+    elif module == "guardian.workers.document_embed_worker":
+        from guardian.workers.document_embed_worker import run_forever
+    elif module == "guardian.workers.chat_embedding_worker":
+        from guardian.workers.chat_embedding_worker import run_forever
+    elif module == "guardian.workers.warmup_worker":
+        from guardian.workers.warmup_worker import run_forever
+    else:
+        raise SystemExit(f"[runtime] unknown worker module: {module}")
+    run_forever()
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = list(sys.argv[1:] if argv is None else argv)
+    role = (args[0] if args else "backend").strip().lower()
+
+    if role in {"-h", "--help", "help"}:
+        print(
+            "Usage: codexify-runtime [backend|migrator|model-prep|worker-chat|worker-document-embed|worker-chat-embed|worker-warmup]",
+            file=sys.stderr,
+        )
+        raise SystemExit(0)
+
+    if role == "backend":
+        _run_backend()
+        return
+    if role == "migrator":
+        _run_migrator()
+        return
+    if role == "model-prep":
+        _run_model_prep()
+        return
+    if role == "worker-chat":
+        _run_worker("guardian.workers.chat_worker")
+        return
+    if role == "worker-document-embed":
+        _run_worker("guardian.workers.document_embed_worker")
+        return
+    if role == "worker-chat-embed":
+        _run_worker("guardian.workers.chat_embedding_worker")
+        return
+    if role == "worker-warmup":
+        _run_worker("guardian.workers.warmup_worker")
+        return
+
+    raise SystemExit(f"[runtime] unknown role: {role}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.compiled.yml
+++ b/docker-compose.compiled.yml
@@ -3,5 +3,5 @@ name: codexify
 services:
   backend:
     image: codexify-runtime-compiled:local
-    entrypoint: ["/app/runtime/codexify-backend"]
-    command: []
+    entrypoint: ["/app/runtime/codexify-runtime"]
+    command: ["backend"]

--- a/docker-compose.runtime.yml
+++ b/docker-compose.runtime.yml
@@ -107,9 +107,8 @@ services:
         echo "[graph-init] Done."
 
   migrator:
-    image: ${CODEXIFY_IMAGE_REGISTRY:-ghcr.io/resonant-jones}/codexify-backend:${CODEXIFY_IMAGE_TAG:-local-beta}
+    image: ${CODEXIFY_IMAGE_REGISTRY:-ghcr.io/resonant-jones}/codexify-runtime:${CODEXIFY_IMAGE_TAG:-local-beta}
     working_dir: /app
-    entrypoint: ["python"]
     depends_on:
       db:
         condition: service_healthy
@@ -121,7 +120,7 @@ services:
       PYTHONUTF8: "1"
       PYTHONIOENCODING: utf-8
       PYTHONPATH: /app
-      ALEMBIC_CONFIG: /app/backend/alembic.ini
+      ALEMBIC_CONFIG: /app/runtime/alembic.ini
       ENABLE_BLIP_MODEL: "false"
       OPENAI_API_KEY: "${OPENAI_API_KEY:-local}"
       GUARDIAN_API_KEY: "${GUARDIAN_API_KEY:?GUARDIAN_API_KEY must be set in .env}"
@@ -132,12 +131,11 @@ services:
       EMBEDDING_BACKEND: "local"
       CODEXIFY_USE_OPENAI: "0"
     restart: "no"
-    command: ["/app/backend/scripts/docker/run_migrator.py"]
+    command: ["migrator"]
 
   model-prep:
-    image: ${CODEXIFY_IMAGE_REGISTRY:-ghcr.io/resonant-jones}/codexify-backend:${CODEXIFY_IMAGE_TAG:-local-beta}
+    image: ${CODEXIFY_IMAGE_REGISTRY:-ghcr.io/resonant-jones}/codexify-runtime:${CODEXIFY_IMAGE_TAG:-local-beta}
     working_dir: /app
-    entrypoint: ["python"]
     volumes:
       - codexify_models:/models
       - hf_cache:/root/.cache/huggingface
@@ -154,12 +152,11 @@ services:
       EMBED_MODEL_REVISION: "${EMBED_MODEL_REVISION:-}"
       HF_TOKEN: "${HF_TOKEN:-}"
     restart: "no"
-    command: ["/app/guardian/scripts/ensure_embed_model.py"]
+    command: ["model-prep"]
 
   backend:
-    image: ${CODEXIFY_IMAGE_REGISTRY:-ghcr.io/resonant-jones}/codexify-backend:${CODEXIFY_IMAGE_TAG:-local-beta}
+    image: ${CODEXIFY_IMAGE_REGISTRY:-ghcr.io/resonant-jones}/codexify-runtime:${CODEXIFY_IMAGE_TAG:-local-beta}
     working_dir: /app
-    entrypoint: ["python"]
     ports: ["8888:8888"]
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8888/ping', timeout=2).read()"]
@@ -230,34 +227,11 @@ services:
         condition: service_completed_successfully
       graph-init:
         condition: service_completed_successfully
-    command:
-      - -c
-      - |
-        import os
-        import pathlib
-        import runpy
-        import sys
-
-        required = os.getenv("LOCAL_EMBEDDINGS_REQUIRED", "0").strip().lower() in {"1", "true", "yes", "on"}
-        model_dir = pathlib.Path(os.getenv("LOCAL_EMBED_MODEL", "/models/bge-large-en-v1.5"))
-
-        if required and not model_dir.exists():
-          print(
-              f"[backend] ERROR: LOCAL_EMBEDDINGS_REQUIRED=1 but model directory is missing: {model_dir}",
-              file=sys.stderr,
-          )
-          print(
-              "[backend] Run `docker compose run --rm model-prep` or mount a pre-provisioned model.",
-              file=sys.stderr,
-          )
-          raise SystemExit(1)
-
-        runpy.run_path("/app/backend/scripts/docker/run_backend.py", run_name="__main__")
+    command: ["backend"]
 
   worker-warmup:
-    image: ${CODEXIFY_IMAGE_REGISTRY:-ghcr.io/resonant-jones}/codexify-backend:${CODEXIFY_IMAGE_TAG:-local-beta}
+    image: ${CODEXIFY_IMAGE_REGISTRY:-ghcr.io/resonant-jones}/codexify-runtime:${CODEXIFY_IMAGE_TAG:-local-beta}
     working_dir: /app
-    entrypoint: ["python"]
     depends_on:
       redis:
         condition: service_healthy
@@ -300,12 +274,11 @@ services:
       SENTENCE_TRANSFORMERS_HOME: /models
       NEO4J_BOLT_URL: bolt://neo4j:7687
     restart: unless-stopped
-    command: ["-m", "guardian.workers.warmup_worker"]
+    command: ["worker-warmup"]
 
   worker-chat:
-    image: ${CODEXIFY_IMAGE_REGISTRY:-ghcr.io/resonant-jones}/codexify-backend:${CODEXIFY_IMAGE_TAG:-local-beta}
+    image: ${CODEXIFY_IMAGE_REGISTRY:-ghcr.io/resonant-jones}/codexify-runtime:${CODEXIFY_IMAGE_TAG:-local-beta}
     working_dir: /app
-    entrypoint: ["python"]
     depends_on:
       redis:
         condition: service_healthy
@@ -350,12 +323,11 @@ services:
       SENTENCE_TRANSFORMERS_HOME: /models
       NEO4J_BOLT_URL: bolt://neo4j:7687
     restart: unless-stopped
-    command: ["-m", "guardian.workers.chat_worker"]
+    command: ["worker-chat"]
 
   worker-document-embed:
-    image: ${CODEXIFY_IMAGE_REGISTRY:-ghcr.io/resonant-jones}/codexify-backend:${CODEXIFY_IMAGE_TAG:-local-beta}
+    image: ${CODEXIFY_IMAGE_REGISTRY:-ghcr.io/resonant-jones}/codexify-runtime:${CODEXIFY_IMAGE_TAG:-local-beta}
     working_dir: /app
-    entrypoint: ["python"]
     depends_on:
       redis:
         condition: service_healthy
@@ -399,12 +371,11 @@ services:
       CODEXIFY_COLLECTION: "${CODEXIFY_COLLECTION:-codexify_vault_supported}"
       NEO4J_BOLT_URL: bolt://neo4j:7687
     restart: unless-stopped
-    command: ["-m", "guardian.workers.document_embed_worker"]
+    command: ["worker-document-embed"]
 
   worker-chat-embed:
-    image: ${CODEXIFY_IMAGE_REGISTRY:-ghcr.io/resonant-jones}/codexify-backend:${CODEXIFY_IMAGE_TAG:-local-beta}
+    image: ${CODEXIFY_IMAGE_REGISTRY:-ghcr.io/resonant-jones}/codexify-runtime:${CODEXIFY_IMAGE_TAG:-local-beta}
     working_dir: /app
-    entrypoint: ["python"]
     depends_on:
       redis:
         condition: service_healthy
@@ -448,7 +419,7 @@ services:
       CODEXIFY_COLLECTION: "${CODEXIFY_COLLECTION:-codexify_vault_supported}"
       NEO4J_BOLT_URL: bolt://neo4j:7687
     restart: unless-stopped
-    command: ["-m", "guardian.workers.chat_embedding_worker"]
+    command: ["worker-chat-embed"]
 
 volumes:
   pg_data:

--- a/docs/architecture/config-and-ops.md
+++ b/docs/architecture/config-and-ops.md
@@ -168,9 +168,10 @@ Source anchors:
 - Source/dev installs may still use the repository Compose path and local build workflow.
 - The launcher/wizard is responsible for creating local config, validating Compose, pulling the registry-backed runtime images, and starting services in the packaged path.
 - Packaged first-run users should not need Rust, pnpm, Python dev tooling, or a source checkout to reach a usable local runtime.
-- The backend registry image now has a compiled/frozen proof target built with PyInstaller at `backend/compiled_backend_entry.py`.
+- The backend registry image now has a compiled/frozen dispatcher target built with PyInstaller at `backend/compiled_runtime_entry.py`.
 - The proof target lives in `backend/Dockerfile` as `compiled-runtime` and keeps the source-backed runtime stage intact for dev and legacy Compose paths.
-- The proof image is intentionally backend-only for now; workers and migrator still remain source-backed in the existing Docker path until they are proven separately.
+- Packaged runtime now uses a single compiled dispatcher image, `codexify-runtime`, with role-specific commands such as `backend`, `migrator`, `model-prep`, and the worker roles.
+- The compiled runtime ships runtime-owned Alembic config plus the migration tree under `/app/runtime` so the migrator role can run without raw `/app/backend` or `/app/guardian` source paths.
 - The proof image still ships a small set of non-source runtime files needed by startup, including supported-profile YAML and bundled help content.
 - Packaged desktop auth handoff now flows through a Tauri command that returns a sanitized runtime auth/config payload for the local packaged runtime. The frontend consumes the handed-off `GUARDIAN_API_KEY` only in packaged mode, while diagnostics expose only presence and source metadata such as `envPath`, `runtimeRoot`, and `failureKind`.
 - The Guardian auth gate now derives from the same in-memory runtime API key that the desktop API client uses, so packaged desktop mode can satisfy local auth without `VITE_GUARDIAN_API_KEY`; the legacy Vite env key remains a dev-only fallback.

--- a/docs/beta/Cloud-Model-Unlock.md
+++ b/docs/beta/Cloud-Model-Unlock.md
@@ -1,0 +1,80 @@
+# Cloud Model Unlock
+
+This is optional.
+
+Do not commit or share API keys.
+
+Cloud routing may send prompt or content data to the selected provider.
+
+Provider billing and rate limits may apply.
+
+Use your own key unless Resonant Jones explicitly gave you a temporary testing key.
+
+Your tester-editable config file is:
+
+- `~/Codexify/.env`
+
+## Before You Change Anything
+
+Start from the local reset values if you want the safest baseline:
+
+```dotenv
+ALLOW_CLOUD_PROVIDERS=false
+CODEXIFY_LOCAL_ONLY_MODE=true
+LLM_PROVIDER=local
+```
+
+## OpenAI-Style Example
+
+Use placeholder values only:
+
+```dotenv
+ALLOW_CLOUD_PROVIDERS=true
+CODEXIFY_LOCAL_ONLY_MODE=false
+LLM_PROVIDER=openai
+OPENAI_API_KEY=replace_with_your_key
+OPENAI_MODEL=replace_with_supported_model
+```
+
+If your tester notes include an OpenAI base URL, add it too:
+
+```dotenv
+OPENAI_BASE_URL=replace_with_supported_base_url
+```
+
+## Anthropic-Style Example
+
+The current packaged beta contract does not ship a dedicated `ANTHROPIC_MODEL` variable.
+
+If your invite says to use an Anthropic-style cloud path, use the repo-supported Anthropic-compatible settings for that build.
+
+For the current repo contract, that means the MiniMax Anthropic-compatible surface:
+
+```dotenv
+ALLOW_CLOUD_PROVIDERS=true
+CODEXIFY_LOCAL_ONLY_MODE=false
+LLM_PROVIDER=minimax
+MINIMAX_API_KEY=replace_with_your_key
+MINIMAX_API_BASE=https://api.minimax.io/anthropic
+MINIMAX_API_FLAVOR=anthropic
+MINIMAX_MODEL=replace_with_supported_model
+```
+
+If your tester build explicitly uses a direct Anthropic provider, follow the invite notes from Resonant Jones and keep the key placeholder-only.
+
+## Local Reset Example
+
+If you want to go back to the default local-only posture:
+
+```dotenv
+ALLOW_CLOUD_PROVIDERS=false
+CODEXIFY_LOCAL_ONLY_MODE=true
+LLM_PROVIDER=local
+```
+
+## Safety Notes
+
+- Keep API keys in `~/Codexify/.env`
+- Do not put real keys in the DMG
+- Do not paste your key into screenshots or public messages
+- If you are not sure which path you are using, ask before sending sensitive content

--- a/docs/beta/Known-Issues.md
+++ b/docs/beta/Known-Issues.md
@@ -1,0 +1,41 @@
+# Known Issues
+
+This is a trusted private beta, not a public release.
+
+Please expect rough edges.
+
+## Things To Expect
+
+- Docker Desktop must be running.
+- The first launch can be slow.
+- Local model responses may be slow depending on your hardware.
+- Startup diagnostics may be verbose.
+- Some advanced surfaces may appear in the UI, but they are not the focus of this first test.
+
+## Cloud Routing Notes
+
+- Cloud models are optional.
+- Cloud routing requires explicit opt-in.
+- Cloud routing requires a user-provided API key unless you were given a temporary key for testing.
+- Cloud routing may send prompt or content data to the configured provider.
+- Provider billing and rate limits may apply.
+
+## Rough Edges We Still Want To Learn About
+
+- Model availability
+- Live updates
+- Document and advanced features
+- Local hardware limitations
+- Configuration complexity for power users
+
+## If Startup Fails
+
+- Copy the visible diagnostic panel if you can.
+- A screenshot is even better.
+- Do not paste sensitive personal data unless you understand whether you are using local routing or cloud routing.
+
+## General Reminder
+
+- This beta is meant to prove the local-first desktop loop.
+- It is not a polished public installer.
+- It is not meant to feel finished everywhere.

--- a/docs/beta/Power-User-Comparison.md
+++ b/docs/beta/Power-User-Comparison.md
@@ -1,0 +1,72 @@
+# Power User Comparison
+
+Use this template if you are comparing local and cloud behavior.
+
+Please include screenshots or logs when something fails.
+
+## Test Context
+
+- Tester name:
+- Date:
+- Machine specs:
+  - Mac model:
+  - macOS version:
+  - Memory:
+  - CPU / Apple Silicon:
+  - Storage free space:
+- Network notes:
+
+## Local Run
+
+- Local model used:
+- Ollama status:
+- Startup time:
+- First response time:
+- Quality impression:
+- Reliability issues:
+- Privacy comfort:
+- Which path felt more "Codexify":
+
+## Cloud Run
+
+- Cloud provider used:
+- Cloud model used:
+- API key source:
+- Startup time:
+- First response time:
+- Quality impression:
+- Reliability issues:
+- Privacy comfort:
+- Which path felt more "Codexify":
+
+## Local vs Cloud Comparison
+
+- Speed:
+- Answer quality:
+- Consistency:
+- Failure modes:
+- Setup burden:
+- Hardware impact:
+- When local was enough:
+- When cloud felt better:
+
+## Bugs and Evidence
+
+- Bugs seen:
+- Screenshots attached:
+- Logs attached:
+- Diagnostic panel notes:
+- Reproduction steps:
+
+## Feature Confusion
+
+- What was unclear?
+- Which labels were hard to understand?
+- Which settings felt too advanced?
+- What should be simplified before broader beta?
+
+## Final Recommendation
+
+- Keep local-first as the default:
+- Offer cloud unlock as optional:
+- Anything we should change before widening the beta:

--- a/docs/beta/Private-Beta-Checklist.md
+++ b/docs/beta/Private-Beta-Checklist.md
@@ -1,0 +1,52 @@
+# Private Beta Checklist
+
+Use this before sharing the macOS DMG with trusted testers.
+
+## Release Checklist
+
+- [ ] Confirm the repo is clean.
+- [ ] Confirm the current commit hash.
+- [ ] Rebuild the final app and DMG.
+- [ ] Confirm the `/Applications/Codexify.app` timestamp after install.
+- [ ] Confirm the packaged runtime starts.
+- [ ] Confirm one local `hello` response.
+- [ ] Rotate or regenerate the local beta `GUARDIAN_API_KEY` before sharing if needed.
+- [ ] Confirm no real API keys are present in the docs.
+- [ ] Confirm the DMG is uploaded to Google Drive.
+- [ ] Upload the docs in `docs/beta/` beside the DMG.
+- [ ] Send testers the right track instructions.
+- [ ] Ask testers for screenshots of failures.
+- [ ] Record tester feedback.
+
+## Do Not Share Yet
+
+- [ ] Do not send this to public forums.
+- [ ] Do not send it to users who expect a polished installer.
+- [ ] Do not send cloud unlock instructions to testers who are not comfortable with API keys.
+- [ ] Do not present advanced unlocks as the default path.
+
+## Tester Packet Contents
+
+Make sure the private Drive folder includes:
+
+- The DMG
+- `README-FIRST.md`
+- `Known-Issues.md`
+- `Tester-Tracks.md`
+- `Cloud-Model-Unlock.md`
+- `Power-User-Comparison.md`
+- `Private-Beta-Checklist.md`
+
+## Notes To Capture Before Sending
+
+- Which testers are on Track A
+- Which testers are on Track B
+- Which testers are on Track C
+- Which testers need follow-up
+- Which testers should not receive cloud instructions
+
+## Final Reminder
+
+Keep the beta local-first by default.
+
+Cloud unlock is optional and should stay explicit.

--- a/docs/beta/README-FIRST.md
+++ b/docs/beta/README-FIRST.md
@@ -1,0 +1,65 @@
+# Codexify Private MacOS Local Beta
+
+This is the private macOS local-beta package for trusted testers.
+
+It is not a public release.
+
+The goal is simple: install Codexify, start it on a Mac, and see whether the local-first app can open, chat, and keep your thread after reopening.
+
+## Before You Start
+
+You will need:
+
+- macOS
+- Docker Desktop installed and running
+- Ollama installed and running if you are testing the local model path
+- The required local model available in Ollama if you stay on the default local path
+
+## First Launch
+
+The first launch may take several minutes.
+
+That is normal.
+
+During first launch:
+
+- Docker images may be pulled
+- Runtime files will be created under `~/Codexify`
+- The app may look busy before it becomes usable
+
+## Quick Smoke Test
+
+1. Open Codexify.
+2. Wait for startup to finish.
+3. Send `hello`.
+4. Confirm that an assistant response appears.
+5. Close Codexify.
+6. Reopen Codexify.
+7. Confirm that the thread is still there.
+
+If the thread is still there after reopening, the basic local beta loop is working.
+
+## Where Your Runtime Config Lives
+
+Your tester-editable runtime config file is:
+
+- `~/Codexify/.env`
+
+Do not edit the app bundle itself.
+
+In particular, do not edit:
+
+- `/Applications/Codexify.app/Contents/Resources`
+
+## What We Want From You
+
+Please tell us:
+
+- Did it open?
+- Did startup complete?
+- Did chat work?
+- Did reopening preserve the thread?
+- What felt confusing?
+- What felt helpful?
+
+If something failed, a screenshot of the visible error or diagnostic panel is especially helpful.

--- a/docs/beta/Tester-Tracks.md
+++ b/docs/beta/Tester-Tracks.md
@@ -1,0 +1,83 @@
+# Tester Tracks
+
+Pick the track that matches your comfort level.
+
+The default path is local-first and local-only.
+
+## Track A: Gentle Local Beta
+
+Best for:
+
+- Non-technical testers
+- Busy-life testers who want cognitive offload
+- Anyone who just wants to see whether the app opens and chats
+
+What to do:
+
+1. Use the DMG as shipped.
+2. Do not edit config unless we ask you to.
+3. Open the app.
+4. Send a simple message.
+5. Reopen the app and check that the thread is still there.
+
+What we are testing:
+
+- Install
+- Open
+- Chat
+- Reopen
+- Thread persistence
+
+Goal:
+
+- Does Codexify reduce friction instead of adding it?
+
+## Track B: Cloud Convenience Beta
+
+Best for:
+
+- Testers with limited hardware
+- Testers who still want usable responses even if local inference is slow
+
+What to do:
+
+1. Follow the local install first.
+2. Add the optional cloud env settings in `~/Codexify/.env`.
+3. Use your own API key unless you were given a temporary key.
+4. Test chat response quality and basic reliability.
+
+Important:
+
+- Cloud routing is opt-in.
+- Cloud routing may send prompt or content data to the provider.
+- Billing and rate limits may apply.
+- Do not use this track unless you are comfortable with API keys and cloud data routing.
+
+Goal:
+
+- Does Codexify stay usable when inference is routed to a cloud model?
+
+## Track C: Power User Comparison Beta
+
+Best for:
+
+- Technical testers
+- Power users
+- People willing to compare local and cloud paths directly
+
+What to do:
+
+1. Test the local path first.
+2. Test one cloud path if you are comfortable doing so.
+3. Compare speed, quality, reliability, privacy comfort, model selection, and failure modes.
+4. Record what felt better and what felt worse.
+
+Goal:
+
+- Help us decide where local-first is enough and where cloud routing actually helps.
+
+## If You Are Unsure
+
+Choose Track A.
+
+That is the safest and simplest path.

--- a/frontend/src/components/persona/layout/AppShell.runtimeHealth.test.tsx
+++ b/frontend/src/components/persona/layout/AppShell.runtimeHealth.test.tsx
@@ -44,6 +44,13 @@ type RuntimeHealthMock = {
       transportErrorClass: string | null;
       parsedStatus: string | null;
       parsedOk: boolean | null;
+      detailsStatus?: string | null;
+      detailsOk?: boolean | null;
+      provider?: string | null;
+      model?: string | null;
+      providerRuntimeAvailable?: boolean | null;
+      endpointResolutionState?: string | null;
+      failureReason?: string | null;
     };
     liveEvents: {
       endpoint: string | null;
@@ -99,13 +106,20 @@ const runtimeHealthState: RuntimeHealthMock = {
       parsedStatus: "healthy",
       parsedOk: true,
     },
-    llm: {
-      endpoint: "/api/health/llm",
-      httpStatus: 200,
-      transportErrorClass: null,
-      parsedStatus: "online",
-      parsedOk: true,
-    },
+      llm: {
+        endpoint: "/api/health/llm",
+        httpStatus: 200,
+        transportErrorClass: null,
+        parsedStatus: "online",
+        parsedOk: true,
+        detailsStatus: "online",
+        detailsOk: true,
+        provider: "local",
+        model: "library2/ministral-3:8b",
+        providerRuntimeAvailable: true,
+        endpointResolutionState: "available",
+        failureReason: null,
+      },
     liveEvents: {
       endpoint: "http://127.0.0.1:8888/api/events",
       connectionState: LIVE_EVENT_CONNECTION_STATES.CONNECTED,
@@ -168,6 +182,27 @@ vi.mock("@/hooks/useRuntimeHealth", () => ({
           ? "true"
           : "false"
       }`,
+      `parsed llm details status=${diagnostics.llm.detailsStatus ?? "<none>"}`,
+      `parsed llm details ok=${
+        diagnostics.llm.detailsOk == null
+          ? "<unknown>"
+          : diagnostics.llm.detailsOk
+          ? "true"
+          : "false"
+      }`,
+      `parsed llm provider=${diagnostics.llm.provider ?? "<none>"}`,
+      `parsed llm model=${diagnostics.llm.model ?? "<none>"}`,
+      `parsed llm provider runtime available=${
+        diagnostics.llm.providerRuntimeAvailable == null
+          ? "<unknown>"
+          : diagnostics.llm.providerRuntimeAvailable
+          ? "true"
+          : "false"
+      }`,
+      `parsed llm endpoint resolution state=${
+        diagnostics.llm.endpointResolutionState ?? "<none>"
+      }`,
+      `parsed llm failure reason=${diagnostics.llm.failureReason ?? "<none>"}`,
       `live events endpoint called=${diagnostics.liveEvents.endpoint ?? "<unresolved>"}`,
       `live events connection state=${diagnostics.liveEvents.connectionState}`,
       `live events last event=${diagnostics.liveEvents.lastEventAt ?? "<none>"}`,
@@ -368,13 +403,20 @@ describe("AppShell runtime health banner", () => {
         parsedStatus: "healthy",
         parsedOk: true,
       },
-      llm: {
-        endpoint: "/api/health/llm",
-        httpStatus: 200,
-        transportErrorClass: null,
-        parsedStatus: "online",
-        parsedOk: true,
-      },
+    llm: {
+      endpoint: "/api/health/llm",
+      httpStatus: 200,
+      transportErrorClass: null,
+      parsedStatus: "online",
+      parsedOk: true,
+      detailsStatus: "online",
+      detailsOk: true,
+      provider: "local",
+      model: "library2/ministral-3:8b",
+      providerRuntimeAvailable: true,
+      endpointResolutionState: "available",
+      failureReason: null,
+    },
       liveEvents: {
         endpoint: "http://127.0.0.1:8888/api/events",
         connectionState: LIVE_EVENT_CONNECTION_STATES.CONNECTED,
@@ -447,6 +489,13 @@ describe("AppShell runtime health banner", () => {
         transportErrorClass: null,
         parsedStatus: "online",
         parsedOk: true,
+        detailsStatus: "online",
+        detailsOk: true,
+        provider: "local",
+        model: "library2/ministral-3:8b",
+        providerRuntimeAvailable: true,
+        endpointResolutionState: "available",
+        failureReason: null,
       },
       liveEvents: {
         endpoint: "http://127.0.0.1:8888/api/events",
@@ -511,6 +560,13 @@ describe("AppShell runtime health banner", () => {
       transportErrorClass: null,
       parsedStatus: "offline",
       parsedOk: false,
+      detailsStatus: "offline",
+      detailsOk: false,
+      provider: "local",
+      model: "library2/ministral-3:8b",
+      providerRuntimeAvailable: false,
+      endpointResolutionState: "unavailable",
+      failureReason: "provider_runtime.available=false",
     };
     runtimeHealthState.diagnostics.liveEvents = {
       endpoint: "http://127.0.0.1:8888/api/events",
@@ -602,6 +658,13 @@ describe("AppShell runtime health banner", () => {
         transportErrorClass: null,
         parsedStatus: "online",
         parsedOk: true,
+        detailsStatus: "online",
+        detailsOk: true,
+        provider: "local",
+        model: "library2/ministral-3:8b",
+        providerRuntimeAvailable: true,
+        endpointResolutionState: "available",
+        failureReason: null,
       },
       liveEvents: {
         endpoint: "http://127.0.0.1:8888/api/events",
@@ -641,6 +704,17 @@ describe("AppShell runtime health banner", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/chat endpoint called=\/health\/chat/i)).toBeInTheDocument();
     expect(screen.getByText(/llm endpoint called=\/api\/health\/llm/i)).toBeInTheDocument();
+    expect(screen.getByText(/parsed llm details status=online/i)).toBeInTheDocument();
+    expect(screen.getByText(/parsed llm provider=local/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/parsed llm model=library2\/ministral-3:8b/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/parsed llm provider runtime available=true/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/parsed llm endpoint resolution state=available/i)
+    ).toBeInTheDocument();
     expect(screen.getByText(/failureKind=chat_unhealthy/i)).toBeInTheDocument();
     expect(screen.queryByText("desktop-secret-key")).toBeNull();
   });

--- a/frontend/src/hooks/useRuntimeHealth.test.ts
+++ b/frontend/src/hooks/useRuntimeHealth.test.ts
@@ -125,7 +125,7 @@ const flushPromises = async () => {
 
 function mockHealthResponses(overrides: {
   chat?: "ok" | "fail" | "missing" | "unreachable";
-  llm?: "ok" | "fail" | "missing" | "unreachable";
+  llm?: "ok" | "fail" | "missing" | "unreachable" | "nested-ok" | "nested-fail";
 } = {}) {
   const chat = overrides.chat ?? "ok";
   const llm = overrides.llm ?? "ok";
@@ -134,6 +134,38 @@ function mockHealthResponses(overrides: {
     if (path === "/api/health/llm") {
       if (llm === "ok") {
         return Promise.resolve({ data: { ok: true, status: "online" } });
+      }
+      if (llm === "nested-ok") {
+        return Promise.resolve({
+          data: {
+            status: "ok",
+            ok: true,
+            provider: "local",
+            model: "library2/ministral-3:8b",
+            details: {
+              status: "online",
+              ok: true,
+              provider_runtime: { available: true },
+              endpoint_resolution: { state: "available" },
+            },
+          },
+        });
+      }
+      if (llm === "nested-fail") {
+        return Promise.resolve({
+          data: {
+            status: "ok",
+            ok: true,
+            provider: "local",
+            model: "library2/ministral-3:8b",
+            details: {
+              status: "offline",
+              ok: false,
+              provider_runtime: { available: false },
+              endpoint_resolution: { state: "unavailable" },
+            },
+          },
+        });
       }
       if (llm === "missing") {
         const error = new Error("not found") as Error & {
@@ -250,10 +282,39 @@ describe("useRuntimeHealth", () => {
       expect(result.current.diagnostics.llm.httpStatus).toBe(200);
       expect(result.current.diagnostics.llm.parsedStatus).toBe("online");
       expect(result.current.diagnostics.llm.parsedOk).toBe(true);
+      expect(result.current.diagnostics.llm.detailsStatus).toBeNull();
+      expect(result.current.diagnostics.llm.detailsOk).toBeNull();
+      expect(result.current.diagnostics.llm.providerRuntimeAvailable).toBeNull();
+      expect(result.current.diagnostics.llm.endpointResolutionState).toBeNull();
       expect(result.current.diagnostics.failureKind).toBeNull();
       expect(result.current.diagnostics.currentComputedStateSource).toBe(
         "live-poll"
       );
+    });
+  });
+
+  it("treats the nested model-health payload as healthy when the local path is available", async () => {
+    mockHealthResponses({ llm: "nested-ok" });
+    const { result } = renderHook(() => useRuntimeHealth());
+    await act(async () => {
+      await flushPromises();
+    });
+    await waitFor(() => {
+      expect(result.current.status).toBe(RUNTIME_HEALTH_STATUSES.HEALTHY);
+      expect(result.current.llmHealthy).toBe(true);
+      expect(result.current.diagnostics.llm.parsedStatus).toBe("ok");
+      expect(result.current.diagnostics.llm.parsedOk).toBe(true);
+      expect(result.current.diagnostics.llm.detailsStatus).toBe("online");
+      expect(result.current.diagnostics.llm.detailsOk).toBe(true);
+      expect(result.current.diagnostics.llm.providerRuntimeAvailable).toBe(true);
+      expect(result.current.diagnostics.llm.endpointResolutionState).toBe(
+        "available"
+      );
+      expect(result.current.diagnostics.llm.provider).toBe("local");
+      expect(result.current.diagnostics.llm.model).toBe(
+        "library2/ministral-3:8b"
+      );
+      expect(result.current.diagnostics.failureKind).toBeNull();
     });
   });
 
@@ -419,6 +480,34 @@ describe("useRuntimeHealth", () => {
     await waitFor(() => {
       expect(result.current.failureKind).toBe(
         RUNTIME_HEALTH_FAILURE_KINDS.LLM_UNHEALTHY
+      );
+    });
+  });
+
+  it("keeps llm unhealthy when the nested local model path is still unavailable", async () => {
+    mockHealthResponses({ llm: "nested-fail" });
+    const { result } = renderHook(() => useRuntimeHealth());
+    await act(async () => {
+      await flushPromises();
+    });
+    await waitFor(() => {
+      expect(result.current.status).toBe(RUNTIME_HEALTH_STATUSES.DEGRADED);
+      expect(result.current.failureKind).toBe(
+        RUNTIME_HEALTH_FAILURE_KINDS.LLM_UNHEALTHY
+      );
+      expect(result.current.llmHealthy).toBe(false);
+      expect(result.current.diagnostics.llm.parsedStatus).toBe("ok");
+      expect(result.current.diagnostics.llm.parsedOk).toBe(true);
+      expect(result.current.diagnostics.llm.detailsStatus).toBe("offline");
+      expect(result.current.diagnostics.llm.detailsOk).toBe(false);
+      expect(result.current.diagnostics.llm.providerRuntimeAvailable).toBe(
+        false
+      );
+      expect(result.current.diagnostics.llm.endpointResolutionState).toBe(
+        "unavailable"
+      );
+      expect(result.current.diagnostics.llm.failureReason).toBe(
+        "details.ok=false"
       );
     });
   });

--- a/frontend/src/hooks/useRuntimeHealth.ts
+++ b/frontend/src/hooks/useRuntimeHealth.ts
@@ -50,6 +50,13 @@ export type RuntimeHealthEndpointObservation = {
   transportErrorClass: string | null;
   parsedStatus: string | null;
   parsedOk: boolean | null;
+  detailsStatus?: string | null;
+  detailsOk?: boolean | null;
+  provider?: string | null;
+  model?: string | null;
+  providerRuntimeAvailable?: boolean | null;
+  endpointResolutionState?: string | null;
+  failureReason?: string | null;
 };
 
 export type RuntimeHealthDiagnostics = {
@@ -148,6 +155,30 @@ function isHealthStatusToken(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+function isGreenStatusToken(value: string | null): boolean {
+  return Boolean(value && ["ok", "healthy", "online"].includes(value));
+}
+
+function isRedStatusToken(value: string | null): boolean {
+  return Boolean(
+    value &&
+      ["offline", "degraded", "error", "unavailable", "red", "failed"].includes(
+        value
+      )
+  );
+}
+
+function readPayloadValue(payload: unknown, path: string[]): unknown {
+  let current: unknown = payload;
+  for (const key of path) {
+    if (!current || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
 type HealthResult = {
   reachable: boolean;
   ok: boolean | null;
@@ -179,15 +210,32 @@ function getTransportErrorClass(error: unknown): string | null {
 }
 
 function readParsedStatus(payload: unknown): string | null {
-  if (!payload || typeof payload !== "object") return null;
-  const candidate = payload as { status?: unknown };
-  return isHealthStatusToken(candidate.status);
+  const topLevel = isHealthStatusToken(readPayloadValue(payload, ["status"]));
+  if (topLevel) return topLevel;
+  return isHealthStatusToken(readPayloadValue(payload, ["details", "status"]));
 }
 
 function readParsedOk(payload: unknown): boolean | null {
-  if (!payload || typeof payload !== "object") return null;
-  const candidate = payload as { ok?: unknown };
-  return typeof candidate.ok === "boolean" ? candidate.ok : null;
+  const topLevel = readPayloadValue(payload, ["ok"]);
+  if (typeof topLevel === "boolean") return topLevel;
+  const nested = readPayloadValue(payload, ["details", "ok"]);
+  return typeof nested === "boolean" ? nested : null;
+}
+
+function readPayloadString(
+  payload: unknown,
+  path: string[]
+): string | null {
+  const value = readPayloadValue(payload, path);
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function readPayloadBoolean(
+  payload: unknown,
+  path: string[]
+): boolean | null {
+  const value = readPayloadValue(payload, path);
+  return typeof value === "boolean" ? value : null;
 }
 
 function deriveHealthySignal(payload: unknown, httpStatus: number | null): boolean | null {
@@ -195,7 +243,48 @@ function deriveHealthySignal(payload: unknown, httpStatus: number | null): boole
   if (parsedOk !== null) return parsedOk;
   const parsedStatus = readParsedStatus(payload);
   if (parsedStatus) {
-    return ["ok", "healthy", "online"].includes(parsedStatus);
+    return isGreenStatusToken(parsedStatus);
+  }
+  if (httpStatus == null) return null;
+  return httpStatus >= 200 && httpStatus < 300;
+}
+
+function deriveLlmHealthySignal(
+  payload: unknown,
+  httpStatus: number | null
+): boolean | null {
+  const parsedOk = readParsedOk(payload);
+  const parsedStatus = readParsedStatus(payload);
+  const detailsOk = readPayloadBoolean(payload, ["details", "ok"]);
+  const providerRuntimeAvailable =
+    readPayloadBoolean(payload, ["details", "provider_runtime", "available"]) ??
+    readPayloadBoolean(payload, ["provider_runtime", "available"]);
+  const endpointResolutionState =
+    readPayloadString(payload, ["details", "endpoint_resolution", "state"]) ??
+    readPayloadString(payload, ["endpoint_resolution", "state"]);
+
+  const positiveSignals = [
+    parsedOk === true,
+    isGreenStatusToken(parsedStatus),
+    detailsOk === true,
+    providerRuntimeAvailable === true,
+    endpointResolutionState === "available",
+  ].some(Boolean);
+
+  const negativeSignals = [
+    parsedOk === false,
+    isRedStatusToken(parsedStatus),
+    detailsOk === false,
+    providerRuntimeAvailable === false,
+    endpointResolutionState != null &&
+      endpointResolutionState.toLowerCase() !== "available",
+    ].some(Boolean);
+
+  if (negativeSignals) {
+    return false;
+  }
+  if (positiveSignals) {
+    return true;
   }
   if (httpStatus == null) return null;
   return httpStatus >= 200 && httpStatus < 300;
@@ -210,7 +299,10 @@ function summarizeHealthResult(
 } {
   if (result.status === "fulfilled") {
     const payload = result.value?.data ?? null;
-    const derivedHealthy = deriveHealthySignal(payload, 200);
+    const isLlmEndpoint = endpoint === LLM_HEALTH_ENDPOINT;
+    const derivedHealthy = isLlmEndpoint
+      ? deriveLlmHealthySignal(payload, 200)
+      : deriveHealthySignal(payload, 200);
     return {
       endpoint,
       reachable: true,
@@ -221,6 +313,21 @@ function summarizeHealthResult(
       transportErrorClass: null,
       parsedStatus: readParsedStatus(payload),
       parsedOk: readParsedOk(payload),
+      detailsStatus: readPayloadString(payload, ["details", "status"]),
+      detailsOk: readPayloadBoolean(payload, ["details", "ok"]),
+      provider: isLlmEndpoint ? readPayloadString(payload, ["provider"]) : null,
+      model: isLlmEndpoint ? readPayloadString(payload, ["model"]) : null,
+      providerRuntimeAvailable: isLlmEndpoint
+        ? readPayloadBoolean(payload, ["details", "provider_runtime", "available"]) ??
+          readPayloadBoolean(payload, ["provider_runtime", "available"])
+        : null,
+      endpointResolutionState: isLlmEndpoint
+        ? readPayloadString(payload, ["details", "endpoint_resolution", "state"]) ??
+          readPayloadString(payload, ["endpoint_resolution", "state"])
+        : null,
+      failureReason: isLlmEndpoint
+        ? deriveLlmFailureReason(payload)
+        : null,
       payload,
     };
   }
@@ -231,18 +338,76 @@ function summarizeHealthResult(
     null;
   const missing = status === 404;
   const reachable = status != null;
+  const isLlmEndpoint = endpoint === LLM_HEALTH_ENDPOINT;
   return {
     endpoint,
     reachable,
-    ok: missing ? false : deriveHealthySignal(payload, status),
-    derivedHealthy: missing ? false : deriveHealthySignal(payload, status),
+    ok: missing
+      ? false
+      : isLlmEndpoint
+        ? deriveLlmHealthySignal(payload, status)
+        : deriveHealthySignal(payload, status),
+    derivedHealthy: missing
+      ? false
+      : isLlmEndpoint
+        ? deriveLlmHealthySignal(payload, status)
+        : deriveHealthySignal(payload, status),
     missing,
     httpStatus: status,
     transportErrorClass: status == null ? getTransportErrorClass(result.reason) : null,
     parsedStatus: readParsedStatus(payload),
     parsedOk: readParsedOk(payload),
+    detailsStatus: readPayloadString(payload, ["details", "status"]),
+    detailsOk: readPayloadBoolean(payload, ["details", "ok"]),
+    provider: isLlmEndpoint ? readPayloadString(payload, ["provider"]) : null,
+    model: isLlmEndpoint ? readPayloadString(payload, ["model"]) : null,
+    providerRuntimeAvailable: isLlmEndpoint
+      ? readPayloadBoolean(payload, ["details", "provider_runtime", "available"]) ??
+        readPayloadBoolean(payload, ["provider_runtime", "available"])
+      : null,
+    endpointResolutionState: isLlmEndpoint
+      ? readPayloadString(payload, ["details", "endpoint_resolution", "state"]) ??
+        readPayloadString(payload, ["endpoint_resolution", "state"])
+      : null,
+    failureReason: isLlmEndpoint ? deriveLlmFailureReason(payload) : null,
     payload,
   };
+}
+
+function deriveLlmFailureReason(payload: unknown): string | null {
+  const parsedStatus = readParsedStatus(payload);
+  const parsedOk = readParsedOk(payload);
+  const detailsStatus = readPayloadString(payload, ["details", "status"]);
+  const detailsOk = readPayloadBoolean(payload, ["details", "ok"]);
+  const provider = readPayloadString(payload, ["provider"]);
+  const providerRuntimeAvailable =
+    readPayloadBoolean(payload, ["details", "provider_runtime", "available"]) ??
+    readPayloadBoolean(payload, ["provider_runtime", "available"]);
+  const endpointResolutionState =
+    readPayloadString(payload, ["details", "endpoint_resolution", "state"]) ??
+    readPayloadString(payload, ["endpoint_resolution", "state"]);
+
+  if (provider && provider.trim().toLowerCase() !== "local") {
+    return `provider=${provider}`;
+  }
+  if (parsedOk === false) return "ok=false";
+  if (detailsOk === false) return "details.ok=false";
+  if (providerRuntimeAvailable === false) {
+    return "provider_runtime.available=false";
+  }
+  if (
+    endpointResolutionState &&
+    endpointResolutionState.trim().toLowerCase() !== "available"
+  ) {
+    return `endpoint_resolution.state=${endpointResolutionState}`;
+  }
+  if (isRedStatusToken(detailsStatus)) {
+    return `details.status=${detailsStatus}`;
+  }
+  if (isRedStatusToken(parsedStatus)) {
+    return `status=${parsedStatus}`;
+  }
+  return null;
 }
 
 function resolveRuntimeHealthAuthSource(): RuntimeHealthAuthSource {
@@ -330,6 +495,27 @@ export function formatRuntimeHealthDiagnostics(
           ? "true"
           : "false"
     }`,
+    `parsed llm details status=${diagnostics.llm.detailsStatus ?? "<none>"}`,
+    `parsed llm details ok=${
+      diagnostics.llm.detailsOk == null
+        ? "<unknown>"
+        : diagnostics.llm.detailsOk
+          ? "true"
+          : "false"
+    }`,
+    `parsed llm provider=${diagnostics.llm.provider ?? "<none>"}`,
+    `parsed llm model=${diagnostics.llm.model ?? "<none>"}`,
+    `parsed llm provider runtime available=${
+      diagnostics.llm.providerRuntimeAvailable == null
+        ? "<unknown>"
+        : diagnostics.llm.providerRuntimeAvailable
+          ? "true"
+          : "false"
+    }`,
+    `parsed llm endpoint resolution state=${
+      diagnostics.llm.endpointResolutionState ?? "<none>"
+    }`,
+    `parsed llm failure reason=${diagnostics.llm.failureReason ?? "<none>"}`,
     `live events endpoint called=${diagnostics.liveEvents.endpoint ?? "<unresolved>"}`,
     `live events connection state=${diagnostics.liveEvents.connectionState}`,
     `live events last event=${formatTimestamp(diagnostics.liveEvents.lastEventAt)}`,
@@ -526,6 +712,13 @@ export function useRuntimeHealth(): RuntimeHealthStatus {
       transportErrorClass: snapshot.llm.transportErrorClass,
       parsedStatus: snapshot.llm.parsedStatus,
       parsedOk: snapshot.llm.parsedOk,
+      detailsStatus: snapshot.llm.detailsStatus,
+      detailsOk: snapshot.llm.detailsOk,
+      provider: snapshot.llm.provider,
+      model: snapshot.llm.model,
+      providerRuntimeAvailable: snapshot.llm.providerRuntimeAvailable,
+      endpointResolutionState: snapshot.llm.endpointResolutionState,
+      failureReason: snapshot.llm.failureReason,
     },
     liveEvents: {
       endpoint: liveEventsDiagnostics.endpoint,

--- a/frontend/src/lib/runtimeBootstrap.test.ts
+++ b/frontend/src/lib/runtimeBootstrap.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
+import { act } from "@testing-library/react";
 
 vi.mock("@/lib/runtimeConfig", async () => {
   const actual = await vi.importActual<typeof import("@/lib/runtimeConfig")>(
@@ -19,8 +20,11 @@ import {
   mapRuntimePreflightFailureToState,
   getBootstrapDisplayCopy,
   getBootstrapRecoveryActions,
+  formatRuntimeReadinessResult,
   runPullRuntimeImages,
   runRuntimeBootstrapPreflight,
+  waitForRuntimeReady,
+  normalizeRuntimeReadiness,
   type RuntimePreflight,
 } from "@/lib/runtimeBootstrap";
 import {
@@ -29,10 +33,19 @@ import {
   isTauriRuntime,
 } from "@/lib/runtimeConfig";
 
+const flushPromises = async () => {
+  await Promise.resolve();
+  await vi.advanceTimersByTimeAsync(0);
+};
+
 describe("runtime bootstrap preflight", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(isTauriRuntime).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("classifies a native bridge import failure separately from Docker failures", async () => {
@@ -138,5 +151,121 @@ describe("runtime bootstrap preflight", () => {
     );
     expect(result.step).toBe("pull-images");
     expect(result.ok).toBe(true);
+  });
+
+  it("normalizes and formats packaged readiness diagnostics from the native dispatcher", () => {
+    const readiness = normalizeRuntimeReadiness({
+      ok: true,
+      ready: true,
+      backendReachable: true,
+      startupReady: true,
+      redisReady: true,
+      chatReady: true,
+      llmReady: true,
+      probeContext: "host-native",
+      llmStatus: "ok",
+      llmDetailsStatus: "online",
+      llmDetailsOk: true,
+      llmProvider: "local",
+      llmModel: "library2/ministral-3:8b",
+      llmProviderRuntimeAvailable: true,
+      llmEndpointResolutionState: "available",
+      llmFailureReason: null,
+      checks: [
+        {
+          endpoint: "http://127.0.0.1:8888/api/health/llm",
+          ok: true,
+          statusCode: 200,
+          detail: "HTTP/1.1 200 OK",
+          responseExcerpt: "{\"status\":\"ok\"}",
+        },
+      ],
+    });
+
+    expect(readiness.llmReady).toBe(true);
+    expect(readiness.probeContext).toBe("host-native");
+    expect(readiness.llmStatus).toBe("ok");
+    expect(readiness.llmDetailsStatus).toBe("online");
+    expect(readiness.llmDetailsOk).toBe(true);
+    expect(readiness.llmProvider).toBe("local");
+    expect(readiness.llmModel).toBe("library2/ministral-3:8b");
+    expect(readiness.llmProviderRuntimeAvailable).toBe(true);
+    expect(readiness.llmEndpointResolutionState).toBe("available");
+
+    const rendered = formatRuntimeReadinessResult(readiness);
+    expect(rendered).toContain("probeContext=host-native");
+    expect(rendered).toContain("llmStatus=ok");
+    expect(rendered).toContain("llmDetailsStatus=online");
+    expect(rendered).toContain("llmDetailsOk=true");
+    expect(rendered).toContain("llmProvider=local");
+    expect(rendered).toContain("llmModel=library2/ministral-3:8b");
+    expect(rendered).toContain("llmProviderRuntimeAvailable=true");
+    expect(rendered).toContain("llmEndpointResolutionState=available");
+    expect(rendered).toContain("llmReady=true");
+  });
+
+  it("keeps the startup gate moving when readiness turns green after an earlier red poll", async () => {
+    vi.useFakeTimers();
+    vi.mocked(invokeTauriCommand)
+      .mockResolvedValueOnce({
+        ok: false,
+        ready: false,
+        step: "health-check",
+        backendReachable: true,
+        startupReady: true,
+        redisReady: true,
+        chatReady: true,
+        llmReady: false,
+        probeContext: "host-native",
+        llmStatus: "ok",
+        llmDetailsStatus: "online",
+        llmDetailsOk: false,
+        llmProvider: "local",
+        llmModel: "library2/ministral-3:8b",
+        llmProviderRuntimeAvailable: false,
+        llmEndpointResolutionState: "unavailable",
+        llmFailureReason: "provider_runtime.available=false",
+        checks: [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        ready: true,
+        step: "health-check",
+        backendReachable: true,
+        startupReady: true,
+        redisReady: true,
+        chatReady: true,
+        llmReady: true,
+        probeContext: "host-native",
+        llmStatus: "ok",
+        llmDetailsStatus: "online",
+        llmDetailsOk: true,
+        llmProvider: "local",
+        llmModel: "library2/ministral-3:8b",
+        llmProviderRuntimeAvailable: true,
+        llmEndpointResolutionState: "available",
+        checks: [],
+      });
+
+    const readinessPromise = waitForRuntimeReady({
+      timeoutMs: 6_000,
+      intervalMs: 500,
+    });
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+      await flushPromises();
+    });
+
+    const result = await readinessPromise;
+
+    expect(result.ok).toBe(true);
+    expect(result.attempts).toBe(2);
+    expect(result.lastCheck.llmReady).toBe(true);
+    expect(result.lastCheck.llmFailureReason).toBeUndefined();
   });
 });

--- a/frontend/src/lib/runtimeBootstrap.ts
+++ b/frontend/src/lib/runtimeBootstrap.ts
@@ -75,6 +75,15 @@ export type RuntimeReadinessResult = BootstrapStepResult & {
   redisReady: boolean;
   chatReady: boolean;
   llmReady?: boolean;
+  probeContext?: "host-native" | "container-local" | "frontend" | "unknown";
+  llmStatus?: string | null;
+  llmDetailsStatus?: string | null;
+  llmDetailsOk?: boolean | null;
+  llmProvider?: string | null;
+  llmModel?: string | null;
+  llmProviderRuntimeAvailable?: boolean | null;
+  llmEndpointResolutionState?: string | null;
+  llmFailureReason?: string | null;
   checks: HealthEndpointCheck[];
 };
 
@@ -228,6 +237,23 @@ function normalizeOptionalBoolean(value: unknown): boolean | undefined {
   if (value === true) return true;
   if (value === false) return false;
   return undefined;
+}
+
+function normalizeOptionalBooleanOrNull(value: unknown): boolean | null {
+  if (value === true) return true;
+  if (value === false) return false;
+  return null;
+}
+
+function normalizeProbeContext(
+  value: unknown
+): "host-native" | "container-local" | "frontend" | "unknown" | undefined {
+  return value === "host-native" ||
+    value === "container-local" ||
+    value === "frontend" ||
+    value === "unknown"
+    ? value
+    : undefined;
 }
 
 function normalizeBootstrapLogService(
@@ -419,6 +445,25 @@ export function normalizeRuntimeReadiness(
     redisReady: asBoolean(source.redisReady ?? source.redis_ready),
     chatReady: asBoolean(source.chatReady ?? source.chat_ready),
     llmReady: normalizeOptionalBoolean(source.llmReady ?? source.llm_ready),
+    probeContext: normalizeProbeContext(source.probeContext ?? source.probe_context),
+    llmStatus: normalizeText(source.llmStatus ?? source.llm_status),
+    llmDetailsStatus: normalizeText(
+      source.llmDetailsStatus ?? source.llm_details_status
+    ),
+    llmDetailsOk: normalizeOptionalBooleanOrNull(
+      source.llmDetailsOk ?? source.llm_details_ok
+    ),
+    llmProvider: normalizeText(source.llmProvider ?? source.llm_provider),
+    llmModel: normalizeText(source.llmModel ?? source.llm_model),
+    llmProviderRuntimeAvailable: normalizeOptionalBooleanOrNull(
+      source.llmProviderRuntimeAvailable ??
+        source.llm_provider_runtime_available
+    ),
+    llmEndpointResolutionState: normalizeText(
+      source.llmEndpointResolutionState ??
+        source.llm_endpoint_resolution_state
+    ),
+    llmFailureReason: normalizeText(source.llmFailureReason ?? source.llm_failure_reason),
     checks: rawChecks.map((item) => normalizeEndpointCheck(item)),
   };
 }
@@ -1676,10 +1721,43 @@ export function formatRuntimeReadinessResult(
   if (result.failureKind) {
     lines.push(`failureKind=${result.failureKind}`);
   }
+  if (result.probeContext) {
+    lines.push(`probeContext=${result.probeContext}`);
+  }
+  if (result.llmStatus) {
+    lines.push(`llmStatus=${result.llmStatus}`);
+  }
+  if (result.llmDetailsStatus) {
+    lines.push(`llmDetailsStatus=${result.llmDetailsStatus}`);
+  }
+  if (typeof result.llmDetailsOk === "boolean") {
+    lines.push(`llmDetailsOk=${result.llmDetailsOk}`);
+  }
+  if (result.llmProvider) {
+    lines.push(`llmProvider=${result.llmProvider}`);
+  }
+  if (result.llmModel) {
+    lines.push(`llmModel=${result.llmModel}`);
+  }
+  if (typeof result.llmProviderRuntimeAvailable === "boolean") {
+    lines.push(
+      `llmProviderRuntimeAvailable=${result.llmProviderRuntimeAvailable}`
+    );
+  }
+  if (result.llmEndpointResolutionState) {
+    lines.push(
+      `llmEndpointResolutionState=${result.llmEndpointResolutionState}`
+    );
+  }
   if (typeof result.llmReady === "boolean") {
     lines.push(`llmReady=${result.llmReady}`);
   } else {
     lines.push("llmReady=not-gated");
+  }
+  if (result.llmReady === false) {
+    lines.push(
+      `llmFailureReason=${result.llmFailureReason ?? "<none>"}`
+    );
   }
   if (result.command) {
     lines.push(`command=${result.command}`);

--- a/frontend/src/lib/runtimeConfig.ts
+++ b/frontend/src/lib/runtimeConfig.ts
@@ -1,4 +1,9 @@
 import { combineBaseAndPath } from "@/lib/urlJoin";
+import {
+  invokeTauriCommand as invokeNativeTauriCommand,
+  NativeBridgeUnavailableError,
+} from "@/lib/tauriBridge";
+export { NativeBridgeUnavailableError, NATIVE_BRIDGE_FAILURE_KIND } from "@/lib/tauriBridge";
 
 export type RuntimeMode = "web" | "tauri";
 export type AuthMode = "local" | "remote";
@@ -66,24 +71,6 @@ let runtimeConfigHydrationState: RuntimeConfigHydrationState = defaultMode() ===
 let runtimeConfigHydrationFailureKind: string | null = null;
 let runtimeConfigVersion = 0;
 const runtimeConfigListeners = new Set<() => void>();
-
-type TauriCoreApi = {
-  invoke: <T = unknown>(
-    command: string,
-    payload?: Record<string, unknown>
-  ) => Promise<T>;
-};
-
-export const NATIVE_BRIDGE_FAILURE_KIND = "native-bridge-unavailable" as const;
-
-export class NativeBridgeUnavailableError extends Error {
-  readonly code = NATIVE_BRIDGE_FAILURE_KIND;
-
-  constructor(message: string) {
-    super(message);
-    this.name = "NativeBridgeUnavailableError";
-  }
-}
 
 function emitRuntimeConfigChange(): void {
   runtimeConfigVersion += 1;
@@ -203,30 +190,6 @@ export function isTauriRuntime(): boolean {
   );
 }
 
-function readInjectedTauriCore(): TauriCoreApi | null {
-  if (typeof window === "undefined") return null;
-  const candidate = (window as any).__CFY_TAURI_CORE__;
-  if (!candidate || typeof candidate.invoke !== "function") return null;
-  return candidate as TauriCoreApi;
-}
-
-async function loadTauriCore(): Promise<TauriCoreApi> {
-  const injected = readInjectedTauriCore();
-  if (injected) return injected;
-  try {
-    const imported = (await new Function(
-      'return import("@tauri-apps/api/core")'
-    )()) as TauriCoreApi;
-    return imported;
-  } catch (error) {
-    const detail =
-      error instanceof Error
-        ? error.message
-        : String(error ?? "Unknown native bridge import error");
-    throw new NativeBridgeUnavailableError(detail);
-  }
-}
-
 function normalizeLauncherStartupHandoff(
   payload: unknown
 ): LauncherStartupHandoff | null {
@@ -308,12 +271,14 @@ function normalizeDesktopRuntimeAuthConfig(
 export async function readDesktopLauncherStartupHandoff(): Promise<LauncherStartupHandoff | null> {
   if (!isTauriRuntime()) return null;
   try {
-    const core = await loadTauriCore();
-    const payload = await core.invoke<unknown>(
+    const payload = await invokeNativeTauriCommand<unknown>(
       "desktop_get_launcher_startup_handoff"
     );
     return normalizeLauncherStartupHandoff(payload);
-  } catch {
+  } catch (error) {
+    if (error instanceof NativeBridgeUnavailableError) {
+      throw error;
+    }
     return null;
   }
 }
@@ -464,8 +429,7 @@ async function readTauriRuntimeConfig(): Promise<TauriRuntimeConfig | null> {
     return null;
   }
   try {
-    const core = await loadTauriCore();
-    const payload = await core.invoke<unknown>(
+    const payload = await invokeNativeTauriCommand<unknown>(
       "desktop_get_runtime_auth_config"
     );
     const authConfig = normalizeDesktopRuntimeAuthConfig(payload);
@@ -496,7 +460,9 @@ async function readTauriRuntimeConfig(): Promise<TauriRuntimeConfig | null> {
       };
     }
 
-    const legacyPayload = await core.invoke<any>("desktop_get_runtime_config");
+    const legacyPayload = await invokeNativeTauriCommand<any>(
+      "desktop_get_runtime_config"
+    );
     if (!legacyPayload || typeof legacyPayload !== "object") return null;
     desktopRuntimeAuthConfigCache = {
       mode: "tauri",
@@ -531,7 +497,10 @@ async function readTauriRuntimeConfig(): Promise<TauriRuntimeConfig | null> {
       sharePublicBaseUrl: desktopRuntimeAuthConfigCache.sharePublicBaseUrl,
       authMode: desktopRuntimeAuthConfigCache.authMode,
     };
-  } catch {
+  } catch (error) {
+    if (error instanceof NativeBridgeUnavailableError) {
+      throw error;
+    }
     return null;
   }
 }
@@ -745,10 +714,12 @@ export async function openExternalUrl(url: string): Promise<boolean> {
 
   if (isTauriRuntime()) {
     try {
-      const core = await loadTauriCore();
-      await core.invoke("desktop_open_external", { url: trimmed });
+      await invokeNativeTauriCommand("desktop_open_external", { url: trimmed });
       return true;
-    } catch {
+    } catch (error) {
+      if (error instanceof NativeBridgeUnavailableError) {
+        return false;
+      }
       return false;
     }
   }
@@ -769,6 +740,5 @@ export async function invokeTauriCommand<T = unknown>(
       "Tauri native bridge is unavailable outside the desktop runtime."
     );
   }
-  const core = await loadTauriCore();
-  return core.invoke<T>(command, payload);
+  return invokeNativeTauriCommand<T>(command, payload);
 }

--- a/frontend/src/lib/tauriBridge.test.ts
+++ b/frontend/src/lib/tauriBridge.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  NATIVE_BRIDGE_FAILURE_KIND,
+  NativeBridgeUnavailableError,
+  invokeTauriCommand,
+} from "@/lib/tauriBridge";
+
+describe("tauri bridge", () => {
+  afterEach(() => {
+    delete (window as any).__TAURI_IPC__;
+    delete (window as any).__TAURI_INTERNALS__;
+    delete (window as any).__CFY_TAURI_CORE__;
+  });
+
+  it("classifies browser-mode command access as native bridge unavailable", async () => {
+    delete (window as any).__TAURI_IPC__;
+    delete (window as any).__TAURI_INTERNALS__;
+    delete (window as any).__CFY_TAURI_CORE__;
+
+    await expect(invokeTauriCommand("desktop_get_runtime_config")).rejects.toMatchObject(
+      {
+        code: NATIVE_BRIDGE_FAILURE_KIND,
+      }
+    );
+  });
+
+  it("uses the injected core when present", async () => {
+    const invoke = vi.fn().mockResolvedValue("ok");
+    (window as any).__TAURI_IPC__ = {};
+    (window as any).__CFY_TAURI_CORE__ = { invoke };
+
+    await expect(invokeTauriCommand("desktop_get_api_key")).resolves.toBe("ok");
+    expect(invoke).toHaveBeenCalledWith("desktop_get_api_key", undefined);
+  });
+
+  it("exposes the native bridge error class for packaged diagnostics", () => {
+    const error = new NativeBridgeUnavailableError("boom");
+    expect(error.code).toBe(NATIVE_BRIDGE_FAILURE_KIND);
+    expect(error.name).toBe("NativeBridgeUnavailableError");
+  });
+});

--- a/frontend/src/lib/tauriBridge.ts
+++ b/frontend/src/lib/tauriBridge.ts
@@ -1,0 +1,62 @@
+export type TauriCoreApi = {
+  invoke: <T = unknown>(
+    command: string,
+    payload?: Record<string, unknown>
+  ) => Promise<T>;
+};
+
+const TAURI_CORE_WINDOW_KEY = "__CFY_TAURI_CORE__";
+
+export const NATIVE_BRIDGE_FAILURE_KIND = "native-bridge-unavailable" as const;
+
+export class NativeBridgeUnavailableError extends Error {
+  readonly code = NATIVE_BRIDGE_FAILURE_KIND;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "NativeBridgeUnavailableError";
+  }
+}
+
+function readInjectedTauriCore(): TauriCoreApi | null {
+  if (typeof window === "undefined") return null;
+  const candidate = (window as any)[TAURI_CORE_WINDOW_KEY];
+  if (!candidate || typeof candidate.invoke !== "function") return null;
+  return candidate as TauriCoreApi;
+}
+
+export function isTauriRuntime(): boolean {
+  if (typeof window === "undefined") return false;
+  return (
+    typeof (window as any).__TAURI_IPC__ !== "undefined" ||
+    typeof (window as any).__TAURI_INTERNALS__ !== "undefined"
+  );
+}
+
+export async function loadTauriCore(): Promise<TauriCoreApi> {
+  const injected = readInjectedTauriCore();
+  if (injected) return injected;
+
+  try {
+    return (await import("@tauri-apps/api/core")) as TauriCoreApi;
+  } catch (error) {
+    const detail =
+      error instanceof Error
+        ? error.message
+        : String(error ?? "Unknown native bridge import error");
+    throw new NativeBridgeUnavailableError(detail);
+  }
+}
+
+export async function invokeTauriCommand<T = unknown>(
+  command: string,
+  payload?: Record<string, unknown>
+): Promise<T> {
+  if (!isTauriRuntime()) {
+    throw new NativeBridgeUnavailableError(
+      "Tauri native bridge is unavailable outside the desktop runtime."
+    );
+  }
+  const core = await loadTauriCore();
+  return core.invoke<T>(command, payload);
+}

--- a/frontend/src/persona/PersonaEngine.ts
+++ b/frontend/src/persona/PersonaEngine.ts
@@ -1,3 +1,5 @@
+import { invokeTauriCommand } from "@/lib/tauriBridge";
+
 /**
  * Detect if we are running inside a Tauri desktop runtime.
  */
@@ -48,8 +50,7 @@ export const PersonaEngine = {
     memory_tags: string[]
   ): Promise<GenerationResult> {
     if (isTauri()) {
-      const { invoke } = await new Function('return import("@tauri-apps/api/core")')();
-      const out = (await invoke("generate_with_memory", {
+      const out = (await invokeTauriCommand("generate_with_memory", {
         inputPrompt: input_prompt,
         personaId: persona_id,
         memoryTags: memory_tags,
@@ -68,8 +69,7 @@ export const PersonaEngine = {
    */
   async getAllTags(persona_id: string): Promise<TagStats[]> {
     if (isTauri()) {
-      const { invoke } = await new Function('return import("@tauri-apps/api/core")')();
-      const tags = (await invoke("get_all_tags", {
+      const tags = (await invokeTauriCommand("get_all_tags", {
         personaId: persona_id,
       })) as TagStats[];
       return tags;

--- a/packaging/pyinstaller/codexify_runtime.spec
+++ b/packaging/pyinstaller/codexify_runtime.spec
@@ -1,0 +1,82 @@
+# -*- mode: python ; coding: utf-8 -*-
+from pathlib import Path
+
+from PyInstaller.building.build_main import Analysis, COLLECT, EXE, PYZ
+from PyInstaller.utils.hooks import collect_submodules
+
+repo_root = Path.cwd()
+
+datas = [
+    (str(repo_root / "config" / "public_routes.yaml"), "config"),
+    (str(repo_root / "docs" / "builtin-help" / "codexify-guide.md"), "docs/builtin-help"),
+    (str(repo_root / "guardian" / "contracts.py"), "bootstrap/guardian"),
+    (str(repo_root / "guardian" / "contracts" / "imprint_snapshot.py"), "bootstrap/guardian/contracts"),
+    (str(repo_root / "guardian" / "contracts" / "imprint_proposal.py"), "bootstrap/guardian/contracts"),
+]
+datas.extend(
+    (
+        str(path),
+        "config/supported_profiles",
+    )
+    for path in sorted((repo_root / "config" / "supported_profiles").glob("*.yaml"))
+)
+hiddenimports = [
+    "backend.compiled_backend_entry",
+    "backend.rag.chatgpt_migration",
+    "backend.scripts.seed_defaults",
+    "chromadb.api.rust",
+    "chromadb.telemetry.product",
+    "chromadb.telemetry.product.posthog",
+    "guardian.contracts",
+    "guardian.contracts.imprint_proposal",
+    "guardian.contracts.imprint_snapshot",
+    "guardian.scripts.ensure_embed_model",
+    "guardian.workers.chat_worker",
+    "guardian.workers.chat_embedding_worker",
+    "guardian.workers.document_embed_worker",
+    "guardian.workers.warmup_worker",
+    "psycopg",
+    "psycopg2",
+    *collect_submodules("guardian.contracts"),
+]
+
+a = Analysis(
+    [str(repo_root / "backend" / "compiled_runtime_entry.py")],
+    pathex=[str(repo_root)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+pyz = PYZ(a.pure)
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="codexify-runtime",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name="codexify-runtime",
+)

--- a/scripts/verification/check_compiled_runtime_image.sh
+++ b/scripts/verification/check_compiled_runtime_image.sh
@@ -5,11 +5,15 @@ IMAGE_NAME="${1:-codexify-runtime-compiled:local}"
 
 docker run --rm --entrypoint sh "${IMAGE_NAME}" -lc '
   set -eu
-  test -x /app/runtime/codexify-backend
+  test -x /app/runtime/codexify-runtime
   test -d /app/runtime/_internal
+  test -f /app/runtime/alembic.ini
+  test -d /app/runtime/migrations
   test -d /app/config
   test -d /app/docs/builtin-help
   test ! -d /app/backend
   test ! -d /app/tests
   test ! -d /app/guardian
+  test ! -e /app/runtime/codexify-backend
+  /app/runtime/codexify-runtime --help >/dev/null 2>&1
 '

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -253,6 +253,24 @@ pub struct RuntimeReadiness {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub llm_ready: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub probe_context: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llm_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llm_details_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llm_details_ok: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llm_provider: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llm_model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llm_provider_runtime_available: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llm_endpoint_resolution_state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llm_failure_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_kind: Option<String>,
@@ -3034,6 +3052,170 @@ fn json_status_matches(value: &Value, expected: &str) -> bool {
         .unwrap_or(false)
 }
 
+fn json_nested_field<'a>(value: &'a Value, path: &[&str]) -> Option<&'a Value> {
+    let mut current = value;
+    for key in path {
+        current = current.get(*key)?;
+    }
+    Some(current)
+}
+
+fn json_nested_bool_field(value: &Value, path: &[&str]) -> Option<bool> {
+    json_nested_field(value, path).and_then(|entry| entry.as_bool())
+}
+
+fn json_nested_string_field(value: &Value, path: &[&str]) -> Option<String> {
+    json_nested_field(value, path)
+        .and_then(|entry| entry.as_str())
+        .and_then(|text| {
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
+}
+
+fn is_green_llm_status(value: Option<&str>) -> bool {
+    value
+        .map(|status| {
+            matches!(
+                status.to_ascii_lowercase().as_str(),
+                "ok" | "healthy" | "online"
+            )
+        })
+        .unwrap_or(false)
+}
+
+fn is_red_llm_status(value: Option<&str>) -> bool {
+    value
+        .map(|status| {
+            matches!(
+                status.to_ascii_lowercase().as_str(),
+                "offline" | "degraded" | "error" | "unavailable" | "red" | "failed"
+            )
+        })
+        .unwrap_or(false)
+}
+
+#[derive(Debug, Clone)]
+struct LlmReadinessSignals {
+    provider: Option<String>,
+    model: Option<String>,
+    status: Option<String>,
+    details_status: Option<String>,
+    details_ok: Option<bool>,
+    provider_runtime_available: Option<bool>,
+    endpoint_resolution_state: Option<String>,
+    ready: Option<bool>,
+    failure_reason: Option<String>,
+}
+
+fn llm_readiness_signals(llm_json: Option<&Value>) -> LlmReadinessSignals {
+    let Some(value) = llm_json else {
+        return LlmReadinessSignals {
+            provider: None,
+            model: None,
+            status: None,
+            details_status: None,
+            details_ok: None,
+            provider_runtime_available: None,
+            endpoint_resolution_state: None,
+            ready: Some(false),
+            failure_reason: Some("llm-health-payload-missing".to_string()),
+        };
+    };
+
+    let provider = json_string_field(value, "provider");
+    let model = json_string_field(value, "model");
+    let status = json_string_field(value, "status");
+    let details = value.get("details");
+    let details_status = details.and_then(|entry| json_string_field(entry, "status"));
+    let details_ok = details.and_then(|entry| json_bool_field(entry, "ok"));
+    let provider_runtime_available = details
+        .and_then(|entry| json_nested_bool_field(entry, &["provider_runtime", "available"]))
+        .or_else(|| json_nested_bool_field(value, &["provider_runtime", "available"]));
+    let endpoint_resolution_state = details
+        .and_then(|entry| json_nested_string_field(entry, &["endpoint_resolution", "state"]))
+        .or_else(|| json_nested_string_field(value, &["endpoint_resolution", "state"]));
+
+    let positive_signal = is_green_llm_status(status.as_deref())
+        || is_green_llm_status(details_status.as_deref())
+        || details_ok == Some(true)
+        || provider_runtime_available == Some(true)
+        || endpoint_resolution_state
+            .as_deref()
+            .map(|state| state.eq_ignore_ascii_case("available"))
+            .unwrap_or(false);
+    let negative_signal = provider
+        .as_deref()
+        .map(|provider| !provider.eq_ignore_ascii_case("local"))
+        .unwrap_or(false)
+        || details_ok == Some(false)
+        || provider_runtime_available == Some(false)
+        || endpoint_resolution_state
+            .as_deref()
+            .map(|state| !state.eq_ignore_ascii_case("available"))
+            .unwrap_or(false)
+        || is_red_llm_status(status.as_deref())
+        || is_red_llm_status(details_status.as_deref());
+
+    let ready = if negative_signal {
+        Some(false)
+    } else if positive_signal {
+        Some(true)
+    } else {
+        Some(false)
+    };
+
+    let failure_reason = if ready == Some(true) {
+        None
+    } else if provider
+        .as_deref()
+        .map(|provider| !provider.eq_ignore_ascii_case("local"))
+        .unwrap_or(false)
+    {
+        provider
+            .as_deref()
+            .map(|provider| format!("provider={provider}"))
+    } else if provider_runtime_available == Some(false) {
+        Some("provider_runtime.available=false".to_string())
+    } else if details_ok == Some(false) {
+        Some("details.ok=false".to_string())
+    } else if endpoint_resolution_state
+        .as_deref()
+        .map(|state| !state.eq_ignore_ascii_case("available"))
+        .unwrap_or(false)
+    {
+        endpoint_resolution_state
+            .as_deref()
+            .map(|state| format!("endpoint_resolution.state={state}"))
+    } else if is_red_llm_status(details_status.as_deref()) {
+        details_status
+            .as_deref()
+            .map(|status| format!("details.status={status}"))
+    } else if is_red_llm_status(status.as_deref()) {
+        status.as_deref().map(|status| format!("status={status}"))
+    } else if provider_runtime_available == Some(true) || details_ok == Some(true) {
+        None
+    } else {
+        Some("llm-health-unavailable".to_string())
+    };
+
+    LlmReadinessSignals {
+        provider,
+        model,
+        status,
+        details_status,
+        details_ok,
+        provider_runtime_available,
+        endpoint_resolution_state,
+        ready,
+        failure_reason,
+    }
+}
+
 fn bool_label(value: bool) -> &'static str {
     if value {
         "true"
@@ -5338,6 +5520,7 @@ fn runtime_readiness_snapshot(runtime: Option<&BootstrapRuntime>) -> RuntimeRead
     let health_json = health_body.as_deref().and_then(parse_json_body);
     let chat_json = chat_body.as_deref().and_then(parse_json_body);
     let llm_json = llm_body.as_deref().and_then(parse_json_body);
+    let llm_signals = llm_readiness_signals(llm_json.as_ref());
 
     let backend_reachable = ping_check.ok;
     let startup_ready = health_check.ok
@@ -5358,23 +5541,20 @@ fn runtime_readiness_snapshot(runtime: Option<&BootstrapRuntime>) -> RuntimeRead
     let chat_status_reason = chat_completion_service
         .and_then(|value| json_string_field(value, "status_reason"))
         .unwrap_or_else(|| "unknown".to_string());
-
-    let llm_provider = llm_json
-        .as_ref()
-        .and_then(|value| json_string_field(value, "provider"));
-    let llm_status = llm_json
-        .as_ref()
-        .and_then(|value| json_string_field(value, "status"))
+    let llm_provider = llm_signals.provider.clone();
+    let llm_status = llm_signals
+        .status
+        .clone()
         .unwrap_or_else(|| "unknown".to_string());
-    let llm_ready = match llm_provider.as_deref() {
-        Some(provider) if provider.eq_ignore_ascii_case("local") => Some(
-            llm_check.ok
-                && llm_json
-                    .as_ref()
-                    .map(|value| json_status_matches(value, "online"))
-                    .unwrap_or(false),
-        ),
-        Some(_) => None,
+    let llm_ready = match llm_signals.ready {
+        Some(ready) if llm_provider
+            .as_deref()
+            .map(|provider| provider.eq_ignore_ascii_case("local"))
+            .unwrap_or(true) =>
+        {
+            Some(ready && llm_check.ok)
+        }
+        Some(ready) => Some(ready && llm_check.ok),
         None => Some(false),
     };
 
@@ -5392,12 +5572,47 @@ fn runtime_readiness_snapshot(runtime: Option<&BootstrapRuntime>) -> RuntimeRead
             format!("redisReady={}", bool_label(redis_ready)),
             format!("chatReady={}", bool_label(chat_ready)),
             format!("chatStatusReason={chat_status_reason}"),
+            "probeContext=host-native".to_string(),
+            format!("llmEndpoint={llm_health_url}"),
             format!(
                 "llmProvider={}",
                 llm_provider.as_deref().unwrap_or("unknown")
             ),
             format!("llmStatus={llm_status}"),
+            format!(
+                "llmDetailsStatus={}",
+                llm_signals
+                    .details_status
+                    .as_deref()
+                    .unwrap_or("unknown")
+            ),
+            format!(
+                "llmDetailsOk={}",
+                option_bool_label(llm_signals.details_ok)
+            ),
+            format!(
+                "llmModel={}",
+                llm_signals.model.as_deref().unwrap_or("unknown")
+            ),
+            format!(
+                "llmProviderRuntimeAvailable={}",
+                option_bool_label(llm_signals.provider_runtime_available)
+            ),
+            format!(
+                "llmEndpointResolutionState={}",
+                llm_signals
+                    .endpoint_resolution_state
+                    .as_deref()
+                    .unwrap_or("unknown")
+            ),
             format!("llmReady={}", option_bool_label(llm_ready)),
+            format!(
+                "llmFailureReason={}",
+                llm_signals
+                    .failure_reason
+                    .as_deref()
+                    .unwrap_or("none")
+            ),
             format!("ready={}", bool_label(ready)),
         ];
 
@@ -5456,6 +5671,15 @@ fn runtime_readiness_snapshot(runtime: Option<&BootstrapRuntime>) -> RuntimeRead
         redis_ready,
         chat_ready,
         llm_ready,
+        probe_context: Some("host-native".to_string()),
+        llm_status: llm_signals.status,
+        llm_details_status: llm_signals.details_status,
+        llm_details_ok: llm_signals.details_ok,
+        llm_provider: llm_signals.provider,
+        llm_model: llm_signals.model,
+        llm_provider_runtime_available: llm_signals.provider_runtime_available,
+        llm_endpoint_resolution_state: llm_signals.endpoint_resolution_state,
+        llm_failure_reason: llm_signals.failure_reason,
         detail,
         failure_kind,
         runtime_context: runtime.map(|resolved| resolved.runtime_context.clone()),
@@ -5489,6 +5713,7 @@ mod tests {
     use super::*;
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
+    use serde_json::json;
 
     fn unique_temp_dir(prefix: &str) -> PathBuf {
         let stamp = SystemTime::now()
@@ -5798,5 +6023,72 @@ mod tests {
         let err = desktop_media_size_guard(DESKTOP_MEDIA_MAX_BYTES + 1)
             .expect_err("expected oversize payload to be rejected");
         assert_eq!(err.kind, "too_large");
+    }
+
+    #[test]
+    fn llm_readiness_signals_accepts_nested_online_payload() {
+        let payload = json!({
+            "status": "ok",
+            "ok": true,
+            "provider": "local",
+            "model": "library2/ministral-3:8b",
+            "details": {
+                "status": "online",
+                "ok": true,
+                "provider_runtime": {
+                    "available": true
+                },
+                "endpoint_resolution": {
+                    "state": "available"
+                }
+            }
+        });
+
+        let signals = llm_readiness_signals(Some(&payload));
+
+        assert_eq!(signals.provider.as_deref(), Some("local"));
+        assert_eq!(signals.model.as_deref(), Some("library2/ministral-3:8b"));
+        assert_eq!(signals.status.as_deref(), Some("ok"));
+        assert_eq!(signals.details_status.as_deref(), Some("online"));
+        assert_eq!(signals.details_ok, Some(true));
+        assert_eq!(signals.provider_runtime_available, Some(true));
+        assert_eq!(
+            signals.endpoint_resolution_state.as_deref(),
+            Some("available")
+        );
+        assert_eq!(signals.ready, Some(true));
+        assert_eq!(signals.failure_reason, None);
+    }
+
+    #[test]
+    fn llm_readiness_signals_fail_closed_when_local_model_path_is_unavailable() {
+        let payload = json!({
+            "status": "ok",
+            "ok": true,
+            "provider": "local",
+            "model": "library2/ministral-3:8b",
+            "details": {
+                "status": "offline",
+                "ok": false,
+                "provider_runtime": {
+                    "available": false
+                },
+                "endpoint_resolution": {
+                    "state": "unavailable"
+                }
+            }
+        });
+
+        let signals = llm_readiness_signals(Some(&payload));
+
+        assert_eq!(signals.ready, Some(false));
+        assert_eq!(signals.failure_reason.as_deref(), Some("provider_runtime.available=false"));
+        assert_eq!(signals.details_status.as_deref(), Some("offline"));
+        assert_eq!(signals.details_ok, Some(false));
+        assert_eq!(signals.provider_runtime_available, Some(false));
+        assert_eq!(
+            signals.endpoint_resolution_state.as_deref(),
+            Some("unavailable")
+        );
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -612,7 +612,7 @@ fn packaged_runtime_image_tag(runtime: &BootstrapRuntime) -> String {
 
 fn packaged_runtime_backend_image(runtime: &BootstrapRuntime) -> String {
     format!(
-        "{}/codexify-backend:{}",
+        "{}/codexify-runtime:{}",
         packaged_runtime_image_registry(runtime),
         packaged_runtime_image_tag(runtime)
     )

--- a/tests/ops/test_compiled_runtime_contract.py
+++ b/tests/ops/test_compiled_runtime_contract.py
@@ -1,7 +1,10 @@
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 
-def test_compiled_backend_docker_target_and_overlay_exist() -> None:
+def test_compiled_runtime_docker_target_and_overlay_exist() -> None:
     repo_root = Path(__file__).resolve().parents[2]
 
     dockerfile = (repo_root / "backend" / "Dockerfile").read_text(
@@ -17,9 +20,81 @@ def test_compiled_backend_docker_target_and_overlay_exist() -> None:
         in dockerfile
     )
     assert (
-        "pyinstaller /src/packaging/pyinstaller/codexify_backend.spec"
+        "pyinstaller /src/packaging/pyinstaller/codexify_runtime.spec"
         in dockerfile
     )
-    assert "ENTRYPOINT [\"/app/runtime/codexify-backend\"]" in dockerfile
+    assert "COPY backend/alembic.ini /app/runtime/alembic.ini" in dockerfile
+    assert "COPY backend/migrations /app/runtime/migrations" in dockerfile
+    assert "ENTRYPOINT [\"/app/runtime/codexify-runtime\"]" in dockerfile
+    assert "CMD [\"backend\"]" in dockerfile
     assert "image: codexify-runtime-compiled:local" in overlay
-    assert "command: []" in overlay
+    assert 'entrypoint: ["/app/runtime/codexify-runtime"]' in overlay
+    assert 'command: ["backend"]' in overlay
+
+
+def test_compiled_runtime_dispatcher_migrator_role_uses_runtime_migrations(
+    tmp_path: Path,
+) -> None:
+    from backend import compiled_runtime_entry as runtime_entry
+
+    calls: dict[str, object] = {}
+    alembic_cfg = tmp_path / "alembic.ini"
+    alembic_cfg.write_text("[alembic]\n", encoding="utf-8")
+
+    class DummyConfig:
+        def __init__(self, path: str) -> None:
+            calls["config_path"] = path
+
+        def set_main_option(self, key: str, value: str) -> None:
+            calls[key] = value
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(runtime_entry, "Config", DummyConfig)
+    monkeypatch.setattr(
+        runtime_entry,
+        "command",
+        SimpleNamespace(
+            upgrade=lambda config, target: calls.update(
+                upgraded_to=target, upgrade_config=config
+            )
+        ),
+    )
+    monkeypatch.setattr(runtime_entry, "_wait_for_db", lambda: "dsn")
+    monkeypatch.setattr(runtime_entry, "seed_defaults_main", lambda: 0)
+    monkeypatch.setenv("ALEMBIC_CONFIG", str(alembic_cfg))
+
+    try:
+        runtime_entry._run_migrator()
+    finally:
+        monkeypatch.undo()
+
+    assert calls["config_path"] == str(alembic_cfg)
+    assert calls["script_location"] == "/app/runtime/migrations"
+    assert calls["upgraded_to"] == "heads"
+    assert isinstance(calls["upgrade_config"], DummyConfig)
+
+
+def test_compiled_runtime_dispatcher_backend_preflight_still_blocks_missing_models(
+) -> None:
+    from backend import compiled_runtime_entry as runtime_entry
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setenv("LOCAL_EMBEDDINGS_REQUIRED", "1")
+    monkeypatch.setenv("LOCAL_EMBED_MODEL", "/private/tmp/codexify-missing-model")
+
+    backend_called = {"value": False}
+
+    monkeypatch.setattr(
+        runtime_entry,
+        "backend_main",
+        lambda: backend_called.update(value=True),
+    )
+
+    try:
+        with pytest.raises(SystemExit) as excinfo:
+            runtime_entry._run_backend()
+    finally:
+        monkeypatch.undo()
+
+    assert excinfo.value.code == 1
+    assert backend_called["value"] is False

--- a/tests/ops/test_registry_runtime_compose_contract.py
+++ b/tests/ops/test_registry_runtime_compose_contract.py
@@ -23,7 +23,20 @@ def test_packaged_registry_compose_contract_exists_and_avoids_bind_mounts() -> N
     assert "build:" not in text
     assert "\n      - ./" not in text
     assert "frontend:" not in text
-    assert "image: ${CODEXIFY_IMAGE_REGISTRY:-ghcr.io/resonant-jones}/codexify-backend:${CODEXIFY_IMAGE_TAG:-local-beta}" in text
+    assert "image: ${CODEXIFY_IMAGE_REGISTRY:-ghcr.io/resonant-jones}/codexify-runtime:${CODEXIFY_IMAGE_TAG:-local-beta}" in text
+    assert "/app/backend/scripts/docker/run_migrator.py" not in text
+    assert "/app/backend" not in text
+    assert "/app/guardian" not in text
+    assert "python -m guardian." not in text
+    assert "runpy.run_path" not in text
+    assert "codexify-backend" not in text
+    assert 'command: ["migrator"]' in text
+    assert 'command: ["model-prep"]' in text
+    assert 'command: ["backend"]' in text
+    assert 'command: ["worker-chat"]' in text
+    assert 'command: ["worker-document-embed"]' in text
+    assert 'command: ["worker-chat-embed"]' in text
+    assert 'command: ["worker-warmup"]' in text
 
     for marker in required_services:
         assert marker in text


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
