### PR TITLE
Restore media upload and health route wiring in the lightweight backend app

### DIFF
--- a/guardian/routes/health.py
+++ b/guardian/routes/health.py
@@ -730,6 +730,7 @@ def llm_catalog(include: str | None = Query(default=None)):
 
 
 @router.get("/health/chat")
+@router.get("/api/health/chat")
 def health_chat():
     """Get health status of chat subsystem."""
     # Import from core dependencies module

--- a/guardian/server/app.py
+++ b/guardian/server/app.py
@@ -20,6 +20,9 @@ except ImportError:
 
 from guardian.connectors.google import router as google_connect_router
 from guardian.retrieve.api import router as retrieve_router
+from guardian.routes import embeddings as embeddings_routes
+from guardian.routes import health as health_routes
+from guardian.routes import media as media_routes
 from guardian.server.codexify_api import oauth_status as codexify_oauth_status
 from guardian.server.codexify_api import router as codexify_router
 
@@ -106,10 +109,13 @@ app.include_router(chat_threads_router)
 app.include_router(chat_thread_router)
 app.include_router(api_chat_router)
 app.include_router(imprint_router)
+app.include_router(health_routes.router)
 app.include_router(projects_router)
 app.include_router(api_projects_router)
 app.include_router(threads_router)
 app.include_router(api_threads_router)
+app.include_router(embeddings_routes.router)
+app.include_router(media_routes.router, prefix="/api/media")
 app.include_router(flows_router)
 
 

--- a/tests/server/test_core_route_wiring.py
+++ b/tests/server/test_core_route_wiring.py
@@ -1,0 +1,15 @@
+from guardian.server.app import app
+
+
+def test_server_app_includes_health_and_media_routes():
+    paths = {
+        getattr(route, "path", None)
+        for route in app.routes
+        if getattr(route, "path", None)
+    }
+
+    assert "/health/chat" in paths
+    assert "/api/health/chat" in paths
+    assert "/api/embeddings" in paths
+    assert "/api/media/upload/image" in paths
+    assert "/api/media/upload/document" in paths


### PR DESCRIPTION
## Summary
- Re-expose `/api/health/chat` alongside the canonical `/health/chat` path so frontend health checks stop 404ing in API-base-backed dev setups.
- Wire the lightweight server app to the shared health, embeddings, and media routers so image and document uploads are served again.
- Add a regression test covering the server app route surface for chat health, embeddings, and media upload endpoints.

## Testing
- Added route-wiring regression coverage for the server app.
- Syntax-level checks passed for the edited Python files.
- Full pytest execution was not run in this workspace because the bundled Python environment is missing `pytest`.