### PR TITLE
Add Codexify.Space source architecture KB export

### DIFF
--- a/docs/exports/codexify-space-source-kb/00-current-codexify-truth.md
+++ b/docs/exports/codexify-space-source-kb/00-current-codexify-truth.md
@@ -1,0 +1,55 @@
+# Current Codexify Truth
+
+## Current phase
+
+- `Current`: Codexify is in local-first beta hardening on `main`.
+
+## Current supported reality
+
+- `Current`: The supported install and runtime path is local Docker Compose.
+- `Current`: The supported provider posture is local-only, with `LLM_PROVIDER=local`, `CODEXIFY_LOCAL_ONLY_MODE=true`, and `ALLOW_CLOUD_PROVIDERS=false`.
+- `Current`: Chat completion works on the supported path and persists back into the source thread.
+- `Current`: Upload -> embed -> readback works on the supported path.
+- `Current`: Workspace-local retrieval is supported on the current tip.
+- `Current`: Image-turn containment is proven on the supported profile.
+- `Current`: Guardian-returned coding results can land back in the source thread on the supported path.
+
+## What is not yet true
+
+- `Not Current`: Cloud-provider beta support is not a safe public claim.
+- `Not Current`: The packaged desktop shell does not replace the supported local Compose path.
+- `Not Current`: Command bus, delegation, federation, and graph-write surfaces are not part of the present public release promise by default.
+- `Not Current`: Internal/manual local-model draft work is not public release proof.
+- `Not Current`: UI dispatch, lease allocation, live agent execution, merge automation, and similar operator-control surfaces are not settled public product claims.
+
+## Active blockers or release risks
+
+- `Current risk`: Chat still depends on Redis and worker health, so acceptance does not guarantee completion.
+- `Current risk`: Legacy and canonical config paths still coexist, so operator drift remains possible.
+- `Current risk`: Supported-path proof must be refreshed whenever runtime behavior drifts.
+
+## What Codexify.Space may safely say
+
+- `Current`: Codexify is a local-first AI workspace.
+- `Current`: It is currently being hardened around a supported local Docker Compose path.
+- `Current`: It is designed around user-owned context, inspectable runtime truth, and proof-before-promise discipline.
+- `Current`: It supports conversation, document ingestion, retrieval-backed context, and artifact continuity on the supported path.
+- `Philosophy`: It treats continuity, ownership, and inspectability as product doctrine rather than marketing garnish.
+
+## What Codexify.Space must not imply
+
+- Do not imply hosted SaaS maturity.
+- Do not imply cloud-provider support is part of the current safe default.
+- Do not imply desktop packaging is the primary supported runtime.
+- Do not imply autonomous agents, federation, graph writes, or delegation are shipped public guarantees.
+- Do not imply acceptance equals completion, or that visible events guarantee UI receipt.
+- Do not imply memory means hidden profiling or durable trait inference by default.
+
+## Source docs used
+
+- `docs/architecture/00-current-state.md`
+- `docs/architecture/system-overview.md`
+- `docs/architecture/flows.md`
+- `docs/architecture/config-and-ops.md`
+- `docs/architecture/tech-debt-and-risks.md`
+- `docs/beta/README-FIRST.md`

--- a/docs/exports/codexify-space-source-kb/01-product-identity-and-public-story.md
+++ b/docs/exports/codexify-space-source-kb/01-product-identity-and-public-story.md
@@ -1,0 +1,51 @@
+# Product Identity and Public Story
+
+## Core framing
+
+- `Current`: Codexify is a local-first AI workspace for preserving the continuity of real work.
+- `Philosophy`: It is a continuity substrate, not just a chatbot wrapper.
+- `Current`: Its strongest truthful story is user-owned memory, project continuity, retrieval-backed context, and inspectable runtime behavior.
+
+## Public story elements that are grounded
+
+- `Current`: Local-first AI workspace
+- `Current`: User-owned memory posture
+- `Current`: Project, thread, document, and artifact continuity
+- `Current`: Inspectable runtime truth and proof surfaces
+- `Current`: Proof-before-promise discipline
+
+## What the story should teach
+
+- Chat history is not the same thing as durable working memory.
+- Context is infrastructure, not disposable residue.
+- Retrieval is a working surface for continuity, not mystical omniscience.
+- AI help becomes more useful when the path from prompt to artifact remains inspectable.
+
+## Mythic framing versus factual claims
+
+- `Philosophy`: Mythic or atmospheric framing can support the mood of continuity, archives, observatories, and memory.
+- `Rule`: Mythic language must never substitute for product truth.
+- `Rule`: If a sentence names a capability, it needs a claim label and a proof-aware basis.
+
+## Suggested public language patterns
+
+- "A local-first workspace for AI conversations, documents, and project continuity."
+- "Built to help serious AI work accumulate somewhere you control."
+- "Inspectable context, bounded memory, and proof-aware runtime surfaces."
+- "Turns scattered chats, uploads, and artifacts into retrievable working context."
+- "Designed for continuity without surrender."
+
+## Prohibited public language patterns
+
+- "Fully autonomous agent platform."
+- "Enterprise-ready distributed intelligence network."
+- "Perfect memory."
+- "Zero context loss."
+- "Hosted cloud intelligence fabric."
+- "Profiles you automatically and knows who you are."
+- "Your AI never forgets anything."
+
+## Public stance
+
+- `Current`: Keep the site sober, specific, and evidence-backed.
+- `Philosophy`: Let the atmosphere feel mythic if needed, but keep the claims plain.

