### PR TITLE
Add command-first Codex entry draft flow

### DIFF
--- a/docs/architecture/adr/029-codex-entry-command-first-draft-flow.md
+++ b/docs/architecture/adr/029-codex-entry-command-first-draft-flow.md
@@ -28,6 +28,8 @@ Users need a lightweight way to capture conversation highlights as structured Ma
    - `source_message_id` (or `source_message_ids` range) — the prior messages whose content fed the draft
    - `thread_id` is required; `project_id` and `persona_id` are nullable
 
+Slash aliases are exact command aliases only. They do not imply semantic detection, display-label aliasing, or automatic Codex Entry creation.
+
 ## Consequences
 
 - **Positive**: Chat-native, no new UI chrome, reuses existing codex infrastructure

--- a/docs/architecture/adr/029-codex-entry-command-first-draft-flow.md
+++ b/docs/architecture/adr/029-codex-entry-command-first-draft-flow.md
@@ -1,0 +1,58 @@
+# Codex Entry — Command-First Draft Flow
+
+**Status**: accepted  
+**Date**: 2026-05-18  
+**Deciders**: resonant-jones
+
+## Context
+
+Users need a lightweight way to capture conversation highlights as structured Markdown artifacts without breaking their chat flow. The artifact type already exists (`CodexEntry` / `.cdx` files), but creation required external tooling. This ADR defines a chat-native `/codex_entry` slash command that generates a transient draft card from the immediately preceding thread context, without persisting anything until the user explicitly saves.
+
+## Decision
+
+1. **`/codex_entry` is the trigger**, not a standalone button. No persistent global or page-level "Codex Entry" trigger button exists.
+
+2. **Draft body comes from prior thread context**, not from the command text itself. The `/codex_entry` message is recorded as `trigger_message_id` lineage; the prior message range is recorded as `source_message_ids`.
+
+3. **Draft is transient** — rendered as a `CodexDraftCard` in the chat conversation lane with three actions:
+   - **Save to Codex** — persists through `POST /api/codex/entries` with `createdFrom: slash_command` and `retrievalEnabled: false`
+   - **Download** — client-side Markdown export, no persistence
+   - **Dismiss** — clears the draft locally, no persistence
+
+4. **Save pipeline reuses the existing codex save seam** (`guardian/codex/service.py` → `save_codex_entry`). No new storage schema.
+
+5. **Retrieval is disabled by default** — enforced in the context broker through `retrieval_enabled: false` filtering. Codex entries are excluded from RAG results unless explicitly opted in.
+
+6. **Lineage preserves distinct trigger/source separation**:
+   - `trigger_message_id` — the message that invoked `/codex_entry`
+   - `source_message_id` (or `source_message_ids` range) — the prior messages whose content fed the draft
+   - `thread_id` is required; `project_id` and `persona_id` are nullable
+
+## Consequences
+
+- **Positive**: Chat-native, no new UI chrome, reuses existing codex infrastructure
+- **Positive**: Retrieval exclusion by default prevents codex entries from polluting RAG context without explicit opt-in
+- **Negative**: Draft generation is a separate API call after the `/codex_entry` message is sent (not a pure completion-side effect), adding one round-trip
+- **Neutral**: Semantic detection of "save-worthy" content is out of scope; the user must explicitly invoke the command
+
+## Implementation
+
+| Layer | Component | File |
+|-------|-----------|------|
+| Route | `POST /api/codex/entries` (save) | `guardian/routes/codex.py` |
+| Route | `POST /api/codex/entries/draft` (generate) | `guardian/routes/codex.py` |
+| Model | `CodexEntry` with trigger/source/retrieval fields | `guardian/codex/models.py` |
+| Service | `save_codex_entry()` | `guardian/codex/service.py` |
+| Broker | `_filter_codex_entries()` retrieval exclusion | `guardian/context/broker.py` |
+| Slash | `/codex_entry` (aliases: `/codex`, `/entry`, `/artifact`) | `frontend/src/contracts/slashCommands.ts` |
+| Card | `CodexDraftCard` (Save/Download/Dismiss) | `frontend/src/features/chat/components/CodexDraftCard.tsx` |
+| API | `generateCodexDraft()`, `saveCodexEntry()`, `downloadCodexDraftAsMarkdown()` | `frontend/src/api/codex.ts` |
+| Chat | Draft state + handlers in GuardianChat | `frontend/src/features/chat/GuardianChat.tsx` |
+| Chat | Card rendering in ChatView | `frontend/src/features/chat/ChatView.tsx` |
+| Composer | Generalized slash intent parsing | `frontend/src/features/chat/components/Composer.tsx` |
+
+## Related
+
+- Codex entry lineage contract: `guardian/codex/lineage.py`
+- Account export / restore contract: `docs/architecture/account-export-restore-contract.md`
+- Codexify API server: `guardian/server/codexify_api.py`

--- a/docs/architecture/adr/adr-index.md
+++ b/docs/architecture/adr/adr-index.md
@@ -64,6 +64,7 @@ Use this note as the local map for all ADRs.
 24. [[025-workspace-obsidian-selection-and-injection-contract|ADR-024 Workspace Obsidian Selection and Injection Contract]] — canonical contract for truthfully distinguishing workspace-local searchability, broker selection, completion-context injection, and assistant reflection for Obsidian-backed notes.
 25. [[026-graph-write-runtime-flag-boundary-on-supported-compose-path|ADR-026 Graph Write Runtime Flag Boundary on Supported Compose Path]] — repairs the default-off graph-write runtime boundary on the supported Docker Compose path so documented contract matches enforced behavior.
 26. [[028-execution-ledger-campaign-runner-contract|ADR-028 Execution Ledger Campaign Runner Contract]] — defines Execution Ledger as a governed Campaign Runner extension over goals, campaigns, work orders, attempts, and Guardian-owned lineage/evidence seams.
+27. [[029-codex-entry-command-first-draft-flow|ADR-029 Codex Entry Command-First Draft Flow]] — chat-native `/codex_entry` slash command that generates transient draft cards from prior context with Save/Download/Dismiss actions, reusing the existing codex save seam and enforcing default retrieval exclusion.
 
 ---
 
@@ -361,6 +362,14 @@ Primary companion notes:
   * [[self-extending-agent-plugin-system|Self-Extending Agent Plugin System]]
   * [[flows|Critical Flows]]
   * [[data-and-storage|Data and Storage]]
+  * [[00-current-state]]
+
+* [[029-codex-entry-command-first-draft-flow|ADR-029 Codex Entry Command-First Draft Flow]] links to:
+
+  * [[001-Queue-Based-Completion-Acceptance-Model|ADR-001 Queue-Based Completion Acceptance Model]]
+  * [[022-Guardian-Intent-Spine-and-Cross-Surface-Control-Plane|ADR-022 Guardian Intent Spine and Cross-Surface Control Plane]]
+  * [[account-export-restore-contract|Account Export + Restore Contract]]
+  * [[chat-runtime-contract|Chat Runtime Contract]]
   * [[00-current-state]]
 ---
 

--- a/frontend/src/api/codex.ts
+++ b/frontend/src/api/codex.ts
@@ -8,13 +8,72 @@ export type CodexEntrySummary = {
   created_at?: string;
   updated_at?: string;
   thread_id?: string;
+  source_thread_id?: string;
+  source_message_id?: string;
+  trigger_message_id?: string;
   author_id?: string;
   heat_score?: number;
+  created_from?: string;
+  retrieval_enabled?: boolean;
+  project_id?: string;
+  persona_id?: string;
 };
 
 export type CodexEntry = CodexEntrySummary & {
   body: string;
   message_ids?: string[];
+};
+
+export type CodexDraftLineage = {
+  thread_id: number;
+  trigger_message_id: number | null;
+  source_message_ids: number[];
+  first_source_message_id: number | null;
+  last_source_message_id: number | null;
+};
+
+export type CodexDraft = {
+  title: string;
+  body: string;
+  lineage: CodexDraftLineage;
+  source_summary: string;
+};
+
+export type CodexDraftResponse = {
+  ok: boolean;
+  draft: CodexDraft | null;
+  reason?: string;
+  detail?: string;
+};
+
+export type CodexSaveRequest = {
+  title: string;
+  body: string;
+  thread_id?: number | null;
+  source_thread_id?: number | null;
+  source_message_id?: number | null;
+  trigger_message_id?: number | null;
+  message_ids?: number[] | null;
+  author_id?: string | null;
+  created_from?: string | null;
+  retrieval_enabled?: boolean;
+  project_id?: number | null;
+  persona_id?: string | null;
+};
+
+export type CodexSaveResponse = {
+  ok: boolean;
+  entry: {
+    id: string;
+    title: string;
+    created_at?: string;
+    thread_id?: string;
+    source_thread_id?: string;
+    source_message_id?: string;
+    trigger_message_id?: string;
+    created_from?: string;
+    retrieval_enabled?: boolean;
+  };
 };
 
 export async function listCodexEntries(): Promise<CodexEntrySummary[]> {
@@ -41,10 +100,50 @@ export async function getCodexEntry(id: string): Promise<CodexEntry> {
   }
 }
 
