### PR TITLE
docs: record public webui ghcr handoff

### DIFF
--- a/docs/architecture/00-current-state.md
+++ b/docs/architecture/00-current-state.md
@@ -13,7 +13,7 @@ This file is authoritative for:
 - what is and is not part of the present release promise
 
 ## Current phase
-Codexify is in local-beta hardening on `main`. The supported path is still the local Docker Compose stack with a local-only provider policy, while current beta distribution includes both the macOS desktop shell and the standalone webUI Docker bundle over that same backend. The webUI package is GHCR-hosted and access-controlled for this beta release, so anonymous clean-shell pullability is not guaranteed. Recent merged work tightened startup ingestion and retrieval sharing. Quarantined surfaces remain outside the beta promise.
+Codexify is in local-beta hardening on `main`. The supported path is still the local Docker Compose stack with a local-only provider policy, while current beta distribution includes both the macOS desktop shell and the standalone webUI Docker bundle over that same backend. The webUI package is GHCR-hosted and now anonymously pullable for the published local-beta tag. Recent merged work tightened startup ingestion and retrieval sharing. Quarantined surfaces remain outside the beta promise.
 
 Fresh private beta release evidence is recorded in [`docs/beta/2026-04-30-local-beta-release-evidence.md`](../beta/2026-04-30-local-beta-release-evidence.md).
 