--- a/docs/exports/codexify-space-source-kb/02-runtime-architecture-for-public-explanation.md
+++ b/docs/exports/codexify-space-source-kb/02-runtime-architecture-for-public-explanation.md
@@ -1,0 +1,54 @@
+# Runtime Architecture for Public Explanation
+
+## Public-safe component map
+
+- `Current`: React frontend
+- `Current`: FastAPI backend
+- `Current`: Postgres as the primary system of record
+- `Current`: Redis for queues, locks, heartbeats, and task-event transport
+- `Current`: Worker processes for chat, embeddings, and related background tasks
+- `Current`: Retrieval and vector layer for semantic context
+- `Current`: Media and document ingestion pipeline
+- `Current`: Local versus cloud provider boundary, with current support anchored to local-only posture
+- `Exploration`: Optional graph concepts exist in the repo, but graph writes remain default-off on the supported Compose path
+
+## Simplified explanation
+
+Codexify is not a single model call with a pretty shell around it.
+The product is a multi-part local runtime: UI, backend, database, queue, workers, and retrieval surfaces working together to preserve thread continuity and artifact lineage.
+
+## Simplified diagram
+
+```mermaid
+flowchart LR
+    UI["Frontend UI"] --> API["FastAPI backend"]
+    API --> PG["Postgres"]
+    API --> R["Redis"]
+    API --> VS["Retrieval and vector layer"]
+    API --> ST["Media and document storage"]
+    R --> W["Background workers"]
+    W --> PG
+    W --> VS
+    API --> LP["Local provider lane"]
+    API -. optional and policy-bound .-> CP["Cloud provider lane"]
+    API -. default-off concepts .-> G["Graph lane"]
+```
+
+## What this proves
+
+- `Current`: Codexify has a real runtime architecture beyond a browser prompt box.
+- `Current`: Background work, persistence, and retrieval are part of the product story.
+- `Current`: Local-first posture is enforced at the runtime and config layer, not just in brand language.
+
+## What this does not prove
+
+- It does not prove public cloud support is part of the current release promise.
+- It does not prove the site repo uses this same architecture.
+- It does not prove every optional seam is release-ready.
+- It does not prove acceptance of a task means successful completion.
+
+## Public explanation guidance
+
+- Explain the runtime as a bounded local system with explicit storage, queue, worker, and retrieval layers.
+- Do not expose unnecessary internal topology, private routes, or operator-only details.
+- Keep the emphasis on inspectability, ownership, and continuity rather than novelty theater.

--- a/docs/exports/codexify-space-source-kb/03-local-first-and-ownership-doctrine.md
+++ b/docs/exports/codexify-space-source-kb/03-local-first-and-ownership-doctrine.md
@@ -1,0 +1,37 @@
+# Local-First and Ownership Doctrine
+
+## Local-first supported path
+
+- `Current`: The supported path is local Docker Compose with local-only provider posture.
+- `Current`: Local-first is the release truth, not a fallback mode.
+
+## Ownership boundary
+
+- `Current`: User work, threads, documents, and continuity surfaces are meant to stay under user-visible control.
+- `Philosophy`: Codexify's value proposition is not just model access. It is ownership of the surrounding memory and artifact layer.
+
+## What local-first means here
+
+- The supported runtime runs locally.
+- Provider posture is explicitly local-only on the supported path.
+- Storage, retrieval, and artifact continuity are described as user-bounded product surfaces.
+- Inspectability matters as much as output quality.
+
+## What local-first does not automatically mean
+
+- It does not automatically mean offline under every condition.
+- It does not automatically mean no network dependencies exist anywhere in the repo.
+- It does not automatically mean every packaging path is equally supported.
+- It does not automatically mean every future provider or sync concept is approved for release.
+
+## Cloud-provider caution
+
+- `Current`: Treat cloud-provider support as outside the safe default unless current truth changes.
+- `Public rule`: If a public page mentions cloud options at all, it must be clearly labeled and non-default.
+
+## Public claim guidance
+
+- Safe: "Local-first is the supported product posture."
+- Safe: "The current supported path is a local runtime."
+- Unsafe: "Run anywhere with seamless cloud-provider support."
+- Unsafe: "Desktop and Compose are identical supported paths."

