### PR TITLE
docs: clarify webui ghcr pullability

### DIFF
--- a/docs/architecture/00-current-state.md
+++ b/docs/architecture/00-current-state.md
@@ -2,7 +2,7 @@
 This file is Codexify's canonical short-form source of truth for current operational and release state. If it conflicts with older architecture, planning, or roadmap language on short-horizon reality, this file wins.
 
 ## Last updated
-2026-04-29
+2026-04-30
 
 ## Interpretation rule
 This file is authoritative for:
@@ -13,7 +13,7 @@ This file is authoritative for:
 - what is and is not part of the present release promise
 
 ## Current phase
-Codexify is in local-beta hardening on `main`. The supported path is still the local Docker Compose stack with a local-only provider policy, while current beta distribution now includes both the macOS desktop shell and the standalone webUI Docker bundle over that same backend. Recent merged work tightened startup ingestion and retrieval sharing. Quarantined surfaces remain outside the beta promise.
+Codexify is in local-beta hardening on `main`. The supported path is still the local Docker Compose stack with a local-only provider policy, while current beta distribution includes both the macOS desktop shell and the standalone webUI Docker bundle over that same backend. The webUI package is GHCR-hosted and access-controlled for this beta release, so anonymous clean-shell pullability is not guaranteed. Recent merged work tightened startup ingestion and retrieval sharing. Quarantined surfaces remain outside the beta promise.
 
 ## What changed recently
 - Verified active personal facts now flow through the backend chat context path and into the provider-ready prompt block as a bounded, user-scoped identity-context source; candidate, disputed, and inactive facts are excluded before prompt assembly.
@@ -37,7 +37,7 @@ Codexify is in local-beta hardening on `main`. The supported path is still the l
 - Local Docker Compose remains the supported install path.
 - The supported beta distribution surface is now split into:
   - macOS desktop DMG for testers who want the Tauri shell on macOS.
-  - Universal webUI Docker bundle for non-macOS testers or anyone who wants browser-only access.
+  - WebUI Docker bundle for non-macOS testers or anyone who wants browser-only access, with GHCR authentication required when package access is not public for the tester identity.
 - Both paths use the same local backend runtime and the same local-only provider policy.
 - Supported beta posture is intended to be local-only, but the live backend container currently reports `CODEXIFY_BETA_CORE_ONLY=false`, `CODEXIFY_LOCAL_ONLY_MODE=false`, and `ALLOW_CLOUD_PROVIDERS=true`, so the running stack is not in the supported posture.
 - Chat acceptance, worker execution, and Postgres persistence still work for plain chat completion on the current live runtime.
@@ -65,6 +65,7 @@ Codexify is in local-beta hardening on `main`. The supported path is still the l
 - exportability is now a first-class invariant.
 
 ## Not yet true / do not assume
+- Do not assume `ghcr.io/resonant-jones/codexify-webui:local-beta` is anonymously pullable from a clean shell; current evidence shows the runtime image is publicly pullable, while the webUI image requires GHCR access for this tester identity.
 - Do not assume the supported-path golden tasks or identity-boundary suites replace the need for fresh live release evidence on the exact current `main` tip; these are backend seam tests, not full live Compose runtime proof.
 - Do not assume the bounded tool-augmented completion proof closes the broader release gate by itself; it proves the tool-loop slice only, not the full release evidence pack.
 - Do not assume the Obsidian ingest→retrieve seam proof constitutes a full connector sync or live runtime validation; it uses an in-memory fixture at the backend route level.

