### PR TITLE
Enforce supplied external transport policy in command bus invoke

### DIFF
--- a/guardian/command_bus/contracts.py
+++ b/guardian/command_bus/contracts.py
@@ -85,6 +85,23 @@ class InvokePermissionProfile(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class InvokeExternalPolicyRule(BaseModel):
+    """Optional supplied rule for external transport policy checks."""
+
+    effect: Literal["allow", "deny"]
+    connector_name: str | None = Field(default=None, max_length=255)
+    transport: str | None = Field(default=None, max_length=64)
+    command_namespace: str | None = Field(default=None, max_length=255)
+    command_name: str | None = Field(default=None, max_length=255)
+    url_host_pattern: str | None = Field(default=None, max_length=512)
+    url_scheme: str | None = Field(default=None, max_length=32)
+    project_id: str | None = Field(default=None, max_length=255)
+    thread_id: str | None = Field(default=None, max_length=255)
+    reason: str = Field(default="", max_length=1024)
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class InvokeRequest(BaseModel):
     """Command invocation payload."""
 
@@ -95,6 +112,18 @@ class InvokeRequest(BaseModel):
     idempotency_key: str | None = Field(default=None, max_length=255)
     provenance_json: dict[str, Any] = Field(default_factory=dict)
     permission_profile: InvokePermissionProfile | None = None
+    external_transport: str | None = Field(default=None, max_length=64)
+    external_target_url: str | None = Field(default=None, max_length=2048)
+    external_policy_rules: tuple[InvokeExternalPolicyRule, ...] = Field(
+        default_factory=tuple
+    )
+    external_command_namespace: str | None = Field(
+        default=None, max_length=255
+    )
+    external_command_name: str | None = Field(default=None, max_length=255)
+    external_project_id: str | None = Field(default=None, max_length=255)
+    external_thread_id: str | None = Field(default=None, max_length=255)
+    external_connector_name: str | None = Field(default=None, max_length=255)
 
     model_config = ConfigDict(extra="forbid")
 

--- a/guardian/command_bus/invoke.py
+++ b/guardian/command_bus/invoke.py
@@ -12,8 +12,16 @@ from fastapi import HTTPException
 from guardian.command_bus.contracts import (
     INVOKE_VERSION,
     MAX_PAYLOAD_BYTES,
+    InvokeExternalPolicyRule,
     InvokePermissionProfile,
     InvokeRequest,
+)
+from guardian.connectors.external_transport_policy import (
+    CommandTuple,
+    ExternalPolicyDecision,
+    ExternalPolicyRequest,
+    ExternalPolicyRule,
+    evaluate_external_transport_policy,
 )
 from guardian.command_bus.permission_profiles import (
     PermissionProfile,
@@ -177,6 +185,90 @@ def _build_permission_profile_request(
     )
 
 
+_EXTERNAL_POLICY_TRIGGER_FIELDS: frozenset[str] = frozenset(
+    {
+        "external_transport",
+        "external_target_url",
+        "external_policy_rules",
+        "external_command_namespace",
+        "external_command_name",
+        "external_connector_name",
+    }
+)
+
+
+def _invoke_fields_set(payload: InvokeRequest) -> set[str]:
+    raw_set = getattr(payload, "model_fields_set", None)
+    if isinstance(raw_set, set):
+        return raw_set
+    legacy_set = getattr(payload, "__fields_set__", None)
+    if isinstance(legacy_set, set):
+        return legacy_set
+    return set()
+
+
+def _external_policy_is_triggered(payload: InvokeRequest) -> bool:
+    fields_set = _invoke_fields_set(payload)
+    return any(
+        field_name in fields_set
+        for field_name in _EXTERNAL_POLICY_TRIGGER_FIELDS
+    )
+
+
+def _build_external_policy_command_tuple(
+    payload: InvokeRequest,
+) -> CommandTuple | None:
+    namespace = _optional_text(payload.external_command_namespace)
+    name = _optional_text(payload.external_command_name)
+    if namespace is None or name is None:
+        return None
+    return CommandTuple(namespace=namespace, name=name)
+
+
+def _build_external_policy_rules(
+    policy_rules: tuple[InvokeExternalPolicyRule, ...],
+) -> list[ExternalPolicyRule]:
+    rules: list[ExternalPolicyRule] = []
+    for rule in policy_rules:
+        command = None
+        namespace = _optional_text(rule.command_namespace)
+        name = _optional_text(rule.command_name)
+        if namespace is not None and name is not None:
+            command = CommandTuple(namespace=namespace, name=name)
+        rules.append(
+            ExternalPolicyRule(
+                effect=rule.effect,
+                connector_name=rule.connector_name,
+                transport=rule.transport,
+                command=command,
+                url_host_pattern=rule.url_host_pattern,
+                url_scheme=rule.url_scheme,
+                project_id=rule.project_id,
+                thread_id=rule.thread_id,
+                reason=rule.reason,
+            )
+        )
+    return rules
+
+
+def _build_external_policy_request(
+    *,
+    payload: InvokeRequest,
+    auth_subject: str,
+) -> ExternalPolicyRequest:
+    connector_name = _optional_text(payload.external_connector_name) or ""
+    return ExternalPolicyRequest(
+        actor_id=payload.actor.id,
+        subject_id=auth_subject,
+        connector_name=connector_name,
+        transport=payload.external_transport or "",
+        command=_build_external_policy_command_tuple(payload),
+        target_url=payload.external_target_url,
+        project_id=_optional_text(payload.external_project_id),
+        thread_id=_optional_text(payload.external_thread_id),
+    )
+
+
 async def execute_invoke(
     *,
     payload: InvokeRequest,
@@ -254,6 +346,7 @@ async def execute_invoke(
     )
 
     permission_profile_decision = None
+    external_policy_decision: ExternalPolicyDecision | None = None
     pre_dispatch_blocked_reason: str | None = None
     if payload.permission_profile is not None:
         profile = _build_permission_profile(payload.permission_profile)
@@ -271,6 +364,26 @@ async def execute_invoke(
         if not permission_profile_decision.allowed:
             pre_dispatch_blocked_reason = (
                 f"permission_profile_denied:{permission_profile_decision.code}"
+            )
+    if _external_policy_is_triggered(payload):
+        external_policy_request = _build_external_policy_request(
+            payload=payload,
+            auth_subject=auth_subject,
+        )
+        external_policy_rules = _build_external_policy_rules(
+            payload.external_policy_rules
+        )
+        external_policy_decision = evaluate_external_transport_policy(
+            external_policy_request,
+            external_policy_rules,
+        )
+        if (
+            not external_policy_decision.allowed
+            and pre_dispatch_blocked_reason is None
+        ):
+            pre_dispatch_blocked_reason = (
+                "external_transport_policy_denied:"
+                f"{external_policy_decision.code}"
             )
 
     args_hash = compute_args_hash(args_dict)
@@ -319,6 +432,14 @@ async def execute_invoke(
             "reason": permission_profile_decision.reason,
             "blocked_before_dispatch": (
                 not permission_profile_decision.allowed
+            ),
+        }
+    if external_policy_decision is not None:
+        created_payload["external_transport_policy"] = {
+            "code": external_policy_decision.code,
+            "reason": external_policy_decision.reason,
+            "blocked_before_dispatch": (
+                not external_policy_decision.allowed
             ),
         }
     store.append_event(
@@ -378,6 +499,14 @@ async def execute_invoke(
                     not permission_profile_decision.allowed
                 ),
             }
+        if external_policy_decision is not None:
+            blocked_payload["external_transport_policy"] = {
+                "code": external_policy_decision.code,
+                "reason": external_policy_decision.reason,
+                "blocked_before_dispatch": (
+                    not external_policy_decision.allowed
+                ),
+            }
         store.append_event(
             run_id=run_id,
             event_type="run.blocked",
@@ -398,6 +527,14 @@ async def execute_invoke(
                 "reason": permission_profile_decision.reason,
                 "blocked_before_dispatch": (
                     not permission_profile_decision.allowed
+                ),
+            }
+        if external_policy_decision is not None:
+            blocked_response["external_transport_policy"] = {
+                "code": external_policy_decision.code,
+                "reason": external_policy_decision.reason,
+                "blocked_before_dispatch": (
+                    not external_policy_decision.allowed
                 ),
             }
         if invoke_policy.warnings:

--- a/tests/command_bus/test_invoke_external_transport_policy_enforcement.py
+++ b/tests/command_bus/test_invoke_external_transport_policy_enforcement.py
@@ -1,0 +1,509 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from guardian.command_bus import invoke as invoke_module
+from guardian.command_bus.contracts import (
+    ActorSpec,
+    CommandSpec,
+    InvokeArguments,
+    InvokeRequest,
+)
+from guardian.command_bus.store import CommandBusStore
+
+
+def _command(
+    *,
+    command_id: str = "cmd.read.health",
+    method: str = "GET",
+    path_template: str = "/health",
+    effect: str = "read",
+) -> CommandSpec:
+    risk = "read_only" if effect == "read" else "mutating"
+    return CommandSpec(
+        command_id=command_id,
+        method=method,
+        path_template=path_template,
+        risk=risk,
+        effect=effect,
+        idempotency="safe",
+        approval_mode="none",
+    )
+
+
+def _permission_profile(
+    command_id: str,
+    **overrides: Any,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "profile_id": "profile-1",
+        "actor_id": "operator",
+        "subject_id": "operator",
+        "task_id": "task-1",
+        "project_id": None,
+        "thread_id": None,
+        "allowed_command_classes": (),
+        "denied_command_classes": (),
+        "allowed_command_ids": (command_id,),
+        "denied_command_ids": (),
+        "filesystem_access": "none",
+        "allowed_write_roots": (),
+        "shell_allowed": False,
+        "shell_read_only": True,
+        "allowed_shell_commands": (),
+        "network_allowed": False,
+        "connector_allowed": False,
+        "request_task_id": "task-1",
+        "request_project_id": None,
+        "request_thread_id": None,
+        "request_command_class": None,
+        "requested_write_paths": (),
+        "uses_shell": False,
+        "shell_command": None,
+        "shell_mutates": False,
+        "uses_network": False,
+        "uses_connector": False,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _allow_rule(**overrides: Any) -> dict[str, Any]:
+    rule: dict[str, Any] = {
+        "effect": "allow",
+        "connector_name": "github",
+        "transport": "https",
+        "reason": "allow rule",
+    }
+    rule.update(overrides)
+    return rule
+
+
+def _deny_rule(**overrides: Any) -> dict[str, Any]:
+    rule: dict[str, Any] = {
+        "effect": "deny",
+        "connector_name": "github",
+        "transport": "https",
+        "reason": "deny rule",
+    }
+    rule.update(overrides)
+    return rule
+
+
+async def _invoke(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    external_payload: dict[str, Any] | None = None,
+    permission_profile: dict[str, Any] | None = None,
+    command: CommandSpec | None = None,
+) -> tuple[dict[str, Any], list[dict[str, Any]], CommandBusStore]:
+    resolved_command = command or _command()
+    manifest = SimpleNamespace(manifest_version="1.0")
+    monkeypatch.setattr(
+        invoke_module,
+        "build_command_index",
+        lambda _app: ({resolved_command.command_id: resolved_command}, manifest),
+    )
+
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_execute_loopback_request(**kwargs: Any) -> dict[str, Any]:
+        calls.append(dict(kwargs))
+        return {"status_code": 200, "body": {"ok": True}}
+
+    monkeypatch.setattr(
+        invoke_module,
+        "execute_loopback_request",
+        _fake_execute_loopback_request,
+    )
+    monkeypatch.setenv(
+        "GUARDIAN_COMMAND_BUS_LOOPBACK_BASE", "http://127.0.0.1:9999"
+    )
+
+    payload_data: dict[str, Any] = {
+        "invoke_version": "1.0",
+        "command_id": resolved_command.command_id,
+        "actor": ActorSpec(kind="human", id="operator"),
+        "arguments": InvokeArguments(),
+        "permission_profile": permission_profile,
+    }
+    if external_payload:
+        payload_data.update(external_payload)
+    payload = InvokeRequest(**payload_data)
+
+    store = CommandBusStore()
+    result = await invoke_module.execute_invoke(
+        payload=payload,
+        auth_subject="operator",
+        inbound_headers={"x-api-key": "test-key", "x-user-id": "operator"},
+        store=store,
+        app=object(),
+        execution_lane="tools",
+        allow_write_execution=True,
+        confirmation_granted=False,
+    )
+    return result, calls, store
+
+
+def _base_external_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "external_transport": "https",
+        "external_connector_name": "github",
+        "external_policy_rules": (_allow_rule(),),
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.asyncio
+async def test_no_external_metadata_preserves_existing_invoke_behavior(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, calls, _store = await _invoke(monkeypatch)
+    assert result["status"] == "completed"
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_matching_allow_policy_permits_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload=_base_external_payload(),
+    )
+    assert result["status"] == "completed"
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_rules_denies_before_dispatch_with_no_allow_rule(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload=_base_external_payload(external_policy_rules=()),
+    )
+    assert result["status"] == "blocked"
+    assert result["error"] == "external_transport_policy_denied:no_allow_rule"
+    assert len(calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_missing_rules_when_triggered_denies_with_no_allow_rule(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload={
+            "external_transport": "https",
+            "external_connector_name": "github",
+        },
+    )
+    assert result["status"] == "blocked"
+    assert result["error"] == "external_transport_policy_denied:no_allow_rule"
+    assert len(calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_deny_rule_overrides_allow_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload=_base_external_payload(
+            external_policy_rules=(
+                _allow_rule(reason="allow-first"),
+                _deny_rule(reason="explicit-deny"),
+            )
+        ),
+    )
+    assert result["status"] == "blocked"
+    assert result["error"] == "external_transport_policy_denied:denied_by_rule"
+    assert result["external_transport_policy"]["reason"] == "explicit-deny"
+    assert len(calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_unknown_transport_denies_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload=_base_external_payload(
+            external_transport="ftp",
+            external_policy_rules=(_allow_rule(transport="ftp"),),
+        ),
+    )
+    assert result["status"] == "blocked"
+    assert result["external_transport_policy"]["code"] == "unsupported_transport"
+    assert len(calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_malformed_target_url_denies_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload=_base_external_payload(
+            external_target_url="http://[::1",
+            external_policy_rules=(
+                _allow_rule(url_host_pattern="api.example.com"),
+            ),
+        ),
+    )
+    assert result["status"] == "blocked"
+    assert result["external_transport_policy"]["code"] == "malformed_url"
+    assert len(calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_connector_name_mismatch_denies_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload=_base_external_payload(
+            external_policy_rules=(
+                _allow_rule(connector_name="not-github"),
+            ),
+        ),
+    )
+    assert result["status"] == "blocked"
+    assert result["external_transport_policy"]["code"] == "no_allow_rule"
+    assert len(calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_exact_url_host_match_allows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload=_base_external_payload(
+            external_target_url="https://api.example.com/v1/repos",
+            external_policy_rules=(
+                _allow_rule(
+                    url_host_pattern="api.example.com",
+                    url_scheme="https",
+                ),
+            ),
+        ),
+    )
+    assert result["status"] == "completed"
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_wildcard_host_match_allows_valid_subdomain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload=_base_external_payload(
+            external_target_url="https://api.example.com/resource",
+            external_policy_rules=(_allow_rule(url_host_pattern="*.example.com"),),
+        ),
+    )
+    assert result["status"] == "completed"
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_wildcard_host_rejects_boundary_unsafe_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload=_base_external_payload(
+            external_target_url="https://badexample.com/resource",
+            external_policy_rules=(_allow_rule(url_host_pattern="*.example.com"),),
+        ),
+    )
+    assert result["status"] == "blocked"
+    assert result["external_transport_policy"]["code"] == "no_allow_rule"
+    assert len(calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_command_tuple_mismatch_denies_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload=_base_external_payload(
+            external_command_namespace="repos",
+            external_command_name="write",
+            external_policy_rules=(
+                _allow_rule(
+                    command_namespace="repos",
+                    command_name="read",
+                ),
+            ),
+        ),
+    )
+    assert result["status"] == "blocked"
+    assert result["external_transport_policy"]["code"] == "no_allow_rule"
+    assert len(calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_project_scope_mismatch_denies_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload=_base_external_payload(
+            external_project_id="project-b",
+            external_policy_rules=(_allow_rule(project_id="project-a"),),
+        ),
+    )
+    assert result["status"] == "blocked"
+    assert result["external_transport_policy"]["code"] == "no_allow_rule"
+    assert len(calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_thread_scope_mismatch_denies_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload=_base_external_payload(
+            external_thread_id="thread-b",
+            external_policy_rules=(_allow_rule(thread_id="thread-a"),),
+        ),
+    )
+    assert result["status"] == "blocked"
+    assert result["external_transport_policy"]["code"] == "no_allow_rule"
+    assert len(calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_denial_result_includes_evaluator_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload=_base_external_payload(
+            external_policy_rules=(_deny_rule(reason="blocked"),),
+        ),
+    )
+    assert result["status"] == "blocked"
+    assert result["external_transport_policy"]["code"] == "denied_by_rule"
+    assert len(calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_denial_result_includes_evaluator_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload=_base_external_payload(
+            external_policy_rules=(_deny_rule(reason="blocked-for-reason"),),
+        ),
+    )
+    assert result["status"] == "blocked"
+    assert (
+        result["external_transport_policy"]["reason"] == "blocked-for-reason"
+    )
+    assert len(calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_denial_result_includes_blocked_before_dispatch_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload=_base_external_payload(
+            external_policy_rules=(_deny_rule(reason="blocked-marker"),),
+        ),
+    )
+    assert result["status"] == "blocked"
+    assert result["external_transport_policy"]["blocked_before_dispatch"] is True
+    assert len(calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_blocked_path_does_not_call_underlying_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload=_base_external_payload(
+            external_policy_rules=(_deny_rule(reason="stop"),),
+        ),
+    )
+    assert result["status"] == "blocked"
+    assert len(calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_allowed_path_calls_underlying_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload=_base_external_payload(),
+    )
+    assert result["status"] == "completed"
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_permission_and_external_allow_both_continue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    command = _command()
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload=_base_external_payload(),
+        permission_profile=_permission_profile(command.command_id),
+        command=command,
+    )
+    assert result["status"] == "completed"
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_permission_denies_while_external_allows_blocks_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    command = _command()
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload=_base_external_payload(),
+        permission_profile=_permission_profile(
+            command.command_id,
+            denied_command_ids=(command.command_id,),
+        ),
+        command=command,
+    )
+    assert result["status"] == "blocked"
+    assert result["error"] == "permission_profile_denied:command_id_denied"
+    assert len(calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_permission_allows_while_external_denies_blocks_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    command = _command()
+    result, calls, _store = await _invoke(
+        monkeypatch,
+        external_payload=_base_external_payload(
+            external_policy_rules=(_deny_rule(reason="external-stop"),),
+        ),
+        permission_profile=_permission_profile(command.command_id),
+        command=command,
+    )
+    assert result["status"] == "blocked"
+    assert result["error"] == "external_transport_policy_denied:denied_by_rule"
+    assert result["external_transport_policy"]["reason"] == "external-stop"
+    assert len(calls) == 0


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