--- a/docs/exports/codexify-space-source-kb/04-memory-identity-and-sovereignty-boundaries.md
+++ b/docs/exports/codexify-space-source-kb/04-memory-identity-and-sovereignty-boundaries.md
@@ -1,0 +1,36 @@
+# Memory, Identity, and Sovereignty Boundaries
+
+## Memory doctrine
+
+- `Current`: Chat history is not durable identity by default.
+- `Current`: Light identity modeling exists as a minimal imprint layer.
+- `Current`: Deep identity is opt-in, inspectable, editable, and resettable when described by current policy.
+
+## Persona doctrine
+
+- `Current`: Personas borrow identity. They do not own it.
+- `Current`: Cross-persona continuity must remain user-directed, not silently assumed.
+
+## Sensitive inference rule
+
+- `Current`: No durable sensitive trait inference without explicit consent.
+- `Current`: Topics such as diagnosis, politics, trauma, religion, sexual orientation, and gender identity may appear in diary-like chat history without becoming durable identity flags by default.
+
+## Public-copy implications
+
+- Do not imply hidden profiling.
+- Do not imply manipulative personalization.
+- Do not imply the system silently builds a secret identity dossier.
+- Do use language about inspectability, consent, editability, reset, and user control.
+
+## Sovereignty language
+
+- `Safe`: sovereignty through inspectability, explicit boundaries, and user control
+- `Unsafe`: sovereignty as mystical omnipotence or absolute privacy guarantee
+
+## Public sentence patterns
+
+- Safe: "Memory is bounded, inspectable, and user-governed."
+- Safe: "Identity features are not the same thing as chat history."
+- Unsafe: "Codexify learns who you really are."
+- Unsafe: "Codexify builds a deep psychological model by default."

--- a/docs/exports/codexify-space-source-kb/05-retrieval-continuity-and-artifact-lineage.md
+++ b/docs/exports/codexify-space-source-kb/05-retrieval-continuity-and-artifact-lineage.md
@@ -1,0 +1,34 @@
+# Retrieval, Continuity, and Artifact Lineage
+
+## Continuity surfaces
+
+- `Current`: Threads are continuity surfaces.
+- `Current`: Projects are continuity surfaces.
+- `Current`: Documents and uploaded artifacts are continuity surfaces.
+- `Philosophy`: The system is strongest when the path from question to artifact stays visible.
+
+## Retrieval doctrine
+
+- `Current`: Retrieval is working context, not mystical memory.
+- `Current`: Upload -> embed -> readback is part of the supported path.
+- `Current`: Workspace-local retrieval is supported on the current tip.
+- `Rule`: Public descriptions should emphasize context assembly, retrieval posture, and bounded source selection.
+
+## Provenance and lineage
+
+- `Current`: Source provenance and relationship structure matter in export and restore doctrine.
+- `Current`: Source thread and source message lineage matter in contracts around result return and durable artifacts.
+- `Philosophy`: Artifacts should not appear as if they came from nowhere.
+
+## What Codexify.Space should teach
+
+- Retrieval is how working context gets assembled.
+- A project can keep track of documents, threads, and outputs together.
+- The value is not only the final artifact but the lineage that produced it.
+
+## Visual and content implications
+
+- Show thread-to-document-to-artifact relationships.
+- Prefer diagrams, timelines, path imagery, and library or ledger metaphors.
+- Avoid portraying retrieval as psychic omniscience.
+- Avoid "the AI simply remembers everything" framing.

--- a/docs/exports/codexify-space-source-kb/06-runtime-honesty-and-proof-surfaces.md
+++ b/docs/exports/codexify-space-source-kb/06-runtime-honesty-and-proof-surfaces.md
@@ -1,0 +1,40 @@
+# Runtime Honesty and Proof Surfaces
+
+## Runtime honesty doctrine
+
+- `Current`: Runtime truth should be surfaced, not hidden.
+- `Current`: Acceptance is not completion.
+- `Current`: Task-event publication is not the same as UI receipt.
+- `Current`: Health, catalog, and supported-profile surfaces must be read together.
+
+## Evidence posture
+
+- `Current`: Proof artifacts matter.
+- `Current`: Risk registers and current-state docs are part of truth, not embarrassment to be hidden.
+- `Current`: Public claims should point to proof surfaces when possible.
+
+## Proof surfaces worth referencing
+
+- current-state docs
+- supported-path proof artifacts
+- health and catalog surfaces
+- beta evidence and proof notes
+- architecture contracts and current risk docs
+- Founder Log or dev-log style records when they function as dated development evidence
+
+## Founder Log guidance
+
+- `Current use`: Treat Founder Log style material as a living development and proof record, not as substitute truth.
+- `Rule`: Narrative logs are strongest when they point back to proof artifacts, audits, or current-state updates.
+
+## Public-site behavior
+
+- Good public posture shows what is proven, what is bounded, and what is still being hardened.
+- Bad public posture hides uncertainty behind "it just works" mythology.
+
+## Public phrasing examples
+
+- Safe: "The supported path is evidence-backed and intentionally narrow."
+- Safe: "Codexify distinguishes accepted work from completed work."
+- Unsafe: "Every event you see means the work definitely finished."
+- Unsafe: "Operational truth is automatic and invisible."

