### PR TITLE
Add Campaign Runner intention packet seam

### DIFF
--- a/codex_runner/prompts/audit_report_to_campaign_runner.md
+++ b/codex_runner/prompts/audit_report_to_campaign_runner.md
@@ -10,6 +10,16 @@ Inputs:
 - Repo root: <REPO_ROOT>
 - Stage-A audit JSON: <PASTE MEGA_AUDIT_OUTPUT_JSON_HERE>
 
+Intention packet:
+- Stage B may use the intention packet only to interpret and filter Stage-A findings.
+- Stage B must not invent campaigns or tasks unsupported by Stage-A evidence.
+- Stage B must preserve independently mergeable task scope.
+- Stage B must prefer discovery tasks over speculative implementation when evidence is insufficient.
+- Stage B must not widen release claims or runtime support claims.
+- Stage B must not treat the intention packet as runtime proof.
+
+<INTENTION_PACKET>
+
 Hard constraints:
 1. `audit_id` must be copied exactly from Stage-A JSON.
 2. Emit `campaigns` as 0..N entries.

--- a/codex_runner/prompts/mega_audit.md
+++ b/codex_runner/prompts/mega_audit.md
@@ -11,6 +11,15 @@ Runner-owned constraints:
 - `generated_at` must be ISO-8601 UTC.
 - `agent.mode` must be `audit`.
 
+Intention packet:
+- The intention packet is operator-authored planning input.
+- It may narrow the audit objective, scope, non-goals, and evidence posture.
+- It must not override runner-owned constraints, schema requirements, repo evidence requirements, or output JSON-only mode.
+- Audit against the intention packet, but separate repo-grounded findings from unsupported intention claims.
+- Prefer discovery-only output when the repo does not support the intention.
+
+<INTENTION_PACKET>
+
 Model identification:
 - Determine `agent.model` by running `python codex_runner/model_id_helper.py`.
 - Parse `MODEL_ID=<value>` and set `agent.model` to `<value>`.

