### PR TITLE
Codex/add vision capability validation

### DIFF
--- a/docs/architecture/00-current-state.md
+++ b/docs/architecture/00-current-state.md
@@ -2,7 +2,7 @@
 This file is Codexify's canonical short-form source of truth for current operational and release state. If it conflicts with older architecture, planning, or roadmap language on short-horizon reality, this file wins.
 
 ## Last updated
-2026-05-07
+2026-05-08
 
 ## Interpretation rule
 This file is authoritative for:
@@ -32,7 +32,7 @@ Codexify is in late beta hardening on `main`. The codebase now carries the local
 - The retrieval-posture explainer UI surface was added to the Command Center with a standalone panel and per-thread posture history display.
 - Executable backend-seam evaluation suites continue to provide coverage for: identity-boundary proof (project scope containment, explicit widening, exclusion filters), supported-path golden tasks (completion acceptance, RAG trace isolation, Obsidian ingest→retrieve seam), and broker/source-mode matrix reconciliation.
 - Fresh live proof was re-run on the exact current `main` tip. Chat completion still works and the chat ownership seam normalizes a browser display label to `local`, and the supported local Compose migrator now reaches the merged extension/eval head cleanly so the expected `agent_extension_*` tables are present again. The live backend container still needs a separate supported-profile recheck, and the bounded tool-loop cases still regress instead of matching the claimed supported-path behavior.
-Fresh live proof on 2026-05-05 now confirms the supported local-first posture on the current tip, including provider/catalog/health alignment, upload -> embed -> retrieve, image-turn containment, coding-result return, and runtime-target normalization. On 2026-05-07, the workspace-local Obsidian E2E proof harness also passed on the supported local Compose path, and the evidence is recorded in `docs/proofs/2026-05-07-workspace-obsidian-e2e-proof.md`. That proof is evidence of the supported path, not release signoff.
+Fresh live proof on 2026-05-05 now confirmed the supported local-first posture on the current tip, including provider/catalog/health alignment, upload -> embed -> retrieve, image-turn containment, coding-result return, and runtime-target normalization. On 2026-05-07, the workspace-local Obsidian E2E proof harness also passed on the supported local Compose path, and the evidence is recorded in `docs/proofs/2026-05-07-workspace-obsidian-e2e-proof.md`. On 2026-05-08, the document upload -> embed -> retrieve seam was rechecked and the previously blocked document readback/retrieval path was re-proven on the supported local Compose path. That proof is evidence of the supported path, not release signoff.
 
 - Coding worker results now ingest back through Guardian with lineage and idempotency guards.
 - Public webUI beta handoff docs and the GHCR pullability note remain on `main`.
@@ -43,7 +43,7 @@ Fresh live proof on 2026-05-05 now confirms the supported local-first posture on
 - Supported beta posture is intended to be local-only, but the live backend container currently reports `CODEXIFY_BETA_CORE_ONLY=false`, `CODEXIFY_LOCAL_ONLY_MODE=false`, and `ALLOW_CLOUD_PROVIDERS=true`, so the running stack is not in the supported posture.
 - Chat acceptance, worker execution, and Postgres persistence still work for plain chat completion on the current live runtime.
 - Single-user ownership on the chat path normalizes browser display labels to `local`; that seam did not leak the display label into persisted thread ownership in this run.
-- Upload -> parse -> embed -> retrieve is not currently proven on the live runtime. The earlier `agent_extension_*` schema gap that blocked document upload on the supported path is repaired on the supported local Compose stack, but the full end-to-end upload -> embed -> retrieve proof still needs a fresh rerun on the current tip.
+- Upload -> parse -> embed -> retrieve is now proven again on the live runtime for the supported local Compose path. The earlier `agent_extension_*` schema gap that blocked document upload on the supported path is repaired on the supported local Compose stack, and the 2026-05-08 recheck confirmed document readback plus supported retrieval on the current tip.
 - The bounded tool-loop slice is not currently behaving as claimed on the live runtime: the one-turn case fails with `tool_command_execution_failed`, and the hard-stop / blocked-result prompts collapse into plain answers instead of staying bounded.
 - Retrieval assembly now keeps user boundaries explicit in the broker and records widening reasons so trace output stays truthful.
 - Built-in system docs/help are seeded at startup and available to retrieval.