--- a/docs/exports/codexify-space-source-kb/07-ui-visual-doctrine-transfer.md
+++ b/docs/exports/codexify-space-source-kb/07-ui-visual-doctrine-transfer.md
@@ -1,0 +1,39 @@
+# UI and Visual Doctrine Transfer
+
+## What transfers
+
+- `Current doctrine`: token discipline
+- `Current doctrine`: structural consistency
+- `Current doctrine`: restraint over improvisation
+- `Current doctrine`: atmosphere plus legibility
+
+## Token discipline
+
+- The app UI treats tokens as law, not suggestion.
+- Public-site work should preserve the same attitude even if the exact implementation differs.
+- Repeated visual meaning should come from a system, not ad hoc exceptions.
+
+## Glass and spatial law
+
+- `Current inspiration`: layered glass, slab structure, and spacing law are part of Codexify's app-side design canon.
+- `Transfer rule`: use this as inspiration for atmosphere and structural seriousness, not as a claim that Codexify.Space literally shares the same implementation.
+
+## Separation rule
+
+- Codexify app UI and Codexify.Space website UI are not the same thing.
+- The site may borrow mood, discipline, and structure without pretending to be the runtime shell.
+
+## Site-facing visual principles
+
+- Preserve atmosphere.
+- Preserve restraint.
+- Preserve legibility.
+- Preserve structural clarity.
+- Avoid generic dark SaaS layouts when they flatten identity.
+- Avoid decorative noise that weakens proof, continuity, or sovereignty themes.
+
+## Practical transfer
+
+- Favor deliberate grids, path-like movement, and artifact-oriented composition.
+- Use interface motifs carefully: panels, ledgers, archives, traces, observatory instruments.
+- Keep diagnostics-inspired visuals readable and sober.

--- a/docs/exports/codexify-space-source-kb/08-public-claim-discipline.md
+++ b/docs/exports/codexify-space-source-kb/08-public-claim-discipline.md
@@ -1,0 +1,56 @@
+# Public Claim Discipline
+
+## Required labels
+
+- `Current`: supported and safe to describe as present reality
+- `In development`: active work with meaningful implementation motion, but not safe to present as shipped
+- `Exploration`: researched, drafted, or partially scaffolded, but not product promise
+- `Roadmap`: directional future intent
+- `Philosophy`: values, doctrine, and framing that guide the product without claiming a shipped feature
+
+## General rules
+
+- Every public-facing capability statement should carry one of the labels above.
+- Choose the narrowest truthful label.
+- `Current` must align with current-state docs and supported-path proof posture.
+- Do not turn architecture presence into claim permission.
+
+## Rules for capability claims
+
+- Route presence is not enough.
+- Catalog presence is not enough.
+- Spec or ADR presence is not enough.
+- A current claim should describe supported behavior, not just code existence.
+
+## Rules for beta and download claims
+
+- Beta claims must stay narrow and evidence-backed.
+- Do not imply public launch readiness without dated evidence.
+- Do not imply desktop packaging replaces the supported Compose path.
+
+## Rules for local-first claims
+
+- Local-first can be claimed as current posture.
+- Do not silently widen that into cloud parity or universal offline guarantees.
+
+## Rules for AI and agent claims
+
+- Do not claim fully autonomous agents.
+- Do not claim unsupervised delegation as a public promise.
+- Do not claim command-bus, federation, or graph concepts as shipped product highlights unless current truth changes.
+
+## Rules for image and worldbuilding claims
+
+- Images may dramatize doctrine.
+- Images must not imply unproven runtime behavior.
+- Environmental storytelling must stay behind current product truth, not outrun it.
+
+## Safe and unsafe examples
+
+| Claim | Label | Safe? | Why |
+|---|---|---:|---|
+| "Codexify is currently being hardened around a supported local Docker Compose runtime." | `Current` | yes | Matches current-state truth. |
+| "Codexify supports cloud-provider beta workflows." | `Current` | no | Current docs say not to assume that. |
+| "Codexify is designed around user-owned continuity and inspectable runtime truth." | `Philosophy` | yes | Doctrine-backed and not overstated. |
+| "Codexify has optional graph concepts in the repo, but graph writes remain default-off on the supported path." | `Exploration` | yes | Truthful and bounded. |
+| "Codexify.Space runs the same architecture as Codexify." | `Current` | no | Cross-repo implementation claim without proof. |

