### PR TITLE
Add Job Intelligence Layer spec scaffold and planning contracts

### DIFF
--- a/docs/specs/job-intelligence-layer-baseline.md
+++ b/docs/specs/job-intelligence-layer-baseline.md
@@ -1,0 +1,132 @@
+# Job Intelligence Layer Baseline
+
+This document is a baseline orientation artifact for the Job Intelligence Layer concept. It is not an implementation plan and not a release promise. It does not describe shipped runtime behavior in Codexify's current supported beta surface.
+
+## Purpose
+
+Job Intelligence Layer is framed as a reusable applied workflow pattern:
+
+- customer interaction in
+- structured operational profile out
+- human review before confirmation
+- durable operational memory after confirmation
+
+The intent is to turn ambiguous intake into actionable structure while preserving operator control.
+
+## Product Thesis
+
+The core thesis is:
+
+- the system should compress ambiguity before human labor begins
+- the output should be a reviewed operational record, not only a chatbot transcript
+- the human operator remains final authority for confirmation, correction, and downstream action
+
+## Initial Domain Example
+
+The first seed example is plumbing or service-call intake. A customer interaction can be transformed into a draft operational profile that highlights concrete intake elements such as:
+
+- symptoms
+- job-site details
+- access notes
+- system type
+- urgency
+- scheduling preference
+- policy or pricing questions
+
+Plumbing is the motivating starting example, not the permanent domain boundary.
+
+## Portable Pattern
+
+If validated, the same pattern could later apply to intake-heavy lanes such as:
+
+- HVAC
+- electrical
+- cleaning
+- repair shops
+- consulting intake
+- other service, order, or case intake businesses
+
+This document does not commit Codexify to supporting all of these domains now.
+
+## Codexify Relationship
+
+This concept starts inside Codexify as a docs-first incubation lane.
+
+Why start here:
+
+- Codexify already has conversation runtime primitives
+- Codexify already has durable storage primitives
+- Codexify already has artifact and worker primitives
+- Codexify already has workflow-planning language and contract surfaces
+
+Using Codexify as the incubation substrate allows concept validation before rebuilding scaffolding elsewhere.
+
+If the lane proves durable, it may later be:
+
+- kept as a Codexify workflow feature
+- extracted as a vertical product
+- split into a separate repository
+- packaged as an applied Codexify deployment profile
+
+This baseline does not claim any hosted, SaaS, on-prem, or hybrid commitment.
+
+## MVP Shape
+
+First plausible MVP shape:
+
+- transcript or message text input
+- extraction pass
+- generated Job Profile draft
+- human review and edit
+- confirmed record persistence
+
+Explicitly out of scope for the first MVP:
+
+- full AI voice agent
+- autonomous dispatch
+- route optimization
+- billing automation
+- customer-facing production messaging
+- compliance-sensitive recording or transcription handling
+
+## Architectural Boundaries
+
+If implementation proceeds later, architecture-impacting surfaces will need explicit atomic tasks, including:
+
+- data contracts
+- identity and customer-memory boundaries
+- event and provenance model
+- workflow extraction behavior
+- possible transcription or audio handling
+- external communication surfaces
+- operator review UI
+
+No changes to these surfaces are made or promised by this baseline document.
+
+## Memory and Record Doctrine
+
+The baseline memory doctrine for this lane is:
+
+- store concrete events and facts, not opinions
+- derive actions from evidence
+- keep human review and correction available
+- avoid durable subjective labels such as "difficult customer"
+- prefer structured facts such as payment issue, dispute, access problem, safety flag, or follow-up requirement
+
+## Open Questions
+
+- Which delivery posture fits first validation: on-prem, hosted, or hybrid?
+- What transcription consent and retention policy is acceptable per deployment context?
+- Where is the minimum local-vs-cloud model boundary for this lane?
+- Should Job Profile live in Codexify core or an extracted package?
+- Which vertical should be validated first?
+- What minimum review UI is required for safe operator confirmation?
+- Which schema becomes canonical for Job Profile and revision history?
+
+## Next Step
+
+The next task should create the dedicated directory scaffold under:
+
+- `docs/specs/job-intelligence-layer/`
+
+No implementation work should begin until both this baseline orientation document and the directory scaffold exist.

