### PR TITLE
docs(feedback): add issue forms and passive intake guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,0 +1,79 @@
+name: Bug report
+description: Report something that is broken, inconsistent, or failing.
+title: "bug: "
+labels:
+  - bug
+  - intake
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this. Small observations are useful; precise reproduction steps are gold.
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: What happened?
+      description: Describe the behavior you observed.
+      placeholder: "When I clicked the + chat tab, it created multiple empty conversations."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      placeholder: "I expected one new empty tab, or for the + button to be disabled until I typed something."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the smallest sequence of actions that reliably triggers it.
+      placeholder: |
+        1. Open Codexify
+        2. Open project/chat
+        3. Click + twice
+        4. Notice duplicate empty threads
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual result
+      description: Include exact text, errors, screenshots, or logs if available.
+      placeholder: "Two tabs appeared with the same name and I could not tell which one was active."
+    validations:
+      required: false
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - S0 - Blocks core use
+        - S1 - Major workflow break
+        - S2 - Confusing but usable
+        - S3 - Polish / papercut
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser/app, branch, OS, and local ports if relevant.
+      placeholder: "Chrome on macOS, cleanup-webui-atlas, frontend 5173, backend 8888"
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Extra notes
+      description: Anything else that may help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02-ux-friction.yml
+++ b/.github/ISSUE_TEMPLATE/02-ux-friction.yml
@@ -1,0 +1,80 @@
+name: UX friction
+description: Report confusing, uncertain, or awkward interactions that may not be bugs.
+title: "ux: "
+labels:
+  - ux
+  - friction
+  - intake
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when the system technically works, but the interface makes the behavior hard to understand. This is the papercut net.
+
+  - type: textarea
+    id: moment
+    attributes:
+      label: Moment of confusion
+      description: What were you trying to do when the UI felt unclear?
+      placeholder: "I was trying to understand the multi-tab chat behavior."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expectation
+    attributes:
+      label: What you expected
+      placeholder: "I expected the labels to tell me whether I was in an existing chat, a new unsaved chat, or a duplicate."
+    validations:
+      required: true
+
+  - type: textarea
+    id: uncertainty
+    attributes:
+      label: What felt uncertain?
+      description: Capture the user's mental model, not just the visible UI.
+      placeholder: "I could not tell if 'My thread' and 'New thread' were separate conversations, tabs, or copies."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Interaction path
+      description: What did you click or type, in order?
+      placeholder: |
+        1. Opened project chat
+        2. Clicked + in the top-right
+        3. Renamed one thread
+        4. Switched tabs
+    validations:
+      required: false
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Impact
+      options:
+        - Blocks understanding
+        - Causes wrong action
+        - Slows me down
+        - Minor polish issue
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+      description: Optional. A rough idea is fine.
+      placeholder: "Rename 'My thread' to 'Current chat' and disable + while an empty new chat already exists."
+    validations:
+      required: false
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Screenshot, recording, or notes
+      description: Paste screenshots, logs, or raw observations here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/03-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/03-feature-request.yml
@@ -1,0 +1,55 @@
+name: Feature request
+description: Suggest a new capability or workflow improvement.
+title: "feat: "
+labels:
+  - enhancement
+  - intake
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for new capability requests. If something feels confusing but already exists, use UX friction instead.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or workflow gap
+      description: What are you trying to accomplish?
+      placeholder: "I want to toggle multi-tab chat off when I only need one working thread."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      placeholder: "Add a user setting for multi-tab chat: enabled/disabled."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      placeholder: "Disable the + button when an empty tab already exists, instead of adding a global setting."
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - High - unlocks core workflow
+        - Medium - useful soon
+        - Low - nice to have
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Extra context
+      description: Add screenshots, examples from other tools, or rough acceptance criteria.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Feedback intake guide
+    url: https://github.com/Resonant-Jones/Codexify/blob/main/docs/feedback-intake.md
+    about: Use this guide to turn passive notes into structured Codexify feedback.

