### PR TITLE
Forward multi-model Whoosh'd launcher env through smoke startup

### DIFF
--- a/docs/Ops/WHOOSHD_LOCAL_RUNTIME_RUNBOOK.md
+++ b/docs/Ops/WHOOSHD_LOCAL_RUNTIME_RUNBOOK.md
@@ -79,6 +79,11 @@ For MLX-VLM-backed Gemma 4 profiles:
 mkdir -p /Volumes/Dev_SSD/whooshd/model-weights
 ```
 
+If your Whoosh'd installation manages multiple local models, keep the
+registry in a file and point the launcher at it with
+`WHOOSHD_MODEL_REGISTRY_PATH=/path/to/registry.yaml`. You can also set
+`WHOOSHD_MLX_MODEL` to choose the default MLX model at launch time.
+
 ## Start Whoosh'd
 
 Stub mode proves the API contract without a model:
@@ -97,6 +102,10 @@ WHOOSHD_ADAPTER=mlx \
 WHOOSHD_MLX_MODEL=mlx-community/Llama-3.2-3B-Instruct-4bit \
 "$WHOOSHD_PYTHON" -m uvicorn whooshd.app:app --host 127.0.0.1 --port 8000
 ```
+
+If your runtime has several registered models, keep the default selected
+model in `WHOOSHD_MLX_MODEL` and point `WHOOSHD_MODEL_REGISTRY_PATH` at the
+registry file that enumerates the rest.
 
 MLX-VLM mode can serve a Gemma 4 profile directly through an OpenAI-compatible
 API:
@@ -158,6 +167,13 @@ LOCAL_COMPAT_FIRST=1
 LOCAL_ENABLE_OLLAMA_GENERATE_FALLBACK=0
 VAULTNODE_BASE_URL=http://host.docker.internal:8000
 VAULTNODE_HEALTH_ENDPOINTS=/v1/models,/api/tags
