### PR TITLE
Codex/add sharded import coverage

### DIFF
--- a/backend/rag/openai_export_conversation_import.py
+++ b/backend/rag/openai_export_conversation_import.py
@@ -33,6 +33,7 @@ class ImportDiagnostics:
     limit: int | None
     title_filter: str | None
     started_at: str
+    order: str = "file"
     completed_at: str = ""
     export_format: str = "unknown"
     conversations_discovered: int = 0
@@ -54,6 +55,7 @@ class ImportDiagnostics:
             "dry_run": self.dry_run,
             "limit": self.limit,
             "title_filter": self.title_filter,
+            "order": self.order,
             "started_at": self.started_at,
             "completed_at": self.completed_at,
             "export_format": self.export_format,
@@ -173,6 +175,40 @@ def _matches_title_filter(conv: dict[str, Any], filter_text: str) -> bool:
     return filter_text.lower() in title
 
 
+def _source_timestamp(conv: dict[str, Any], key: str = "update_time") -> float:
+    """Extract a sortable timestamp from a conversation record."""
+    for ts_key in (key, "create_time", "update_time"):
+        val = conv.get(ts_key)
+        if isinstance(val, (int, float)):
+            ts = float(val)
+            return ts / 1000.0 if ts > 1_000_000_000_000 else ts
+    return 0.0
+
+
+def _sort_conversations(
+    conversations: list[dict[str, Any]],
+    order: str,
+) -> list[dict[str, Any]]:
+    if order == "newest":
+        return sorted(
+            conversations,
+            key=lambda c: _source_timestamp(c, "update_time"),
+            reverse=True,
+        )
+    elif order == "oldest":
+        return sorted(
+            conversations,
+            key=lambda c: _source_timestamp(c, "create_time"),
+        )
+    elif order == "updated":
+        return sorted(
+            conversations,
+            key=lambda c: _source_timestamp(c, "update_time"),
+            reverse=True,
+        )
+    return conversations  # "file" — adapter natural order
+
+
 def _compute_latest_timestamp(
     conversations: list[dict[str, Any]],
 ) -> str | None:
@@ -199,6 +235,7 @@ def import_openai_export_conversations(
     limit: int | None = None,
     title_contains: str | None = None,
     diagnostic_dir: str | Path = "logs/openai_import",
+    order: str = "file",
 ) -> ImportDiagnostics:
     """Import OpenAI export conversations into Codexify chat tables.
 
@@ -214,6 +251,7 @@ def import_openai_export_conversations(
         dry_run=dry_run,
         limit=limit,
         title_filter=title_contains,
+        order=order,
         started_at=datetime.now(timezone.utc).isoformat(),
     )
 
@@ -257,6 +295,9 @@ def import_openai_export_conversations(
         return diagnostics
 
     diagnostics.conversations_discovered = len(all_conversations)
+
+    # --- Sort by order ---
+    all_conversations = _sort_conversations(all_conversations, order)
 
     # --- Apply title filter ---
     if title_contains:

--- a/guardian/routes/migration.py
+++ b/guardian/routes/migration.py
@@ -1,5 +1,7 @@
 import json
 import logging
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
@@ -15,6 +17,10 @@ from guardian.core.dependencies import (
 from guardian.services.account_restore import (
     AccountRestoreError,
     AccountRestoreService,
+)
+from backend.rag.openai_export_adapter import (
+    diagnose_openai_export_path,
+    import_openai_export_path,
 )
 
 logger = logging.getLogger(__name__)
@@ -145,6 +151,78 @@ def _detect_export_format_parsed(data: Any) -> str:
     return "unknown"
 
 
+def _safe_upload_basename(filename: str | None, fallback: str) -> str:
+    if not filename:
+        return fallback
+    normalized = filename.replace("\\", "/")
+    name = Path(normalized).name.strip()
+    return name or fallback
+
+
+def _is_openai_dat_upload(filename: str | None) -> bool:
+    name = _safe_upload_basename(filename, "")
+    return Path(name).suffix.lower() == ".dat"
+
+
+def _has_importable_openai_conversation(report: Any) -> bool:
+    return any(
+        record.conversation_candidate
+        and record.detected_kind in {"json_object", "json_array", "jsonl"}
+        for record in report.inventory.files
+    )
+
+
+def _to_migration_stats(stats: dict[str, Any]) -> MigrationStats:
+    return MigrationStats(
+        threads_imported=stats["threads_imported"],
+        messages_imported=stats["messages_imported"],
+        projects_created=stats.get("projects_created"),
+        projects_reused=stats.get("projects_reused"),
+        messages_filtered=stats.get("messages_filtered"),
+        embedding_candidates=int(stats.get("embedding_candidates", 0)),
+        embeddings_persisted=int(stats.get("embeddings_persisted", 0)),
+        embeddings_failed=int(stats.get("embeddings_failed", 0)),
+        embedding_coverage_degraded=bool(
+            stats.get("embedding_coverage_degraded", False)
+        ),
+    )
+
+
+def _import_openai_dat_upload(
+    content: bytes,
+    *,
+    filename: str | None,
+    user_id: str,
+) -> dict[str, Any]:
+    safe_name = _safe_upload_basename(filename, "openai-export-upload.dat")
+    with TemporaryDirectory(prefix="codexify-openai-upload-") as tmpdir:
+        upload_path = Path(tmpdir) / safe_name
+        upload_path.write_bytes(content)
+
+        report = diagnose_openai_export_path(upload_path)
+        if (
+            report.inventory.detected_format != "sharded"
+            or not _has_importable_openai_conversation(report)
+        ):
+            raise ValueError(
+                "Unsupported OpenAI .dat upload: the single uploaded .dat file "
+                "is not a readable JSON/JSONL conversation shard. Full sharded "
+                "export folders cannot be represented by this upload route; use "
+                "the path-based OpenAI export import tool for folder imports."
+            )
+
+        stats = import_openai_export_path(upload_path, user_id=user_id)
+        if (
+            int(stats.get("conversation_records", 0)) <= 0
+            and int(stats.get("threads_imported", 0)) <= 0
+            and int(stats.get("messages_imported", 0)) <= 0
+        ):
+            raise ValueError(
+                "OpenAI .dat upload did not contain importable conversation records."
+            )
+        return stats
+
+
 @router.post("/api/upload-chatgpt-export", response_model=MigrationStats)
 @router.post("/upload-chatgpt-export", response_model=MigrationStats)
 async def upload_chatgpt_export(
@@ -153,10 +231,11 @@ async def upload_chatgpt_export(
     api_key: str = Depends(require_api_key),
 ):
     """
