### PR TITLE
Codex/restore persona studio and flow

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1430,6 +1430,11 @@ export default function App() {
         </main>
       </div>
     );
+  } else if (
+    (personaStudioRoute || flowBuilderRoute) &&
+    shouldBlockNestedWorkspaceShell()
+  ) {
+    mainContent = <WorkspaceRecursionGuard />;
   } else if (personaStudioRoute || flowBuilderRoute) {
     mainContent = <AppShell />;
   } else if (shareRoute && shareToken) {

--- a/frontend/src/components/persona/layout/AppShell.tsx
+++ b/frontend/src/components/persona/layout/AppShell.tsx
@@ -2895,26 +2895,6 @@ export default function AppShell({
               <PhonePressButton
                 isPhoneShell={isPhoneShell}
                 className="pill-tab shrink-0 whitespace-nowrap"
-                data-state={view === "flowBuilder" ? "active" : "inactive"}
-                aria-current={view === "flowBuilder" ? "page" : undefined}
-                onClick={() => navigateToView("flowBuilder")}
-                style={getMobileNavPillStyle("flowBuilder")}
-              >
-                Flow Builder
-              </PhonePressButton>
-              <PhonePressButton
-                isPhoneShell={isPhoneShell}
-                className="pill-tab shrink-0 whitespace-nowrap"
-                data-state={view === "personaStudio" ? "active" : "inactive"}
-                aria-current={view === "personaStudio" ? "page" : undefined}
-                onClick={() => navigateToView("personaStudio")}
-                style={getMobileNavPillStyle("personaStudio")}
-              >
-                Persona Studio
-              </PhonePressButton>
-              <PhonePressButton
-                isPhoneShell={isPhoneShell}
-                className="pill-tab shrink-0 whitespace-nowrap"
                 data-state={view === "documents" ? "active" : "inactive"}
                 aria-current={view === "documents" ? "page" : undefined}
                 onClick={() => navigateToView("documents")}
@@ -2931,6 +2911,26 @@ export default function AppShell({
                 style={getMobileNavPillStyle("gallery")}
               >
                 Gallery
+              </PhonePressButton>
+              <PhonePressButton
+                isPhoneShell={isPhoneShell}
+                className="pill-tab shrink-0 whitespace-nowrap"
+                data-state={view === "flowBuilder" ? "active" : "inactive"}
+                aria-current={view === "flowBuilder" ? "page" : undefined}
+                onClick={() => navigateToView("flowBuilder")}
+                style={getMobileNavPillStyle("flowBuilder")}
+              >
+                Flow Builder
+              </PhonePressButton>
+              <PhonePressButton
+                isPhoneShell={isPhoneShell}
+                className="pill-tab shrink-0 whitespace-nowrap"
+                data-state={view === "personaStudio" ? "active" : "inactive"}
+                aria-current={view === "personaStudio" ? "page" : undefined}
+                onClick={() => navigateToView("personaStudio")}
+                style={getMobileNavPillStyle("personaStudio")}
+              >
+                Persona Studio
               </PhonePressButton>
             </div>
           </div>

--- a/frontend/src/components/persona/layout/__tests__/AppShell.test.tsx
+++ b/frontend/src/components/persona/layout/__tests__/AppShell.test.tsx
@@ -590,7 +590,7 @@ describe("AppShell settings utility trigger", () => {
     vi.clearAllMocks();
   });
 
-  it("keeps Flow Builder and Persona Studio visible in the primary nav", async () => {
+  it("keeps the primary nav in the preferred visual order", async () => {
     const user = userEvent.setup();
     localStorage.setItem("cfy.lastView", "dashboard");
 
@@ -618,12 +618,34 @@ describe("AppShell settings utility trigger", () => {
       "max-w-full"
     );
     const primaryNav = within(screen.getByTestId("app-shell-top-nav"));
+    const navButtonOrder = primaryNav
+      .getAllByRole("button")
+      .map((button) => button.textContent?.trim() ?? "")
+      .filter((label) =>
+        [
+          "Guardian",
+          "Dashboard",
+          "Documents",
+          "Gallery",
+          "Flow Builder",
+          "Persona Studio",
+        ].includes(label)
+      );
+
+    expect(navButtonOrder).toEqual([
+      "Guardian",
+      "Dashboard",
+      "Documents",
+      "Gallery",
+      "Flow Builder",
+      "Persona Studio",
+    ]);
     expect(primaryNav.getByRole("button", { name: "Guardian" })).toBeInTheDocument();
     expect(primaryNav.getByRole("button", { name: "Dashboard" })).toBeInTheDocument();
-    expect(primaryNav.getByRole("button", { name: "Flow Builder" })).toBeInTheDocument();
-    expect(primaryNav.getByRole("button", { name: "Persona Studio" })).toBeInTheDocument();
     expect(primaryNav.getByRole("button", { name: "Documents" })).toBeInTheDocument();
     expect(primaryNav.getByRole("button", { name: "Gallery" })).toBeInTheDocument();
+    expect(primaryNav.getByRole("button", { name: "Flow Builder" })).toBeInTheDocument();
+    expect(primaryNav.getByRole("button", { name: "Persona Studio" })).toBeInTheDocument();
     expect(screen.queryByTestId("settings-view-mock")).not.toBeInTheDocument();
 
     await user.click(primaryNav.getByRole("button", { name: "Flow Builder" }));

--- a/frontend/src/components/persona/layout/__tests__/GuardianChatWithSidebar.stability.test.tsx
+++ b/frontend/src/components/persona/layout/__tests__/GuardianChatWithSidebar.stability.test.tsx
@@ -514,6 +514,16 @@ describe("GuardianChatWithSidebar stability contract", () => {
     expect(screen.getByTestId("guardian-chat-mock")).toBeInTheDocument();
   });
 
+  it("lets the desktop Guardian frame stretch to the workspace pane", () => {
+    render(<GuardianChatWithSidebar guardianName="Guardian" userName="User" />);
+
+    const guardianLayout = screen
+      .getByTestId("guardian-chat-mock")
+      .closest("[data-guardian-layout]");
+
+    expect(guardianLayout).toHaveStyle({ maxWidth: "100%" });
+  });
+
   it("keeps selected thread stable when pagination appends", async () => {
     setupThreadApi({
       all: {

--- a/frontend/src/components/persona/layout/mobileShellProfile.ts
+++ b/frontend/src/components/persona/layout/mobileShellProfile.ts
@@ -86,7 +86,7 @@ const DESKTOP_SHELL_PROFILE = {
   },
   guardian: {
     singleLane: false,
-    frameMaxWidth: "1500px",
+    frameMaxWidth: "100%",
     drawerWidth: "min(360px, 90vw)",
   },
   workspace: {

--- a/frontend/src/features/chat/__tests__/GuardianChat.session-tabs.test.tsx
+++ b/frontend/src/features/chat/__tests__/GuardianChat.session-tabs.test.tsx
@@ -7,6 +7,7 @@ import GuardianChat, {
 import {
   CHAT_LANE_MAX_WIDTH,
   CHAT_LANE_MAX_WIDTH_CLASS,
+  GUARDIAN_SHELL_MAX_WIDTH,
   GUARDIAN_SHELL_MAX_WIDTH_CLASS,
 } from "@/features/chat/chatLane";
 
@@ -333,6 +334,7 @@ describe("GuardianChat session-tab binding", () => {
     await waitFor(() => {
       const shell = screen.getByTestId("guardian-shell");
       expect(shell.className).toContain(GUARDIAN_SHELL_MAX_WIDTH_CLASS);
+      expect(shell).toHaveStyle({ maxWidth: GUARDIAN_SHELL_MAX_WIDTH });
 
       const lane = screen.getByTestId("composer-conversation-lane");
       expect(lane).toHaveStyle({ maxWidth: `${CHAT_LANE_MAX_WIDTH}px` });

--- a/frontend/src/features/chat/chatLane.ts
+++ b/frontend/src/features/chat/chatLane.ts
@@ -31,14 +31,14 @@ export const CHAT_COMPOSER_SEND_EDGE_INSET_CLASS = "pr-[48px]";
 export const CHAT_COMPOSER_SEND_SLOT_BALANCE_CLASS =
   "md:mr-6 lg:mr-8 xl:mr-10";
 
-// Outer Guardian surface ceiling for fullscreen layouts. Keeps the shell large
-// enough for future workspace activation without letting the empty side bands
-// dominate the scene on very wide displays.
-export const GUARDIAN_SHELL_MAX_WIDTH = 1500;
+// Outer Guardian surface ceiling for fullscreen layouts. Keep the panel itself
+// aligned with the AppShell workspace pane; inner chat lanes still own their
+// readable text width.
+export const GUARDIAN_SHELL_MAX_WIDTH = "100%";
 
 // Static class companion for shell consumers that need the canonical Tailwind
 // contract alongside the numeric token.
-export const GUARDIAN_SHELL_MAX_WIDTH_CLASS = "max-w-[1500px]";
+export const GUARDIAN_SHELL_MAX_WIDTH_CLASS = "max-w-full";
 
 // Token-friendly padding expression reused by chat surfaces so portrait and
 // fullscreen share the same baseline inset without bespoke numbers.

--- a/frontend/src/features/workspace/__tests__/WorkspaceInvocation.test.tsx
+++ b/frontend/src/features/workspace/__tests__/WorkspaceInvocation.test.tsx
@@ -312,7 +312,7 @@ describe("workspace invocation contract", () => {
     });
   });
 
-  it("blocks nested shell rendering when the app re-enters inside a workspace preview", async () => {
+  it("blocks nested Flow Builder shell rendering inside a workspace preview", async () => {
     vi.doMock("@/features/workspace/state/useWorkspaceState", async () => {
       const actual =
         await vi.importActual<typeof import("@/features/workspace/state/useWorkspaceState")>(
@@ -323,6 +323,8 @@ describe("workspace invocation contract", () => {
         shouldBlockNestedWorkspaceShell: vi.fn(() => true),
       };
     });
+
+    window.history.pushState({}, "", "/flow-builder");
 
     const { default: App } = await import("@/App");
 


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
