### PR TITLE
Make assistant audio lazy-loaded on demand

### DIFF
--- a/frontend/src/features/chat/ChatView.tsx
+++ b/frontend/src/features/chat/ChatView.tsx
@@ -21,6 +21,7 @@ import type {
   CompletionState,
   StreamingDraft,
 } from "@/features/chat/useChat";
+import api from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { parseDocumentContextContent } from "@/lib/documentContext";
 import { useMobileShellProfile } from "@/components/persona/layout/mobileShellProfile";
@@ -39,6 +40,12 @@ type BubblePlayState =
   | "pending"
   | "unavailable"
   | "disabled";
+
+type LazyAudioState = {
+  status: "pending" | "ready" | "failed";
+  audioUrl: string | null;
+  audioError: string | null;
+};
 
 type ChatSurfaceState =
   | {
@@ -125,6 +132,27 @@ function buildChatSurfaceState(args: {
     title: "No messages yet",
     detail: "This thread is ready. Start the conversation below.",
   };
+}
+
+function getVoiceSpeakErrorMessage(error: unknown): string {
+  const response = error as {
+    response?: { data?: { detail?: unknown } | unknown; status?: number };
+    message?: string;
+  };
+  const detail = response?.response?.data;
+  if (detail && typeof detail === "object") {
+    const candidate = (detail as { detail?: unknown }).detail;
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate;
+    }
+    if (candidate != null) {
+      return String(candidate);
+    }
+  }
+  if (typeof response?.message === "string" && response.message.trim()) {
+    return response.message;
+  }
+  return error instanceof Error && error.message ? error.message : "Audio unavailable";
 }
 
 function ChatSurfaceStateCard({ state }: { state: ChatSurfaceState }) {
@@ -225,6 +253,9 @@ export function ChatView({
   const voiceUnavailableMessageIdsRef = useRef<Record<number, true>>({});
   const [voiceRouteMissing, setVoiceRouteMissing] = useState(false);
   const voiceRouteMissingRef = useRef(false);
+  const [lazyAudioStates, setLazyAudioStates] = useState<
+    Record<number, LazyAudioState>
+  >({});
   const lastAutoReadMessageIdRef = useRef<number | null>(null);
   const autoReadPrimedRef = useRef(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
@@ -308,6 +339,16 @@ export function ChatView({
     setVoiceUnavailableMessageIds(voiceUnavailableMessageIdsRef.current);
   }, []);
 
+  const clearVoiceUnavailable = useCallback((messageId: number) => {
+    if (!voiceUnavailableMessageIdsRef.current[messageId]) {
+      return;
+    }
+    const next = { ...voiceUnavailableMessageIdsRef.current };
+    delete next[messageId];
+    voiceUnavailableMessageIdsRef.current = next;
+    setVoiceUnavailableMessageIds(next);
+  }, []);
+
   const measureChatViewport = useCallback(() => {
     const el = containerRef.current;
     if (!el) {
@@ -354,6 +395,7 @@ export function ChatView({
     setVoiceUnavailableMessageIds({});
     voiceRouteMissingRef.current = false;
     setVoiceRouteMissing(false);
+    setLazyAudioStates({});
     setHasOverflow(false);
     setShowJumpToLatest(false);
   }, [threadId]);
@@ -494,41 +536,144 @@ export function ChatView({
     [isVoiceUnavailable, markVoiceUnavailable, showToast, voiceReadAloudEnabled]
   );
 
-  const handlePlayClick = useCallback(
+  const resolveMessageAudioState = useCallback(
     (message: ChatMessage) => {
       const messageId = Number(message.id);
+      const override = Number.isFinite(messageId)
+        ? lazyAudioStates[messageId]
+        : undefined;
+      const messageAudioStatus =
+        override?.status ?? (message.audio_status ?? "unavailable");
       const messageAudioUrl =
-        typeof message.audio_url === "string" && message.audio_url.trim()
+        override?.audioUrl ??
+        (typeof message.audio_url === "string" && message.audio_url.trim()
           ? message.audio_url
-          : null;
+          : null);
+      const messageAudioError =
+        override?.audioError ??
+        (typeof message.audio_error === "string" && message.audio_error.trim()
+          ? message.audio_error
+          : null);
+      return {
+        messageId,
+        status: messageAudioStatus,
+        url: messageAudioUrl,
+        error: messageAudioError,
+      };
+    },
+    [lazyAudioStates]
+  );
+
+  const requestAndPlayMessageAudio = useCallback(
+    async (message: ChatMessage) => {
+      const { messageId } = resolveMessageAudioState(message);
+      if (!Number.isFinite(messageId)) {
+        return;
+      }
       if (!voiceReadAloudEnabled || voiceRouteMissingRef.current) {
         showToast("Voice disabled");
         return;
       }
+
+      clearVoiceUnavailable(messageId);
+      setLazyAudioStates((previous) => ({
+        ...previous,
+        [messageId]: {
+          status: "pending",
+          audioUrl: null,
+          audioError: null,
+        },
+      }));
+
+      try {
+        const response = await api.post(`/voice/messages/${messageId}/speak`, {
+          force_regenerate: false,
+        });
+        const audioAsset = (response?.data as {
+          audio_asset?: { stream_url?: unknown; src_url?: unknown };
+        })?.audio_asset;
+        const audioUrl =
+          typeof audioAsset?.stream_url === "string" &&
+          audioAsset.stream_url.trim()
+            ? audioAsset.stream_url.trim()
+            : typeof audioAsset?.src_url === "string" &&
+                audioAsset.src_url.trim()
+              ? audioAsset.src_url.trim()
+              : null;
+        if (!audioUrl) {
+          throw new Error("Audio unavailable");
+        }
+
+        setLazyAudioStates((previous) => ({
+          ...previous,
+          [messageId]: {
+            status: "ready",
+            audioUrl,
+            audioError: null,
+          },
+        }));
+
+        await playMessageAudio(messageId, audioUrl, {
+          manual: true,
+          unavailableMessage: "Audio unavailable",
+        });
+      } catch (error) {
+        const errorMessage = getVoiceSpeakErrorMessage(error);
+        setLazyAudioStates((previous) => ({
+          ...previous,
+          [messageId]: {
+            status: "failed",
+            audioUrl: null,
+            audioError: errorMessage,
+          },
+        }));
+        showToast(errorMessage);
+      }
+    },
+    [
+      clearVoiceUnavailable,
+      playMessageAudio,
+      resolveMessageAudioState,
+      showToast,
+      voiceReadAloudEnabled,
+    ]
+  );
+
+  const handlePlayClick = useCallback(
+    (message: ChatMessage) => {
+      const audioState = resolveMessageAudioState(message);
+      const { messageId, status, url } = audioState;
       if (!Number.isFinite(messageId)) return;
-      if (message.audio_status === "pending") {
-        showToast("Audio is still generating");
+      if (!voiceReadAloudEnabled || voiceRouteMissingRef.current) {
+        showToast("Voice disabled");
         return;
       }
-      if (message.audio_status === "failed") {
-        showToast(message.audio_error || "Audio unavailable");
+      if (status === "pending") {
+        showToast("Audio is still generating");
         return;
       }
       if (
         isVoiceUnavailable(messageId) ||
-        message.audio_status !== "ready" ||
-        !messageAudioUrl
+        status !== "ready" ||
+        !url
       ) {
-        showToast("Audio unavailable");
+        void requestAndPlayMessageAudio(message);
         return;
       }
 
-      void playMessageAudio(messageId, messageAudioUrl, {
+      void playMessageAudio(messageId, url, {
         manual: true,
-        unavailableMessage: message.audio_error || "Audio unavailable",
+        unavailableMessage: audioState.error || "Audio unavailable",
       });
     },
-    [isVoiceUnavailable, playMessageAudio, showToast, voiceReadAloudEnabled]
+    [
+      isVoiceUnavailable,
+      playMessageAudio,
+      requestAndPlayMessageAudio,
+      resolveMessageAudioState,
+      showToast,
+      voiceReadAloudEnabled,
+    ]
   );
 
   useEffect(() => {
@@ -653,13 +798,11 @@ export function ChatView({
         >
           {surfaceState ? <ChatSurfaceStateCard state={surfaceState} /> : null}
           {messages.map((message, index) => {
-            const messageId = Number(message.id);
+            const audioState = resolveMessageAudioState(message);
+            const messageId = audioState.messageId;
             const canPlay = message.role !== "user" && Number.isFinite(messageId);
-            const messageAudioStatus = message.audio_status;
-            const messageAudioUrl =
-              typeof message.audio_url === "string" && message.audio_url.trim()
-                ? message.audio_url
-                : null;
+            const messageAudioStatus = audioState.status;
+            const messageAudioUrl = audioState.url;
             const showPlay =
               canPlay && voiceReadAloudEnabled && !voiceRouteMissing;
             const messageVoiceUnavailable = Boolean(

--- a/frontend/src/features/chat/__tests__/ChatView.loop-guards.test.tsx
+++ b/frontend/src/features/chat/__tests__/ChatView.loop-guards.test.tsx
@@ -14,8 +14,10 @@ const appendMessageMock = vi.fn();
 const shouldRefreshMock = vi.fn().mockReturnValue(false);
 const markRefreshedMock = vi.fn();
 const subscribeMock = vi.fn();
-const apiPostMock = vi.fn();
-const apiGetMock = vi.fn();
+const apiMocks = vi.hoisted(() => ({
+  apiPostMock: vi.fn(),
+  apiGetMock: vi.fn(),
+}));
 const getInFlightCompletionTurnIdMock = vi.fn();
 const clearInFlightCompletionTurnIdMock = vi.fn();
 const pollOptionsHistory: any[] = [];
@@ -72,6 +74,16 @@ vi.mock("@/hooks/useLiveEvents", () => ({
   }),
 }));
 
+vi.mock("@/lib/api", () => ({
+  default: {
+    get: apiMocks.apiGetMock,
+    post: apiMocks.apiPostMock,
+  },
+}));
+
+const apiPostMock = apiMocks.apiPostMock;
+const apiGetMock = apiMocks.apiGetMock;
+
 vi.mock("@/features/chat/hooks/useChatAutoScroll", async () => {
   const React = await vi.importActual<typeof import("react")>("react");
   return {
@@ -106,11 +118,11 @@ vi.mock("@/features/chat/components/ChatBubble", () => ({
       playState === "pending"
         ? "Generating audio"
         : playState === "unavailable"
-          ? "Audio unavailable"
+          ? "Generate audio"
           : playState === "playing"
             ? "Playing..."
             : "Read Aloud";
-    const disabled = playState === "pending" || playState === "unavailable";
+    const disabled = playState === "pending" || playState === "disabled";
     return (
       <div data-testid={`bubble-${message.id}`}>
         <div>{message.content}</div>
@@ -202,8 +214,47 @@ describe("ChatView loop guards", () => {
     );
 
     expect(screen.getByRole("button", { name: "Generating audio" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Audio unavailable" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Generate audio" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Read Aloud" })).toBeEnabled();
+  });
+
+  it("lazily synthesizes audio when the user clicks play on an ungenerated assistant message", async () => {
+    apiPostMock.mockResolvedValueOnce({
+      data: {
+        audio_asset: {
+          stream_url: "/api/voice/audio/99",
+        },
+        cached: false,
+      },
+    });
+
+    render(
+      <ChatView
+        threadId={7}
+        guardianName="Guardian"
+        messages={[
+          buildMessage(3, "assistant", {
+            audio_status: "unavailable",
+          }),
+        ]}
+        loading={false}
+        error={null}
+        hasMore={false}
+        completionState={baseCompletion}
+        endCompletion={vi.fn()}
+        voiceReadAloudEnabled
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Generate audio" }));
+
+    await waitFor(() =>
+      expect(apiPostMock).toHaveBeenCalledWith(
+        "/voice/messages/3/speak",
+        { force_regenerate: false }
+      )
+    );
+    await waitFor(() => expect(audioPlayMock).toHaveBeenCalled());
   });
 
   it("renders a visible loading state before any messages arrive", () => {

--- a/frontend/src/features/chat/components/ChatBubble.tsx
+++ b/frontend/src/features/chat/components/ChatBubble.tsx
@@ -484,7 +484,7 @@ export function ChatBubble({
       : resolvedPlayState === "pending"
         ? "Generating audio"
       : resolvedPlayState === "unavailable"
-        ? "Audio unavailable"
+        ? "Generate audio"
         : resolvedPlayState === "disabled"
           ? "Voice disabled"
           : "Read Aloud";
@@ -493,11 +493,11 @@ export function ChatBubble({
       ? "Playing audio"
       : resolvedPlayState === "pending"
         ? "Generating audio"
-        : "Read message aloud";
+        : resolvedPlayState === "unavailable"
+          ? "Generate audio"
+          : "Read message aloud";
   const playDisabled =
-    resolvedPlayState === "pending" ||
-    resolvedPlayState === "unavailable" ||
-    resolvedPlayState === "disabled";
+    resolvedPlayState === "pending" || resolvedPlayState === "disabled";
   const boundedUserMessage = !isGuardian && isOversizedUserMessage(cleanedContent);
   const [expandedUserMessage, setExpandedUserMessage] = React.useState(false);
 

--- a/frontend/src/features/chat/components/__tests__/ChatBubble.test.tsx
+++ b/frontend/src/features/chat/components/__tests__/ChatBubble.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { serializeDocumentContextMessage } from "@/lib/documentContext";
@@ -227,6 +227,31 @@ describe("ChatBubble", () => {
       "min-w-0"
     );
     expect(container.querySelector(".codexifyCodeBlockPre")).toBeInTheDocument();
+  });
+
+  it("keeps the read-aloud control enabled when audio has not been generated yet", () => {
+    const onPlay = vi.fn();
+
+    render(
+      <ChatBubble
+        isGuardian
+        message={{
+          id: "msg-play-lazy",
+          authorId: "bot",
+          authorName: "Guardian",
+          content: "Read this later",
+          createdAt: Date.now(),
+        }}
+        showPlay
+        playState="unavailable"
+        onPlay={onPlay}
+      />
+    );
+
+    const button = screen.getByRole("button", { name: "Generate audio" });
+    expect(button).toBeEnabled();
+    fireEvent.click(button);
+    expect(onPlay).toHaveBeenCalledTimes(1);
   });
 
   it("normalizes TeX-style arrows in assistant prose without breaking markdown", () => {

--- a/guardian/tests/workers/test_chat_worker_completion_semantics.py
+++ b/guardian/tests/workers/test_chat_worker_completion_semantics.py
@@ -982,7 +982,7 @@ def test_audio_generation_schedule_failure_does_not_fail_text_reply(
     assert all(event_type != "task.failed" for event_type, _ in published)
 
 
-def test_schedule_audio_generation_defaults_enabled_when_flag_absent(
+def test_schedule_audio_generation_defaults_disabled_when_flag_absent(
     monkeypatch,
 ):
     submitted: list[dict[str, object]] = []
@@ -1022,6 +1022,52 @@ def test_schedule_audio_generation_defaults_enabled_when_flag_absent(
         message_id=991,
         assistant_text="generate this",
         task_id="task-audio-default-on",
+        turn_id=TURN_ID,
+    )
+
+    assert scheduled is False
+    assert pending == []
+    assert submitted == []
+
+
+def test_schedule_audio_generation_honors_explicit_enable_flag(
+    monkeypatch,
+):
+    submitted: list[dict[str, object]] = []
+    pending: list[dict[str, object]] = []
+
+    monkeypatch.setenv("CODEXIFY_ASSISTANT_MESSAGE_AUDIO_AUTOGENERATE", "1")
+    monkeypatch.setattr(
+        chat_worker,
+        "find_cached_asset",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "upsert_message_audio_asset_status",
+        lambda **kwargs: pending.append(dict(kwargs))
+        or {"id": 1, "status": "pending"},
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "_assistant_message_audio_provider_key",
+        lambda: ("chatterbox", "http://tts:8000"),
+    )
+
+    class _FakeExecutor:
+        def submit(self, fn, **kwargs):
+            submitted.append({"fn": fn, **kwargs})
+            return object()
+
+    monkeypatch.setattr(
+        chat_worker, "_ASSISTANT_AUDIO_EXECUTOR", _FakeExecutor()
+    )
+
+    scheduled = chat_worker._schedule_assistant_message_audio_generation(
+        thread_id=61,
+        message_id=991,
+        assistant_text="generate this",
+        task_id="task-audio-enabled",
         turn_id=TURN_ID,
     )
 

--- a/guardian/workers/chat_worker.py
+++ b/guardian/workers/chat_worker.py
@@ -749,9 +749,6 @@ def _fallback_provider_candidates(
 
 
 def _assistant_message_audio_autogenerate_effective_enabled() -> bool:
-    raw = os.getenv("CODEXIFY_ASSISTANT_MESSAGE_AUDIO_AUTOGENERATE")
-    if raw is None:
-        return True
     return assistant_message_audio_autogenerate_enabled()
 
 


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