--- a/docs/exports/codexify-space-source-kb/09-codexify-space-content-map.md
+++ b/docs/exports/codexify-space-source-kb/09-codexify-space-content-map.md
@@ -1,0 +1,27 @@
+# Codexify.Space Content Map
+
+| Section | Purpose | Public claim role | Proof anchor | Visual role | What not to imply |
+|---|---|---|---|---|---|
+| Hero / Altar | Establish thesis and emotional posture | `Philosophy` plus one narrow `Current` line | `00-current-codexify-truth.md` | Memory spine, archive, observatory, restraint | Do not imply hosted SaaS, autonomy, or total memory |
+| Overview | Explain what Codexify is in plain language | `Current` | current truth plus product story docs | Quiet architecture, continuity surfaces | Do not imply Space repo is the runtime |
+| Features | Show supported product surfaces | mostly `Current`, some `In development` if clearly marked | current truth, runtime explanation, proof docs | Panels, ledgers, artifacts, documents | Do not include internal-only or unsupported surfaces as defaults |
+| How It Works | Explain the runtime at a public-safe level | `Current` plus bounded `Exploration` notes | runtime architecture doc | Structured diagram, thread -> backend -> workers -> artifacts | Do not expose unnecessary internal topology |
+| Roadmap | Separate future intent from present truth | `Roadmap` and `Exploration` | roadmap boundaries doc | Horizon, schematics, distant structures | Do not blur roadmap into current capability |
+| Philosophy | Explain local-first, ownership, identity, proof | `Philosophy` | doctrine docs | Calm, essay-like, archival worldbuilding | Do not market doctrine as feature proof |
+| Founder Log | Show living development history | mixed labels, explicit per entry | proof surfaces and logs | field notes, observatory journal | Do not let narrative outrun current truth |
+| Download Beta | Explain supported paths and beta posture | `Current` | beta docs and release evidence | operator console, practical onboarding | Do not imply public GA or universal installer maturity |
+| Documentation | Link outward to truth and proof surfaces | mixed | source map and current truth | library, index, map room | Do not present stale docs as equal authority |
+| Current Truth / Proof Surface | Give a stable honesty page | `Current` | current truth and proof docs | audit board, status ledger | Do not overpromise with marketing gloss |
+
+## Editorial ordering suggestion
+
+1. Hero / Altar
+2. Overview
+3. Features
+4. How It Works
+5. Current Truth / Proof Surface
+6. Founder Log
+7. Philosophy
+8. Roadmap
+9. Download Beta
+10. Documentation

--- a/docs/exports/codexify-space-source-kb/10-image-and-worldbuilding-implications.md
+++ b/docs/exports/codexify-space-source-kb/10-image-and-worldbuilding-implications.md
@@ -1,0 +1,53 @@
+# Image and Worldbuilding Implications
+
+## Core rule
+
+Images are not decorative filler.
+They should reinforce continuity, memory, provenance, locality, and inspectability.
+
+## What environmental imagery should express
+
+- continuity
+- memory
+- provenance
+- locality
+- inspectability
+- artifact permanence
+- system restraint
+
+## Worldbuilding guardrail
+
+- `Rule`: Worldbuilding must not outrun claims.
+- `Rule`: If the product truth is bounded, the imagery should feel bounded too.
+- `Rule`: Mood may expand the emotional field, but it may not fabricate shipped behavior.
+
+## Suggested visual metaphors
+
+- archive
+- observatory
+- continuity field
+- local workspace
+- thread or path
+- proof ledger
+- memory grove
+- artifact vault
+
+## Recommended uses
+
+- Archive: documents, continuity, saved context
+- Observatory: inspectability, runtime truth, operator seriousness
+- Continuity field: thread-to-artifact flow
+- Local workspace: ownership and locality
+- Proof ledger: evidence, receipts, disciplined claims
+
+## What to avoid
+
+- generic cyberpunk control rooms
+- neon SaaS dashboards with no lineage meaning
+- anthropomorphic AI god imagery
+- imagery that implies invisible omniscience or total surveillance
+
+## Pipeline note
+
+Deterministic image placement, generation, and governance should be defined by a separate Codexify.Space KB or image-pipeline contract.
+This export only transfers doctrine and narrative constraints.

