### PR TITLE
Codex/add sharded import coverage

### DIFF
--- a/.github/workflows/guardian-ci.yml
+++ b/.github/workflows/guardian-ci.yml
@@ -144,7 +144,9 @@ jobs:
           python-version: "3.11"
           cache: "pip"
           cache-dependency-path: |
-            backend/requirements.txt
+            backend/requirements-ci.txt
+            requirements/base.in
+            requirements/dev.in
             pyproject.toml
 
       - name: Install dependencies (Linux-safe)
@@ -153,9 +155,8 @@ jobs:
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install -r backend/requirements.txt
+          python -m pip install -r backend/requirements-ci.txt
           python -m pip install -e .
-          python -m pip install pytest pytest-asyncio
 
       - name: Run backend tests
         if: ${{ needs.changes.outputs.run_backend == 'true' }}

--- a/backend/rag/chatgpt_migration.py
+++ b/backend/rag/chatgpt_migration.py
@@ -1755,9 +1755,17 @@ def ingest_chatgpt_export(
 
 
 def ingest_chatgpt_conversation_records(
-    data: List[Dict[str, Any]], user_id: Optional[str] = None
+    data: List[Dict[str, Any]],
+    user_id: Optional[str] = None,
+    embedding_mode: str = "enqueue",
 ) -> Dict[str, int]:
-    """Ingest validated ChatGPT-shaped conversation records."""
+    """Ingest validated ChatGPT-shaped conversation records.
+
+    embedding_mode controls inline embedding enqueue behavior:
+    - "defer": skip inline enqueue, leave embeddings to worker backfill
+    - "enqueue": best-effort enqueue after import (backward-compatible default)
+    - "off": skip inline enqueue, report as explicitly disabled
+    """
     if not user_id:
         raise ValueError(
             "ingest_chatgpt_conversation_records requires a valid user_id (got None or empty)"
@@ -1853,13 +1861,30 @@ def ingest_chatgpt_conversation_records(
             logger.error("Failed to import conversation: %s", e)
             continue
 
-    embedding_diagnostics = _process_chatgpt_embedding_batches(
-        chatlog_db=chatlog_db,
-        items=pending_embed_items,
-        message_ids=pending_embed_message_ids,
-        operation="import",
-        failure_reason="embedding_coverage_degraded",
-    )
+    embedding_diagnostics: Dict[str, Any] = {
+        "embedding_candidates": len(pending_embed_items),
+        "embeddings_persisted": 0,
+        "embeddings_failed": 0,
+        "embedding_coverage_degraded": False,
+        "embedding_mode": embedding_mode,
+    }
+
+    if embedding_mode in ("defer", "off"):
+        if pending_embed_items:
+            logger.info(
+                "ChatGPT import embedding %s: %d candidates deferred to worker backfill",
+                embedding_mode,
+                len(pending_embed_items),
+            )
+    elif embedding_mode == "enqueue":
+        embedding_diagnostics = _process_chatgpt_embedding_batches(
+            chatlog_db=chatlog_db,
+            items=pending_embed_items,
+            message_ids=pending_embed_message_ids,
+            operation="import",
+            failure_reason="embedding_coverage_degraded",
+        )
+    embedding_diagnostics["embedding_mode"] = embedding_mode
 
     return {
         "threads_imported": threads_count,

--- a/backend/rag/openai_export_conversation_import.py
+++ b/backend/rag/openai_export_conversation_import.py
@@ -48,6 +48,13 @@ class ImportDiagnostics:
     skipped_records: list[dict[str, str]] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
     latest_source_timestamp: str | None = None
+    # Embedding phase (separate from text import)
+    embedding_mode: str = "defer"
+    embedding_candidates: int = 0
+    embedding_enqueued: int = 0
+    embedding_deferred: int = 0
+    embedding_failed: int = 0
+    text_import_complete: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -71,6 +78,12 @@ class ImportDiagnostics:
             "skipped_records": self.skipped_records[:50],
             "errors": self.errors,
             "latest_source_timestamp": self.latest_source_timestamp,
+            "embedding_mode": self.embedding_mode,
+            "embedding_candidates": self.embedding_candidates,
+            "embedding_enqueued": self.embedding_enqueued,
+            "embedding_deferred": self.embedding_deferred,
+            "embedding_failed": self.embedding_failed,
+            "text_import_complete": self.text_import_complete,
         }
 
 
@@ -236,6 +249,7 @@ def import_openai_export_conversations(
     title_contains: str | None = None,
     diagnostic_dir: str | Path = "logs/openai_import",
     order: str = "file",
+    embedding_mode: str = "defer",
 ) -> ImportDiagnostics:
     """Import OpenAI export conversations into Codexify chat tables.
 
@@ -252,6 +266,7 @@ def import_openai_export_conversations(
         limit=limit,
         title_filter=title_contains,
         order=order,
+        embedding_mode=embedding_mode,
         started_at=datetime.now(timezone.utc).isoformat(),
     )
 
@@ -373,6 +388,7 @@ def import_openai_export_conversations(
         import_stats = ingest_chatgpt_conversation_records(
             all_conversations,
             user_id=user_id,
+            embedding_mode=embedding_mode,
         )
     except Exception as exc:
         diagnostics.errors.append(f"Import failed: {exc}")
@@ -390,6 +406,21 @@ def import_openai_export_conversations(
     diagnostics.messages_skipped_duplicate = (
         diagnostics.messages_discovered - diagnostics.messages_imported
     )
+    diagnostics.text_import_complete = True
+
+    # Capture embedding stats separately from text import
+    diagnostics.embedding_mode = import_stats.get(
+        "embedding_mode", embedding_mode
+    )
+    diagnostics.embedding_candidates = import_stats.get(
+        "embedding_candidates", 0
+    )
+    emb_persisted = import_stats.get("embeddings_persisted", 0)
+    emb_failed = import_stats.get("embeddings_failed", 0)
+    diagnostics.embedding_enqueued = emb_persisted
+    diagnostics.embedding_failed = emb_failed
+    if embedding_mode == "defer":
+        diagnostics.embedding_deferred = diagnostics.embedding_candidates
 
     diagnostics.completed_at = datetime.now(timezone.utc).isoformat()
     _write_diagnostics(diagnostics, diag_dir)

--- a/backend/requirements-ci.txt
+++ b/backend/requirements-ci.txt
@@ -1,0 +1,35 @@
+# CPU-safe dependency set for Guardian CI backend validation.
+#
+# Keep this file separate from backend/requirements.txt. The backend lock is
+# used by local/Docker runtime paths and includes optional AI/runtime packages
+# from requirements/ai.in, including torch/torchvision/MLX. GitHub's
+# ubuntu-latest backend job validates deterministic route/export behavior and
+# should not install the GPU-oriented stack.
+
+-r ../requirements/base.in
+-r ../requirements/dev.in
+
+# Route/test imports not currently represented in pyproject.toml or base.in.
+httpx
+python-multipart
+PyJWT
+pypdf
+pillow
+pydub
+psutil
+sse-starlette
+
+# Cloud-provider clients used by mocked route paths. These are API clients only;
+# they do not pull local inference/GPU wheels.
+groq
+litellm
+openai
+
+# Graph adapter imports are exercised in backend tests, but the graph backend
+# remains disabled/no-op unless explicitly configured.
+neo4j
+neomodel
+
+# Lightweight retrieval helpers used by deterministic tests.
+markdownify
+rank-bm25

--- a/codex_runner/README.md
+++ b/codex_runner/README.md
@@ -233,6 +233,31 @@ Verify default policy:
 - `pi` provider: `node` executable on PATH plus `codex_runner/src/agent-wrapper.js`
 - Downstream provider/model identity is brokered by Pi rather than selected as a direct Campaign Runner provider choice.
 
+### Codex CLI install and auth recovery
+
+Guardian's official coding executor still requires the `codex` executable to be available to the same shell user that runs Codexify. If a collaborator sees `codex executable not found on PATH`, use this recovery path before retrying the task:
+
+```bash
+npm install -g @openai/codex
+codex login
+codex --version
+codex exec "ping"
+```
+
+If `codex --version` works in an interactive terminal but Codexify still reports it missing, set `CODEXIFY_CODEX_BIN` to the absolute executable path returned by:
+
+```bash
+command -v codex
+```
+
+Then restart the Codexify backend or worker process and verify the health surface:
+
+```bash
+curl http://127.0.0.1:8000/api/health/executors
+```
+
+The Codex row should no longer report `not_installed`. Auth is still intentionally reported as `unknown` until a runtime probe executes, so use `codex exec "ping"` as the local auth check.
+
 ## Safety defaults
 
 - Hard-fail on dirty preflight.

--- a/guardian/core/executors/codex_executor.py
+++ b/guardian/core/executors/codex_executor.py
@@ -15,6 +15,10 @@ from pathlib import Path
 from typing import Any, Callable
 
 from guardian.core.config import get_settings
+from guardian.core.executors.health import (
+    CODEX_RECOVERY_DOC,
+    CODEX_RECOVERY_STEPS,
+)
 from guardian.core.executors.base import (
     CodeExecutor,
     CodexifyExecutorRequest,
@@ -34,6 +38,15 @@ logger = logging.getLogger(__name__)
 
 _PROCESS_POLL_SECONDS = 0.1
 _TERMINATION_GRACE_SECONDS = 5.0
+
+
+def _codex_recovery_details(*, cwd: str, binary: str) -> dict[str, Any]:
+    return {
+        "cwd": cwd,
+        "binary": binary,
+        "recovery_steps": list(CODEX_RECOVERY_STEPS),
+        "recovery_doc": CODEX_RECOVERY_DOC,
+    }
 
 
 def _utc_now_iso() -> str:
@@ -282,7 +295,12 @@ class CodexExecutor(CodeExecutor):
             failure = ExecutorFailure(
                 error_code=ErrorCode.DELEGATION_EXECUTOR_NOT_FOUND.value,
                 failure_class="FileNotFoundError",
-                message=f"Codex binary not found: {executable}",
+                message=(
+                    f"Codex executable not found on PATH: {executable}. "
+                    "Install with `npm install -g @openai/codex`, "
+                    "authenticate with `codex login`, then verify with "
+                    "`codex --version`."
+                ),
                 request_id=request.request_id,
                 thread_id=request.thread_id,
                 source_message_id=request.source_message_id,
@@ -294,7 +312,10 @@ class CodexExecutor(CodeExecutor):
                 timeout_seconds=timeout_seconds,
                 stdout="",
                 stderr="",
-                details={"cwd": request.repo_path},
+                details=_codex_recovery_details(
+                    cwd=request.repo_path,
+                    binary=executable,
+                ),
                 provenance={
                     "request_id": request.request_id,
                     "delegation_id": request.delegation_id,

--- a/guardian/core/executors/health.py
+++ b/guardian/core/executors/health.py
@@ -14,7 +14,16 @@ from guardian.core.executors.registry import (
 from guardian.protocol_tokens import (
     ExecutorAuthState,
     ExecutorAvailabilityState,
+    ExecutorId,
 )
+
+CODEX_RECOVERY_STEPS: tuple[str, ...] = (
+    "Install the official Codex CLI: npm install -g @openai/codex",
+    "Authenticate the same shell user that runs Codexify: codex login",
+    "Verify PATH and auth before retrying: codex --version && codex exec 'ping'",
+    "If Codex is installed outside PATH, set CODEXIFY_CODEX_BIN to the absolute codex executable path.",
+)
+CODEX_RECOVERY_DOC = "codex_runner/README.md#codex-cli-install-and-auth-recovery"
 
 
 @dataclass(frozen=True, slots=True)
@@ -31,6 +40,8 @@ class ExecutorHealth:
     supports_direct_provider_config: bool
     supported_auth_modes: tuple[str, ...]
     status_detail: str | None
+    recovery_steps: tuple[str, ...] = ()
+    recovery_doc: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -64,7 +75,10 @@ def _detect_auth_state(entry: ExecutorRegistryEntry) -> tuple[str, str | None]:
     if not path:
         return ExecutorAuthState.UNKNOWN.value, "binary path env var is empty"
     if not shutil.which(path):
-        return ExecutorAuthState.UNKNOWN.value, "binary not found on PATH"
+        return (
+            ExecutorAuthState.UNKNOWN.value,
+            f"{entry.install_label} executable not found on PATH",
+        )
     return (
         ExecutorAuthState.UNKNOWN.value,
         "auth state requires runtime probe; cannot determine statically",
@@ -76,7 +90,10 @@ def _derive_availability(
     auth_state: str,
 ) -> tuple[str, str | None]:
     if not installed:
-        return ExecutorAvailabilityState.NOT_INSTALLED.value, "binary not found"
+        return (
+            ExecutorAvailabilityState.NOT_INSTALLED.value,
+            "executable not found on PATH",
+        )
     if auth_state == ExecutorAuthState.AUTHENTICATED.value:
         return ExecutorAvailabilityState.READY.value, None
     if auth_state == ExecutorAuthState.UNKNOWN.value:
@@ -104,6 +121,20 @@ def get_executor_health(entry: ExecutorRegistryEntry) -> ExecutorHealth:
     else:
         status_detail = availability_detail or auth_detail
 
+    recovery_steps: tuple[str, ...] = ()
+    recovery_doc: str | None = None
+    if entry.executor_id == ExecutorId.CODEX and (
+        not installed
+        or availability_state
+        in {
+            ExecutorAvailabilityState.DEGRADED.value,
+            ExecutorAvailabilityState.UNAVAILABLE.value,
+            ExecutorAvailabilityState.NOT_INSTALLED.value,
+        }
+    ):
+        recovery_steps = CODEX_RECOVERY_STEPS
+        recovery_doc = CODEX_RECOVERY_DOC
+
     return ExecutorHealth(
         executor_id=entry.executor_id.value,
         label=entry.install_label,
@@ -117,6 +148,8 @@ def get_executor_health(entry: ExecutorRegistryEntry) -> ExecutorHealth:
         supports_direct_provider_config=entry.supports_direct_provider_config,
         supported_auth_modes=tuple(m.value for m in entry.supported_auth_modes),
         status_detail=status_detail,
+        recovery_steps=recovery_steps,
+        recovery_doc=recovery_doc,
     )
 
 

--- a/local_exports/openai/README.md
+++ b/local_exports/openai/README.md
@@ -84,5 +84,28 @@ primary keys. Import is idempotent — rerunning does not duplicate records.
 
 Diagnostics are written to `logs/openai_import/`.
 
+### Embedding behavior
+
+By default, embeddings are **deferred** — text import completes quickly
+and embeddings are handled later by the normal chat embedding worker.
+
+- `--embedding-mode defer` (default): skip inline enqueue, workers backfill
+- `--embedding-mode enqueue`: best-effort enqueue after import
+- `--embedding-mode off`: no enqueue, no error reported
+
+Example:
+
+```bash
+python -m scripts.chatgpt_import.cli_migrate import:openai-conversations \
+  --path local_exports/openai/OpenAI-export \
+  --order newest --limit 500
+```
+
+### Ordering
+
+- `--order file` (default): adapter natural order
+- `--order newest`: most recently updated first
+- `--order oldest`: oldest created first
+
 **Warning**: Raw OpenAI export contents remain gitignored. Never commit
 private export payloads, diagnostic outputs, or import logs.

--- a/scripts/chatgpt_import/cli_migrate.py
+++ b/scripts/chatgpt_import/cli_migrate.py
@@ -396,6 +396,11 @@ def import_openai_conversations(
         "--order",
         help="Import order: file (default), newest, oldest, updated",
     ),
+    embedding_mode: str = typer.Option(
+        "defer",
+        "--embedding-mode",
+        help="Embedding behavior: defer (default), enqueue, off",
+    ),
 ):
     """
     Import OpenAI export conversations into Codexify-native chat threads.
@@ -427,6 +432,7 @@ def import_openai_conversations(
         title_contains=title_contains,
         diagnostic_dir=diagnostic_dir,
         order=order,
+        embedding_mode=embedding_mode,
     )
 
     print_header()

--- a/tests/core/test_codex_executor.py
+++ b/tests/core/test_codex_executor.py
@@ -145,7 +145,18 @@ def test_codex_executor_missing_binary_becomes_not_found(
         == ErrorCode.DELEGATION_EXECUTOR_NOT_FOUND.value
     )
     assert result.failure.failure_class == "FileNotFoundError"
-    assert result.error_message == "Codex binary not found: codex"
+    assert result.error_message is not None
+    assert "Codex executable not found on PATH: codex" in result.error_message
+    assert "npm install -g @openai/codex" in result.error_message
+    assert result.failure.details["recovery_doc"] == (
+        "codex_runner/README.md#codex-cli-install-and-auth-recovery"
+    )
+    assert result.failure.details["recovery_steps"] == [
+        "Install the official Codex CLI: npm install -g @openai/codex",
+        "Authenticate the same shell user that runs Codexify: codex login",
+        "Verify PATH and auth before retrying: codex --version && codex exec 'ping'",
+        "If Codex is installed outside PATH, set CODEXIFY_CODEX_BIN to the absolute codex executable path.",
+    ]
     assert result.failure.provenance["request_id"] == "delegation-1"
 
 

--- a/tests/migration/test_openai_export_conversation_import.py
+++ b/tests/migration/test_openai_export_conversation_import.py
@@ -754,3 +754,255 @@ def test_existing_native_chat_not_modified(tmp_path: Path):
     )
 
     assert diag.dry_run is True
+
+
+# --- Embedding mode tests ---
+
+
+def test_default_embedding_mode_is_defer(
+    tmp_path: Path,
+    import_store: ImportStore,
+):
+    """Default import uses deferred embedding mode."""
+    export_root = tmp_path / "export"
+    _write_conversations_json(
+        export_root,
+        [_build_mapping_conversation([("user", "Test", 1.0)])],
+    )
+
+    diag = import_openai_export_conversations(
+        export_root,
+        user_id="tester",
+        diagnostic_dir=tmp_path / "diag",
+    )
+
+    assert diag.embedding_mode == "defer"
+    assert diag.text_import_complete is True
+    assert diag.conversations_imported == 1
+    assert diag.embedding_deferred >= 0
+
+
+def test_embedding_mode_defer_writes_text(
+    tmp_path: Path,
+    import_store: ImportStore,
+):
+    """Text threads/messages are written even when embeddings are deferred."""
+    export_root = tmp_path / "export"
+    _write_conversations_json(
+        export_root,
+        [_build_mapping_conversation([("user", "Deferred test", 1.0)])],
+    )
+
+    diag = import_openai_export_conversations(
+        export_root,
+        user_id="tester",
+        embedding_mode="defer",
+        diagnostic_dir=tmp_path / "diag",
+    )
+
+    assert diag.text_import_complete is True
+    assert diag.conversations_imported == 1
+    assert diag.messages_imported == 1
+    assert len(import_store.threads) == 1
+    assert len(import_store.messages) == 1
+
+
+def test_embedding_mode_off_skips_enqueue(
+    tmp_path: Path,
+    import_store: ImportStore,
+):
+    """--embedding-mode off skips enqueue and reports it."""
+    export_root = tmp_path / "export"
+    _write_conversations_json(
+        export_root,
+        [_build_mapping_conversation([("user", "Off test", 1.0)])],
+    )
+
+    diag = import_openai_export_conversations(
+        export_root,
+        user_id="tester",
+        embedding_mode="off",
+        diagnostic_dir=tmp_path / "diag",
+    )
+
+    assert diag.embedding_mode == "off"
+    assert diag.text_import_complete is True
+    assert diag.conversations_imported == 1
+    assert diag.embedding_enqueued == 0
+
+
+def test_embedding_mode_enqueue_in_bounded_way(
+    tmp_path: Path,
+    import_store: ImportStore,
+):
+    """--embedding-mode enqueue attempts enqueue but text import completes."""
+    export_root = tmp_path / "export"
+    _write_conversations_json(
+        export_root,
+        [_build_mapping_conversation([("user", "Enqueue test", 1.0)])],
+    )
+
+    diag = import_openai_export_conversations(
+        export_root,
+        user_id="tester",
+        embedding_mode="enqueue",
+        diagnostic_dir=tmp_path / "diag",
+    )
+
+    assert diag.embedding_mode == "enqueue"
+    assert diag.text_import_complete is True
+    assert diag.conversations_imported == 1
+
+
+def test_embedding_failure_does_not_fail_text_import(
+    tmp_path: Path,
+    import_store: ImportStore,
+):
+    """Redis/embedding failure does not block text import completion."""
+    export_root = tmp_path / "export"
+    _write_conversations_json(
+        export_root,
+        [_build_mapping_conversation([("user", "Resilient test", 1.0)])],
+    )
+
+    diag = import_openai_export_conversations(
+        export_root,
+        user_id="tester",
+        embedding_mode="enqueue",
+        diagnostic_dir=tmp_path / "diag",
+    )
+
+    assert diag.text_import_complete is True
+    assert diag.conversations_imported == 1
+    assert len(diag.errors) == 0
+
+
+def test_diagnostics_report_embedding_phase_separately(
+    tmp_path: Path,
+):
+    """Diagnostics separate text import from embedding status."""
+    export_root = tmp_path / "export"
+    _write_conversations_json(
+        export_root,
+        [_build_mapping_conversation([("user", "Diag test", 1.0)])],
+    )
+    diag_dir = tmp_path / "logs/openai_import"
+
+    import_openai_export_conversations(
+        export_root,
+        user_id="tester",
+        embedding_mode="defer",
+        dry_run=True,
+        diagnostic_dir=diag_dir,
+    )
+
+    json_files = list(diag_dir.glob("import_diagnostics_*.json"))
+    assert len(json_files) == 1
+    diag_data = json.loads(json_files[0].read_text())
+
+    assert "text_import_complete" in diag_data
+    assert "embedding_mode" in diag_data
+    assert diag_data["embedding_mode"] == "defer"
+    assert "embedding_candidates" in diag_data
+
+
+def test_order_flags_work_with_embedding_deferral(
+    tmp_path: Path,
+    import_store: ImportStore,
+):
+    """--order flags work correctly with deferred embedding."""
+    export_root = tmp_path / "export"
+    _write_conversations_json(
+        export_root,
+        [
+            _build_mapping_conversation(
+                [("user", "Old", 1000.0)],
+                conversation_id="old-conv",
+                title="Oldest",
+            ),
+            _build_mapping_conversation(
+                [("user", "New", 2000.0)],
+                conversation_id="new-conv",
+                title="Newest",
+            ),
+        ],
+    )
+
+    diag = import_openai_export_conversations(
+        export_root,
+        user_id="tester",
+        order="newest",
+        embedding_mode="defer",
+        diagnostic_dir=tmp_path / "diag",
+    )
+
+    assert diag.text_import_complete is True
+    assert diag.embedding_mode == "defer"
+    assert diag.conversations_imported == 2
+
+
+def test_idempotent_rerun_with_deferred_embeddings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    import_modules: ImportModules,
+):
+    """Idempotent re-run works with deferred embedding mode."""
+    store = ImportStore()
+    monkeypatch.setattr(import_modules.dependencies, "chatlog_db", store)
+    monkeypatch.setattr(
+        import_modules.dependencies, "init_database", lambda: store
+    )
+    monkeypatch.setattr(
+        import_modules.chatgpt_migration,
+        "_persist_temporal_metadata",
+        lambda *_args, **_kwargs: None,
+    )
+
+    find_thread_calls: list = []
+
+    def _find_thread(db, *, user_id, source_thread_id):
+        find_thread_calls.append((user_id, source_thread_id))
+        if len(find_thread_calls) > 1:
+            return 1
+        return None
+
+    def _find_message(db, thread_id, source_message_id):
+        if len(find_thread_calls) > 1:
+            return {"id": 999, "extra_meta": {}}
+        return None
+
+    monkeypatch.setattr(
+        import_modules.chatgpt_migration,
+        "_find_existing_thread_for_source",
+        _find_thread,
+    )
+    monkeypatch.setattr(
+        import_modules.chatgpt_migration,
+        "_find_existing_message_for_source",
+        _find_message,
+    )
+
+    export_root = tmp_path / "export"
+    _write_conversations_json(
+        export_root,
+        [_build_mapping_conversation(
+            [("user", "A", 1.0)],
+            conversation_id="stable",
+            title="Stable",
+        )],
+    )
+
+    first = import_openai_export_conversations(
+        export_root, user_id="tester",
+        embedding_mode="defer",
+        diagnostic_dir=tmp_path / "diag1",
+    )
+    second = import_openai_export_conversations(
+        export_root, user_id="tester",
+        embedding_mode="defer",
+        diagnostic_dir=tmp_path / "diag2",
+    )
+
+    assert first.conversations_imported == 1
+    assert first.embedding_mode == "defer"
+    assert second.conversations_imported == 0

--- a/tests/routes/test_health_routes.py
+++ b/tests/routes/test_health_routes.py
@@ -202,6 +202,8 @@ def test_health_executors_includes_required_fields(test_client):
         assert "supports_direct_provider_config" in executor
         assert "supported_auth_modes" in executor
         assert "status_detail" in executor
+        assert "recovery_steps" in executor
+        assert "recovery_doc" in executor
 
 
 def test_health_executors_preserves_release_posture(test_client):
@@ -241,3 +243,33 @@ def test_health_executors_availability_states_are_valid(test_client):
     valid_states = {"ready", "degraded", "unavailable", "not_installed"}
     for executor in executors:
         assert executor["availability_state"] in valid_states
+
+
+def test_health_executors_codex_missing_path_includes_recovery(
+    test_client,
+    monkeypatch,
+):
+    monkeypatch.delenv("CODEXIFY_CODEX_BIN", raising=False)
+    monkeypatch.setattr(
+        "guardian.core.executors.health.shutil.which",
+        lambda _binary: None,
+    )
+
+    response = test_client.get("/api/health/executors")
+
+    assert response.status_code == 200
+    payload = response.json()
+    executors = {e["executor_id"]: e for e in payload["executors"]}
+    codex = executors["codex"]
+
+    assert codex["installed"] is False
+    assert codex["availability_state"] == "not_installed"
+    assert codex["recovery_doc"] == (
+        "codex_runner/README.md#codex-cli-install-and-auth-recovery"
+    )
+    assert codex["recovery_steps"] == [
+        "Install the official Codex CLI: npm install -g @openai/codex",
+        "Authenticate the same shell user that runs Codexify: codex login",
+        "Verify PATH and auth before retrying: codex --version && codex exec 'ping'",
+        "If Codex is installed outside PATH, set CODEXIFY_CODEX_BIN to the absolute codex executable path.",
+    ]


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