--- a/docs/specs/job-intelligence-layer/00-overview.md
+++ b/docs/specs/job-intelligence-layer/00-overview.md
@@ -1,0 +1,21 @@
+# Job Intelligence Layer Overview
+
+## Purpose
+
+This lane defines a reusable applied workflow pattern for turning customer interaction intake into a reviewed operational record that can be used for execution planning and follow-through.
+
+## Core Loop
+
+1. Interaction input
+2. Structured operational profile draft
+3. Human review
+4. Confirmed operational record
+
+## Relationship to Codexify
+
+This lane starts inside Codexify as an incubation substrate because Codexify already provides relevant conversation, storage, artifact, worker, and workflow-planning primitives that can host early specification work without rebuilding infrastructure first.
+
+## Non-Release Disclaimer
+
+This document is part of a docs-only incubation lane.
+It is not a release promise and does not claim shipped runtime support.

--- a/docs/specs/job-intelligence-layer/01-mvp-scope.md
+++ b/docs/specs/job-intelligence-layer/01-mvp-scope.md
@@ -1,0 +1,23 @@
+# Job Intelligence Layer MVP Scope
+
+## MVP Included
+
+- Transcript or message text input
+- Extraction pass
+- Generated Job Profile draft
+- Human review and edit
+- Confirmed record persistence
+
+## MVP Excluded
+
+- Full AI voice agent
+- Autonomous dispatch
+- Route optimization
+- Billing automation
+- Customer-facing production messaging
+- Compliance-sensitive recording or transcription handling
+
+## First Validation Target
+
+The first validation target is service-call intake, using plumbing as the motivating example.
+The goal is to prove that intake ambiguity can be converted into a reviewed operational profile draft before downstream labor begins.

--- a/docs/specs/job-intelligence-layer/02-job-profile-contract-notes.md
+++ b/docs/specs/job-intelligence-layer/02-job-profile-contract-notes.md
@@ -1,0 +1,23 @@
+# Job Profile Contract Notes
+
+This document captures draft contract notes only.
+It is not a canonical schema.
+
+## Draft Contract Areas
+
+- Customer and contact
+- Site and location
+- Issue or request summary
+- Symptoms and details
+- Urgency
+- Access notes
+- Scheduling preference
+- Policy or pricing questions
+- Risk or safety flags
+- Human review metadata
+
+## Memory and Record Doctrine
+
+- Store events and facts, not opinions.
+- Avoid subjective durable labels.
+- Use structured event records such as payment issue, dispute, access problem, safety flag, or follow-up requirement.

--- a/docs/specs/job-intelligence-layer/03-call-assist-workflow.md
+++ b/docs/specs/job-intelligence-layer/03-call-assist-workflow.md
@@ -1,0 +1,14 @@
+# Call Assist Workflow
+
+## Initial Workflow Idea
+
+1. Human handles the call.
+2. System transcribes or receives transcript text.
+3. System extracts draft job details.
+4. Human reviews and corrects.
+5. Confirmed record is stored.
+
+## Boundaries
+
+- Transcription and audio handling are not implemented in this lane today.
+- Consent and retention policy for transcription or recording are explicitly deferred.

--- a/docs/specs/job-intelligence-layer/04-vertical-adaptation-notes.md
+++ b/docs/specs/job-intelligence-layer/04-vertical-adaptation-notes.md
@@ -1,0 +1,14 @@
+# Vertical Adaptation Notes
+
+Plumbing and service-call intake is the seed example for first validation.
+
+## Possible Future Verticals
+
+- HVAC
+- Electrical
+- Cleaning
+- Repair shops
+- Consulting intake
+- Other intake-heavy service, order, or case businesses
+
+No vertical beyond the first validation target is committed by this scaffold.