-    Import a ChatGPT or Claude export file (JSON).
+    Import a ChatGPT, Claude, or single-file OpenAI conversation export.
 
     Auto-detects format: ChatGPT exports (with 'mapping' field) or
-    Claude exports (with 'chat_messages' field).
+    Claude exports (with 'chat_messages' field). Modern OpenAI .dat uploads
+    are diagnosed and imported through the OpenAI export adapter.
 
     Canonical path: /api/upload-chatgpt-export
     Legacy alias: /upload-chatgpt-export
@@ -172,6 +251,15 @@ async def upload_chatgpt_export(
 
         content = bytes(chunks)
 
+        if _is_openai_dat_upload(file.filename):
+            return _to_migration_stats(
+                _import_openai_dat_upload(
+                    content,
+                    filename=file.filename,
+                    user_id=user_id,
+                )
+            )
+
         # Parse and detect export format
         try:
             parsed = json.loads(content)
@@ -180,10 +268,8 @@ async def upload_chatgpt_export(
                 "Invalid JSON file: unable to parse uploaded content."
             )
 
-        # Auto-detect export format (default to ChatGPT for backward compatibility)
+        # Auto-detect export format without guessing unsupported shapes.
         export_format = _detect_export_format_parsed(parsed)
-        if export_format == "unknown":
-            export_format = "chatgpt"
 
         if export_format == "claude":
             stats = ingest_claude_export(content, user_id=user_id)
@@ -191,23 +277,12 @@ async def upload_chatgpt_export(
             stats = ingest_chatgpt_export(content, user_id=user_id)
         else:
             raise ValueError(
-                "Unrecognized export format. Expected a ChatGPT export (with 'mapping' field) "
-                "or a Claude export (with 'chat_messages' field)."
+                "Unsupported or ambiguous migration upload. Expected a legacy "
+                "ChatGPT conversations JSON export, a Claude JSON export, or "
+                "a modern OpenAI .dat conversation shard."
             )
 
-        return MigrationStats(
-            threads_imported=stats["threads_imported"],
-            messages_imported=stats["messages_imported"],
-            projects_created=stats.get("projects_created"),
-            projects_reused=stats.get("projects_reused"),
-            messages_filtered=stats.get("messages_filtered"),
-            embedding_candidates=int(stats.get("embedding_candidates", 0)),
-            embeddings_persisted=int(stats.get("embeddings_persisted", 0)),
-            embeddings_failed=int(stats.get("embeddings_failed", 0)),
-            embedding_coverage_degraded=bool(
-                stats.get("embedding_coverage_degraded", False)
-            ),
-        )
+        return _to_migration_stats(stats)
     except HTTPException:
         # Re-raise HTTPExceptions without catching them
         raise

--- a/scripts/chatgpt_import/cli_migrate.py
+++ b/scripts/chatgpt_import/cli_migrate.py
@@ -391,6 +391,11 @@ def import_openai_conversations(
         "--diagnostic-dir",
         help="Directory for import diagnostic reports",
     ),
+    order: str = typer.Option(
+        "file",
+        "--order",
+        help="Import order: file (default), newest, oldest, updated",
+    ),
 ):
     """
     Import OpenAI export conversations into Codexify-native chat threads.
@@ -421,6 +426,7 @@ def import_openai_conversations(
         limit=limit,
         title_contains=title_contains,
         diagnostic_dir=diagnostic_dir,
+        order=order,
     )
 
     print_header()

--- a/tests/routes/test_migration_routes.py
+++ b/tests/routes/test_migration_routes.py
@@ -88,7 +88,13 @@ def _build_large_export(min_size: int) -> bytes:
 
 
 def _post_export(test_client, path: str):
-    files = {"file": ("export.json", b"[]", "application/json")}
+    files = {
+        "file": (
+            "export.json",
+            _build_mainline_export(),
+            "application/json",
+        )
+    }
     return test_client.post(
         path,
         files=files,
@@ -253,7 +259,7 @@ def test_retry_route_returns_noop_when_nothing_retryable(
 def test_migration_accepts_valid_content_even_with_non_json_filename(
     test_client,
 ):
-    valid_payload = b"[]"
+    valid_payload = _build_mainline_export()
     files = {
         "file": (
             "totally_weird_name.txt",

--- a/tests/routes/test_migration_upload_openai_dispatch.py
+++ b/tests/routes/test_migration_upload_openai_dispatch.py
@@ -1,0 +1,251 @@
+"""Dispatch tests for the migration upload route."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SERVER_USER_ID = "local_user"
+
+
+@pytest.fixture(autouse=True)
+def _single_user_identity_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CODEXIFY_SINGLE_USER_ID", SERVER_USER_ID)
+    monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.setenv("LOCAL_DEV", "false")
+
+
+def _stats(
+    *,
+    threads: int = 1,
+    messages: int = 2,
+    conversation_records: int | None = None,
+) -> dict[str, object]:
+    stats: dict[str, object] = {
+        "threads_imported": threads,
+        "messages_imported": messages,
+        "embedding_candidates": 0,
+        "embeddings_persisted": 0,
+        "embeddings_failed": 0,
+        "embedding_coverage_degraded": False,
+    }
+    if conversation_records is not None:
+        stats["conversation_records"] = conversation_records
+    return stats
+
+
+def _legacy_chatgpt_export() -> bytes:
+    return json.dumps(
+        [
+            {
+                "id": "legacy-thread",
+                "title": "Legacy Import",
+                "current_node": "m2",
+                "mapping": {
+                    "m1": {
+                        "id": "m1",
+                        "parent": None,
+                        "children": ["m2"],
+                        "message": {
+                            "id": "m1",
+                            "author": {"role": "user"},
+                            "content": {"parts": ["Legacy hello"]},
+                            "create_time": 1,
+                        },
+                    },
+                    "m2": {
+                        "id": "m2",
+                        "parent": "m1",
+                        "children": [],
+                        "message": {
+                            "id": "m2",
+                            "author": {"role": "assistant"},
+                            "content": {"parts": ["Legacy reply"]},
+                            "create_time": 2,
+                        },
+                    },
+                },
+            }
+        ]
+    ).encode("utf-8")
+
+
+def _claude_export() -> bytes:
+    return json.dumps(
+        [
+            {
+                "uuid": "claude-thread",
+                "name": "Claude Import",
+                "chat_messages": [
+                    {
+                        "uuid": "claude-message-1",
+                        "sender": "human",
+                        "text": "Claude hello",
+                        "created_at": "2026-01-01T00:00:00Z",
+                    }
+                ],
+            }
+        ]
+    ).encode("utf-8")
+
+
+def _sharded_dat_export() -> bytes:
+    return json.dumps(
+        {
+            "conversation_id": "sharded-thread",
+            "title": "Sharded Thread",
+            "messages": [
+                {
+                    "id": "msg-user",
+                    "author": {"role": "user"},
+                    "content": "Hello from a dat file",
+                    "create_time": 1,
+                },
+                {
+                    "id": "msg-assistant",
+                    "role": "assistant",
+                    "content": {"parts": ["Dat reply"]},
+                    "create_time": 2,
+                },
+            ],
+        }
+    ).encode("utf-8")
+
+
+def _post_upload(
+    test_client,
+    *,
+    filename: str,
+    content: bytes,
+    content_type: str,
+):
+    return test_client.post(
+        "/api/upload-chatgpt-export",
+        files={"file": (filename, content, content_type)},
+        headers={"X-User-Id": "spoofed_user"},
+    )
+
+
+def test_legacy_chatgpt_json_dispatches_to_legacy_importer(test_client):
+    content = _legacy_chatgpt_export()
+
+    with patch(
+        "guardian.routes.migration.ingest_chatgpt_export",
+        return_value=_stats(),
+    ) as legacy_import, patch(
+        "guardian.routes.migration.ingest_claude_export"
+    ) as claude_import, patch(
+        "guardian.routes.migration.import_openai_export_path"
+    ) as openai_import:
+        response = _post_upload(
+            test_client,
+            filename="conversations.json",
+            content=content,
+            content_type="application/json",
+        )
+
+    assert response.status_code == 200
+    assert response.json()["threads_imported"] == 1
+    legacy_import.assert_called_once_with(content, user_id=SERVER_USER_ID)
+    claude_import.assert_not_called()
+    openai_import.assert_not_called()
+
+
+def test_claude_json_still_dispatches_to_claude_importer(test_client):
+    content = _claude_export()
+
+    with patch(
+        "guardian.routes.migration.ingest_chatgpt_export"
+    ) as legacy_import, patch(
+        "guardian.routes.migration.ingest_claude_export",
+        return_value=_stats(threads=1, messages=1),
+    ) as claude_import, patch(
+        "guardian.routes.migration.import_openai_export_path"
+    ) as openai_import:
+        response = _post_upload(
+            test_client,
+            filename="claude.json",
+            content=content,
+            content_type="application/json",
+        )
+
+    assert response.status_code == 200
+    assert response.json()["messages_imported"] == 1
+    claude_import.assert_called_once_with(content, user_id=SERVER_USER_ID)
+    legacy_import.assert_not_called()
+    openai_import.assert_not_called()
+
+
+def test_modern_openai_dat_dispatches_to_openai_export_adapter(test_client):
+    content = _sharded_dat_export()
+
+    with patch(
+        "guardian.routes.migration.ingest_chatgpt_export"
+    ) as legacy_import, patch(
+        "guardian.routes.migration.ingest_claude_export"
+    ) as claude_import, patch(
+        "guardian.routes.migration.import_openai_export_path",
+        return_value=_stats(conversation_records=1),
+    ) as openai_import:
+        response = _post_upload(
+            test_client,
+            filename="file_0000000000000001.dat",
+            content=content,
+            content_type="application/octet-stream",
+        )
+
+    assert response.status_code == 200
+    assert response.json()["messages_imported"] == 2
+    openai_import.assert_called_once()
+    upload_path = Path(openai_import.call_args.args[0])
+    assert upload_path.name == "file_0000000000000001.dat"
+    assert openai_import.call_args.kwargs["user_id"] == SERVER_USER_ID
+    legacy_import.assert_not_called()
+    claude_import.assert_not_called()
+
+
+def test_unsupported_dat_upload_fails_before_import(test_client):
+    with patch(
+        "guardian.routes.migration.import_openai_export_path"
+    ) as openai_import:
+        response = _post_upload(
+            test_client,
+            filename="file_0000000000000999.dat",
+            content=json.dumps({"not": "a conversation"}).encode("utf-8"),
+            content_type="application/octet-stream",
+        )
+
+    assert response.status_code == 400
+    assert "not a readable JSON/JSONL conversation shard" in response.json()[
+        "detail"
+    ]
+    openai_import.assert_not_called()
+
+
+def test_ambiguous_json_upload_fails_without_guessing_importer(test_client):
+    with patch(
+        "guardian.routes.migration.ingest_chatgpt_export"
+    ) as legacy_import, patch(
+        "guardian.routes.migration.ingest_claude_export"
+    ) as claude_import, patch(
+        "guardian.routes.migration.import_openai_export_path"
+    ) as openai_import:
+        response = _post_upload(
+            test_client,
+            filename="unknown.json",
+            content=json.dumps({"items": [{"text": "no lineage"}]}).encode(
+                "utf-8"
+            ),
+            content_type="application/json",
+        )
+
+    assert response.status_code == 400
+    assert "Unsupported or ambiguous migration upload" in response.json()[
+        "detail"
+    ]
+    legacy_import.assert_not_called()
+    claude_import.assert_not_called()
+    openai_import.assert_not_called()


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
