### PR TITLE
feat: add OpenAI export corpus reconnaissance

### DIFF
--- a/backend/rag/openai_export_corpus_recon.py
+++ b/backend/rag/openai_export_corpus_recon.py
@@ -318,7 +318,6 @@ class OpenAIExportCorpusRecon:
         # Classify all files
         json_files: list[OpenAIExportFileRecord] = []
         asset_files: list[OpenAIExportFileRecord] = []
-        parse_failures: list[str] = []
 
         for record in inventory.files:
             kind = record.detected_kind
@@ -326,15 +325,14 @@ class OpenAIExportCorpusRecon:
 
             if kind in {"json_object", "json_array", "jsonl"}:
                 json_files.append(record)
-                if not record.parse_success:
-                    parse_failures.append(record.path)
-                    stats.parse_failures += 1
-                    stats.failed_paths.append(
-                        {
-                            "path": record.path,
-                            "error": record.parse_error or "unknown",
-                        }
-                    )
+            elif kind == "invalid_json":
+                stats.parse_failures += 1
+                stats.failed_paths.append(
+                    {
+                        "path": record.path,
+                        "error": record.parse_error or "invalid_json",
+                    }
+                )
             elif kind in {
                 "image_png",
                 "image_jpeg",
@@ -360,38 +358,28 @@ class OpenAIExportCorpusRecon:
 
         stats.json_like_files = len(json_files)
 
-        # Extract conversations from JSON files
+        # Extract conversations from sniffed JSON/JSONL files. Do not assume
+        # legacy conversations.json or modern conversations-*.json names.
         all_conversations: list[ReconConversation] = []
-        conversation_json_files: set[str] = set()
 
         for record in json_files:
-            if not record.parse_success:
-                continue
-            path_lower = Path(record.path).name.lower()
-            if path_lower.startswith("conversations-") and path_lower.endswith(
-                ".json"
-            ):
-                conversation_json_files.add(record.path)
-
-        # Parse conversation shards
-        for record in json_files:
-            if record.path not in conversation_json_files:
-                continue
             try:
-                payload = json.loads(
-                    Path(record.absolute_path).read_text(encoding="utf-8-sig")
-                )
-            except Exception:
+                payloads = list(_iter_json_payloads(record))
+            except Exception as exc:
                 stats.parse_failures += 1
                 stats.failed_paths.append(
-                    {"path": record.path, "error": "json_parse_failed"}
+                    {"path": record.path, "error": str(exc) or "json_parse_failed"}
                 )
                 continue
 
-            for conv in self._iter_conversations_from_payload(payload):
-                recon_conv = self._build_recon_conversation(conv)
-                if recon_conv:
-                    all_conversations.append(recon_conv)
+            before = len(all_conversations)
+            for payload in payloads:
+                for conv in self._iter_conversations_from_payload(payload):
+                    recon_conv = self._build_recon_conversation(conv)
+                    if recon_conv:
+                        all_conversations.append(recon_conv)
+            if len(all_conversations) == before:
+                stats.skipped_files += 1
 
         stats.conversations = all_conversations
         stats.conversations_found = len(all_conversations)
@@ -457,9 +445,9 @@ class OpenAIExportCorpusRecon:
             else:
                 stats.non_sharded_count += 1
 
-            # Orphan check: assets NOT in a workspace or files directory
-            if not _is_workspace_or_files_asset(record.path):
-                stats.orphan_assets_found += 1
+            # V1 recon does not perform manifest correlation, so assets are
+            # inventory-preserved as orphaned until a later pass links them.
+            stats.orphan_assets_found += 1
 
         return stats
 
@@ -845,6 +833,19 @@ def _coerce_epoch_seconds(value: Any) -> float | None:
         except ValueError:
             pass
     return None
+
+
+def _iter_json_payloads(record: OpenAIExportFileRecord) -> Iterator[Any]:
+    path = Path(record.absolute_path)
+    if record.detected_kind in {"json_object", "json_array"}:
+        yield json.loads(path.read_text(encoding="utf-8-sig"))
+        return
+    if record.detected_kind == "jsonl":
+        with path.open("r", encoding="utf-8-sig") as fh:
+            for line in fh:
+                raw = line.strip()
+                if raw:
+                    yield json.loads(raw)
 
 
 def _linearize_mainline(

--- a/tests/migration/test_openai_export_corpus_recon.py
+++ b/tests/migration/test_openai_export_corpus_recon.py
@@ -199,6 +199,86 @@ def test_recon_scans_legacy_conversations_json(tmp_path: Path):
     assert stats.parse_failures == 0
 
 
+def test_recon_scans_legacy_filename_conversations_json(tmp_path: Path):
+    export_root = tmp_path / "legacy"
+    export_root.mkdir()
+    _write_conversations_json(
+        export_root,
+        [
+            _build_mapping_conversation(
+                [("user", "Legacy hello", 1.0), ("assistant", "Legacy reply", 2.0)],
+                conversation_id="legacy-conv",
+                title="Legacy Conversation",
+            )
+        ],
+        filename="conversations.json",
+    )
+
+    recon = OpenAIExportCorpusRecon()
+    stats = recon.scan(export_root)
+
+    assert stats.conversations_found == 1
+    assert stats.messages_scanned == 2
+    assert stats.conversations[0].conversation_id == "legacy-conv"
+    assert stats.conversations[0].title == "Legacy Conversation"
+
+
+def test_recon_scans_json_payload_inside_dat_file(tmp_path: Path):
+    export_root = tmp_path / "dat-json"
+    export_root.mkdir()
+    (export_root / "file-000000.dat").write_text(
+        json.dumps(
+            [
+                _build_mapping_conversation(
+                    [("user", "Opaque JSON data", 1704067200.0)],
+                    conversation_id="dat-conv",
+                    title="DAT Conversation",
+                )
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    recon = OpenAIExportCorpusRecon()
+    stats = recon.scan(export_root)
+
+    assert stats.json_like_files == 1
+    assert stats.conversations_found == 1
+    assert stats.messages_scanned == 1
+    assert stats.conversations[0].conversation_id == "dat-conv"
+
+
+def test_recon_scans_jsonl_payload_inside_dat_file(tmp_path: Path):
+    export_root = tmp_path / "dat-jsonl"
+    export_root.mkdir()
+    records = [
+        _build_messages_container(
+            [
+                {
+                    "id": "m1",
+                    "role": "user",
+                    "content": "JSONL Guardian note",
+                    "created_at": 1704067200.0,
+                }
+            ],
+            conversation_id="jsonl-conv",
+            title="JSONL Conversation",
+        )
+    ]
+    (export_root / "opaque.dat").write_text(
+        "\n".join(json.dumps(item) for item in records),
+        encoding="utf-8",
+    )
+
+    recon = OpenAIExportCorpusRecon()
+    stats = recon.scan(export_root)
+
+    assert stats.json_like_files == 1
+    assert stats.conversations_found == 1
+    assert stats.messages_scanned == 1
+    assert stats.keyword_counts["Guardian"] == 1
+
+
 def test_recon_handles_multiple_conversation_shards(tmp_path: Path):
     export_root = tmp_path / "sharded"
     export_root.mkdir()
@@ -483,7 +563,7 @@ def test_recon_distinguishes_orphan_vs_workspace_assets(tmp_path: Path):
     stats = recon.scan(export_root)
 
     assert stats.assets_found == 3
-    assert stats.orphan_assets_found == 1  # only the Unassigned one
+    assert stats.orphan_assets_found == 3  # V1 has not correlated asset links.
 
 
 def test_recon_asset_size_bucket_counts(tmp_path: Path):
@@ -665,7 +745,7 @@ def test_run_corpus_recon_full_pipeline(tmp_path: Path):
     assert stats.conversations_found == 2
     assert stats.messages_scanned == 5
     assert stats.assets_found == 3
-    assert stats.orphan_assets_found == 1
+    assert stats.orphan_assets_found == 3
     assert stats.messages_by_year[2024] == 5
     assert stats.keyword_counts.get("Guardian", 0) > 0
     assert stats.keyword_counts.get("Codexify", 0) > 0


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