+```
+
+For a multi-model Whoosh'd host, the launcher can also pass through:
+
+```dotenv
+WHOOSHD_MODEL_REGISTRY_PATH=/path/to/whooshd-model-registry.yaml
+WHOOSHD_MLX_MODEL=mlx-community/Llama-3.2-3B-Instruct-4bit
 ```
 
 Then start the supported Compose path:

--- a/docs/local-provider-whooshd.md
+++ b/docs/local-provider-whooshd.md
@@ -53,6 +53,12 @@ Whoosh'd smoke override currently sets:
 
 Those defaults are configuration, not live-model proof.
 
+If your Whoosh'd host maintains a registry of several models, point the
+launcher at it with `WHOOSHD_MODEL_REGISTRY_PATH` and use
+`WHOOSHD_MLX_MODEL` to choose the default MLX model at startup. The launcher
+now forwards both env vars when present so the host can expose multiple
+registered models without hardcoding a single selection in Codexify.
+
 ## Live Inventory Truth
 
 Codexify treats Whoosh'd live inventory as proven only by Whoosh'd HTTP

--- a/scripts/whooshd_ensure.sh
+++ b/scripts/whooshd_ensure.sh
@@ -11,7 +11,8 @@
 #   1. Probes localhost:8000/health
 #   2. If healthy → done
 #   3. If not → starts Whoosh'd via the installed `whooshd` CLI
-#      with --codexify (binds 0.0.0.0:8000) and --adapter mlx
+#      with --codexify (binds 0.0.0.0:8000) and the configured model
+#      registry / selected-model env vars
 #   4. Waits up to 30s for health check
 #
 # Requires the `whooshd` CLI to be available on PATH (installed at
@@ -27,6 +28,9 @@ NC='\033[0m'
 
 HEALTH_URL="${WHOOSHD_HEALTH_URL:-http://127.0.0.1:8000/health}"
 MAX_WAIT_SEC="${WHOOSHD_ENSURE_TIMEOUT:-30}"
+WHOOSHD_ADAPTER="${WHOOSHD_ADAPTER:-mlx}"
+WHOOSHD_MODEL_REGISTRY_PATH="${WHOOSHD_MODEL_REGISTRY_PATH:-}"
+WHOOSHD_MLX_MODEL="${WHOOSHD_MLX_MODEL:-${WHOOSHD_MODEL:-}}"
 
 echo "── Whoosh'd ensure ──"
 
@@ -58,15 +62,32 @@ if [[ -z "$WHOOSHD_BIN" ]]; then
 fi
 
 echo "  Using whooshd at: $WHOOSHD_BIN"
+echo "  Adapter: $WHOOSHD_ADAPTER"
+if [[ -n "$WHOOSHD_MODEL_REGISTRY_PATH" ]]; then
+    echo "  Model registry: $WHOOSHD_MODEL_REGISTRY_PATH"
+fi
+if [[ -n "$WHOOSHD_MLX_MODEL" ]]; then
+    echo "  Selected model: $WHOOSHD_MLX_MODEL"
+fi
 
 # ── Step 3: Start Whoosh'd in Codexify mode ──
 # --codexify binds 0.0.0.0:8000 so Docker containers can reach it
-# --adapter mlx uses MLX backend
 WHOOSHD_LOG="${WHOOSHD_LOG:-/tmp/whooshd-codexify.log}"
-echo "  Starting: whooshd --codexify --adapter mlx"
+echo "  Starting: whooshd --codexify --adapter $WHOOSHD_ADAPTER"
 echo "  Log: $WHOOSHD_LOG"
 
-nohup "$WHOOSHD_BIN" --codexify --adapter mlx > "$WHOOSHD_LOG" 2>&1 &
+launch_env=(
+    "WHOOSHD_MLX_ENABLED=true"
+    "WHOOSHD_ADAPTER=$WHOOSHD_ADAPTER"
+)
+if [[ -n "$WHOOSHD_MODEL_REGISTRY_PATH" ]]; then
+    launch_env+=("WHOOSHD_MODEL_REGISTRY_PATH=$WHOOSHD_MODEL_REGISTRY_PATH")
+fi
+if [[ -n "$WHOOSHD_MLX_MODEL" ]]; then
+    launch_env+=("WHOOSHD_MLX_MODEL=$WHOOSHD_MLX_MODEL")
+fi
+
+nohup env "${launch_env[@]}" "$WHOOSHD_BIN" --codexify --adapter "$WHOOSHD_ADAPTER" > "$WHOOSHD_LOG" 2>&1 &
 WHOOSHD_PID=$!
 echo "  PID: $WHOOSHD_PID"
 

--- a/tests/test_whooshd_smoke_env_contract.py
+++ b/tests/test_whooshd_smoke_env_contract.py
@@ -253,6 +253,13 @@ class TestSmokeWrapperScriptExists:
         content = script_path.read_text()
         assert "docker-compose.whooshd-smoke.yml" in content
 
+    def test_launcher_script_forwards_multi_model_env(self):
+        script_path = Path("scripts/whooshd_ensure.sh")
+        content = script_path.read_text()
+        assert "WHOOSHD_MODEL_REGISTRY_PATH" in content
+        assert "WHOOSHD_MLX_MODEL" in content
+        assert "WHOOSHD_ADAPTER" in content
+
     def test_script_passes_bash_syntax_check(self):
         """This is verified at module load time via bash -n above."""
         script_path = Path("scripts/whooshd_docker_smoke_up.sh")


### PR DESCRIPTION
## Summary
- Update the Whoosh'd runtime runbook to document multi-model registry support and default MLX model selection.
- Teach `scripts/whooshd_ensure.sh` to forward `WHOOSHD_MODEL_REGISTRY_PATH`, `WHOOSHD_MLX_MODEL`, and the adapter setting when launching Whoosh'd.
- Add a regression test to cover the launcher env contract.

## Testing
- Not run (not requested)
- Added a unit-level contract check for the launcher script env forwarding