### PR TITLE
Document Codexify development map and job intelligence layer contracts

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -76,6 +76,7 @@ Before generating architecture diagrams, read the [`KB Validity Matrix`](./kb-va
 ## Doc Map
 
 - [`00-current-state.md`](./00-current-state.md): live operational truth, current release/readiness interpretation, and short-horizon priorities.
+- [Codexify Development Map v1](./codexify-development-map-v1.md): visual current-state orientation map for subsystem boundaries, dependency edges, data spine, UI/runtime separation, and development maturity posture. It is not a release promise and does not override `00-current-state.md`.
 - [Architecture Atlas](./architecture-atlas.md): peer-facing reading guide for the validated architecture corpus, runtime diagrams, and UI diagrams.
 - [Agent Protocol Operations Index](./agent-protocol-operations.md): agent-facing map for task rituals, campaign/task interpretation, architecture-impact workflow, validation expectations, and contingency behavior.
 - [Execution Ledger Gate Artifacts Contract](./execution-ledger-gate-artifacts-contract.md): docs-only follow-through contract for ADR-028 defining gate artifacts, acceptance-criteria mapping, implementation plans, and completion/proof evidence mapping onto Campaign Runner and Guardian execution surfaces.

--- a/docs/specs/job-intelligence-layer/11-prompt-and-pipeline-contract.md
+++ b/docs/specs/job-intelligence-layer/11-prompt-and-pipeline-contract.md
@@ -1,0 +1,280 @@
+# Prompt and Pipeline Contract
+
+This is a planning contract.
+It is not implemented.
+It does not create prompt files.
+It does not define model behavior, API behavior, worker behavior, UI behavior, persistence behavior, or canonical token behavior.
+It defines the intended decomposition of a future Job Intelligence Layer processing pipeline.
+
+## Purpose
+
+The future pipeline should transform raw intake text into a reviewable Job Profile draft through small, inspectable passes.
+
+The pipeline should prioritize:
+
+- preservation of raw customer language
+- explicit uncertainty
+- separation of stated facts from inferred fields
+- human review before operational use
+- lineage from source text to generated draft
+- portability across intake-heavy business verticals
+
+## Pipeline Shape
+
+```text
+source intake
+-> intake sanitation/preflight
+-> extraction pass
+-> classification pass
+-> ambiguity pass
+-> policy-question pass
+-> risk/safety pass
+-> draft assembly pass
+-> review-prep pass
+-> human review gate
+```
+
+This is a planning sequence only.
+No runtime processor exists.
+Future implementation may combine or split passes if proof requires it, but it must preserve the same reviewable semantics.
+
+## Pass Responsibilities
+
+### Intake sanitation/preflight
+
+- verifies input exists
+- strips no meaning-bearing content
+- identifies obvious empty or unusable input
+- does not redact or retain data because retention and redaction policy is deferred
+
+### Extraction pass
+
+- extracts directly stated facts
+- preserves raw descriptions
+- marks unknowns
+
+### Classification pass
+
+- proposes service vertical and category
+- includes confidence
+- avoids overstating uncertain details
+
+### Ambiguity pass
+
+- identifies contradictions, missing fields, and unclear statements
+- produces review recommendations
+
+### Policy-question pass
+
+- separates diagnostic fees, pricing, warranties, scheduling policy, and business-policy questions from job symptoms
+- avoids price commitments
+
+### Risk/safety pass
+
+- identifies factual reported risks
+- avoids stigmatizing language
+- avoids subjective customer labels
+
+### Draft assembly pass
+
+- assembles a Job Profile draft from prior pass outputs
+- preserves source and inference boundaries
+
+### Review-prep pass
+
+- highlights low-confidence fields, ambiguities, missing information, and fields needing explicit human attention
+
+## Conceptual Pipeline Input
+
+```json
+{
+  "interaction_id": "interaction_placeholder_001",
+  "source_channel": "phone",
+  "interaction_type": "service_call_transcript",
+  "source_text": "The tub faucet keeps dripping after all handles are turned off.",
+  "received_at": "2026-05-17T14:30:00Z",
+  "known_context": {
+    "business_vertical": "plumbing",
+    "existing_customer_id": "customer_placeholder_001",
+    "existing_site_id": "site_placeholder_001"
+  },
+  "operator_notes": "Customer asked about diagnostic fee and requested an afternoon window."
+}
+```
+
+This is not an API contract.
+This is not a schema.
+
+## Conceptual Pipeline Output
+
+```json
+{
+  "pipeline_run_id": "pipeline_run_placeholder_001",
+  "source_interaction_id": "interaction_placeholder_001",
+  "passes": {
+    "preflight": {
+      "status": "ok"
+    },
+    "extraction": {
+      "stated_facts": {
+        "raw_description": "The tub faucet keeps dripping after all handles are turned off."
+      }
+    },
+    "classification": {
+      "service_type": "plumbing",
+      "category": "fixture_leak",
+      "confidence": "medium"
+    },
+    "ambiguity": {
+      "items": [
+        "brand_unknown",
+        "exact_internal_failure_unknown"
+      ]
+    },
+    "policy_questions": {
+      "items": [
+        "diagnostic_fee",
+        "general_pricing_expectation"
+      ]
+    },
+    "risk_and_safety": {
+      "signals": []
+    },
+    "draft_assembly": {
+      "status": "assembled"
+    },
+    "review_prep": {
+      "requires_attention": true
+    }
+  },
+  "job_profile_draft": {
+    "status": "needs_review",
+    "source": {
+      "raw_description": "The tub faucet keeps dripping after all handles are turned off."
+    },
+    "request": {
+      "summary": "Reported tub fixture drip while off."
+    }
+  },
+  "review_packet": {
+    "requires_review": true,
+    "attention_fields": [
+      "classification.category",
+      "request.summary"
+    ],
+    "missing_information": [
+      "fixture_brand",
+      "exact_access_constraints"
+    ],
+    "low_confidence_fields": [
+      "classification.category"
+    ],
+    "policy_questions": [
+      "diagnostic_fee",
+      "general_pricing_expectation"
+    ],
+    "human_action_recommendation": "review_and_edit_before_confirmation"
+  },
+  "lineage": {
+    "source_interaction_id": "interaction_placeholder_001",
+    "extraction_reference": "extraction_placeholder_001",
+    "draft_reference": "job_profile_draft_placeholder_001"
+  },
+  "metadata": {
+    "created_at": "2026-05-17T14:31:00Z",
+    "planning_contract_version": "draft_v1"
+  }
+}
+```
+
+This is illustrative only.
+This is not canonical.
+This is not implemented.
+
+## Prompt Design Rules
+
+- prompts must be narrow and pass-specific
+- prompts must prefer `unknown` over guessing
+- prompts must not convert customer emotion into durable customer identity
+- prompts must not infer sensitive traits
+- prompts must not make pricing commitments
+- prompts must not make scheduling commitments
+- prompts must not claim dispatch has occurred
+- prompts must preserve policy questions separately
+- prompts must expose uncertainty for review
+- prompts must return structured output suitable for validation
+- prompts must be testable against synthetic scenarios before real customer data
+
+## Output Validation Expectations
+
+At planning level, future output validation should check:
+
+- required planning fields are present
+- raw description is preserved
+- inferred fields are marked separately from stated facts
+- confidence and uncertainty is present for inferred fields
+- missing information is visible
+- policy questions are not mixed into job symptoms
+- risk and safety flags are factual and non-stigmatizing
+- no subjective customer labels are generated
+- review is required before confirmation
+
+No validator is implemented by this document.
+No canonical schema is created by this document.
+
+## Failure and Degraded Output Handling
+
+Planning expectations:
+
+- empty input should fail closed as unusable
+- low-quality input should produce a partial draft plus review needs
+- contradictory input should produce ambiguity notes
+- model-invalid output should not become a Job Profile draft
+- if a pass fails, downstream assembly should not silently invent missing fields
+- failed or partial passes should remain visible in future proof surfaces
+
+## Provider and Model Boundary
+
+- no provider or model is selected by this contract
+- local vs cloud model boundary remains deferred
+- voice and transcription model selection remains deferred
+- latency requirements are not proven
+- future provider decisions must respect current Codexify local-first supported reality unless a separate architecture-impact task changes that posture
+
+## Relationship to Flow Builder
+
+- this pipeline resembles an elicitation and extraction workflow
+- future implementation may reuse or inform Flow Builder concepts
+- this document does not claim Flow Builder runtime support
+- any binding to Flow Builder must be a separate architecture-impact task
+
+## Non-Goals
+
+- no prompt files
+- no model selection
+- no prompt registry
+- no API route
+- no worker
+- no persistence model
+- no database migration
+- no UI implementation
+- no executable fixture
+- no automated test
+- no canonical JSON Schema
+- no canonical runtime tokens
+- no transcription consent policy
+- no retention and redaction policy
+- no pricing automation
+- no dispatch automation
+
+## Open Questions
+
+- Which pass should be implemented first for a proof?
+- Should the first proof use one prompt or multiple pass-specific prompts?
+- Should draft assembly be model-generated, deterministic, or hybrid?
+- Should validation occur after every pass or only after draft assembly?
+- Should extraction output map directly into Job Profile draft fields or through an intermediate normalized shape?
+- What synthetic fixture set is enough before using real examples?
+- What model and provider boundary is acceptable for a local-first proof?
+- Should this become a Flow Builder-compatible workflow later?
+- What proof justifies creating actual prompt files?

--- a/docs/specs/job-intelligence-layer/README.md
+++ b/docs/specs/job-intelligence-layer/README.md
@@ -19,6 +19,7 @@ Baseline orientation document:
 - [`08-human-review-gate-contract.md`](./08-human-review-gate-contract.md): Defines the planning boundary between generated draft data and future confirmed operational records.
 - [`09-lineage-and-revision-contract.md`](./09-lineage-and-revision-contract.md): Defines planning expectations for source traceability, revision history, confirmation lineage, and supersession relationships.
 - [`10-mvp-validation-scenario.md`](./10-mvp-validation-scenario.md): Defines the first synthetic MVP scenario and proof expectations before any implementation work begins.
+- [`11-prompt-and-pipeline-contract.md`](./11-prompt-and-pipeline-contract.md): Defines the planning decomposition for future pass-based prompt and processing pipeline behavior before runtime implementation.
 
 ## Do Not Assume
 


### PR DESCRIPTION
## Summary
- Added the Codexify Development Map v1 to the architecture KB entrypoint so the new visual current-state map is discoverable from the main architecture reading path.
- Updated the job intelligence layer docs to clarify the prompt and pipeline contract and keep the docs entrypoints aligned.
- Preserved the current-truth hierarchy: `00-current-state.md` remains the release-truth gate, and the development map stays an orientation artifact only.

## Testing
- `python3 scripts/validate_docs.py` passed.
- `git diff --check` passed.
- No automated runtime tests run; this is a docs-only change.