--- a/docs/beta/2026-04-30-local-beta-release-evidence.md
+++ b/docs/beta/2026-04-30-local-beta-release-evidence.md
@@ -1,0 +1,30 @@
+# 2026-04-30 Local Beta Release Evidence
+
+This note records the GHCR pullability state for the local-beta runtime images and the fallback validation path for the webUI bundle.
+
+## Registry Pull Checks
+
+- Clean shell baseline: `docker logout ghcr.io`
+- Runtime image pull: `docker pull ghcr.io/resonant-jones/codexify-runtime:local-beta`
+  - Result: successful anonymous pull
+- WebUI image pull: `docker pull ghcr.io/resonant-jones/codexify-webui:local-beta`
+  - Result: `unauthorized` from a clean shell
+- GHCR login using the current GitHub identity: `gh auth token | docker login ghcr.io -u Resonant-Jones --password-stdin`
+  - Result: login succeeded
+- WebUI image pull after login: `docker pull ghcr.io/resonant-jones/codexify-webui:local-beta`
+  - Result: `403 Forbidden`
+- Package listing probe: `gh api '/users/Resonant-Jones/packages?package_type=container&per_page=100'`
+  - Result: `403` with a `read:packages` scope requirement
+
+## Interpretation
+
+- `ghcr.io/resonant-jones/codexify-runtime:local-beta` is publicly pullable from a clean shell.
+- `ghcr.io/resonant-jones/codexify-webui:local-beta` is not anonymously pullable.
+- The current GitHub identity used in this workspace does not have sufficient package access to pull the webUI image, even after Docker login to GHCR.
+- The webUI beta bundle must therefore be documented as GHCR-authenticated for this tester identity unless package access is granted later.
+
+## Fallback Validation Path
+
+- The local bundle validation script remains the supported local-build fallback:
+  - `bash scripts/verification/check_webui_runtime_bundle.sh`
+- That script validates the Compose bundle and local frontend build, but it does not prove registry pullability.

--- a/docs/beta/Private-Beta-Checklist.md
+++ b/docs/beta/Private-Beta-Checklist.md
@@ -23,6 +23,8 @@ Use this before sharing either private beta bundle.
 
 - [ ] Confirm the repo is clean.
 - [ ] Confirm the current commit hash.
+- [ ] Confirm GHCR access before install.
+- [ ] Confirm the tester's GitHub account can access the `codexify-webui` package, or that their GHCR token includes `read:packages`, if the webUI image is private.
 - [ ] Build the webUI Docker bundle.
 - [ ] Confirm `docker compose -f docker-compose.webui-runtime.yml up -d` starts the stack.
 - [ ] Confirm `http://localhost:3000` responds with HTML.
@@ -31,6 +33,7 @@ Use this before sharing either private beta bundle.
 - [ ] Confirm document and image uploads work through the browser bundle.
 - [ ] Confirm the repo root `.env` file is the editable config source for the Docker bundle.
 - [ ] Confirm no real API keys are present in the docs.
+- [ ] If GHCR pull fails, switch to the local rebuild fallback and record that the registry path is access-controlled.
 - [ ] Upload the docs in `docs/beta/` beside the bundle instructions.
 - [ ] Send testers the webUI track instructions.
 - [ ] Ask testers for screenshots of failures.

--- a/docs/beta/README-FIRST.md
+++ b/docs/beta/README-FIRST.md
@@ -65,7 +65,7 @@ In particular, do not edit:
 
 ## WebUI Docker Bundle
 
-This is the universal non-macOS beta path.
+This is the browser-first beta path.
 
 Use it when you want the browser UI without the Tauri shell.
 
@@ -74,6 +74,12 @@ You will need:
 - Docker Desktop installed and running
 - Ollama installed and running if you are testing the local model path
 - The required local model available in Ollama if you stay on the default local path
+
+GHCR access note:
+
+- The webUI bundle is published through GHCR.
+- Before install, confirm you can authenticate to `ghcr.io` with a GitHub account that has access to the `codexify-webui` package, or with a GitHub personal access token that includes `read:packages`.
+- If `docker pull ghcr.io/resonant-jones/codexify-webui:local-beta` returns `unauthorized` or `403 Forbidden`, you need GHCR access before the Docker bundle will install cleanly.
 
 Start the bundle with:
 
@@ -93,6 +99,12 @@ Quick smoke test:
 6. Confirm that the thread is still there.
 
 WebUI runtime config lives in the repository root `.env` file used by Docker Compose. Do not edit the macOS app bundle for this path.
+
+If you cannot pull the webUI image from GHCR, use the local rebuild fallback from this repo:
+
+- `bash scripts/verification/check_webui_runtime_bundle.sh`
+
+That script validates the local build and Compose startup path, but it is not registry pull proof.
 
 ## What We Want From You
 


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
