### PR TITLE
feat: webui-basic with group chat, @luna routing, and 2D atlas

### DIFF
--- a/backend/rag/embedder.py
+++ b/backend/rag/embedder.py
@@ -636,6 +636,76 @@ class LocalSemanticEmbedder:
         ids = result.get("ids") or []
         return [str(value) for value in ids]
 
+    def iter_chunks_for_atlas(
+        self,
+        where: dict[str, Any],
+        limit: int,
+        offset: int,
+        include_embeddings: bool = True,
+        text_preview_chars: int = 200,
+    ) -> dict[str, Any]:
+        """Bulk-enumerate chunks for the Atlas visualisation.
+
+        Returns ``{"backend", "total", "items": [{id, text, preview,
+        metadata, embedding}]}``. Chroma-only in v1; FAISS returns an
+        empty result (FAISS is process-local and cannot reliably enumerate
+        across restarts, so Atlas falls back to an empty grid rather than
+        fabricating coordinates).
+        """
+        empty: dict[str, Any] = {
+            "backend": self.store if self.store in ("chroma", "faiss") else "none",
+            "total": 0,
+            "items": [],
+        }
+        if self.store != "chroma" or self._chroma_collection is None:
+            return empty
+        if not where:
+            # Atlas requires a user-scoped filter; refuse unfiltered enumeration
+            # to avoid leaking every tenant's chunks.
+            return empty
+
+        safe_limit = max(1, min(int(limit), 5000))
+        safe_offset = max(0, int(offset))
+        preview_chars = max(0, min(int(text_preview_chars), 2000))
+
+        total = self._chroma_collection.count() or 0
+        if total == 0 or safe_offset >= total:
+            return {"backend": "chroma", "total": total, "items": []}
+
+        include = ["documents", "metadatas"]
+        if include_embeddings:
+            include.append("embeddings")
+        raw = self._chroma_collection.get(
+            where=where,
+            limit=safe_limit,
+            offset=safe_offset,
+            include=include,
+        )
+
+        ids = raw.get("ids") if raw.get("ids") is not None else []
+        docs = raw.get("documents") if raw.get("documents") is not None else []
+        metas = raw.get("metadatas") if raw.get("metadatas") is not None else []
+        embs = raw.get("embeddings") if raw.get("embeddings") is not None else []
+
+        items: list[dict[str, Any]] = []
+        for i, chunk_id in enumerate(ids):
+            text = docs[i] if i < len(docs) and docs[i] is not None else ""
+            meta = metas[i] if i < len(metas) and metas[i] is not None else {}
+            emb: list[float] = []
+            if include_embeddings and i < len(embs) and embs[i] is not None:
+                emb = [float(x) for x in embs[i]]
+            items.append(
+                {
+                    "id": str(chunk_id),
+                    "text": str(text),
+                    "preview": str(text)[:preview_chars] if text else "",
+                    "metadata": dict(meta) if isinstance(meta, dict) else {},
+                    "embedding": emb,
+                }
+            )
+
+        return {"backend": "chroma", "total": total, "items": items}
+
     def delete_by_ids(self, ids: list[str]) -> int:
         """Delete documents by id (Chroma only)."""
         if self.store != "chroma" or self._chroma_collection is None:

--- a/config/supported_profiles/v1-local-core-web-mcp.yaml
+++ b/config/supported_profiles/v1-local-core-web-mcp.yaml
@@ -35,6 +35,7 @@ route_posture:
     - migration
     - embeddings
     - obsidian
+    - atlas
   internal_only:
     - command_bus
   quarantined:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,16 @@
+services:
+  backend:
+    volumes:
+      - ./webui-basic:/app/webui-basic:ro
+  worker-chat:
+    volumes:
+      - ./guardian:/app/codexify
+      - ./guardian:/app/guardian
+      - ./backend:/app/backend
+      - ./config:/app/config:ro
+      - ./plugins:/app/plugins:ro
+      - codexify_cli_home:/home/codexify
+      - hf_cache:/root/.cache/huggingface
+      - ./models/bge-large-en-v1.5:/models/bge-large-en-v1.5:ro
+      - ./models:/models
+      - ./.chroma:/app/.chroma

--- a/docs/guardian/setup-proofs/zac-whooshd-local-setup.md
+++ b/docs/guardian/setup-proofs/zac-whooshd-local-setup.md
@@ -1,0 +1,227 @@
+# Zac Whoosh'd Local Setup Proof
+
+## Run metadata
+
+| Field | Value |
+|---|---|
+| Date/time | 2026-06-20T04:02 UTC |
+| Machine class | Apple Silicon macOS |
+| Repo branch | `main` |
+| HEAD | `a971ac175a0bd33dc225791cfef907598d95aa7e` |
+| Worktree dirty before setup | No (clean) |
+| Local env file modified | `.env` (local-only, not committed) |
+
+## Env keys configured
+
+The following keys were set or changed in `.env`:
+
+- `GUARDIAN_API_KEY` (secret, not shown)
+- `CODEXIFY_LOCAL_ONLY_MODE=true`
+- `ALLOW_CLOUD_PROVIDERS=false`
+- `LLM_PROVIDER=local`
+- `CODEXIFY_CONFIG_SOURCE=core`
+- `AI_BACKEND=local` (legacy compat only; `LLM_PROVIDER` is canonical)
+- `LOCAL_RUNTIME_PRESET=whooshd-mlx`
+- `LOCAL_BASE_URL=http://host.docker.internal:8000/v1`
+- `LOCAL_DOCKER_FALLBACK_BASE_URL=http://host.docker.internal:8000/v1`
+- `LOCAL_PROVIDER_DISPLAY_NAME=Whoosh'd`
+- `LOCAL_PROVIDER_VENDOR=whooshd`
+- `LOCAL_CHAT_MODEL=mlx-community/gemma-4-12B-it-qat-4bit`
+- `LOCAL_LLM_MODEL=mlx-community/gemma-4-12B-it-qat-4bit`
+- `LLM_MODEL=mlx-community/gemma-4-12B-it-qat-4bit`
+- `LOCAL_API_KEY=local`
+- `LOCAL_COMPAT_FIRST=1`
+- `LOCAL_ENABLE_OLLAMA_GENERATE_FALLBACK=0`
+- `VAULTNODE_BASE_URL=http://host.docker.internal:8000`
+- `VAULTNODE_HEALTH_ENDPOINTS=/health,/health/runtime,/ready,/v1/models,/api/tags`
+- `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB` (defaults)
+- `NEO4J_USER`, `NEO4J_PASS` (secret, not shown)
+- `EMBED_PROVIDER=local`
+- `CODEXIFY_EMBEDDINGS_BACKEND=local`
+- `LOCAL_EMBED_MODEL=/models/bge-large-en-v1.5`
+- `OPENAI_API_KEY=local` (SDK init placeholder)
+
+## Whoosh'd inventory proof
+
+### Host-side endpoint
+
+```
+GET http://127.0.0.1:8000/v1/models
+```
+
+Response:
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "mlx-community/gemma-4-12B-it-qat-4bit",
+      "object": "model",
+      "created": 1700000000,
+      "owned_by": "whooshd"
+    }
+  ]
+}
+```
+
+### Whoosh'd health
+
+```json
+{
+  "ok": true,
+  "runner": "whooshd",
+  "version": "0.1.0rc1",
+  "status": "ready",
+  "model_lifecycle": "ready",
+  "memory": { "pressure": "normal", "total_gb": 32.0 }
+}
+```
+
+### Docker-visible base URL
+
+`http://host.docker.internal:8000/v1`
+
+### Selected model id from live inventory
+
+`mlx-community/gemma-4-12B-it-qat-4bit`
+
+## Docker Compose validation
+
+```
+docker compose config >/tmp/codexify-compose-config.txt
+```
+
+Result: exit 0, config valid.
+
+## Docker Compose services started
+
+| Service | Status |
+|---|---|
+| db (postgres:15) | healthy |
+| redis (redis:7-alpine) | healthy |
+| neo4j (neo4j:5) | healthy |
+| migrator | completed successfully |
+| model-prep | completed successfully |
+| graph-init | completed successfully |
+| backend | healthy |
+| worker-chat | running |
+| worker-chat-embed | running |
+| worker-document-embed | running |
+| worker-warmup | running |
+
+Note: The `neo4j_data` volume was recreated during setup because the prior volume's password did not match the new `.env`. Neo4j graph writes remain default-off (`CODEXIFY_ENABLE_GRAPH_WRITES=false`).
+
+## Health endpoint results
+
+### GET /health
+
+```json
+{
+  "status": "ok",
+  "service": "core",
+  "details": {
+    "supported_profile": {
+      "name": "v1-local-core-web-mcp",
+      "valid": true,
+      "mismatches": [],
+      "selected_provider": "local",
+      "selected_provider_supported": true,
+      "release_hold": true
+    }
+  }
+}
+```
+
+Result: **ok**. Supported profile valid, provider `local`, no mismatches.
+
+### GET /health/chat
+
+```json
+{
+  "ok": true,
+  "status": "healthy",
+  "redis": "ok",
+  "worker": { "status": "fresh", "heartbeat_age_seconds": 1.884 },
+  "queue": { "depth": 0, "status": "progressing" },
+  "completion_service": { "ok": true, "redis_reachable": true, "enqueue_test_ok": true, "worker_heartbeat_detected": true },
+  "provider": "local",
+  "model": "mlx-community/gemma-4-12B-it-qat-4bit",
+  "provider_runtime": { "id": "local", "authorized": true, "available": true, "enabled": true },
+  "configured_model_available": true
+}
+```
+
+Result: **healthy**. Redis ok, worker heartbeat fresh, enqueue ok, provider available, model available.
+
+### GET /api/health/llm
+
+```json
+{
+  "status": "ok",
+  "service": "llm",
+  "details": {
+    "provider": "local",
+    "model": "mlx-community/gemma-4-12B-it-qat-4bit",
+    "local_base_url": "http://host.docker.internal:8000/v1",
+    "provider_runtime": { "id": "local", "authorized": true, "available": true, "enabled": true },
+    "completion_service": { "ok": true },
+    "ok": true,
+    "status": "online",
+    "configured_model_available": true
+  }
+}
+```
+
+Result: **ok/online**. Provider local, model available, endpoint resolved.
+
+### GET /api/llm/catalog?include=all
+
+Result: **ok**. Local provider entry:
+
+- `id: local`, `displayName: Whoosh'd`, `enabled: true`, `authorized: true`, `available: true`
+- Model: `mlx-community/gemma-4-12B-it-qat-4bit` (vision_chat, confirmed)
+- `truth.executable: true`, `truth.selectable: true`, `truth.supported_profile_approved: true`
+- All cloud providers: disabled (egress disallowed or missing credentials)
+
+## Chat completion proof
+
+| Step | Result |
+|---|---|
+| Thread created | Thread 23 (`Whooshd setup proof`) |
+| User message posted | Message 140 |
+| Completion accepted | Task `b083d493-4042-470f-97ea-ca3bf6770346` |
+| Worker dequeued | `[task] running type=chat_completion` |
+| Context assembled | 1 message, depth=normal |
+| Provider call | `ai_router: chat.inference.request.built` |
+| Assistant persisted | Message 141 |
+| Task completed | `[task] completed` |
+
+### Assistant response
+
+> Hello! I'm here and ready whenever you are. How can I help you get started today?
+
+### Execution metadata from persisted message
+
+```
+final_provider: local
+final_model: mlx-community/gemma-4-12B-it-qat-4bit
+selection_source: whooshd_model_profile
+fallback_triggered: false
+completion_truth.completed: true
+```
+
+## Upload -> embed -> readback proof
+
+**Not run.** Reason: this proof focuses on the Whoosh'd chat completion path. The existing workspace proof harness (`scripts/proofs/prove_workspace_obsidian_e2e.py`) was not exercised here; it can be run as a separate proof artifact.
+
+## Limitations and drift
+
+- `release_hold: true` is reported by `/health`. This is expected for the current beta posture and not a setup issue.
+- The task events endpoint (`/api/tasks/{task_id}/events`) returned empty arrays during polling, but the worker logs and persisted messages prove completion succeeded. The task-event visibility path may have a timing or transport nuance worth investigating separately.
+- The `supported_profile_mismatches` in the worker-side `final_provider_truth` metadata contains `"supported profile manifest is not configured"` — this is a worker-scoped context difference (the worker does not load the supported profile manifest at runtime), not a setup failure.
+- `cloud_capable_configuration_present: true` appears in health output. This is because `OPENAI_API_KEY=local` is set as an SDK init placeholder. Cloud providers remain disabled by egress policy.
+
+## Verdict
+
+**go** — Whoosh'd local runtime is configured, reachable from Docker containers, model inventory is live, all health surfaces are green, and an end-to-end chat completion was executed and persisted using the local provider with `mlx-community/gemma-4-12B-it-qat-4bit`.

