### PR TITLE
feat(flow-builder): add canonical flow draft state model

### DIFF
--- a/frontend/src/features/flowBuilder/FlowBuilderPage.tsx
+++ b/frontend/src/features/flowBuilder/FlowBuilderPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import Textarea from "@/components/ui/textarea";
 
@@ -6,74 +6,27 @@ import FlowBuilderChatDock from "./components/FlowBuilderChatDock";
 import FlowBuilderGraphCanvas from "./components/FlowBuilderGraphCanvas";
 import FlowBuilderParameterRail from "./components/FlowBuilderParameterRail";
 import {
+  getCurrentNodeSelection,
+  getGraphVisibleNodes,
+  getOrderedStageProgress,
+  getSupportChatContextSummary,
+  getValidationSummary,
+  useFlowDraftState,
+} from "./hooks/useFlowDraftState";
+import {
   DEFAULT_FLOW_BUILDER_MODE,
   getFlowBuilderPath,
   hasFlowBuilderModeQuery,
   parseFlowBuilderMode,
   type FlowBuilderMode,
 } from "./flowBuilderRoute";
-import {
-  createFlowBuilderExpertiseDraft,
-  type FlowBuilderExpertiseDraft,
-} from "./flowBuilderDraft";
+import type { FlowDraftContent, FlowDraftStageId } from "./model/flowDraft";
 
 const FLOW_BUILDER_LAST_MODE_STORAGE_KEY = "cfy.flowBuilder.mode";
 
 type FlowBuilderPageProps = {
   onReturnToGuardian?: () => void;
 };
-
-type FlowBuilderStage = {
-  id: string;
-  label: string;
-  description: string;
-  chip: string;
-};
-
-const FLOW_BUILDER_STAGES: FlowBuilderStage[] = [
-  {
-    id: "select-source",
-    label: "Select Source",
-    description: "Choose the input seam that should anchor the first draft.",
-    chip: "01",
-  },
-  {
-    id: "define-constraints",
-    label: "Define Constraints",
-    description: "Set the bounds, limits, and non-negotiables that shape the draft.",
-    chip: "02",
-  },
-  {
-    id: "set-outcomes",
-    label: "Set Outcomes",
-    description: "Name the intended result before the flow starts to harden.",
-    chip: "03",
-  },
-  {
-    id: "add-steps",
-    label: "Add Steps",
-    description: "Lay out the explicit steps that make the plan inspectable.",
-    chip: "04",
-  },
-  {
-    id: "insert-conditions",
-    label: "Insert Conditions",
-    description: "Mark the branch points where the draft needs a choice or guardrail.",
-    chip: "05",
-  },
-  {
-    id: "validation-gates",
-    label: "Validation Gates",
-    description: "Keep the checks visible so unresolved edges stay honest.",
-    chip: "06",
-  },
-  {
-    id: "review-validate",
-    label: "Review & Validate",
-    description: "Shape the handoff into a readable artifact for review.",
-    chip: "07",
-  },
-];
 
 function isFlowBuilderPathname(pathname: string): boolean {
   return pathname.startsWith("/flow-builder");
@@ -175,14 +128,7 @@ export default function FlowBuilderPage({
   onReturnToGuardian,
 }: FlowBuilderPageProps = {}) {
   const initialMode = resolveInitialFlowBuilderMode();
-  const [mode, setModeState] = useState<FlowBuilderMode>(initialMode);
-  const [selectedStageId, setSelectedStageId] = useState<FlowBuilderStage["id"]>(
-    initialMode === "expertise" ? "define-constraints" : "select-source"
-  );
-  const [assistantDockOpen, setAssistantDockOpen] = useState(true);
-  const [expertiseDraft, setExpertiseDraft] = useState<FlowBuilderExpertiseDraft | null>(
-    () => (initialMode === "expertise" ? createFlowBuilderExpertiseDraft() : null)
-  );
+  const { actions, draft, view } = useFlowDraftState(initialMode);
 
   const handleReturnToGuardian = useCallback(() => {
     if (onReturnToGuardian) {
@@ -211,11 +157,7 @@ export default function FlowBuilderPage({
           ? DEFAULT_FLOW_BUILDER_MODE
           : readPersistedFlowBuilderMode() ?? DEFAULT_FLOW_BUILDER_MODE);
 
-      setModeState((current) => (current === nextMode ? current : nextMode));
-      persistFlowBuilderMode(nextMode);
-      if (nextMode === "expertise") {
-        setExpertiseDraft((current) => current ?? createFlowBuilderExpertiseDraft());
-      }
+      actions.setMode(nextMode);
       canonicalizeFlowBuilderLocation(nextMode);
     };
 
@@ -225,40 +167,43 @@ export default function FlowBuilderPage({
     return () => {
       window.removeEventListener("popstate", syncFromLocation);
     };
-  }, []);
+  }, [actions]);
 
   useEffect(() => {
-    persistFlowBuilderMode(mode);
-  }, [mode]);
+    persistFlowBuilderMode(view.mode);
+    canonicalizeFlowBuilderLocation(view.mode);
+  }, [view.mode]);
 
   const currentRoute = useMemo(() => {
     if (typeof window === "undefined") {
-      return getFlowBuilderPath(mode);
+      return getFlowBuilderPath(view.mode);
     }
 
     if (isFlowBuilderPathname(window.location.pathname)) {
-      return getFlowBuilderPath(mode);
+      return getFlowBuilderPath(view.mode);
     }
 
     return `${window.location.pathname}${window.location.search}`;
-  }, [mode]);
+  }, [view.mode]);
 