--- a/docs/architecture/2026-05-05-supported-profile-live-proof.md
+++ b/docs/architecture/2026-05-05-supported-profile-live-proof.md
@@ -364,3 +364,64 @@ This proof does not prove:
 - quarantine surfaces as part of the release promise
 - that the provider-registry unit-test slice is clean in every environment
 - that all future runtime changes will preserve this exact evidence without re-running the proof
+
+---
+
+## 2026-05-08 Follow-up Recheck
+
+**Recheck date:** 2026-05-08
+**Commit under test:** `1775466302ed9c55f915a453b02100383febdcd6`
+**Runtime path:** Supported local Docker Compose stack
+
+This follow-up rechecked the previously blocked document route proof after the backend startup blocker was cleared.
+
+### Recheck Commands
+
+```sh
+docker compose restart backend worker-document-embed
+docker compose ps
+docker compose logs --tail=120 backend
+```
+
+```sh
+docker compose exec -T backend python - <<'PY'
+import json, os, urllib.error, urllib.request
+base = 'http://127.0.0.1:8888'
+headers = {'X-API-Key': os.environ['GUARDIAN_API_KEY']}
+
+def request(method, path, body=None, extra_headers=None):
+    req_headers = dict(headers)
+    if extra_headers:
+        req_headers.update(extra_headers)
+    data = None if body is None else (body if isinstance(body, bytes) else body.encode())
+    req = urllib.request.Request(base + path, data=data, headers=req_headers, method=method)
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return resp.status, resp.read().decode()
+
+status, raw = request('GET', '/api/media/documents/84c6ab2f-2a4f-4257-bbfa-613b055657b3')
+print(status, raw)
+status, raw = request('GET', '/api/chat/28/messages')
+print(status, raw)
+status, raw = request('GET', '/api/chat/debug/rag-trace/28/latest')
+print(status, raw)
+PY
+```
+
+### Observed Evidence
+
+- The live supported upload path succeeded with a thread-scoped document attachment.
+- Explicit `project_id=1` upload input returned `404 Project not found`, so the supported recheck used `thread_id=28` without the explicit project override.
+- Uploaded document id: `84c6ab2f-2a4f-4257-bbfa-613b055657b3`
+- Thread id: `28`
+- Sentinel text: `SUPPORTED_PROOF_SENTINEL_2026_05_08`
+- `GET /api/media/documents/84c6ab2f-2a4f-4257-bbfa-613b055657b3` returned `embedding_status: ready`
+- The document detail response preserved the parsed text and embedding timestamps
+- `GET /api/chat/28/messages` returned an assistant response containing the exact sentinel token
+- The assistant payload recorded `retrieval_injected: true`, `linked_document_injected: true`, and `effective_source_mode: project`
+- `GET /api/chat/debug/rag-trace/28/latest` showed `source_mode: project`, `retrieval_query_matches_latest_turn: true`, `widen_reason: none`, and `linked_document_count: 3`
+
+### Follow-up Verdict
+
+**PASS**
+
+The previously blocked document readback and supported-path retrieval recheck now pass again on the live local Compose path. This re-proves the document upload -> embed -> retrieve seam on the supported runtime, but it does not change the historical PARTIAL verdict in this artifact or upgrade broader release readiness.

--- a/guardian/core/chat_completion_service.py
+++ b/guardian/core/chat_completion_service.py
@@ -1642,7 +1642,6 @@ def _filter_image_refusal_semantic_context(
     *,
     suppression_trace: dict[str, Any] | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any] | None] | list[dict[str, Any]]:
-) -> list[dict[str, Any]] | tuple[list[dict[str, Any]], dict[str, Any] | None]:
     if not _image_attachments_from_meta(latest_user_meta):
         filtered = [item for item in semantic_items or [] if isinstance(item, dict)]
         if isinstance(suppression_trace, dict):
@@ -2697,8 +2696,6 @@ def _build_retrieval_provenance(
         "retrieval_status": retrieval_status,
     }
 
