### PR TITLE
Add Codex Knowledge Compiler architecture contract

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -78,6 +78,7 @@ Before generating architecture diagrams, read the [`KB Validity Matrix`](./kb-va
 ## Doc Map
 
 - [`00-current-state.md`](./00-current-state.md): live operational truth, current release/readiness interpretation, and short-horizon priorities.
+- [Codex Knowledge Compiler Contract](./codex-knowledge-compiler-contract.md): docs-only architecture contract for the reusable scoped knowledge-compilation pattern behind Codex Wiki / LLM Wiki / compiled project memory. It does not claim runtime implementation or release support and does not override `00-current-state.md`.
 - [Codexify Development Map v1](./codexify-development-map-v1.md): visual current-state orientation map for subsystem boundaries, dependency edges, data spine, UI/runtime separation, and development maturity posture. It is not a release promise and does not override `00-current-state.md`.
 - [Architecture Atlas](./architecture-atlas.md): peer-facing reading guide for the validated architecture corpus, runtime diagrams, and UI diagrams.
 - [Agent Protocol Operations Index](./agent-protocol-operations.md): agent-facing map for task rituals, campaign/task interpretation, architecture-impact workflow, validation expectations, and contingency behavior.

--- a/docs/architecture/codex-knowledge-compiler-contract.md
+++ b/docs/architecture/codex-knowledge-compiler-contract.md
@@ -268,6 +268,40 @@ That dry-run should:
 
 This slice is recommended because it exercises scope policy, provenance, change detection, draft generation, and proof reporting without widening the supported runtime promise.
 
+## Implementation Note: Backend Dry-Run Harness
+
+A backend-only dry-run harness now exists under `guardian/knowledge_compiler/`.
+
+It proves only:
+
+- project-scoped source normalization contracts
+- deterministic hash-based change detection
+- draft-only compiled artifact proposals
+- dry-run proof report shape
+
+It does not prove:
+
+- persistence
+- routing
+- retrieval behavior
+- scheduling
+- graph writes
+- model execution
+- UI review
+- publication
+- export/restore inclusion
+- autonomous maintenance
+
+Validation command used:
+
+- `pytest -v tests/knowledge_compiler/test_dry_run.py`
+
+Test file path:
+
+- `tests/knowledge_compiler/test_dry_run.py`
+
+Future live behavior still requires separate implementation work and the documentation follow-through described below. This dry-run harness is proof of a pure backend seam only; it is not a release promise.
+
 ## Documentation Follow-Through
 
 Future implementation tasks should update related architecture docs only when live behavior changes:

--- a/docs/architecture/codex-knowledge-compiler-contract.md
+++ b/docs/architecture/codex-knowledge-compiler-contract.md
@@ -1,0 +1,295 @@
+# Codex Knowledge Compiler Contract
+
+> Classification: architecture contract
+> Status: draft
+> Implementation status: docs-only contract. This document defines concept and boundary only; it does not introduce runtime implementation.
+
+## Title and Status
+
+- Title: `Codex Knowledge Compiler Contract`
+- Classification: `architecture contract`
+- Status: `draft`
+- Implementation posture: docs-only contract; no runtime implementation is introduced by this document
+
+## Purpose
+
+Codex Knowledge Compiler is the reusable, scoped compilation engine that may later transform raw project, workspace, system, or domain source material into reviewed, provenance-aware, retrieval-efficient knowledge artifacts and scoped agent knowledge graphs.
+
+This contract generalizes the repeatable Codex Wiki / LLM Wiki / compiled project memory pattern without limiting Codexify to Obsidian, Markdown, or any single source substrate.
+
+This document is intentionally architectural and future-facing. It does not claim runtime behavior, release support, or proof beyond the current Codexify truth surfaces.
+
+## Non-Goals
+
+This task does not:
+
+- add runtime code
+- add database tables
+- add migrations
+- add API routes
+- add workers
+- add cron jobs
+- add UI
+- enable graph writes
+- change retrieval routing
+- change `ContextBroker` behavior
+- change identity modeling
+- change persona ownership
+- connect the local-model draft adapter to scheduling, publishing, Heartbeat, command dispatch, or release approval
+- claim public release readiness
+
+## Vocabulary
+
+The following terms are canonical for this contract:
+
+| Term | Meaning |
+|---|---|
+| `Codex Knowledge Compiler` | The future reusable engine that compiles bounded source material into reviewable knowledge artifacts under an explicit scope policy. |
+| `Knowledge Scope` | The read/write boundary that defines what source material a compilation run may inspect and what artifact surfaces it may later affect. |
+| `Source Adapter` | The future normalization seam that turns source-specific material into the compiler's conceptual source shape without changing source-of-truth ownership. |
+| `Knowledge Source Item` | One normalized source record eligible for discovery, hashing, extraction, provenance, and compilation. |
+| `Compiled Knowledge Artifact` | A derived, provenance-bearing output produced by the compiler, still distinct from raw source material. |
+| `Retrieval Card` | A compact retrieval-oriented artifact meant to make later retrieval more efficient without replacing raw provenance. |
+| `Concept Node` | A conceptual graph node representing an extracted concept, entity, topic, or durable semantic anchor. |
+| `Relationship Edge` | A conceptual graph edge representing a typed relationship between nodes or artifacts. |
+| `Compilation Run` | One bounded execution attempt over a declared scope, trigger, and source set. |
+| `Review Gate` | The checkpoint that decides whether compiler output stays draft-only, is approved, or is policy-eligible for later publication. |
+| `Publisher` | The future seam that may materialize approved outputs into durable compiled-memory, retrieval, or graph-bearing surfaces. |
+| `Maintenance Finding` | A derived issue that reports drift, staleness, contradiction, orphaning, or other follow-up conditions discovered during compilation or maintenance. |
+| `Scope Policy` | The rules that bound scope-local reads, writes, exclusions, review posture, and future publication behavior. |
+| `Compiler Budget` | The bounded limits for one run, such as source count, model calls, wall time, artifact count, or write operations. |
+| `Compiler Proof Surface` | The durable evidence record required to explain what a run discovered, skipped, proposed, approved, published, and refused. |
+
+If any of these terms later become runtime literals, event names, statuses, or other branch-bearing values, they must graduate into the appropriate canonical token registry before spreading through routes, workers, queues, or UI surfaces.
+
+## Scope Model
+
+The compiler is scope-aware. The first conceptual scope kinds are:
+
+- `project`
+- `workspace`
+- `system`
+- `domain`
+
+These scope kinds are not implementation claims. They are the first contractual read/write boundary vocabulary for future work.
+
+| Scope kind | What it may read | What it may write | Likely cadence | Review requirement posture | Examples |
+|---|---|---|---|---|---|
+| `project` | Project-bound threads, project documents, project artifacts, project-local notes, project-local audits, and project-local repo evidence that policy allows | Draft compiled artifacts, proof records, and later approved project-scoped outputs only within the same project boundary | Manual or changed-source-triggered is likely; continuous background execution is not implied | Human review is the default posture unless a future narrow policy explicitly approves auto-publish for low-risk outputs | A project wiki draft, project decision digest, project retrieval cards |
+| `workspace` | Same-user local workspace material such as workspace-local notes, repo files, local documents, or local audits allowed by policy | Draft workspace-scoped artifacts, proof records, and later approved workspace-local outputs | Manual, scheduled, or changed-source-triggered is possible later; none are implemented here | Review must remain explicit when workspace data could widen recall or durable memory | A workspace-local knowledge pack, Obsidian-backed draft index, repo knowledge cards |
+| `system` | Codexify-owned system docs, audits, architecture notes, runbooks, and runtime evidence that governance later permits | Draft system knowledge artifacts, proof records, and later approved system reference outputs | Likely periodic or release-triggered in the future | Review should be strict because system-scoped output can look authoritative | A release-readiness digest, architecture reference cards, operator maintenance findings |
+| `domain` | A declared bounded corpus for a topic, client, field, or knowledge domain that policy explicitly scopes | Draft domain artifacts, proof records, and later approved domain-specific knowledge outputs | Manual or scheduled is plausible later | Review must verify that domain outputs stay attributable and do not impersonate canonical truth | A domain glossary, contradiction report, domain concept graph draft |
+
+## Pipeline Model
+
+The reusable future pipeline is:
+
+`discover sources -> normalize -> detect changes -> extract -> relate -> compile -> review -> publish -> retrieve -> maintain`
+
+| Phase | Purpose | Allowed side effects for this future phase | Prohibited side effects | Required provenance expectations |
+|---|---|---|---|---|
+| `discover sources` | Enumerate candidate source items within the declared scope and policy boundary | Discovery logs, candidate lists, and bounded proof metadata | Hidden widening beyond scope, silent source mutation, durable publication | Every candidate must be attributable to a scope kind, scope id, and source origin |
+| `normalize` | Convert source-specific material into the conceptual source shape used by later phases | Ephemeral normalization output, hashes, and proof metadata | Rewriting raw sources, silently dropping provenance, declaring normalized shape as source-of-truth | Normalized items must preserve enough provenance to jump back to raw origin |
+| `detect changes` | Determine which sources are new, changed, unchanged, excluded, or stale for this run | Change summaries, hashes, skip reasons, and proof metadata | Guessing changes without evidence, mutating raw content to force diffs | Hashes, timestamps, and exclusion reasons must remain traceable per item |
+| `extract` | Derive candidate summaries, decisions, concepts, facts, or issue signals from normalized source items | Draft extraction artifacts and proof metadata | Durable publication without review, subjective labeling without policy support | Every extracted proposal must point back to the contributing source items |
+| `relate` | Propose semantic relationships across extracted items, concepts, decisions, or artifacts | Draft relationship proposals and proof metadata | Treating proposed relationships as canonical truth, emitting graph writes by default | Each proposed relationship must record why it exists and which sources support it |
+| `compile` | Assemble higher-level artifacts optimized for later review, retrieval, or graph use | Draft compiled artifacts, retrieval-card proposals, and proof metadata | Overwriting raw sources, publishing by implication, widening retrieval policy | Compiled artifacts must preserve source coverage and derivation lineage |
+| `review` | Decide whether draft outputs stay draft-only, are approved, or are blocked | Review notes, approval metadata, rejection metadata | Silent approval, policy bypass, retroactive provenance rewriting | Review decisions must remain attributable to reviewer identity or policy source |
+| `publish` | Materialize approved outputs into future durable artifact surfaces | Explicit writes to approved durable surfaces, bounded indexes, or portable artifacts if later implemented | Publishing unreviewed output by default, widening release claims, bypassing exclusions | Published outputs must preserve source provenance, review state, and publication context |
+| `retrieve` | Make approved artifacts available to future retrieval or lookup flows if governance later permits | Retrieval-visible indexes or cards for approved outputs only | Implicit retrieval visibility for draft artifacts, bypassing retrieval policy, treating searchability as proof of use | Retrieval-visible outputs must retain provenance and approval state |
+| `maintain` | Detect drift, contradictions, stale artifacts, orphaning, or recompile needs over time | Maintenance findings, re-review flags, and proof metadata | Silent auto-rewrite of published truth, hidden background widening | Maintenance output must explain what changed, what is stale, and which sources or artifacts were examined |
+
+## Source Adapter Contract
+
+Future source adapters should normalize source material into a shape conceptually equivalent to:
+
+```ts
+type KnowledgeSourceItem = {
+  sourceId: string;
+  scopeKind: "project" | "workspace" | "system" | "domain";
+  scopeId: string;
+  sourceType:
+    | "thread"
+    | "message"
+    | "document"
+    | "artifact"
+    | "obsidian_note"
+    | "repo_file"
+    | "audit"
+    | "external";
+  title?: string;
+  contentRef?: string;
+  contentHash: string;
+  createdAt?: string;
+  updatedAt?: string;
+  provenance: {
+    threadId?: string;
+    messageId?: string;
+    projectId?: string;
+    artifactId?: string;
+    documentId?: string;
+    filePath?: string;
+    url?: string;
+  };
+};
+```
+
+The exact runtime type may differ later. The provenance requirements do not. A future implementation may rename fields, add fields, or encode them differently, but it must preserve the ability to attribute source origin, scope, and derivation without collapsing raw source ownership.
+
+## Output Artifact Contract
+
+The first conceptual output families are:
+
+| Artifact family | Purpose | Source provenance requirement | Review posture | Retrieval-visible before approval |
+|---|---|---|---|---|
+| `CodexEntryDraft` | Human-readable draft entry that packages a bounded compiled result for review or later save behavior | Must point to the source scope and contributing source items or ranges | Draft-only by default | No |
+| `SourceSummary` | Condensed summary of one source item or a tightly bounded source set | Must preserve item-level provenance and content-hash linkage | Review required before durable publication | No |
+| `ConceptCard` | Reviewable concept artifact describing an extracted concept and why it matters | Must cite supporting source items and conflicting evidence when present | Review required | No |
+| `DecisionRecord` | Extracted or compiled record of a project, system, or domain decision with provenance | Must preserve source decision lineage and decision-confidence basis | Review required, especially when it could look authoritative | No |
+| `RetrievalCard` | Compact retrieval-oriented artifact that later helps retrieval efficiency or explainability | Must preserve source lineage and approval state | Review required before any retrieval visibility | No |
+| `RelationshipEdge` | Proposed relationship between concepts, artifacts, or decisions | Must preserve supporting source references and relation rationale | Review required before durable graph or retrieval use | No |
+| `MaintenanceFinding` | Issue artifact reporting drift, staleness, orphaning, or policy follow-up needs | Must identify the examined artifact/source set and the evidence for the finding | Review recommended; policy may later allow low-risk auto-publish with strict proof | Not by default |
+| `ContradictionFinding` | Issue artifact reporting competing claims, conflicting decisions, or unresolved semantic conflict | Must preserve all materially conflicting source references | Review required | No |
+
+## Review Gate Doctrine
+
+- Unreviewed compiler output is draft-only by default.
+- Publishing to durable compiled memory requires an explicit review or a policy-approved auto-publish rule.
+- Identity-sensitive or user-trait-like output must not bypass IDDB policy.
+- Diary, excluded, and private-source policies must be respected.
+- No durable subjective labels may be created without explicit consent and policy support.
+
+Review gates exist to keep compiled knowledge attributable and reversible instead of silently turning draft interpretation into canonical truth.
+
+## Scheduling and Budget Doctrine
+
+Future compiler runs may be:
+
+- manual
+- scheduled
+- changed-source triggered
+- event triggered
+
+This contract does not implement scheduling.
+
+Future runs must declare and respect bounded budgets, including:
+
+- max sources per run
+- max model calls
+- max wall time
+- max artifacts
+- max graph edges
+- max retrieval cards
+- max write operations
+
+Every future recurring compiler run must use leases or equivalent ownership to prevent duplicate concurrent runs for the same scope.
+
+## Proof Surface
+
+Any future implementation must provide a durable compiler proof surface that records at least:
+
+- scope kind and scope id
+- run id
+- trigger kind
+- source candidates discovered
+- changed sources detected
+- sources skipped with reasons
+- draft artifacts generated
+- artifacts approved
+- artifacts published
+- retrieval cards generated
+- graph edges proposed or emitted
+- budget used
+- errors and retry posture
+- provenance summary
+- policy exclusions
+- review status
+
+Debug traces are diagnostic only and cannot replace durable run or proof records.
+
+## Invariants
+
+The following invariants are non-negotiable:
+
+- The compiler is scope-aware but domain-agnostic.
+- Scopes configure what may be read and written; scopes do not fork compiler logic.
+- Raw sources must not be overwritten by compilation.
+- Published compiled artifacts must preserve source provenance.
+- Reviewable drafts must remain distinguishable from confirmed or published knowledge.
+- Identity modeling must remain governed by IDDB policy.
+- Personas may consume scoped compiled knowledge but must not own user identity.
+- Graph writes remain default-off unless governed by graph-write contracts and runtime flags.
+- Retrieval policy remains governed by the retrieval router and `ContextBroker` contracts.
+- Route or queue acceptance must not be represented as completed compilation.
+- No future background loop may silently widen the release promise.
+
+## Relationship to Existing Systems
+
+This contract relates to the current architecture as follows:
+
+- Codex entries and thread-artifact lineage:
+  compiled outputs may later produce Codex-entry-like drafts or saved artifacts, but lineage must remain source-addressable and export-safe. This contract does not claim a live Codex Knowledge Compiler path today.
+- `ContextBroker` and retrieval router policy:
+  future compiler outputs may later become retrieval inputs or retrieval aids, but retrieval policy remains separately governed by ADR-004, the retrieval router decision table, and current `ContextBroker` doctrine.
+- workspace-local Obsidian retrieval:
+  workspace-local retrieval is already its own supported runtime seam. This contract does not redefine Obsidian selection, injection, or proof; it only reserves a future source-adapter lane that could normalize workspace-local note material under explicit scope policy.
+- vector retrieval:
+  future approved artifacts may later become retrieval-efficient surfaces, but this contract does not change vector-store behavior, indexing, or retrieval visibility.
+- optional graph context:
+  the compiler may later propose concept nodes or relationship edges, but graph writes remain governed by existing graph-write contracts and explicit runtime flags.
+- command bus and future tool/workflow plugins:
+  future compiler tooling may eventually use plugin or command-bus-adjacent lanes, but plugin sovereignty, permissions, lineage, and runtime-binding rules remain governed by ADR-010 and related contracts.
+- cron and scheduling:
+  future recurring compilation may use scheduling, but no scheduler contract or implementation is introduced here.
+- local-model draft adapter:
+  future low-risk draft generation may eventually consume local-model lanes, but the current local-model draft adapter remains internal or manual only and is not connected here to scheduling, publishing, command dispatch, Heartbeat, or release approval.
+- export and restore provenance:
+  if compiled artifacts later become portable account state, they must preserve provenance, lineage, relationship semantics, and restore behavior consistent with the account export and restore contract.
+
+Unimplemented relationships remain future-facing and must not be presented as release truth until they are separately proven.
+
+## First Implementation Slice Recommendation
+
+Recommended next slice:
+
+`Project-scoped Knowledge Compiler dry-run harness`
+
+That dry-run should:
+
+- load a small bounded set of project, thread, message, and document source items
+- normalize them
+- detect changed sources by hash
+- produce draft artifact proposals in memory or test fixtures
+- return a proof report
+- perform no durable writes except optional test-only fixtures
+- not change retrieval behavior
+- not publish artifacts
+- not emit graph writes
+
+This slice is recommended because it exercises scope policy, provenance, change detection, draft generation, and proof reporting without widening the supported runtime promise.
+
+## Documentation Follow-Through
+
+Future implementation tasks should update related architecture docs only when live behavior changes:
+
+- `00-current-state.md` only when runtime behavior changes
+- `flows.md` when a live flow exists
+- `data-and-storage.md` when persistence changes
+- `router-decision-table.md` if retrieval routing changes
+- `runtime-protocol-token-contract.md` if new statuses, events, or machine-readable values become runtime tokens
+- `account-export-restore-contract.md` if compiled artifacts become portable account state
+
+## Governing References
+
+- [`00-current-state.md`](./00-current-state.md)
+- [`router-decision-table.md`](./router-decision-table.md)
+- [`runtime-protocol-token-contract.md`](./runtime-protocol-token-contract.md)
+- [`account-export-restore-contract.md`](./account-export-restore-contract.md)
+- [`self-extending-agent-plugin-system.md`](./self-extending-agent-plugin-system.md)
+- [`delegation-runtime.md`](./delegation-runtime.md)
+- [`adr/004-retrieval-policy-as-control-plane.md`](./adr/004-retrieval-policy-as-control-plane.md)
+- [`adr/010-self-extending-agent-plugin-system.md`](./adr/010-self-extending-agent-plugin-system.md)
+- [`adr/015-continuity-engine-working-set-and-decay-contract.md`](./adr/015-continuity-engine-working-set-and-decay-contract.md)
+- [`adr/016-continuity-governance-surface-contract.md`](./adr/016-continuity-governance-surface-contract.md)
+- [`adr/024-context-command-active-connector-semantics.md`](./adr/024-context-command-active-connector-semantics.md)
+- [`adr/029-codex-entry-command-first-draft-flow.md`](./adr/029-codex-entry-command-first-draft-flow.md)

--- a/guardian/knowledge_compiler/__init__.py
+++ b/guardian/knowledge_compiler/__init__.py
@@ -1,0 +1,37 @@
+"""Public package surface for the Knowledge Compiler dry-run harness."""
+
+from __future__ import annotations
+
+from guardian.knowledge_compiler.contracts import (
+    CompiledKnowledgeArtifact,
+    KnowledgeArtifactKind,
+    KnowledgeChangeState,
+    KnowledgeCompilerBudget,
+    KnowledgeCompilerDryRunRequest,
+    KnowledgeCompilerProofReport,
+    KnowledgeReviewState,
+    KnowledgeScopeKind,
+    KnowledgeSourceChange,
+    KnowledgeSourceItem,
+    KnowledgeSourceProvenance,
+    KnowledgeSourceType,
+)
+from guardian.knowledge_compiler.dry_run import (
+    run_project_knowledge_compiler_dry_run,
+)
+
+__all__ = [
+    "CompiledKnowledgeArtifact",
+    "KnowledgeArtifactKind",
+    "KnowledgeChangeState",
+    "KnowledgeCompilerBudget",
+    "KnowledgeCompilerDryRunRequest",
+    "KnowledgeCompilerProofReport",
+    "KnowledgeReviewState",
+    "KnowledgeScopeKind",
+    "KnowledgeSourceChange",
+    "KnowledgeSourceItem",
+    "KnowledgeSourceProvenance",
+    "KnowledgeSourceType",
+    "run_project_knowledge_compiler_dry_run",
+]

--- a/guardian/knowledge_compiler/contracts.py
+++ b/guardian/knowledge_compiler/contracts.py
@@ -1,0 +1,404 @@
+"""Pure contracts for the Codex Knowledge Compiler dry-run harness.
+
+This module is intentionally dependency-light. It models bounded, deterministic
+contracts only and does not import runtime routes, workers, or persistence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+
+def _clean_required_text(value: object, field_name: str) -> str:
+    text = str(value).strip()
+    if not text:
+        raise ValueError(f"{field_name} must be non-empty.")
+    return text
+
+
+def _clean_optional_text(value: object | None) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalize_enum(
+    value: object,
+    enum_type: type[Enum],
+    field_name: str,
+) -> Enum:
+    if isinstance(value, enum_type):
+        return value
+    try:
+        return enum_type(str(value).strip())
+    except ValueError as exc:
+        raise ValueError(
+            f"{field_name} must be one of {[member.value for member in enum_type]}."
+        ) from exc
+
+
+def _normalize_string_mapping(
+    value: Mapping[str, object] | None,
+) -> dict[str, str]:
+    if not value:
+        return {}
+    normalized: dict[str, str] = {}
+    for key, item in value.items():
+        normalized[_clean_required_text(key, "mapping key")] = str(item)
+    return normalized
+
+
+def _normalize_hash_mapping(
+    value: Mapping[str, object] | None,
+) -> dict[str, str]:
+    if not value:
+        return {}
+    normalized: dict[str, str] = {}
+    for key, item in value.items():
+        source_id = _clean_required_text(key, "previous_hashes key")
+        normalized[source_id] = _clean_required_text(
+            item, f"previous_hashes[{source_id}]"
+        )
+    return normalized
+
+
+def _normalize_string_tuple(
+    values: Sequence[object] | None,
+    *,
+    field_name: str,
+) -> tuple[str, ...]:
+    if not values:
+        return ()
+    return tuple(
+        _clean_required_text(value, field_name)
+        for value in values
+    )
+
+
+class KnowledgeScopeKind(str, Enum):
+    PROJECT = "project"
+    WORKSPACE = "workspace"
+    SYSTEM = "system"
+    DOMAIN = "domain"
+
+
+class KnowledgeSourceType(str, Enum):
+    THREAD = "thread"
+    MESSAGE = "message"
+    DOCUMENT = "document"
+    ARTIFACT = "artifact"
+    OBSIDIAN_NOTE = "obsidian_note"
+    REPO_FILE = "repo_file"
+    AUDIT = "audit"
+    EXTERNAL = "external"
+
+
+class KnowledgeArtifactKind(str, Enum):
+    CODEX_ENTRY_DRAFT = "codex_entry_draft"
+    SOURCE_SUMMARY = "source_summary"
+    CONCEPT_CARD = "concept_card"
+    DECISION_RECORD = "decision_record"
+    RETRIEVAL_CARD = "retrieval_card"
+    RELATIONSHIP_EDGE = "relationship_edge"
+    MAINTENANCE_FINDING = "maintenance_finding"
+    CONTRADICTION_FINDING = "contradiction_finding"
+
+
+class KnowledgeReviewState(str, Enum):
+    DRAFT = "draft"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    PUBLISHED = "published"
+
+
+class KnowledgeChangeState(str, Enum):
+    NEW = "new"
+    CHANGED = "changed"
+    UNCHANGED = "unchanged"
+    EXCLUDED = "excluded"
+    STALE = "stale"
+
+
+@dataclass(frozen=True, slots=True)
+class KnowledgeSourceProvenance:
+    thread_id: str | None = None
+    message_id: str | None = None
+    project_id: str | None = None
+    artifact_id: str | None = None
+    document_id: str | None = None
+    file_path: str | None = None
+    url: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "thread_id", _clean_optional_text(self.thread_id))
+        object.__setattr__(self, "message_id", _clean_optional_text(self.message_id))
+        object.__setattr__(self, "project_id", _clean_optional_text(self.project_id))
+        object.__setattr__(self, "artifact_id", _clean_optional_text(self.artifact_id))
+        object.__setattr__(self, "document_id", _clean_optional_text(self.document_id))
+        object.__setattr__(self, "file_path", _clean_optional_text(self.file_path))
+        object.__setattr__(self, "url", _clean_optional_text(self.url))
+
+
+@dataclass(frozen=True, slots=True)
+class KnowledgeSourceItem:
+    source_id: str
+    scope_kind: KnowledgeScopeKind
+    scope_id: str
+    source_type: KnowledgeSourceType
+    title: str | None
+    content: str
+    content_hash: str
+    created_at: str | None
+    updated_at: str | None
+    provenance: KnowledgeSourceProvenance
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "source_id", _clean_required_text(self.source_id, "source_id"))
+        object.__setattr__(
+            self,
+            "scope_kind",
+            _normalize_enum(self.scope_kind, KnowledgeScopeKind, "scope_kind"),
+        )
+        object.__setattr__(self, "scope_id", _clean_required_text(self.scope_id, "scope_id"))
+        object.__setattr__(
+            self,
+            "source_type",
+            _normalize_enum(self.source_type, KnowledgeSourceType, "source_type"),
+        )
+        object.__setattr__(self, "title", _clean_optional_text(self.title))
+        object.__setattr__(self, "content", str(self.content))
+        object.__setattr__(
+            self, "content_hash", _clean_required_text(self.content_hash, "content_hash")
+        )
+        object.__setattr__(self, "created_at", _clean_optional_text(self.created_at))
+        object.__setattr__(self, "updated_at", _clean_optional_text(self.updated_at))
+        if not isinstance(self.provenance, KnowledgeSourceProvenance):
+            raise ValueError("provenance must be a KnowledgeSourceProvenance.")
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledKnowledgeArtifact:
+    artifact_id: str
+    artifact_kind: KnowledgeArtifactKind
+    scope_kind: KnowledgeScopeKind
+    scope_id: str
+    title: str
+    body: str
+    source_ids: tuple[str, ...]
+    review_state: KnowledgeReviewState
+    retrieval_visible: bool
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "artifact_id", _clean_required_text(self.artifact_id, "artifact_id"))
+        object.__setattr__(
+            self,
+            "artifact_kind",
+            _normalize_enum(
+                self.artifact_kind, KnowledgeArtifactKind, "artifact_kind"
+            ),
+        )
+        object.__setattr__(
+            self,
+            "scope_kind",
+            _normalize_enum(self.scope_kind, KnowledgeScopeKind, "scope_kind"),
+        )
+        object.__setattr__(self, "scope_id", _clean_required_text(self.scope_id, "scope_id"))
+        object.__setattr__(self, "title", _clean_required_text(self.title, "title"))
+        object.__setattr__(self, "body", str(self.body))
+        normalized_source_ids = _normalize_string_tuple(
+            self.source_ids,
+            field_name="source_ids",
+        )
+        if not normalized_source_ids:
+            raise ValueError("Every artifact must have at least one source_id.")
+        object.__setattr__(self, "source_ids", normalized_source_ids)
+        object.__setattr__(
+            self,
+            "review_state",
+            _normalize_enum(self.review_state, KnowledgeReviewState, "review_state"),
+        )
+        object.__setattr__(self, "retrieval_visible", bool(self.retrieval_visible))
+        object.__setattr__(self, "metadata", _normalize_string_mapping(self.metadata))
+
+
+@dataclass(frozen=True, slots=True)
+class KnowledgeSourceChange:
+    source_id: str
+    change_state: KnowledgeChangeState
+    previous_hash: str | None
+    current_hash: str
+    reason: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "source_id", _clean_required_text(self.source_id, "source_id"))
+        object.__setattr__(
+            self,
+            "change_state",
+            _normalize_enum(self.change_state, KnowledgeChangeState, "change_state"),
+        )
+        object.__setattr__(self, "previous_hash", _clean_optional_text(self.previous_hash))
+        object.__setattr__(
+            self, "current_hash", _clean_required_text(self.current_hash, "current_hash")
+        )
+        object.__setattr__(self, "reason", _clean_required_text(self.reason, "reason"))
+
+
+@dataclass(frozen=True, slots=True)
+class KnowledgeCompilerBudget:
+    max_sources: int
+    max_artifacts: int
+    max_model_calls: int
+    max_wall_time_seconds: int
+    max_graph_edges: int
+    max_write_operations: int
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "max_sources",
+            "max_artifacts",
+            "max_model_calls",
+            "max_wall_time_seconds",
+            "max_graph_edges",
+            "max_write_operations",
+        ):
+            value = int(getattr(self, field_name))
+            if value < 0:
+                raise ValueError(f"{field_name} must be non-negative.")
+            object.__setattr__(self, field_name, value)
+
+
+@dataclass(frozen=True, slots=True)
+class KnowledgeCompilerDryRunRequest:
+    scope_kind: KnowledgeScopeKind
+    scope_id: str
+    trigger_kind: str
+    sources: tuple[KnowledgeSourceItem, ...]
+    previous_hashes: dict[str, str]
+    budget: KnowledgeCompilerBudget
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "scope_kind",
+            _normalize_enum(self.scope_kind, KnowledgeScopeKind, "scope_kind"),
+        )
+        object.__setattr__(self, "scope_id", _clean_required_text(self.scope_id, "scope_id"))
+        object.__setattr__(
+            self, "trigger_kind", _clean_required_text(self.trigger_kind, "trigger_kind")
+        )
+        if not isinstance(self.budget, KnowledgeCompilerBudget):
+            raise ValueError("budget must be a KnowledgeCompilerBudget.")
+        normalized_sources = tuple(self.sources or ())
+        for source in normalized_sources:
+            if not isinstance(source, KnowledgeSourceItem):
+                raise ValueError("sources must contain KnowledgeSourceItem values.")
+        object.__setattr__(self, "sources", normalized_sources)
+        object.__setattr__(
+            self, "previous_hashes", _normalize_hash_mapping(self.previous_hashes)
+        )
+        if self.budget.max_model_calls > 0:
+            raise ValueError("Dry-run requests cannot request model calls.")
+        if self.budget.max_write_operations > 0:
+            raise ValueError("Dry-run requests cannot request write operations.")
+
+
+@dataclass(frozen=True, slots=True)
+class KnowledgeCompilerProofReport:
+    run_id: str
+    scope_kind: KnowledgeScopeKind
+    scope_id: str
+    trigger_kind: str
+    source_candidates_discovered: int
+    changed_sources_detected: int
+    sources_skipped: tuple[str, ...]
+    source_changes: tuple[KnowledgeSourceChange, ...]
+    draft_artifacts_generated: int
+    artifacts_approved: int
+    artifacts_published: int
+    retrieval_cards_generated: int
+    graph_edges_proposed: int
+    budget_used: dict[str, int]
+    errors: tuple[str, ...]
+    policy_exclusions: tuple[str, ...]
+    review_status: str
+    artifacts: tuple[CompiledKnowledgeArtifact, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "run_id", _clean_required_text(self.run_id, "run_id"))
+        object.__setattr__(
+            self,
+            "scope_kind",
+            _normalize_enum(self.scope_kind, KnowledgeScopeKind, "scope_kind"),
+        )
+        object.__setattr__(self, "scope_id", _clean_required_text(self.scope_id, "scope_id"))
+        object.__setattr__(
+            self, "trigger_kind", _clean_required_text(self.trigger_kind, "trigger_kind")
+        )
+        for field_name in (
+            "source_candidates_discovered",
+            "changed_sources_detected",
+            "draft_artifacts_generated",
+            "artifacts_approved",
+            "artifacts_published",
+            "retrieval_cards_generated",
+            "graph_edges_proposed",
+        ):
+            value = int(getattr(self, field_name))
+            if value < 0:
+                raise ValueError(f"{field_name} must be non-negative.")
+            object.__setattr__(self, field_name, value)
+        object.__setattr__(
+            self,
+            "sources_skipped",
+            _normalize_string_tuple(self.sources_skipped, field_name="sources_skipped"),
+        )
+        source_changes = tuple(self.source_changes or ())
+        for item in source_changes:
+            if not isinstance(item, KnowledgeSourceChange):
+                raise ValueError("source_changes must contain KnowledgeSourceChange values.")
+        object.__setattr__(self, "source_changes", source_changes)
+        normalized_budget_used = {
+            _clean_required_text(key, "budget_used key"): int(value)
+            for key, value in (self.budget_used or {}).items()
+        }
+        object.__setattr__(self, "budget_used", normalized_budget_used)
+        object.__setattr__(
+            self, "errors", _normalize_string_tuple(self.errors, field_name="errors")
+        )
+        object.__setattr__(
+            self,
+            "policy_exclusions",
+            _normalize_string_tuple(
+                self.policy_exclusions, field_name="policy_exclusions"
+            ),
+        )
+        object.__setattr__(
+            self, "review_status", _clean_required_text(self.review_status, "review_status")
+        )
+        artifacts = tuple(self.artifacts or ())
+        for artifact in artifacts:
+            if not isinstance(artifact, CompiledKnowledgeArtifact):
+                raise ValueError(
+                    "artifacts must contain CompiledKnowledgeArtifact values."
+                )
+        object.__setattr__(self, "artifacts", artifacts)
+
+
+__all__ = [
+    "CompiledKnowledgeArtifact",
+    "KnowledgeArtifactKind",
+    "KnowledgeChangeState",
+    "KnowledgeCompilerBudget",
+    "KnowledgeCompilerDryRunRequest",
+    "KnowledgeCompilerProofReport",
+    "KnowledgeReviewState",
+    "KnowledgeScopeKind",
+    "KnowledgeSourceChange",
+    "KnowledgeSourceItem",
+    "KnowledgeSourceProvenance",
+    "KnowledgeSourceType",
+]

--- a/guardian/knowledge_compiler/dry_run.py
+++ b/guardian/knowledge_compiler/dry_run.py
@@ -1,0 +1,217 @@
+"""Deterministic project-scoped dry-run harness for the Knowledge Compiler."""
+
+from __future__ import annotations
+
+import hashlib
+
+from guardian.knowledge_compiler.contracts import (
+    CompiledKnowledgeArtifact,
+    KnowledgeArtifactKind,
+    KnowledgeChangeState,
+    KnowledgeCompilerDryRunRequest,
+    KnowledgeCompilerProofReport,
+    KnowledgeReviewState,
+    KnowledgeScopeKind,
+    KnowledgeSourceChange,
+    KnowledgeSourceItem,
+)
+
+
+def _stable_digest(parts: tuple[str, ...]) -> str:
+    payload = "\n".join(parts).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _build_run_id(request: KnowledgeCompilerDryRunRequest) -> str:
+    source_fingerprint = tuple(
+        f"{source.source_id}:{source.content_hash}"
+        for source in sorted(request.sources, key=lambda item: item.source_id)
+    )
+    previous_hash_fingerprint = tuple(
+        f"{source_id}:{request.previous_hashes[source_id]}"
+        for source_id in sorted(request.previous_hashes)
+    )
+    digest = _stable_digest(
+        (
+            request.scope_kind.value,
+            request.scope_id,
+            request.trigger_kind,
+            *source_fingerprint,
+            *previous_hash_fingerprint,
+            str(request.budget.max_sources),
+            str(request.budget.max_artifacts),
+            str(request.budget.max_model_calls),
+            str(request.budget.max_wall_time_seconds),
+            str(request.budget.max_graph_edges),
+            str(request.budget.max_write_operations),
+        )
+    )
+    return f"kcdryrun_{digest[:16]}"
+
+
+def _build_artifact_id(source: KnowledgeSourceItem) -> str:
+    digest = _stable_digest(
+        (
+            source.scope_kind.value,
+            source.scope_id,
+            source.source_id,
+            source.content_hash,
+        )
+    )
+    return f"kcdraft_{digest[:16]}"
+
+
+def _detect_change(
+    source: KnowledgeSourceItem,
+    previous_hashes: dict[str, str],
+) -> KnowledgeSourceChange:
+    previous_hash = previous_hashes.get(source.source_id)
+    if previous_hash is None:
+        return KnowledgeSourceChange(
+            source_id=source.source_id,
+            change_state=KnowledgeChangeState.NEW,
+            previous_hash=None,
+            current_hash=source.content_hash,
+            reason="no previous hash recorded",
+        )
+    if previous_hash != source.content_hash:
+        return KnowledgeSourceChange(
+            source_id=source.source_id,
+            change_state=KnowledgeChangeState.CHANGED,
+            previous_hash=previous_hash,
+            current_hash=source.content_hash,
+            reason="content hash changed",
+        )
+    return KnowledgeSourceChange(
+        source_id=source.source_id,
+        change_state=KnowledgeChangeState.UNCHANGED,
+        previous_hash=previous_hash,
+        current_hash=source.content_hash,
+        reason="content hash unchanged",
+    )
+
+
+def _build_excluded_change(source: KnowledgeSourceItem) -> KnowledgeSourceChange:
+    return KnowledgeSourceChange(
+        source_id=source.source_id,
+        change_state=KnowledgeChangeState.EXCLUDED,
+        previous_hash=None,
+        current_hash=source.content_hash,
+        reason="skipped because max_sources budget was exceeded",
+    )
+
+
+def _build_draft_artifact(
+    source: KnowledgeSourceItem,
+    change: KnowledgeSourceChange,
+) -> CompiledKnowledgeArtifact:
+    title = source.title or f"Draft knowledge artifact for {source.source_id}"
+    body = "\n".join(
+        (
+            "Draft Codex knowledge artifact proposal",
+            f"Scope: {source.scope_kind.value}/{source.scope_id}",
+            f"Source ID: {source.source_id}",
+            f"Source Type: {source.source_type.value}",
+            f"Change State: {change.change_state.value}",
+            f"Content Hash: {source.content_hash}",
+            "",
+            source.content,
+        )
+    )
+    return CompiledKnowledgeArtifact(
+        artifact_id=_build_artifact_id(source),
+        artifact_kind=KnowledgeArtifactKind.CODEX_ENTRY_DRAFT,
+        scope_kind=source.scope_kind,
+        scope_id=source.scope_id,
+        title=title,
+        body=body,
+        source_ids=(source.source_id,),
+        review_state=KnowledgeReviewState.DRAFT,
+        retrieval_visible=False,
+        metadata={
+            "source_type": source.source_type.value,
+            "change_state": change.change_state.value,
+        },
+    )
+
+
+def run_project_knowledge_compiler_dry_run(
+    request: KnowledgeCompilerDryRunRequest,
+) -> KnowledgeCompilerProofReport:
+    """Run the first pure project-scoped Knowledge Compiler dry-run harness."""
+
+    if request.scope_kind != KnowledgeScopeKind.PROJECT:
+        raise ValueError(
+            "run_project_knowledge_compiler_dry_run only supports project scope."
+        )
+    if request.budget.max_model_calls > 0:
+        raise ValueError("Dry-run budgets must not allow model calls.")
+    if request.budget.max_write_operations > 0:
+        raise ValueError("Dry-run budgets must not allow write operations.")
+
+    sorted_sources = tuple(
+        sorted(request.sources, key=lambda item: item.source_id)
+    )
+    included_sources = sorted_sources[: request.budget.max_sources]
+    skipped_sources = sorted_sources[request.budget.max_sources :]
+
+    source_changes: list[KnowledgeSourceChange] = []
+    changed_sources_detected = 0
+
+    for source in included_sources:
+        change = _detect_change(source, request.previous_hashes)
+        source_changes.append(change)
+        if change.change_state in (
+            KnowledgeChangeState.NEW,
+            KnowledgeChangeState.CHANGED,
+        ):
+            changed_sources_detected += 1
+
+    for source in skipped_sources:
+        source_changes.append(_build_excluded_change(source))
+
+    artifacts: list[CompiledKnowledgeArtifact] = []
+    for change in source_changes:
+        if change.change_state not in (
+            KnowledgeChangeState.NEW,
+            KnowledgeChangeState.CHANGED,
+        ):
+            continue
+        if len(artifacts) >= request.budget.max_artifacts:
+            break
+        source = next(
+            item for item in included_sources if item.source_id == change.source_id
+        )
+        artifacts.append(_build_draft_artifact(source, change))
+
+    return KnowledgeCompilerProofReport(
+        run_id=_build_run_id(request),
+        scope_kind=request.scope_kind,
+        scope_id=request.scope_id,
+        trigger_kind=request.trigger_kind,
+        source_candidates_discovered=len(sorted_sources),
+        changed_sources_detected=changed_sources_detected,
+        sources_skipped=tuple(source.source_id for source in skipped_sources),
+        source_changes=tuple(source_changes),
+        draft_artifacts_generated=len(artifacts),
+        artifacts_approved=0,
+        artifacts_published=0,
+        retrieval_cards_generated=0,
+        graph_edges_proposed=0,
+        budget_used={
+            "sources_considered": len(included_sources),
+            "sources_skipped": len(skipped_sources),
+            "artifacts_generated": len(artifacts),
+            "model_calls": 0,
+            "graph_edges": 0,
+            "write_operations": 0,
+            "wall_time_seconds": 0,
+        },
+        errors=(),
+        policy_exclusions=(),
+        review_status="draft_only",
+        artifacts=tuple(artifacts),
+    )
+
+
+__all__ = ["run_project_knowledge_compiler_dry_run"]

--- a/tests/knowledge_compiler/test_dry_run.py
+++ b/tests/knowledge_compiler/test_dry_run.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _load_knowledge_compiler_package() -> types.ModuleType:
+    repo_root = Path(__file__).resolve().parents[2]
+    guardian_root = repo_root / "guardian"
+    package_root = guardian_root / "knowledge_compiler"
+
+    guardian_package = types.ModuleType("guardian")
+    guardian_package.__path__ = [str(guardian_root)]
+    sys.modules["guardian"] = guardian_package
+
+    spec = importlib.util.spec_from_file_location(
+        "guardian.knowledge_compiler",
+        package_root / "__init__.py",
+        submodule_search_locations=[str(package_root)],
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load guardian.knowledge_compiler package.")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["guardian.knowledge_compiler"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+knowledge_compiler = _load_knowledge_compiler_package()
+
+KnowledgeArtifactKind = knowledge_compiler.KnowledgeArtifactKind
+KnowledgeChangeState = knowledge_compiler.KnowledgeChangeState
+KnowledgeCompilerBudget = knowledge_compiler.KnowledgeCompilerBudget
+KnowledgeCompilerDryRunRequest = knowledge_compiler.KnowledgeCompilerDryRunRequest
+KnowledgeReviewState = knowledge_compiler.KnowledgeReviewState
+KnowledgeScopeKind = knowledge_compiler.KnowledgeScopeKind
+KnowledgeSourceItem = knowledge_compiler.KnowledgeSourceItem
+KnowledgeSourceProvenance = knowledge_compiler.KnowledgeSourceProvenance
+KnowledgeSourceType = knowledge_compiler.KnowledgeSourceType
+run_project_knowledge_compiler_dry_run = (
+    knowledge_compiler.run_project_knowledge_compiler_dry_run
+)
+
+
+def _hash_for(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _source(
+    source_id: str,
+    *,
+    content: str | None = None,
+    scope_kind: KnowledgeScopeKind = KnowledgeScopeKind.PROJECT,
+    scope_id: str = "project-123",
+    source_type: KnowledgeSourceType = KnowledgeSourceType.DOCUMENT,
+    title: str | None = None,
+) -> KnowledgeSourceItem:
+    normalized_content = content or f"content for {source_id}"
+    return KnowledgeSourceItem(
+        source_id=source_id,
+        scope_kind=scope_kind,
+        scope_id=scope_id,
+        source_type=source_type,
+        title=title or f"Title for {source_id}",
+        content=normalized_content,
+        content_hash=_hash_for(normalized_content),
+        created_at="2026-05-19T00:00:00Z",
+        updated_at="2026-05-19T00:00:00Z",
+        provenance=KnowledgeSourceProvenance(
+            project_id=scope_id,
+            document_id=f"doc-{source_id}",
+        ),
+    )
+
+
+def _budget(
+    *,
+    max_sources: int = 10,
+    max_artifacts: int = 10,
+    max_model_calls: int = 0,
+    max_wall_time_seconds: int = 30,
+    max_graph_edges: int = 0,
+    max_write_operations: int = 0,
+) -> KnowledgeCompilerBudget:
+    return KnowledgeCompilerBudget(
+        max_sources=max_sources,
+        max_artifacts=max_artifacts,
+        max_model_calls=max_model_calls,
+        max_wall_time_seconds=max_wall_time_seconds,
+        max_graph_edges=max_graph_edges,
+        max_write_operations=max_write_operations,
+    )
+
+
+def _request(
+    *sources: KnowledgeSourceItem,
+    scope_kind: KnowledgeScopeKind = KnowledgeScopeKind.PROJECT,
+    scope_id: str = "project-123",
+    trigger_kind: str = "manual",
+    previous_hashes: dict[str, str] | None = None,
+    budget: KnowledgeCompilerBudget | None = None,
+) -> KnowledgeCompilerDryRunRequest:
+    return KnowledgeCompilerDryRunRequest(
+        scope_kind=scope_kind,
+        scope_id=scope_id,
+        trigger_kind=trigger_kind,
+        sources=tuple(sources),
+        previous_hashes=previous_hashes or {},
+        budget=budget or _budget(),
+    )
+
+
+def test_project_dry_run_accepts_bounded_project_sources() -> None:
+    first = _source("source-2", source_type=KnowledgeSourceType.MESSAGE)
+    second = _source("source-1", source_type=KnowledgeSourceType.DOCUMENT)
+
+    report = run_project_knowledge_compiler_dry_run(_request(first, second))
+
+    assert report.scope_kind == KnowledgeScopeKind.PROJECT
+    assert report.source_candidates_discovered == 2
+    assert [change.source_id for change in report.source_changes] == [
+        "source-1",
+        "source-2",
+    ]
+    assert report.draft_artifacts_generated == 2
+
+
+def test_non_project_scope_is_rejected() -> None:
+    source = _source(
+        "source-1",
+        scope_kind=KnowledgeScopeKind.WORKSPACE,
+        scope_id="workspace-123",
+    )
+    request = _request(
+        source,
+        scope_kind=KnowledgeScopeKind.WORKSPACE,
+        scope_id="workspace-123",
+    )
+
+    with pytest.raises(ValueError, match="only supports project scope"):
+        run_project_knowledge_compiler_dry_run(request)
+
+
+def test_new_source_detection() -> None:
+    source = _source("source-1")
+
+    report = run_project_knowledge_compiler_dry_run(_request(source))
+
+    assert report.changed_sources_detected == 1
+    assert report.source_changes[0].change_state == KnowledgeChangeState.NEW
+    assert report.artifacts[0].metadata["change_state"] == "new"
+
+
+def test_changed_source_detection() -> None:
+    source = _source("source-1", content="new content")
+    request = _request(
+        source,
+        previous_hashes={"source-1": _hash_for("old content")},
+    )
+
+    report = run_project_knowledge_compiler_dry_run(request)
+
+    assert report.changed_sources_detected == 1
+    assert report.source_changes[0].change_state == KnowledgeChangeState.CHANGED
+
+
+def test_unchanged_source_does_not_produce_a_draft_artifact() -> None:
+    source = _source("source-1")
+    request = _request(
+        source,
+        previous_hashes={"source-1": source.content_hash},
+    )
+
+    report = run_project_knowledge_compiler_dry_run(request)
+
+    assert report.changed_sources_detected == 0
+    assert report.source_changes[0].change_state == KnowledgeChangeState.UNCHANGED
+    assert report.draft_artifacts_generated == 0
+    assert report.artifacts == ()
+
+
+def test_skipped_sources_are_reported_when_over_max_sources() -> None:
+    first = _source("source-1")
+    second = _source("source-2")
+    third = _source("source-3")
+    request = _request(
+        third,
+        first,
+        second,
+        budget=_budget(max_sources=2, max_artifacts=10),
+    )
+
+    report = run_project_knowledge_compiler_dry_run(request)
+
+    assert report.sources_skipped == ("source-3",)
+    assert report.source_changes[-1].change_state == KnowledgeChangeState.EXCLUDED
+    assert report.budget_used["sources_skipped"] == 1
+
+
+def test_max_artifacts_is_enforced() -> None:
+    request = _request(
+        _source("source-1"),
+        _source("source-2"),
+        _source("source-3"),
+        budget=_budget(max_sources=3, max_artifacts=2),
+    )
+
+    report = run_project_knowledge_compiler_dry_run(request)
+
+    assert report.changed_sources_detected == 3
+    assert report.draft_artifacts_generated == 2
+    assert len(report.artifacts) == 2
+
+
+def test_generated_artifact_ids_are_deterministic() -> None:
+    request = _request(_source("source-1", content="stable"))
+
+    first_report = run_project_knowledge_compiler_dry_run(request)
+    second_report = run_project_knowledge_compiler_dry_run(request)
+
+    assert first_report.run_id == second_report.run_id
+    assert first_report.artifacts[0].artifact_id == second_report.artifacts[0].artifact_id
+
+
+def test_generated_artifacts_are_draft_only_and_not_retrieval_visible() -> None:
+    report = run_project_knowledge_compiler_dry_run(_request(_source("source-1")))
+
+    artifact = report.artifacts[0]
+    assert artifact.artifact_kind == KnowledgeArtifactKind.CODEX_ENTRY_DRAFT
+    assert artifact.review_state == KnowledgeReviewState.DRAFT
+    assert artifact.retrieval_visible is False
+
+
+def test_provenance_source_ids_are_preserved() -> None:
+    source = _source("source-1")
+
+    report = run_project_knowledge_compiler_dry_run(_request(source))
+
+    assert report.artifacts[0].source_ids == ("source-1",)
+
+
+def test_model_call_budget_greater_than_zero_is_rejected() -> None:
+    with pytest.raises(ValueError, match="model calls"):
+        _request(_source("source-1"), budget=_budget(max_model_calls=1))
+
+
+def test_write_operation_budget_greater_than_zero_is_rejected() -> None:
+    with pytest.raises(ValueError, match="write operations"):
+        _request(_source("source-1"), budget=_budget(max_write_operations=1))
+
+
+def test_no_mutable_default_leakage_between_reports() -> None:
+    request = _request(_source("source-1"))
+
+    first_report = run_project_knowledge_compiler_dry_run(request)
+    second_report = run_project_knowledge_compiler_dry_run(request)
+
+    first_report.budget_used["artifacts_generated"] = 999
+    first_report.artifacts[0].metadata["change_state"] = "mutated"
+
+    assert second_report.budget_used["artifacts_generated"] == 1
+    assert second_report.artifacts[0].metadata["change_state"] == "new"
+
+
+def test_proof_report_counts_match_generated_artifacts_and_changes() -> None:
+    new_source = _source("source-1", content="new source")
+    changed_source = _source("source-2", content="changed source")
+    unchanged_source = _source("source-3", content="unchanged source")
+    request = _request(
+        new_source,
+        changed_source,
+        unchanged_source,
+        previous_hashes={
+            "source-2": _hash_for("old changed source"),
+            "source-3": unchanged_source.content_hash,
+        },
+        budget=_budget(max_sources=3, max_artifacts=10),
+    )
+
+    report = run_project_knowledge_compiler_dry_run(request)
+
+    assert report.source_candidates_discovered == 3
+    assert report.changed_sources_detected == 2
+    assert report.draft_artifacts_generated == 2
+    assert len(report.artifacts) == 2
+    assert len(report.source_changes) == 3
+    assert report.artifacts_approved == 0
+    assert report.artifacts_published == 0
+    assert report.retrieval_cards_generated == 0
+    assert report.graph_edges_proposed == 0


### PR DESCRIPTION
## Summary
- Added a new docs-only architecture contract for the Codex Knowledge Compiler concept.
- Defined the scope model, pipeline phases, source adapter shape, output artifact families, review gate doctrine, budgets, proof surface, invariants, and follow-through guidance.
- Updated the architecture KB map in `docs/architecture/README.md` to point to the new contract without changing current-state truth.

## Testing
- Docs validation passed locally.
- `git diff --check` passed.
- Not run (not requested).