--- a/codex_runner/runner.py
+++ b/codex_runner/runner.py
@@ -37,6 +37,11 @@ DEFAULT_TASK_RESULT_SCHEMA_PATH = (
 DEFAULT_COMPILER_JSON_TOKEN = "<PASTE MEGA_AUDIT_OUTPUT_JSON_HERE>"
 DEFAULT_REPO_ROOT_TOKEN = "<REPO_ROOT>"
 DEFAULT_AUDIT_ID_TOKEN = "<AUDIT_ID>"
+DEFAULT_INTENTION_PACKET_TOKEN = "<INTENTION_PACKET>"
+DEFAULT_INTENTION_PACKET_TEXT = (
+    "No explicit intention packet was provided. Use the default "
+    "repository-grounded audit posture and do not infer a narrower target."
+)
 
 CAMPAIGN_ID_PATTERN = re.compile(
     r"^(?P<date>\d{4}-\d{2}-\d{2})::(?P<slug>[a-z0-9_]+)::(?P<seq>\d{3})$"
@@ -96,6 +101,50 @@ def sha256_text(value: str) -> str:
 
 def sha256_file(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def replace_template_placeholders(
+    template: str, replacements: dict[str, str]
+) -> str:
+    rendered = template
+    replacement_values = list(replacements.values())
+    sentinels: dict[str, str] = {}
+
+    for index, (token, value) in enumerate(replacements.items()):
+        if not token:
+            continue
+        seed = sha256_text(f"{index}:{token}")[:12]
+        sentinel = f"__RUNNER_PLACEHOLDER_{index}_{seed}__"
+        while sentinel in rendered or any(
+            sentinel in replacement for replacement in replacement_values
+        ):
+            seed = sha256_text(seed)[:12]
+            sentinel = f"__RUNNER_PLACEHOLDER_{index}_{seed}__"
+        rendered = rendered.replace(token, sentinel)
+        sentinels[sentinel] = value
+
+    for sentinel, value in sentinels.items():
+        rendered = rendered.replace(sentinel, value)
+    return rendered
+
+
+def validate_intention_packet_file(path: Path) -> None:
+    if not path.exists():
+        raise RunnerError(f"Intention packet file not found: {path}")
+    if path.is_dir():
+        raise RunnerError(f"Intention packet path is a directory: {path}")
+
+
+def load_intention_packet(path: Path | None) -> str:
+    if path is None:
+        return DEFAULT_INTENTION_PACKET_TEXT
+    validate_intention_packet_file(path)
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise RunnerError(
+            f"Intention packet file must be UTF-8 text: {path}"
+        ) from exc
 
 
 def json_read(path: Path) -> dict[str, Any]:
@@ -899,14 +948,23 @@ def enforce_scope_guard(
 
 
 def render_audit_prompt(
-    template: str, repo_root: Path, audit_id: str, run_id: str
+    template: str,
+    repo_root: Path,
+    audit_id: str,
+    run_id: str,
+    intention_packet_text: str = DEFAULT_INTENTION_PACKET_TEXT,
 ) -> str:
-    rendered = template
-    rendered = rendered.replace(DEFAULT_REPO_ROOT_TOKEN, str(repo_root))
-    rendered = rendered.replace(DEFAULT_AUDIT_ID_TOKEN, audit_id)
-    rendered = rendered.replace("{{AUDIT_ID}}", audit_id)
-    rendered = rendered.replace("<RUN_ID>", run_id)
-    rendered = rendered.replace("{{RUN_ID}}", run_id)
+    rendered = replace_template_placeholders(
+        template,
+        {
+            DEFAULT_REPO_ROOT_TOKEN: str(repo_root),
+            DEFAULT_AUDIT_ID_TOKEN: audit_id,
+            "{{AUDIT_ID}}": audit_id,
+            "<RUN_ID>": run_id,
+            "{{RUN_ID}}": run_id,
+            DEFAULT_INTENTION_PACKET_TOKEN: intention_packet_text,
+        },
+    )
 
     if (
         DEFAULT_AUDIT_ID_TOKEN not in template
@@ -921,12 +979,21 @@ def render_audit_prompt(
 
 
 def render_compiler_prompt(
-    template: str, repo_root: Path, mega_payload: dict[str, Any]
+    template: str,
+    repo_root: Path,
+    mega_payload: dict[str, Any],
+    intention_packet_text: str = DEFAULT_INTENTION_PACKET_TEXT,
 ) -> str:
     mega_json = json.dumps(mega_payload, indent=2, ensure_ascii=False)
-    rendered = template.replace(DEFAULT_REPO_ROOT_TOKEN, str(repo_root))
-    rendered = rendered.replace(DEFAULT_COMPILER_JSON_TOKEN, mega_json)
-    rendered = rendered.replace("<AUDIT_JSON>", mega_json)
+    rendered = replace_template_placeholders(
+        template,
+        {
+            DEFAULT_REPO_ROOT_TOKEN: str(repo_root),
+            DEFAULT_COMPILER_JSON_TOKEN: mega_json,
+            "<AUDIT_JSON>": mega_json,
+            DEFAULT_INTENTION_PACKET_TOKEN: intention_packet_text,
+        },
+    )
     if (
         DEFAULT_COMPILER_JSON_TOKEN not in template
         and "<AUDIT_JSON>" not in template
@@ -1242,8 +1309,9 @@ def run_inputs_payload(
     pass_index: int,
     execute_mode: str,
     provider: str,
+    intention_packet_sha256: str | None = None,
 ) -> dict[str, Any]:
-    return {
+    payload = {
         "repo_root": str(repo_root.resolve()),
         "base_ref": base_ref_sha,
         "provider": provider,
@@ -1254,6 +1322,9 @@ def run_inputs_payload(
         "pass_index": pass_index,
         "execute_mode": execute_mode,
     }
+    if intention_packet_sha256 is not None:
+        payload["intention_packet_sha256"] = intention_packet_sha256
+    return payload
 
 
 def write_run_meta(
@@ -1275,22 +1346,30 @@ def write_run_meta(
     provider: str,
     provider_models: dict[str, str | None],
     provider_settings_sanitized: list[str],
+    intention_packet_file: Path | None = None,
+    intention_packet_sha256: str | None = None,
 ) -> None:
+    inputs = {
+        "audit_prompt_file": str(audit_prompt_file.resolve()),
+        "audit_schema_file": str(audit_schema_file.resolve()),
+        "compiler_prompt_file": str(compiler_prompt_file.resolve()),
+        "campaign_set_schema_file": str(campaign_set_schema_file.resolve()),
+        "audit_prompt_sha256": hashes.audit_prompt_sha256,
+        "audit_schema_sha256": hashes.audit_schema_sha256,
+        "compiler_prompt_sha256": hashes.compiler_prompt_sha256,
+        "campaign_set_schema_sha256": hashes.campaign_set_schema_sha256,
+    }
+    if intention_packet_file is not None:
+        inputs["intention_packet_file"] = str(intention_packet_file.resolve())
+    if intention_packet_sha256 is not None:
+        inputs["intention_packet_sha256"] = intention_packet_sha256
+
     payload = {
         "run_id": run_id,
         "audit_id": audit_id,
         "generated_at": now_iso(),
         "resolved_base_ref_sha": base_ref_sha,
-        "inputs": {
-            "audit_prompt_file": str(audit_prompt_file.resolve()),
-            "audit_schema_file": str(audit_schema_file.resolve()),
-            "compiler_prompt_file": str(compiler_prompt_file.resolve()),
-            "campaign_set_schema_file": str(campaign_set_schema_file.resolve()),
-            "audit_prompt_sha256": hashes.audit_prompt_sha256,
-            "audit_schema_sha256": hashes.audit_schema_sha256,
-            "compiler_prompt_sha256": hashes.compiler_prompt_sha256,
-            "campaign_set_schema_sha256": hashes.campaign_set_schema_sha256,
-        },
+        "inputs": inputs,
         "cli_args": cli_args,
         "preflight": {
             "git_clean": preflight_clean,
@@ -1393,6 +1472,12 @@ def run_pass(
         compiler_prompt_sha256=sha256_file(args.compiler_prompt_file),
         campaign_set_schema_sha256=sha256_file(args.campaign_set_schema_file),
     )
+    intention_packet_text = load_intention_packet(args.intention_packet_file)
+    intention_packet_sha256 = (
+        sha256_text(intention_packet_text)
+        if args.intention_packet_file is not None
+        else None
+    )
 
     run_inputs = run_inputs_payload(
         repo_root=repo_root,
@@ -1403,6 +1488,7 @@ def run_pass(
         if args.execute and not args.dry_run
         else "dry-run",
         provider=args.provider,
+        intention_packet_sha256=intention_packet_sha256,
     )
     run_id = sha256_text(canonical_json(run_inputs))[:12]
     audit_id = f"AUDIT_{run_id}"
@@ -1415,7 +1501,11 @@ def run_pass(
 
     audit_prompt_template = args.audit_prompt_file.read_text(encoding="utf-8")
     audit_prompt_text = render_audit_prompt(
-        audit_prompt_template, repo_root, audit_id, run_id
+        audit_prompt_template,
+        repo_root,
+        audit_id,
+        run_id,
+        intention_packet_text,
     )
     text_write(audit_dir_abs / "audit_input_prompt.md", audit_prompt_text)
 
@@ -1440,7 +1530,10 @@ def run_pass(
 
     compiler_template = args.compiler_prompt_file.read_text(encoding="utf-8")
     compiler_prompt_text = render_compiler_prompt(
-        compiler_template, repo_root, audit_payload
+        compiler_template,
+        repo_root,
+        audit_payload,
+        intention_packet_text,
     )
     text_write(audit_dir_abs / "compiler_input_prompt.md", compiler_prompt_text)
 
@@ -1520,6 +1613,8 @@ def run_pass(
         provider=args.provider,
         provider_models=active_models,
         provider_settings_sanitized=active_settings_sanitized,
+        intention_packet_file=args.intention_packet_file,
+        intention_packet_sha256=intention_packet_sha256,
     )
     write_run_meta(audit_dir_abs / "run_meta.json", **run_meta_kwargs)
     write_run_meta(run_dir_abs / "run_meta.json", **run_meta_kwargs)
@@ -1843,6 +1938,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--compiler-prompt-file", type=Path, required=True)
     parser.add_argument("--campaign-set-schema-file", type=Path, required=True)
     parser.add_argument(
+        "--intention-packet-file",
+        type=Path,
+        default=None,
+        help="Optional UTF-8 markdown intention packet for Stage A and Stage B",
+    )
+    parser.add_argument(
         "--task-result-schema-file",
         type=Path,
         default=DEFAULT_TASK_RESULT_SCHEMA_PATH,
@@ -1907,6 +2008,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     args.campaign_set_schema_file = (
         args.campaign_set_schema_file.expanduser().resolve()
     )
+    if args.intention_packet_file is not None:
+        args.intention_packet_file = (
+            args.intention_packet_file.expanduser().resolve()
+        )
     args.task_result_schema_file = (
         args.task_result_schema_file.expanduser().resolve()
     )
@@ -1939,6 +2044,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     for path in required_paths:
         if not path.exists():
             raise RunnerError(f"Required file not found: {path}")
+    if args.intention_packet_file is not None:
+        validate_intention_packet_file(args.intention_packet_file)
 
     return args
 

--- a/codex_runner/tests/test_intention_packet_prompting.py
+++ b/codex_runner/tests/test_intention_packet_prompting.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import runner
+
+
+def _write_required_runner_files(tmp_path: Path) -> dict[str, Path]:
+    paths = {
+        "audit_prompt": tmp_path / "audit.md",
+        "audit_schema": tmp_path / "audit.schema.json",
+        "compiler_prompt": tmp_path / "compiler.md",
+        "campaign_schema": tmp_path / "campaign.schema.json",
+        "task_schema": tmp_path / "task.schema.json",
+    }
+    for path in paths.values():
+        path.write_text("{}", encoding="utf-8")
+    return paths
+
+
+def test_prompt_assembly_without_intention_packet_uses_fallback() -> None:
+    audit_prompt = runner.render_audit_prompt(
+        "Intention:\n<INTENTION_PACKET>\nAudit: <AUDIT_ID>",
+        Path("/repo"),
+        "AUDIT_abc123def456",
+        "abc123def456",
+    )
+    compiler_prompt = runner.render_compiler_prompt(
+        "Intention:\n<INTENTION_PACKET>\nAudit: <PASTE MEGA_AUDIT_OUTPUT_JSON_HERE>",
+        Path("/repo"),
+        {"audit_id": "AUDIT_abc123def456"},
+    )
+
+    assert runner.DEFAULT_INTENTION_PACKET_TEXT in audit_prompt
+    assert runner.DEFAULT_INTENTION_PACKET_TEXT in compiler_prompt
+    assert runner.DEFAULT_INTENTION_PACKET_TEXT == (
+        "No explicit intention packet was provided. Use the default "
+        "repository-grounded audit posture and do not infer a narrower target."
+    )
+
+
+def test_prompt_assembly_injects_intention_packet_into_both_stages(
+    tmp_path: Path,
+) -> None:
+    packet_path = tmp_path / "intention.md"
+    packet_body = (
+        "# Operator Intention\n\n"
+        "- Scope: Campaign Runner prompt seam only.\n"
+        "- Non-goal: no provider behavior changes.\n"
+    )
+    packet_path.write_text(packet_body, encoding="utf-8")
+    packet_text = runner.load_intention_packet(packet_path)
+
+    audit_prompt = runner.render_audit_prompt(
+        "Intention:\n<INTENTION_PACKET>\nAudit: <AUDIT_ID>",
+        Path("/repo"),
+        "AUDIT_abc123def456",
+        "abc123def456",
+        packet_text,
+    )
+    compiler_prompt = runner.render_compiler_prompt(
+        "Intention:\n<INTENTION_PACKET>\nAudit: <PASTE MEGA_AUDIT_OUTPUT_JSON_HERE>",
+        Path("/repo"),
+        {"audit_id": "AUDIT_abc123def456"},
+        packet_text,
+    )
+
+    assert packet_body in audit_prompt
+    assert packet_body in compiler_prompt
+    assert runner.DEFAULT_INTENTION_PACKET_TEXT not in audit_prompt
+    assert runner.DEFAULT_INTENTION_PACKET_TEXT not in compiler_prompt
+
+
+def test_intention_packet_text_is_preserved_exactly(tmp_path: Path) -> None:
+    packet_path = tmp_path / "intention.md"
+    packet_body = "Line one\n\nLine two with trailing spaces.  \n"
+    packet_path.write_text(packet_body, encoding="utf-8")
+
+    assert runner.load_intention_packet(packet_path) == packet_body
+
+
+def test_intention_packet_does_not_mutate_runner_owned_placeholders() -> None:
+    packet_text = (
+        "Packet literals: <REPO_ROOT> <AUDIT_ID> <RUN_ID> "
+        "<PASTE MEGA_AUDIT_OUTPUT_JSON_HERE> <AUDIT_JSON>"
+    )
+    audit_prompt = runner.render_audit_prompt(
+        (
+            "Repo: <REPO_ROOT>\n"
+            "Audit: <AUDIT_ID>\n"
+            "Run: <RUN_ID>\n"
+            "Packet:\n<INTENTION_PACKET>"
+        ),
+        Path("/repo"),
+        "AUDIT_abc123def456",
+        "abc123def456",
+        packet_text,
+    )
+
+    assert "Repo: /repo" in audit_prompt
+    assert "Audit: AUDIT_abc123def456" in audit_prompt
+    assert "Run: abc123def456" in audit_prompt
+    assert packet_text in audit_prompt
+
+    audit_payload = {
+        "audit_id": "AUDIT_abc123def456",
+        "note": "<INTENTION_PACKET> <REPO_ROOT> <AUDIT_JSON>",
+    }
+    compiler_prompt = runner.render_compiler_prompt(
+        (
+            "Repo: <REPO_ROOT>\n"
+            "Audit: <PASTE MEGA_AUDIT_OUTPUT_JSON_HERE>\n"
+            "Packet:\n<INTENTION_PACKET>"
+        ),
+        Path("/repo"),
+        audit_payload,
+        packet_text,
+    )
+
+    assert "Repo: /repo" in compiler_prompt
+    assert packet_text in compiler_prompt
+    pasted_json = json.dumps(audit_payload, indent=2, ensure_ascii=False)
+    assert pasted_json in compiler_prompt
+
+
+def test_missing_intention_packet_path_fails_clearly(tmp_path: Path) -> None:
+    missing = tmp_path / "missing-intention.md"
+
+    with pytest.raises(
+        runner.RunnerError, match="Intention packet file not found"
+    ):
+        runner.load_intention_packet(missing)
+
+
+def test_parse_args_validates_missing_intention_packet_path(
+    tmp_path: Path,
+) -> None:
+    paths = _write_required_runner_files(tmp_path)
+    missing = tmp_path / "missing-intention.md"
+
+    with pytest.raises(
+        runner.RunnerError, match="Intention packet file not found"
+    ):
+        runner.parse_args(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "--audit-prompt-file",
+                str(paths["audit_prompt"]),
+                "--audit-schema-file",
+                str(paths["audit_schema"]),
+                "--compiler-prompt-file",
+                str(paths["compiler_prompt"]),
+                "--campaign-set-schema-file",
+                str(paths["campaign_schema"]),
+                "--task-result-schema-file",
+                str(paths["task_schema"]),
+                "--intention-packet-file",
+                str(missing),
+                "--dry-run",
+            ]
+        )
+
+
+def test_parse_args_accepts_intention_packet_file(tmp_path: Path) -> None:
+    paths = _write_required_runner_files(tmp_path)
+    packet_path = tmp_path / "intention.md"
+    packet_path.write_text("intent", encoding="utf-8")
+
+    args = runner.parse_args(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--audit-prompt-file",
+            str(paths["audit_prompt"]),
+            "--audit-schema-file",
+            str(paths["audit_schema"]),
+            "--compiler-prompt-file",
+            str(paths["compiler_prompt"]),
+            "--campaign-set-schema-file",
+            str(paths["campaign_schema"]),
+            "--task-result-schema-file",
+            str(paths["task_schema"]),
+            "--intention-packet-file",
+            str(packet_path),
+            "--dry-run",
+        ]
+    )
+
+    assert args.intention_packet_file == packet_path.resolve()
+
+
+def test_directory_intention_packet_path_fails_clearly(tmp_path: Path) -> None:
+    with pytest.raises(
+        runner.RunnerError, match="Intention packet path is a directory"
+    ):
+        runner.load_intention_packet(tmp_path)

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -48,6 +48,8 @@ If you are working on Guardian-mediated coding-agent execution or future Pi SDK 
 
 If you are working on Execution Ledger gate artifacts, acceptance-criteria mapping, implementation-plan artifacts, or completion/proof evidence mapping over Campaign Runner and Guardian rails, start with [`Execution Ledger Gate Artifacts Contract`](./execution-ledger-gate-artifacts-contract.md) after ADR-028.
 
+If you are working on Campaign Runner Stage A/Stage B planning objectives or operator-authored prompt intent, read [`Campaign Runner Intention Packet Contract`](./campaign-runner-intention-packet-contract.md). That contract defines the bounded intention input seam without changing provider behavior, schemas, Pi broker semantics, Guardian ownership, or current release truth.
+
 If you are working on proposed Execution Ledger token vocabularies (gate decisions, plan states, acceptance results, proof decisions, escalation reasons) before runtime tokenization, start with [`Execution Ledger Token Domain Proposal`](./execution-ledger-token-domain-proposal.md) after the gate/artifact contract.
 
 If you are working on Pi SDK integration, Pi-like external coding-agent harnesses, or invocation governance boundaries, start with [`Pi Invocation Boundary Contract`](./pi-invocation-boundary-contract.md) first, then apply [`ADR-020: Guardian Mediated Coding Agent Execution Contract`](./adr/020-guardian-mediated-coding-agent-execution-contract.md) for Guardian ownership and result-return doctrine.
@@ -90,6 +92,7 @@ Before generating architecture diagrams, read the [`KB Validity Matrix`](./kb-va
 - [Architecture Atlas](./architecture-atlas.md): peer-facing reading guide for the validated architecture corpus, runtime diagrams, and UI diagrams.
 - [Agent Protocol Operations Index](./agent-protocol-operations.md): agent-facing map for task rituals, campaign/task interpretation, architecture-impact workflow, validation expectations, and contingency behavior.
 - [Execution Ledger Gate Artifacts Contract](./execution-ledger-gate-artifacts-contract.md): docs-only follow-through contract for ADR-028 defining gate artifacts, acceptance-criteria mapping, implementation plans, and completion/proof evidence mapping onto Campaign Runner and Guardian execution surfaces.
+- [Campaign Runner Intention Packet Contract](./campaign-runner-intention-packet-contract.md): bounded operator-authored planning input seam for Stage A audit and Stage B campaign compilation; not runtime proof and not a release-claim source.
 - [Execution Ledger Token Domain Proposal](./execution-ledger-token-domain-proposal.md): docs-only proposal for candidate Execution Ledger token domains, semantics, and registry placement guidance before runtime tokenization.
 - [Workspace Surface Spec v1](./codexify_workspace_surface_spec_v_1.md): UI/design-canon contract for Workspace as Shelf + Scratchpad + Inspector across Dashboard, Guardian, and Documents; not first-pass runtime topology truth.
 - [Persona Studio Architecture](./persona-studio.md): shell-integrated persona/profile configuration surface, local draft state, diagnostics preview, and boundary rules; complements the broader product spec.

--- a/docs/architecture/campaign-runner-intention-packet-contract.md
+++ b/docs/architecture/campaign-runner-intention-packet-contract.md
@@ -1,0 +1,247 @@
+# Campaign Runner Intention Packet Contract
+
+Purpose: Define the bounded operator-authored intention packet seam for Campaign Runner Stage A audit and Stage B campaign compilation.
+Last updated: 2026-06-05
+Source anchors:
+- codex_runner/runner.py
+- codex_runner/prompts/mega_audit.md
+- codex_runner/prompts/audit_report_to_campaign_runner.md
+- codex_runner/schemas/mega_audit_output.schema.json
+- codex_runner/schemas/campaign_set.schema.json
+- docs/architecture/00-current-state.md
+- docs/architecture/pi-invocation-boundary-contract.md
+- docs/architecture/agent-tool-loop-contract.md
+- docs/architecture/agent-protocol-operations.md
+- docs/architecture/runtime-protocol-token-contract.md
+- docs/architecture/adr/020-guardian-mediated-coding-agent-execution-contract.md
+- docs/architecture/adr/028-execution-ledger-campaign-runner-contract.md
+- docs/architecture/adr/036-campaign-runner-provider-adapter-contract.md
+- docs/architecture/adr/037-campaign-runner-pi-provider-broker.md
+
+## Purpose
+
+Campaign Runner has two prompt-governed planning stages:
+
+- Stage A audits the repository and emits `mega_audit_output.schema.json`.
+- Stage B compiles Stage-A evidence into campaigns and tasks that conform to `campaign_set.schema.json`.
+
+The Intention Packet gives both stages the same explicit operator-authored objective without requiring ad hoc edits to the prompt templates.
+
+The packet exists to help Campaign Runner produce better bounded campaigns, not broader autonomy.
+
+## Scope
+
+The Intention Packet seam applies only to Campaign Runner prompt assembly for:
+
+- Stage A audit prompting
+- Stage B campaign compilation prompting
+
+The packet may constrain:
+
+- audit objective
+- scope
+- non-goals
+- evidence requirements
+- campaign-shaping rules
+- Codexify task-lane expectations
+
+Nodes in scope:
+
+- operator workstation running `codex_runner/runner.py`
+- local repository checkout being audited
+- provider adapter lane used by Campaign Runner
+- persisted runner artifacts under `docs/_audits/` and `docs/_campaign_runs/`
+
+Trust boundaries:
+
+- operator-authored packet text is trusted only as planning input
+- repository evidence remains the source for findings
+- runner-owned identifiers and schema validation remain runner authority
+- provider output remains untrusted until schema validation passes
+
+Threat model:
+
+- honest-but-buggy operators may overstate the intended target
+- provider output may follow packet language beyond repo evidence
+- packet text may contain strings that look like runner placeholders
+- malicious packet text must not become executable code or override runner-owned values
+
+## Non-Goals
+
+This seam does not:
+
+- add autonomous execution
+- add direct Codex or Claude execution paths
+- change Pi broker execution semantics
+- change provider behavior
+- change queue, worker, route, UI, or database behavior
+- change schema-required output shapes
+- bypass schema validation
+- authorize merge automation, lease allocation, or live agent execution
+- widen current release support claims
+- make the packet an ADR
+- make the packet runtime proof
+
+## Contract Shape
+
+The packet is plain UTF-8 markdown text supplied with:
+
+```bash
+python codex_runner/runner.py --intention-packet-file /path/to/intention.md
+```
+
+When provided:
+
+- the runner reads the file as UTF-8 text
+- missing files fail closed
+- directory paths fail closed
+- the text is treated as inert prompt context
+- the same resolved packet text is injected into Stage A and Stage B
+- the packet hash is included in deterministic run inputs
+
+When omitted, the runner injects this fallback text:
+
+```text
+No explicit intention packet was provided. Use the default repository-grounded audit posture and do not infer a narrower target.
+```
+
+The injection placeholder is:
+
+```text
+<INTENTION_PACKET>
+```
+
+The packet cannot override runner-owned placeholders such as:
+
+- `<AUDIT_ID>`
+- `<REPO_ROOT>`
+- `<RUN_ID>`
+- `<PASTE MEGA_AUDIT_OUTPUT_JSON_HERE>`
+- `<AUDIT_JSON>`
+
+The runner replaces placeholders only in the prompt template, not inside inserted packet text or pasted Stage-A JSON.
+
+## Example Intention Packet
+
+```markdown
+# Campaign Runner Intention Packet
+
+Objective:
+- Audit whether Campaign Runner can support an explicit operator-authored planning input for Stage A and Stage B.
+
+Scope:
+- codex_runner/runner.py
+- codex_runner/prompts/mega_audit.md
+- codex_runner/prompts/audit_report_to_campaign_runner.md
+- codex_runner/tests/
+- docs/architecture/
+
+Non-goals:
+- Do not add provider behavior.
+- Do not add autonomous execution.
+- Do not change schemas unless the audit proves a strict need.
+
+Evidence posture:
+- Prefer repo-grounded findings.
+- Separate implemented behavior from future planning.
+- If the repo cannot support an implementation task safely, produce a discovery task.
+
+Campaign shaping:
+- Keep tasks independently mergeable.
+- Keep release claims subordinate to docs/architecture/00-current-state.md.
+```
+
+## Stage A Responsibilities
+
+Stage A must:
+
+- audit against the intention packet
+- keep `mega_audit_output.schema.json` authoritative
+- preserve runner-owned constraints
+- ground findings in repository evidence
+- separate repo-grounded findings from unsupported packet claims
+- emit discovery-oriented findings when the repository does not support the requested intention
+- avoid presenting packet language as proof of runtime capability
+
+Stage A must not:
+
+- infer runtime support from the packet
+- invent findings unsupported by repository evidence
+- override `audit_id`, `repo.path`, JSON-only mode, or schema requirements
+
+## Stage B Responsibilities
+
+Stage B must:
+
+- use the packet only to interpret and filter Stage-A findings
+- keep `campaign_set.schema.json` authoritative
+- preserve independently mergeable task scope
+- prefer discovery tasks over speculative implementation when evidence is insufficient
+- keep campaign and task output grounded in Stage-A evidence
+- avoid widening release claims or runtime support claims
+
+Stage B must not:
+
+- invent campaigns or tasks unsupported by Stage-A evidence
+- treat the packet as runtime proof
+- add git commit instructions unless the current task artifact contract supports them safely
+- bypass task scope, file-path, or schema constraints
+
+## Invariants
+
+- The Intention Packet is an operator-authored planning artifact.
+- It is not runtime proof.
+- It is not an ADR by itself.
+- It cannot override schemas.
+- It cannot override runner-owned constraints.
+- It cannot override provider governance.
+- It cannot override Guardian ownership.
+- It cannot override Pi broker boundaries.
+- It cannot override `00-current-state.md`.
+- It cannot introduce autonomous execution.
+- It cannot authorize direct provider CLI execution.
+- It cannot mutate pasted Stage-A JSON.
+- Existing provider output validation remains authoritative.
+
+## Failure Policy
+
+The runner fails closed when:
+
+- `--intention-packet-file` points to a missing file
+- `--intention-packet-file` points to a directory
+- the file cannot be decoded as UTF-8 text
+
+The runner does not parse, execute, or transform the packet as code.
+
+If the packet asks for behavior unsupported by repository evidence, Stage A should make that lack of support explicit and Stage B should prefer discovery tasks or no campaign over speculative implementation.
+
+## Relationship to Pi Invocation Boundary
+
+The Intention Packet is upstream planning context. It is not a Pi invocation envelope, Pi receipt, harness artifact, command authorization, or result-return proof.
+
+The Pi Invocation Boundary remains the governing contract for future Pi-like harness invocation, including Guardian ownership, command authority, result return, lineage, and provider-lane separation.
+
+This seam does not:
+
+- implement a Pi SDK call
+- change Pi broker behavior
+- bypass Guardian-mediated coding-agent execution doctrine
+- grant command authority to packet text
+- make Campaign Runner depend on Pi internals
+
+## Relationship to Current Release Truth
+
+`docs/architecture/00-current-state.md` remains the short-horizon release truth gate.
+
+The Intention Packet can align Campaign Runner planning around a specific objective, but it cannot prove that the objective is implemented, supported, release-ready, or end-to-end live.
+
+Current release truth still forbids assuming:
+
+- UI dispatch
+- lease allocation
+- live agent execution
+- merge automation
+- autonomous self-modification
+- provider support beyond the proven supported path
+
+This contract adds a bounded prompt-intention input seam only.


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