@@ -39,7 +39,7 @@ Fresh private beta release evidence is recorded in [`docs/beta/2026-04-30-local-
 - Local Docker Compose remains the supported install path.
 - The supported beta distribution surface is now split into:
   - macOS desktop DMG for testers who want the Tauri shell on macOS.
-  - WebUI Docker bundle for non-macOS testers or anyone who wants browser-only access, with GHCR authentication required when package access is not public for the tester identity.
+  - WebUI Docker bundle for non-macOS testers or anyone who wants browser-only access.
 - Both paths use the same local backend runtime and the same local-only provider policy.
 - Supported beta posture is intended to be local-only, but the live backend container currently reports `CODEXIFY_BETA_CORE_ONLY=false`, `CODEXIFY_LOCAL_ONLY_MODE=false`, and `ALLOW_CLOUD_PROVIDERS=true`, so the running stack is not in the supported posture.
 - Chat acceptance, worker execution, and Postgres persistence still work for plain chat completion on the current live runtime.
@@ -67,7 +67,7 @@ Fresh private beta release evidence is recorded in [`docs/beta/2026-04-30-local-
 - exportability is now a first-class invariant.
 
 ## Not yet true / do not assume
-- Do not assume `ghcr.io/resonant-jones/codexify-webui:local-beta` is anonymously pullable from a clean shell; current evidence shows the runtime image is publicly pullable, while the webUI image requires GHCR access for this tester identity.
+- Do not assume the GHCR visibility state for other tags or packages matches the `local-beta` release visibility.
 - Do not assume the supported-path golden tasks or identity-boundary suites replace the need for fresh live release evidence on the exact current `main` tip; these are backend seam tests, not full live Compose runtime proof.
 - Do not assume the bounded tool-augmented completion proof closes the broader release gate by itself; it proves the tool-loop slice only, not the full release evidence pack.
 - Do not assume the Obsidian ingest→retrieve seam proof constitutes a full connector sync or live runtime validation; it uses an in-memory fixture at the backend route level.

--- a/docs/beta/2026-04-30-local-beta-release-evidence.md
+++ b/docs/beta/2026-04-30-local-beta-release-evidence.md
@@ -8,20 +8,13 @@ This note records the GHCR pullability state for the local-beta runtime images a
 - Runtime image pull: `docker pull ghcr.io/resonant-jones/codexify-runtime:local-beta`
   - Result: successful anonymous pull
 - WebUI image pull: `docker pull ghcr.io/resonant-jones/codexify-webui:local-beta`
-  - Result: `unauthorized` from a clean shell
-- GHCR login using the current GitHub identity: `gh auth token | docker login ghcr.io -u Resonant-Jones --password-stdin`
-  - Result: login succeeded
-- WebUI image pull after login: `docker pull ghcr.io/resonant-jones/codexify-webui:local-beta`
-  - Result: `403 Forbidden`
-- Package listing probe: `gh api '/users/Resonant-Jones/packages?package_type=container&per_page=100'`
-  - Result: `403` with a `read:packages` scope requirement
+  - Result: successful anonymous pull
 
 ## Interpretation
 
 - `ghcr.io/resonant-jones/codexify-runtime:local-beta` is publicly pullable from a clean shell.
-- `ghcr.io/resonant-jones/codexify-webui:local-beta` is not anonymously pullable.
-- The current GitHub identity used in this workspace does not have sufficient package access to pull the webUI image, even after Docker login to GHCR.
-- The webUI beta bundle must therefore be documented as GHCR-authenticated for this tester identity unless package access is granted later.
+- `ghcr.io/resonant-jones/codexify-webui:local-beta` is publicly pullable from a clean shell.
+- The low-friction webUI beta bundle path is now restored for anonymous pull from the registry.
 
 ## Fallback Validation Path
 

--- a/docs/beta/Private-Beta-Checklist.md
+++ b/docs/beta/Private-Beta-Checklist.md
@@ -27,8 +27,7 @@ The current handoff evidence is recorded in [2026-04-30 local beta release evide
 
 - [ ] Confirm the repo is clean.
 - [ ] Confirm the current commit hash.
-- [ ] Confirm GHCR access before install.
-- [ ] Confirm the tester's GitHub account can access the `codexify-webui` package, or that their GHCR token includes `read:packages`, if the webUI image is private.
+- [ ] Confirm anonymous pull works for `ghcr.io/resonant-jones/codexify-webui:local-beta`.
 - [ ] Build the webUI Docker bundle.
 - [ ] Confirm `docker compose -f docker-compose.webui-runtime.yml up -d` starts the stack.
 - [ ] Confirm `http://localhost:3000` responds with HTML.
@@ -37,7 +36,8 @@ The current handoff evidence is recorded in [2026-04-30 local beta release evide
 - [ ] Confirm document and image uploads work through the browser bundle.
 - [ ] Confirm the repo root `.env` file is the editable config source for the Docker bundle.
 - [ ] Confirm no real API keys are present in the docs.
-- [ ] If GHCR pull fails, switch to the local rebuild fallback and record that the registry path is access-controlled.
+- [ ] If anonymous GHCR pull fails because of rate limits, stale cache, or a private fork/mirror, try GHCR login and record the cause.
+- [ ] If GHCR still fails, switch to the local rebuild fallback and record that the registry path is not usable from a clean shell.
 - [ ] Upload the docs in `docs/beta/` beside the bundle instructions.
 - [ ] Send testers the webUI track instructions.
 - [ ] Ask testers for screenshots of failures.

--- a/docs/beta/README-FIRST.md
+++ b/docs/beta/README-FIRST.md
@@ -72,6 +72,7 @@ In particular, do not edit:
 This is the browser-first beta path.
 
 Use it when you want the browser UI without the Tauri shell.
+This is the low-friction webUI Docker path.
 
 You will need:
 
@@ -79,11 +80,15 @@ You will need:
 - Ollama installed and running if you are testing the local model path
 - The required local model available in Ollama if you stay on the default local path
 
-GHCR access note:
+Normal path:
 
-- The webUI bundle is published through GHCR.
-- Before install, confirm you can authenticate to `ghcr.io` with a GitHub account that has access to the `codexify-webui` package, or with a GitHub personal access token that includes `read:packages`.
-- If `docker pull ghcr.io/resonant-jones/codexify-webui:local-beta` returns `unauthorized` or `403 Forbidden`, you need GHCR access before the Docker bundle will install cleanly.
+- `docker pull ghcr.io/resonant-jones/codexify-webui:local-beta` should work from a clean shell without GHCR login.
+- `docker pull ghcr.io/resonant-jones/codexify-runtime:local-beta` should also work from a clean shell.
+
+Troubleshooting note:
+
+- If anonymous pulls fail because of GitHub rate limits, stale Docker cache state, or a private fork/mirror, authenticate to `ghcr.io` and retry.
+- GHCR login is a fallback for those edge cases, not the normal beta handoff path.
 
 Start the bundle with:
 


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