--- a/docs/specs/job-intelligence-layer/05-open-questions.md
+++ b/docs/specs/job-intelligence-layer/05-open-questions.md
@@ -1,0 +1,10 @@
+# Open Questions
+
+- Should this lane be delivered on-prem, hosted, or hybrid?
+- What transcription consent and retention policy is required?
+- What is the local versus cloud model boundary for this lane?
+- Should Job Profile live in Codexify core or in an extracted package?
+- Which business vertical should be validated first?
+- What minimum review UI is needed?
+- What schema should be canonical?
+- What proof would justify moving from docs-only incubation to implementation?

--- a/docs/specs/job-intelligence-layer/06-job-profile-draft-contract.md
+++ b/docs/specs/job-intelligence-layer/06-job-profile-draft-contract.md
@@ -1,0 +1,214 @@
+# Job Profile Draft Contract
+
+This is a planning contract draft.
+It is not a canonical schema.
+It is not implemented.
+It does not define database tables, API responses, prompt outputs, or UI behavior yet.
+
+## Purpose
+
+The Job Profile is the central structured artifact produced from an intake interaction.
+It is intended to represent:
+
+- what the customer said
+- what the system inferred
+- what the human reviewed
+- what was confirmed for operational use
+
+## Lifecycle
+
+Conceptual draft lifecycle states:
+
+- `draft_created`
+- `needs_review`
+- `reviewed`
+- `confirmed`
+- `rejected`
+- `superseded`
+
+These are planning terms only for this draft contract and are not canonical runtime tokens.
+
+## Contract Shape
+
+```json
+{
+  "job_profile_id": "jp_draft_0001",
+  "version": 1,
+  "status": "needs_review",
+  "source": {
+    "interaction_type": "phone_call",
+    "transcript_available": true,
+    "raw_description": "Customer reports water around the base of the water heater and asks if emergency service is available."
+  },
+  "customer": {
+    "name": "Alex Rivera",
+    "phone": "+1-555-0100",
+    "email": "alex.rivera@example.com"
+  },
+  "site": {
+    "address": "123 Maple Ave, Springfield, NY 10001",
+    "access_notes": "Gate code required after 6 PM; dog in backyard."
+  },
+  "request": {
+    "summary": "Possible water heater leak with active water accumulation.",
+    "symptoms": [
+      "Water pooling near heater",
+      "Dripping sound reported"
+    ],
+    "known_equipment": [
+      "Gas water heater"
+    ]
+  },
+  "classification": {
+    "service_type": "plumbing",
+    "category": "water_heater_leak",
+    "confidence": 0.74
+  },
+  "scheduling": {
+    "preference": "same_day_if_possible",
+    "constraints": [
+      "Customer available after 4 PM"
+    ]
+  },
+  "policy_questions": {
+    "items": [
+      "Diagnostic fee amount",
+      "Warranty coverage for replacement parts"
+    ]
+  },
+  "risk_and_safety": {
+    "flags": [
+      "water_active",
+      "requires_ppe"
+    ],
+    "notes": "Customer reports active water near appliance."
+  },
+  "events": [
+    {
+      "event_type": "follow_up_required",
+      "details": "Customer requested callback with ETA options.",
+      "recorded_at": "2026-05-16T14:10:00Z"
+    }
+  ],
+  "review": {
+    "required": true,
+    "reviewed_by": null,
+    "reviewed_at": null,
+    "corrections": []
+  },
+  "lineage": {
+    "source_thread_id": "thread_123",
+    "source_message_id": "msg_456"
+  },
+  "metadata": {
+    "created_at": "2026-05-16T14:08:00Z",
+    "updated_at": "2026-05-16T14:10:00Z"
+  }
+}
+```
+
+## Field Groups
+
+### Source
+
+- Captures raw intake origin and interaction context.
+- Tracks transcript or message source context.
+- Original customer language should be preserved when available.
+
+### Customer
+
+- Captures contact identity for the job.
+- Must avoid durable personality judgments or subjective labels.
+
+### Site
+
+- Captures job location and access context.
+- Safety and access notes should remain factual and concrete.
+
+### Request
+
+- Captures issue summary and concrete symptoms.
+- Must preserve separation between raw customer description and interpreted summary.
+
+### Classification
+
+- Captures service type, category, and confidence as planning fields.
+- Confidence is advisory and must remain human-reviewable.
+
+### Scheduling
+
+- Captures preferences and constraints only.
+- Does not imply autonomous dispatch behavior.
+
+### Policy Questions
+
+- Captures questions about fees, diagnostics, pricing, warranties, or related business policy.
+- Does not imply automated pricing commitments.
+
+### Risk and Safety
+
+- Captures factual safety or access flags.
+- Must avoid stigmatizing language.
+- Example flags: `access_problem`, `biohazard_observed`, `aggressive_animal_reported`, `requires_ppe`, `water_active`, `electrical_risk_reported`.
+
+### Events
+
+- Captures concrete event records only.
+- Example events include payment issue, dispute, cancellation, follow-up requirement, access problem, and safety flag.
+
+### Review
+
+- Captures human confirmation state and readiness for operational use.
+- Includes corrections and reviewer metadata.
+
+### Lineage
+
+- Captures source thread, message, or related artifact references.
+- Preserves traceability from intake interaction to Job Profile.
+
+### Metadata
+
+- Captures timestamps and versioning surfaces for the draft artifact.
+
+## Event and Fact Doctrine
+
+- Store concrete events and facts, not opinions.
+- Do not store subjective labels such as `difficult_customer`.
+- Prefer event records like:
+- `payment_issue`
+- `service_dispute`
+- `access_problem`
+- `safety_flag`
+- `follow_up_required`
+- `customer_correction`
+- Derived actions should be computed from evidence, not stored as personality judgments.
+
+## Review Doctrine
+
+- The system drafts.
+- The human confirms.
+- Every generated field must be editable before confirmation.
+- Low-confidence classification must remain visibly reviewable in any future UI.
+- Confirmed records should preserve correction history.
+
+## Non-Goals
+
+- No database schema
+- No migration
+- No API contract
+- No JSON Schema file
+- No prompt contract
+- No UI contract
+- No autonomous dispatch semantics
+- No transcription retention policy
+- No pricing automation
+
+## Open Questions
+
+- Which fields are required for first MVP?
+- Which fields should be optional?
+- Should draft lifecycle terms become canonical tokens later?
+- Should Job Profile lineage bind to Codexify thread and message lineage or a new vertical-specific source model?
+- How should revisions be represented?
+- How much customer and contact data is necessary for validation without creating avoidable privacy risk?
+- What proof would justify moving this from draft contract to canonical schema?