--- a/docs/exports/codexify-space-source-kb/11-agent-operating-protocol.md
+++ b/docs/exports/codexify-space-source-kb/11-agent-operating-protocol.md
@@ -1,0 +1,35 @@
+# Agent Operating Protocol
+
+## Start order
+
+1. Read [`00-current-codexify-truth.md`](./00-current-codexify-truth.md).
+2. Check [`08-public-claim-discipline.md`](./08-public-claim-discipline.md).
+3. Check [`13-source-map.md`](./13-source-map.md) before relying on a claim or image doctrine.
+
+## Operating rules
+
+- Keep Codexify product truth and Codexify.Space implementation truth distinct.
+- Do not overstate.
+- Do not import private or internal-only claims into public copy.
+- Prefer precise architecture-derived language over hype.
+- If a claim is not clearly supported, downgrade it or omit it.
+
+## For visual tasks
+
+- Preserve spatial gravitas.
+- Preserve restraint.
+- Avoid generic templates.
+- Use atmosphere in service of continuity, provenance, and inspectability.
+
+## For implementation tasks
+
+- Validate against current truth before editing.
+- Keep the change atomic.
+- Preserve label discipline on capability statements.
+- Commit only after the public claim surface is internally coherent.
+
+## When in doubt
+
+- current truth beats older narrative
+- supported path beats broader architecture presence
+- proof beats aspiration

--- a/docs/exports/codexify-space-source-kb/12-roadmap-boundaries-and-non-promises.md
+++ b/docs/exports/codexify-space-source-kb/12-roadmap-boundaries-and-non-promises.md
@@ -1,0 +1,31 @@
+# Roadmap Boundaries and Non-Promises
+
+## Keep these out of default public promise
+
+- internal-only command surfaces
+- experimental delegation paths
+- autonomous agent framing
+- graph-write claims
+- federation claims
+- broad command-bus claims
+- unsupported cloud-provider support claims
+- desktop-packaging parity claims
+
+## Current boundary calls
+
+- `Exploration`: graph concepts may be discussed only as bounded optional architecture, not as current product promise
+- `Exploration`: Pi-like invocation boundary work is contract and validation only, not live runtime execution
+- `Exploration`: self-extending plugin doctrine exists, but autonomous plugin execution does not
+- `Roadmap`: richer command-center or observability-deck surfaces may be discussed only as future-facing work
+
+## Public-site specific non-promises
+
+- Chronograph or environmental AI behavior on Codexify.Space should be treated as Codexify.Space roadmap unless independently implemented there.
+- Worldbuilding systems on the public site are not evidence that Codexify runtime features exist.
+
+## Other warnings to preserve
+
+- Acceptance is not completion.
+- Event publication is not UI receipt.
+- Health truth, catalog truth, and support truth must stay distinct.
+- Current docs and proof posture beat old README-era ambition.

