### PR TITLE
Centralize workspace agent-update signal classification

### DIFF
--- a/frontend/src/features/workspace/__tests__/WorkspaceShelfPanel.test.tsx
+++ b/frontend/src/features/workspace/__tests__/WorkspaceShelfPanel.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import WorkspaceShelfPanel from "../components/WorkspaceShelfPanel";
+import { isAgentUpdatedWorkspaceItem } from "../workspaceArtifactSignals";
 
 vi.mock("@/components/ui/PreviewTile", () => ({
   default: ({
@@ -56,6 +57,29 @@ describe("WorkspaceShelfPanel", () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+  });
+
+  describe("agent update signal classification", () => {
+    it("matches the existing assistant/agent source-tag hints", () => {
+      expect(isAgentUpdatedWorkspaceItem({ source_tag: "assistant" })).toBe(true);
+      expect(isAgentUpdatedWorkspaceItem({ source_tag: "agent" })).toBe(true);
+      expect(isAgentUpdatedWorkspaceItem({ source_tag: "generated" })).toBe(true);
+      expect(isAgentUpdatedWorkspaceItem({ source_tag: "automation" })).toBe(true);
+      expect(isAgentUpdatedWorkspaceItem({ source_tag: "system" })).toBe(true);
+      expect(isAgentUpdatedWorkspaceItem({ source_tag: "codex" })).toBe(true);
+    });
+
+    it("is case-insensitive and ignores unknown or empty source tags", () => {
+      expect(
+        isAgentUpdatedWorkspaceItem({ source_tag: "  Assistant-Update  " })
+      ).toBe(true);
+      expect(
+        isAgentUpdatedWorkspaceItem({ source_tag: "user-uploaded" })
+      ).toBe(false);
+      expect(isAgentUpdatedWorkspaceItem({ source_tag: "" })).toBe(false);
+      expect(isAgentUpdatedWorkspaceItem({ source_tag: null })).toBe(false);
+      expect(isAgentUpdatedWorkspaceItem(undefined)).toBe(false);
+    });
   });
 
   describe("empty states", () => {

--- a/frontend/src/features/workspace/components/WorkspaceShelfPanel.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceShelfPanel.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from "react";
 
 import DocumentTile from "@/components/documents/DocumentTile";
 import PreviewTile from "@/components/ui/PreviewTile";
+import { isAgentUpdatedWorkspaceItem } from "../workspaceArtifactSignals";
 
 type MediaBase = {
   id: string;
@@ -22,14 +23,6 @@ type ImageItem = MediaBase;
 type ShelfItem = { kind: "document"; item: DocumentItem } | { kind: "image"; item: ImageItem };
 
 const WORKSPACE_SHELF_AGENT_READ_STORAGE_KEY = "cfy.workspace.shelf.agent-read.v1";
-const AGENT_UPDATE_SOURCE_TAG_HINTS = [
-  "assistant",
-  "agent",
-  "generated",
-  "automation",
-  "system",
-  "codex",
-];
 
 type ShelfReadState = Record<string, string>;
 
@@ -56,20 +49,6 @@ function persistShelfReadState(state: ShelfReadState) {
   } catch {
     // Local persistence is best effort for this first-pass UX state.
   }
-}
-
-function normalizeSourceTag(tag: string | null | undefined): string {
-  return String(tag ?? "")
-    .trim()
-    .toLowerCase();
-}
-
-function hasAgentUpdateSource(item: MediaBase): boolean {
-  const normalizedTag = normalizeSourceTag(item.source_tag);
-  if (!normalizedTag) return false;
-  return AGENT_UPDATE_SOURCE_TAG_HINTS.some((hint) =>
-    normalizedTag.includes(hint)
-  );
 }
 
 function getShelfItemKey(item: ShelfItem): string {
@@ -300,7 +279,7 @@ export default function WorkspaceShelfPanel({
   }, [shelfReadState]);
 
   const markShelfItemAsRead = useCallback((item: ShelfItem) => {
-    if (!hasAgentUpdateSource(item.item)) return;
+    if (!isAgentUpdatedWorkspaceItem(item.item)) return;
     const key = getShelfItemKey(item);
     const version = getShelfItemVersion(item.item);
     setShelfReadState((previous) => {
@@ -311,7 +290,7 @@ export default function WorkspaceShelfPanel({
 
   const hasUnreadAgentUpdate = useCallback(
     (item: ShelfItem) => {
-      if (!hasAgentUpdateSource(item.item)) return false;
+      if (!isAgentUpdatedWorkspaceItem(item.item)) return false;
       const key = getShelfItemKey(item);
       const version = getShelfItemVersion(item.item);
       return shelfReadState[key] !== version;

--- a/frontend/src/features/workspace/workspaceArtifactSignals.ts
+++ b/frontend/src/features/workspace/workspaceArtifactSignals.ts
@@ -1,0 +1,28 @@
+const AGENT_UPDATE_SOURCE_TAG_HINTS = [
+  "assistant",
+  "agent",
+  "generated",
+  "automation",
+  "system",
+  "codex",
+];
+
+type WorkspaceArtifactSignalCandidate = {
+  source_tag?: string | null;
+};
+
+function normalizeSourceTag(tag: string | null | undefined): string {
+  return String(tag ?? "")
+    .trim()
+    .toLowerCase();
+}
+
+export function isAgentUpdatedWorkspaceItem(
+  item: WorkspaceArtifactSignalCandidate | null | undefined
+): boolean {
+  const normalizedTag = normalizeSourceTag(item?.source_tag);
+  if (!normalizedTag) return false;
+  return AGENT_UPDATE_SOURCE_TAG_HINTS.some((hint) =>
+    normalizedTag.includes(hint)
+  );
+}


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