+export async function generateCodexDraft(
+  threadId: number,
+  triggerMessageId?: number | null,
+): Promise<CodexDraftResponse> {
+  const res = await api.post<CodexDraftResponse>("/codex/entries/draft", {
+    thread_id: threadId,
+    trigger_message_id: triggerMessageId ?? null,
+  });
+  return res.data;
+}
+
+export async function saveCodexEntry(
+  payload: CodexSaveRequest,
+): Promise<CodexSaveResponse> {
+  const res = await api.post<CodexSaveResponse>("/codex/entries", payload);
+  return res.data;
+}
+
 export function getCodexExportUrl(id: string): string {
   const base = (ENV.apiBase || "").replace(/\/+$/, "");
   const path = `/codex/entries/${id}/export`;
   if (!base) return path;
   const needsSlash = !path.startsWith("/");
   return `${base}${needsSlash ? "/" : ""}${path}`;
+}
+
+export function downloadCodexDraftAsMarkdown(draft: CodexDraft): void {
+  const frontmatter = [
+    "---",
+    `title: ${draft.title}`,
+    `thread_id: ${draft.lineage.thread_id}`,
+    `created_from: slash_command`,
+    `retrieval_enabled: false`,
+    "---",
+    "",
+  ].join("\n");
+  const content = `${frontmatter}\n${draft.body}`;
+  const blob = new Blob([content], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `${draft.title.replace(/[^a-zA-Z0-9]+/g, "-").toLowerCase() || "codex-entry"}.md`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
 }

--- a/frontend/src/contracts/slashCommands.ts
+++ b/frontend/src/contracts/slashCommands.ts
@@ -8,6 +8,7 @@ export type SlashCommandId =
   | "secure"
   | "connect"
   | "obsidian"
+  | "codex_entry"
   | "help";
 
 export type SlashCommandIntentKind =
@@ -17,6 +18,7 @@ export type SlashCommandIntentKind =
   | "automation"
   | "security"
   | "integration"
+  | "codex"
   | "help";
 
 export type SlashCommandRetrievalHint =
@@ -146,6 +148,18 @@ export const SLASH_COMMANDS = [
     scaffold: "/obsidian",
     effects: {
       intentKind: "integration",
+      retrievalHint: "none",
+    },
+  },
+  {
+    id: "codex_entry",
+    label: "Codex Entry",
+    description: "Generate a Codex Entry draft from the conversation.",
+    aliases: ["codex", "entry", "artifact"],
+    keywords: ["save", "draft", "note", "capture", "preserve"],
+    scaffold: "/codex_entry",
+    effects: {
+      intentKind: "codex",
       retrievalHint: "none",
     },
   },

--- a/frontend/src/features/chat/ChatView.tsx
+++ b/frontend/src/features/chat/ChatView.tsx
@@ -22,6 +22,8 @@ import type {
   StreamingDraft,
 } from "@/features/chat/useChat";
 import api from "@/lib/api";
+import { CodexDraftCard } from "@/features/chat/components/CodexDraftCard";
+import type { CodexDraft } from "@/api/codex";
 import { cn } from "@/lib/utils";
 import { parseDocumentContextContent } from "@/lib/documentContext";
 import { useMobileShellProfile } from "@/components/persona/layout/mobileShellProfile";
@@ -237,6 +239,10 @@ export function ChatView({
   streamingDraft = null,
   onCancelInference,
   onSwitchToFast,
+  codexDraft = null,
+  onCodexDraftSave,
+  onCodexDraftDownload,
+  onCodexDraftDismiss,
 }: {
   threadId: number;
   guardianName?: string;
@@ -262,6 +268,10 @@ export function ChatView({
   streamingDraft?: StreamingDraft | null;
   onCancelInference?: () => void;
   onSwitchToFast?: () => void;
+  codexDraft?: CodexDraft | null;
+  onCodexDraftSave?: (draft: CodexDraft) => void | Promise<void>;
+  onCodexDraftDownload?: (draft: CodexDraft) => void;
+  onCodexDraftDismiss?: () => void;
 }) {
   const { containerRef, endRef } = useChatAutoScroll(messages.length);
   const initialScrollRef = useRef(true);
@@ -957,6 +967,15 @@ export function ChatView({
               </div>
             );
           })}
+
+          {codexDraft && onCodexDraftSave && onCodexDraftDownload && onCodexDraftDismiss ? (
+            <CodexDraftCard
+              draft={codexDraft}
+              onSave={onCodexDraftSave}
+              onDownload={onCodexDraftDownload}
+              onDismiss={onCodexDraftDismiss}
+            />
+          ) : null}
 
           {showStreamingDraft ? (
             <div

--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -59,6 +59,12 @@ import {
   getMobileTouchTargetStyle,
 } from "@/components/persona/layout/mobileMotionContract";
 import { useMobileGestureState } from "@/hooks/useMobileGestureState";
+import {
+  generateCodexDraft,
+  saveCodexEntry,
+  downloadCodexDraftAsMarkdown,
+  type CodexDraft,
+} from "@/api/codex";
 import { setTrace } from "@/state/contextTrace";
 import PromptCostIndicator from "./components/PromptCostIndicator";
 import RAGTracePanel from "./panels/RAGTracePanel";
@@ -948,6 +954,7 @@ export function GuardianChat({
   const [chatReloadVersion, setChatReloadVersion] = useState(0);
   const [composerShellReserve, setComposerShellReserve] = useState(160);
   const [threadTitle, setThreadTitle] = useState<string>(activeThread?.title ?? NEW_THREAD_TITLE);
+  const [codexDraft, setCodexDraft] = useState<CodexDraft | null>(null);
   const voiceFileInputRef = useRef<HTMLInputElement | null>(null);
   const composerShellRef = useRef<HTMLDivElement | null>(null);
   const [voiceUploading, setVoiceUploading] = useState(false);
@@ -1833,6 +1840,11 @@ export function GuardianChat({
 
   useEffect(() => {
     effectiveThreadIdRef.current = effectiveThreadId;
+  }, [effectiveThreadId]);
+
+  // Clear codex draft on thread change
+  useEffect(() => {
+    setCodexDraft(null);
   }, [effectiveThreadId]);
 
   useEffect(() => {
@@ -3013,6 +3025,50 @@ export function GuardianChat({
     []
   );
 
+  // Codex Entry draft flow — bound to the active thread.
+  const handleCodexDraftRequest = useCallback(
+    async (threadId: number, triggerMessageId?: number | null) => {
+      setCodexDraft(null); // clear any prior draft
+      try {
+        const response = await generateCodexDraft(threadId, triggerMessageId);
+        if (response.ok && response.draft) {
+          setCodexDraft(response.draft);
+        }
+      } catch (err) {
+        console.warn("[codex] draft generation failed", err);
+      }
+    },
+    [],
+  );
+
+  const handleCodexDraftSave = useCallback(
+    async (draft: CodexDraft) => {
+      await saveCodexEntry({
+        title: draft.title,
+        body: draft.body,
+        thread_id: draft.lineage.thread_id,
+        source_thread_id: draft.lineage.thread_id,
+        source_message_id: draft.lineage.last_source_message_id,
+        trigger_message_id: draft.lineage.trigger_message_id,
+        message_ids: draft.lineage.source_message_ids,
+        created_from: "slash_command",
+        retrieval_enabled: false,
+      });
+    },
+    [],
+  );
+
+  const handleCodexDraftDownload = useCallback(
+    (draft: CodexDraft) => {
+      downloadCodexDraftAsMarkdown(draft);
+    },
+    [],
+  );
+
+  const handleCodexDraftDismiss = useCallback(() => {
+    setCodexDraft(null);
+  }, []);
+
   // Enhanced send handler with auto-thread creation
   const handleSendMessage = async (
     text: string,
@@ -3151,6 +3207,12 @@ export function GuardianChat({
 
         // Complete the thread and refresh.
         startInferenceForThread(createdThreadId);
+
+        // Detect codex_entry command and request a draft
+        if (options?.slashIntent?.commandId === "codex_entry") {
+          void handleCodexDraftRequest(createdThreadId);
+        }
+
         const completionOutcome = await completeThread(createdThreadId, options);
         if (completionOutcome !== "ok" && completionOutcome !== "inflight") {
           setTurnLockForThread(createdThreadId, false);
@@ -3198,6 +3260,12 @@ export function GuardianChat({
 
         // Fire-and-forget completion a beat later so the just-sent message is persisted
         startInferenceForThread(targetThreadId);
+
+        // Detect codex_entry command and request a draft
+        if (options?.slashIntent?.commandId === "codex_entry") {
+          void handleCodexDraftRequest(targetThreadId);
+        }
+
         setTimeout(() => {
           if (targetThreadId == null) return;
           void (async () => {
@@ -3870,6 +3938,10 @@ export function GuardianChat({
               streamingDraft={streamingDraft}
               onCancelInference={handleCancelInference}
               onSwitchToFast={handleSwitchToNoThink}
+              codexDraft={codexDraft}
+              onCodexDraftSave={handleCodexDraftSave}
+              onCodexDraftDownload={handleCodexDraftDownload}
+              onCodexDraftDismiss={handleCodexDraftDismiss}
             />
           </div>
         ) : (

--- a/frontend/src/features/chat/components/CodexDraftCard.tsx
+++ b/frontend/src/features/chat/components/CodexDraftCard.tsx
@@ -1,0 +1,219 @@
+/**
+ * CodexDraftCard
+ *
+ * Transient card rendered inline in the chat conversation lane when a
+ * /codex_entry command produces a draft.  The card shows a label,
+ * preview, source summary, and three actions:
+ *
+ *  - Save to Codex  → persists through POST /api/codex/entries
+ *  - Download       → client-side Markdown export (no save)
+ *  - Dismiss        → clears the draft locally (no save)
+ */
+import {
+  BookOpen,
+  Download,
+  FileText,
+  Save,
+  X,
+} from "lucide-react";
+import React, { useCallback, useState } from "react";
+
+import type { CodexDraft } from "@/api/codex";
+
+export type CodexDraftCardAction = "save" | "download" | "dismiss";
+
+export type CodexDraftCardProps = {
+  draft: CodexDraft;
+  onSave: (draft: CodexDraft) => void | Promise<void>;
+  onDownload: (draft: CodexDraft) => void;
+  onDismiss: () => void;
+};
+
+const PREVIEW_MAX_CHARS = 280;
+
+function truncatePreview(body: string, maxChars: number): string {
+  const cleaned = body.replace(/^#+\s+/gm, "").trim();
+  if (cleaned.length <= maxChars) return cleaned;
+  return cleaned.slice(0, maxChars).replace(/\s+\S*$/, "") + "…";
+}
+
+export function CodexDraftCard({
+  draft,
+  onSave,
+  onDownload,
+  onDismiss,
+}: CodexDraftCardProps) {
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  const handleSave = useCallback(async () => {
+    if (saving || saved) return;
+    setSaving(true);
+    try {
+      await onSave(draft);
+      setSaved(true);
+    } finally {
+      setSaving(false);
+    }
+  }, [draft, onSave, saved, saving]);
+
+  const handleDownload = useCallback(() => {
+    onDownload(draft);
+  }, [draft, onDownload]);
+
+  return (
+    <div
+      data-testid="codex-draft-card"
+      className="w-full flex justify-start min-w-0"
+    >
+      <div
+        className="max-w-[min(38rem,calc(100%-1rem))] min-w-0 rounded-[22px] border shadow-sm overflow-hidden"
+        style={{
+          background:
+            "color-mix(in oklab, var(--panel-sheet, var(--panel-bg)) 82%, transparent)",
+          borderColor: "var(--panel-border)",
+          color: "var(--text)",
+        }}
+      >
+        {/* Header */}
+        <div className="flex items-center gap-2 px-4 pt-3 pb-2">
+          <BookOpen
+            className="h-4 w-4 shrink-0"
+            style={{ color: "var(--accent, rgb(99 102 241))" }}
+            aria-hidden="true"
+          />
+          <span className="text-sm font-semibold tracking-tight">
+            Codex Entry
+          </span>
+          <span
+            className="text-xs px-2 py-0.5 rounded-full"
+            style={{
+              background:
+                "color-mix(in oklab, var(--accent, rgb(99 102 241)) 20%, transparent)",
+              color: "var(--accent, rgb(99 102 241))",
+            }}
+          >
+            Draft
+          </span>
+          {saved ? (
+            <span
+              className="text-xs px-2 py-0.5 rounded-full ml-auto"
+              style={{
+                background:
+                  "color-mix(in oklab, rgb(34 197 94) 18%, transparent)",
+                color: "rgb(34 197 94)",
+              }}
+            >
+              Saved
+            </span>
+          ) : null}
+        </div>
+
+        {/* Title */}
+        <div className="px-4 pb-1">
+          <h3 className="text-base font-medium leading-snug truncate">
+            {draft.title || "Codex Entry"}
+          </h3>
+        </div>
+
+        {/* Preview */}
+        <div className="px-4 pb-1">
+          <p
+            className="text-sm leading-relaxed line-clamp-3"
+            style={{ color: "var(--muted)" }}
+          >
+            {truncatePreview(draft.body, PREVIEW_MAX_CHARS)}
+          </p>
+        </div>
+
+        {/* Source summary */}
+        <div className="px-4 pb-2">
+          <div className="flex items-center gap-1.5">
+            <FileText
+              className="h-3 w-3 shrink-0"
+              style={{ color: "var(--muted)" }}
+              aria-hidden="true"
+            />
+            <span
+              className="text-xs"
+              style={{ color: "var(--muted)" }}
+            >
+              {draft.source_summary}
+            </span>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div
+          className="flex items-center gap-1 px-3 py-2 border-t"
+          style={{ borderColor: "var(--panel-border)" }}
+        >
+          <button
+            type="button"
+            data-testid="codex-draft-save"
+            disabled={saving || saved}
+            onClick={handleSave}
+            className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50"
+            style={{
+              background:
+                "color-mix(in oklab, var(--accent, rgb(99 102 241)) 16%, transparent)",
+              color: "var(--accent, rgb(99 102 241))",
+            }}
+          >
+            {saving ? (
+              <>
+                <span
+                  className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent"
+                  aria-hidden="true"
+                />
+                Saving…
+              </>
+            ) : saved ? (
+              <>
+                <Save className="h-3.5 w-3.5" aria-hidden="true" />
+                Saved
+              </>
+            ) : (
+              <>
+                <Save className="h-3.5 w-3.5" aria-hidden="true" />
+                Save to Codex
+              </>
+            )}
+          </button>
+
+          <button
+            type="button"
+            data-testid="codex-draft-download"
+            onClick={handleDownload}
+            className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-colors"
+            style={{
+              background:
+                "color-mix(in oklab, var(--panel-bg) 60%, transparent)",
+              color: "var(--text)",
+            }}
+          >
+            <Download className="h-3.5 w-3.5" aria-hidden="true" />
+            Download
+          </button>
+
+          <button
+            type="button"
+            data-testid="codex-draft-dismiss"
+            onClick={onDismiss}
+            className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-colors ml-auto"
+            style={{
+              background:
+                "color-mix(in oklab, var(--panel-bg) 60%, transparent)",
+              color: "var(--muted)",
+            }}
+          >
+            <X className="h-3.5 w-3.5" aria-hidden="true" />
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CodexDraftCard;

--- a/frontend/src/features/chat/components/Composer.tsx
+++ b/frontend/src/features/chat/components/Composer.tsx
@@ -80,17 +80,17 @@ const autosizeComposerTextarea = (el: HTMLTextAreaElement) => {
 export type ComposerSendOptions = {
   threadIdOverride?: number;
   slashIntent?: {
-    commandId: "obsidian";
-    rawToken: string;
-    queryText: string;
-    intentKind: "knowledge";
-    retrievalHint: "personal_knowledge";
+    commandId: string;
+    rawToken?: string;
+    queryText?: string;
+    intentKind: string;
+    retrievalHint?: string;
     rawInput: string;
-    contextDirectives: Array<{
-      kind: "connector_context";
-      connectorId: "obsidian";
-      invocation: "turn_scoped";
-      queryText: string;
+    contextDirectives?: Array<{
+      kind: string;
+      connectorId?: string;
+      invocation?: string;
+      queryText?: string;
     }>;
   };
 };
@@ -405,28 +405,45 @@ export function Composer({
     return lines.join("\n\n").trim();
   };
 
-  const parseObsidianSlashIntent = (rawValue: string): ComposerSendOptions["slashIntent"] | undefined => {
+  const parseSlashIntent = (rawValue: string): ComposerSendOptions["slashIntent"] | undefined => {
     const rawInput = rawValue.trim();
-    const match = rawInput.match(/^\/obsidian(?:\s+([\s\S]*))?$/i);
-    if (!match) return undefined;
-    const queryText = String(match[1] || "").trim();
-    if (!queryText) return undefined;
-    return {
-      commandId: "obsidian",
-      rawToken: "/obsidian",
-      queryText,
-      intentKind: "knowledge",
-      retrievalHint: "personal_knowledge",
-      rawInput,
-      contextDirectives: [
-        {
-          kind: "connector_context",
-          connectorId: "obsidian",
-          invocation: "turn_scoped",
-          queryText,
-        },
-      ],
-    };
+
+    // Obsidian: /obsidian <query>
+    const obsidianMatch = rawInput.match(/^\/obsidian(?:\s+([\s\S]*))?$/i);
+    if (obsidianMatch) {
+      const queryText = String(obsidianMatch[1] || "").trim();
+      if (!queryText) return undefined;
+      return {
+        commandId: "obsidian",
+        rawToken: "/obsidian",
+        queryText,
+        intentKind: "knowledge",
+        retrievalHint: "personal_knowledge",
+        rawInput,
+        contextDirectives: [
+          {
+            kind: "connector_context",
+            connectorId: "obsidian",
+            invocation: "turn_scoped",
+            queryText,
+          },
+        ],
+      };
+    }
+
+    // Codex Entry: /codex_entry (or aliases /codex, /entry, /artifact)
+    const codexMatch = rawInput.match(/^\/(codex_entry|codex|entry|artifact)(?:\s.*)?$/i);
+    if (codexMatch) {
+      return {
+        commandId: "codex_entry",
+        rawToken: `/${codexMatch[1].toLowerCase()}`,
+        intentKind: "codex",
+        retrievalHint: "none",
+        rawInput,
+      };
+    }
+
+    return undefined;
   };
 
   const resolveProjectId = () => {
@@ -540,7 +557,7 @@ export function Composer({
       return;
     }
 
-    const slashIntent = parseObsidianSlashIntent(value);
+    const slashIntent = parseSlashIntent(value);
     const bodyText = slashIntent?.queryText ?? value.trim();
     const hasAttachments = draftAttachments.length > 0;
     if (!bodyText && !hasAttachments) return;

--- a/guardian/codex/models.py
+++ b/guardian/codex/models.py
@@ -19,9 +19,14 @@ class CodexEntry:
     thread_id: str | None = None
     source_thread_id: str | None = None
     source_message_id: str | None = None
+    trigger_message_id: str | None = None
     message_ids: list[str] = field(default_factory=list)
     lineage_missing: bool = False
     author_id: str | None = None
     heat_score: float | None = None
     body: str | None = None
     frontmatter: dict = field(default_factory=dict)
+    created_from: str | None = None
+    retrieval_enabled: bool = False
+    project_id: str | None = None
+    persona_id: str | None = None

--- a/guardian/codex/service.py
+++ b/guardian/codex/service.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import hashlib
 import os
+import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable, List, Optional, Tuple
+from typing import Any, Iterable, List, Optional, Tuple
 
 import yaml
 
@@ -77,6 +78,17 @@ def _entry_id(path: Path) -> str:
     return f"{base}_{digest}"
 
 
+def _coerce_bool_fm(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    normalized = str(value).strip().lower()
+    return normalized in {"1", "true", "yes", "y"}
+
+
 def _parse_entry(path: Path, include_body: bool = False) -> CodexEntry:
     raw_text = path.read_text(encoding="utf-8")
     fm, body = _split_frontmatter(raw_text)
@@ -101,10 +113,13 @@ def _parse_entry(path: Path, include_body: bool = False) -> CodexEntry:
         or fm.get("message_id")
         or (message_ids[0] if message_ids else None)
     )
+    trigger_message_id = fm.get("trigger_message_id")
     lineage_missing = source_thread_id in (None, "") or source_message_id in (
         None,
         "",
     )
+
+    retrieval_enabled_raw = _coerce_bool_fm(fm.get("retrieval_enabled"))
 
     entry = CodexEntry(
         id=fm.get("id") or _entry_id(path),
@@ -126,6 +141,11 @@ def _parse_entry(path: Path, include_body: bool = False) -> CodexEntry:
             if source_message_id not in (None, "")
             else None
         ),
+        trigger_message_id=(
+            str(trigger_message_id)
+            if trigger_message_id not in (None, "")
+            else None
+        ),
         message_ids=message_ids,
         lineage_missing=lineage_missing,
         author_id=fm.get("author"),
@@ -136,6 +156,12 @@ def _parse_entry(path: Path, include_body: bool = False) -> CodexEntry:
         ),
         frontmatter=fm,
         body=body if include_body else None,
+        created_from=fm.get("created_from"),
+        retrieval_enabled=(
+            retrieval_enabled_raw if retrieval_enabled_raw is not None else False
+        ),
+        project_id=fm.get("project_id"),
+        persona_id=fm.get("persona_id"),
     )
     return entry
 
@@ -188,3 +214,82 @@ def read_raw_entry(entry_id: str) -> tuple[CodexEntry, str]:
     content = path.read_text(encoding="utf-8")
     entry = _parse_entry(path, include_body=True)
     return entry, content
+
+
+def _build_frontmatter_block(fm: dict) -> str:
+    """Serialize a frontmatter dict to a YAML block with --- delimiters."""
+    if not fm:
+        return ""
+    dumped = yaml.dump(fm, default_flow_style=False, allow_unicode=True, sort_keys=False)
+    return f"---\n{dumped}---\n"
+
+
+def save_codex_entry(
+    *,
+    title: str,
+    body: str,
+    thread_id: str | None = None,
+    source_thread_id: str | None = None,
+    source_message_id: str | None = None,
+    trigger_message_id: str | None = None,
+    message_ids: list[str] | None = None,
+    author_id: str | None = None,
+    created_from: str | None = None,
+    retrieval_enabled: bool = False,
+    project_id: str | None = None,
+    persona_id: str | None = None,
+    heat_score: float | None = None,
+    entry_id: str | None = None,
+) -> CodexEntry:
+    """Persist a new Codex Entry as a .cdx file on disk.
+
+    Returns the parsed CodexEntry after saving.
+    """
+    root = _ensure_root()
+    now = datetime.now(timezone.utc)
+    now_iso = now.isoformat()
+
+    # Build frontmatter
+    fm: dict[str, Any] = {}
+    if title:
+        fm["title"] = title
+    fm["created_at"] = now_iso
+    fm["updated_at"] = now_iso
+    if thread_id:
+        fm["thread_id"] = str(thread_id)
+    if source_thread_id:
+        fm["source_thread_id"] = str(source_thread_id)
+    if source_message_id:
+        fm["source_message_id"] = str(source_message_id)
+    if trigger_message_id:
+        fm["trigger_message_id"] = str(trigger_message_id)
+    if message_ids:
+        fm["message_ids"] = [str(m) for m in message_ids if m]
+    if author_id:
+        fm["author"] = str(author_id)
+    if created_from:
+        fm["created_from"] = str(created_from)
+    fm["retrieval_enabled"] = bool(retrieval_enabled)
+    if project_id:
+        fm["project_id"] = str(project_id)
+    if persona_id:
+        fm["persona_id"] = str(persona_id)
+    if heat_score is not None:
+        fm["heat_score"] = float(heat_score)
+
+    # Derive a stable filename
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", title).strip("-").lower() or "codex-entry"
+    timestamp = now.strftime("%Y%m%d-%H%M%S")
+    filename = f"{slug}-{timestamp}.cdx"
+    filepath = root / filename
+
+    # If an explicit entry_id is provided, inject it
+    if entry_id:
+        fm["id"] = str(entry_id)
+
+    # Assemble and write
+    frontmatter_block = _build_frontmatter_block(fm)
+    content = f"{frontmatter_block}\n{body}\n"
+    filepath.write_text(content, encoding="utf-8")
+
+    return _parse_entry(filepath, include_body=True)

--- a/guardian/context/broker.py
+++ b/guardian/context/broker.py
@@ -1253,6 +1253,9 @@ class ContextBroker:
                 0,
                 "skipped",
             )
+            context["obsidian"] = self._filter_codex_entries(
+                context.get("obsidian", [])
+            )
             return context, rag_trace
         if normalized_depth != "shallow" and self.always_search_thread_first:
             try:
@@ -1802,6 +1805,20 @@ class ContextBroker:
             )
         except Exception:
             pass
+
+        # Apply codex entry retrieval exclusion before returning
+        context["semantic"] = self._filter_codex_entries(
+            context.get("semantic", [])
+        )
+        context["obsidian"] = self._filter_codex_entries(
+            context.get("obsidian", [])
+        )
+        if isinstance(context.get("docs"), dict):
+            context["docs"] = self._filter_codex_from_doc_buckets(context["docs"])
+        if "memory" in context:
+            context["memory"] = self._filter_codex_entries(
+                context.get("memory", [])
+            )
 
         return context, rag_trace
 
@@ -2480,6 +2497,52 @@ class ContextBroker:
         }:
             return 0
         return 1
+
+    @staticmethod
+    def _filter_codex_entries(
+        items: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Filter out codex entries with retrieval disabled.
+
+        Codex entries are excluded from retrieval by default unless
+        explicitly opted in via ``retrieval_enabled: true`` in their
+        frontmatter. This filter checks both top-level and nested
+        metadata fields.
+        """
+        filtered: list[dict[str, Any]] = []
+        for item in items:
+            if not isinstance(item, dict):
+                filtered.append(item)
+                continue
+
+            source_type = str(item.get("source_type") or "").strip().lower()
+            if source_type == "codex_entry":
+                retrieval_enabled = item.get("retrieval_enabled")
+                metadata = item.get("metadata")
+                if isinstance(metadata, dict):
+                    if retrieval_enabled is None:
+                        retrieval_enabled = metadata.get("retrieval_enabled")
+                if retrieval_enabled is not True:
+                    continue
+
+            doc_type = str(item.get("type") or "").strip().lower()
+            if doc_type == "codex_entry":
+                retrieval_enabled = item.get("retrieval_enabled")
+                if retrieval_enabled is not True:
+                    continue
+
+            filtered.append(item)
+        return filtered
+
+    @staticmethod
+    def _filter_codex_from_doc_buckets(
+        docs: Dict[str, List[Dict[str, Any]]],
+    ) -> Dict[str, List[Dict[str, Any]]]:
+        """Apply codex entry filtering across all doc buckets."""
+        return {
+            key: ContextBroker._filter_codex_entries(value)
+            for key, value in docs.items()
+        }
 
     @classmethod
     def _sort_retrieval_items(

--- a/guardian/routes/codex.py
+++ b/guardian/routes/codex.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi import APIRouter, Body, Depends, HTTPException, Response
+from pydantic import BaseModel, Field
 
 from guardian.codex.lineage import ensure_lineage_exists, parse_lineage
 from guardian.codex.service import (
@@ -11,6 +12,7 @@ from guardian.codex.service import (
     load_codex_entry,
     read_codex_body,
     read_raw_entry,
+    save_codex_entry,
 )
 
 try:
@@ -51,9 +53,14 @@ def _summary_payload(entry) -> dict:
         "thread_id": entry.thread_id,
         "source_thread_id": entry.source_thread_id,
         "source_message_id": entry.source_message_id,
+        "trigger_message_id": entry.trigger_message_id,
         "lineage_missing": entry.lineage_missing,
         "author_id": entry.author_id,
         "heat_score": entry.heat_score,
+        "created_from": entry.created_from,
+        "retrieval_enabled": entry.retrieval_enabled,
+        "project_id": entry.project_id,
+        "persona_id": entry.persona_id,
     }
 
 
@@ -206,3 +213,222 @@ async def export_codex_entry(
         "Content-Type": "text/markdown; charset=utf-8",
     }
     return Response(content=raw, media_type="text/markdown", headers=headers)
+
+
+# ---------------------------------------------------------------------------
+# Save and Draft endpoints
+# ---------------------------------------------------------------------------
+
+class CodexEntrySaveRequest(BaseModel):
+    title: str
+    body: str
+    thread_id: int | None = None
+    source_thread_id: int | None = None
+    source_message_id: int | None = None
+    trigger_message_id: int | None = None
+    message_ids: list[int] | None = None
+    author_id: str | None = None
+    created_from: str | None = None
+    retrieval_enabled: bool = False
+    project_id: int | None = None
+    persona_id: str | None = None
+
+
+class CodexDraftRequest(BaseModel):
+    thread_id: int
+    trigger_message_id: int | None = None
+
+
+@router.post("/api/codex/entries", tags=["codex"])
+async def save_codex_entry_route(
+    body: CodexEntrySaveRequest,
+    api_key: str = Depends(require_api_key),
+) -> dict:
+    """Persist a Codex Entry artifact."""
+    _ = api_key
+    try:
+        entry = save_codex_entry(
+            title=body.title,
+            body=body.body,
+            thread_id=str(body.thread_id) if body.thread_id else None,
+            source_thread_id=str(body.source_thread_id) if body.source_thread_id else None,
+            source_message_id=str(body.source_message_id) if body.source_message_id else None,
+            trigger_message_id=str(body.trigger_message_id) if body.trigger_message_id else None,
+            message_ids=[str(m) for m in body.message_ids] if body.message_ids else None,
+            author_id=body.author_id,
+            created_from=body.created_from or "slash_command",
+            retrieval_enabled=body.retrieval_enabled,
+            project_id=str(body.project_id) if body.project_id else None,
+            persona_id=body.persona_id,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return {
+        "ok": True,
+        "entry": {
+            "id": entry.id,
+            "title": entry.title,
+            "created_at": _iso(entry.created_at),
+            "thread_id": entry.thread_id,
+            "source_thread_id": entry.source_thread_id,
+            "source_message_id": entry.source_message_id,
+            "trigger_message_id": entry.trigger_message_id,
+            "created_from": entry.created_from,
+            "retrieval_enabled": entry.retrieval_enabled,
+        },
+    }
+
+
+@router.post("/api/codex/entries/draft", tags=["codex"])
+async def generate_codex_draft(
+    body: CodexDraftRequest,
+    api_key: str = Depends(require_api_key),
+) -> dict:
+    """Generate a Codex Entry draft from prior thread context.
+
+    The draft body is derived from the preceding messages in the thread
+    window, not from the command text itself.  The trigger_message_id
+    records which message invoked the command; source lineage records
+    the prior message(s) that fed the draft.
+    """
+    _ = api_key
+    thread_id = body.thread_id
+    trigger_message_id = body.trigger_message_id
+
+    if chatlog_db is None:
+        raise HTTPException(status_code=503, detail="Chat log backend unavailable")
+
+    # Fetch recent messages from the thread
+    try:
+        items = chatlog_db.list_messages(thread_id, limit=50, offset=0)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to fetch thread messages: {e}")
+
+    if not items:
+        return {
+            "ok": True,
+            "draft": None,
+            "reason": "no_context",
+            "detail": "Thread has no prior messages to draft from.",
+        }
+
+    # Sort by message id ascending
+    try:
+        items = sorted(items, key=lambda m: m.get("id") or 0)
+    except Exception:
+        pass
+
+    # Find the trigger message
+    trigger_idx: int | None = None
+    if trigger_message_id is not None:
+        for idx, item in enumerate(items):
+            mid = _coerce_thread_id(item.get("id"))
+            if mid == trigger_message_id:
+                trigger_idx = idx
+                break
+    elif items:
+        # If no trigger specified, the last message is the trigger
+        trigger_idx = len(items) - 1
+
+    if trigger_idx is None:
+        return {
+            "ok": True,
+            "draft": None,
+            "reason": "no_trigger",
+            "detail": "Could not locate the trigger message in thread history.",
+        }
+
+    # Source context: messages *before* the trigger, excluding the trigger
+    prior_items = items[:trigger_idx]
+    if not prior_items:
+        return {
+            "ok": True,
+            "draft": None,
+            "reason": "empty_source",
+            "detail": "No prior messages available to generate a draft from. "
+                       "Send at least one message before invoking /codex_entry.",
+        }
+
+    trigger_item = items[trigger_idx]
+    trigger_mid = _coerce_thread_id(trigger_item.get("id"))
+
+    # Collect source message IDs
+    source_message_ids: list[int] = []
+    source_bodies: list[str] = []
+    last_source_mid: int | None = None
+    for item in prior_items:
+        mid = _coerce_thread_id(item.get("id"))
+        content = item.get("content")
+        if mid is not None:
+            source_message_ids.append(mid)
+            last_source_mid = mid
+        if isinstance(content, str) and content.strip():
+            source_bodies.append(content.strip())
+
+    if not source_bodies:
+        return {
+            "ok": True,
+            "draft": None,
+            "reason": "empty_source",
+            "detail": "Prior messages contained no usable text content.",
+        }
+
+    # Build a simple draft title from the first source message
+    draft_title = _derive_draft_title(source_bodies[0])
+
+    # Assemble draft body from the prior context
+    draft_body = _assemble_draft_body(source_bodies)
+
+    # Derive first and last source message IDs for the range
+    first_source_mid = source_message_ids[0] if source_message_ids else last_source_mid
+
+    return {
+        "ok": True,
+        "draft": {
+            "title": draft_title,
+            "body": draft_body,
+            "lineage": {
+                "thread_id": thread_id,
+                "trigger_message_id": trigger_mid,
+                "source_message_ids": source_message_ids,
+                "first_source_message_id": first_source_mid,
+                "last_source_message_id": last_source_mid,
+            },
+            "source_summary": _derive_source_summary(prior_items),
+        },
+    }
+
+
+def _derive_draft_title(first_body: str) -> str:
+    """Derive a short draft title from the first source message body."""
+    cleaned = first_body[:120].strip().replace("\n", " ")
+    # Remove leading slash commands
+    cleaned = re.sub(r"^/\S+\s*", "", cleaned)
+    if len(cleaned) > 80:
+        cleaned = cleaned[:77].rsplit(" ", 1)[0] + "..."
+    return cleaned or "Codex Entry"
+
+
+def _assemble_draft_body(source_bodies: list[str]) -> str:
+    """Assemble a markdown draft body from prior context messages."""
+    parts: list[str] = []
+    for idx, body_text in enumerate(source_bodies):
+        role = "user" if idx % 2 == 0 else "assistant"
+        label = "User" if role == "user" else "Assistant"
+        parts.append(f"## {label}\n\n{body_text}\n")
+    return "\n".join(parts)
+
+
+def _derive_source_summary(prior_items: list[dict]) -> str:
+    """Derive a short human-readable summary of the source context."""
+    roles: list[str] = []
+    for item in prior_items:
+        role = str(item.get("role") or "").strip().lower()
+        roles.append(role or "unknown")
+    user_count = roles.count("user")
+    assistant_count = roles.count("assistant")
+    return (
+        f"{len(prior_items)} messages "
+        f"({user_count} user, {assistant_count} assistant)"
+    )

--- a/tests/context/test_codex_entries_retrieval_policy.py
+++ b/tests/context/test_codex_entries_retrieval_policy.py
@@ -1,0 +1,115 @@
+"""Focused tests for Codex Entry retrieval exclusion policy."""
+
+from __future__ import annotations
+
+from guardian.context.broker import ContextBroker
+
+
+def test_codex_entries_with_retrieval_disabled_are_excluded():
+    items = [
+        {
+            "id": "codex-disabled",
+            "source_type": "codex_entry",
+            "retrieval_enabled": False,
+            "text": "Drafted Codex Entry",
+        },
+        {
+            "id": "codex-missing-flag",
+            "source_type": "codex_entry",
+            "metadata": {},
+            "text": "Legacy Codex Entry",
+        },
+        {
+            "id": "project-doc",
+            "source_type": "document",
+            "text": "Project Knowledge Base document",
+        },
+    ]
+
+    filtered = ContextBroker._filter_codex_entries(items)
+
+    assert [item["id"] for item in filtered] == ["project-doc"]
+
+
+def test_codex_entries_with_retrieval_enabled_are_not_excluded():
+    items = [
+        {
+            "id": "codex-enabled",
+            "source_type": "codex_entry",
+            "metadata": {"retrieval_enabled": True},
+            "text": "Opted-in Codex Entry",
+        },
+        {
+            "id": "ordinary-doc",
+            "type": "document",
+            "text": "Ordinary document",
+        },
+    ]
+
+    filtered = ContextBroker._filter_codex_entries(items)
+
+    assert [item["id"] for item in filtered] == [
+        "codex-enabled",
+        "ordinary-doc",
+    ]
+
+
+def test_non_codex_documents_are_not_filtered_by_codex_exclusion_rule():
+    items = [
+        {
+            "id": "pkb-doc",
+            "source_type": "document",
+            "metadata": {"document_scope": "project"},
+            "text": "Project Knowledge Base material",
+        },
+        {
+            "id": "thread-doc",
+            "type": "uploaded_document",
+            "text": "Thread-linked document",
+        },
+        {
+            "id": "semantic-hit",
+            "source_type": "semantic",
+            "text": "Non-Codex semantic hit",
+        },
+    ]
+
+    filtered = ContextBroker._filter_codex_entries(items)
+
+    assert filtered == items
+
+
+def test_doc_bucket_filter_preserves_non_codex_project_knowledge_boundary():
+    docs = {
+        "project": [
+            {
+                "id": "project-doc",
+                "source_type": "document",
+                "metadata": {"document_scope": "project"},
+            },
+            {
+                "id": "disabled-codex",
+                "source_type": "codex_entry",
+                "retrieval_enabled": False,
+            },
+        ],
+        "thread": [
+            {
+                "id": "thread-doc",
+                "type": "uploaded_document",
+            },
+            {
+                "id": "enabled-codex",
+                "type": "codex_entry",
+                "retrieval_enabled": True,
+            },
+        ],
+    }
+
+    filtered = ContextBroker._filter_codex_from_doc_buckets(docs)
+
+    assert [item["id"] for item in filtered["project"]] == ["project-doc"]
+    assert [item["id"] for item in filtered["thread"]] == [
+        "thread-doc",
+        "enabled-codex",
+    ]

--- a/tests/routes/test_codex_draft_routes.py
+++ b/tests/routes/test_codex_draft_routes.py
@@ -1,0 +1,339 @@
+"""Tests for the codex entry draft and save routes."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from guardian.codex import service as codex_service
+from guardian.codex.lineage import (
+    _set_session_factory as _set_lineage_session_factory,
+)
+from guardian.codex.lineage import (
+    reset_session_factory as reset_lineage_session_factory,
+)
+from guardian.routes import codex as codex_routes
+
+
+@pytest.fixture(autouse=True)
+def _reset_lineage_state():
+    reset_lineage_session_factory()
+    yield
+    reset_lineage_session_factory()
+
+
+def _seed_chatlog(
+    monkeypatch, tmp_path, *, thread_id: int, messages: list[dict]
+) -> None:
+    """Seed a SQLite-backed chatlog with thread and messages for testing."""
+    db_path = str(tmp_path / "chatlog.db")
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        future=True,
+        connect_args={"check_same_thread": False},
+    )
+    Session = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False, future=True
+    )
+    with Session() as session:
+        session.execute(
+            text("CREATE TABLE IF NOT EXISTS chat_threads (id INTEGER PRIMARY KEY)")
+        )
+        session.execute(
+            text(
+                """
+                CREATE TABLE IF NOT EXISTS chat_messages (
+                    id INTEGER PRIMARY KEY,
+                    thread_id INTEGER NOT NULL,
+                    role TEXT,
+                    content TEXT
+                )
+                """
+            )
+        )
+        session.execute(
+            text("INSERT INTO chat_threads (id) VALUES (:thread_id)"),
+            {"thread_id": thread_id},
+        )
+        for msg in messages:
+            session.execute(
+                text(
+                    "INSERT INTO chat_messages (id, thread_id, role, content) "
+                    "VALUES (:id, :thread_id, :role, :content)"
+                ),
+                {
+                    "id": msg["id"],
+                    "thread_id": thread_id,
+                    "role": msg.get("role", "user"),
+                    "content": msg.get("content", ""),
+                },
+            )
+        session.commit()
+
+    # Wire the chatlog db dependency
+    from guardian.codex import lineage as lineage_mod
+    _set_lineage_session_factory(Session)
+
+    # Create a simple mock chatlog_db
+    class MockChatlogDB:
+        def get_chat_thread(self, tid):
+            return {"id": tid, "user_id": "local"}
+
+        def list_messages(self, tid, limit=50, offset=0, **kwargs):
+            with Session() as s:
+                rows = s.execute(
+                    text(
+                        "SELECT id, thread_id, role, content "
+                        "FROM chat_messages WHERE thread_id = :tid "
+                        "ORDER BY id ASC LIMIT :limit OFFSET :offset"
+                    ),
+                    {"tid": tid, "limit": limit, "offset": offset},
+                ).fetchall()
+            return [
+                {"id": row[0], "thread_id": row[1], "role": row[2], "content": row[3]}
+                for row in rows
+            ]
+
+    monkeypatch.setattr(
+        codex_routes, "chatlog_db", MockChatlogDB()
+    )
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(codex_routes.router)
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Draft endpoint tests
+# ---------------------------------------------------------------------------
+
+def test_draft_returns_candidate(monkeypatch, tmp_path):
+    """POST /api/codex/entries/draft returns a draft from prior context."""
+    codex_root = tmp_path / "codex"
+    codex_root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(codex_service, "CODEX_ROOT", codex_root)
+
+    _seed_chatlog(
+        monkeypatch,
+        tmp_path,
+        thread_id=10,
+        messages=[
+            {"id": 1, "role": "user", "content": "What is decentralized AI?"},
+            {"id": 2, "role": "assistant", "content": "It's AI that runs on edge devices..."},
+            {"id": 3, "role": "user", "content": "/codex_entry"},
+        ],
+    )
+
+    client = TestClient(_make_app())
+    response = client.post("/api/codex/entries/draft", json={
+        "thread_id": 10,
+        "trigger_message_id": 3,
+    })
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["draft"] is not None
+    assert payload["draft"]["title"]
+    assert payload["draft"]["body"]
+    # The draft body should come from prior context, not the command
+    assert "What is decentralized AI?" in payload["draft"]["body"]
+    assert "/codex_entry" not in payload["draft"]["body"]
+    # Lineage should include source message ids
+    assert payload["draft"]["lineage"]["thread_id"] == 10
+    assert payload["draft"]["lineage"]["trigger_message_id"] == 3
+    assert 1 in payload["draft"]["lineage"]["source_message_ids"]
+    assert 2 in payload["draft"]["lineage"]["source_message_ids"]
+
+
+def test_draft_does_not_persist_entry(monkeypatch, tmp_path):
+    """The draft endpoint must NOT persist a Codex Entry."""
+    codex_root = tmp_path / "codex"
+    codex_root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(codex_service, "CODEX_ROOT", codex_root)
+
+    _seed_chatlog(
+        monkeypatch,
+        tmp_path,
+        thread_id=20,
+        messages=[
+            {"id": 10, "role": "user", "content": "Hello"},
+            {"id": 11, "role": "user", "content": "/codex_entry"},
+        ],
+    )
+
+    client = TestClient(_make_app())
+    response = client.post("/api/codex/entries/draft", json={
+        "thread_id": 20,
+        "trigger_message_id": 11,
+    })
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["draft"] is not None
+
+    # No .cdx files should have been created
+    cdx_files = list(codex_root.glob("**/*.cdx"))
+    assert len(cdx_files) == 0, f"Expected 0 .cdx files, found {cdx_files}"
+
+
+def test_draft_no_context_returns_empty(monkeypatch, tmp_path):
+    """When there's no prior context, draft returns null."""
+    codex_root = tmp_path / "codex"
+    codex_root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(codex_service, "CODEX_ROOT", codex_root)
+
+    _seed_chatlog(
+        monkeypatch,
+        tmp_path,
+        thread_id=30,
+        messages=[
+            {"id": 50, "role": "user", "content": "/codex_entry"},
+        ],
+    )
+
+    client = TestClient(_make_app())
+    response = client.post("/api/codex/entries/draft", json={
+        "thread_id": 30,
+        "trigger_message_id": 50,
+    })
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["draft"] is None
+    assert payload["reason"] == "empty_source"
+
+
+def test_draft_empty_thread_returns_no_context(monkeypatch, tmp_path):
+    """When thread has no messages at all, returns no_context."""
+    codex_root = tmp_path / "codex"
+    codex_root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(codex_service, "CODEX_ROOT", codex_root)
+
+    _seed_chatlog(
+        monkeypatch,
+        tmp_path,
+        thread_id=40,
+        messages=[],
+    )
+
+    client = TestClient(_make_app())
+    response = client.post("/api/codex/entries/draft", json={
+        "thread_id": 40,
+    })
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["draft"] is None
+    assert payload["reason"] == "no_context"
+
+
+# ---------------------------------------------------------------------------
+# Save endpoint tests
+# ---------------------------------------------------------------------------
+
+def test_save_persists_markdown(monkeypatch, tmp_path):
+    """POST /api/codex/entries persists a Codex Entry with frontmatter."""
+    codex_root = tmp_path / "codex"
+    codex_root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(codex_service, "CODEX_ROOT", codex_root)
+
+    client = TestClient(_make_app())
+    response = client.post("/api/codex/entries", json={
+        "title": "Test Entry",
+        "body": "# Hello\n\nThis is a test.",
+        "thread_id": 10,
+        "source_thread_id": 10,
+        "source_message_id": 2,
+        "trigger_message_id": 3,
+        "message_ids": [1, 2],
+        "created_from": "slash_command",
+        "retrieval_enabled": False,
+    })
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["entry"]["title"] == "Test Entry"
+    assert payload["entry"]["created_from"] == "slash_command"
+    assert payload["entry"]["retrieval_enabled"] is False
+    assert payload["entry"]["source_message_id"] == "2"
+    assert payload["entry"]["trigger_message_id"] == "3"
+
+    # Verify file exists on disk
+    cdx_files = list(codex_root.glob("**/*.cdx"))
+    assert len(cdx_files) == 1
+    content = cdx_files[0].read_text(encoding="utf-8")
+    assert "created_from: slash_command" in content
+    assert "retrieval_enabled: false" in content
+    assert "source_message_id: '2'" in content or "source_message_id: 2" in content
+    assert "trigger_message_id: '3'" in content or "trigger_message_id: 3" in content
+
+
+def test_save_persists_created_from(monkeypatch, tmp_path):
+    """Save payload carries createdFrom: slash_command in frontmatter."""
+    codex_root = tmp_path / "codex"
+    codex_root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(codex_service, "CODEX_ROOT", codex_root)
+
+    client = TestClient(_make_app())
+    response = client.post("/api/codex/entries", json={
+        "title": "From Slash",
+        "body": "Content",
+        "created_from": "slash_command",
+    })
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["entry"]["created_from"] == "slash_command"
+
+    cdx_files = list(codex_root.glob("**/*.cdx"))
+    content = cdx_files[0].read_text(encoding="utf-8")
+    assert "created_from: slash_command" in content
+
+
+def test_save_persists_retrieval_enabled_false(monkeypatch, tmp_path):
+    """Save payload carries retrievalEnabled: false in frontmatter by default."""
+    codex_root = tmp_path / "codex"
+    codex_root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(codex_service, "CODEX_ROOT", codex_root)
+
+    client = TestClient(_make_app())
+    response = client.post("/api/codex/entries", json={
+        "title": "Retrieval Off",
+        "body": "Content",
+        "retrieval_enabled": False,
+    })
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["entry"]["retrieval_enabled"] is False
+
+    cdx_files = list(codex_root.glob("**/*.cdx"))
+    content = cdx_files[0].read_text(encoding="utf-8")
+    assert "retrieval_enabled: false" in content
+
+
+def test_save_trigger_separate_from_source(monkeypatch, tmp_path):
+    """Trigger message ID is stored separately from source message ID."""
+    codex_root = tmp_path / "codex"
+    codex_root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(codex_service, "CODEX_ROOT", codex_root)
+
+    client = TestClient(_make_app())
+    response = client.post("/api/codex/entries", json={
+        "title": "Trigger vs Source",
+        "body": "Body",
+        "source_message_id": 10,
+        "trigger_message_id": 11,
+    })
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["entry"]["source_message_id"] == "10"
+    assert payload["entry"]["trigger_message_id"] == "11"
+
+    cdx_files = list(codex_root.glob("**/*.cdx"))
+    content = cdx_files[0].read_text(encoding="utf-8")
+    assert "source_message_id" in content
+    assert "trigger_message_id" in content

--- a/tests/routes/test_codex_draft_routes.py
+++ b/tests/routes/test_codex_draft_routes.py
@@ -17,6 +17,8 @@ from guardian.codex.lineage import (
 )
 from guardian.routes import codex as codex_routes
 
+API_HEADERS = {"X-API-Key": "test"}
+
 
 @pytest.fixture(autouse=True)
 def _reset_lineage_state():
@@ -40,7 +42,9 @@ def _seed_chatlog(
     )
     with Session() as session:
         session.execute(
-            text("CREATE TABLE IF NOT EXISTS chat_threads (id INTEGER PRIMARY KEY)")
+            text(
+                "CREATE TABLE IF NOT EXISTS chat_threads (id INTEGER PRIMARY KEY)"
+            )
         )
         session.execute(
             text(
@@ -75,6 +79,7 @@ def _seed_chatlog(
 
     # Wire the chatlog db dependency
     from guardian.codex import lineage as lineage_mod
+
     _set_lineage_session_factory(Session)
 
     # Create a simple mock chatlog_db
@@ -93,13 +98,16 @@ def _seed_chatlog(
                     {"tid": tid, "limit": limit, "offset": offset},
                 ).fetchall()
             return [
-                {"id": row[0], "thread_id": row[1], "role": row[2], "content": row[3]}
+                {
+                    "id": row[0],
+                    "thread_id": row[1],
+                    "role": row[2],
+                    "content": row[3],
+                }
                 for row in rows
             ]
 
-    monkeypatch.setattr(
-        codex_routes, "chatlog_db", MockChatlogDB()
-    )
+    monkeypatch.setattr(codex_routes, "chatlog_db", MockChatlogDB())
 
 
 def _make_app() -> FastAPI:
@@ -111,6 +119,7 @@ def _make_app() -> FastAPI:
 # ---------------------------------------------------------------------------
 # Draft endpoint tests
 # ---------------------------------------------------------------------------
+
 
 def test_draft_returns_candidate(monkeypatch, tmp_path):
     """POST /api/codex/entries/draft returns a draft from prior context."""
@@ -124,16 +133,24 @@ def test_draft_returns_candidate(monkeypatch, tmp_path):
         thread_id=10,
         messages=[
             {"id": 1, "role": "user", "content": "What is decentralized AI?"},
-            {"id": 2, "role": "assistant", "content": "It's AI that runs on edge devices..."},
+            {
+                "id": 2,
+                "role": "assistant",
+                "content": "It's AI that runs on edge devices...",
+            },
             {"id": 3, "role": "user", "content": "/codex_entry"},
         ],
     )
 
     client = TestClient(_make_app())
-    response = client.post("/api/codex/entries/draft", json={
-        "thread_id": 10,
-        "trigger_message_id": 3,
-    })
+    response = client.post(
+        "/api/codex/entries/draft",
+        json={
+            "thread_id": 10,
+            "trigger_message_id": 3,
+        },
+        headers=API_HEADERS,
+    )
     assert response.status_code == 200
     payload = response.json()
     assert payload["ok"] is True
@@ -148,6 +165,7 @@ def test_draft_returns_candidate(monkeypatch, tmp_path):
     assert payload["draft"]["lineage"]["trigger_message_id"] == 3
     assert 1 in payload["draft"]["lineage"]["source_message_ids"]
     assert 2 in payload["draft"]["lineage"]["source_message_ids"]
+    assert 3 not in payload["draft"]["lineage"]["source_message_ids"]
 
 
 def test_draft_does_not_persist_entry(monkeypatch, tmp_path):
@@ -167,10 +185,14 @@ def test_draft_does_not_persist_entry(monkeypatch, tmp_path):
     )
 
     client = TestClient(_make_app())
-    response = client.post("/api/codex/entries/draft", json={
-        "thread_id": 20,
-        "trigger_message_id": 11,
-    })
+    response = client.post(
+        "/api/codex/entries/draft",
+        json={
+            "thread_id": 20,
+            "trigger_message_id": 11,
+        },
+        headers=API_HEADERS,
+    )
     assert response.status_code == 200
     payload = response.json()
     assert payload["ok"] is True
@@ -197,10 +219,14 @@ def test_draft_no_context_returns_empty(monkeypatch, tmp_path):
     )
 
     client = TestClient(_make_app())
-    response = client.post("/api/codex/entries/draft", json={
-        "thread_id": 30,
-        "trigger_message_id": 50,
-    })
+    response = client.post(
+        "/api/codex/entries/draft",
+        json={
+            "thread_id": 30,
+            "trigger_message_id": 50,
+        },
+        headers=API_HEADERS,
+    )
     assert response.status_code == 200
     payload = response.json()
     assert payload["ok"] is True
@@ -222,9 +248,13 @@ def test_draft_empty_thread_returns_no_context(monkeypatch, tmp_path):
     )
 
     client = TestClient(_make_app())
-    response = client.post("/api/codex/entries/draft", json={
-        "thread_id": 40,
-    })
+    response = client.post(
+        "/api/codex/entries/draft",
+        json={
+            "thread_id": 40,
+        },
+        headers=API_HEADERS,
+    )
     assert response.status_code == 200
     payload = response.json()
     assert payload["ok"] is True
@@ -236,6 +266,7 @@ def test_draft_empty_thread_returns_no_context(monkeypatch, tmp_path):
 # Save endpoint tests
 # ---------------------------------------------------------------------------
 
+
 def test_save_persists_markdown(monkeypatch, tmp_path):
     """POST /api/codex/entries persists a Codex Entry with frontmatter."""
     codex_root = tmp_path / "codex"
@@ -243,17 +274,21 @@ def test_save_persists_markdown(monkeypatch, tmp_path):
     monkeypatch.setattr(codex_service, "CODEX_ROOT", codex_root)
 
     client = TestClient(_make_app())
-    response = client.post("/api/codex/entries", json={
-        "title": "Test Entry",
-        "body": "# Hello\n\nThis is a test.",
-        "thread_id": 10,
-        "source_thread_id": 10,
-        "source_message_id": 2,
-        "trigger_message_id": 3,
-        "message_ids": [1, 2],
-        "created_from": "slash_command",
-        "retrieval_enabled": False,
-    })
+    response = client.post(
+        "/api/codex/entries",
+        json={
+            "title": "Test Entry",
+            "body": "# Hello\n\nThis is a test.",
+            "thread_id": 10,
+            "source_thread_id": 10,
+            "source_message_id": 2,
+            "trigger_message_id": 3,
+            "message_ids": [1, 2],
+            "created_from": "slash_command",
+            "retrieval_enabled": False,
+        },
+        headers=API_HEADERS,
+    )
     assert response.status_code == 200
     payload = response.json()
     assert payload["ok"] is True
@@ -269,8 +304,13 @@ def test_save_persists_markdown(monkeypatch, tmp_path):
     content = cdx_files[0].read_text(encoding="utf-8")
     assert "created_from: slash_command" in content
     assert "retrieval_enabled: false" in content
-    assert "source_message_id: '2'" in content or "source_message_id: 2" in content
-    assert "trigger_message_id: '3'" in content or "trigger_message_id: 3" in content
+    assert (
+        "source_message_id: '2'" in content or "source_message_id: 2" in content
+    )
+    assert (
+        "trigger_message_id: '3'" in content
+        or "trigger_message_id: 3" in content
+    )
 
 
 def test_save_persists_created_from(monkeypatch, tmp_path):
@@ -280,11 +320,15 @@ def test_save_persists_created_from(monkeypatch, tmp_path):
     monkeypatch.setattr(codex_service, "CODEX_ROOT", codex_root)
 
     client = TestClient(_make_app())
-    response = client.post("/api/codex/entries", json={
-        "title": "From Slash",
-        "body": "Content",
-        "created_from": "slash_command",
-    })
+    response = client.post(
+        "/api/codex/entries",
+        json={
+            "title": "From Slash",
+            "body": "Content",
+            "created_from": "slash_command",
+        },
+        headers=API_HEADERS,
+    )
     assert response.status_code == 200
     payload = response.json()
     assert payload["entry"]["created_from"] == "slash_command"
@@ -301,11 +345,15 @@ def test_save_persists_retrieval_enabled_false(monkeypatch, tmp_path):
     monkeypatch.setattr(codex_service, "CODEX_ROOT", codex_root)
 
     client = TestClient(_make_app())
-    response = client.post("/api/codex/entries", json={
-        "title": "Retrieval Off",
-        "body": "Content",
-        "retrieval_enabled": False,
-    })
+    response = client.post(
+        "/api/codex/entries",
+        json={
+            "title": "Retrieval Off",
+            "body": "Content",
+            "retrieval_enabled": False,
+        },
+        headers=API_HEADERS,
+    )
     assert response.status_code == 200
     payload = response.json()
     assert payload["entry"]["retrieval_enabled"] is False
@@ -322,12 +370,16 @@ def test_save_trigger_separate_from_source(monkeypatch, tmp_path):
     monkeypatch.setattr(codex_service, "CODEX_ROOT", codex_root)
 
     client = TestClient(_make_app())
-    response = client.post("/api/codex/entries", json={
-        "title": "Trigger vs Source",
-        "body": "Body",
-        "source_message_id": 10,
-        "trigger_message_id": 11,
-    })
+    response = client.post(
+        "/api/codex/entries",
+        json={
+            "title": "Trigger vs Source",
+            "body": "Body",
+            "source_message_id": 10,
+            "trigger_message_id": 11,
+        },
+        headers=API_HEADERS,
+    )
     assert response.status_code == 200
     payload = response.json()
     assert payload["entry"]["source_message_id"] == "10"


### PR DESCRIPTION
## Summary
- Adds a command-first Codex entry drafting flow across chat, routes, and frontend surfaces.
- Wires the new Codex draft contract into the broker, service layer, and dedicated route support.
- Documents the architecture change with a new ADR and updates the ADR index.

## Testing
- Not run (not requested)