--- a/docs/exports/codexify-space-source-kb/13-source-map.md
+++ b/docs/exports/codexify-space-source-kb/13-source-map.md
@@ -1,0 +1,45 @@
+# Source Map
+
+## Notes
+
+- This exported KB is a distillation, not a copy of the source corpus.
+- No required pre-read files from the task prompt were absent in this workspace.
+- Some legacy or broader docs exist in the repo but were intentionally not used as public truth when the validity matrix or current-state docs marked them as risky.
+
+## Source table
+
+| Path | What it contributed | Confidence | Safe for public-site use | Notes / caveats |
+|---|---|---|---|---|
+| `docs/architecture/00-current-state.md` | Canonical short-horizon truth, supported posture, blockers, non-promises | high | yes | Highest authority inside this export for current product truth |
+| `docs/architecture/README.md` | KB routing, architecture framing, source-anchor discipline | high | yes | Good for orientation, not a release proof artifact by itself |
+| `docs/architecture/kb-validity-matrix.md` | Trust rules, doc quarantine rules, separation of current truth from drift | high | yes | Critical for excluding legacy or misleading sources |
+| `docs/architecture/architecture-atlas.md` | Reading order, runtime-vs-UI distinction, ADR lane framing | high | yes | Helpful meta-layer, not a capability proof source |
+| `docs/architecture/system-overview.md` | Public-safe component map, topology, supported local runtime shape | high | yes | Structural source, not release readiness by itself |
+| `docs/architecture/flows.md` | Queue-backed behavior, acceptance semantics, retrieval and ingestion flow truth | high | yes | Needed for runtime honesty and "acceptance is not completion" doctrine |
+| `docs/architecture/data-and-storage.md` | Persistence layers, continuity surfaces, provenance-bearing entities | high | yes | Use at conceptual level; do not expose unnecessary storage internals |
+| `docs/architecture/config-and-ops.md` | Supported local-only posture, provider governance, health truth surfaces | high | yes | Strong source for public runtime-boundary explanation |
+| `docs/architecture/modules-and-ownership.md` | Real subsystem seams and high-coupling areas | medium | yes | Useful for internal understanding; only selectively public-safe |
+| `docs/architecture/tech-debt-and-risks.md` | Risk register, operator burden, release caveats | high | yes | Important for honesty surfaces and claim discipline |
+| `docs/architecture/runtime-protocol-token-contract.md` | Token-discipline concept for runtime truth surfaces | high | yes | Use as doctrine, not as marketing copy |
+| `docs/architecture/chat-runtime-contract.md` | Provider/runtime vs request-state separation | high | yes | Important for public explanation of runtime honesty |
+| `docs/architecture/account-export-restore-contract.md` | Artifact lineage, provenance, explicit relationship preservation | high | yes | Strong source for continuity and export doctrine |
+| `docs/architecture/agent-protocol-operations.md` | Agent work rules, non-widening discipline, output expectations | high | yes | Shaped exported AGENTS guidance |
+| `docs/architecture/self-extending-agent-plugin-system.md` | Bounded extension doctrine and explicit non-goals | medium | limited | Good for roadmap boundaries; not safe as shipped capability claim |
+| `docs/architecture/pi-invocation-boundary-contract.md` | Contract-only Pi boundary, provider separation, explicit deferrals | medium | limited | Safe only when clearly labeled as contract-only or exploration |
+| `docs/iddb_policy_v1.md` | Memory layers, opt-in deep identity, persona borrowing, sensitive inference bounds | high | yes | Canonical identity-policy source used instead of implying profiling |
+| `docs/beta/README-FIRST.md` | Beta posture, supported entry paths, private-beta caution | high | yes | Helpful for beta/download language; do not overgeneralize |
+| `docs/release/public-portal-snapshot-workflow.md` | Private source-vault vs public-portal boundary and copy-safe export logic | high | yes | Directly relevant to cross-repo KB export boundary |
+| `docs/release/open-source-tiering/public-readiness-checklist.md` | Public-readiness cautions and claim discipline checks | high | yes | Useful for public safety and boundary truth |
+| `docs/Marketing/README.md` | Proof-tier precedence and draft-only marketing governance | high | yes | Important claim-governance source |
+| `docs/Marketing/messaging/pillars.md` | Proof tier definitions and safe claim directions | high | yes | Strong source for claim labeling and content guidance |
+| `docs/Marketing/brand/constitution.md` | Forbidden claim patterns and required language discipline | high | yes | Strong public-story constraint source |
+| `docs/Marketing/master-campaign-brief.md` | Continuity narrative, mood lanes, worldbuilding language, safe claim posture ideas | medium | limited | Internal-use source; useful for atmosphere, not direct public proof |
+| `docs/Website/README.md` | Website content boundary as derived output, not truth source | medium | yes | Reinforces "derived output" stance |
+| `docs/ui/UI-DESIGN-MAP.md` | Transferable app-side visual discipline: slabs, glass, spacing, structural consistency | medium | limited | Visual doctrine only; not runtime truth |
+
+## Sources intentionally treated with caution
+
+- `docs/Codexify/README.md`
+  - Present in the repo, but the validity matrix classifies it as misleading identity drift for first-pass current truth work.
+- `docs/guardian/iddb_policy_v1.md`
+  - Present in the repo, but the canonical path used here was `docs/iddb_policy_v1.md`.

--- a/docs/exports/codexify-space-source-kb/AGENTS.md
+++ b/docs/exports/codexify-space-source-kb/AGENTS.md
@@ -1,0 +1,35 @@
+# Agent Instructions for Codexify.Space Source KB
+
+## Start here
+
+- Read [`README.md`](./README.md) first.
+- Read [`00-current-codexify-truth.md`](./00-current-codexify-truth.md) next.
+- Check [`13-source-map.md`](./13-source-map.md) before relying on a capability claim, risk statement, or visual transfer rule.
+
+## Core rules
+
+- Do not turn infrastructure internals into public promises.
+- Do not claim roadmap work as shipped.
+- Do not upgrade route presence, catalog presence, or architecture notes into release proof.
+- Do not use Codexify backend architecture as Codexify.Space implementation architecture unless the Space repo explicitly implements it.
+- Do not change public copy without checking [`08-public-claim-discipline.md`](./08-public-claim-discipline.md).
+- Do not change visual or worldbuilding direction without checking [`07-ui-visual-doctrine-transfer.md`](./07-ui-visual-doctrine-transfer.md) and [`10-image-and-worldbuilding-implications.md`](./10-image-and-worldbuilding-implications.md).
+
+## Claim discipline
+
+- Label public-facing capability statements as `Current`, `In development`, `Exploration`, `Roadmap`, or `Philosophy`.
+- Prefer the narrowest truthful label.
+- If evidence is mixed, downgrade the claim instead of polishing it.
+
+## Boundary discipline
+
+- Keep Codexify product truth distinct from Codexify.Space site truth.
+- Keep mythic framing distinct from factual claims.
+- Keep internal-only surfaces, experimental seams, and unsupported install modes out of default public promise.
+
+## Working style
+
+- Keep work atomic.
+- Validate against current truth before changing words.
+- Preserve proof-backed language.
+- When uncertain, state the uncertainty directly instead of smoothing it over.