--- a/docs/specs/job-intelligence-layer/07-extraction-pass-contract.md
+++ b/docs/specs/job-intelligence-layer/07-extraction-pass-contract.md
@@ -1,0 +1,198 @@
+# Extraction Pass Contract
+
+This is a planning contract.
+It is not a runtime prompt.
+It is not a canonical schema.
+It is not implemented.
+It does not define API behavior, model behavior, worker behavior, or UI behavior.
+
+## Purpose
+
+The extraction pass is intended to convert raw intake text into a structured draft suitable for a future Job Profile review flow.
+
+The pass should identify:
+
+- customer-provided facts
+- inferred job details
+- unanswered questions
+- uncertainty
+- review needs
+
+## Input
+
+Conceptual planning input shape:
+
+```json
+{
+  "interaction_id": "intake_0001",
+  "interaction_type": "phone_call_transcript",
+  "source_text": "My kitchen sink has been backing up for two days and water is leaking under the cabinet.",
+  "transcript_available": true,
+  "source_channel": "phone",
+  "received_at": "2026-05-16T16:45:00Z",
+  "known_context": {
+    "business_vertical": "plumbing",
+    "existing_customer_id": null,
+    "existing_site_id": null,
+    "operator_notes": "Caller asked if emergency after-hours response is possible."
+  }
+}
+```
+
+This shape is planning-only and is not an API contract.
+
+## Output
+
+Conceptual planning output shape:
+
+```json
+{
+  "extraction_id": "extract_0001",
+  "source_interaction_id": "intake_0001",
+  "extracted_fields": {
+    "raw_description": "My kitchen sink has been backing up for two days and water is leaking under the cabinet.",
+    "symptoms": [
+      "sink backing up",
+      "water leaking under cabinet"
+    ],
+    "urgency_phrase": "two days"
+  },
+  "inferred_fields": {
+    "service_type": "plumbing",
+    "category": "drain_or_leak_issue",
+    "possible_risk_flags": [
+      "water_active"
+    ]
+  },
+  "ambiguities": [
+    {
+      "field": "exact_leak_source",
+      "reason": "caller reported leak area but not confirmed origin"
+    }
+  ],
+  "missing_information": [
+    "full_service_address",
+    "site_access_constraints",
+    "equipment_brand_or_model"
+  ],
+  "risk_signals": [
+    "water_active",
+    "after_hours_urgency"
+  ],
+  "policy_questions": [
+    "after_hours_service_fee"
+  ],
+  "review_recommendations": [
+    "confirm exact leak source",
+    "confirm service address",
+    "confirm urgency and scheduling window"
+  ],
+  "confidence": {
+    "overall": "medium",
+    "service_type": "high",
+    "category": "medium",
+    "urgency": "low"
+  },
+  "metadata": {
+    "created_at": "2026-05-16T16:46:30Z",
+    "planning_contract_version": "draft_v1"
+  }
+}
+```
+
+The output must distinguish directly stated facts, inferred fields, uncertain fields, missing fields, and review needs.
+
+## Extraction Rules
+
+- Preserve raw language when useful.
+- Do not overwrite raw description with interpreted summary.
+- Prefer `unknown` over guessing.
+- Use confidence values only as review aids.
+- Mark ambiguity explicitly.
+- Do not make pricing commitments.
+- Do not make scheduling commitments.
+- Do not create subjective customer labels.
+- Do not infer sensitive traits.
+- Treat safety and access details as factual observations or customer reports.
+- Surface policy questions separately from job symptoms.
+
+## Ambiguity Handling
+
+Ambiguity should be represented as explicit reviewable entries when intake details are unclear.
+
+Examples:
+
+- unclear service type
+- unknown brand or equipment
+- unclear urgency
+- uncertain location or access
+- customer asking policy or pricing questions
+- contradictory details
+
+Ambiguous fields should become review recommendations, and ambiguity should never be silently converted into confirmed truth.
+
+## Confidence Guidance
+
+Planning-only confidence bands:
+
+- `high`
+- `medium`
+- `low`
+- `unknown`
+
+These are draft planning terms and are not canonical runtime tokens yet.
+
+Guidance:
+
+- `high`: directly stated or strongly supported by source text
+- `medium`: likely interpretation but still reviewable
+- `low`: weak inference or partial signal
+- `unknown`: unavailable, missing, or unclear
+
+## Risk Signal Guidance
+
+Factual risk-signal examples:
+
+- `active_leak_reported`
+- `water_active`
+- `electrical_risk_reported`
+- `access_problem`
+- `requires_ppe`
+- `biohazard_reported`
+- `aggressive_animal_reported`
+- `after_hours_urgency`
+- `payment_issue_reference`
+- `prior_dispute_reference`
+
+These are draft planning labels, not canonical runtime tokens. If implemented later, canonicalization must follow runtime token discipline.
+
+## Human Review Requirements
+
+- Every generated field must be editable.
+- Low-confidence fields must be surfaced.
+- Ambiguities must be visible.
+- Corrections should be preserved in future revision history.
+- Human confirmation is required before a Job Profile becomes operationally usable.
+
+## Non-Goals
+
+- No prompt implementation
+- No model selection
+- No transcript storage policy
+- No transcription consent policy
+- No pricing automation
+- No scheduling automation
+- No API route
+- No persistence model
+- No UI contract
+- No canonical token registry
+
+## Open Questions
+
+- Should extraction become a reusable Flow Builder step later?
+- Should extraction output map directly into Job Profile draft fields or through an intermediate normalization shape?
+- Which fields are required for the first validation target?
+- What threshold should require human review?
+- Should confidence values become canonical tokens later?
+- How should extraction corrections feed future evaluation?
+- How should source text be retained, redacted, or excluded?