-  const selectedStageIndex = useMemo(() => {
-    const index = FLOW_BUILDER_STAGES.findIndex((stage) => stage.id === selectedStageId);
-    return index === -1 ? 0 : index;
-  }, [selectedStageId]);
-
-  const selectedStage = FLOW_BUILDER_STAGES[selectedStageIndex] ?? FLOW_BUILDER_STAGES[0];
+  const currentSelection = useMemo(
+    () => getCurrentNodeSelection(draft, view),
+    [draft, view]
+  );
+  const stageProgress = useMemo(() => getOrderedStageProgress(draft, view), [draft, view]);
+  const graphVisibleNodes = useMemo(() => getGraphVisibleNodes(draft), [draft]);
+  const validationSummary = useMemo(() => getValidationSummary(draft), [draft]);
+  const supportChatContext = useMemo(
+    () => getSupportChatContextSummary(draft, view),
+    [draft, view]
+  );
 
   const handleSelectMode = useCallback(
     (nextMode: FlowBuilderMode) => {
-      setModeState(nextMode);
-      persistFlowBuilderMode(nextMode);
-      if (nextMode === "expertise") {
-        setExpertiseDraft((current) => current ?? createFlowBuilderExpertiseDraft());
-      }
+      actions.setMode(nextMode);
 
       if (typeof window === "undefined") return;
+      if (!isFlowBuilderPathname(window.location.pathname)) return;
 
       const nextPath = getFlowBuilderPath(nextMode);
       const currentPath = `${window.location.pathname}${window.location.search}`;
@@ -266,13 +211,45 @@ export default function FlowBuilderPage({
         window.history.pushState({}, "", nextPath);
       }
     },
-    []
+    [actions]
+  );
+
+  const handleSelectStage = useCallback(
+    (stageId: FlowDraftStageId) => {
+      actions.selectStage(stageId);
+    },
+    [actions]
+  );
+
+  const handleSelectNode = useCallback(
+    (nodeId: string) => {
+      actions.selectNode(nodeId);
+    },
+    [actions]
+  );
+
+  const handleMoveNode = useCallback(
+    (nodeId: string, direction: "up" | "down") => {
+      actions.moveNode(nodeId, direction);
+    },
+    [actions]
+  );
+
+  const handleToggleSupportDock = useCallback(() => {
+    actions.toggleSupportChatDock();
+  }, [actions]);
+
+  const handleDraftFieldChange = useCallback(
+    (field: keyof FlowDraftContent, value: string) => {
+      actions.updateDraftFields({ [field]: value } as Partial<FlowDraftContent>);
+    },
+    [actions]
   );
 
   return (
     <div
       data-testid="flow-builder-page"
-      data-flow-builder-mode={mode}
+      data-flow-builder-mode={view.mode}
       className="flex h-full min-h-0 w-full flex-col gap-5 overflow-auto p-[var(--card-pad)]"
     >
       <div
@@ -321,14 +298,14 @@ export default function FlowBuilderPage({
 
           <div className="flex flex-wrap items-center gap-2 lg:justify-end">
             <ModeButton
-              active={mode === "process"}
+              active={view.mode === "process"}
               description="Start from the steps you already know."
               label="Process"
               onClick={() => handleSelectMode("process")}
               testId="flow-builder-mode-process"
             />
             <ModeButton
-              active={mode === "expertise"}
+              active={view.mode === "expertise"}
               description="Start from the outcome and constraints."
               label="Expertise"
               onClick={() => handleSelectMode("expertise")}
@@ -348,27 +325,30 @@ export default function FlowBuilderPage({
 
         <div className="grid flex-1 gap-4 p-4 sm:p-6 xl:grid-cols-[minmax(240px,280px)_minmax(0,1fr)_minmax(280px,340px)]">
           <FlowBuilderParameterRail
-            stages={FLOW_BUILDER_STAGES}
-            selectedStageId={selectedStage.id}
-            onSelectStage={setSelectedStageId}
+            currentSelection={currentSelection}
+            onSelectStage={handleSelectStage}
+            stageProgress={stageProgress}
+            validationSummary={validationSummary}
           />
 
           <FlowBuilderGraphCanvas
-            modeLabel={mode === "expertise" ? "Expertise" : "Process"}
-            selectedStage={selectedStage}
-            selectedStageIndex={selectedStageIndex}
-            stages={FLOW_BUILDER_STAGES}
+            currentSelection={currentSelection}
+            graphVisibleNodes={graphVisibleNodes}
+            modeLabel={view.mode === "expertise" ? "Expertise" : "Process"}
+            onMoveNode={handleMoveNode}
+            onSelectNode={handleSelectNode}
+            validationSummary={validationSummary}
           />
 
           <FlowBuilderChatDock
-            modeLabel={mode === "expertise" ? "Expertise" : "Process"}
-            onToggleOpen={() => setAssistantDockOpen((current) => !current)}
-            open={assistantDockOpen}
-            selectedStage={selectedStage}
+            onToggleOpen={handleToggleSupportDock}
+            open={view.supportChatOpen}
+            supportChatContext={supportChatContext}
+            validationSummary={validationSummary}
           />
         </div>
 
-        {mode === "expertise" && expertiseDraft ? (
+        {view.mode === "expertise" ? (
           <section
             data-testid="flow-builder-draft-spec"
             className="border-t border-[var(--panel-border)] p-4 sm:p-6"
@@ -405,7 +385,7 @@ export default function FlowBuilderPage({
 
             <div className="mt-3 max-w-2xl space-y-2">
               <h2 className="text-lg font-semibold tracking-[-0.02em]">
-                {expertiseDraft.title}
+                {draft.meta.title}
               </h2>
               <p className="text-sm leading-6" style={{ color: "var(--muted)" }}>
                 This stub keeps the expertise lane honest: it makes the specification visible and
@@ -424,13 +404,13 @@ export default function FlowBuilderPage({
                 <div className="text-[11px] uppercase tracking-[0.2em]" style={{ color: "var(--muted)" }}>
                   Runtime
                 </div>
-                <div className="mt-2 text-sm font-medium">{expertiseDraft.runtimeSupport}</div>
+                <div className="mt-2 text-sm font-medium">{draft.meta.runtimeSupport}</div>
               </div>
               <div className="rounded-[16px] border px-3 py-3" style={{ borderColor: "var(--panel-border)" }}>
                 <div className="text-[11px] uppercase tracking-[0.2em]" style={{ color: "var(--muted)" }}>
                   Status
                 </div>
-                <div className="mt-2 text-sm font-medium">{expertiseDraft.status}</div>
+                <div className="mt-2 text-sm font-medium">{draft.meta.status}</div>
               </div>
             </div>
 
@@ -442,12 +422,8 @@ export default function FlowBuilderPage({
                 <Textarea
                   data-testid="flow-builder-draft-objective"
                   className="mt-2 min-h-28"
-                  value={expertiseDraft.objective}
-                  onChange={(event) =>
-                    setExpertiseDraft((current) =>
-                      current ? { ...current, objective: event.target.value } : current
-                    )
-                  }
+                  value={draft.content.objective}
+                  onChange={(event) => handleDraftFieldChange("objective", event.target.value)}
                 />
               </label>
 
@@ -458,12 +434,8 @@ export default function FlowBuilderPage({
                 <Textarea
                   data-testid="flow-builder-draft-assumptions"
                   className="mt-2 min-h-28"
-                  value={expertiseDraft.assumptions}
-                  onChange={(event) =>
-                    setExpertiseDraft((current) =>
-                      current ? { ...current, assumptions: event.target.value } : current
-                    )
-                  }
+                  value={draft.content.assumptions}
+                  onChange={(event) => handleDraftFieldChange("assumptions", event.target.value)}
                 />
               </label>
 
@@ -474,12 +446,8 @@ export default function FlowBuilderPage({
                 <Textarea
                   data-testid="flow-builder-draft-unknowns"
                   className="mt-2 min-h-28"
-                  value={expertiseDraft.unknowns}
-                  onChange={(event) =>
-                    setExpertiseDraft((current) =>
-                      current ? { ...current, unknowns: event.target.value } : current
-                    )
-                  }
+                  value={draft.content.unknowns}
+                  onChange={(event) => handleDraftFieldChange("unknowns", event.target.value)}
                 />
               </label>
 
@@ -490,13 +458,9 @@ export default function FlowBuilderPage({
                 <Textarea
                   data-testid="flow-builder-draft-validation-questions"
                   className="mt-2 min-h-28"
-                  value={expertiseDraft.validationQuestions}
+                  value={draft.content.validationQuestions}
                   onChange={(event) =>
-                    setExpertiseDraft((current) =>
-                      current
-                        ? { ...current, validationQuestions: event.target.value }
-                        : current
-                    )
+                    handleDraftFieldChange("validationQuestions", event.target.value)
                   }
                 />
               </label>

--- a/frontend/src/features/flowBuilder/__tests__/FlowBuilderPage.test.tsx
+++ b/frontend/src/features/flowBuilder/__tests__/FlowBuilderPage.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import FlowBuilderPage from "../FlowBuilderPage";
+import { getFlowDraftStageNodeId } from "../model/flowDraft";
 
 describe("FlowBuilderPage layout", () => {
   beforeEach(() => {
@@ -14,7 +15,7 @@ describe("FlowBuilderPage layout", () => {
     cleanup();
   });
 
-  it("renders the three-zone layout and keeps the spec-first copy truthful", async () => {
+  it("renders the graph-first layout and keeps the spec-first copy truthful", async () => {
     render(<FlowBuilderPage />);
 
     await waitFor(() => {
@@ -35,7 +36,7 @@ describe("FlowBuilderPage layout", () => {
     expect(screen.getByTestId("flow-builder-route")).toHaveTextContent("/flow-builder?mode=process");
   });
 
-  it("renders the expected staged parameter list and updates selection", async () => {
+  it("keeps the parameter rail, graph, and support dock aligned on the same shared selection", async () => {
     const user = userEvent.setup();
 
     render(<FlowBuilderPage />);
@@ -45,68 +46,85 @@ describe("FlowBuilderPage layout", () => {
     });
 
     const parameterRail = screen.getByTestId("flow-builder-parameter-rail");
-    const stages = [
-      "select-source",
-      "define-constraints",
-      "set-outcomes",
-      "add-steps",
-      "insert-conditions",
-      "validation-gates",
-      "review-validate",
-    ];
-
-    stages.forEach((stage) => {
-      expect(within(parameterRail).getByTestId(`flow-builder-stage-${stage}`)).toBeVisible();
-    });
-
-    expect(within(parameterRail).getByTestId("flow-builder-stage-select-source")).toHaveAttribute(
-      "aria-pressed",
-      "true"
-    );
+    const graphCanvas = screen.getByTestId("flow-builder-graph-canvas");
+    const chatDock = screen.getByTestId("flow-builder-chat-dock");
 
     await user.click(within(parameterRail).getByTestId("flow-builder-stage-define-constraints"));
 
     await waitFor(() => {
+      expect(within(parameterRail).getByTestId("flow-builder-stage-define-constraints")).toHaveAttribute(
+        "aria-pressed",
+        "true"
+      );
+    });
+
+    expect(graphCanvas).toHaveTextContent(/Seeded from Define Constraints/i);
+    expect(within(chatDock).getByTestId("flow-builder-support-context")).toHaveTextContent(
+      /Stage: Define Constraints/i
+    );
+    expect(within(chatDock).getByTestId("flow-builder-support-context")).toHaveTextContent(
+      /Validation: 1 warning/i
+    );
+
+    await user.click(
+      within(graphCanvas).getByTestId(
+        `flow-builder-graph-node-${getFlowDraftStageNodeId("set-outcomes")}`
+      )
+    );
+
+    await waitFor(() => {
       expect(
-        within(parameterRail).getByTestId("flow-builder-stage-define-constraints")
+        within(parameterRail).getByTestId("flow-builder-stage-set-outcomes")
       ).toHaveAttribute("aria-pressed", "true");
     });
-    expect(within(parameterRail).getByTestId("flow-builder-stage-select-source")).toHaveAttribute(
-      "aria-pressed",
-      "false"
-    );
-    expect(screen.getByTestId("flow-builder-graph-canvas")).toHaveTextContent(
-      /Seeded from Define Constraints/i
+
+    expect(within(chatDock).getByTestId("flow-builder-support-context")).toHaveTextContent(
+      /Node: Set Outcomes/i
     );
   });
 
-  it("dismisses and reopens the assistant dock without disturbing the builder layout", async () => {
+  it("updates the canonical draft order when a graph node is reordered", async () => {
     const user = userEvent.setup();
 
     render(<FlowBuilderPage />);
 
-    const dock = screen.getByTestId("flow-builder-chat-dock");
-    expect(dock).toBeVisible();
-    expect(within(dock).getByText(/Embedded Guardian review space/i)).toBeVisible();
-
-    await user.click(screen.getByTestId("flow-builder-assistant-toggle"));
-
     await waitFor(() => {
-      expect(screen.getByTestId("flow-builder-chat-dock")).toHaveTextContent(
-        /Assistant dock hidden/i
-      );
+      expect(window.location.search).toBe("?mode=process");
     });
 
-    await user.click(screen.getByTestId("flow-builder-assistant-toggle"));
+    const graphCanvas = screen.getByTestId("flow-builder-graph-canvas");
+    const orderStrip = within(graphCanvas).getByTestId("flow-builder-draft-order");
+
+    expect(orderStrip).toHaveTextContent(
+      /1\. Select Source.*2\. Define Constraints.*3\. Set Outcomes/s
+    );
+
+    await user.click(
+      within(graphCanvas).getByTestId(
+        `flow-builder-graph-node-${getFlowDraftStageNodeId("set-outcomes")}`
+      )
+    );
+    await waitFor(() => {
+      expect(
+        within(graphCanvas).getByTestId(
+          `flow-builder-node-move-down-${getFlowDraftStageNodeId("set-outcomes")}`
+        )
+      ).toBeVisible();
+    });
+    await user.click(
+      within(graphCanvas).getByTestId(
+        `flow-builder-node-move-down-${getFlowDraftStageNodeId("set-outcomes")}`
+      )
+    );
 
     await waitFor(() => {
-      expect(screen.getByTestId("flow-builder-chat-dock")).toHaveTextContent(
-        /Embedded Guardian review space/i
+      expect(orderStrip).toHaveTextContent(
+        /1\. Select Source.*2\. Define Constraints.*3\. Add Steps.*4\. Set Outcomes/s
       );
     });
   });
 
-  it("keeps the expertise lane honest and editable without implying execution support", async () => {
+  it("dismisses and reopens the support dock without losing the shared draft state", async () => {
     const user = userEvent.setup();
 
     window.history.pushState({}, "", "/flow-builder?mode=expertise");
@@ -119,20 +137,39 @@ describe("FlowBuilderPage layout", () => {
       );
     });
 
-    const draftArtifact = screen.getByTestId("flow-builder-draft-spec");
-    expect(draftArtifact).toBeVisible();
-    expect(within(draftArtifact).getByText(/^draft specification artifact$/i)).toBeVisible();
-    expect(within(draftArtifact).getByText(/^non-runtime$/i)).toBeVisible();
-    expect(within(draftArtifact).getByText(/^draft only$/i)).toBeVisible();
-    expect(
-      within(draftArtifact).getByText(/without claiming compile or execution support/i)
-    ).toBeVisible();
+    const dock = screen.getByTestId("flow-builder-chat-dock");
+    expect(dock).toBeVisible();
+    expect(within(dock).getByTestId("flow-builder-support-context")).toHaveTextContent(
+      /Draft specification/i
+    );
 
     const objective = screen.getByTestId("flow-builder-draft-objective");
     await user.clear(objective);
-    await user.type(objective, "Capture the first-pass workflow outcome.");
+    await user.type(objective, "Capture the canonical draft across dock toggles.");
 
-    expect(objective).toHaveValue("Capture the first-pass workflow outcome.");
+    await user.click(screen.getByTestId("flow-builder-assistant-toggle"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("flow-builder-chat-dock")).toHaveTextContent(/Assistant dock hidden/i);
+    });
+
+    await user.click(screen.getByTestId("flow-builder-assistant-toggle"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("flow-builder-chat-dock")).toHaveTextContent(
+        /Embedded Guardian review space/i
+      );
+    });
+
+    expect(screen.getByTestId("flow-builder-draft-objective")).toHaveValue(
+      "Capture the canonical draft across dock toggles."
+    );
+    const draftSpec = screen.getByTestId("flow-builder-draft-spec");
+    expect(within(draftSpec).getByText(/non-runtime/i)).toBeVisible();
+    expect(within(draftSpec).getByText(/draft only/i)).toBeVisible();
+    expect(
+      within(draftSpec).getByText(/without claiming compile or execution support/i)
+    ).toBeVisible();
   });
 
   it("canonicalizes the route and keeps the selected mode in sync with history", async () => {

--- a/frontend/src/features/flowBuilder/__tests__/flowDraft.test.ts
+++ b/frontend/src/features/flowBuilder/__tests__/flowDraft.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createInitialFlowDraftState,
+  flowDraftReducer,
+  getCurrentNodeSelection,
+  getGraphVisibleNodes,
+  getOrderedStageProgress,
+  getSupportChatContextSummary,
+  getValidationSummary,
+} from "../hooks/useFlowDraftState";
+import {
+  FLOW_DRAFT_STAGE_REGISTRY,
+  createSpecFirstFlowDraft,
+  getFlowDraftStageNodeId,
+} from "../model/flowDraft";
+
+describe("flow draft model", () => {
+  it("creates the canonical spec-first draft and stage registry", () => {
+    const draft = createSpecFirstFlowDraft("2026-04-30T00:00:00.000Z");
+
+    expect(draft.meta.title).toBe("Draft specification");
+    expect(draft.meta.status).toBe("draft-only");
+    expect(draft.meta.runtimeSupport).toBe("none");
+    expect(draft.nodes.map((node) => node.stageId)).toEqual(
+      FLOW_DRAFT_STAGE_REGISTRY.map((stage) => stage.id)
+    );
+    expect(draft.edges).toHaveLength(FLOW_DRAFT_STAGE_REGISTRY.length - 1);
+    expect(getValidationSummary(draft)).toMatchObject({
+      total: 1,
+      warningCount: 1,
+      errorCount: 0,
+      label: "1 warning",
+    });
+  });
+
+  it("keeps stage selection, node selection, and graph order on one reducer spine", () => {
+    let state = createInitialFlowDraftState("process", "2026-04-30T00:00:00.000Z");
+
+    expect(state.view.selection.stageId).toBe("select-source");
+    expect(state.view.selection.nodeId).toBe(getFlowDraftStageNodeId("select-source"));
+
+    state = flowDraftReducer(state, { type: "selectStage", stageId: "set-outcomes" });
+    expect(getCurrentNodeSelection(state.draft, state.view)).toMatchObject({
+      stage: { id: "set-outcomes", label: "Set Outcomes" },
+      node: { id: getFlowDraftStageNodeId("set-outcomes") },
+    });
+
+    state = flowDraftReducer(state, {
+      type: "updateNodeFields",
+      nodeId: getFlowDraftStageNodeId("set-outcomes"),
+      fields: { outcome: "Keep the desired result visible." },
+    });
+
+    expect(getCurrentNodeSelection(state.draft, state.view).node?.fields.outcome).toBe(
+      "Keep the desired result visible."
+    );
+
+    state = flowDraftReducer(state, {
+      type: "moveNode",
+      nodeId: getFlowDraftStageNodeId("set-outcomes"),
+      direction: "up",
+    });
+
+    expect(getGraphVisibleNodes(state.draft).map((node) => node.stageId)).toEqual([
+      "select-source",
+      "set-outcomes",
+      "define-constraints",
+      "add-steps",
+      "insert-conditions",
+      "validation-gates",
+      "review-validate",
+    ]);
+    expect(getCurrentNodeSelection(state.draft, state.view).node?.id).toBe(
+      getFlowDraftStageNodeId("set-outcomes")
+    );
+    expect(getOrderedStageProgress(state.draft, state.view).find((item) => item.isSelected)?.stage.id).toBe(
+      "set-outcomes"
+    );
+  });
+
+  it("replaces and patches validation issues without losing the shared summary", () => {
+    let state = createInitialFlowDraftState("expertise", "2026-04-30T00:00:00.000Z");
+
+    state = flowDraftReducer(state, {
+      type: "replaceValidationIssues",
+      issues: [
+        {
+          id: "issue-error",
+          severity: "error",
+          message: "Missing execution boundary.",
+          stageId: "review-validate",
+        },
+      ],
+    });
+
+    expect(getValidationSummary(state.draft)).toMatchObject({
+      total: 1,
+      errorCount: 1,
+      warningCount: 0,
+      primarySeverity: "error",
+      label: "1 error",
+    });
+
+    state = flowDraftReducer(state, {
+      type: "patchValidationIssues",
+      issues: [
+        {
+          id: "issue-error",
+          message: "Missing execution boundary before compile support can exist.",
+        },
+        {
+          id: "issue-note",
+          severity: "info",
+          message: "Draft remains inspectable only.",
+          stageId: "define-constraints",
+        },
+      ],
+    });
+
+    expect(getValidationSummary(state.draft)).toMatchObject({
+      total: 2,
+      errorCount: 1,
+      infoCount: 1,
+      warningCount: 0,
+      primarySeverity: "error",
+      label: "1 error",
+    });
+    expect(
+      getSupportChatContextSummary(state.draft, state.view)
+    ).toMatchObject({
+      selectedStageLabel: "Define Constraints",
+      validationLabel: "1 error",
+      dockStateLabel: "Open",
+    });
+  });
+
+  it("dismisses and reopens the support dock without mutating the draft content", () => {
+    let state = createInitialFlowDraftState("process", "2026-04-30T00:00:00.000Z");
+
+    state = flowDraftReducer(state, {
+      type: "updateDraftFields",
+      fields: {
+        objective: "Hold the canonical draft together across the dock toggle.",
+      },
+    });
+    state = flowDraftReducer(state, { type: "dismissSupportChatDock" });
+    expect(state.view.supportChatOpen).toBe(false);
+    expect(state.draft.content.objective).toBe(
+      "Hold the canonical draft together across the dock toggle."
+    );
+
+    state = flowDraftReducer(state, { type: "reopenSupportChatDock" });
+    expect(state.view.supportChatOpen).toBe(true);
+    expect(state.draft.content.objective).toBe(
+      "Hold the canonical draft together across the dock toggle."
+    );
+  });
+});

--- a/frontend/src/features/flowBuilder/components/FlowBuilderChatDock.tsx
+++ b/frontend/src/features/flowBuilder/components/FlowBuilderChatDock.tsx
@@ -1,17 +1,12 @@
 import { MessageSquareMore, X } from "lucide-react";
 
-type FlowBuilderStage = {
-  id: string;
-  label: string;
-  description: string;
-  chip: string;
-};
+import type { FlowDraftSupportContextSummary, FlowDraftValidationSummary } from "../model/flowDraft";
 
 type FlowBuilderChatDockProps = {
-  modeLabel: string;
   onToggleOpen: () => void;
   open: boolean;
-  selectedStage: FlowBuilderStage;
+  supportChatContext: FlowDraftSupportContextSummary;
+  validationSummary: FlowDraftValidationSummary;
 };
 
 const ASSISTANT_NOTES = [
@@ -21,10 +16,10 @@ const ASSISTANT_NOTES = [
 ];
 
 export default function FlowBuilderChatDock({
-  modeLabel,
   onToggleOpen,
   open,
-  selectedStage,
+  supportChatContext,
+  validationSummary,
 }: FlowBuilderChatDockProps) {
   if (!open) {
     return (
@@ -60,8 +55,9 @@ export default function FlowBuilderChatDock({
             Open
           </span>
         </button>
-        <div className="px-4 py-4 text-sm leading-6" style={{ color: "var(--muted)" }}>
-          The builder stays dominant. The dock returns when you need review notes beside the graph.
+        <div className="space-y-2 px-4 py-4 text-sm leading-6" style={{ color: "var(--muted)" }}>
+          <div>{supportChatContext.dockStateLabel} support lane.</div>
+          <div>{validationSummary.label}</div>
         </div>
       </aside>
     );
@@ -87,7 +83,7 @@ export default function FlowBuilderChatDock({
             </div>
           </div>
           <p className="mt-2 text-sm leading-6" style={{ color: "var(--muted)" }}>
-            Embedded Guardian review space for {modeLabel.toLowerCase()} drafting.
+            Embedded Guardian review space for {supportChatContext.modeLabel.toLowerCase()} drafting.
           </p>
         </div>
         <button
@@ -121,6 +117,7 @@ export default function FlowBuilderChatDock({
         ))}
 
         <div
+          data-testid="flow-builder-support-context"
           className="rounded-[var(--tile-radius,19px)] border px-4 py-3"
           style={{
             borderColor: "var(--panel-border)",
@@ -128,11 +125,13 @@ export default function FlowBuilderChatDock({
           }}
         >
           <div className="text-[11px] uppercase tracking-[0.22em]" style={{ color: "var(--muted)" }}>
-            Selected stage
+            Shared draft context
           </div>
-          <div className="mt-2 text-sm font-medium">{selectedStage.label}</div>
-          <div className="mt-2 text-sm leading-6" style={{ color: "var(--muted)" }}>
-            {selectedStage.description}
+          <div className="mt-2 text-sm font-medium">{supportChatContext.draftTitle}</div>
+          <div className="mt-2 space-y-1 text-sm leading-6" style={{ color: "var(--muted)" }}>
+            <div>Stage: {supportChatContext.selectedStageLabel}</div>
+            <div>Node: {supportChatContext.selectedNodeLabel}</div>
+            <div>Validation: {validationSummary.label}</div>
           </div>
         </div>
       </div>
@@ -146,7 +145,7 @@ export default function FlowBuilderChatDock({
             color: "var(--muted)",
           }}
         >
-          Sidecar notes only. No backend chat integration is wired here.
+          {supportChatContext.provenanceLabel}. Validation {validationSummary.label}. Sidecar notes only. No backend chat integration is wired here.
         </div>
       </div>
     </aside>

--- a/frontend/src/features/flowBuilder/components/FlowBuilderGraphCanvas.tsx
+++ b/frontend/src/features/flowBuilder/components/FlowBuilderGraphCanvas.tsx
@@ -1,39 +1,85 @@
-type FlowBuilderStage = {
-  id: string;
-  label: string;
-  description: string;
-  chip: string;
-};
+import { ChevronDown, ChevronUp, Move } from "lucide-react";
+
+import {
+  type FlowDraftNode,
+  type FlowDraftSelection,
+  type FlowDraftValidationSummary,
+} from "../model/flowDraft";
 
 type FlowBuilderGraphCanvasProps = {
+  currentSelection: FlowDraftSelection;
+  graphVisibleNodes: FlowDraftNode[];
   modeLabel: string;
-  selectedStage: FlowBuilderStage;
-  selectedStageIndex: number;
-  stages: FlowBuilderStage[];
+  onMoveNode: (nodeId: string, direction: "up" | "down") => void;
+  onSelectNode: (nodeId: string) => void;
+  validationSummary: FlowDraftValidationSummary;
 };
 
-type FlowNode = {
-  label: string;
-  note: string;
-  active?: boolean;
-  compact?: boolean;
-  x: string;
-  y: string;
+type GraphPosition = {
+  left: string;
+  top: string;
+  x: number;
+  y: number;
 };
 
-function NodeCard({ node }: { node: FlowNode }) {
+const GRAPH_POSITIONS: GraphPosition[] = [
+  { left: "50%", top: "18%", x: 500, y: 130 },
+  { left: "27%", top: "34%", x: 270, y: 250 },
+  { left: "73%", top: "34%", x: 730, y: 250 },
+  { left: "34%", top: "56%", x: 340, y: 400 },
+  { left: "50%", top: "62%", x: 500, y: 450 },
+  { left: "66%", top: "56%", x: 660, y: 400 },
+  { left: "50%", top: "80%", x: 500, y: 570 },
+];
+
+function getNodeFieldPreview(node: FlowDraftNode): string {
+  const entries = Object.entries(node.fields);
+  if (entries.length === 0) {
+    return node.summary;
+  }
+
+  return entries
+    .slice(0, 2)
+    .map(([field, value]) => `${field}: ${value}`)
+    .join(" · ");
+}
+
+function NodeCard({
+  node,
+  active,
+  position,
+  onMoveNode,
+  onSelectNode,
+}: {
+  active: boolean;
+  node: FlowDraftNode;
+  onMoveNode: (nodeId: string, direction: "up" | "down") => void;
+  onSelectNode: (nodeId: string) => void;
+  position: GraphPosition;
+}) {
   return (
     <div
+      data-testid={`flow-builder-graph-node-${node.id}`}
+      role="button"
+      tabIndex={0}
+      aria-pressed={active}
+      onClick={() => onSelectNode(node.id)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onSelectNode(node.id);
+        }
+      }}
       className={[
-        "absolute -translate-x-1/2 -translate-y-1/2 rounded-[var(--tile-radius,19px)] border px-4 py-3 text-left backdrop-blur-sm",
-        node.active ? "shadow-[0_24px_42px_rgba(0,0,0,0.3)]" : "shadow-[0_10px_24px_rgba(0,0,0,0.16)]",
-        node.compact ? "min-w-[180px]" : "min-w-[240px]",
+        "absolute -translate-x-1/2 -translate-y-1/2 rounded-[var(--tile-radius,19px)] border px-4 py-3 text-left backdrop-blur-sm transition",
+        active ? "shadow-[0_24px_42px_rgba(0,0,0,0.3)]" : "shadow-[0_10px_24px_rgba(0,0,0,0.16)]",
+        node.kind === "validation" ? "min-w-[210px]" : "min-w-[240px]",
       ].join(" ")}
       style={{
-        left: node.x,
-        top: node.y,
-        borderColor: node.active ? "var(--accent)" : "var(--panel-border)",
-        background: node.active
+        left: position.left,
+        top: position.top,
+        borderColor: active ? "var(--accent)" : "var(--panel-border)",
+        background: active
           ? "color-mix(in oklab, var(--accent) 15%, var(--panel-bg))"
           : "color-mix(in oklab, var(--panel-bg) 90%, transparent)",
       }}
@@ -42,69 +88,71 @@ function NodeCard({ node }: { node: FlowNode }) {
         <span
           className="h-2.5 w-2.5 rounded-full"
           style={{
-            backgroundColor: node.active ? "var(--accent-strong)" : "var(--accent-weak)",
-            boxShadow: node.active ? "0 0 0 6px color-mix(in oklab, var(--accent) 12%, transparent)" : "none",
+            backgroundColor: active ? "var(--accent-strong)" : "var(--accent-weak)",
+            boxShadow: active ? "0 0 0 6px color-mix(in oklab, var(--accent) 12%, transparent)" : "none",
           }}
         />
         <div className="text-[11px] uppercase tracking-[0.22em]" style={{ color: "var(--muted)" }}>
-          {node.active ? "Seeded state" : "Derived node"}
+          {node.kind}
         </div>
       </div>
       <div className="mt-2 text-sm font-semibold tracking-[-0.02em]">{node.label}</div>
       <div className="mt-2 text-sm leading-6" style={{ color: "var(--muted)" }}>
-        {node.note}
+        {node.summary}
       </div>
+      <div className="mt-2 text-xs leading-5" style={{ color: "var(--muted)" }}>
+        {getNodeFieldPreview(node)}
+      </div>
+
+      {active ? (
+        <div className="mt-3 flex items-center gap-2">
+          <button
+            type="button"
+            data-testid={`flow-builder-node-move-up-${node.id}`}
+            onClick={(event) => {
+              event.stopPropagation();
+              onMoveNode(node.id, "up");
+            }}
+            className="inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[10px] uppercase tracking-[0.18em] transition hover:-translate-y-[1px]"
+            style={{
+              borderColor: "var(--panel-border)",
+              background: "color-mix(in oklab, var(--chip-bg) 88%, transparent)",
+            }}
+          >
+            <ChevronUp className="h-3.5 w-3.5" />
+            Up
+          </button>
+          <button
+            type="button"
+            data-testid={`flow-builder-node-move-down-${node.id}`}
+            onClick={(event) => {
+              event.stopPropagation();
+              onMoveNode(node.id, "down");
+            }}
+            className="inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[10px] uppercase tracking-[0.18em] transition hover:-translate-y-[1px]"
+            style={{
+              borderColor: "var(--panel-border)",
+              background: "color-mix(in oklab, var(--chip-bg) 88%, transparent)",
+            }}
+          >
+            <ChevronDown className="h-3.5 w-3.5" />
+            Down
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }
 
 export default function FlowBuilderGraphCanvas({
+  currentSelection,
+  graphVisibleNodes,
   modeLabel,
-  selectedStage,
-  selectedStageIndex,
-  stages,
+  onMoveNode,
+  onSelectNode,
+  validationSummary,
 }: FlowBuilderGraphCanvasProps) {
-  const previousStage = stages[Math.max(0, selectedStageIndex - 1)] ?? selectedStage;
-  const nextStage = stages[Math.min(stages.length - 1, selectedStageIndex + 1)] ?? selectedStage;
-  const reviewStage = stages[stages.length - 1] ?? selectedStage;
-
-  const nodes: FlowNode[] = [
-    {
-      label: selectedStage.label,
-      note: selectedStage.description,
-      active: true,
-      x: "50%",
-      y: "24%",
-    },
-    {
-      label: previousStage.label,
-      note: "The upstream choice that feeds the current seed.",
-      compact: true,
-      x: "28%",
-      y: "43%",
-    },
-    {
-      label: nextStage.label,
-      note: "The next visible step in the draft chain.",
-      compact: true,
-      x: "72%",
-      y: "43%",
-    },
-    {
-      label: "Validation Gate",
-      note: "Keep the unresolved edges visible before anything is treated as final.",
-      compact: true,
-      x: "38%",
-      y: "68%",
-    },
-    {
-      label: reviewStage.label,
-      note: "This remains a draft surface for inspection and review.",
-      compact: true,
-      x: "62%",
-      y: "68%",
-    },
-  ];
+  const positions = graphVisibleNodes.map((_, index) => GRAPH_POSITIONS[index] ?? GRAPH_POSITIONS[GRAPH_POSITIONS.length - 1]);
 
   return (
     <section
@@ -150,14 +198,24 @@ export default function FlowBuilderGraphCanvas({
           >
             {modeLabel}
           </span>
+          <span
+            className="rounded-full border px-2.5 py-1 text-[11px] uppercase tracking-[0.2em]"
+            style={{
+              borderColor: "var(--chip-border)",
+              background: "color-mix(in oklab, var(--chip-bg) 88%, transparent)",
+              color: "var(--muted)",
+            }}
+          >
+            Validation {validationSummary.label}
+          </span>
         </div>
         <div className="mt-2 max-w-2xl space-y-2">
           <h2 className="text-lg font-semibold tracking-[-0.02em] sm:text-xl">
-            Seeded from {selectedStage.label}
+            Seeded from {currentSelection.stage.label}
           </h2>
           <p className="text-sm leading-6" style={{ color: "var(--muted)" }}>
             The graph is a drafting surface, not an execution surface. It keeps the current stage,
-            its neighbors, and the review boundary legible in one view.
+            its neighboring structure, and the review boundary legible in one view.
           </p>
         </div>
       </div>
@@ -170,28 +228,32 @@ export default function FlowBuilderGraphCanvas({
           preserveAspectRatio="none"
         >
           <g stroke="color-mix(in oklab, var(--accent-weak) 45%, transparent)" strokeWidth="2">
-            <path d="M500 164 L500 278" />
-            <path d="M500 278 L278 314" />
-            <path d="M500 278 L722 314" />
-            <path d="M278 314 L386 486" />
-            <path d="M722 314 L614 486" />
-            <path d="M500 278 L500 540" strokeDasharray="8 10" />
+            {graphVisibleNodes.slice(0, -1).map((node, index) => {
+              const from = positions[index];
+              const to = positions[index + 1] ?? positions[index];
+              return <line key={`${node.id}-edge`} x1={from.x} y1={from.y} x2={to.x} y2={to.y} />;
+            })}
           </g>
           <g fill="color-mix(in oklab, var(--accent) 70%, transparent)">
-            <circle cx="500" cy="164" r="7" />
-            <circle cx="500" cy="278" r="7" />
-            <circle cx="278" cy="314" r="6" />
-            <circle cx="722" cy="314" r="6" />
-            <circle cx="386" cy="486" r="6" />
-            <circle cx="614" cy="486" r="6" />
+            {positions.map((position, index) => (
+              <circle key={`${index}-${position.x}-${position.y}`} cx={position.x} cy={position.y} r="6" />
+            ))}
           </g>
         </svg>
 
-        {nodes.map((node, index) => (
-          <NodeCard key={`${node.label}-${index}`} node={node} />
+        {graphVisibleNodes.map((node, index) => (
+          <NodeCard
+            key={node.id}
+            active={node.id === currentSelection.nodeId}
+            node={node}
+            onMoveNode={onMoveNode}
+            onSelectNode={onSelectNode}
+            position={positions[index] ?? GRAPH_POSITIONS[GRAPH_POSITIONS.length - 1]}
+          />
         ))}
 
         <div
+          data-testid="flow-builder-draft-order"
           className="absolute bottom-4 left-4 right-4 flex flex-wrap items-center justify-between gap-3 rounded-[var(--tile-radius,19px)] border px-4 py-3 backdrop-blur-sm"
           style={{
             borderColor: "var(--panel-border)",
@@ -199,17 +261,39 @@ export default function FlowBuilderGraphCanvas({
           }}
         >
           <div className="min-w-0">
-            <div className="text-[11px] uppercase tracking-[0.22em]" style={{ color: "var(--muted)" }}>
-              Current seed
+            <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.22em]" style={{ color: "var(--muted)" }}>
+              <Move className="h-3.5 w-3.5" />
+              Draft order
             </div>
-            <div className="mt-1 text-sm font-medium">{selectedStage.label}</div>
+            <div className="mt-2 flex flex-wrap gap-2 text-sm">
+              {graphVisibleNodes.map((node, index) => (
+                <span
+                  key={node.id}
+                  data-testid={`flow-builder-draft-order-item-${node.id}`}
+                  className="rounded-full border px-2.5 py-1"
+                  style={{
+                    borderColor: node.id === currentSelection.nodeId ? "var(--accent)" : "var(--panel-border)",
+                    background:
+                      node.id === currentSelection.nodeId
+                        ? "color-mix(in oklab, var(--accent) 14%, var(--panel-bg))"
+                        : "color-mix(in oklab, var(--chip-bg) 86%, transparent)",
+                  }}
+                >
+                  {index + 1}. {node.label}
+                </span>
+              ))}
+            </div>
           </div>
+
           <div className="flex items-center gap-2 text-xs uppercase tracking-[0.22em]" style={{ color: "var(--muted)" }}>
             <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
-              Stage {selectedStageIndex + 1}
+              {currentSelection.stage.label}
             </span>
             <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
               Draft only
+            </span>
+            <span className="rounded-full border px-2 py-1" style={{ borderColor: "var(--panel-border)" }}>
+              {validationSummary.label}
             </span>
           </div>
         </div>

--- a/frontend/src/features/flowBuilder/components/FlowBuilderParameterRail.tsx
+++ b/frontend/src/features/flowBuilder/components/FlowBuilderParameterRail.tsx
@@ -1,22 +1,23 @@
 import { Check } from "lucide-react";
 
-type FlowBuilderStage = {
-  id: string;
-  label: string;
-  description: string;
-  chip: string;
-};
+import {
+  type FlowDraftSelection,
+  type FlowDraftStageProgress,
+  type FlowDraftValidationSummary,
+} from "../model/flowDraft";
 
 type FlowBuilderParameterRailProps = {
-  onSelectStage: (stageId: string) => void;
-  selectedStageId: string;
-  stages: FlowBuilderStage[];
+  currentSelection: FlowDraftSelection;
+  onSelectStage: (stageId: FlowDraftSelection["stageId"]) => void;
+  stageProgress: FlowDraftStageProgress[];
+  validationSummary: FlowDraftValidationSummary;
 };
 
 export default function FlowBuilderParameterRail({
+  currentSelection,
   onSelectStage,
-  selectedStageId,
-  stages,
+  stageProgress,
+  validationSummary,
 }: FlowBuilderParameterRailProps) {
   return (
     <aside
@@ -39,16 +40,16 @@ export default function FlowBuilderParameterRail({
       </div>
 
       <div className="flex-1 space-y-2 p-4">
-        {stages.map((stage, index) => {
-          const active = stage.id === selectedStageId;
+        {stageProgress.map((stageItem) => {
+          const active = stageItem.stage.id === currentSelection.stageId;
 
           return (
             <button
-              key={stage.id}
+              key={stageItem.stage.id}
               type="button"
-              data-testid={`flow-builder-stage-${stage.id}`}
+              data-testid={`flow-builder-stage-${stageItem.stage.id}`}
               aria-pressed={active}
-              onClick={() => onSelectStage(stage.id)}
+              onClick={() => onSelectStage(stageItem.stage.id)}
               className={[
                 "flex w-full items-start gap-3 rounded-[var(--tile-radius,19px)] border px-4 py-4 text-left transition",
                 active ? "shadow-[0_14px_32px_rgba(0,0,0,0.22)]" : "hover:-translate-y-[1px]",
@@ -70,30 +71,72 @@ export default function FlowBuilderParameterRail({
                   color: active ? "var(--text)" : "var(--muted)",
                 }}
               >
-                {active ? <Check className="h-4 w-4" /> : stage.chip}
+                {active ? <Check className="h-4 w-4" /> : stageItem.stage.chip}
               </span>
 
               <span className="min-w-0 flex-1">
                 <span className="flex items-center justify-between gap-3">
-                  <span className="text-sm font-semibold tracking-[-0.02em]">{stage.label}</span>
-                  <span
-                    className="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.2em]"
-                    style={{
-                      borderColor: "var(--chip-border)",
-                      background: "color-mix(in oklab, var(--chip-bg) 88%, transparent)",
-                      color: "var(--muted)",
-                    }}
-                  >
-                    {index + 1}
+                  <span className="text-sm font-semibold tracking-[-0.02em]">
+                    {stageItem.stage.label}
+                  </span>
+                  <span className="flex items-center gap-2">
+                    <span
+                      className="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.2em]"
+                      style={{
+                        borderColor: "var(--chip-border)",
+                        background: "color-mix(in oklab, var(--chip-bg) 88%, transparent)",
+                        color: "var(--muted)",
+                      }}
+                    >
+                      {stageItem.index + 1}
+                    </span>
+                    {stageItem.issueCount > 0 ? (
+                      <span
+                        data-testid={`flow-builder-stage-issues-${stageItem.stage.id}`}
+                        className="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.2em]"
+                        style={{
+                          borderColor: "color-mix(in oklab, var(--accent) 55%, var(--panel-border))",
+                          background: "color-mix(in oklab, var(--accent) 14%, var(--panel-bg))",
+                          color: "var(--text)",
+                        }}
+                      >
+                        {stageItem.issueCount} issue{stageItem.issueCount === 1 ? "" : "s"}
+                      </span>
+                    ) : null}
                   </span>
                 </span>
                 <span className="mt-2 block text-sm leading-6" style={{ color: "var(--muted)" }}>
-                  {stage.description}
+                  {stageItem.stage.description}
                 </span>
               </span>
             </button>
           );
         })}
+      </div>
+
+      <div className="border-t border-[var(--panel-border)] p-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            className="rounded-full border px-2.5 py-1 text-[11px] uppercase tracking-[0.2em]"
+            style={{
+              borderColor: "var(--chip-border)",
+              background: "color-mix(in oklab, var(--chip-bg) 88%, transparent)",
+              color: "var(--muted)",
+            }}
+          >
+            Validation {validationSummary.label}
+          </span>
+          <span
+            className="rounded-full border px-2.5 py-1 text-[11px] uppercase tracking-[0.2em]"
+            style={{
+              borderColor: "var(--chip-border)",
+              background: "color-mix(in oklab, var(--chip-bg) 88%, transparent)",
+              color: "var(--muted)",
+            }}
+          >
+            Stage {currentSelection.stage.label}
+          </span>
+        </div>
       </div>
     </aside>
   );

--- a/frontend/src/features/flowBuilder/flowBuilderDraft.ts
+++ b/frontend/src/features/flowBuilder/flowBuilderDraft.ts
@@ -1,10 +1,18 @@
-import type { FlowBuilderMode } from "./flowBuilderRoute";
+import {
+  FLOW_DRAFT_INITIAL_RUNTIME_SUPPORT,
+  FLOW_DRAFT_INITIAL_STATUS,
+  FLOW_DRAFT_INITIAL_TITLE,
+  type FlowDraftContent,
+  type FlowDraftRuntimeSupport,
+  type FlowDraftLifecycleStatus,
+  createSpecFirstFlowDraft,
+} from "./model/flowDraft";
 
 export type FlowBuilderExpertiseDraft = {
-  sourceMode: Extract<FlowBuilderMode, "expertise">;
+  sourceMode: "expertise";
   title: string;
-  status: "draft-only";
-  runtimeSupport: "none";
+  status: FlowDraftLifecycleStatus;
+  runtimeSupport: FlowDraftRuntimeSupport;
   objective: string;
   assumptions: string;
   unknowns: string;
@@ -12,18 +20,17 @@ export type FlowBuilderExpertiseDraft = {
 };
 
 export function createFlowBuilderExpertiseDraft(): FlowBuilderExpertiseDraft {
+  const draft = createSpecFirstFlowDraft();
   return {
     sourceMode: "expertise",
-    title: "Draft specification",
-    status: "draft-only",
-    runtimeSupport: "none",
-    objective:
-      "Describe the desired outcome, domain vocabulary, and scope before any runnable path is considered.",
-    assumptions:
-      "List what is being inferred from expertise versus what still needs confirmation.",
-    unknowns:
-      "Record missing steps, unresolved dependencies, and any boundary that needs review.",
-    validationQuestions:
-      "Write the questions that must be answered before this draft can be considered stable.",
+    title: FLOW_DRAFT_INITIAL_TITLE,
+    status: FLOW_DRAFT_INITIAL_STATUS,
+    runtimeSupport: FLOW_DRAFT_INITIAL_RUNTIME_SUPPORT,
+    objective: draft.content.objective,
+    assumptions: draft.content.assumptions,
+    unknowns: draft.content.unknowns,
+    validationQuestions: draft.content.validationQuestions,
   };
 }
+
+export type { FlowDraftContent };

--- a/frontend/src/features/flowBuilder/hooks/useFlowDraftState.ts
+++ b/frontend/src/features/flowBuilder/hooks/useFlowDraftState.ts
@@ -1,0 +1,496 @@
+import { useMemo, useReducer } from "react";
+
+import {
+  createSpecFirstFlowDraft,
+  FLOW_DRAFT_STAGE_REGISTRY,
+  getFlowDraftStageDefinition,
+  getFlowDraftStageIndex,
+  getFlowDraftStageNodeId,
+  getInitialFlowDraftSelection,
+  type FlowBuilderViewState,
+  type FlowDraft,
+  type FlowDraftContent,
+  type FlowDraftEdge,
+  type FlowDraftNode,
+  type FlowDraftStageDefinition,
+  type FlowDraftStageProgress,
+  type FlowDraftSelectionSnapshot,
+  type FlowDraftSupportContextSummary,
+  type FlowDraftValidationIssue,
+  type FlowDraftValidationSummary,
+  type FlowDraftValidationSeverity,
+  type FlowBuilderMode,
+} from "../model/flowDraft";
+import { DEFAULT_FLOW_BUILDER_MODE } from "../flowBuilderRoute";
+
+export interface FlowDraftState {
+  draft: FlowDraft;
+  view: FlowBuilderViewState;
+}
+
+export type FlowDraftNodeFieldPatch = Record<string, string>;
+export type FlowDraftNodeMoveDirection = "up" | "down";
+
+export type FlowDraftAction =
+  | { type: "selectStage"; stageId: FlowDraftStageDefinition["id"] }
+  | { type: "selectNode"; nodeId: string }
+  | { type: "selectEdge"; edgeId: string | null }
+  | { type: "updateNodeFields"; nodeId: string; fields: FlowDraftNodeFieldPatch }
+  | { type: "updateDraftFields"; fields: Partial<FlowDraftContent> }
+  | { type: "replaceValidationIssues"; issues: FlowDraftValidationIssue[] }
+  | { type: "patchValidationIssues"; issues: Array<Partial<FlowDraftValidationIssue> & { id: string }> }
+  | { type: "moveNode"; nodeId: string; direction: FlowDraftNodeMoveDirection }
+  | { type: "dismissSupportChatDock" }
+  | { type: "reopenSupportChatDock" }
+  | { type: "toggleSupportChatDock" }
+  | { type: "setMode"; mode: FlowBuilderMode };
+
+function cloneFlowDraftNode(node: FlowDraftNode): FlowDraftNode {
+  return {
+    ...node,
+    fields: { ...node.fields },
+  };
+}
+
+function normalizeValidationIssues(
+  issues: FlowDraftValidationIssue[]
+): FlowDraftValidationIssue[] {
+  const severityRank: Record<FlowDraftValidationSeverity, number> = {
+    error: 0,
+    warning: 1,
+    info: 2,
+  };
+
+  return [...issues].sort((left, right) => {
+    const severityDelta = severityRank[left.severity] - severityRank[right.severity];
+    if (severityDelta !== 0) {
+      return severityDelta;
+    }
+
+    const stageDelta =
+      (getFlowDraftStageIndex(left.stageId ?? FLOW_DRAFT_STAGE_REGISTRY[0].id) ?? 0) -
+      (getFlowDraftStageIndex(right.stageId ?? FLOW_DRAFT_STAGE_REGISTRY[0].id) ?? 0);
+    if (stageDelta !== 0) {
+      return stageDelta;
+    }
+
+    const messageDelta = left.message.localeCompare(right.message);
+    if (messageDelta !== 0) {
+      return messageDelta;
+    }
+
+    return left.id.localeCompare(right.id);
+  });
+}
+
+function upsertValidationIssues(
+  existingIssues: FlowDraftValidationIssue[],
+  patches: Array<Partial<FlowDraftValidationIssue> & { id: string }>
+): FlowDraftValidationIssue[] {
+  const nextIssues = [...existingIssues];
+
+  for (const patch of patches) {
+    const index = nextIssues.findIndex((issue) => issue.id === patch.id);
+    if (index === -1) {
+      nextIssues.push({
+        id: patch.id,
+        severity: patch.severity ?? "warning",
+        message: patch.message ?? "Validation issue updated.",
+        stageId: patch.stageId,
+        nodeId: patch.nodeId,
+        fieldPath: patch.fieldPath,
+        source: patch.source,
+      });
+      continue;
+    }
+
+    nextIssues[index] = {
+      ...nextIssues[index],
+      ...patch,
+      severity: patch.severity ?? nextIssues[index].severity,
+      message: patch.message ?? nextIssues[index].message,
+    };
+  }
+
+  return normalizeValidationIssues(nextIssues);
+}
+
+function moveArrayItem<T>(items: T[], fromIndex: number, toIndex: number): T[] {
+  if (fromIndex === toIndex) {
+    return items;
+  }
+
+  const nextItems = [...items];
+  const [item] = nextItems.splice(fromIndex, 1);
+  nextItems.splice(toIndex, 0, item);
+  return nextItems;
+}
+
+function createSequenceEdges(nodes: FlowDraftNode[]): FlowDraftEdge[] {
+  return nodes.slice(0, -1).map((node, index) => ({
+    id: `flow-draft-edge:${node.id}->${nodes[index + 1]?.id ?? "unknown"}`,
+    kind: "sequence",
+    fromNodeId: node.id,
+    toNodeId: nodes[index + 1]?.id ?? node.id,
+    label: `${node.label} to ${nodes[index + 1]?.label ?? node.label}`,
+  }));
+}
+
+export function createInitialFlowDraftState(
+  initialMode: FlowBuilderMode = DEFAULT_FLOW_BUILDER_MODE,
+  now: string = new Date().toISOString()
+): FlowDraftState {
+  return {
+    draft: createSpecFirstFlowDraft(now, { createdFrom: "manual" }),
+    view: {
+      mode: initialMode,
+      selection: getInitialFlowDraftSelection(initialMode),
+      supportChatOpen: true,
+    },
+  };
+}
+
+export function flowDraftReducer(
+  state: FlowDraftState,
+  action: FlowDraftAction
+): FlowDraftState {
+  switch (action.type) {
+    case "selectStage": {
+      const selectedNodeId = getFlowDraftStageNodeId(action.stageId);
+      return {
+        ...state,
+        view: {
+          ...state.view,
+          selection: {
+            stageId: action.stageId,
+            nodeId: selectedNodeId,
+            edgeId: null,
+          },
+        },
+      };
+    }
+
+    case "selectNode": {
+      const selectedNode = state.draft.nodes.find((node) => node.id === action.nodeId);
+      if (!selectedNode) {
+        return state;
+      }
+
+      return {
+        ...state,
+        view: {
+          ...state.view,
+          selection: {
+            stageId: selectedNode.stageId ?? state.view.selection.stageId,
+            nodeId: selectedNode.id,
+            edgeId: null,
+          },
+        },
+      };
+    }
+
+    case "selectEdge":
+      return {
+        ...state,
+        view: {
+          ...state.view,
+          selection: {
+            ...state.view.selection,
+            edgeId: action.edgeId,
+          },
+        },
+      };
+
+    case "updateNodeFields": {
+      const nextNodes = state.draft.nodes.map((node) =>
+        node.id === action.nodeId
+          ? {
+              ...cloneFlowDraftNode(node),
+              fields: {
+                ...node.fields,
+                ...action.fields,
+              },
+            }
+          : cloneFlowDraftNode(node)
+      );
+
+      return {
+        ...state,
+        draft: {
+          ...state.draft,
+          nodes: nextNodes,
+        },
+      };
+    }
+
+    case "updateDraftFields":
+      return {
+        ...state,
+        draft: {
+          ...state.draft,
+          content: {
+            ...state.draft.content,
+            ...action.fields,
+          },
+        },
+      };
+
+    case "replaceValidationIssues":
+      return {
+        ...state,
+        draft: {
+          ...state.draft,
+          validationIssues: normalizeValidationIssues(action.issues),
+        },
+      };
+
+    case "patchValidationIssues":
+      return {
+        ...state,
+        draft: {
+          ...state.draft,
+          validationIssues: upsertValidationIssues(state.draft.validationIssues, action.issues),
+        },
+      };
+
+    case "moveNode": {
+      const fromIndex = state.draft.nodes.findIndex((node) => node.id === action.nodeId);
+      if (fromIndex === -1) {
+        return state;
+      }
+
+      const toIndex =
+        action.direction === "up"
+          ? Math.max(0, fromIndex - 1)
+          : Math.min(state.draft.nodes.length - 1, fromIndex + 1);
+      if (fromIndex === toIndex) {
+        return state;
+      }
+
+      const reordered = moveArrayItem(
+        state.draft.nodes.map((node) => cloneFlowDraftNode(node)),
+        fromIndex,
+        toIndex
+      ).map((node, order) => ({
+        ...node,
+        order,
+      }));
+
+      return {
+        ...state,
+        draft: {
+          ...state.draft,
+          nodes: reordered,
+          edges: createSequenceEdges(reordered),
+        },
+      };
+    }
+
+    case "dismissSupportChatDock":
+      return {
+        ...state,
+        view: {
+          ...state.view,
+          supportChatOpen: false,
+        },
+      };
+
+    case "reopenSupportChatDock":
+      return {
+        ...state,
+        view: {
+          ...state.view,
+          supportChatOpen: true,
+        },
+      };
+
+    case "toggleSupportChatDock":
+      return {
+        ...state,
+        view: {
+          ...state.view,
+          supportChatOpen: !state.view.supportChatOpen,
+        },
+      };
+
+    case "setMode":
+      if (state.view.mode === action.mode) {
+        return state;
+      }
+
+      return {
+        ...state,
+        view: {
+          ...state.view,
+          mode: action.mode,
+        },
+      };
+
+    default:
+      return state;
+  }
+}
+
+export function getGraphVisibleNodes(draft: FlowDraft): FlowDraftNode[] {
+  return [...draft.nodes]
+    .filter((node) => node.visible !== false)
+    .sort((left, right) => left.order - right.order)
+    .map((node) => ({ ...node, fields: { ...node.fields } }));
+}
+
+export function getCurrentNodeSelection(
+  draft: FlowDraft,
+  view: FlowBuilderViewState
+): FlowDraftSelectionSnapshot {
+  const stage = getFlowDraftStageDefinition(view.selection.stageId);
+  const node = draft.nodes.find((entry) => entry.id === view.selection.nodeId) ?? null;
+  const edge = view.selection.edgeId
+    ? draft.edges.find((entry) => entry.id === view.selection.edgeId) ?? null
+    : null;
+
+  return {
+    stageId: view.selection.stageId,
+    nodeId: view.selection.nodeId,
+    edgeId: view.selection.edgeId ?? null,
+    stage,
+    node,
+    edge,
+  };
+}
+
+export function getOrderedStageProgress(
+  draft: FlowDraft,
+  view: FlowBuilderViewState
+): FlowDraftStageProgress[] {
+  const selectedIndex = getFlowDraftStageIndex(view.selection.stageId);
+  return FLOW_DRAFT_STAGE_REGISTRY.map((stage, index) => {
+    const issueCount = draft.validationIssues.filter((issue) => issue.stageId === stage.id).length;
+    const state: FlowDraftStageProgress["state"] =
+      index < selectedIndex ? "complete" : index === selectedIndex ? "current" : "pending";
+
+    return {
+      stage,
+      index,
+      issueCount,
+      state,
+      isSelected: stage.id === view.selection.stageId,
+    };
+  });
+}
+
+export function getValidationSummary(draft: FlowDraft): FlowDraftValidationSummary {
+  const summary = draft.validationIssues.reduce(
+    (accumulator, issue) => {
+      accumulator.total += 1;
+      if (issue.severity === "error") accumulator.errorCount += 1;
+      if (issue.severity === "warning") accumulator.warningCount += 1;
+      if (issue.severity === "info") accumulator.infoCount += 1;
+      return accumulator;
+    },
+    {
+      total: 0,
+      infoCount: 0,
+      warningCount: 0,
+      errorCount: 0,
+    }
+  );
+
+  const primarySeverity: FlowDraftValidationSummary["primarySeverity"] =
+    summary.errorCount > 0 ? "error" : summary.warningCount > 0 ? "warning" : summary.infoCount > 0 ? "info" : "none";
+
+  const label =
+    summary.total === 0
+      ? "No validation issues"
+      : summary.errorCount > 0
+        ? `${summary.errorCount} error${summary.errorCount === 1 ? "" : "s"}`
+        : summary.warningCount > 0
+          ? `${summary.warningCount} warning${summary.warningCount === 1 ? "" : "s"}`
+          : `${summary.infoCount} note${summary.infoCount === 1 ? "" : "s"}`;
+
+  return {
+    ...summary,
+    label,
+    primarySeverity,
+  };
+}
+
+export function getSupportChatContextSummary(
+  draft: FlowDraft,
+  view: FlowBuilderViewState
+): FlowDraftSupportContextSummary {
+  const selection = getCurrentNodeSelection(draft, view);
+  const validationSummary = getValidationSummary(draft);
+  const provenance = draft.meta.provenance;
+
+  return {
+    draftTitle: draft.meta.title,
+    modeLabel: view.mode === "expertise" ? "Expertise" : "Process",
+    selectedStageLabel: selection.stage.label,
+    selectedNodeLabel: selection.node?.label ?? selection.stage.label,
+    validationLabel: validationSummary.label,
+    provenanceLabel: provenance?.originThreadId
+      ? `Origin thread ${provenance.originThreadId}`
+      : provenance?.createdFrom
+        ? `Created from ${provenance.createdFrom.replace("-", " ")}`
+        : "No thread binding",
+    dockStateLabel: view.supportChatOpen ? "Open" : "Dismissed",
+  };
+}
+
+export interface FlowDraftActions {
+  selectStage: (stageId: FlowDraftStageDefinition["id"]) => void;
+  selectNode: (nodeId: string) => void;
+  selectEdge: (edgeId: string | null) => void;
+  updateNodeFields: (nodeId: string, fields: FlowDraftNodeFieldPatch) => void;
+  updateDraftFields: (fields: Partial<FlowDraftContent>) => void;
+  replaceValidationIssues: (issues: FlowDraftValidationIssue[]) => void;
+  patchValidationIssues: (issues: Array<Partial<FlowDraftValidationIssue> & { id: string }>) => void;
+  moveNode: (nodeId: string, direction: FlowDraftNodeMoveDirection) => void;
+  dismissSupportChatDock: () => void;
+  reopenSupportChatDock: () => void;
+  toggleSupportChatDock: () => void;
+  setMode: (mode: FlowBuilderMode) => void;
+}
+
+export function useFlowDraftState(initialMode: FlowBuilderMode = DEFAULT_FLOW_BUILDER_MODE) {
+  const [state, dispatch] = useReducer(flowDraftReducer, initialMode, createInitialFlowDraftState);
+
+  const actions = useMemo<FlowDraftActions>(
+    () => ({
+      selectStage: (stageId) => dispatch({ type: "selectStage", stageId }),
+      selectNode: (nodeId) => dispatch({ type: "selectNode", nodeId }),
+      selectEdge: (edgeId) => dispatch({ type: "selectEdge", edgeId }),
+      updateNodeFields: (nodeId, fields) =>
+        dispatch({ type: "updateNodeFields", nodeId, fields }),
+      updateDraftFields: (fields) => dispatch({ type: "updateDraftFields", fields }),
+      replaceValidationIssues: (issues) =>
+        dispatch({ type: "replaceValidationIssues", issues }),
+      patchValidationIssues: (issues) => dispatch({ type: "patchValidationIssues", issues }),
+      moveNode: (nodeId, direction) => dispatch({ type: "moveNode", nodeId, direction }),
+      dismissSupportChatDock: () => dispatch({ type: "dismissSupportChatDock" }),
+      reopenSupportChatDock: () => dispatch({ type: "reopenSupportChatDock" }),
+      toggleSupportChatDock: () => dispatch({ type: "toggleSupportChatDock" }),
+      setMode: (mode) => dispatch({ type: "setMode", mode }),
+    }),
+    []
+  );
+
+  const derived = useMemo(
+    () => ({
+      currentSelection: getCurrentNodeSelection(state.draft, state.view),
+      graphVisibleNodes: getGraphVisibleNodes(state.draft),
+      orderedStageProgress: getOrderedStageProgress(state.draft, state.view),
+      validationSummary: getValidationSummary(state.draft),
+      supportChatContext: getSupportChatContextSummary(state.draft, state.view),
+    }),
+    [state.draft, state.view]
+  );
+
+  return {
+    state,
+    draft: state.draft,
+    view: state.view,
+    actions,
+    derived,
+  };
+}

--- a/frontend/src/features/flowBuilder/model/flowDraft.ts
+++ b/frontend/src/features/flowBuilder/model/flowDraft.ts
@@ -1,0 +1,328 @@
+import type { FlowBuilderMode } from "../flowBuilderRoute";
+
+export type FlowDraftStageId =
+  | "select-source"
+  | "define-constraints"
+  | "set-outcomes"
+  | "add-steps"
+  | "insert-conditions"
+  | "validation-gates"
+  | "review-validate";
+
+export type FlowDraftNodeKind = "stage" | "summary" | "validation" | "support";
+export type FlowDraftEdgeKind = "sequence" | "dependency" | "note";
+export type FlowDraftValidationSeverity = "info" | "warning" | "error";
+export type FlowDraftLifecycleStatus = "draft-only";
+export type FlowDraftRuntimeSupport = "none";
+export type FlowDraftCreationOrigin =
+  | "manual"
+  | "stage-rail"
+  | "graph-edit"
+  | "assistant-suggestion";
+
+export interface FlowDraftStageDefinition {
+  id: FlowDraftStageId;
+  order: number;
+  label: string;
+  description: string;
+  chip: string;
+}
+
+export const FLOW_DRAFT_STAGE_REGISTRY = [
+  {
+    id: "select-source",
+    order: 0,
+    label: "Select Source",
+    description: "Choose the input seam that should anchor the first draft.",
+    chip: "01",
+  },
+  {
+    id: "define-constraints",
+    order: 1,
+    label: "Define Constraints",
+    description: "Set the bounds, limits, and non-negotiables that shape the draft.",
+    chip: "02",
+  },
+  {
+    id: "set-outcomes",
+    order: 2,
+    label: "Set Outcomes",
+    description: "Name the intended result before the flow starts to harden.",
+    chip: "03",
+  },
+  {
+    id: "add-steps",
+    order: 3,
+    label: "Add Steps",
+    description: "Lay out the explicit steps that make the plan inspectable.",
+    chip: "04",
+  },
+  {
+    id: "insert-conditions",
+    order: 4,
+    label: "Insert Conditions",
+    description: "Mark the branch points where the draft needs a choice or guardrail.",
+    chip: "05",
+  },
+  {
+    id: "validation-gates",
+    order: 5,
+    label: "Validation Gates",
+    description: "Keep the checks visible so unresolved edges stay honest.",
+    chip: "06",
+  },
+  {
+    id: "review-validate",
+    order: 6,
+    label: "Review & Validate",
+    description: "Shape the handoff into a readable artifact for review.",
+    chip: "07",
+  },
+] as const satisfies readonly FlowDraftStageDefinition[];
+
+export type FlowDraftStageRegistry = typeof FLOW_DRAFT_STAGE_REGISTRY;
+
+export interface FlowDraftProvenanceRef {
+  originThreadId?: string;
+  originMessageId?: string;
+  originRequestId?: string;
+  createdFrom?: FlowDraftCreationOrigin;
+}
+
+export interface FlowDraftMeta {
+  id: string;
+  title: string;
+  status: FlowDraftLifecycleStatus;
+  runtimeSupport: FlowDraftRuntimeSupport;
+  createdAt: string;
+  updatedAt: string;
+  provenance?: FlowDraftProvenanceRef;
+}
+
+export interface FlowDraftContent {
+  objective: string;
+  assumptions: string;
+  unknowns: string;
+  validationQuestions: string;
+}
+
+export interface FlowDraftNode {
+  id: string;
+  kind: FlowDraftNodeKind;
+  stageId?: FlowDraftStageId;
+  label: string;
+  summary: string;
+  order: number;
+  fields: Record<string, string>;
+  visible?: boolean;
+  provenance?: FlowDraftProvenanceRef;
+}
+
+export interface FlowDraftEdge {
+  id: string;
+  kind: FlowDraftEdgeKind;
+  fromNodeId: string;
+  toNodeId: string;
+  label: string;
+  visible?: boolean;
+  provenance?: FlowDraftProvenanceRef;
+}
+
+export interface FlowDraftSelection {
+  stageId: FlowDraftStageId;
+  nodeId: string;
+  edgeId?: string | null;
+}
+
+export interface FlowDraftValidationIssue {
+  id: string;
+  severity: FlowDraftValidationSeverity;
+  message: string;
+  stageId?: FlowDraftStageId;
+  nodeId?: string;
+  fieldPath?: string;
+  source?: string;
+}
+
+export interface FlowDraft {
+  meta: FlowDraftMeta;
+  content: FlowDraftContent;
+  nodes: FlowDraftNode[];
+  edges: FlowDraftEdge[];
+  validationIssues: FlowDraftValidationIssue[];
+}
+
+export interface FlowBuilderViewState {
+  mode: FlowBuilderMode;
+  selection: FlowDraftSelection;
+  supportChatOpen: boolean;
+}
+
+export interface FlowDraftValidationSummary {
+  total: number;
+  infoCount: number;
+  warningCount: number;
+  errorCount: number;
+  label: string;
+  primarySeverity: FlowDraftValidationSeverity | "none";
+}
+
+export interface FlowDraftStageProgress {
+  stage: FlowDraftStageDefinition;
+  index: number;
+  issueCount: number;
+  state: "complete" | "current" | "pending";
+  isSelected: boolean;
+}
+
+export interface FlowDraftSelectionSnapshot {
+  stageId: FlowDraftStageId;
+  nodeId: string | null;
+  edgeId: string | null;
+  stage: FlowDraftStageDefinition;
+  node: FlowDraftNode | null;
+  edge: FlowDraftEdge | null;
+}
+
+export interface FlowDraftSupportContextSummary {
+  draftTitle: string;
+  modeLabel: string;
+  selectedStageLabel: string;
+  selectedNodeLabel: string;
+  validationLabel: string;
+  provenanceLabel: string;
+  dockStateLabel: string;
+}
+
+export const FLOW_DRAFT_INITIAL_TITLE = "Draft specification";
+export const FLOW_DRAFT_INITIAL_STATUS: FlowDraftLifecycleStatus = "draft-only";
+export const FLOW_DRAFT_INITIAL_RUNTIME_SUPPORT: FlowDraftRuntimeSupport = "none";
+export const FLOW_DRAFT_DEFAULT_CONTENT: FlowDraftContent = {
+  objective:
+    "Describe the desired outcome, domain vocabulary, and scope before any runnable path is considered.",
+  assumptions:
+    "List what is being inferred from expertise versus what still needs confirmation.",
+  unknowns:
+    "Record missing steps, unresolved dependencies, and any boundary that needs review.",
+  validationQuestions:
+    "Write the questions that must be answered before this draft can be considered stable.",
+};
+
+export function getFlowDraftStageDefinition(stageId: FlowDraftStageId): FlowDraftStageDefinition {
+  const stage = FLOW_DRAFT_STAGE_REGISTRY.find((entry) => entry.id === stageId);
+  if (!stage) {
+    return FLOW_DRAFT_STAGE_REGISTRY[0];
+  }
+
+  return stage;
+}
+
+export function getFlowDraftStageNodeId(stageId: FlowDraftStageId): string {
+  return `flow-draft-stage-node:${stageId}`;
+}
+
+export function getFlowDraftStageIndex(stageId: FlowDraftStageId): number {
+  return FLOW_DRAFT_STAGE_REGISTRY.findIndex((entry) => entry.id === stageId);
+}
+
+export function getInitialFlowDraftSelection(mode: FlowBuilderMode): FlowDraftSelection {
+  const stageId: FlowDraftStageId =
+    mode === "expertise" ? "define-constraints" : FLOW_DRAFT_STAGE_REGISTRY[0].id;
+
+  return {
+    stageId,
+    nodeId: getFlowDraftStageNodeId(stageId),
+    edgeId: null,
+  };
+}
+
+function createFlowDraftStageNodes(
+  content: FlowDraftContent,
+  provenance: FlowDraftProvenanceRef | undefined
+): FlowDraftNode[] {
+  return FLOW_DRAFT_STAGE_REGISTRY.map((stage) => {
+    const fieldSeed =
+      stage.id === "select-source"
+        ? {
+            source: "Build from process or build from expertise.",
+          }
+        : stage.id === "define-constraints"
+          ? {
+              objective: content.objective,
+              assumptions: content.assumptions,
+            }
+          : stage.id === "set-outcomes"
+            ? {
+                outcome: "Keep the intended result visible before the draft hardens.",
+              }
+            : stage.id === "add-steps"
+              ? {
+                  steps: "Lay out the explicit steps that make the plan inspectable.",
+                }
+              : stage.id === "insert-conditions"
+                ? {
+                    conditions: "Mark branches and guardrails instead of hiding them.",
+                  }
+                : stage.id === "validation-gates"
+                  ? {
+                      validationQuestions: content.validationQuestions,
+                    }
+                  : {
+                      review: "Keep the handoff readable and draft-only.",
+                    };
+
+    return {
+      id: getFlowDraftStageNodeId(stage.id),
+      kind: "stage",
+      stageId: stage.id,
+      label: stage.label,
+      summary: stage.description,
+      order: stage.order,
+      fields: fieldSeed,
+      provenance,
+    };
+  });
+}
+
+function createFlowDraftEdges(nodes: FlowDraftNode[]): FlowDraftEdge[] {
+  return nodes.slice(0, -1).map((node, index) => ({
+    id: `flow-draft-edge:${node.id}->${nodes[index + 1]?.id ?? "unknown"}`,
+    kind: "sequence",
+    fromNodeId: node.id,
+    toNodeId: nodes[index + 1]?.id ?? node.id,
+    label: `${node.label} to ${nodes[index + 1]?.label ?? node.label}`,
+  }));
+}
+
+export function createSpecFirstFlowDraft(
+  now: string = new Date().toISOString(),
+  provenance?: FlowDraftProvenanceRef
+): FlowDraft {
+  const normalizedProvenance = provenance ?? { createdFrom: "manual" };
+  const content = { ...FLOW_DRAFT_DEFAULT_CONTENT };
+  const nodes = createFlowDraftStageNodes(content, normalizedProvenance);
+
+  return {
+    meta: {
+      id: "flow-draft:spec-first",
+      title: FLOW_DRAFT_INITIAL_TITLE,
+      status: FLOW_DRAFT_INITIAL_STATUS,
+      runtimeSupport: FLOW_DRAFT_INITIAL_RUNTIME_SUPPORT,
+      createdAt: now,
+      updatedAt: now,
+      provenance: normalizedProvenance,
+    },
+    content,
+    nodes,
+    edges: createFlowDraftEdges(nodes),
+    validationIssues: [
+      {
+        id: "flow-draft-validation:spec-first-warning",
+        severity: "warning",
+        message: "This draft is still spec-first; execution remains out of scope.",
+        stageId: "review-validate",
+        source: "initial-seed",
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