--- a/docs/exports/codexify-space-source-kb/README.md
+++ b/docs/exports/codexify-space-source-kb/README.md
@@ -1,0 +1,68 @@
+# Codexify.Space Source KB
+
+## What this is
+
+This folder is a portable knowledge base exported from the Codexify infrastructure repo.
+It is meant to be copied into the separate Codexify.Space repo as source material for public-site agents, designers, and copy or worldbuilding work.
+
+This KB explains Codexify-the-product and Codexify-the-infrastructure as it currently stands.
+It does not define Codexify.Space's own implementation architecture.
+
+## Source and destination
+
+- Generated from: `Codexify-main` infrastructure repo
+- Intended destination: `Codexify.Space` repo
+
+## How to use this KB
+
+1. Read [`00-current-codexify-truth.md`](./00-current-codexify-truth.md) first.
+2. Use the rest of the docs to shape public explanation, claim discipline, IA, visuals, and future site-agent work.
+3. Treat this folder as a bounded derivative of the infrastructure repo, not as a free license to restate internal architecture as public promise.
+4. Check [`13-source-map.md`](./13-source-map.md) before relying on a sensitive or ambitious claim.
+
+## Interpretation rules
+
+- Inside this exported KB, [`00-current-codexify-truth.md`](./00-current-codexify-truth.md) wins on short-horizon product truth.
+- If a public-facing statement is not supported there, it must be downgraded, labeled, or omitted.
+- Codexify product truth and Codexify.Space implementation truth stay separate.
+
+## Boundary rule
+
+This KB explains Codexify so Codexify.Space can talk about it accurately.
+It does not say that the Codexify.Space site already runs the same backend, workers, queues, retrieval stack, or app shell unless the Space repo explicitly implements those things.
+
+## Reading order
+
+1. [`00-current-codexify-truth.md`](./00-current-codexify-truth.md)
+2. [`01-product-identity-and-public-story.md`](./01-product-identity-and-public-story.md)
+3. [`08-public-claim-discipline.md`](./08-public-claim-discipline.md)
+4. [`02-runtime-architecture-for-public-explanation.md`](./02-runtime-architecture-for-public-explanation.md)
+5. [`03-local-first-and-ownership-doctrine.md`](./03-local-first-and-ownership-doctrine.md)
+6. [`04-memory-identity-and-sovereignty-boundaries.md`](./04-memory-identity-and-sovereignty-boundaries.md)
+7. [`05-retrieval-continuity-and-artifact-lineage.md`](./05-retrieval-continuity-and-artifact-lineage.md)
+8. [`06-runtime-honesty-and-proof-surfaces.md`](./06-runtime-honesty-and-proof-surfaces.md)
+9. [`07-ui-visual-doctrine-transfer.md`](./07-ui-visual-doctrine-transfer.md)
+10. [`09-codexify-space-content-map.md`](./09-codexify-space-content-map.md)
+11. [`10-image-and-worldbuilding-implications.md`](./10-image-and-worldbuilding-implications.md)
+12. [`11-agent-operating-protocol.md`](./11-agent-operating-protocol.md)
+13. [`12-roadmap-boundaries-and-non-promises.md`](./12-roadmap-boundaries-and-non-promises.md)
+14. [`13-source-map.md`](./13-source-map.md)
+
+## Doc map
+
+- `README.md`: entrypoint and interpretation rules
+- `AGENTS.md`: operating rules for future agents in the destination repo
+- `00-current-codexify-truth.md`: current short-form truth export
+- `01-product-identity-and-public-story.md`: public story grounded in architecture
+- `02-runtime-architecture-for-public-explanation.md`: public-safe runtime explanation
+- `03-local-first-and-ownership-doctrine.md`: local-first and ownership posture
+- `04-memory-identity-and-sovereignty-boundaries.md`: memory and identity doctrine
+- `05-retrieval-continuity-and-artifact-lineage.md`: retrieval, continuity, provenance
+- `06-runtime-honesty-and-proof-surfaces.md`: proof, inspectability, runtime honesty
+- `07-ui-visual-doctrine-transfer.md`: transferable visual doctrine only
+- `08-public-claim-discipline.md`: labeling and claim rules
+- `09-codexify-space-content-map.md`: recommended public-site IA
+- `10-image-and-worldbuilding-implications.md`: image and environmental guidance
+- `11-agent-operating-protocol.md`: work protocol for future KB users
+- `12-roadmap-boundaries-and-non-promises.md`: what stays deferred or bounded
+- `13-source-map.md`: traceability back to infrastructure-repo sources


### PR DESCRIPTION
## Summary
- Added a portable knowledge base export under `docs/exports/codexify-space-source-kb/` for reuse in the Codexify.Space repo.
- Distills current Codexify truth, public-story guidance, runtime explanation, claim discipline, visual doctrine, and roadmap boundaries into copy-safe docs.
- Includes an agent-facing README, operating instructions, and a source map back to the infrastructure architecture corpus.

## Testing
- Not run (not requested)