--- a/guardian/context/broker.py
+++ b/guardian/context/broker.py
@@ -2614,6 +2614,24 @@ class ContextBroker:
             )
             return [], WIDEN_REASON_NONE, diagnostics
 
+        if len(primary_hits) < k and project_id is not None:
+            try:
+                project_output = await search_fn(
+                    query,
+                    k - len(primary_hits),
+                    namespace=f"project:{project_id}",
+                    user_id=user_id,
+                )
+                project_hits, _ = self._unpack_search_output(project_output)
+                seen_texts = {h.get("text", "") for h in primary_hits}
+                for hit in project_hits:
+                    if hit.get("text", "") not in seen_texts:
+                        primary_hits.append(hit)
+                        seen_texts.add(hit.get("text", ""))
+                diagnostics["project_namespace_hit_count"] = len(project_hits)
+            except Exception as _proj_exc:
+                logger.warning("[ContextBroker] project namespace search failed: %s", _proj_exc)
+
         widen_reason = self._determine_widen_reason(primary_hits, k)
         is_memory_search = (
             getattr(search_fn, "__name__", "") == "_search_memory"

--- a/guardian/core/ai_router.py
+++ b/guardian/core/ai_router.py
@@ -2157,7 +2157,12 @@ def call_local(
         "messages": adapted_messages,
         "temperature": 0.7 if temperature is None else float(temperature),
     }
-    if max_tokens is not None:
+    # Cap output tokens so whooshd/mlx-vlm can't silently truncate with their
+    # own default (typically 512-1024). Caller's explicit `max_tokens` wins;
+    # otherwise use LOCAL_MAX_TOKENS setting, else a generous default.
+    if max_tokens is None:
+        max_tokens = int(getattr(settings, "LOCAL_MAX_TOKENS", 2048))
+    if max_tokens and int(max_tokens) > 0:
         payload["max_tokens"] = int(max_tokens)
 
     # ── ThreadWake segment metadata (Whoosh'd integration) ─────────────
@@ -2417,7 +2422,12 @@ def stream_local(
         "temperature": 0.7 if temperature is None else float(temperature),
         "stream": True,
     }
-    if max_tokens is not None:
+    # See `call_local` for the rationale. Same cap is applied to streaming
+    # completions so the SSE event stream length matches the non-streaming
+    # response length.
+    if max_tokens is None:
+        max_tokens = int(getattr(settings, "LOCAL_MAX_TOKENS", 2048))
+    if max_tokens and int(max_tokens) > 0:
         payload["max_tokens"] = int(max_tokens)
 
     # ── ThreadWake segment metadata (Whoosh'd integration) ─────────────

--- a/guardian/core/chat_completion_service.py
+++ b/guardian/core/chat_completion_service.py
@@ -161,6 +161,126 @@ def _extract_latest_turn_message_id(task: Any) -> int | None:
     return value if value > 0 else None
 
 
+# webui stores the latest user turn as "[username]: <message>" and the
+# "@guardian" mention is appended inline. Both tokens are noise to the embedder
+# and dominate the cosine match against the knowledge base, so strip them from
+# the retrieval query only. The user_id is still passed to the system prompt
+# builder via bundle.user_id / task.user_id so identity is preserved.
+_LEADING_USERNAME_TAG_RE = re.compile(r"^\s*\[[^\]\n]{1,40}\]:\s*")
+_GUARDIAN_MENTION_RE = re.compile(r"@guardian\b", re.IGNORECASE)
+
+
+def _clean_retrieval_query(raw: str | None) -> str:
+    """
+    Strip the leading `[username]: ` sender tag and any `@guardian` mention
+    from a user message before it is sent to the vector store as the
+    retrieval query. Returns a whitespace-collapsed string.
+
+    Empty / non-string input returns "" so callers can pass optional content
+    safely. Attachment/doc tiles are extracted earlier by
+    `render_content_for_inference` and survive the strip.
+    """
+    if not isinstance(raw, str) or not raw.strip():
+        return ""
+    cleaned = _LEADING_USERNAME_TAG_RE.sub("", raw, count=1)
+    cleaned = _GUARDIAN_MENTION_RE.sub("", cleaned)
+    cleaned = " ".join(cleaned.split())
+    return cleaned.strip()
+
+
+def _extract_finish_reason(result: dict[str, Any] | None) -> str | None:
+    """
+    Best-effort extraction of `finish_reason` from a completion result.
+
+    `call_local` / `call_groq` return only the assistant text string, so this
+    will usually be None. When the underlying provider response is preserved
+    on the result (e.g. some tool-decision paths or wrapped responses), the
+    OpenAI-style `choices[0].finish_reason` is surfaced here.
+    """
+    if not isinstance(result, dict):
+        return None
+    raw = result.get("raw")
+    if isinstance(raw, dict):
+        choices = raw.get("choices")
+        if isinstance(choices, list) and choices:
+            first = choices[0]
+            if isinstance(first, dict):
+                reason = first.get("finish_reason")
+                if reason:
+                    return str(reason)
+    execution = result.get("execution")
+    if isinstance(execution, dict):
+        reason = execution.get("finish_reason")
+        if reason:
+            return str(reason)
+    return None
+
+
+def _summarize_retrieval_bundle(bundle: Any) -> dict[str, Any]:
+    """
+    Compact summary of a retrieval bundle for diagnostic logging. Counts the
+    number of hits per channel (semantic/memory/graph/personal-facts) so you
+    can see at a glance whether context actually made it into the prompt.
+    """
+    if not isinstance(bundle, dict):
+        return {"present": False}
+    summary: dict[str, Any] = {"present": True}
+    for key in ("semantic", "memory", "graph", "personal_facts", "verified_personal_facts"):
+        value = bundle.get(key)
+        if isinstance(value, list):
+            summary[key] = len(value)
+        elif value:
+            summary[key] = "present"
+        else:
+            summary[key] = 0
+    query_value = bundle.get("retrieval_query")
+    if isinstance(query_value, str):
+        summary["retrieval_query_chars"] = len(query_value)
+    return summary
+
+
+def _log_completion_diagnostics(
+    *,
+    task: Any,
+    provider: Any,
+    model: Any,
+    bundle: Any,
+    assistant_text: str,
+    result: dict[str, Any],
+) -> None:
+    """
+    Emit a single structured log line per completion with what the model
+    actually returned. Used to diagnose "messages truncated in the UI":
+    if `assistant_text_length` is small and `finish_reason == "length"`,
+    the model hit its output cap (look at LOCAL_MAX_TOKENS / provider
+    default). If `finish_reason` is None, the providers didn't surface it
+    — that's normal for Codexify's current local/groq paths.
+    """
+    try:
+        assistant_length = len(assistant_text or "")
+        finish_reason = _extract_finish_reason(result)
+        bundle_summary = _summarize_retrieval_bundle(bundle)
+        request_id = (
+            str(getattr(task, "task_id", "") or "").strip()
+            or str(result.get("requestId") or "").strip()
+            or None
+        )
+        logger.info(
+            "chat.completion.finished",
+            extra={
+                "provider": str(provider) if provider else None,
+                "model": str(model) if model else None,
+                "request_id": request_id,
+                "assistant_text_length": assistant_length,
+                "finish_reason": finish_reason,
+                "retrieval_bundle": bundle_summary,
+            },
+        )
+    except Exception:
+        # Diagnostics must never break the completion path.
+        logger.exception("chat.completion.diagnostics_failed")
+
+
 def _command_bus_app() -> Any:
     from guardian.guardian_api import app as guardian_app
 
@@ -3547,7 +3667,12 @@ async def build_messages_for_llm(
 
     conversation_messages = [*history_messages, latest_turn]
     # Retrieval must follow the latest user turn, not earlier history.
-    retrieval_query = render_content_for_inference(latest_turn.get("content"))
+    # Strip the "[username]: " sender tag and any "@guardian" mention from the
+    # query so they don't dominate the embedding match against the KB. The
+    # user_id is still threaded through to the system prompt separately.
+    retrieval_query = _clean_retrieval_query(
+        render_content_for_inference(latest_turn.get("content"))
+    )
     latest_turn_trace_fields = _latest_turn_trace_fields(
         latest_turn,
         retrieval_query=retrieval_query,
@@ -4710,6 +4835,14 @@ def run_chat_completion_task(
         cancel_check=cancel_check,
     )
     assistant_text = str(result.get("assistant_text") or "")
+    _log_completion_diagnostics(
+        task=task,
+        provider=provider,
+        model=model,
+        bundle=bundle,
+        assistant_text=assistant_text,
+        result=result,
+    )
     payload_summary = dict(result.get("payload_summary") or payload_summary)
     payload_summary["requested_provider"] = requested_provider
     payload_summary["requested_model"] = requested_model

--- a/guardian/guardian_api.py
+++ b/guardian/guardian_api.py
@@ -39,7 +39,8 @@ from fastapi import (
 )
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
-from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from sqlalchemy import exc as sa_exc
 
@@ -497,7 +498,7 @@ def _retrieval_proof_state(
 from backend import llm_overrides
 
 # Import all routers (after DB init so dependencies.chatlog_db is ready)
-from guardian.routes import admin, agent, agent_orchestration
+from guardian.routes import admin, agent, agent_orchestration, atlas
 from guardian.routes import auth as auth_routes
 from guardian.routes import backfill, coding_work_orders
 from guardian.routes import command_bus as command_bus_routes
@@ -1046,6 +1047,12 @@ _include_router(
     label="embeddings",
     flag_name="CODEXIFY_ENABLE_EMBEDDINGS_ROUTES",
     include_fn=lambda: app.include_router(embeddings.router),
+    core_surface=True,
+)
+_include_router(
+    label="atlas",
+    flag_name="CODEXIFY_ENABLE_ATLAS_ROUTES",
+    include_fn=lambda: app.include_router(atlas.router),
     core_surface=True,
 )
 _include_router(
@@ -1662,6 +1669,26 @@ def health_retrieval(
             "error": search_error,
         },
     }
+
+
+# =========================
+# Basic Web UI (webui-basic)
+# =========================
+
+_WEBUI_BASIC_DIR = Path(__file__).resolve().parent.parent / "webui-basic"
+if _WEBUI_BASIC_DIR.is_dir():
+    @app.get("/ui", response_class=HTMLResponse, include_in_schema=False)
+    def webui_basic_index():
+        return (_WEBUI_BASIC_DIR / "index.html").read_text()
+
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(_WEBUI_BASIC_DIR)),
+        name="webui-basic",
+    )
+    logger.info("[webui-basic] Serving from %s at /ui", _WEBUI_BASIC_DIR)
+else:
+    logger.info("[webui-basic] %s not found, skipping UI mount", _WEBUI_BASIC_DIR)
 
 
 # =========================

--- a/guardian/routes/atlas.py
+++ b/guardian/routes/atlas.py
@@ -1,0 +1,151 @@
+"""Atlas routes — bulk chunk listing for the 2D embedding map in webui-basic."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, ConfigDict, Field
+
+from guardian.core.dependencies import (
+    RequestUserScope,
+    get_request_user_scope,
+    get_single_user_id,
+    get_vector_store,
+    require_api_key,
+)
+from guardian.vector.store import _normalize_namespace
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/atlas", tags=["Atlas"])
+
+
+class AtlasChunkMetadata(BaseModel):
+    """Pass-through chunk metadata; extra keys are preserved."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    source: Optional[str] = None
+    doc_id: Optional[str] = None
+    thread_id: Optional[str] = None
+    project_id: Optional[str] = None
+    namespace: Optional[str] = None
+    role: Optional[str] = None
+    timestamp: Optional[str] = None
+    title: Optional[str] = None
+    slug: Optional[str] = None
+
+
+class AtlasChunk(BaseModel):
+    id: str
+    text: str
+    preview: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    embedding: list[float] = Field(default_factory=list)
+
+
+class AtlasChunksResponse(BaseModel):
+    ok: bool = True
+    backend: str
+    total: int
+    limit: int
+    offset: int
+    next_offset: Optional[int]
+    has_more: bool
+    items: list[AtlasChunk]
+
+
+@router.get("/chunks", response_model=AtlasChunksResponse)
+def atlas_list_chunks(
+    project_id: Optional[int] = Query(default=None),
+    namespace: Optional[str] = Query(default=None),
+    limit: int = Query(default=500, ge=1, le=5000),
+    offset: int = Query(default=0, ge=0),
+    text_preview_chars: int = Query(default=200, ge=0, le=2000),
+    include_embeddings: bool = Query(default=True),
+    api_key: str = Depends(require_api_key),
+    request_user_scope: RequestUserScope = Depends(get_request_user_scope),
+) -> AtlasChunksResponse:
+    """Return a paginated, user-scoped slice of vector store chunks for Atlas.
+
+    The response includes the raw embedding vectors so the browser can run
+    PCA locally. ``user_id`` is *always* derived from the request scope and
+    never accepted from the client — this is the only safe way to prevent
+    cross-tenant leaks when listing arbitrary chunks.
+    """
+    del api_key  # satisfied by Depends; kept in signature for parity with sibling routes
+
+    scoped_user_id = request_user_scope.user_id or get_single_user_id()
+
+    effective_namespace = _normalize_namespace(namespace)
+    if effective_namespace is None and project_id is not None:
+        effective_namespace = f"project:{project_id}"
+
+    where: dict[str, Any] = {"user_id": str(scoped_user_id)}
+    if effective_namespace:
+        where["namespace"] = effective_namespace
+
+    try:
+        vector_store = get_vector_store()
+    except Exception as exc:
+        logger.warning("Atlas: vector store unavailable: %s", exc)
+        return AtlasChunksResponse(
+            backend="none",
+            total=0,
+            limit=limit,
+            offset=offset,
+            next_offset=None,
+            has_more=False,
+            items=[],
+        )
+
+    embedder = getattr(vector_store, "embedder", None)
+    iter_method = getattr(embedder, "iter_chunks_for_atlas", None)
+    if iter_method is None:
+        # Older embedder without Atlas support — return empty rather than 501
+        # so the UI degrades gracefully.
+        logger.info("Atlas: embedder lacks iter_chunks_for_atlas; returning empty")
+        return AtlasChunksResponse(
+            backend=getattr(embedder, "store", "none") or "none",
+            total=0,
+            limit=limit,
+            offset=offset,
+            next_offset=None,
+            has_more=False,
+            items=[],
+        )
+
+    result = iter_method(
+        where=where,
+        limit=limit,
+        offset=offset,
+        include_embeddings=include_embeddings,
+        text_preview_chars=text_preview_chars,
+    )
+
+    raw_items = result.get("items") or []
+    items = [
+        AtlasChunk(
+            id=str(item.get("id", "")),
+            text=str(item.get("text", "") or ""),
+            preview=str(item.get("preview", "") or ""),
+            metadata=dict(item.get("metadata") or {}),
+            embedding=list(item.get("embedding") or []),
+        )
+        for item in raw_items
+    ]
+
+    total = int(result.get("total") or 0)
+    backend = str(result.get("backend") or "none")
+    next_offset = (offset + len(items)) if len(items) >= limit and (offset + len(items)) < total else None
+
+    return AtlasChunksResponse(
+        backend=backend,
+        total=total,
+        limit=limit,
+        offset=offset,
+        next_offset=next_offset,
+        has_more=next_offset is not None,
+        items=items,
+    )

--- a/guardian/routes/chat.py
+++ b/guardian/routes/chat.py
@@ -137,6 +137,119 @@ CHAT_WORKER_HEARTBEAT_KEY = os.getenv(
     "CHAT_WORKER_HEARTBEAT_KEY", "codexify:worker:chat:heartbeat"
 )
 
+# --- @luna mention routing via n8n ---
+import re as _re
+
+import httpx as _httpx
+
+_LUNA_N8N_WEBHOOK_URL = os.getenv("LUNA_N8N_WEBHOOK_URL", "").strip()
+_LUNA_MENTION_ENABLED = os.getenv("LUNA_MENTION_ENABLED", "false").lower() in {
+    "1",
+    "true",
+    "yes",
+}
+_LUNA_MENTION_RE = _re.compile(r"@luna\b", _re.IGNORECASE)
+
+
+def _is_luna_mention(text: str) -> bool:
+    return _LUNA_MENTION_ENABLED and bool(_LUNA_MENTION_RE.search(text or ""))
+
+
+def _strip_luna_mention(text: str) -> str:
+    return _LUNA_MENTION_RE.sub("", text).strip()
+
+
+async def _route_to_luna_n8n(
+    message_text: str,
+    thread_id: int,
+    context: list[dict[str, str]] | None = None,
+    timeout: float = 90.0,
+) -> str | None:
+    if not _LUNA_N8N_WEBHOOK_URL:
+        logger.warning("[luna] LUNA_N8N_WEBHOOK_URL not configured")
+        return None
+    user_text = _strip_luna_mention(message_text)
+    transcript_lines: list[str] = []
+    for msg in (context or []):
+        role = msg.get("role", "unknown")
+        content = (msg.get("content") or "").strip()
+        if not content:
+            continue
+        if role == "assistant" and content.startswith("[luna] "):
+            transcript_lines.append(f"Luna: {content[7:]}")
+        elif role == "assistant":
+            transcript_lines.append(f"Guardian: {content}")
+        else:
+            transcript_lines.append(f"Zac: {content}")
+    transcript = "\n".join(transcript_lines[-45:])
+    payload = {
+        "chatInput": (
+            "[You are replying inside Zac's Codexify app — his alternative web UI. "
+            "This is not the n8n chat or iMessage. Zac mentioned you with @luna. "
+            "Guardian is the other AI assistant in this chat (the default Codexify model). "
+            "Reply naturally as Luna.]\n\n"
+            "[Full chat transcript from this Codexify thread — read it all before replying:]\n"
+            + transcript + "\n\n"
+            "[Zac's latest message to you:]\n"
+            + user_text
+        ),
+        "sessionId": f"codexify-thread-{thread_id}",
+        "metadata": {
+            "interface": "codexify",
+            "source": "at-mention",
+            "thread_id": thread_id,
+        },
+    }
+    try:
+        async with _httpx.AsyncClient() as client:
+            resp = await client.post(
+                _LUNA_N8N_WEBHOOK_URL,
+                json=payload,
+                timeout=timeout,
+                headers={"Accept": "application/json, text/plain, */*"},
+            )
+            resp.raise_for_status()
+            return _extract_luna_reply(resp.text)
+    except Exception as exc:
+        logger.error("[luna] n8n webhook failed: %s", exc)
+        return None
+
+
+def _extract_luna_reply(raw: str) -> str:
+    if not raw:
+        return ""
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return raw.strip()
+    if isinstance(data, str):
+        return data.strip()
+    if isinstance(data, list):
+        parts = []
+        for item in data:
+            if isinstance(item, dict):
+                parts.append(
+                    str(
+                        item.get("output")
+                        or item.get("text")
+                        or item.get("response")
+                        or item.get("message")
+                        or ""
+                    ).strip()
+                )
+            elif isinstance(item, str):
+                parts.append(item.strip())
+        return "\n\n".join(p for p in parts if p)
+    if isinstance(data, dict):
+        return str(
+            data.get("output")
+            or data.get("text")
+            or data.get("response")
+            or data.get("message")
+            or ""
+        ).strip()
+    return str(data).strip()
+
 
 def _completion_service_unavailable(reason: str) -> HTTPException:
     return HTTPException(
@@ -2983,6 +3096,101 @@ async def chat_complete(
         if isinstance(latest_turn, dict)
         else None
     )
+
+    # --- @luna mention interception ---
+    latest_turn_content = ""
+    if isinstance(latest_turn, dict):
+        _ltc = latest_turn.get("content")
+        if isinstance(_ltc, str):
+            latest_turn_content = _ltc
+        elif isinstance(_ltc, list):
+            latest_turn_content = " ".join(
+                str(p.get("text", ""))
+                for p in _ltc
+                if isinstance(p, dict) and p.get("type") == "text"
+            )
+    logger.info(
+        "[luna] latest_turn_content=%r mention_enabled=%s match=%s",
+        latest_turn_content[:120] if latest_turn_content else "",
+        _LUNA_MENTION_ENABLED,
+        bool(_LUNA_MENTION_RE.search(latest_turn_content or "")),
+    )
+    if _is_luna_mention(latest_turn_content):
+        luna_task_id = str(uuid.uuid4())
+        turn_id = _normalize_turn_id(body.turn_id)
+        try:
+            task_events.publish_with_visibility(
+                luna_task_id,
+                TASK_EVENT_TYPE_TASK_CREATED,
+                {
+                    "type": "chat_completion",
+                    "thread_id": thread_id,
+                    "origin": "luna_mention",
+                    "turn_id": turn_id,
+                },
+            )
+        except Exception:
+            pass
+        luna_reply = await _route_to_luna_n8n(
+            latest_turn_content,
+            thread_id,
+            context=context,
+        )
+        if luna_reply:
+            luna_reply = "[luna] " + luna_reply
+            from guardian.core import dependencies as _luna_deps
+
+            try:
+                _luna_deps.chatlog_db.create_message(
+                    thread_id, "assistant", luna_reply
+                )
+            except Exception as exc:
+                logger.error("[luna] failed to save reply: %s", exc)
+            try:
+                task_events.publish(
+                    luna_task_id,
+                    TaskEventType.TASK_COMPLETED.value,
+                    {
+                        "task_id": luna_task_id,
+                        "thread_id": thread_id,
+                        "status": "completed",
+                        "response": luna_reply,
+                        "execution": {
+                            "attempted_provider": "luna",
+                            "attempted_model": "Luna (n8n)",
+                            "final_provider": "luna",
+                            "final_model": "Luna (n8n)",
+                            "fallback_triggered": False,
+                        },
+                    },
+                )
+            except Exception:
+                pass
+            return {
+                "ok": True,
+                "acceptance_status": "accepted",
+                "acceptance_warnings": [],
+                "task_id": luna_task_id,
+                "turn_id": turn_id,
+                "thread_id": thread_id,
+                "source_mode": "luna",
+                "depth_mode": "normal",
+                "requested_depth_mode": "normal",
+                "effective_depth_mode": "normal",
+                "depth_downgrade_reason": None,
+                "messages_url": f"/api/chat/{thread_id}/messages",
+                "trace_url": f"/api/chat/debug/rag-trace/{thread_id}/latest",
+                "execution": {
+                    "attempted_provider": "luna",
+                    "attempted_model": "Luna (n8n)",
+                    "final_provider": "luna",
+                    "final_model": "Luna (n8n)",
+                    "fallback_triggered": False,
+                },
+            }
+        logger.warning("[luna] no reply from n8n; falling through to normal completion")
+    # --- end @luna interception ---
+
     requested_source_mode = normalize_source_mode(
         body.source_mode
     ) or _source_mode_from_message_metadata(latest_turn)

--- a/guardian/runtime/embed/embedder.py
+++ b/guardian/runtime/embed/embedder.py
@@ -191,7 +191,14 @@ class CodexifyEmbedder:
                 "count": len(docs),
             }
 
-    def search(self, query: str, k: int = 5) -> list[dict[str, Any]]:
+    def search(
+        self,
+        query: str,
+        k: int = 5,
+        *,
+        namespace: Optional[str] = None,
+        user_id: Optional[str] = None,
+    ) -> list[dict[str, Any]]:
         """Search the vector store for the query."""
         if self.store != "chroma":
             raise NotImplementedError(
@@ -201,20 +208,38 @@ class CodexifyEmbedder:
         if self._chroma_collection is None:
             raise RuntimeError("Chroma collection not initialized")
 
-        # Embed the query
         query_embeddings = self.embed_texts([query])
 
-        # Query Chroma
-        results = self._chroma_collection.query(
-            query_embeddings=query_embeddings, n_results=k
-        )
+        where_filter: dict[str, Any] | None = None
+        conditions: list[dict[str, Any]] = []
+        conditions.append({"source": {"$ne": "chat"}})
+        if namespace:
+            conditions.append({"namespace": namespace})
+        if user_id:
+            conditions.append({"user_id": user_id})
+        if len(conditions) > 1:
+            where_filter = {"$and": conditions}
+        elif len(conditions) == 1:
+            where_filter = conditions[0]
 
-        # Format results to match the expected output structure
-        # Chroma returns lists of lists (one per query), we only have one query
-        formatted_results = []
+        fetch_k = min(k * 3, 30)
+        query_kwargs: dict[str, Any] = {
+            "query_embeddings": query_embeddings,
+            "n_results": fetch_k,
+        }
+        if where_filter:
+            query_kwargs["where"] = where_filter
+
+        try:
+            results = self._chroma_collection.query(**query_kwargs)
+        except Exception:
+            results = self._chroma_collection.query(
+                query_embeddings=query_embeddings, n_results=fetch_k
+            )
+
+        formatted_results: list[dict[str, Any]] = []
 
         if results and results["documents"]:
-            # Unpack the first (and only) query result
             docs = results["documents"][0]
             metas = (
                 results["metadatas"][0]
@@ -227,15 +252,27 @@ class CodexifyEmbedder:
                 else [0.0] * len(docs)
             )
 
+            seen_texts: set[str] = set()
+            doc_results: list[dict[str, Any]] = []
+            chat_results: list[dict[str, Any]] = []
+
             for doc, meta, dist in zip(docs, metas, distances):
-                formatted_results.append(
-                    {
-                        "text": doc,
-                        "meta": meta,
-                        "score": 1.0
-                        - dist,  # Convert distance to similarity score roughly
-                    }
-                )
+                if doc in seen_texts:
+                    continue
+                seen_texts.add(doc)
+                entry = {
+                    "text": doc,
+                    "meta": meta,
+                    "metadata": meta,
+                    "user_id": meta.get("user_id", ""),
+                    "score": 1.0 - dist,
+                }
+                if meta.get("source") == "chat":
+                    chat_results.append(entry)
+                else:
+                    doc_results.append(entry)
+
+            formatted_results = (doc_results + chat_results)[:k]
 
         return formatted_results
 

--- a/webui-basic/index.html
+++ b/webui-basic/index.html
@@ -170,6 +170,7 @@ body {
   <aside class="sidebar" id="sidebar">
     <div class="sidebar-header">
       <h1>Codexify</h1>
+      <select id="projectPicker" style="background:var(--surface2);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:3px 6px;font-size:12px;max-width:120px;"></select>
       <button class="btn btn-sm" id="btnNew">+ New</button>
     </div>
     <div class="sidebar-tabs">
@@ -233,6 +234,7 @@ body {
   var pollTimer = null;
   var waitingForAssistant = false;
   var activeTab = 'threads';
+  var currentProjectId = null;
   // Atlas state
   var atlasLoaded = false;
   var atlasLoading = false;
@@ -327,7 +329,9 @@ body {
 
   // --- Threads ---
   function loadThreads() {
-    api('/api/chat/threads?limit=50&offset=0').then(function(data) {
+    var url = '/api/chat/threads?limit=50&offset=0';
+    if (currentProjectId !== null) url += '&project_id=' + currentProjectId;
+    api(url).then(function(data) {
       var threads = data.threads || data;
       var list = document.getElementById('threadList');
       if (!threads.length) { list.innerHTML = '<div class="empty-panel">No threads yet. Tap + New.</div>'; return; }
@@ -448,7 +452,9 @@ body {
     if (n && n.trim()) { userName = n.trim(); localStorage.setItem('codexify_username', userName); this.textContent = userName; }
   };
   document.getElementById('btnNew').onclick = function() {
-    api('/api/chat/threads', 'POST', { title: 'New chat' }).then(function(d) {
+    var body = { title: 'New chat' };
+    if (currentProjectId !== null) body.project_id = currentProjectId;
+    api('/api/chat/threads', 'POST', body).then(function(d) {
       var id = d.id || (d.thread && d.thread.id);
       loadThreads(); if (id) selectThread(id);
     }).catch(function(){});
@@ -534,7 +540,9 @@ body {
     if (atlasLoading) return;
     atlasLoading = true;
     document.getElementById('atlasCount').textContent = 'Loading…';
-    api('/api/atlas/chunks?limit=2000&include_embeddings=true', 'GET')
+    var atlasUrl = '/api/atlas/chunks?limit=2000&include_embeddings=true';
+    if (currentProjectId !== null) atlasUrl += '&project_id=' + currentProjectId;
+    api(atlasUrl, 'GET')
       .then(function(resp) {
         atlasLoaded = true;
         atlasLoading = false;
@@ -812,8 +820,31 @@ body {
     atlasResizeTimer = setTimeout(renderAtlas, 150);
   });
 
+  // --- Projects ---
+  function loadProjects() {
+    api('/api/projects').then(function(data) {
+      var projects = Array.isArray(data) ? data : (data.projects || []);
+      var picker = document.getElementById('projectPicker');
+      picker.innerHTML = '<option value="">All Projects</option>';
+      projects.forEach(function(p) {
+        var opt = document.createElement('option');
+        opt.value = p.id;
+        opt.textContent = p.name;
+        if (currentProjectId !== null && +p.id === +currentProjectId) opt.selected = true;
+        picker.appendChild(opt);
+      });
+    }).catch(function() {});
+  }
+  document.getElementById('projectPicker').onchange = function() {
+    var v = this.value;
+    currentProjectId = v ? +v : null;
+    loadThreads();
+    if (activeTab === 'atlas') { atlasLoaded = false; atlasChunks = []; atlasProjection = []; loadAtlas(); }
+  };
+
   // --- Boot ---
   checkHealth();
+  loadProjects();
   loadThreads();
   setInterval(checkHealth, 15000);
   console.log('Codexify UI loaded, user=' + userName);

--- a/webui-basic/index.html
+++ b/webui-basic/index.html
@@ -1,0 +1,823 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+<meta http-equiv="Pragma" content="no-cache">
+<meta http-equiv="Expires" content="0">
+<title>Codexify</title>
+<style>
+:root {
+  --bg: #0a0a0a; --surface: #111; --surface2: #1a1a1a; --surface3: #222;
+  --border: #2a2a2a; --text: #e4e4e4; --text-dim: #777; --text-faint: #555;
+  --accent: #6c8cff; --accent-dim: #3a4d8c; --accent-soft: rgba(108,140,255,0.12);
+  --green: #4caf50; --orange: #ff9800; --red: #ff4d4d;
+  --user-bg: #162240; --other-bg: #1a2a1a; --assistant-bg: #141414; --luna-bg: #1a1428;
+  --radius: 12px; --radius-sm: 8px;
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro", system-ui, sans-serif;
+  background: var(--bg); color: var(--text); height: 100dvh; overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+}
+.app { display: flex; height: 100dvh; width: 100%; }
+
+.sidebar {
+  width: 300px; min-width: 300px; background: var(--surface);
+  border-right: 1px solid var(--border); display: flex; flex-direction: column;
+  transition: transform 0.25s ease;
+}
+.sidebar-header {
+  padding: 14px 16px; border-bottom: 1px solid var(--border);
+  display: flex; align-items: center; gap: 8px;
+}
+.sidebar-header h1 { font-size: 15px; font-weight: 600; flex: 1; }
+.sidebar-tabs { display: flex; border-bottom: 1px solid var(--border); }
+.sidebar-tab {
+  flex: 1; padding: 10px 0; text-align: center; font-size: 12px; font-weight: 500;
+  color: var(--text-dim); background: none; border: none; cursor: pointer;
+  border-bottom: 2px solid transparent;
+}
+.sidebar-tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+.sidebar-panel { flex: 1; overflow-y: auto; -webkit-overflow-scrolling: touch; }
+.thread-list, .doc-list { display: none; flex-direction: column; }
+.thread-list.active, .doc-list.active { display: flex; }
+.thread-item {
+  padding: 12px 16px; border-bottom: 1px solid var(--border);
+  cursor: pointer; display: flex; align-items: center; gap: 8px;
+}
+.thread-item:active, .thread-item.active { background: var(--surface2); }
+.thread-item .thread-info { flex: 1; min-width: 0; }
+.thread-item .title { font-size: 13px; font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.thread-item .meta { font-size: 11px; color: var(--text-dim); margin-top: 2px; }
+.del-btn {
+  background: none; border: none; color: var(--text-faint); font-size: 14px;
+  cursor: pointer; padding: 4px 6px; border-radius: 4px; flex-shrink: 0;
+}
+.doc-item { padding: 10px 16px; border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 10px; }
+.doc-item .doc-icon { font-size: 18px; flex-shrink: 0; }
+.doc-item .doc-info { flex: 1; min-width: 0; }
+.doc-item .doc-name { font-size: 13px; font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.doc-item .doc-meta { font-size: 11px; color: var(--text-dim); margin-top: 1px; }
+.doc-item .doc-status { font-size: 10px; font-weight: 600; text-transform: uppercase; padding: 2px 6px; border-radius: 4px; flex-shrink: 0; }
+.doc-status.ready { color: var(--green); background: rgba(76,175,80,0.12); }
+.doc-status.processing { color: var(--orange); background: rgba(255,152,0,0.12); }
+.upload-zone {
+  margin: 12px 16px; padding: 24px; border: 2px dashed var(--border);
+  border-radius: var(--radius); text-align: center; color: var(--text-dim);
+  font-size: 13px; cursor: pointer;
+}
+.upload-zone input { display: none; }
+.empty-panel { padding: 32px 16px; text-align: center; color: var(--text-dim); font-size: 13px; }
+
+.atlas-pane { flex: 1; display: none; flex-direction: column; min-width: 0; background: var(--bg); position: relative; }
+.atlas-pane.active { display: flex; }
+.atlas-toolbar {
+  padding: 8px 16px; border-bottom: 1px solid var(--border);
+  display: flex; gap: 10px; align-items: center; font-size: 12px;
+  color: var(--text-dim); background: var(--surface);
+}
+.atlas-toolbar select, .atlas-toolbar button {
+  background: var(--surface2); color: var(--text); border: 1px solid var(--border);
+  border-radius: 6px; padding: 4px 8px; font-size: 12px;
+}
+.atlas-toolbar button { cursor: pointer; }
+.atlas-toolbar button:hover { border-color: var(--accent); }
+.atlas-canvas-wrap { flex: 1; position: relative; overflow: hidden; }
+.atlas-canvas-wrap canvas { display: block; width: 100%; height: 100%; }
+.atlas-tooltip {
+  position: absolute; pointer-events: none;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 6px; padding: 8px 10px; font-size: 12px; color: var(--text);
+  max-width: 320px; box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+  display: none; z-index: 10;
+}
+.atlas-tooltip .tt-meta { color: var(--text-dim); font-size: 11px; margin-bottom: 4px; }
+.atlas-tooltip .tt-text { white-space: pre-wrap; max-height: 140px; overflow: auto; line-height: 1.4; }
+.atlas-empty { padding: 32px; text-align: center; color: var(--text-dim); font-size: 13px; }
+
+.chat-pane { flex: 1; display: flex; flex-direction: column; min-width: 0; }
+.chat-header {
+  padding: 10px 16px; border-bottom: 1px solid var(--border);
+  display: flex; align-items: center; gap: 10px; background: var(--surface); min-height: 46px;
+}
+.chat-header .thread-title { font-size: 14px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
+.user-badge { font-size: 11px; color: var(--accent); background: var(--accent-soft); padding: 3px 8px; border-radius: 10px; cursor: pointer; }
+.menu-btn { display: none; background: none; border: none; color: var(--text); font-size: 20px; cursor: pointer; padding: 4px; }
+
+.messages { flex: 1; overflow-y: auto; -webkit-overflow-scrolling: touch; padding: 12px 16px; display: flex; flex-direction: column; gap: 8px; }
+.message { max-width: 82%; padding: 8px 12px; border-radius: var(--radius); font-size: 14px; line-height: 1.5; word-wrap: break-word; white-space: pre-wrap; }
+.message.user-self { align-self: flex-end; background: var(--user-bg); border-bottom-right-radius: 4px; }
+.message.user-other { align-self: flex-start; background: var(--other-bg); border-bottom-left-radius: 4px; }
+.message.assistant { align-self: flex-start; background: var(--assistant-bg); border: 1px solid var(--border); border-bottom-left-radius: 4px; max-width: 90%; }
+.message .msg-name { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 3px; }
+.message.user-self .msg-name { color: var(--accent); }
+.message.user-other .msg-name { color: #6dbb6d; }
+.message.assistant .msg-name { color: var(--text-dim); }
+.message.luna { background: var(--luna-bg); border-color: #2d1f4e; }
+.message.luna .msg-name { color: #b39ddb; }
+
+.typing-indicator { align-self: flex-start; padding: 8px 12px; background: var(--assistant-bg); border: 1px solid var(--border); border-radius: var(--radius); font-size: 13px; color: var(--text-dim); display: none; }
+.typing-indicator.visible { display: block; }
+
+.no-thread { flex: 1; display: flex; align-items: center; justify-content: center; color: var(--text-dim); font-size: 13px; text-align: center; padding: 32px; }
+
+.composer { padding: 10px 16px; border-top: 1px solid var(--border); background: var(--surface); display: flex; gap: 8px; align-items: flex-end; }
+.composer textarea {
+  flex: 1; background: var(--surface2); border: 1px solid var(--border);
+  border-radius: var(--radius); color: var(--text); padding: 10px 14px;
+  font-size: 15px; font-family: inherit; line-height: 1.4;
+  resize: none; outline: none; max-height: 120px; min-height: 42px;
+}
+.composer textarea::placeholder { color: var(--text-faint); }
+.composer textarea:focus { border-color: var(--accent-dim); }
+.icon-btn {
+  width: 40px; height: 40px; border-radius: 50%; border: none; color: #fff;
+  font-size: 16px; cursor: pointer; display: flex; align-items: center;
+  justify-content: center; flex-shrink: 0;
+}
+.icon-btn:disabled { opacity: 0.25; }
+.send-btn { background: var(--accent); }
+.attach-btn { background: var(--surface3); color: var(--text-dim); font-size: 18px; }
+.attach-btn input { display: none; }
+
+.status-bar { padding: 5px 16px; background: var(--surface); border-top: 1px solid var(--border); font-size: 11px; color: var(--text-dim); display: flex; align-items: center; gap: 6px; }
+.status-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--green); flex-shrink: 0; }
+.status-dot.offline { background: var(--red); }
+.status-dot.pending { background: var(--orange); }
+
+.btn { background: var(--accent); color: #fff; border: none; border-radius: var(--radius-sm); padding: 8px 14px; font-size: 13px; font-weight: 500; cursor: pointer; }
+.btn-sm { padding: 5px 10px; font-size: 12px; }
+.overlay { display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99; }
+.overlay.open { display: block; }
+
+@media (max-width: 700px) {
+  .sidebar { position: fixed; top: 0; left: 0; bottom: 0; z-index: 100; transform: translateX(-100%); width: 280px; min-width: 0; }
+  .sidebar.open { transform: translateX(0); }
+  .menu-btn { display: block; }
+}
+::-webkit-scrollbar { width: 4px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+</style>
+</head>
+<body>
+<div class="app" style="display:none" id="appRoot">
+  <div class="overlay" id="overlay"></div>
+  <aside class="sidebar" id="sidebar">
+    <div class="sidebar-header">
+      <h1>Codexify</h1>
+      <button class="btn btn-sm" id="btnNew">+ New</button>
+    </div>
+    <div class="sidebar-tabs">
+      <button class="sidebar-tab active" data-tab="threads" id="tabThreads">Threads</button>
+      <button class="sidebar-tab" data-tab="docs" id="tabDocs">Docs</button>
+      <button class="sidebar-tab" data-tab="atlas" id="tabAtlas">Atlas</button>
+    </div>
+    <div class="sidebar-panel">
+      <div class="thread-list active" id="threadList"><div class="empty-panel">Loading...</div></div>
+      <div class="doc-list" id="docList">
+        <div class="upload-zone" id="uploadZone">
+          Drop files here or tap to upload
+          <input type="file" id="uploadInput" multiple accept=".md,.txt,.pdf,.csv,.json,.html,.doc,.docx">
+        </div>
+        <div id="docItems"></div>
+      </div>
+    </div>
+  </aside>
+  <main class="chat-pane" id="chatPane">
+    <div class="chat-header">
+      <button class="menu-btn" id="menuBtn">&#9776;</button>
+      <div class="thread-title" id="chatTitle">Codexify</div>
+      <div class="user-badge" id="userBadge"></div>
+    </div>
+    <div class="messages" id="messages">
+      <div class="no-thread">Select or create a thread to start</div>
+    </div>
+    <div class="typing-indicator" id="typing"><span>Thinking...</span></div>
+    <div class="composer" id="composer" style="display:none;">
+      <button class="icon-btn attach-btn" id="attachBtn">+</button>
+      <input type="file" id="attachInput" multiple accept=".md,.txt,.pdf,.csv,.json,.html,.doc,.docx" style="display:none">
+      <textarea id="input" placeholder="Message... (@Guardian to invoke AI)" rows="1"></textarea>
+      <button class="icon-btn send-btn" id="sendBtn" disabled>&#9654;</button>
+    </div>
+    <div class="status-bar">
+      <div class="status-dot" id="statusDot"></div>
+      <span id="statusText">Connecting...</span>
+    </div>
+  </main>
+  <main class="atlas-pane" id="atlasPane">
+    <div class="atlas-toolbar">
+      <select id="atlasNamespace"><option value="">All namespaces</option></select>
+      <span id="atlasCount">—</span>
+      <button id="atlasRefresh">Refresh</button>
+      <span style="margin-left:auto;color:var(--text-faint);font-size:11px;">Drag a chunk for details · Esc to close</span>
+    </div>
+    <div class="atlas-canvas-wrap" id="atlasWrap">
+      <canvas id="atlasCanvas"></canvas>
+      <div class="atlas-tooltip" id="atlasTooltip"></div>
+    </div>
+  </main>
+</div>
+
+<script>
+(function() {
+  // --- State ---
+  var apiKey = localStorage.getItem('codexify_apikey') || '';
+  var userName = localStorage.getItem('codexify_username') || '';
+  var currentThreadId = null;
+  var lastMessageId = null;
+  var pollTimer = null;
+  var waitingForAssistant = false;
+  var activeTab = 'threads';
+  // Atlas state
+  var atlasLoaded = false;
+  var atlasLoading = false;
+  var atlasChunks = [];
+  var atlasProjection = [];
+  var atlasHover = -1;
+  var atlasPin = -1;
+  var atlasActiveNamespace = '';
+
+  // --- Prompt for API key & name ---
+  while (!apiKey) {
+    var k = prompt('Enter Guardian API key:');
+    if (k && k.trim()) { apiKey = k.trim(); localStorage.setItem('codexify_apikey', apiKey); }
+  }
+  while (!userName) {
+    var n = prompt('Enter your display name:');
+    if (n && n.trim()) { userName = n.trim(); localStorage.setItem('codexify_username', userName); }
+  }
+  document.getElementById('appRoot').style.display = 'flex';
+  document.getElementById('userBadge').textContent = userName;
+
+  // --- API ---
+  function api(path, method, body) {
+    var opts = { method: method || 'GET', headers: { 'x-api-key': apiKey } };
+    if (body) { opts.headers['Content-Type'] = 'application/json'; opts.body = JSON.stringify(body); }
+    return fetch(path, opts).then(function(r) { if (!r.ok) throw new Error(r.status); return r.json(); });
+  }
+
+  // --- Sound ---
+  function ping() {
+    try {
+      var ctx = new (window.AudioContext || window.webkitAudioContext)();
+      var osc = ctx.createOscillator(); var g = ctx.createGain();
+      osc.connect(g); g.connect(ctx.destination);
+      osc.frequency.value = 880; osc.type = 'sine'; g.gain.value = 1.0;
+      osc.start(); g.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.3);
+      osc.stop(ctx.currentTime + 0.3);
+    } catch(e) {}
+  }
+
+  // --- Render ---
+  function esc(s) { var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+  function renderMessages(msgs) {
+    var el = document.getElementById('messages');
+    if (!msgs || !msgs.length) { el.innerHTML = '<div class="no-thread">No messages yet</div>'; return; }
+    el.innerHTML = msgs.map(function(m) {
+      if (m.role === 'assistant') {
+        var content = m.content || '';
+        var isLuna = /^\[luna\]/i.test(content);
+        if (isLuna) { content = content.replace(/^\[luna\]\s*/i, ''); }
+        var aClass = isLuna ? 'message assistant luna' : 'message assistant';
+        var aName = isLuna ? 'Luna' : 'Guardian';
+        return '<div class="' + aClass + '"><div class="msg-name">' + aName + '</div>' + esc(content) + '</div>';
+      }
+      var content = m.content || '';
+      var name = 'User';
+      var match = content.match(/^\[([^\]]{1,30})\]:\s*/);
+      if (match) { name = match[1]; content = content.slice(match[0].length); }
+      var cls = (name === userName) ? 'user-self' : 'user-other';
+      return '<div class="message ' + cls + '"><div class="msg-name">' + esc(name) + '</div>' + esc(content) + '</div>';
+    }).join('');
+    el.scrollTop = el.scrollHeight;
+  }
+
+  // --- Poll (the ONE loop) ---
+  function startPoll() {
+    if (pollTimer) return;
+    pollTimer = setInterval(function() {
+      if (!currentThreadId) return;
+      api('/api/chat/' + currentThreadId + '/messages').then(function(data) {
+        var msgs = data.messages || [];
+        var newLastId = msgs.length ? msgs[msgs.length - 1].id : null;
+        if (newLastId !== lastMessageId) {
+          lastMessageId = newLastId;
+          ping();
+          renderMessages(msgs);
+          if (waitingForAssistant && msgs.length && msgs[msgs.length - 1].role === 'assistant') {
+            waitingForAssistant = false;
+            document.getElementById('typing').style.display = 'none';
+            loadThreads();
+          }
+        }
+      }).catch(function() {});
+    }, 500);
+  }
+
+  function stopPoll() {
+    if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+    lastMessageId = null;
+  }
+
+  // --- Threads ---
+  function loadThreads() {
+    api('/api/chat/threads?limit=50&offset=0').then(function(data) {
+      var threads = data.threads || data;
+      var list = document.getElementById('threadList');
+      if (!threads.length) { list.innerHTML = '<div class="empty-panel">No threads yet. Tap + New.</div>'; return; }
+      list.innerHTML = threads.map(function(t) {
+        var ago = timeAgo(new Date(t.updated_at || t.created_at));
+        var active = (currentThreadId === t.id) ? ' active' : '';
+        return '<div class="thread-item' + active + '" data-id="' + t.id + '">' +
+          '<div class="thread-info"><div class="title">' + esc(t.title || 'Untitled') + '</div><div class="meta">' + ago + '</div></div>' +
+          '<button class="del-btn" data-rename="' + t.id + '" title="Rename">&#9998;</button>' +
+          '<button class="del-btn" data-delete="' + t.id + '" title="Delete">&times;</button></div>';
+      }).join('');
+    }).catch(function() {});
+  }
+
+  function selectThread(id) {
+    stopPoll();
+    currentThreadId = id;
+    api('/api/chat/' + id + '/messages').then(function(data) {
+      var msgs = data.messages || [];
+      lastMessageId = msgs.length ? msgs[msgs.length - 1].id : null;
+      renderMessages(msgs);
+      document.getElementById('chatTitle').textContent = 'Thread ' + id;
+      document.getElementById('composer').style.display = 'flex';
+      document.querySelectorAll('.thread-item').forEach(function(e) { e.classList.toggle('active', +e.dataset.id === id); });
+      var el = document.querySelector('.thread-item[data-id="' + id + '"] .title');
+      if (el) document.getElementById('chatTitle').textContent = el.textContent;
+      closeSidebar();
+      startPoll();
+    }).catch(function() {});
+  }
+
+  // --- Send ---
+  function sendMessage() {
+    var input = document.getElementById('input');
+    var text = input.value.trim();
+    if (!text || !currentThreadId) return;
+    input.value = ''; input.style.height = 'auto';
+    document.getElementById('sendBtn').disabled = true;
+
+    var tagged = '[' + userName + ']: ' + text;
+    var invokeGuardian = /@guardian/i.test(text) || /@luna/i.test(text);
+
+    api('/api/chat/' + currentThreadId + '/messages', 'POST', { role: 'user', content: tagged }).then(function() {
+      return api('/api/chat/' + currentThreadId + '/messages');
+    }).then(function(data) {
+      var msgs = data.messages || [];
+      lastMessageId = msgs.length ? msgs[msgs.length - 1].id : null;
+      renderMessages(msgs);
+
+      if (invokeGuardian) {
+        document.getElementById('typing').style.display = 'block';
+        waitingForAssistant = true;
+        api('/api/chat/' + currentThreadId + '/complete', 'POST', {}).catch(function() {
+          waitingForAssistant = false;
+          document.getElementById('typing').style.display = 'none';
+        });
+      }
+    }).catch(function(e) {
+      console.error('send failed', e);
+    }).finally(function() {
+      document.getElementById('sendBtn').disabled = false;
+    });
+  }
+
+  // --- Docs ---
+  function loadDocs() {
+    api('/api/media/documents').then(function(data) {
+      var docs = data.documents || [];
+      var el = document.getElementById('docItems');
+      if (!docs.length) { el.innerHTML = '<div class="empty-panel">No documents yet</div>'; return; }
+      el.innerHTML = docs.map(function(d) {
+        var size = d.filesize < 1048576 ? (d.filesize/1024).toFixed(1)+' KB' : (d.filesize/1048576).toFixed(1)+' MB';
+        var st = d.embedding_status || 'unknown';
+        var cls = (st==='completed'||st==='ready') ? 'ready' : st==='processing' ? 'processing' : '';
+        var label = st==='completed' ? 'Indexed' : st;
+        return '<div class="doc-item"><div class="doc-icon">\u{1F4C4}</div><div class="doc-info"><div class="doc-name">' +
+          esc(d.filename) + '</div><div class="doc-meta">' + size + '</div></div><div class="doc-status ' + cls + '">' +
+          esc(label) + '</div><button class="del-btn" data-deldoc="' + d.id + '">&times;</button></div>';
+      }).join('');
+    }).catch(function() {});
+  }
+
+  function uploadFile(file) {
+    var form = new FormData(); form.append('file', file);
+    fetch('/api/media/upload/document', { method: 'POST', headers: { 'x-api-key': apiKey }, body: form }).then(function() { loadDocs(); }).catch(function() {});
+  }
+
+  // --- Health ---
+  function checkHealth() {
+    api('/health/chat').then(function(h) {
+      document.getElementById('statusDot').className = h.ok ? 'status-dot' : 'status-dot pending';
+      document.getElementById('statusText').textContent = h.ok ? ((h.model||'').split('/').pop()||'local') + ' • ready' : 'Degraded';
+    }).catch(function() {
+      document.getElementById('statusDot').className = 'status-dot offline';
+      document.getElementById('statusText').textContent = 'Offline';
+    });
+  }
+
+  function timeAgo(d) {
+    var s = Math.floor((Date.now() - d.getTime()) / 1000);
+    if (s < 60) return 'just now'; if (s < 3600) return Math.floor(s/60)+'m ago';
+    if (s < 86400) return Math.floor(s/3600)+'h ago'; return Math.floor(s/86400)+'d ago';
+  }
+
+  function closeSidebar() {
+    document.getElementById('sidebar').classList.remove('open');
+    document.getElementById('overlay').classList.remove('open');
+  }
+
+  // --- Events (all delegated) ---
+  document.getElementById('overlay').onclick = function() { closeSidebar(); };
+  document.getElementById('menuBtn').onclick = function() {
+    document.getElementById('sidebar').classList.toggle('open');
+    document.getElementById('overlay').classList.toggle('open');
+  };
+  document.getElementById('userBadge').onclick = function() {
+    var n = prompt('Change display name:', userName);
+    if (n && n.trim()) { userName = n.trim(); localStorage.setItem('codexify_username', userName); this.textContent = userName; }
+  };
+  document.getElementById('btnNew').onclick = function() {
+    api('/api/chat/threads', 'POST', { title: 'New chat' }).then(function(d) {
+      var id = d.id || (d.thread && d.thread.id);
+      loadThreads(); if (id) selectThread(id);
+    }).catch(function(){});
+  };
+  document.getElementById('tabThreads').onclick = function() {
+    activeTab = 'threads';
+    document.getElementById('tabThreads').classList.add('active'); document.getElementById('tabDocs').classList.remove('active'); document.getElementById('tabAtlas').classList.remove('active');
+    document.getElementById('threadList').classList.add('active'); document.getElementById('docList').classList.remove('active');
+    document.getElementById('chatPane').style.display = 'flex'; document.getElementById('atlasPane').classList.remove('active');
+  };
+  document.getElementById('tabDocs').onclick = function() {
+    activeTab = 'docs';
+    document.getElementById('tabDocs').classList.add('active'); document.getElementById('tabThreads').classList.remove('active'); document.getElementById('tabAtlas').classList.remove('active');
+    document.getElementById('docList').classList.add('active'); document.getElementById('threadList').classList.remove('active');
+    document.getElementById('chatPane').style.display = 'flex'; document.getElementById('atlasPane').classList.remove('active');
+    loadDocs();
+  };
+  document.getElementById('tabAtlas').onclick = function() {
+    activeTab = 'atlas';
+    document.getElementById('tabAtlas').classList.add('active'); document.getElementById('tabThreads').classList.remove('active'); document.getElementById('tabDocs').classList.remove('active');
+    document.getElementById('chatPane').style.display = 'none'; document.getElementById('atlasPane').classList.add('active');
+    loadAtlas();
+  };
+  document.getElementById('threadList').onclick = function(e) {
+    var item = e.target.closest('.thread-item');
+    if (e.target.dataset.rename) {
+      e.stopPropagation();
+      var id = +e.target.dataset.rename;
+      var el = e.target.closest('.thread-item').querySelector('.title');
+      var cur = el ? el.textContent : '';
+      var name = prompt('Rename thread:', cur);
+      if (name && name.trim()) { api('/api/chat/threads/' + id, 'PATCH', { title: name.trim() }).then(function() { loadThreads(); if (currentThreadId === id) document.getElementById('chatTitle').textContent = name.trim(); }); }
+      return;
+    }
+    if (e.target.dataset.delete) {
+      e.stopPropagation();
+      if (confirm('Delete thread?')) {
+        var id = +e.target.dataset.delete;
+        api('/api/chat/threads/' + id, 'DELETE').then(function() {
+          if (currentThreadId === id) { currentThreadId = null; stopPoll(); document.getElementById('messages').innerHTML = '<div class="no-thread">Select a thread</div>'; document.getElementById('composer').style.display = 'none'; }
+          loadThreads();
+        });
+      }
+      return;
+    }
+    if (item) selectThread(+item.dataset.id);
+  };
+  document.getElementById('docItems').onclick = function(e) {
+    if (e.target.dataset.deldoc) {
+      if (confirm('Delete document?')) { api('/api/media/documents/' + e.target.dataset.deldoc, 'DELETE').then(function() { loadDocs(); }); }
+    }
+  };
+  document.getElementById('uploadZone').onclick = function() { document.getElementById('uploadInput').click(); };
+  document.getElementById('uploadInput').onchange = function() { Array.from(this.files).forEach(uploadFile); };
+  document.getElementById('attachBtn').onclick = function() { document.getElementById('attachInput').click(); };
+  document.getElementById('attachInput').onchange = function() { Array.from(this.files).forEach(uploadFile); };
+  document.getElementById('sendBtn').onclick = sendMessage;
+  document.getElementById('input').oninput = function() {
+    this.style.height = 'auto'; this.style.height = Math.min(this.scrollHeight, 120) + 'px';
+    document.getElementById('sendBtn').disabled = !this.value.trim();
+  };
+  document.getElementById('input').onkeydown = function(e) {
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendMessage(); }
+  };
+
+  // --- Atlas ---
+  // Colour palette used to colour-code chunks by namespace. Rotates through
+  // the design tokens (--accent, --green, --orange, --red) plus a few
+  // hand-picked extras so adjacent namespaces stay distinguishable.
+  var ATLAS_PALETTE = [
+    '#6c8cff', '#4caf50', '#ff9800', '#ff4d4d',
+    '#b39ddb', '#26c6da', '#ffd54f', '#ec407a',
+  ];
+
+  function atlasColourForNamespace(ns) {
+    if (!ns) return ATLAS_PALETTE[0];
+    var h = 0;
+    for (var i = 0; i < ns.length; i++) h = ((h << 5) - h + ns.charCodeAt(i)) | 0;
+    return ATLAS_PALETTE[Math.abs(h) % ATLAS_PALETTE.length];
+  }
+
+  function loadAtlas() {
+    if (atlasLoading) return;
+    atlasLoading = true;
+    document.getElementById('atlasCount').textContent = 'Loading…';
+    api('/api/atlas/chunks?limit=2000&include_embeddings=true', 'GET')
+      .then(function(resp) {
+        atlasLoaded = true;
+        atlasLoading = false;
+        atlasChunks = (resp && resp.items) || [];
+        atlasProjection = pcaProject(atlasChunks, 2);
+        populateAtlasNamespaceFilter();
+        document.getElementById('atlasCount').textContent =
+          atlasChunks.length + ' / ' + (resp && resp.total || 0) + ' chunks (' + (resp && resp.backend || '?') + ')';
+        renderAtlas();
+      })
+      .catch(function(err) {
+        atlasLoading = false;
+        document.getElementById('atlasCount').textContent = 'Error: ' + (err && err.message || err);
+      });
+  }
+
+  function populateAtlasNamespaceFilter() {
+    var select = document.getElementById('atlasNamespace');
+    var seen = {};
+    atlasChunks.forEach(function(c) {
+      var ns = (c.metadata && c.metadata.namespace) || '';
+      if (ns) seen[ns] = true;
+    });
+    var current = atlasActiveNamespace;
+    select.innerHTML = '<option value="">All namespaces</option>';
+    Object.keys(seen).sort().forEach(function(ns) {
+      var opt = document.createElement('option');
+      opt.value = ns; opt.textContent = ns;
+      if (ns === current) opt.selected = true;
+      select.appendChild(opt);
+    });
+  }
+
+  // Power-iteration PCA on the embedding matrix.
+  // - Centres the data, builds the covariance matrix, then finds the top
+  //   `dims` eigenvectors via repeated multiplication. No deps.
+  // - Skips degenerate cases (< 3 vectors or zero variance) by returning
+  //   the raw 2 leading axes so the canvas still draws something useful.
+  function pcaProject(chunks, dims) {
+    dims = dims || 2;
+    var pts = chunks
+      .map(function(c) { return c.embedding; })
+      .filter(function(e) { return e && e.length; });
+    if (!pts.length) return [];
+    var D = pts[0].length;
+    var N = Math.min(pts.length, dims);
+    var out = chunks.map(function() { return new Array(dims).fill(0); });
+    if (pts.length < 3) {
+      // Fallback: use the first two dimensions verbatim
+      for (var i = 0; i < chunks.length; i++) {
+        if (!chunks[i].embedding || !chunks[i].embedding.length) continue;
+        out[i][0] = chunks[i].embedding[0] || 0;
+        out[i][1] = chunks[i].embedding[1] || 0;
+      }
+      return out;
+    }
+    // Mean-centre
+    var mean = new Array(D).fill(0);
+    for (var ii = 0; ii < pts.length; ii++) {
+      for (var j = 0; j < D; j++) mean[j] += pts[ii][j];
+    }
+    for (var jj = 0; jj < D; jj++) mean[jj] /= pts.length;
+    var centred = pts.map(function(p) {
+      return p.map(function(v, k) { return v - mean[k]; });
+    });
+    // Top-N eigenvectors via power iteration on the covariance matrix
+    var vectors = [];
+    var deflated = centred.slice();
+    for (var d = 0; d < N; d++) {
+      var v = new Array(D);
+      for (var s = 0; s < D; s++) v[s] = Math.sin((s + 1) * (d + 1) * 0.7) * 0.5;
+      // Iterate
+      for (var iter = 0; iter < 60; iter++) {
+        var Av = new Array(D).fill(0);
+        for (var r = 0; r < deflated.length; r++) {
+          var row = deflated[r];
+          for (var c2 = 0; c2 < D; c2++) Av[c2] += row[c2] * v[c2] / deflated.length;
+        }
+        // Orthogonalise against previously found vectors
+        for (var p2 = 0; p2 < vectors.length; p2++) {
+          var dot = 0;
+          for (var q2 = 0; q2 < D; q2++) dot += Av[q2] * vectors[p2][q2];
+          for (var q3 = 0; q3 < D; q3++) Av[q3] -= dot * vectors[p2][q3];
+        }
+        var norm = 0;
+        for (var n2 = 0; n2 < D; n2++) norm += Av[n2] * Av[n2];
+        norm = Math.sqrt(norm) || 1;
+        v = Av.map(function(x) { return x / norm; });
+      }
+      vectors.push(v);
+      // Deflate: remove this component's contribution from the data
+      deflated = deflated.map(function(row) {
+        var proj = 0;
+        for (var t = 0; t < D; t++) proj += row[t] * v[t];
+        return row.map(function(x, k) { return x - proj * v[k]; });
+      });
+    }
+    // Project chunks onto the eigenvectors
+    var projIdx = 0;
+    for (var ci = 0; ci < chunks.length; ci++) {
+      if (!chunks[ci].embedding || !chunks[ci].embedding.length) continue;
+      var emb = chunks[ci].embedding;
+      for (var dd = 0; dd < N && dd < dims; dd++) {
+        var dot2 = 0;
+        for (var kk = 0; kk < D; kk++) dot2 += (emb[kk] - mean[kk]) * vectors[dd][kk];
+        out[ci][dd] = dot2;
+      }
+    }
+    return out;
+  }
+
+  function atlasFilteredIndices() {
+    if (!atlasActiveNamespace) {
+      return atlasChunks.map(function(_, i) { return i; });
+    }
+    var out = [];
+    atlasChunks.forEach(function(c, i) {
+      var ns = (c.metadata && c.metadata.namespace) || '';
+      if (ns === atlasActiveNamespace) out.push(i);
+    });
+    return out;
+  }
+
+  function renderAtlas() {
+    var canvas = document.getElementById('atlasCanvas');
+    var wrap = document.getElementById('atlasWrap');
+    if (!canvas || !wrap) return;
+    // Size canvas to its container
+    var w = wrap.clientWidth, h = wrap.clientHeight;
+    var dpr = window.devicePixelRatio || 1;
+    canvas.width = w * dpr; canvas.height = h * dpr;
+    canvas.style.width = w + 'px'; canvas.style.height = h + 'px';
+    var ctx = canvas.getContext('2d');
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, w, h);
+
+    var indices = atlasFilteredIndices();
+    if (!indices.length) {
+      ctx.fillStyle = '#777';
+      ctx.font = '13px -apple-system, system-ui, sans-serif';
+      ctx.textAlign = 'center';
+      ctx.fillText(atlasLoaded ? 'No chunks in this namespace' : 'Atlas not loaded', w / 2, h / 2);
+      return;
+    }
+    // Compute bounds across the projected points
+    var xmin = Infinity, xmax = -Infinity, ymin = Infinity, ymax = -Infinity;
+    indices.forEach(function(i) {
+      var p = atlasProjection[i];
+      if (!p) return;
+      if (p[0] < xmin) xmin = p[0];
+      if (p[0] > xmax) xmax = p[0];
+      if (p[1] < ymin) ymin = p[1];
+      if (p[1] > ymax) ymax = p[1];
+    });
+    var xpad = (xmax - xmin) * 0.08 || 1;
+    var ypad = (ymax - ymin) * 0.08 || 1;
+    xmin -= xpad; xmax += xpad; ymin -= ypad; ymax += ypad;
+    var margin = 24;
+    function project(p) {
+      var x = margin + ((p[0] - xmin) / (xmax - xmin)) * (w - 2 * margin);
+      var y = margin + ((p[1] - ymin) / (ymax - ymin)) * (h - 2 * margin);
+      return { x: x, y: y };
+    }
+    // Draw points
+    var radius = Math.max(2, Math.min(5, 240 / Math.max(indices.length, 50)));
+    var positions = new Array(indices.length);
+    for (var i = 0; i < indices.length; i++) {
+      var idx = indices[i];
+      var p = atlasProjection[idx];
+      if (!p) continue;
+      var pt = project(p);
+      positions[i] = { x: pt.x, y: pt.y, idx: idx };
+      var c = atlasChunks[idx];
+      var ns = (c.metadata && c.metadata.namespace) || '';
+      ctx.fillStyle = atlasColourForNamespace(ns);
+      ctx.beginPath();
+      ctx.arc(pt.x, pt.y, (idx === atlasPin || idx === atlasHover) ? radius + 2 : radius, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    // Stash for hit-testing
+    canvas._atlasPositions = positions;
+    canvas._atlasIndices = indices;
+  }
+
+  function atlasShowTooltip(idx, screenX, screenY, locked) {
+    var tip = document.getElementById('atlasTooltip');
+    var c = atlasChunks[idx];
+    if (!c) { tip.style.display = 'none'; return; }
+    var meta = c.metadata || {};
+    var metaLine = (meta.namespace || '?') + ' · ' + (meta.source || '?');
+    if (meta.role) metaLine += ' · ' + meta.role;
+    if (meta.thread_id) metaLine += ' · thread:' + meta.thread_id;
+    var preview = c.preview || c.text || '';
+    tip.innerHTML = '<div class="tt-meta">' + esc(metaLine) + '</div>' +
+                   '<div class="tt-text">' + esc(preview || '(no preview)') + '</div>';
+    tip.style.display = 'block';
+    var wrap = document.getElementById('atlasWrap').getBoundingClientRect();
+    var left = screenX - wrap.left + 12;
+    var top = screenY - wrap.top + 12;
+    if (left + 320 > wrap.width) left = screenX - wrap.left - 320 - 12;
+    if (top + 160 > wrap.height) top = screenY - wrap.top - 160 - 12;
+    tip.style.left = Math.max(4, left) + 'px';
+    tip.style.top = Math.max(4, top) + 'px';
+    tip._locked = !!locked;
+  }
+
+  function atlasHideTooltip() {
+    if (document.getElementById('atlasTooltip')._locked) return;
+    document.getElementById('atlasTooltip').style.display = 'none';
+  }
+
+  // Wire Atlas DOM events
+  var atlasCanvasEl = document.getElementById('atlasCanvas');
+  atlasCanvasEl.onmousemove = function(e) {
+    var positions = atlasCanvasEl._atlasPositions || [];
+    var found = -1;
+    var bestD2 = 64; // 8px radius squared
+    for (var i = 0; i < positions.length; i++) {
+      var dx = positions[i].x - (e.offsetX);
+      var dy = positions[i].y - (e.offsetY);
+      var d2 = dx * dx + dy * dy;
+      if (d2 < bestD2) { bestD2 = d2; found = positions[i].idx; }
+    }
+    if (found !== atlasHover) {
+      atlasHover = found;
+      renderAtlas();
+    }
+    if (found >= 0) atlasShowTooltip(found, e.clientX, e.clientY, false);
+    else atlasHideTooltip();
+  };
+  atlasCanvasEl.onmouseleave = function() {
+    atlasHover = -1;
+    renderAtlas();
+    atlasHideTooltip();
+  };
+  atlasCanvasEl.onclick = function(e) {
+    var positions = atlasCanvasEl._atlasPositions || [];
+    var found = -1;
+    var bestD2 = 64;
+    for (var i = 0; i < positions.length; i++) {
+      var dx = positions[i].x - (e.offsetX);
+      var dy = positions[i].y - (e.offsetY);
+      var d2 = dx * dx + dy * dy;
+      if (d2 < bestD2) { bestD2 = d2; found = positions[i].idx; }
+    }
+    if (found >= 0) {
+      atlasPin = found;
+      atlasHover = found;
+      renderAtlas();
+      atlasShowTooltip(found, e.clientX, e.clientY, true);
+    } else {
+      atlasPin = -1;
+      atlasHideTooltip();
+      renderAtlas();
+    }
+  };
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape' && atlasPin >= 0) {
+      atlasPin = -1;
+      atlasHideTooltip();
+      renderAtlas();
+    }
+  });
+  document.getElementById('atlasNamespace').onchange = function(e) {
+    atlasActiveNamespace = e.target.value;
+    renderAtlas();
+  };
+  document.getElementById('atlasRefresh').onclick = function() {
+    atlasLoaded = false; atlasChunks = []; atlasProjection = [];
+    loadAtlas();
+  };
+  var atlasResizeTimer = null;
+  window.addEventListener('resize', function() {
+    if (atlasResizeTimer) clearTimeout(atlasResizeTimer);
+    atlasResizeTimer = setTimeout(renderAtlas, 150);
+  });
+
+  // --- Boot ---
+  checkHealth();
+  loadThreads();
+  setInterval(checkHealth, 15000);
+  console.log('Codexify UI loaded, user=' + userName);
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Lightweight single-HTML web UI served at `/ui` — group chat, doc management, and 2D vector atlas visualisation
- @luna mentions in chat route through n8n webhook for Luna replies alongside Guardian
- Atlas API endpoint enumerates user-scoped chunks with embeddings; browser runs PCA and renders interactive scatter plot on canvas
- API key auth wired through all webui fetch calls
- Accessible over Tailscale at `http://pierats-mac-studio.tailf04071.ts.net:8888/ui`

## Files changed
- `webui-basic/index.html` — full UI (chat, docs, atlas in sidebar tabs)
- `guardian/routes/atlas.py` — paginated, user-scoped chunk listing endpoint
- `guardian/routes/chat.py` — @luna mention interception + n8n webhook routing
- `backend/rag/embedder.py` — `iter_chunks_for_atlas()` for Chroma with numpy-safe accessors
- `guardian/guardian_api.py` — atlas router import, webui-basic static file mount at `/ui`
- `config/supported_profiles/v1-local-core-web-mcp.yaml` — added `atlas` to enabled routes
- `docker-compose.override.yml` — volume mount for webui-basic into backend container

## Security notes

**Deployment model:** Single-tenant, designed for trusted Tailscale access only. Must NOT be exposed to the public internet.

**No per-user isolation** — all participants share the same API key and data scope. All threads, docs, and chunks are visible to anyone with the key.

**Known considerations for this threat model (local/Tailscale-only):**

| Concern | Detail | Risk in our context |
|---|---|---|
| API key in localStorage | Stored client-side, readable by any JS on the same origin | Low — Tailscale-only access, no untrusted scripts |
| API key via `prompt()` | Visible on screen, no input masking | Low — physical access already trusted |
| Atlas total count unfiltered | `collection.count()` returns global count, not per-user filtered | None — single user/tenant |
| @luna n8n webhook sends transcript | Up to 45 messages forwarded to `LUNA_N8N_WEBHOOK_URL` | Low — our own n8n instance, local traffic. Collaborators should be aware their messages route through it |
| `_extract_luna_reply` trusts external response | Parses arbitrary JSON from n8n, writes directly as assistant message | Low — trusted internal n8n, not public-facing |
| `/ui` served unauthenticated | HTML/JS loads before API key is entered | Low — page is inert without valid API key, Tailscale restricts access |
| No rate limiting on `/api/atlas/chunks` | Up to 5000 chunks + embeddings per request | None — trusted network, no abuse vector |

**Data safety:** No chunk data, embeddings, or user content is included in this commit. `.chroma/` is gitignored. All 6,287+ chunks remain local on disk only. Only code was pushed.

## Collaborator note
Chris (and any other Tailnet collaborators) will share the same API key and see all threads, docs, and chunks. @luna mentions from any user forward the thread transcript to the n8n webhook.

## Test plan
- [ ] Open `http://pierats-mac-studio.tailf04071.ts.net:8888/ui`
- [ ] Enter API key and display name when prompted
- [ ] Create a thread, send messages, verify chat polling works
- [ ] Send `@luna` mention, verify n8n webhook fires and reply appears as `[luna]`
- [ ] Send `@guardian` mention, verify normal completion flow
- [ ] Click Docs tab, upload a document, verify it appears in list
- [ ] Click Atlas tab, verify scatter plot renders with namespace-coloured chunks
- [ ] Hover/click chunks on atlas, verify tooltip shows metadata + preview
- [ ] Filter by namespace dropdown, verify scatter updates
- [ ] Test from a second Tailscale device to confirm remote access works

🤖 Generated with [Claude Code](https://claude.com/claude-code)