### PR TITLE
Codex/add campaign intent packet seam

### DIFF
--- a/codex_runner/README.md
+++ b/codex_runner/README.md
@@ -178,7 +178,31 @@ Prompt artifacts are review-only. They do not execute tasks, approve work, call 
 
 `--dry-run` prevents generated task execution after Stage A audit and Stage B campaign compilation, but it still uses the configured provider lane for those planning stages. It is not a provider-free proof mode.
 
-For no-provider checks, use the focused prompt-rendering and materialization tests until a separate fixture-backed proof command exists.
+For no-provider artifact checks, use provider-free fixture materialization.
+
+### Provider-free fixture materialization
+
+Use `--materialize-from-fixtures` when Stage A audit JSON and Stage B campaign JSON already exist and you need to validate/materialize Campaign Runner artifacts without invoking Stage A or Stage B providers.
+
+Required inputs:
+- `--audit-json-file`: prevalidated Stage A audit JSON
+- `--campaign-json-file`: prevalidated Stage B campaign JSON
+- existing schemas, either through `--audit-schema-file` / `--campaign-set-schema-file` or the runner defaults
+
+Example:
+
+```bash
+python codex_runner/runner.py \
+  --repo-root /absolute/path/to/repo \
+  --materialize-from-fixtures \
+  --audit-json-file /path/to/audit_output.json \
+  --campaign-json-file /path/to/campaign_set_output.json \
+  --intention-packet-file docs/Campaign/examples/campaign-runner-intention-packet-provider-readiness.md
+```
+
+This mode validates both JSON files against the existing schemas, merges the campaign set, and writes the same review artifact families used by normal materialization: campaign docs, task artifacts, `PROMPT_<task_slug>.md` prompt artifacts, state, run metadata, and execution trace.
+
+Fixture materialization skips Stage A/B provider calls, does not render Stage A/B prompts, does not execute generated tasks, and does not prove runtime, provider, Pi, or release support. It is a proof/materialization lane for operator review.
 
 General flags:
 - `--provider pi`
@@ -187,7 +211,7 @@ General flags:
 - `--execute` or `--dry-run`
 - `--branch-per-campaign` / `--no-branch-per-campaign`
 - `--allow-discovery-fallback`
-- `--auto-commit` / `--no-auto-commit` (`--no-auto-commit` currently hard-fails by design)
+- `--auto-commit` / `--no-auto-commit` (`--no-auto-commit` hard-fails outside fixture materialization by design)
 - `--verify` / `--no-verify`
 - `--debug`
 

--- a/codex_runner/runner.py
+++ b/codex_runner/runner.py
@@ -171,6 +171,42 @@ def json_read(path: Path) -> dict[str, Any]:
     return data
 
 