-
-def _build_model_selection_trace(
 def _build_model_selection_metadata(
     *,
     requested_provider: str | None,
@@ -2794,11 +2791,6 @@ def _build_model_selection_metadata(
         ):
             payload["policy_reason"] = "requested_provider_not_selected"
     return payload
-
-
-def _build_model_selection_metadata(
-    return {key: value for key, value in payload.items() if value is not None}
-
 
 def _build_model_selection_trace(
     *,

--- a/guardian/routes/chat.py
+++ b/guardian/routes/chat.py
@@ -4342,7 +4342,6 @@ def get_latest_rag_trace(
                 )
             )
             if not trace_source_evidence:
-            if not trace_source_evidence and not trace_unavailable_reason:
                 trace_unavailable_reason = (
                     TraceSnapshotAbsenceReason.TRACE_SNAPSHOT_MISSING.value
                 )

--- a/guardian/routes/media.py
+++ b/guardian/routes/media.py
@@ -364,16 +364,32 @@ def _project_is_visible_to_scope(
 
 
 def _get_project_record(db, project_id: int) -> dict[str, Any] | None:
-    try:
-        with db.get_session() as session:
-            project = (
-                session.query(Project).filter(Project.id == project_id).first()
-            )
-            if project is None:
-                return None
-            return _normalize_project_row(project)
-    except Exception:
-        return None
+    projects: list[dict[str, Any]] = []
+    if hasattr(db, "list_projects"):
+        try:
+            projects = db.list_projects() or []
+        except Exception:
+            projects = []
+    if not projects and hasattr(db, "get_session"):
+        try:
+            with db.get_session() as session:
+                rows = session.query(Project).all()
+                projects = [
+                    _normalize_project_row(row)
+                    for row in rows
+                ]
+        except Exception:
+            projects = []
+
+    for project in projects:
+        row = _normalize_project_row(project)
+        try:
+            row_id = int(row.get("id"))
+        except (TypeError, ValueError):
+            continue
+        if row_id == int(project_id):
+            return row
+    return None
 
 
 def _require_project_account_scope(

--- a/tests/routes/test_media_account_scope.py
+++ b/tests/routes/test_media_account_scope.py
@@ -222,6 +222,68 @@ def test_single_user_media_behavior_remains_compatible(monkeypatch):
     assert uploaded_image.user_id == "legacy-user"
 
 
+def test_single_user_media_accepts_project_scoped_queries(
+    monkeypatch,
+):
+    monkeypatch.setenv("CODEXIFY_MULTI_USER_ENABLED", "false")
+    rows_by_model = {
+        media_routes.UploadedImage: [],
+        media_routes.UploadedDocument: [],
+    }
+    db, _session = _make_db(rows_by_model)
+    client = _make_client(
+        monkeypatch,
+        RequestUserScope(
+            user_id="local",
+            subject_id=None,
+            account_id=None,
+            multi_user_enabled=False,
+        ),
+        db,
+    )
+    db.list_projects.return_value = [
+        {
+            "id": 1,
+            "user_id": "local",
+            "name": "General",
+            "description": "Default project for content without a specified project",
+            "identity_depth": "light",
+        }
+    ]
+
+    images_response = client.get(
+        "/api/media/images?project_id=1", headers={"X-API-Key": API_KEY}
+    )
+    documents_response = client.get(
+        "/api/media/documents?project_id=1", headers={"X-API-Key": API_KEY}
+    )
+
+    assert images_response.status_code == 200, images_response.text
+    assert documents_response.status_code == 200, documents_response.text
+
+
+def test_get_project_record_prefers_live_db_handle(
+    monkeypatch,
+):
+    db = SimpleNamespace(
+        list_projects=lambda: [
+            {
+                "id": 1,
+                "user_id": "local",
+                "name": "General",
+                "description": "Default project for content without a specified project",
+            }
+        ]
+    )
+    monkeypatch.setattr(media_routes, "chatlog_db", None, raising=False)
+
+    project = media_routes._get_project_record(db, 1)
+
+    assert project is not None
+    assert project["id"] == 1
+    assert project["name"] == "General"
+
+
 def test_multi_user_upload_persists_authenticated_principal_as_owner(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