--- a/docs/feedback-intake.md
+++ b/docs/feedback-intake.md
@@ -1,0 +1,95 @@
+# Codexify Feedback Intake
+
+This document turns casual tester notes into structured GitHub issues.
+
+The goal is simple: testers should be able to tell their assistant what felt broken, confusing, or missing, and the assistant should package it into the right GitHub issue form.
+
+## Where to submit
+
+Open the repository issues page and choose one of the templates:
+
+- **Bug report**: something is broken, inconsistent, or failing.
+- **UX friction**: something technically works, but feels confusing, uncertain, or awkward.
+- **Feature request**: a missing capability or workflow improvement.
+
+Use **UX friction** when the behavior is not clearly wrong, but the interface does not explain itself well.
+
+## Passive capture phrase
+
+Testers can say this to their assistant:
+
+```text
+Log this as Codexify feedback.
+Type: bug | ux friction | feature request | unsure
+Observed:
+Expected:
+Actual:
+Steps:
+Impact:
+Screenshot/logs:
+Environment:
+```
+
+The assistant should ask at most one clarifying question if a required field is missing. Otherwise, it should create or draft a GitHub issue using the closest template.
+
+## Assistant routing rules
+
+Route the report like this:
+
+| Signal | Template |
+| --- | --- |
+| Error, crash, failed request, missing data, broken flow | Bug report |
+| Confusing label, unclear state, awkward click path, uncertain mental model | UX friction |
+| New setting, new control, new capability, workflow improvement | Feature request |
+
+When in doubt, use **UX friction**. A confusing interaction is still real product data.
+
+## Severity / impact guide
+
+### Bugs
+
+- **S0 - Blocks core use**: Cannot use the main chat, documents, provider, auth, or project flow.
+- **S1 - Major workflow break**: A key flow works only with a workaround.
+- **S2 - Confusing but usable**: The feature works but causes wrong expectations or repeat mistakes.
+- **S3 - Polish / papercut**: Small visual, copy, or interaction issue.
+
+### UX friction
+
+- **Blocks understanding**: User cannot infer what the system is doing.
+- **Causes wrong action**: User clicks or changes something because the UI suggested the wrong model.
+- **Slows me down**: User can recover but loses time.
+- **Minor polish issue**: Annoying, but not workflow-breaking.
+
+## Example: multi-tab chat confusion
+
+```text
+Type: ux friction
+Observed: Multi-tab chat allows multiple tabs, but the labels 'My thread' and 'New thread' made it unclear whether these were tabs, conversations, copies, or unsaved drafts.
+Expected: The UI should make it obvious which tab is active, whether a thread is new/empty, and whether a duplicate was intentionally created.
+Actual: Clicking the + button could create multiple empty threads, making the feature feel like a bug even if multi-tab is intentional.
+Steps:
+1. Open a project chat.
+2. Click + in the top-right chat area.
+3. Click + again before typing.
+4. Rename or switch between threads.
+5. Notice it is unclear which thread owns which state.
+Impact: Blocks understanding.
+Suggestion: Disable + while an empty new thread already exists, rename labels to 'Current chat' / '+ New chat', and hide implementation labels unless Dev Mode is enabled.
+```
+
+## Good issue titles
+
+- `ux: clarify multi-tab chat labels and empty-thread behavior`
+- `bug: gallery receives image but chat attachment disappears`
+- `feat: add setting to disable multi-tab chat`
+
+## Intake contract
+
+A useful issue should answer four questions:
+
+1. What did the tester try to do?
+2. What did they expect?
+3. What actually happened?
+4. What evidence or sequence lets us reproduce or reason about it?
+
+Do not force testers to speak like engineers. Capture the uncertainty. The uncertainty is the artifact.


### PR DESCRIPTION
## Summary

Adds a lightweight feedback intake system for Codexify testers:

- GitHub Issue Forms for bug reports, UX friction, and feature requests
- Template chooser config with blank issues disabled
- `docs/feedback-intake.md` with a passive assistant capture phrase and routing rules

## Why

Matariki is surfacing useful product signal, but the feedback needs a low-friction path into the repo. This lets testers casually describe what felt broken or confusing, then their assistant can package it into a structured GitHub issue.

## Activation

After merge, testers can go to **Issues → New issue** and pick the right form, or tell their assistant:

```text
Log this as Codexify feedback.
Type: bug | ux friction | feature request | unsure
Observed:
Expected:
Actual:
Steps:
Impact:
Screenshot/logs:
Environment:
```

For the current multi-tab confusion, use the **UX friction** template rather than Bug report unless reproduction proves actual duplicate data corruption.