### PR TITLE
docs: refresh weekly current-state override

### DIFF
--- a/docs/architecture/00-current-state.md
+++ b/docs/architecture/00-current-state.md
@@ -2,7 +2,7 @@
 This file is Codexify's canonical short-form source of truth for current operational and release state. If it conflicts with older architecture, planning, or roadmap language on short-horizon reality, this file wins.
 
 ## Last updated
-2026-06-23
+2026-06-24
 
 ## Interpretation rule
 This file is authoritative for:
@@ -13,14 +13,15 @@ This file is authoritative for:
 - what is and is not part of the present release promise
 
 ## Current phase
-Codexify is in local-first beta hardening on `main`. The supported path remains the local Docker Compose stack with local-only provider posture. Recent merged work on `main` added identity and Scout-facing architecture contracts plus the Zac Mac Studio local bring-up path, but those additions do not widen the release promise.
+Codexify is in local-first beta hardening on `main`. The supported path is still the local Docker Compose stack with local-only provider posture, and the week’s merged work is mostly contract and operator-surface expansion rather than new runtime scope.
 
 ## What changed recently
 - `main` added collab chat identity contract docs.
 - `main` added Scout Vault operator-surface baseline docs.
-- `main` added personal-facts guardrails contract docs.
+- `main` added personal-facts guardrails contract docs and review UI support.
 - `main` added Scout endpoint configuration and iOS Scout Vault remote contract docs.
 - `main` added a Zac Mac Studio local bring-up path.
+- `main` imported OpenAI export conversations into chat history and added Task Prompt Archive.
 - `main` preserved the local-only beta posture and current-state override pattern.
 
 ## Current supported reality

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,9 +1,7 @@
 Purpose: Provide a KB-first entry point into Codexify's current architecture so humans and AI can orient quickly, find the right source files, and plan changes with an accurate map.
-Start here for current-state interpretation and release readiness: [`00-current-state.md`](./00-current-state.md).
-Start here: read [`00-current-state.md`](./00-current-state.md) first for current-state interpretation, release readiness, or short-horizon priorities.
-Start here for live operational truth rather than structural architecture: [`00-current-state.md`](./00-current-state.md).
-If you need current-state interpretation rather than subsystem structure, begin with [`00-current-state.md`](./00-current-state.md).
-Last updated: 2026-06-20
+Start here: read [`00-current-state.md`](./00-current-state.md) first when you need current-state interpretation rather than structural architecture.
+If you need live operational truth, release readiness, or short-horizon priorities, begin with [`00-current-state.md`](./00-current-state.md).
+Last updated: 2026-06-24
 Source anchors:
 - docs/architecture/
 - guardian/guardian_api.py
@@ -27,15 +25,6 @@ Source anchors:
 # Codexify Architecture KB
 
 Start here: read [`00-current-state.md`](./00-current-state.md) first when you need current-state interpretation rather than structural architecture. It is the live operational truth layer for release readiness, supported install path, active blockers, and short-horizon priorities.
-
-Start here with [`00-current-state.md`](./00-current-state.md) when you need current-state interpretation rather than structural architecture.
-
-Start here: if you need current-state interpretation rather than structural architecture, read [`00-current-state.md`](./00-current-state.md) first.
-Use it first for live release/readiness interpretation, supported install path, active blockers, and short-horizon priorities.
-If you need the live weekly interpretation of `main`, start with [`00-current-state.md`](./00-current-state.md).
-Begin with [`00-current-state.md`](./00-current-state.md) whenever you need current-state interpretation rather than subsystem structure.
-
-If you need the live operational truth layer, read [`00-current-state.md`](./00-current-state.md) first and treat the rest of the KB as supporting context.
 
 ## What Codexify Is
 


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