--- a/docs/specs/job-intelligence-layer/README.md
+++ b/docs/specs/job-intelligence-layer/README.md
@@ -15,6 +15,7 @@ Baseline orientation document:
 - [`04-vertical-adaptation-notes.md`](./04-vertical-adaptation-notes.md): Tracks portability notes from the seed domain to later vertical candidates.
 - [`05-open-questions.md`](./05-open-questions.md): Lists unresolved decisions required before implementation work is justified.
 - [`06-job-profile-draft-contract.md`](./06-job-profile-draft-contract.md): Proposes the first non-runtime Job Profile contract draft to structure future schema and review-planning work.
+- [`07-extraction-pass-contract.md`](./07-extraction-pass-contract.md): Defines the first planning contract for turning raw intake text into reviewable structured draft extraction outputs.
 
 ## Do Not Assume
 

--- a/docs/specs/job-intelligence-layer/README.md
+++ b/docs/specs/job-intelligence-layer/README.md
@@ -1,0 +1,24 @@
+# Job Intelligence Layer
+
+This directory is a docs-first incubation lane for the Job Intelligence Layer concept.
+It is not a shipped release surface.
+
+Baseline orientation document:
+- [`../job-intelligence-layer-baseline.md`](../job-intelligence-layer-baseline.md)
+
+## Scaffold Map
+
+- [`00-overview.md`](./00-overview.md): Defines the lane purpose, core operational loop, and Codexify incubation framing.
+- [`01-mvp-scope.md`](./01-mvp-scope.md): Captures what the first validation MVP includes and explicitly excludes.
+- [`02-job-profile-contract-notes.md`](./02-job-profile-contract-notes.md): Records draft Job Profile contract areas and memory doctrine notes before any canonical schema decision.
+- [`03-call-assist-workflow.md`](./03-call-assist-workflow.md): Outlines the initial call-assist workflow concept with human review as the control point.
+- [`04-vertical-adaptation-notes.md`](./04-vertical-adaptation-notes.md): Tracks portability notes from the seed domain to later vertical candidates.
+- [`05-open-questions.md`](./05-open-questions.md): Lists unresolved decisions required before implementation work is justified.
+
+## Do Not Assume
+
+- No runtime implementation exists.
+- No Job Profile schema is canonical yet.
+- No transcription pipeline exists.
+- No dispatcher review UI exists.
+- No hosted, SaaS, on-prem, or hybrid delivery model has been selected.

--- a/docs/specs/job-intelligence-layer/README.md
+++ b/docs/specs/job-intelligence-layer/README.md
@@ -14,6 +14,7 @@ Baseline orientation document:
 - [`03-call-assist-workflow.md`](./03-call-assist-workflow.md): Outlines the initial call-assist workflow concept with human review as the control point.
 - [`04-vertical-adaptation-notes.md`](./04-vertical-adaptation-notes.md): Tracks portability notes from the seed domain to later vertical candidates.
 - [`05-open-questions.md`](./05-open-questions.md): Lists unresolved decisions required before implementation work is justified.
+- [`06-job-profile-draft-contract.md`](./06-job-profile-draft-contract.md): Proposes the first non-runtime Job Profile contract draft to structure future schema and review-planning work.
 
 ## Do Not Assume
 


### PR DESCRIPTION
## Summary
- Add a docs-first Job Intelligence Layer baseline and navigable spec scaffold.
- Define the first non-runtime Job Profile draft contract and the extraction-pass planning contract.
- Keep the lane explicitly incubation-only, with no release promise or implementation claim.

## Testing
- Docs validation passed.
- `git diff --check` passed for the updated spec files.