+def validate_json_schema(
+    payload: dict[str, Any], schema_path: Path, label: str
+) -> None:
+    try:
+        from jsonschema import Draft202012Validator, FormatChecker
+    except ImportError as exc:
+        raise RunnerError(
+            "jsonschema is required for fixture materialization validation"
+        ) from exc
+
+    schema = json_read(schema_path)
+    validator = Draft202012Validator(
+        schema,
+        format_checker=FormatChecker(),
+    )
+    errors = sorted(validator.iter_errors(payload), key=lambda error: error.path)
+    if not errors:
+        return
+
+    first = errors[0]
+    path = "$"
+    if first.path:
+        path += "." + ".".join(str(part) for part in first.path)
+    raise RunnerError(
+        f"Schema validation failed for {label}: {path}: {first.message}"
+    )
+
+
+def read_schema_validated_json(
+    json_path: Path, schema_path: Path, label: str
+) -> dict[str, Any]:
+    payload = json_read(json_path)
+    validate_json_schema(payload, schema_path, label)
+    return payload
+
+
 def json_write(path: Path, payload: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
@@ -1596,6 +1632,37 @@ def run_inputs_payload(
     return payload
 
 
+def fixture_run_inputs_payload(
+    *,
+    repo_root: Path,
+    base_ref_sha: str,
+    audit_schema_file: Path,
+    campaign_set_schema_file: Path,
+    audit_json_file: Path,
+    campaign_json_file: Path,
+    intention_packet_sha256: str | None = None,
+) -> dict[str, Any]:
+    payload = {
+        "repo_root": str(repo_root.resolve()),
+        "base_ref": base_ref_sha,
+        "provider": "fixture",
+        "execute_mode": "fixture-materialization",
+        "materialization_mode": "fixtures",
+        "provider_invocation": "skipped",
+        "audit_schema_file": str(audit_schema_file.resolve()),
+        "audit_schema_sha256": sha256_file(audit_schema_file),
+        "campaign_set_schema_file": str(campaign_set_schema_file.resolve()),
+        "campaign_set_schema_sha256": sha256_file(campaign_set_schema_file),
+        "audit_json_file": str(audit_json_file.resolve()),
+        "audit_json_sha256": sha256_file(audit_json_file),
+        "campaign_json_file": str(campaign_json_file.resolve()),
+        "campaign_json_sha256": sha256_file(campaign_json_file),
+    }
+    if intention_packet_sha256 is not None:
+        payload["intention_packet_sha256"] = intention_packet_sha256
+    return payload
+
+
 def write_run_meta(
     path: Path,
     *,
@@ -1651,6 +1718,75 @@ def write_run_meta(
             "name": provider,
             "models": provider_models,
             "settings": provider_settings_sanitized,
+        },
+        "termination_reason": termination_reason,
+    }
+    json_write(path, payload)
+
+
+def write_fixture_run_meta(
+    path: Path,
+    *,
+    run_id: str,
+    audit_id: str,
+    base_ref_sha: str,
+    audit_schema_file: Path,
+    campaign_set_schema_file: Path,
+    audit_json_file: Path,
+    campaign_json_file: Path,
+    cli_args: list[str],
+    preflight_clean: bool,
+    selected_campaign: str | None,
+    selection_rationale: dict[str, Any] | None,
+    termination_reason: str,
+    run_inputs: dict[str, Any],
+    intention_packet_file: Path | None = None,
+    intention_packet_sha256: str | None = None,
+) -> None:
+    inputs: dict[str, Any] = {
+        "audit_schema_file": str(audit_schema_file.resolve()),
+        "audit_schema_sha256": sha256_file(audit_schema_file),
+        "campaign_set_schema_file": str(campaign_set_schema_file.resolve()),
+        "campaign_set_schema_sha256": sha256_file(campaign_set_schema_file),
+        "audit_json_file": str(audit_json_file.resolve()),
+        "audit_json_sha256": sha256_file(audit_json_file),
+        "campaign_json_file": str(campaign_json_file.resolve()),
+        "campaign_json_sha256": sha256_file(campaign_json_file),
+    }
+    if intention_packet_file is not None:
+        inputs["intention_packet_file"] = str(intention_packet_file.resolve())
+    if intention_packet_sha256 is not None:
+        inputs["intention_packet_sha256"] = intention_packet_sha256
+
+    payload = {
+        "run_id": run_id,
+        "audit_id": audit_id,
+        "generated_at": now_iso(),
+        "resolved_base_ref_sha": base_ref_sha,
+        "inputs": inputs,
+        "run_inputs": run_inputs,
+        "cli_args": cli_args,
+        "preflight": {
+            "git_clean": preflight_clean,
+        },
+        "selection": {
+            "selected_campaign": selected_campaign,
+            "rationale": selection_rationale,
+        },
+        "provider": {
+            "name": "fixture",
+            "invocation_skipped": True,
+            "models": {},
+            "settings": [],
+        },
+        "fixture_materialization": {
+            "enabled": True,
+            "provider_invocation_skipped": True,
+            "audit_json_file": str(audit_json_file.resolve()),
+            "campaign_json_file": str(campaign_json_file.resolve()),
+            "intention_packet_file": str(intention_packet_file.resolve())
+            if intention_packet_file is not None
+            else None,
         },
         "termination_reason": termination_reason,
     }
@@ -1718,6 +1854,162 @@ def update_campaign_completion(campaign: dict[str, Any]) -> None:
     campaign["status"] = (
         "completed" if campaign_is_completed(campaign) else "open"
     )
+
+
+def run_fixture_materialization(
+    args: argparse.Namespace,
+    *,
+    base_ref_sha: str,
+    cli_args: list[str],
+) -> dict[str, Any]:
+    repo_root = args.repo_root
+    preflight_clean = git_is_clean(repo_root, args.debug)
+    if not preflight_clean:
+        raise RunnerError("preflight failed: git tree is not clean")
+
+    intention_packet_sha256 = None
+    if args.intention_packet_file is not None:
+        intention_packet_sha256 = sha256_text(
+            load_intention_packet(args.intention_packet_file)
+        )
+
+    audit_payload = read_schema_validated_json(
+        args.audit_json_file,
+        args.audit_schema_file,
+        "audit JSON",
+    )
+    campaign_set_payload = read_schema_validated_json(
+        args.campaign_json_file,
+        args.campaign_set_schema_file,
+        "campaign JSON",
+    )
+
+    audit_id = str(audit_payload.get("audit_id") or "").strip()
+    stage_b_audit_id = str(campaign_set_payload.get("audit_id") or "").strip()
+    if stage_b_audit_id != audit_id:
+        raise RunnerError(
+            "Fixture audit_id mismatch. "
+            f"audit_json={audit_id} campaign_json={stage_b_audit_id}"
+        )
+    run_id = audit_id.removeprefix("AUDIT_")
+
+    run_inputs = fixture_run_inputs_payload(
+        repo_root=repo_root,
+        base_ref_sha=base_ref_sha,
+        audit_schema_file=args.audit_schema_file,
+        campaign_set_schema_file=args.campaign_set_schema_file,
+        audit_json_file=args.audit_json_file,
+        campaign_json_file=args.campaign_json_file,
+        intention_packet_sha256=intention_packet_sha256,
+    )
+
+    today_iso = datetime.now(timezone.utc).date().isoformat()
+    audit_dir_rel = DEFAULT_AUDITS_DIR / today_iso / audit_id
+    audit_dir_abs = repo_root / audit_dir_rel
+    audit_dir_abs.mkdir(parents=True, exist_ok=True)
+    json_write(audit_dir_abs / "run_inputs.json", run_inputs)
+    json_write(audit_dir_abs / "audit_output.json", audit_payload)
+    json_write(audit_dir_abs / "campaign_set_output.json", campaign_set_payload)
+
+    state = load_state(repo_root)
+    previous_sha = state_hash(state)
+    merge_stats = merge_campaign_set(
+        state, campaign_set_payload, audit_id=audit_id
+    )
+
+    selection = select_campaign(state)
+    selected_campaign_slug = selection.campaign_slug if selection else "none"
+    selected_campaign_id = selection.campaign_id if selection else None
+    selection_reason = selection.reason if selection else None
+
+    run_dir_rel = DEFAULT_RUNS_DIR / today_iso / selected_campaign_slug / run_id
+    run_dir_abs = repo_root / run_dir_rel
+    run_dir_abs.mkdir(parents=True, exist_ok=True)
+    json_write(run_dir_abs / "run_inputs.json", run_inputs)
+    json_write(run_dir_abs / "campaign_set_output.json", campaign_set_payload)
+
+    materialized_paths: list[str] = []
+    termination_reason = "fixture_materialization_no_campaign_selected"
+    if selection is None:
+        if merge_stats["campaigns"] == 0 and merge_stats["tasks"] == 0:
+            termination_reason = "fixture_materialization_no_campaigns"
+        else:
+            termination_reason = "fixture_materialization_no_eligible_campaigns"
+    else:
+        campaign = state["campaigns"][selection.campaign_id]
+        materialized_paths = materialize_campaign_artifacts(repo_root, campaign)
+        update_campaign_completion(campaign)
+        termination_reason = "fixture_materialization_selected_campaign_materialized"
+
+    post_state_sha = state_hash(state)
+    save_state(repo_root, state)
+    append_transition(
+        repo_root,
+        run_id=run_id,
+        pass_index=1,
+        reason="fixture_materialization_complete",
+        previous_state_sha=previous_sha,
+        post_state_sha=post_state_sha,
+    )
+
+    run_trace = {
+        "run_id": run_id,
+        "audit_id": audit_id,
+        "pass_index": 1,
+        "base_ref_sha": base_ref_sha,
+        "generated_at": now_iso(),
+        "merge_stats": merge_stats,
+        "selection": {
+            "campaign_id": selected_campaign_id,
+            "campaign_slug": selected_campaign_slug,
+            "reason": selection_reason,
+        },
+        "events": [
+            {
+                "type": "fixture_materialization",
+                "provider_invocation_skipped": True,
+                "materialized_paths": materialized_paths,
+            }
+        ],
+        "termination_reason": termination_reason,
+    }
+    json_write(run_dir_abs / "execution_trace.json", run_trace)
+
+    meta_kwargs = dict(
+        run_id=run_id,
+        audit_id=audit_id,
+        base_ref_sha=base_ref_sha,
+        audit_schema_file=args.audit_schema_file,
+        campaign_set_schema_file=args.campaign_set_schema_file,
+        audit_json_file=args.audit_json_file,
+        campaign_json_file=args.campaign_json_file,
+        cli_args=cli_args,
+        preflight_clean=preflight_clean,
+        selected_campaign=selected_campaign_id,
+        selection_rationale=selection_reason,
+        termination_reason=termination_reason,
+        run_inputs=run_inputs,
+        intention_packet_file=args.intention_packet_file,
+        intention_packet_sha256=intention_packet_sha256,
+    )
+    write_fixture_run_meta(audit_dir_abs / "run_meta.json", **meta_kwargs)
+    write_fixture_run_meta(run_dir_abs / "run_meta.json", **meta_kwargs)
+
+    summary = {
+        "mode": "fixture_materialization",
+        "provider_invocation_skipped": True,
+        "audit_id": audit_id,
+        "run_id": run_id,
+        "selected_campaign": selected_campaign_id,
+        "materialized_paths": materialized_paths,
+        "termination_reason": termination_reason,
+    }
+    log(
+        "Fixture materialization complete; provider invocation was skipped "
+        "because --materialize-from-fixtures was used."
+    )
+    log(json.dumps(summary, indent=2, ensure_ascii=False))
+    return summary
 
 
 def run_pass(
@@ -2203,10 +2495,10 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         help="Absolute path to repo root",
     )
-    parser.add_argument("--audit-prompt-file", type=Path, required=True)
-    parser.add_argument("--audit-schema-file", type=Path, required=True)
-    parser.add_argument("--compiler-prompt-file", type=Path, required=True)
-    parser.add_argument("--campaign-set-schema-file", type=Path, required=True)
+    parser.add_argument("--audit-prompt-file", type=Path)
+    parser.add_argument("--audit-schema-file", type=Path)
+    parser.add_argument("--compiler-prompt-file", type=Path)
+    parser.add_argument("--campaign-set-schema-file", type=Path)
     parser.add_argument(
         "--intention-packet-file",
         type=Path,
@@ -2218,6 +2510,9 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         default=DEFAULT_TASK_RESULT_SCHEMA_PATH,
     )
+    parser.add_argument("--materialize-from-fixtures", action="store_true")
+    parser.add_argument("--audit-json-file", type=Path, default=None)
+    parser.add_argument("--campaign-json-file", type=Path, default=None)
 
     parser.add_argument("--passes", type=int, default=1)
     parser.add_argument("--base-ref", default="HEAD")
@@ -2272,12 +2567,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     args = parser.parse_args(argv)
 
     args.repo_root = args.repo_root.expanduser().resolve()
-    args.audit_prompt_file = args.audit_prompt_file.expanduser().resolve()
-    args.audit_schema_file = args.audit_schema_file.expanduser().resolve()
-    args.compiler_prompt_file = args.compiler_prompt_file.expanduser().resolve()
-    args.campaign_set_schema_file = (
-        args.campaign_set_schema_file.expanduser().resolve()
-    )
+    if args.audit_prompt_file is not None:
+        args.audit_prompt_file = args.audit_prompt_file.expanduser().resolve()
+    if args.audit_schema_file is not None:
+        args.audit_schema_file = args.audit_schema_file.expanduser().resolve()
+    if args.compiler_prompt_file is not None:
+        args.compiler_prompt_file = (
+            args.compiler_prompt_file.expanduser().resolve()
+        )
+    if args.campaign_set_schema_file is not None:
+        args.campaign_set_schema_file = (
+            args.campaign_set_schema_file.expanduser().resolve()
+        )
     if args.intention_packet_file is not None:
         args.intention_packet_file = (
             args.intention_packet_file.expanduser().resolve()
@@ -2285,6 +2586,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     args.task_result_schema_file = (
         args.task_result_schema_file.expanduser().resolve()
     )
+    if args.audit_json_file is not None:
+        args.audit_json_file = args.audit_json_file.expanduser().resolve()
+    if args.campaign_json_file is not None:
+        args.campaign_json_file = args.campaign_json_file.expanduser().resolve()
 
     if args.passes < 1:
         raise RunnerError("--passes must be >= 1")
@@ -2298,22 +2603,59 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     if args.verify is None:
         args.verify = default_verify(os.environ.get("CI"))
 
-    if not args.auto_commit:
+    if not args.auto_commit and not args.materialize_from_fixtures:
         raise RunnerError(
             "--no-auto-commit is not supported in deterministic mode. "
             "Use --auto-commit to preserve clean-tree invariants."
         )
 
-    required_paths = [
-        args.audit_prompt_file,
-        args.audit_schema_file,
-        args.compiler_prompt_file,
-        args.campaign_set_schema_file,
-        args.task_result_schema_file,
-    ]
+    if getattr(args, "materialize_from_fixtures", False):
+        if args.audit_json_file is None:
+            raise RunnerError(
+                "--materialize-from-fixtures requires --audit-json-file"
+            )
+        if args.campaign_json_file is None:
+            raise RunnerError(
+                "--materialize-from-fixtures requires --campaign-json-file"
+            )
+        if args.audit_schema_file is None:
+            args.audit_schema_file = DEFAULT_MEGA_AUDIT_SCHEMA_PATH.resolve()
+        if args.campaign_set_schema_file is None:
+            args.campaign_set_schema_file = (
+                DEFAULT_CAMPAIGN_SET_SCHEMA_PATH.resolve()
+            )
+        required_paths = [
+            args.audit_schema_file,
+            args.campaign_set_schema_file,
+            args.audit_json_file,
+            args.campaign_json_file,
+        ]
+    else:
+        missing_flags = []
+        if args.audit_prompt_file is None:
+            missing_flags.append("--audit-prompt-file")
+        if args.audit_schema_file is None:
+            missing_flags.append("--audit-schema-file")
+        if args.compiler_prompt_file is None:
+            missing_flags.append("--compiler-prompt-file")
+        if args.campaign_set_schema_file is None:
+            missing_flags.append("--campaign-set-schema-file")
+        if missing_flags:
+            raise RunnerError(
+                "Missing required CLI flags: " + ", ".join(missing_flags)
+            )
+        required_paths = [
+            args.audit_prompt_file,
+            args.audit_schema_file,
+            args.compiler_prompt_file,
+            args.campaign_set_schema_file,
+            args.task_result_schema_file,
+        ]
     for path in required_paths:
         if not path.exists():
             raise RunnerError(f"Required file not found: {path}")
+        if path.is_dir():
+            raise RunnerError(f"Required file is a directory: {path}")
     if args.intention_packet_file is not None:
         validate_intention_packet_file(args.intention_packet_file)
 
@@ -2376,10 +2718,19 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(resolved_argv)
 
     ensure_repo_root(args.repo_root, args.debug)
-    ensure_provider_available(args.provider)
 
     base_ref_sha = git_resolve_ref(args.repo_root, args.base_ref, args.debug)
     cli_args = sanitize_cli_args(resolved_argv)
+
+    if getattr(args, "materialize_from_fixtures", False):
+        run_fixture_materialization(
+            args,
+            base_ref_sha=base_ref_sha,
+            cli_args=cli_args,
+        )
+        return 0
+
+    ensure_provider_available(args.provider)
 
     for pass_index in range(1, args.passes + 1):
         run_pass(

--- a/config/whooshd/model-profiles/README.md
+++ b/config/whooshd/model-profiles/README.md
@@ -1,0 +1,11 @@
+# Whoosh'd Model Profiles
+
+This directory contains data-only Whoosh'd local model profiles. Profiles describe local runtime expectations and acceptance gates for future MLX-backed model use.
+
+A profile is not a routed provider. All profiles in this directory must keep `provider_id` as `local` unless a future ADR explicitly changes provider routing doctrine. Whoosh'd is display/vendor metadata under the current provider-governance contract.
+
+Profiles describe runtime start hints, model-family notes, Guardian defaults, transcript leakage policy, acceptance checks, and release posture. They do not prove runtime support by existing.
+
+Live proof still requires health, catalog, supported-profile, queue/worker, and Guardian completion evidence. A profile must not be treated as release-supported until that separate proof exists and the release posture is updated through the normal architecture path.
+
+New profiles must include thought/final-answer leakage policy when the model family supports hidden, analysis, thinking, or channelized output. Guardian-facing transcript output must reject prompt echo and hidden/process/channel leakage before any routed use.

--- a/config/whooshd/model-profiles/README.md
+++ b/config/whooshd/model-profiles/README.md
@@ -6,6 +6,8 @@ A profile is not a routed provider. All profiles in this directory must keep `pr
 
 Profiles describe runtime start hints, model-family notes, Guardian defaults, transcript leakage policy, acceptance checks, and release posture. They do not prove runtime support by existing.
 
+Catalog/UI surfaces may expose profiles as selectable local model choices. The selected model id should remain the runtime model repo that the Whoosh'd/MLX server expects, while the profile id remains metadata for governance and acceptance tracking.
+
 Live proof still requires health, catalog, supported-profile, queue/worker, and Guardian completion evidence. A profile must not be treated as release-supported until that separate proof exists and the release posture is updated through the normal architecture path.
 
 New profiles must include thought/final-answer leakage policy when the model family supports hidden, analysis, thinking, or channelized output. Guardian-facing transcript output must reject prompt echo and hidden/process/channel leakage before any routed use.

--- a/config/whooshd/model-profiles/gemma-4-12b-it-optiq-4bit.json
+++ b/config/whooshd/model-profiles/gemma-4-12b-it-optiq-4bit.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27f655a34beb7942b59bce30010aceaaeb8ddfecd1a9c5394e46595dee270a04
+size 2676

--- a/config/whooshd/model-profiles/gemma-4-e2b-it-4bit.json
+++ b/config/whooshd/model-profiles/gemma-4-e2b-it-4bit.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:30569e50baf410d9b3dd59eaec7e946eca4975645d5a7ec545e0dc7a9ea7bc4b
-size 2492
+oid sha256:69def504b982e3bc5a959f478f7161ee33aee40a88c1d8dfafd6dd86c058df04
+size 2629

--- a/config/whooshd/model-profiles/gemma-4-e2b-it-4bit.json
+++ b/config/whooshd/model-profiles/gemma-4-e2b-it-4bit.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30569e50baf410d9b3dd59eaec7e946eca4975645d5a7ec545e0dc7a9ea7bc4b
+size 2492

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -315,7 +315,7 @@ services:
       # the backend does not inherit the legacy Groq default unless it is
       # explicitly requested.
       CODEXIFY_CONFIG_SOURCE: "${CODEXIFY_CONFIG_SOURCE:-core}"
-      CODEXIFY_SUPPORTED_PROFILE: "${CODEXIFY_SUPPORTED_PROFILE}"
+      CODEXIFY_SUPPORTED_PROFILE: "${CODEXIFY_SUPPORTED_PROFILE:-v1-local-core-web-mcp}"
       # Single-user dev default (used when identity fallback is enabled).
       CODEXIFY_SINGLE_USER_ID: "${CODEXIFY_SINGLE_USER_ID:-local}"
       STORAGE_BASE_PATH: /app/data/media

--- a/docs/Campaign/proofs/campaign-runner-intention-packet-dry-proof-2026-06-08.md
+++ b/docs/Campaign/proofs/campaign-runner-intention-packet-dry-proof-2026-06-08.md
@@ -270,3 +270,13 @@ The blocker is precise: Campaign Runner does not currently expose a provider-fre
 - Add documentation for that provider-free proof mode once implemented.
 - Capture a passing dry proof artifact after that safe mode exists.
 - Capture wet execution proof only as a separate operator-approved task with explicit provider and Pi boundaries.
+
+## Follow-Up Resolution
+
+The original proof stopped because `--dry-run` still invoked the configured provider lanes for Stage A audit and Stage B campaign compilation before materialization.
+
+The follow-up implementation task adds the missing provider-free fixture/materialization mode through `--materialize-from-fixtures`, `--audit-json-file`, and `--campaign-json-file`.
+
+The original proof remains historically accurate. It documented the missing safe-mode seam before this follow-up existed.
+
+A future proof should rerun with fixture Stage A and Stage B JSON using the new mode, confirm schema validation, and inventory the generated campaign, task, and review-only prompt artifacts without claiming wet provider, Pi, runtime, or release support.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -101,7 +101,7 @@ Before generating architecture diagrams, read the [`KB Validity Matrix`](./kb-va
 - [Context Command and Active Connector Semantics](./adr/024-context-command-active-connector-semantics.md): governing contract for slash-command connector invocation, active connector semantics, and turn-scoped connector/tool boundaries.
 - [System Overview](./system-overview.md): current runtime components, topology, and critical paths.
 - [Critical Flows](./flows.md): current trigger-to-output runtime flows with failure modes.
-- [Whoosh'd Model Profiles](./whooshd-model-profiles.md): data-only model profile registry for local Whoosh'd/MLX descriptors; does not change runtime routing or release support by itself.
+- [Whoosh'd Model Profiles](./whooshd-model-profiles.md): local Whoosh'd/MLX profile registry and profile-backed local model selection seam; does not create a new provider id or release support by itself.
 - [Flow Builder Elicitation Lane ADR](./adr/006-flow-builder-elicitation-lane.md): upstream spec-building lane for tacit-knowledge extraction, workflow authoring semantics, and validation-before-execution doctrine.
 - [Flow Builder Thread, Draft, and Receipts Contract ADR](./adr/014-flow-builder-thread-draft-and-receipts-contract.md): canonical Guardian-thread, FlowDraft, Builder-view, and run-receipt contract for flow authoring semantics.
 - [Flow Builder Typed Surface and Run Receipt Contract ADR](./adr/027-flow-builder-typed-surface-and-run-receipt-contract.md): typed vocabulary, validation issue taxonomy, semantic step contract, test/activation distinction, and complete RunReceipt field contract for future implementation planning.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -101,6 +101,7 @@ Before generating architecture diagrams, read the [`KB Validity Matrix`](./kb-va
 - [Context Command and Active Connector Semantics](./adr/024-context-command-active-connector-semantics.md): governing contract for slash-command connector invocation, active connector semantics, and turn-scoped connector/tool boundaries.
 - [System Overview](./system-overview.md): current runtime components, topology, and critical paths.
 - [Critical Flows](./flows.md): current trigger-to-output runtime flows with failure modes.
+- [Whoosh'd Model Profiles](./whooshd-model-profiles.md): data-only model profile registry for local Whoosh'd/MLX descriptors; does not change runtime routing or release support by itself.
 - [Flow Builder Elicitation Lane ADR](./adr/006-flow-builder-elicitation-lane.md): upstream spec-building lane for tacit-knowledge extraction, workflow authoring semantics, and validation-before-execution doctrine.
 - [Flow Builder Thread, Draft, and Receipts Contract ADR](./adr/014-flow-builder-thread-draft-and-receipts-contract.md): canonical Guardian-thread, FlowDraft, Builder-view, and run-receipt contract for flow authoring semantics.
 - [Flow Builder Typed Surface and Run Receipt Contract ADR](./adr/027-flow-builder-typed-surface-and-run-receipt-contract.md): typed vocabulary, validation issue taxonomy, semantic step contract, test/activation distinction, and complete RunReceipt field contract for future implementation planning.

--- a/docs/architecture/campaign-runner-intention-packet-contract.md
+++ b/docs/architecture/campaign-runner-intention-packet-contract.md
@@ -185,6 +185,25 @@ Discovery prompt artifacts are preferred when Stage-A evidence is insufficient o
 
 No generated prompt can widen release truth. `docs/architecture/00-current-state.md` remains authoritative for current support and proof claims.
 
+## Provider-Free Fixture Materialization
+
+Provider-free fixture materialization begins after Stage A audit JSON and Stage B campaign JSON already exist.
+
+This mode validates the supplied audit and campaign JSON against the existing Campaign Runner schemas, then materializes review artifacts using the same deterministic campaign/task/prompt artifact machinery as normal materialization.
+
+This is a proof/materialization lane only. It is not execution authority, task approval, provider permission, Pi invocation authority, merge permission, or release proof.
+
+Provider-free fixture materialization must not:
+
+- invoke Stage A or Stage B providers
+- render Stage A or Stage B prompts
+- execute generated task prompts
+- call Pi, Codex, Claude, DeepSeek, Minimax, OpenAI, or any external provider
+- change provider behavior, Pi broker behavior, queues, workers, routes, databases, or UI behavior
+- prove provider support, Pi execution, runtime readiness, or release readiness
+
+The mode exists so operators can safely prove artifact generation from already-produced fixture JSON while preserving schema authority, runner-owned artifact paths, task-lane metadata, collision guards, and `00-current-state.md` release truth.
+
 ## Example Intention Packet
 
 ```markdown

--- a/docs/architecture/whooshd-model-profiles.md
+++ b/docs/architecture/whooshd-model-profiles.md
@@ -1,0 +1,76 @@
+Purpose: Define the bounded Whoosh'd local model profile registry without changing provider routing, catalog behavior, runtime selection, health semantics, or release posture.
+Last updated: 2026-06-08
+Source anchors:
+- config/whooshd/model-profiles/
+- scripts/validate_whooshd_model_profiles.py
+- docs/architecture/00-current-state.md
+- docs/architecture/config-and-ops.md
+- docs/architecture/chat-runtime-contract.md
+- docs/architecture/runtime-protocol-token-contract.md
+
+# Whoosh'd Model Profiles
+
+## Purpose
+
+Whoosh'd model profiles are data-only local runtime descriptors for MLX-backed local models.
+
+The registry gives future local model work a small file-backed place to record model identity, runtime hints, transcript safety defaults, acceptance checks, and release posture before any runtime routing or catalog exposure is changed.
+
+## Scope
+
+Profiles may describe:
+
+- profile metadata
+- runtime start hints
+- model family notes
+- Guardian defaults
+- acceptance checks
+- release posture
+
+Profiles may also note where a future live proof should store model weights. For this first profile, the operator requirement is to keep downloaded weights off the repo and under `/Volumes/Dev_SSD/` during a separate runtime-proof task. This metadata task does not download or verify those weights.
+
+## Non-Goals
+
+- No new provider id.
+- No runtime routing changes.
+- No catalog changes.
+- No health semantics changes.
+- No release claim expansion.
+- No custom proxy restoration.
+
+## Current First Profile
+
+- Profile id: `gemma-4-e2b-it-4bit`
+- Model repo: `mlx-community/gemma-4-e2b-it-4bit`
+- Runtime hint: `mlx_vlm.server --model mlx-community/gemma-4-e2b-it-4bit --port 8000`
+- Local OpenAI-compatible base URL hint: `http://host.docker.internal:8000/v1`
+
+## Invariants
+
+- Provider id remains `local`.
+- Whoosh'd is display/vendor metadata unless a future ADR changes provider routing.
+- A model profile is not proof of model quality.
+- A model profile is not release support.
+- Model-family hidden/thinking channel leakage must be blocked before Guardian-facing use.
+- Acceptance checks must include no prompt echo, no thought/channel leakage, and Guardian completion smoke.
+- Profile metadata must not be treated as health, catalog, supported-profile, queue/worker, or Guardian completion evidence.
+
+## Follow-Up Path
+
+Later tasks may add live smoke proof, profile selection UI, catalog exposure, or additional model profiles, but those must be separate tasks.
+
+The next live-proof task should verify the selected MLX runtime, keep model weights under `/Volumes/Dev_SSD/`, compare health/catalog/supported-profile posture, confirm queue and worker health, and prove one Guardian chat completion persists back into the source thread without prompt echo or hidden-channel leakage.
+
+## ADR Impact
+
+Classification: Aligned with existing ADRs and contracts; no new ADR required.
+
+Governing anchors:
+
+- `docs/architecture/00-current-state.md`
+- `docs/architecture/config-and-ops.md`
+- `docs/architecture/chat-runtime-contract.md`
+- `docs/architecture/runtime-protocol-token-contract.md`
+- provider governance and supported-profile doctrine
+
+Reason: this creates a bounded data-only registry for local model profiles. It preserves provider id `local`, keeps Whoosh'd as display/vendor metadata, and does not alter runtime semantics, provider routing, catalog exposure, or release support.

--- a/docs/architecture/whooshd-model-profiles.md
+++ b/docs/architecture/whooshd-model-profiles.md
@@ -14,7 +14,7 @@ Source anchors:
 
 Whoosh'd model profiles are data-only local runtime descriptors for MLX-backed local models.
 
-The registry gives future local model work a small file-backed place to record model identity, runtime hints, transcript safety defaults, acceptance checks, and release posture before any runtime routing or catalog exposure is changed.
+The registry gives future local model work a small file-backed place to record model identity, runtime hints, transcript safety defaults, acceptance checks, and release posture. It also gives the existing local model selector a bounded source for Whoosh'd profile-backed choices without creating a new provider id.
 
 ## Scope
 
@@ -29,26 +29,36 @@ Profiles may describe:
 
 Profiles may also note where a future live proof should store model weights. For this first profile, the operator requirement is to keep downloaded weights off the repo and under `/Volumes/Dev_SSD/` during a separate runtime-proof task. This metadata task does not download or verify those weights.
 
+Profiles may be surfaced in the UI as local model choices. The UI-facing selection value is the runtime model repo that the Whoosh'd/MLX server expects, while the profile id remains metadata for governance, acceptance checks, and release posture.
+
 ## Non-Goals
 
 - No new provider id.
-- No runtime routing changes.
-- No catalog changes.
+- No new provider routing lane.
+- No new provider catalog lane.
 - No health semantics changes.
 - No release claim expansion.
 - No custom proxy restoration.
 
-## Current First Profile
+## Current Profiles
 
 - Profile id: `gemma-4-e2b-it-4bit`
 - Model repo: `mlx-community/gemma-4-e2b-it-4bit`
 - Runtime hint: `mlx_vlm.server --model mlx-community/gemma-4-e2b-it-4bit --port 8000`
 - Local OpenAI-compatible base URL hint: `http://host.docker.internal:8000/v1`
+- Weight storage root: `/Volumes/Dev_SSD/whooshd/model-weights`
+
+- Profile id: `gemma-4-12b-it-optiq-4bit`
+- Model repo: `mlx-community/gemma-4-12B-it-OptiQ-4bit`
+- Runtime hint: `mlx_vlm.server --model mlx-community/gemma-4-12B-it-OptiQ-4bit --port 8000`
+- Local OpenAI-compatible base URL hint: `http://host.docker.internal:8000/v1`
+- Weight storage root: `/Volumes/Dev_SSD/whooshd/model-weights`
 
 ## Invariants
 
 - Provider id remains `local`.
 - Whoosh'd is display/vendor metadata unless a future ADR changes provider routing.
+- UI selection between Whoosh'd profiles remains local model selection, not provider selection.
 - A model profile is not proof of model quality.
 - A model profile is not release support.
 - Model-family hidden/thinking channel leakage must be blocked before Guardian-facing use.
@@ -57,9 +67,9 @@ Profiles may also note where a future live proof should store model weights. For
 
 ## Follow-Up Path
 
-Later tasks may add live smoke proof, profile selection UI, catalog exposure, or additional model profiles, but those must be separate tasks.
+Later tasks may add live smoke proof, richer profile management UI, supported-profile updates, or additional model profiles, but those must be separate tasks.
 
-The next live-proof task should verify the selected MLX runtime, keep model weights under `/Volumes/Dev_SSD/`, compare health/catalog/supported-profile posture, confirm queue and worker health, and prove one Guardian chat completion persists back into the source thread without prompt echo or hidden-channel leakage.
+The next live-proof task should verify the selected MLX runtime, keep model weights under `/Volumes/Dev_SSD/whooshd/model-weights`, compare health/catalog/supported-profile posture, confirm queue and worker health, and prove one Guardian chat completion persists back into the source thread without prompt echo or hidden-channel leakage.
 
 ## ADR Impact
 
@@ -73,4 +83,4 @@ Governing anchors:
 - `docs/architecture/runtime-protocol-token-contract.md`
 - provider governance and supported-profile doctrine
 
-Reason: this creates a bounded data-only registry for local model profiles. It preserves provider id `local`, keeps Whoosh'd as display/vendor metadata, and does not alter runtime semantics, provider routing, catalog exposure, or release support.
+Reason: this creates a bounded registry for local model profiles and exposes those profiles through the existing local model-selection seam. It preserves provider id `local`, keeps Whoosh'd as display/vendor metadata, and does not alter provider routing, health semantics, or release support.

--- a/frontend/src/components/ProviderSelect.tsx
+++ b/frontend/src/components/ProviderSelect.tsx
@@ -39,6 +39,9 @@ type CatalogModel = {
   supportsChat?: boolean;
   supportsVision?: boolean;
   supportsTextInput?: boolean;
+  profileId?: string;
+  displayVendor?: string;
+  releaseSupported?: boolean;
   modelKind?: "chat" | "vision_chat" | "utility";
   capabilities?: {
     chat?: boolean;
@@ -188,6 +191,24 @@ export function ProviderSelect({
                         : typeof (model as any).capabilities?.textInput === "boolean"
                           ? (model as any).capabilities.textInput
                           : undefined,
+                  profileId:
+                    typeof (model as any).profile_id === "string"
+                      ? (model as any).profile_id
+                      : typeof (model as any).profileId === "string"
+                        ? (model as any).profileId
+                        : undefined,
+                  displayVendor:
+                    typeof (model as any).display_vendor === "string"
+                      ? (model as any).display_vendor
+                      : typeof (model as any).displayVendor === "string"
+                        ? (model as any).displayVendor
+                        : undefined,
+                  releaseSupported:
+                    typeof (model as any).release_supported === "boolean"
+                      ? (model as any).release_supported
+                      : typeof (model as any).releaseSupported === "boolean"
+                        ? (model as any).releaseSupported
+                        : undefined,
                   modelKind:
                     typeof (model as any).model_kind === "string"
                       ? (model as any).model_kind

--- a/frontend/src/components/__tests__/ProviderSelect.catalog.test.tsx
+++ b/frontend/src/components/__tests__/ProviderSelect.catalog.test.tsx
@@ -121,6 +121,67 @@ describe("ProviderSelect catalog routing", () => {
     expect(onChange).toHaveBeenCalledWith("llama-3.1-70b-versatile");
   });
 
+  it("shows Whoosh'd profile-backed local models as selectable model entries", async () => {
+    (api.get as any).mockResolvedValue({
+      data: {
+        providers: [
+          {
+            id: "local",
+            displayName: "Whoosh'd",
+            enabled: true,
+            authorized: true,
+            available: true,
+            source: {
+              kind: "local",
+              baseUrl: "http://host.docker.internal:8000/v1",
+              label: "host.docker.internal:8000",
+              vendor: "whooshd",
+            },
+            models: [
+              {
+                id: "mlx-community/gemma-4-e2b-it-4bit",
+                displayName: "Gemma 4 E2B Instruct 4-bit",
+                profile_id: "gemma-4-e2b-it-4bit",
+                display_vendor: "Whoosh'd",
+                supports_chat: true,
+                supports_vision: true,
+                model_kind: "vision_chat",
+                release_supported: false,
+              },
+              {
+                id: "mlx-community/gemma-4-12B-it-OptiQ-4bit",
+                displayName: "Gemma 4 12B Instruct OptiQ 4-bit",
+                profile_id: "gemma-4-12b-it-optiq-4bit",
+                display_vendor: "Whoosh'd",
+                supports_chat: true,
+                supports_vision: false,
+                model_kind: "chat",
+                release_supported: false,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const onChange = vi.fn();
+    render(<ProviderSelect value="default" onChange={onChange} openSignal={1} />);
+
+    const whooshdButton = await screen.findByRole("button", {
+      name: "Whoosh'd",
+    });
+    expect(whooshdButton).toBeInTheDocument();
+    fireEvent.click(whooshdButton);
+
+    expect(await screen.findByText("Gemma 4 E2B Instruct 4-bit")).toBeInTheDocument();
+    expect(screen.getByText("Gemma 4 12B Instruct OptiQ 4-bit")).toBeInTheDocument();
+
+    fireEvent.click(providerButton("Gemma 4 12B Instruct OptiQ 4-bit"));
+    expect(onChange).toHaveBeenCalledWith(
+      "mlx-community/gemma-4-12B-it-OptiQ-4bit"
+    );
+  });
+
   it("refreshes catalog on a new open signal and removes unauthorized providers", async () => {
     const initialCatalog = {
       data: {

--- a/frontend/src/features/chat/hooks/useLlmCatalog.ts
+++ b/frontend/src/features/chat/hooks/useLlmCatalog.ts
@@ -20,6 +20,10 @@ export type LlmCatalogModel = {
   alias?: string;
   namespace?: string;
   source?: string;
+  profileId?: string;
+  profileSource?: string;
+  displayVendor?: string;
+  releaseSupported?: boolean;
   contextWindow?: number;
   supportsChat?: boolean;
   supportsVision?: boolean;
@@ -202,6 +206,16 @@ function normalizeModel(
     alias,
     namespace: normalizeString(model.namespace) ?? undefined,
     source: normalizeString(model.source) ?? undefined,
+    profileId:
+      normalizeString(model.profile_id ?? model.profileId) ?? undefined,
+    profileSource:
+      normalizeString(model.profile_source ?? model.profileSource) ??
+      undefined,
+    displayVendor:
+      normalizeString(model.display_vendor ?? model.displayVendor) ??
+      undefined,
+    releaseSupported:
+      normalizeBoolean(model.release_supported ?? model.releaseSupported),
     contextWindow:
       typeof model.contextWindow === "number" && Number.isFinite(model.contextWindow)
         ? model.contextWindow

--- a/guardian/core/ai_router.py
+++ b/guardian/core/ai_router.py
@@ -25,6 +25,7 @@ from guardian.core.provider_registry import (
     provider_routing_requires_discovered_inventory,
     validate_provider_model_selection,
 )
+from guardian.core.whooshd_model_profiles import whooshd_runtime_model_id
 from guardian.protocol_tokens import (
     ErrorCode,
     GuardianProviderFailureKind,
@@ -1123,8 +1124,13 @@ def _local_execution_model_candidates(
     requested_model: str | None = None,
 ) -> tuple[list[tuple[str, str]], bool]:
     strict = _local_chat_model_is_authoritative(settings)
+    requested_whooshd_model = whooshd_runtime_model_id(requested_model)
     raw_candidates: tuple[tuple[str, Any], ...]
-    if strict:
+    if strict and requested_whooshd_model:
+        raw_candidates = (
+            ("whooshd_model_profile", requested_whooshd_model),
+        )
+    elif strict:
         raw_candidates = (
             ("LOCAL_CHAT_MODEL", getattr(settings, "LOCAL_CHAT_MODEL", None)),
         )

--- a/guardian/core/llm_catalog.py
+++ b/guardian/core/llm_catalog.py
@@ -35,6 +35,10 @@ from guardian.core.provider_registry import (
     resolve_provider_for_model as resolve_provider_for_model_registry,
 )
 from guardian.core.provider_truth import build_provider_truth
+from guardian.core.whooshd_model_profiles import (
+    whooshd_profile_by_id_or_repo,
+    whooshd_profile_model_repos,
+)
 
 _MODEL_FAMILY_ALIASES = {
     "deepseek": "DeepSeek",
@@ -135,6 +139,50 @@ def _local_model_capabilities(
         "supports_text_input": True,
         "model_kind": "vision_chat" if supports_vision else "chat",
     }
+
+
+def _whooshd_profile_capabilities(
+    profile: dict[str, Any] | None,
+    *,
+    model_id: str,
+    display_name: str,
+) -> dict[str, Any]:
+    if not profile:
+        return _local_model_capabilities(model_id, display_name)
+
+    raw_capabilities = profile.get("capabilities")
+    capabilities = (
+        raw_capabilities if isinstance(raw_capabilities, dict) else {}
+    )
+    supports_chat = bool(capabilities.get("chat", True))
+    supports_vision = bool(capabilities.get("vision", False))
+    supports_text_input = supports_chat
+    return {
+        "supports_chat": supports_chat,
+        "supports_vision": supports_vision,
+        "supports_text_input": supports_text_input,
+        "model_kind": "vision_chat" if supports_vision else "chat",
+    }
+
+
+def _whooshd_profile_runtime_metadata(
+    profile: dict[str, Any],
+) -> dict[str, Any]:
+    runtime = profile.get("runtime")
+    if not isinstance(runtime, dict):
+        return {}
+    metadata: dict[str, Any] = {}
+    for key in (
+        "kind",
+        "server",
+        "openai_compatible",
+        "default_base_url",
+        "startup_command",
+    ):
+        value = runtime.get(key)
+        if value is not None:
+            metadata[key] = value
+    return metadata
 
 
 def resolve_model_vision_capability_state(
@@ -355,6 +403,12 @@ def _fetch_local_models(
             continue
         seen.add(key)
         deduped.append(key)
+    for model_name in whooshd_profile_model_repos():
+        key = model_name.strip()
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        deduped.append(key)
     local_model_resolution = resolve_local_execution_model(
         settings=settings,
         validate_availability=True,
@@ -395,10 +449,18 @@ def _fetch_local_models(
     )
     entries: list[dict[str, Any]] = []
     for name, identity in zip(deduped, identities, strict=False):
+        profile = whooshd_profile_by_id_or_repo(name)
         display_label = str(
-            identity.get("alias") or identity.get("display_label") or name
+            (profile or {}).get("display_name")
+            or identity.get("alias")
+            or identity.get("display_label")
+            or name
         ).strip()
-        local_capabilities = _local_model_capabilities(name, display_label)
+        local_capabilities = _whooshd_profile_capabilities(
+            profile,
+            model_id=name,
+            display_name=display_label,
+        )
         entry = _base_model_entry(
             name,
             display_name=display_label,
@@ -416,7 +478,9 @@ def _fetch_local_models(
             identity.get("canonical_id") or name
         ).strip()
         entry["display_label"] = str(
-            identity.get("display_label") or display_label
+            (profile or {}).get("display_name")
+            or identity.get("display_label")
+            or display_label
         ).strip()
         entry["alias"] = identity.get("alias")
         namespace = str(identity.get("namespace") or "").strip()
@@ -429,6 +493,24 @@ def _fetch_local_models(
             "supported" if local_capabilities["supports_vision"] else "unknown"
         )
         entry["runtime"] = describe_local_runtime(name, settings=settings)
+        if profile:
+            entry["profile_id"] = str(profile.get("id") or "").strip()
+            entry["profile_source"] = "whooshd_model_profile"
+            entry["display_vendor"] = str(
+                profile.get("display_vendor") or ""
+            ).strip()
+            release_posture = profile.get("release_posture")
+            if isinstance(release_posture, dict):
+                entry["release_posture"] = dict(release_posture)
+                entry["release_supported"] = bool(
+                    release_posture.get("release_supported")
+                )
+            weights = profile.get("weights")
+            if isinstance(weights, dict):
+                entry["weights"] = dict(weights)
+            entry["runtime"]["whooshd_profile"] = (
+                _whooshd_profile_runtime_metadata(profile)
+            )
         entries.append(entry)
     entries = _apply_local_model_overrides(entries)
     if endpoint_resolution.get("state") != "available" and names:

--- a/guardian/core/whooshd_model_profiles.py
+++ b/guardian/core/whooshd_model_profiles.py
@@ -1,0 +1,105 @@
+"""File-backed Whoosh'd local model profile registry."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PROFILE_DIR = ROOT / "config" / "whooshd" / "model-profiles"
+
+
+class WhooshdModelProfileError(ValueError):
+    """Raised when the local Whoosh'd profile registry is malformed."""
+
+
+def _profile_paths(profile_dir: Path = PROFILE_DIR) -> list[Path]:
+    if not profile_dir.exists():
+        return []
+    return sorted(profile_dir.glob("*.json"))
+
+
+def _profile_model_repo(profile: dict[str, Any]) -> str:
+    model = profile.get("model")
+    if not isinstance(model, dict):
+        return ""
+    return str(model.get("repo") or "").strip()
+
+
+def _validate_profile(path: Path, profile: dict[str, Any]) -> None:
+    label = path.relative_to(ROOT)
+    profile_id = str(profile.get("id") or "").strip()
+    if not profile_id:
+        raise WhooshdModelProfileError(f"{label}: missing id")
+    if str(profile.get("provider_id") or "").strip() != "local":
+        raise WhooshdModelProfileError(f"{label}: provider_id must be local")
+    if str(profile.get("display_vendor") or "").strip() != "Whoosh'd":
+        raise WhooshdModelProfileError(
+            f"{label}: display_vendor must be Whoosh'd"
+        )
+    if not _profile_model_repo(profile):
+        raise WhooshdModelProfileError(f"{label}: model.repo is required")
+    release_posture = profile.get("release_posture")
+    if not isinstance(release_posture, dict):
+        raise WhooshdModelProfileError(
+            f"{label}: release_posture must be an object"
+        )
+    if release_posture.get("release_supported") is not False:
+        raise WhooshdModelProfileError(
+            f"{label}: release_posture.release_supported must be false"
+        )
+
+
+@lru_cache(maxsize=1)
+def load_whooshd_model_profiles() -> tuple[dict[str, Any], ...]:
+    profiles: list[dict[str, Any]] = []
+    for path in _profile_paths():
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise WhooshdModelProfileError(
+                f"{path.relative_to(ROOT)}: invalid JSON: {exc}"
+            ) from exc
+        if not isinstance(payload, dict):
+            raise WhooshdModelProfileError(
+                f"{path.relative_to(ROOT)}: profile must be an object"
+            )
+        _validate_profile(path, payload)
+        profiles.append(payload)
+    return tuple(profiles)
+
+
+def whooshd_profile_by_id_or_repo(
+    model_id: str | None,
+) -> dict[str, Any] | None:
+    clean = str(model_id or "").strip()
+    if not clean:
+        return None
+    for profile in load_whooshd_model_profiles():
+        if clean == str(profile.get("id") or "").strip():
+            return profile
+        if clean == _profile_model_repo(profile):
+            return profile
+    return None
+
+
+def whooshd_runtime_model_id(model_id: str | None) -> str | None:
+    profile = whooshd_profile_by_id_or_repo(model_id)
+    if profile is None:
+        return None
+    return _profile_model_repo(profile) or None
+
+
+def whooshd_profile_model_repos() -> list[str]:
+    repos: list[str] = []
+    seen: set[str] = set()
+    for profile in load_whooshd_model_profiles():
+        repo = _profile_model_repo(profile)
+        if not repo or repo in seen:
+            continue
+        seen.add(repo)
+        repos.append(repo)
+    return repos

--- a/scripts/validate_whooshd_model_profiles.py
+++ b/scripts/validate_whooshd_model_profiles.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Validate data-only Whoosh'd local model profile metadata."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROFILE_DIR = ROOT / "config" / "whooshd" / "model-profiles"
+
+REQUIRED_TOP_LEVEL_KEYS = {
+    "schema_version",
+    "id",
+    "display_name",
+    "family",
+    "provider_id",
+    "display_vendor",
+    "runtime",
+    "model",
+    "guardian_defaults",
+    "acceptance_checks",
+    "release_posture",
+}
+
+REQUIRED_ACCEPTANCE_CHECKS = {
+    "no_prompt_echo",
+    "no_thought_channel_leak",
+    "guardian_completion_smoke",
+}
+
+
+def _failures_for_profile(path: Path, profile: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    label = path.relative_to(ROOT)
+
+    missing = sorted(REQUIRED_TOP_LEVEL_KEYS - profile.keys())
+    for key in missing:
+        failures.append(f"{label}: missing required key: {key}")
+
+    if profile.get("provider_id") != "local":
+        failures.append(f"{label}: provider_id must be 'local'")
+
+    if profile.get("display_vendor") != "Whoosh'd":
+        failures.append(f"{label}: display_vendor must be \"Whoosh'd\"")
+
+    release_posture = profile.get("release_posture")
+    if not isinstance(release_posture, dict):
+        failures.append(f"{label}: release_posture must be an object")
+    elif release_posture.get("release_supported") is not False:
+        failures.append(
+            f"{label}: release_posture.release_supported must be false"
+        )
+
+    guardian_defaults = profile.get("guardian_defaults")
+    if not isinstance(guardian_defaults, dict):
+        failures.append(f"{label}: guardian_defaults must be an object")
+    else:
+        if guardian_defaults.get("reject_thought_channel_leaks") is not True:
+            failures.append(
+                f"{label}: guardian_defaults.reject_thought_channel_leaks must be true"
+            )
+        if guardian_defaults.get("history_policy") != "final_answer_only":
+            failures.append(
+                f"{label}: guardian_defaults.history_policy must be 'final_answer_only'"
+            )
+
+    acceptance_checks = profile.get("acceptance_checks")
+    if not isinstance(acceptance_checks, list):
+        failures.append(f"{label}: acceptance_checks must be an array")
+    else:
+        check_ids = {
+            item.get("id")
+            for item in acceptance_checks
+            if isinstance(item, dict)
+        }
+        for check_id in sorted(REQUIRED_ACCEPTANCE_CHECKS - check_ids):
+            failures.append(
+                f"{label}: acceptance_checks missing required id: {check_id}"
+            )
+
+    return failures
+
+
+def validate_profiles() -> int:
+    if not PROFILE_DIR.exists():
+        print(f"Profile directory not found: {PROFILE_DIR}", file=sys.stderr)
+        return 1
+
+    profile_paths = sorted(PROFILE_DIR.glob("*.json"))
+    if not profile_paths:
+        print(f"No model profiles found in {PROFILE_DIR}", file=sys.stderr)
+        return 1
+
+    failures: list[str] = []
+    for path in profile_paths:
+        try:
+            profile = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            failures.append(f"{path.relative_to(ROOT)}: invalid JSON: {exc}")
+            continue
+
+        if not isinstance(profile, dict):
+            failures.append(f"{path.relative_to(ROOT)}: profile must be an object")
+            continue
+
+        failures.extend(_failures_for_profile(path, profile))
+
+    if failures:
+        for failure in failures:
+            print(failure, file=sys.stderr)
+        return 1
+
+    print(f"Validated {len(profile_paths)} Whoosh'd model profile(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(validate_profiles())

--- a/tests/codex_runner/test_runner_v2.py
+++ b/tests/codex_runner/test_runner_v2.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -69,6 +70,100 @@ def _assert_single_fenced_prompt(content: str) -> None:
     assert content.startswith("```text\n")
     assert content.endswith("\n```\n")
     assert content.count("```") == 2
+
+
+def _sample_audit_payload(audit_id: str = "AUDIT_abc123def456") -> dict:
+    return {
+        "audit_id": audit_id,
+        "repo": {
+            "path": str(ROOT),
+            "branch": "test",
+            "commit": "deadbeef",
+        },
+        "generated_at": "2026-06-09T00:00:00Z",
+        "agent": {
+            "name": "fixture",
+            "model": "fixture",
+            "mode": "audit",
+        },
+        "reports": [],
+        "runner_ready_findings": [],
+        "campaign_derivation_rules": {
+            "strategy": "fixture",
+            "group_by": [],
+            "priority_order": ["RISK", "WARN", "INFO"],
+        },
+        "derived_campaigns": [
+            {
+                "campaign_id": "2026-06-09::fixture_alpha::001",
+                "campaign_type": "followup",
+                "source_findings": [],
+            }
+        ],
+    }
+
+
+def _sample_campaign_payload(
+    audit_id: str = "AUDIT_abc123def456",
+    *,
+    task_lane: str = "architecture_impact",
+) -> dict:
+    return {
+        "audit_id": audit_id,
+        "generated_at": "2026-06-09T00:00:00Z",
+        "campaigns": [
+            {
+                "campaign_id": "2026-06-09::fixture_alpha::001",
+                "campaign_slug": "fixture_alpha",
+                "depends_on": [],
+                "campaign_markdown": "# Fixture Campaign\n",
+                "tasks": [
+                    {
+                        "id": "TASK-FIXTURE-001",
+                        "slug": "provider_readiness",
+                        "task_lane": task_lane,
+                        "area": "docs",
+                        "risk": "LOW",
+                        "files": ["codex_runner/runner.py"],
+                        "tests": ["pytest -q tests/codex_runner/test_runner_v2.py"],
+                        "commit_message": "Fixture materialization task",
+                        "task_artifact_markdown": "# Fixture Task\n",
+                        "activation_prompt": "Review fixture materialization only.",
+                        "dependencies": [],
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _write_json(path: runner.Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    runner.json_write(path, payload)
+
+
+def _fixture_args(
+    tmp_path: runner.Path,
+    audit_json: runner.Path,
+    campaign_json: runner.Path,
+    *,
+    intention_packet: runner.Path | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        repo_root=tmp_path,
+        audit_schema_file=ROOT
+        / "codex_runner"
+        / "schemas"
+        / "mega_audit_output.schema.json",
+        campaign_set_schema_file=ROOT
+        / "codex_runner"
+        / "schemas"
+        / "campaign_set.schema.json",
+        audit_json_file=audit_json,
+        campaign_json_file=campaign_json,
+        intention_packet_file=intention_packet,
+        debug=False,
+    )
 
 
 def test_run_id_determinism() -> None:
@@ -432,3 +527,186 @@ def test_missing_task_lane_defaults_prompt_to_discovery(
     )
     assert "Read-only investigation first." in content
     _assert_single_fenced_prompt(content)
+
+
+def test_fixture_materialization_creates_artifact_inventory_without_provider(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: runner.Path
+) -> None:
+    audit_json = tmp_path / "fixtures" / "audit.json"
+    campaign_json = tmp_path / "fixtures" / "campaign.json"
+    packet = tmp_path / "fixtures" / "intention.md"
+    _write_json(audit_json, _sample_audit_payload())
+    _write_json(campaign_json, _sample_campaign_payload())
+    packet.write_text("# Fixture Packet\n", encoding="utf-8")
+
+    def fail_provider(*_args, **_kwargs) -> None:
+        raise AssertionError("provider dispatch must not be called")
+
+    monkeypatch.setattr(runner, "run_provider_exec", fail_provider)
+    monkeypatch.setattr(runner, "render_audit_prompt", fail_provider)
+    monkeypatch.setattr(runner, "render_compiler_prompt", fail_provider)
+    monkeypatch.setattr(runner, "git_is_clean", lambda *_args, **_kw: True)
+
+    summary = runner.run_fixture_materialization(
+        _fixture_args(tmp_path, audit_json, campaign_json, intention_packet=packet),
+        base_ref_sha="deadbeef",
+        cli_args=[
+            "--materialize-from-fixtures",
+            "--audit-json-file",
+            str(audit_json),
+            "--campaign-json-file",
+            str(campaign_json),
+        ],
+    )
+
+    assert summary["provider_invocation_skipped"] is True
+    assert summary["selected_campaign"] == "2026-06-09::fixture_alpha::001"
+
+    campaign_doc = (
+        tmp_path
+        / "docs"
+        / "Campaign"
+        / "CAMPAIGN_2026_06_09_FIXTURE_ALPHA_001.md"
+    )
+    task_artifact = (
+        tmp_path
+        / "docs"
+        / "tasks"
+        / "fixture_alpha_2026_06_09_001"
+        / "TASK_provider_readiness_2026_06_09.md"
+    )
+    prompt_artifact = (
+        tmp_path
+        / "docs"
+        / "tasks"
+        / "fixture_alpha_2026_06_09_001"
+        / "PROMPT_provider_readiness_2026_06_09.md"
+    )
+    today_iso = runner.datetime.now(runner.timezone.utc).date().isoformat()
+    run_meta = (
+        tmp_path
+        / "docs"
+        / "_audits"
+        / today_iso
+        / "AUDIT_abc123def456"
+        / "run_meta.json"
+    )
+    state_path = tmp_path / runner.STATE_PATH
+
+    assert campaign_doc.exists()
+    assert task_artifact.read_text(encoding="utf-8") == "# Fixture Task\n"
+    prompt_content = prompt_artifact.read_text(encoding="utf-8")
+    _assert_single_fenced_prompt(prompt_content)
+    assert "Task lane: architecture_impact" in prompt_content
+    assert "Prompt shape: Architecture-Impact Codexify Task" in prompt_content
+
+    state = runner.json_read(state_path)
+    task = state["campaigns"]["2026-06-09::fixture_alpha::001"]["tasks"][
+        "TASK-FIXTURE-001"
+    ]
+    assert task["task_lane"] == "architecture_impact"
+    assert (
+        task["content_hash"]
+        == state["task_index_by_id"]["TASK-FIXTURE-001"]["content_hash"]
+    )
+
+    meta = runner.json_read(run_meta)
+    assert meta["provider"]["name"] == "fixture"
+    assert meta["provider"]["invocation_skipped"] is True
+    assert meta["fixture_materialization"]["provider_invocation_skipped"] is True
+    assert meta["fixture_materialization"]["audit_json_file"] == str(
+        audit_json.resolve()
+    )
+    assert meta["fixture_materialization"]["campaign_json_file"] == str(
+        campaign_json.resolve()
+    )
+    assert meta["fixture_materialization"]["intention_packet_file"] == str(
+        packet.resolve()
+    )
+
+
+def test_fixture_parse_args_missing_audit_json_fails_clearly(
+    tmp_path: runner.Path,
+) -> None:
+    campaign_json = tmp_path / "campaign.json"
+    _write_json(campaign_json, _sample_campaign_payload())
+
+    with pytest.raises(
+        runner.RunnerError,
+        match="--materialize-from-fixtures requires --audit-json-file",
+    ):
+        runner.parse_args(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "--materialize-from-fixtures",
+                "--campaign-json-file",
+                str(campaign_json),
+            ]
+        )
+
+
+def test_fixture_parse_args_missing_campaign_json_fails_clearly(
+    tmp_path: runner.Path,
+) -> None:
+    audit_json = tmp_path / "audit.json"
+    _write_json(audit_json, _sample_audit_payload())
+
+    with pytest.raises(
+        runner.RunnerError,
+        match="--materialize-from-fixtures requires --campaign-json-file",
+    ):
+        runner.parse_args(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "--materialize-from-fixtures",
+                "--audit-json-file",
+                str(audit_json),
+            ]
+        )
+
+
+def test_fixture_missing_json_path_fails_clearly(tmp_path: runner.Path) -> None:
+    campaign_json = tmp_path / "campaign.json"
+    missing_audit = tmp_path / "missing-audit.json"
+    _write_json(campaign_json, _sample_campaign_payload())
+
+    with pytest.raises(runner.RunnerError, match="Required file not found"):
+        runner.parse_args(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "--materialize-from-fixtures",
+                "--audit-json-file",
+                str(missing_audit),
+                "--campaign-json-file",
+                str(campaign_json),
+            ]
+        )
+
+
+def test_fixture_schema_invalid_campaign_fails_before_materialization(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: runner.Path
+) -> None:
+    audit_json = tmp_path / "fixtures" / "audit.json"
+    campaign_json = tmp_path / "fixtures" / "campaign.json"
+    invalid_campaign = _sample_campaign_payload()
+    del invalid_campaign["campaigns"][0]["tasks"][0]["task_lane"]
+    _write_json(audit_json, _sample_audit_payload())
+    _write_json(campaign_json, invalid_campaign)
+    monkeypatch.setattr(runner, "git_is_clean", lambda *_args, **_kw: True)
+
+    with pytest.raises(
+        runner.RunnerError,
+        match="Schema validation failed for campaign JSON",
+    ):
+        runner.run_fixture_materialization(
+            _fixture_args(tmp_path, audit_json, campaign_json),
+            base_ref_sha="deadbeef",
+            cli_args=["--materialize-from-fixtures"],
+        )
+
+    assert not (tmp_path / "docs" / "Campaign").exists()
+    assert not (tmp_path / "docs" / "tasks").exists()
+    assert not (tmp_path / runner.STATE_PATH).exists()

--- a/tests/config/test_whooshd_model_profiles.py
+++ b/tests/config/test_whooshd_model_profiles.py
@@ -1,0 +1,48 @@
+"""Tests for Whoosh'd local model profile metadata."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PROFILE_PATH = (
+    ROOT
+    / "config"
+    / "whooshd"
+    / "model-profiles"
+    / "gemma-4-e2b-it-4bit.json"
+)
+VALIDATOR_PATH = ROOT / "scripts" / "validate_whooshd_model_profiles.py"
+
+
+def _load_profile() -> dict:
+    return json.loads(PROFILE_PATH.read_text(encoding="utf-8"))
+
+
+def test_validator_passes_for_committed_profiles() -> None:
+    result = subprocess.run(
+        [sys.executable, str(VALIDATOR_PATH)],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Validated 1 Whoosh'd model profile(s)." in result.stdout
+
+
+def test_gemma_4_e2b_profile_preserves_local_provider_boundary() -> None:
+    profile = _load_profile()
+
+    assert profile["id"] == "gemma-4-e2b-it-4bit"
+    assert profile["provider_id"] == "local"
+    assert profile["runtime"]["server"] == "mlx_vlm.server"
+    assert profile["model"]["repo"] == "mlx-community/gemma-4-e2b-it-4bit"
+    assert profile["guardian_defaults"]["requires_final_answer_extraction"] is True
+    assert profile["guardian_defaults"]["reject_thought_channel_leaks"] is True
+    assert profile["release_posture"]["release_supported"] is False

--- a/tests/config/test_whooshd_model_profiles.py
+++ b/tests/config/test_whooshd_model_profiles.py
@@ -9,18 +9,18 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
-PROFILE_PATH = (
-    ROOT
-    / "config"
-    / "whooshd"
-    / "model-profiles"
-    / "gemma-4-e2b-it-4bit.json"
-)
+PROFILE_DIR = ROOT / "config" / "whooshd" / "model-profiles"
+PROFILE_PATH = PROFILE_DIR / "gemma-4-e2b-it-4bit.json"
+OPTIQ_PROFILE_PATH = PROFILE_DIR / "gemma-4-12b-it-optiq-4bit.json"
 VALIDATOR_PATH = ROOT / "scripts" / "validate_whooshd_model_profiles.py"
 
 
 def _load_profile() -> dict:
     return json.loads(PROFILE_PATH.read_text(encoding="utf-8"))
+
+
+def _load_optiq_profile() -> dict:
+    return json.loads(OPTIQ_PROFILE_PATH.read_text(encoding="utf-8"))
 
 
 def test_validator_passes_for_committed_profiles() -> None:
@@ -33,7 +33,7 @@ def test_validator_passes_for_committed_profiles() -> None:
     )
 
     assert result.returncode == 0, result.stderr
-    assert "Validated 1 Whoosh'd model profile(s)." in result.stdout
+    assert "Validated 2 Whoosh'd model profile(s)." in result.stdout
 
 
 def test_gemma_4_e2b_profile_preserves_local_provider_boundary() -> None:
@@ -43,6 +43,22 @@ def test_gemma_4_e2b_profile_preserves_local_provider_boundary() -> None:
     assert profile["provider_id"] == "local"
     assert profile["runtime"]["server"] == "mlx_vlm.server"
     assert profile["model"]["repo"] == "mlx-community/gemma-4-e2b-it-4bit"
+    assert profile["guardian_defaults"]["requires_final_answer_extraction"] is True
+    assert profile["guardian_defaults"]["reject_thought_channel_leaks"] is True
+    assert profile["release_posture"]["release_supported"] is False
+
+
+def test_gemma_4_12b_optiq_profile_preserves_local_provider_boundary() -> None:
+    profile = _load_optiq_profile()
+
+    assert profile["id"] == "gemma-4-12b-it-optiq-4bit"
+    assert profile["provider_id"] == "local"
+    assert profile["runtime"]["server"] == "mlx_vlm.server"
+    assert profile["model"]["repo"] == (
+        "mlx-community/gemma-4-12B-it-OptiQ-4bit"
+    )
+    assert profile["capabilities"]["vision"] is False
+    assert profile["weights"]["storage_root"].startswith("/Volumes/Dev_SSD/")
     assert profile["guardian_defaults"]["requires_final_answer_extraction"] is True
     assert profile["guardian_defaults"]["reject_thought_channel_leaks"] is True
     assert profile["release_posture"]["release_supported"] is False

--- a/tests/core/test_ai_router.py
+++ b/tests/core/test_ai_router.py
@@ -217,6 +217,50 @@ def test_chat_with_ai_local_falls_back_to_host_bridge_on_loopback_failure(
     )
 
 
+def test_stream_local_strict_mode_allows_registered_whooshd_profile_selection(
+    monkeypatch,
+):
+    captured: dict[str, object] = {}
+
+    def _mock_post(url: str, *, json, headers, stream, timeout):
+        captured["url"] = url
+        captured["json"] = json
+        _ = (headers, stream, timeout)
+        return _MockStreamingResponse(
+            [
+                b'data: {"choices":[{"delta":{"content":"Whoosh"}}]}',
+                b'data: {"choices":[{"delta":{"content":"d"}}]}',
+                b"data: [DONE]",
+            ]
+        )
+
+    monkeypatch.setattr("guardian.core.ai_router.requests.post", _mock_post)
+
+    settings = Settings(
+        LLM_PROVIDER="local",
+        CODEXIFY_LOCAL_ONLY_MODE=True,
+        LOCAL_BASE_URL="http://host.docker.internal:8000/v1",
+        LOCAL_LLM_MODEL="library2/ministral-3:8b",
+        LOCAL_CHAT_MODEL="library2/ministral-3:8b",
+    )
+
+    tokens = list(
+        stream_local(
+            [{"role": "user", "content": "hello"}],
+            "gemma-4-12b-it-optiq-4bit",
+            settings=settings,
+        )
+    )
+
+    assert tokens == ["Whoosh", "d"]
+    assert captured["json"]["model"] == (
+        "mlx-community/gemma-4-12B-it-OptiQ-4bit"
+    )
+    assert captured["url"] == (
+        "http://host.docker.internal:8000/v1/chat/completions"
+    )
+
+
 def test_chat_with_ai_local_failure_surfaces_attempt_diagnostics(monkeypatch):
     _disable_supported_profile(monkeypatch)
 

--- a/tests/ops/test_source_compose_supported_profile_contract.py
+++ b/tests/ops/test_source_compose_supported_profile_contract.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_PATH = ROOT / "docker-compose.yml"
+
+
+def _service_block(text: str, service: str) -> str:
+    marker = f"  {service}:\n"
+    start = text.index(marker) + len(marker)
+    block_lines: list[str] = []
+    for line in text[start:].splitlines(keepends=True):
+        if line.startswith("  ") and not line.startswith("    "):
+            break
+        block_lines.append(line)
+    return "".join(block_lines)
+
+
+def test_source_backend_compose_defaults_supported_profile() -> None:
+    text = COMPOSE_PATH.read_text(encoding="utf-8")
+    backend_block = _service_block(text, "backend")
+
+    assert COMPOSE_PATH.is_file()
+    assert (
+        'CODEXIFY_SUPPORTED_PROFILE: "${CODEXIFY_SUPPORTED_PROFILE:-v1-local-core-web-mcp}"'
+        in backend_block
+    )
+    assert 'CODEXIFY_SUPPORTED_PROFILE: "${CODEXIFY_SUPPORTED_PROFILE}"' not in text

--- a/tests/routes/test_llm_catalog.py
+++ b/tests/routes/test_llm_catalog.py
@@ -63,6 +63,13 @@ def _mock_whooshd_catalog_request(url: str, *args, **kwargs) -> _MockResponse:
     return _MockResponse({"data": []}, status_code=404)
 
 
+def _mock_empty_whooshd_catalog_request(
+    url: str, *args, **kwargs
+) -> _MockResponse:
+    _ = (url, args, kwargs)
+    return _MockResponse({"data": []}, status_code=404)
+
+
 def _mock_alibaba_model_index(url: str, *args, **kwargs) -> _MockResponse:
     assert url == "https://dashscope-us.aliyuncs.com/compatible-mode/v1/models"
     return _MockResponse({"data": [{"id": "qwen-plus"}]})
@@ -457,6 +464,73 @@ def test_llm_catalog_labels_whooshd_local_openai_compatible_provider(
             "mlx-community/Llama-3.2-3B-Instruct-4bit"
         )
         assert local["endpoint_resolution"]["state"] == "available"
+    finally:
+        for field, value in snapshot.items():
+            setattr(settings, field, value)
+
+
+def test_llm_catalog_adds_whooshd_profile_models_to_local_provider(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "guardian.core.llm_catalog.requests.get",
+        _mock_empty_whooshd_catalog_request,
+    )
+    _clear_extra_cloud_keys(monkeypatch)
+
+    settings = get_settings()
+    snapshot = {
+        "LOCAL_BASE_URL": settings.LOCAL_BASE_URL,
+        "CODEXIFY_LOCAL_ENDPOINT_CHAIN": settings.CODEXIFY_LOCAL_ENDPOINT_CHAIN,
+        "ALLOW_CLOUD_PROVIDERS": settings.ALLOW_CLOUD_PROVIDERS,
+        "CODEXIFY_LOCAL_ONLY_MODE": settings.CODEXIFY_LOCAL_ONLY_MODE,
+        "CODEXIFY_EGRESS_ALLOWLIST": settings.CODEXIFY_EGRESS_ALLOWLIST,
+        "LOCAL_PROVIDER_DISPLAY_NAME": settings.LOCAL_PROVIDER_DISPLAY_NAME,
+        "LOCAL_PROVIDER_VENDOR": settings.LOCAL_PROVIDER_VENDOR,
+        "LOCAL_LLM_MODEL": settings.LOCAL_LLM_MODEL,
+        "LOCAL_CHAT_MODEL": settings.LOCAL_CHAT_MODEL,
+        "DEFAULT_LOCAL_MODEL": settings.DEFAULT_LOCAL_MODEL,
+        "LLM_MODEL": settings.LLM_MODEL,
+    }
+    try:
+        settings.LOCAL_BASE_URL = "http://host.docker.internal:8000/v1"
+        settings.CODEXIFY_LOCAL_ENDPOINT_CHAIN = (
+            "http://host.docker.internal:8000/v1"
+        )
+        settings.ALLOW_CLOUD_PROVIDERS = False
+        settings.CODEXIFY_LOCAL_ONLY_MODE = True
+        settings.CODEXIFY_EGRESS_ALLOWLIST = ""
+        settings.LOCAL_PROVIDER_DISPLAY_NAME = "Whoosh'd"
+        settings.LOCAL_PROVIDER_VENDOR = "whooshd"
+        settings.LOCAL_LLM_MODEL = "mlx-community/gemma-4-e2b-it-4bit"
+        settings.LOCAL_CHAT_MODEL = "mlx-community/gemma-4-e2b-it-4bit"
+        settings.DEFAULT_LOCAL_MODEL = "mlx-community/gemma-4-e2b-it-4bit"
+        settings.LLM_MODEL = "mlx-community/gemma-4-e2b-it-4bit"
+
+        client = TestClient(app)
+        payload = client.get("/api/llm/catalog").json()
+
+        local = _provider_by_id(payload, "local")
+        models_by_id = {model["id"]: model for model in local["models"]}
+
+        e2b = models_by_id["mlx-community/gemma-4-e2b-it-4bit"]
+        optiq = models_by_id[
+            "mlx-community/gemma-4-12B-it-OptiQ-4bit"
+        ]
+
+        assert local["id"] == "local"
+        assert local["displayName"] == "Whoosh'd"
+        assert e2b["profile_id"] == "gemma-4-e2b-it-4bit"
+        assert e2b["displayName"] == "Gemma 4 E2B Instruct 4-bit"
+        assert e2b["release_supported"] is False
+        assert e2b["supports_vision"] is True
+        assert optiq["profile_id"] == "gemma-4-12b-it-optiq-4bit"
+        assert optiq["displayName"] == "Gemma 4 12B Instruct OptiQ 4-bit"
+        assert optiq["release_supported"] is False
+        assert optiq["supports_vision"] is False
+        assert optiq["weights"]["storage_root"].startswith(
+            "/Volumes/Dev_SSD/"
+        )
     finally:
         for field, value in snapshot.items():
             setattr(settings, field, value)


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
