### PR TITLE
feat(worktree): add read-only worktree lane discovery

### DIFF
--- a/guardian/guardian_api.py
+++ b/guardian/guardian_api.py
@@ -548,6 +548,7 @@ from guardian.routes.projects import ensure_default_project
 from guardian.routes.projects import router as projects_router
 from guardian.routes.user_profile import router as user_profile_router
 from guardian.routes.voice import router as voice_router
+from guardian.routes.worktrees import router as worktrees_router
 from guardian.voice.config import get_voice_runtime_config
 from guardian.voice.runtime import SUPPORTED_INPUT_MIME
 from guardian.voice.service import validate_voice_runtime_dependencies
@@ -1284,6 +1285,11 @@ _include_router(
     include_fn=lambda: app.include_router(continuity_operator.router),
     default_enabled=False,
     core_surface=False,
+)
+_include_router(
+    label="worktrees",
+    flag_name="CODEXIFY_ENABLE_WORKTREE_ROUTES",
+    include_fn=lambda: app.include_router(worktrees_router),
 )
 
 logger.info(

--- a/guardian/routes/worktrees.py
+++ b/guardian/routes/worktrees.py
@@ -1,0 +1,143 @@
+"""Read-only Worktree Lane operator route.
+
+Exposes discovered worktree lanes as structured JSON for the Operator
+Workbench. This route performs discovery + state collection on every call (an
+explicit refresh action is provided as well) and never mutates the repo, the
+index, branches, or files.
+
+Only metadata is returned: path, branch, commit SHA, status counts, upstream
+name, ahead/behind counts, and risk flags. No file contents or diffs are
+inspected or exposed.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from guardian.core.dependencies import require_api_key
+from guardian.worktrees.service import (
+    REPO_PATH_ENV,
+    discover_worktree_lanes,
+    resolve_repo_path,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["worktrees"])
+
+
+class WorktreeLaneModel(BaseModel):
+    """API projection of a single worktree lane."""
+
+    repo_path: str
+    worktree_path: str
+    branch: Optional[str] = None
+    head_sha: Optional[str] = None
+    detached: bool = False
+    bare: bool = False
+    dirty_file_count: int = 0
+    staged_file_count: int = 0
+    unstaged_file_count: int = 0
+    untracked_file_count: int = 0
+    upstream: Optional[str] = None
+    ahead_count: Optional[int] = None
+    behind_count: Optional[int] = None
+    risk_flags: list[str] = Field(default_factory=list)
+    exists: bool = True
+
+
+class WorktreeLanesResponse(BaseModel):
+    """Full operator worktree-lane discovery response."""
+
+    repo_path: str
+    repo_path_source: str
+    lane_count: int
+    lanes: list[WorktreeLaneModel]
+    warnings: list[str] = Field(default_factory=list)
+
+
+def _build_response(repo_path: str, source: str) -> WorktreeLanesResponse:
+    discovery = discover_worktree_lanes(repo_path, repo_path_source=source)
+    if discovery.errors:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "repo_path": discovery.repo_path,
+                "errors": discovery.errors,
+            },
+        )
+    lanes = [
+        WorktreeLaneModel(
+            repo_path=lane.repo_path,
+            worktree_path=lane.worktree_path,
+            branch=lane.branch,
+            head_sha=lane.head_sha,
+            detached=lane.detached,
+            bare=lane.bare,
+            dirty_file_count=lane.dirty_file_count,
+            staged_file_count=lane.staged_file_count,
+            unstaged_file_count=lane.unstaged_file_count,
+            untracked_file_count=lane.untracked_file_count,
+            upstream=lane.upstream,
+            ahead_count=lane.ahead_count,
+            behind_count=lane.behind_count,
+            risk_flags=list(lane.risk_flags),
+            exists=lane.exists,
+        )
+        for lane in discovery.lanes
+    ]
+    return WorktreeLanesResponse(
+        repo_path=discovery.repo_path,
+        repo_path_source=discovery.repo_path_source,
+        lane_count=len(lanes),
+        lanes=lanes,
+        warnings=list(discovery.warnings),
+    )
+
+
+@router.get(
+    "/api/worktrees/lanes",
+    response_model=WorktreeLanesResponse,
+    summary="List worktree lanes (read-only)",
+)
+async def list_worktree_lanes(
+    repo_path: Optional[str] = Query(
+        default=None,
+        description=(
+            "Repository path to inspect. Defaults to the " f"{REPO_PATH_ENV} env var."
+        ),
+    ),
+    api_key: str = Depends(require_api_key),
+) -> WorktreeLanesResponse:
+    """Return the current operational state of every worktree lane.
+
+    Re-runs discovery and read-only state collection on each call. Does not
+    inspect or expose file contents.
+    """
+    _ = api_key
+    resolved, source = resolve_repo_path(repo_path)
+    assert resolved is not None  # resolve_repo_path always falls back
+    return _build_response(resolved, source)
+
+
+@router.post(
+    "/api/worktrees/refresh",
+    response_model=WorktreeLanesResponse,
+    summary="Refresh worktree lanes (read-only)",
+)
+async def refresh_worktree_lanes(
+    repo_path: Optional[str] = Query(default=None),
+    api_key: str = Depends(require_api_key),
+) -> WorktreeLanesResponse:
+    """Explicit refresh action: re-run discovery and state collection.
+
+    Identical to ``GET /api/worktrees/lanes`` and equally non-mutating.
+    """
+    _ = api_key
+    resolved, source = resolve_repo_path(repo_path)
+    assert resolved is not None
+    return _build_response(resolved, source)

--- a/guardian/worktrees/__init__.py
+++ b/guardian/worktrees/__init__.py
@@ -1,0 +1,47 @@
+"""Read-only Worktree Lane MVP package.
+
+Discovers local Git worktrees for a configured repository and reports their
+operational state (branch, HEAD, dirty/staged/untracked counts, upstream,
+ahead/behind, and risk flags) without mutating anything.
+
+See ``docs/architecture/agent-protocol-operations.md`` and the Worktree Lane
+MVP task spec for the visibility-only boundary this package enforces.
+"""
+
+from __future__ import annotations
+
+from guardian.worktrees.model import (
+    MAIN_BRANCHES,
+    RawWorktreeEntry,
+    StatusCounts,
+    WorktreeDiscovery,
+    WorktreeLane,
+)
+from guardian.worktrees.parser import normalize_branch, parse_worktree_porcelain
+from guardian.worktrees.risk import classify_risk_flags
+from guardian.worktrees.service import (
+    DEFAULT_GIT_TIMEOUT_SECONDS,
+    GitError,
+    discover_worktree_lanes,
+    resolve_repo_path,
+    run_git,
+)
+from guardian.worktrees.status import parse_ahead_behind, parse_status_short
+
+__all__ = [
+    "DEFAULT_GIT_TIMEOUT_SECONDS",
+    "GitError",
+    "MAIN_BRANCHES",
+    "RawWorktreeEntry",
+    "StatusCounts",
+    "WorktreeDiscovery",
+    "WorktreeLane",
+    "classify_risk_flags",
+    "discover_worktree_lanes",
+    "normalize_branch",
+    "parse_ahead_behind",
+    "parse_status_short",
+    "parse_worktree_porcelain",
+    "resolve_repo_path",
+    "run_git",
+]

--- a/guardian/worktrees/model.py
+++ b/guardian/worktrees/model.py
@@ -1,0 +1,84 @@
+"""Data models for the read-only Worktree Lane MVP.
+
+These models are intentionally plain dataclasses so the parser, status, and
+risk-classification layers stay free of framework dependencies and easy to
+unit-test. The FastAPI route layer projects them into pydantic response models.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+# Branch names that are treated as the protected "main" lane for risk
+# classification (``dirty_main`` vs ``dirty_worktree``). Kept narrow on
+# purpose: the repo ships on ``main``.
+MAIN_BRANCHES: tuple[str, ...] = ("main", "master")
+
+
+@dataclass
+class RawWorktreeEntry:
+    """A single parsed record from ``git worktree list --porcelain``.
+
+    ``branch_ref`` is the raw symbolic ref (e.g. ``refs/heads/main``) when
+    present. Detached worktrees have ``detached=True`` and ``branch_ref=None``.
+    Bare worktrees have ``bare=True`` and typically no HEAD/branch.
+    """
+
+    worktree_path: Optional[str] = None
+    head_sha: Optional[str] = None
+    branch_ref: Optional[str] = None
+    detached: bool = False
+    bare: bool = False
+
+
+@dataclass
+class StatusCounts:
+    """Aggregated counts derived from ``git status --short`` output."""
+
+    staged: int = 0
+    unstaged: int = 0
+    untracked: int = 0
+    dirty: int = 0
+
+
+@dataclass
+class WorktreeLane:
+    """Full operator-facing state for a single worktree lane.
+
+    Mirrors the required MVP data model. Two additive helper fields are kept:
+
+    * ``exists``        — False when the worktree folder is missing/deleted.
+    * ``had_git_error`` — True when a read-only git command failed
+      unexpectedly (drives the ``git_state_error`` risk flag).
+    """
+
+    repo_path: str
+    worktree_path: str
+    branch: Optional[str] = None
+    head_sha: Optional[str] = None
+    detached: bool = False
+    bare: bool = False
+    dirty_file_count: int = 0
+    staged_file_count: int = 0
+    unstaged_file_count: int = 0
+    untracked_file_count: int = 0
+    upstream: Optional[str] = None
+    ahead_count: Optional[int] = None
+    behind_count: Optional[int] = None
+    risk_flags: list[str] = field(default_factory=list)
+    # Additive operator helpers (not part of the required model shape).
+    exists: bool = True
+    had_git_error: bool = False
+
+
+@dataclass
+class WorktreeDiscovery:
+    """Result of discovering and inspecting all worktree lanes for a repo."""
+
+    repo_path: str
+    repo_path_source: str = "env"
+    lanes: list[WorktreeLane] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)

--- a/guardian/worktrees/parser.py
+++ b/guardian/worktrees/parser.py
@@ -1,0 +1,94 @@
+"""Pure parser for ``git worktree list --porcelain``.
+
+The parser is deliberately string-in / structured-out so it can be unit-tested
+without a git binary. It tolerates partial, empty, and malformed porcelain
+output without raising.
+"""
+
+from __future__ import annotations
+
+from guardian.worktrees.model import RawWorktreeEntry
+
+
+def normalize_branch(branch_ref: str | None) -> str | None:
+    """Convert a symbolic ref like ``refs/heads/main`` to ``main``.
+
+    Returns ``None`` for empty/detached input. Non-``refs/heads/`` refs are
+    returned stripped as-is so unusual branch refs are still visible.
+    """
+    if branch_ref is None:
+        return None
+    ref = branch_ref.strip()
+    if not ref:
+        return None
+    prefix = "refs/heads/"
+    if ref.startswith(prefix):
+        stripped = ref[len(prefix) :].strip()
+        return stripped or None
+    return ref
+
+
+def _entry_from_block(block: dict[str, object]) -> RawWorktreeEntry | None:
+    """Build a ``RawWorktreeEntry`` from a parsed block, or None if invalid.
+
+    A block without a ``worktree`` path is treated as malformed and skipped.
+    """
+    worktree_path = block.get("worktree_path")
+    if not isinstance(worktree_path, str) or not worktree_path.strip():
+        return None
+    head_sha_raw = block.get("head_sha")
+    branch_ref_raw = block.get("branch_ref")
+    return RawWorktreeEntry(
+        worktree_path=worktree_path.strip(),
+        head_sha=head_sha_raw if isinstance(head_sha_raw, str) else None,
+        branch_ref=branch_ref_raw if isinstance(branch_ref_raw, str) else None,
+        detached=bool(block.get("detached", False)),
+        bare=bool(block.get("bare", False)),
+    )
+
+
+def parse_worktree_porcelain(text: str) -> list[RawWorktreeEntry]:
+    """Parse porcelain output into a list of raw worktree entries.
+
+    Supports the documented porcelain keys (``worktree``, ``HEAD``,
+    ``branch``, ``detached``, ``bare``) and tolerates extra/unknown lines such
+    as ``locked`` / ``prunable`` by ignoring them. Entries are separated by
+    blank lines; a trailing block without a following blank line is still
+    captured.
+    """
+    entries: list[RawWorktreeEntry] = []
+    current: dict[str, object] | None = None
+
+    def _flush() -> None:
+        nonlocal current
+        if current is not None:
+            entry = _entry_from_block(current)
+            if entry is not None:
+                entries.append(entry)
+            current = None
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip("\r")
+        if not line.strip():
+            _flush()
+            continue
+        if current is None:
+            current = {}
+        parts = line.split(" ", 1)
+        key = parts[0]
+        value = parts[1] if len(parts) > 1 else ""
+        if key == "worktree":
+            current["worktree_path"] = value
+        elif key == "HEAD":
+            current["head_sha"] = value or None
+        elif key == "branch":
+            current["branch_ref"] = value or None
+        elif key == "detached":
+            current["detached"] = True
+        elif key == "bare":
+            current["bare"] = True
+        # Other recognized-but-ignored porcelain flags (locked, prunable,
+        # and any future unknown lines) are intentionally dropped so a
+        # newer git cannot crash the parser.
+    _flush()
+    return entries

--- a/guardian/worktrees/risk.py
+++ b/guardian/worktrees/risk.py
@@ -1,0 +1,53 @@
+"""Pure risk-flag classification for worktree lanes.
+
+Given a populated :class:`~guardian.worktrees.model.WorktreeLane`, produce the
+deterministic ordered list of risk flags. This is a pure function so the risk
+flag matrix can be unit-tested without git.
+"""
+
+from __future__ import annotations
+
+from guardian.worktrees.model import MAIN_BRANCHES, WorktreeLane
+
+
+def classify_risk_flags(lane: WorktreeLane) -> list[str]:
+    """Return the ordered risk flags for a lane.
+
+    Flags are ordered roughly by severity so the most actionable state
+    surfaces first:
+
+    ``git_state_error`` -> ``missing_head`` -> ``detached_head`` ->
+    ``dirty_main`` / ``dirty_worktree`` -> ``staged_changes`` ->
+    ``untracked_files`` -> ``no_upstream`` -> ``behind_upstream``.
+    """
+    flags: list[str] = []
+
+    if lane.had_git_error:
+        flags.append("git_state_error")
+
+    if lane.head_sha is None and not lane.bare:
+        flags.append("missing_head")
+
+    if lane.detached:
+        flags.append("detached_head")
+
+    is_main = lane.branch in MAIN_BRANCHES
+    if lane.dirty_file_count > 0:
+        flags.append("dirty_main" if is_main else "dirty_worktree")
+
+    if lane.staged_file_count > 0:
+        flags.append("staged_changes")
+
+    if lane.untracked_file_count > 0:
+        flags.append("untracked_files")
+
+    # A detached HEAD or bare worktree has no branch upstream by definition;
+    # ``detached_head`` / bare state already flags it, so ``no_upstream`` is
+    # only meaningful for real branches that lack an upstream.
+    if lane.upstream is None and not lane.detached and not lane.bare:
+        flags.append("no_upstream")
+
+    if lane.behind_count is not None and lane.behind_count > 0:
+        flags.append("behind_upstream")
+
+    return flags

--- a/guardian/worktrees/service.py
+++ b/guardian/worktrees/service.py
@@ -1,0 +1,241 @@
+"""Read-only worktree discovery and state collection service.
+
+This is the visibility layer. It runs ONLY the allowed read-only git commands
+documented in the MVP spec and must never mutate the repository, working tree,
+index, or branches. All mutation commands are out of scope and forbidden.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Protocol
+
+from guardian.worktrees.model import RawWorktreeEntry, WorktreeDiscovery, WorktreeLane
+from guardian.worktrees.parser import normalize_branch, parse_worktree_porcelain
+from guardian.worktrees.risk import classify_risk_flags
+from guardian.worktrees.status import parse_ahead_behind, parse_status_short
+
+logger = logging.getLogger(__name__)
+
+# Environment variable that selects which local repo to inspect.
+REPO_PATH_ENV = "CODEXIFY_WORKTREE_REPO_PATH"
+# Hard ceiling on any single read-only git call so a hung git cannot wedge the
+# operator surface indefinitely.
+DEFAULT_GIT_TIMEOUT_SECONDS = 15.0
+
+
+class GitError(RuntimeError):
+    """Raised when a read-only git command fails unexpectedly."""
+
+
+# A git runner takes an argv list (without the leading "git") and the worktree
+# cwd, and returns stdout. It is injectable so tests can avoid subprocess.
+class GitRunner(Protocol):
+    def __call__(self, args: list[str], *, cwd: str) -> str: ...
+
+
+def run_git(
+    args: list[str],
+    *,
+    cwd: str,
+    timeout: float = DEFAULT_GIT_TIMEOUT_SECONDS,
+) -> str:
+    """Run a read-only git command and return stdout.
+
+    Uses an argv list (never ``shell=True``) so refspec tokens such as
+    ``@{u}`` reach git verbatim without shell expansion or injection risk.
+    Raises :class:`GitError` on non-zero exit, timeout, or OS-level failure.
+    """
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise GitError(
+            f"git {' '.join(args)} timed out after {timeout}s in {cwd}"
+        ) from exc
+    except OSError as exc:
+        raise GitError(f"git invocation failed in {cwd}: {exc}") from exc
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        raise GitError(
+            f"git {' '.join(args)} failed in {cwd} "
+            f"(rc={result.returncode}): {stderr[:300]}"
+        )
+    return result.stdout
+
+
+def resolve_repo_path(
+    explicit: str | None = None,
+    *,
+    env: dict[str, str] | None = None,
+) -> tuple[str | None, str]:
+    """Resolve the repo path to inspect and report where it came from.
+
+    Precedence: explicit argument -> ``CODEXIFY_WORKTREE_REPO_PATH`` env ->
+    development default (the repo this package ships in, clearly labeled).
+
+    Returns ``(path_or_none, source)`` where source is one of
+    ``"query"``, ``"env"``, or ``"dev_default"``.
+    """
+    env = env if env is not None else os.environ
+    if explicit and explicit.strip():
+        return explicit.strip(), "query"
+    env_value = (env.get(REPO_PATH_ENV) or "").strip()
+    if env_value:
+        return env_value, "env"
+    # Clearly-marked development default only: the repo this code ships in.
+    dev_default = Path(__file__).resolve().parents[2]
+    return str(dev_default), "dev_default"
+
+
+def discover_worktree_lanes(
+    repo_path: str,
+    *,
+    repo_path_source: str = "env",
+    git_runner: GitRunner = run_git,
+) -> WorktreeDiscovery:
+    """Discover all worktrees for ``repo_path`` and collect their lane state.
+
+    Non-destructive: only runs read-only git commands. If the repo cannot be
+    inspected at all, returns a :class:`WorktreeDiscovery` with a populated
+    ``errors`` list (the caller decides how to surface that). Per-worktree
+    problems (missing folder, missing upstream) degrade gracefully into lane
+    warnings/risk flags rather than failing the whole discovery.
+    """
+    repo = Path(repo_path)
+    if not repo.exists() or not repo.is_dir():
+        return WorktreeDiscovery(
+            repo_path=str(repo),
+            repo_path_source=repo_path_source,
+            errors=["repo_path does not exist or is not a directory"],
+        )
+
+    porcelain: str
+    try:
+        porcelain = git_runner(["worktree", "list", "--porcelain"], cwd=str(repo))
+    except GitError as exc:
+        return WorktreeDiscovery(
+            repo_path=str(repo),
+            repo_path_source=repo_path_source,
+            errors=[
+                "repo_path is not a Git repository or git is unavailable: " + str(exc)
+            ],
+        )
+
+    raw_entries = parse_worktree_porcelain(porcelain)
+    lanes: list[WorktreeLane] = []
+    warnings: list[str] = []
+    for raw in raw_entries:
+        lane = _collect_lane_state(raw, repo_path=str(repo), git_runner=git_runner)
+        if not lane.exists:
+            warnings.append(f"worktree path no longer exists: {lane.worktree_path}")
+        lanes.append(lane)
+
+    if not lanes:
+        warnings.append("no worktrees discovered beyond main")
+
+    return WorktreeDiscovery(
+        repo_path=str(repo),
+        repo_path_source=repo_path_source,
+        lanes=lanes,
+        warnings=warnings,
+    )
+
+
+def _collect_lane_state(
+    raw: RawWorktreeEntry,
+    *,
+    repo_path: str,
+    git_runner: GitRunner,
+) -> WorktreeLane:
+    """Collect full state for one worktree from read-only git commands."""
+    worktree_path = raw.worktree_path or ""
+    lane = WorktreeLane(
+        repo_path=repo_path,
+        worktree_path=worktree_path,
+        branch=normalize_branch(raw.branch_ref),
+        head_sha=raw.head_sha,
+        detached=raw.detached,
+        bare=raw.bare,
+    )
+
+    wt_path = Path(worktree_path)
+    if not worktree_path or not wt_path.exists():
+        # Deleted/missing worktree folder: keep porcelain-derived facts, do not
+        # attempt to run git inside a non-existent cwd. Mark missing so the
+        # operator gets a clear warning instead of a crash.
+        lane.exists = False
+        lane.risk_flags = classify_risk_flags(lane)
+        return lane
+
+    # Branch confirmation (empty output => detached).
+    try:
+        branch_out = git_runner(["branch", "--show-current"], cwd=worktree_path)
+        current = branch_out.strip()
+        if current:
+            lane.branch = current
+            lane.detached = False
+        else:
+            lane.detached = True
+            lane.branch = None
+    except GitError:
+        lane.had_git_error = True
+
+    # HEAD sha.
+    try:
+        head_out = git_runner(["rev-parse", "HEAD"], cwd=worktree_path)
+        sha = head_out.strip()
+        lane.head_sha = sha or None
+    except GitError:
+        lane.head_sha = None
+        lane.had_git_error = True
+
+    # Dirty / staged / unstaged / untracked counts.
+    try:
+        status_out = git_runner(["status", "--short"], cwd=worktree_path)
+        counts = parse_status_short(status_out)
+        lane.staged_file_count = counts.staged
+        lane.unstaged_file_count = counts.unstaged
+        lane.untracked_file_count = counts.untracked
+        lane.dirty_file_count = counts.dirty
+    except GitError:
+        lane.had_git_error = True
+
+    # Upstream + ahead/behind only apply to real (non-detached, non-bare)
+    # branches. A missing upstream is an expected condition and is surfaced
+    # via the ``no_upstream`` risk flag rather than ``git_state_error``.
+    if not lane.detached and not lane.bare:
+        try:
+            up_out = git_runner(
+                ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+                cwd=worktree_path,
+            )
+            upstream = up_out.strip()
+            lane.upstream = upstream or None
+        except GitError:
+            lane.upstream = None
+
+        if lane.upstream is not None:
+            try:
+                ab_out = git_runner(
+                    ["rev-list", "--left-right", "--count", "HEAD...@{u}"],
+                    cwd=worktree_path,
+                )
+                ahead, behind = parse_ahead_behind(ab_out)
+                lane.ahead_count = ahead
+                lane.behind_count = behind
+            except GitError:
+                lane.had_git_error = True
+
+    lane.risk_flags = classify_risk_flags(lane)
+    return lane

--- a/guardian/worktrees/status.py
+++ b/guardian/worktrees/status.py
@@ -1,0 +1,66 @@
+"""Pure parsers for read-only git status / ahead-behind output.
+
+Both functions are string-in / structured-out so they can be unit-tested
+without a git binary.
+"""
+
+from __future__ import annotations
+
+from guardian.worktrees.model import StatusCounts
+
+
+def parse_status_short(text: str) -> StatusCounts:
+    """Parse ``git status --short`` output into staged/unstaged/untracked counts.
+
+    Interpetation (per the MVP spec):
+
+    * Lines beginning with ``??`` count as untracked.
+    * First status column (index) non-blank counts as staged.
+    * Second status column (worktree) non-blank counts as unstaged.
+    * Any non-empty status line counts toward the total dirty file count.
+
+    A file that is both staged and unstaged (e.g. ``MM``) increments both
+    counters but still counts as a single dirty file.
+    """
+    counts = StatusCounts()
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip("\r")
+        if not line:
+            continue
+        # A well-formed porcelain v1 status line is at least "XY <path>".
+        if len(line) < 2:
+            continue
+        x = line[0]
+        y = line[1]
+        if line.startswith("??"):
+            counts.untracked += 1
+            counts.dirty += 1
+            continue
+        if x != " ":
+            counts.staged += 1
+        if y != " ":
+            counts.unstaged += 1
+        counts.dirty += 1
+    return counts
+
+
+def parse_ahead_behind(text: str) -> tuple[int | None, int | None]:
+    """Parse ``git rev-list --left-right --count HEAD...@{u}`` output.
+
+    Output is two whitespace-separated integers: ``<ahead>\\t<behind>`` where
+    ``ahead`` is commits reachable from HEAD but not the upstream, and
+    ``behind`` is the reverse. Returns ``(None, None)`` on empty/malformed
+    output instead of raising.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return (None, None)
+    parts = stripped.split()
+    if len(parts) != 2:
+        return (None, None)
+    try:
+        ahead = int(parts[0])
+        behind = int(parts[1])
+    except ValueError:
+        return (None, None)
+    return (ahead, behind)

--- a/tests/routes/test_worktrees_route.py
+++ b/tests/routes/test_worktrees_route.py
@@ -1,0 +1,130 @@
+"""Tests for the read-only worktree lane operator route.
+
+Mounts only the worktrees router on a minimal FastAPI app (avoiding the full
+guardian_api bootstrap) and overrides auth + discovery so no subprocess or DB
+is required.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from guardian.routes import worktrees as worktrees_routes
+from guardian.worktrees.model import WorktreeDiscovery, WorktreeLane
+
+
+def _make_app(discovery: WorktreeDiscovery) -> FastAPI:
+    app = FastAPI()
+    app.include_router(worktrees_routes.router)
+    app.dependency_overrides[worktrees_routes.require_api_key] = lambda: "key"
+    worktrees_routes.discover_worktree_lanes = lambda *args, **kwargs: discovery
+    return app
+
+
+def _sample_discovery() -> WorktreeDiscovery:
+    lanes = [
+        WorktreeLane(
+            repo_path="/repo",
+            worktree_path="/repo",
+            branch="main",
+            head_sha="aaa111",
+            upstream="origin/main",
+            ahead_count=0,
+            behind_count=0,
+        ),
+        WorktreeLane(
+            repo_path="/repo",
+            worktree_path="/repo/feat",
+            branch="feat/lane",
+            head_sha="bbb222",
+            upstream="origin/feat/lane",
+            ahead_count=1,
+            behind_count=2,
+            dirty_file_count=2,
+            staged_file_count=1,
+            untracked_file_count=1,
+            risk_flags=[
+                "dirty_worktree",
+                "staged_changes",
+                "untracked_files",
+                "behind_upstream",
+            ],
+        ),
+        WorktreeLane(
+            repo_path="/repo",
+            worktree_path="/repo/gone",
+            branch=None,
+            head_sha="ccc333",
+            detached=True,
+            risk_flags=["detached_head"],
+            exists=False,
+        ),
+    ]
+    return WorktreeDiscovery(
+        repo_path="/repo",
+        repo_path_source="query",
+        lanes=lanes,
+        warnings=["worktree path no longer exists: /repo/gone"],
+    )
+
+
+def test_list_lanes_returns_structured_state() -> None:
+    app = _make_app(_sample_discovery())
+    client = TestClient(app)
+    resp = client.get("/api/worktrees/lanes", params={"repo_path": "/repo"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["repo_path"] == "/repo"
+    assert body["repo_path_source"] == "query"
+    assert body["lane_count"] == 3
+    assert len(body["lanes"]) == 3
+
+    main_lane = next(lane for lane in body["lanes"] if lane["worktree_path"] == "/repo")
+    assert main_lane["branch"] == "main"
+    assert main_lane["head_sha"] == "aaa111"
+    assert main_lane["upstream"] == "origin/main"
+    assert main_lane["risk_flags"] == []
+
+    feat_lane = next(
+        lane for lane in body["lanes"] if lane["worktree_path"] == "/repo/feat"
+    )
+    assert feat_lane["dirty_file_count"] == 2
+    assert feat_lane["staged_file_count"] == 1
+    assert feat_lane["untracked_file_count"] == 1
+    assert feat_lane["ahead_count"] == 1
+    assert feat_lane["behind_count"] == 2
+    assert "behind_upstream" in feat_lane["risk_flags"]
+
+    gone_lane = next(
+        lane for lane in body["lanes"] if lane["worktree_path"] == "/repo/gone"
+    )
+    assert gone_lane["exists"] is False
+    assert gone_lane["detached"] is True
+    assert "detached_head" in gone_lane["risk_flags"]
+    assert any("no longer exists" in w for w in body["warnings"])
+
+
+def test_refresh_returns_same_shape() -> None:
+    app = _make_app(_sample_discovery())
+    client = TestClient(app)
+    resp = client.post("/api/worktrees/refresh", params={"repo_path": "/repo"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["lane_count"] == 3
+    assert body["repo_path_source"] == "query"
+
+
+def test_discovery_errors_return_400() -> None:
+    discovery = WorktreeDiscovery(
+        repo_path="/nope",
+        repo_path_source="env",
+        errors=["repo_path does not exist or is not a directory"],
+    )
+    app = _make_app(discovery)
+    client = TestClient(app)
+    resp = client.get("/api/worktrees/lanes")
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert detail["repo_path"] == "/nope"
+    assert any("does not exist" in e for e in detail["errors"])

--- a/tests/worktrees/test_parser.py
+++ b/tests/worktrees/test_parser.py
@@ -1,0 +1,178 @@
+"""Tests for the ``git worktree list --porcelain`` parser.
+
+Covers the MVP porcelain test matrix: single main worktree, multiple
+worktrees, detached, bare, missing branch line, unexpected extra lines, empty
+output, and malformed output. Also covers ``refs/heads/`` normalization.
+"""
+
+from __future__ import annotations
+
+from guardian.worktrees.parser import normalize_branch, parse_worktree_porcelain
+
+
+# ---------------------------------------------------------------------------
+# normalize_branch
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_branch_strips_refs_heads_prefix() -> None:
+    assert normalize_branch("refs/heads/main") == "main"
+
+
+def test_normalize_branch_handles_feature_slash() -> None:
+    assert normalize_branch("refs/heads/feat/worktree-lane-mvp") == (
+        "feat/worktree-lane-mvp"
+    )
+
+
+def test_normalize_branch_none_for_detached() -> None:
+    assert normalize_branch(None) is None
+
+
+def test_normalize_branch_empty_string_is_none() -> None:
+    assert normalize_branch("") is None
+    assert normalize_branch("   ") is None
+
+
+def test_normalize_branch_passes_through_non_heads_ref() -> None:
+    assert normalize_branch("refs/tags/v1") == "refs/tags/v1"
+
+
+# ---------------------------------------------------------------------------
+# parse_worktree_porcelain — required porcelain matrix
+# ---------------------------------------------------------------------------
+
+
+def test_single_main_worktree() -> None:
+    porcelain = (
+        "worktree /Users/chris/Repos/Codexify\n"
+        "HEAD abc123\n"
+        "branch refs/heads/main\n"
+    )
+    entries = parse_worktree_porcelain(porcelain)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.worktree_path == "/Users/chris/Repos/Codexify"
+    assert entry.head_sha == "abc123"
+    assert entry.branch_ref == "refs/heads/main"
+    assert entry.detached is False
+    assert entry.bare is False
+
+
+def test_multiple_worktrees() -> None:
+    porcelain = (
+        "worktree /Users/chris/Repos/Codexify\n"
+        "HEAD abc123\n"
+        "branch refs/heads/main\n"
+        "\n"
+        "worktree /Users/chris/Repos/Codexify-queue\n"
+        "HEAD def456\n"
+        "branch refs/heads/feat/worktree-lane-mvp\n"
+    )
+    entries = parse_worktree_porcelain(porcelain)
+    assert len(entries) == 2
+    assert entries[0].worktree_path == "/Users/chris/Repos/Codexify"
+    assert entries[1].worktree_path == "/Users/chris/Repos/Codexify-queue"
+    assert entries[1].branch_ref == "refs/heads/feat/worktree-lane-mvp"
+    assert entries[1].head_sha == "def456"
+
+
+def test_detached_worktree() -> None:
+    porcelain = (
+        "worktree /Users/chris/Repos/Codexify-detached\n" "HEAD deadbeef\n" "detached\n"
+    )
+    entries = parse_worktree_porcelain(porcelain)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.detached is True
+    assert entry.bare is False
+    assert entry.branch_ref is None
+    assert entry.head_sha == "deadbeef"
+
+
+def test_bare_worktree_marker() -> None:
+    porcelain = "worktree /Users/chris/Repos/Codexify.git\nbare\n"
+    entries = parse_worktree_porcelain(porcelain)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.bare is True
+    assert entry.detached is False
+    assert entry.branch_ref is None
+
+
+def test_missing_branch_line_keeps_entry_with_none_branch() -> None:
+    porcelain = "worktree /Users/chris/Repos/Codexify\n" "HEAD abc123\n"
+    entries = parse_worktree_porcelain(porcelain)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.branch_ref is None
+    assert entry.detached is False
+    assert entry.bare is False
+    assert entry.head_sha == "abc123"
+
+
+def test_unexpected_extra_porcelain_lines_are_ignored() -> None:
+    porcelain = (
+        "worktree /Users/chris/Repos/Codexify\n"
+        "HEAD abc123\n"
+        "branch refs/heads/main\n"
+        "locked\n"
+        "prunable gc\n"
+        "future-unknown-flag value\n"
+    )
+    entries = parse_worktree_porcelain(porcelain)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.worktree_path == "/Users/chris/Repos/Codexify"
+    assert entry.branch_ref == "refs/heads/main"
+    assert entry.head_sha == "abc123"
+
+
+def test_empty_porcelain_output() -> None:
+    assert parse_worktree_porcelain("") == []
+    assert parse_worktree_porcelain("\n\n\n") == []
+    assert parse_worktree_porcelain("   \n  \n") == []
+
+
+def test_malformed_porcelain_output_skips_block_without_worktree() -> None:
+    # Block missing a worktree path is dropped; a trailing good block still
+    # parses.
+    porcelain = (
+        "HEAD orphansa\n"
+        "branch refs/heads/orphan\n"
+        "\n"
+        "worktree /Users/chris/Repos/Real\n"
+        "HEAD real123\n"
+        "branch refs/heads/main\n"
+    )
+    entries = parse_worktree_porcelain(porcelain)
+    assert len(entries) == 1
+    assert entries[0].worktree_path == "/Users/chris/Repos/Real"
+
+
+def test_trailing_blank_line_does_not_create_empty_entry() -> None:
+    porcelain = (
+        "worktree /Users/chris/Repos/Codexify\n"
+        "HEAD abc123\n"
+        "branch refs/heads/main\n"
+        "\n"
+    )
+    entries = parse_worktree_porcelain(porcelain)
+    assert len(entries) == 1
+    assert entries[0].worktree_path == "/Users/chris/Repos/Codexify"
+
+
+def test_crlf_line_endings_are_handled() -> None:
+    porcelain = (
+        "worktree /Users/chris/Repos/Codexify\r\n"
+        "HEAD abc123\r\n"
+        "branch refs/heads/main\r\n"
+        "\r\n"
+        "worktree /Users/chris/Repos/Other\r\n"
+        "HEAD def456\r\n"
+        "detached\r\n"
+    )
+    entries = parse_worktree_porcelain(porcelain)
+    assert len(entries) == 2
+    assert entries[1].detached is True
+    assert entries[1].head_sha == "def456"

--- a/tests/worktrees/test_risk_flags.py
+++ b/tests/worktrees/test_risk_flags.py
@@ -1,0 +1,132 @@
+"""Tests for worktree risk-flag classification.
+
+Covers the MVP risk matrix: dirty main, dirty feature worktree, detached
+HEAD, no upstream, behind upstream, staged changes, untracked files, missing
+HEAD, plus the ``git_state_error`` flag and a clean lane.
+"""
+
+from __future__ import annotations
+
+from guardian.worktrees.model import WorktreeLane
+from guardian.worktrees.risk import classify_risk_flags
+
+
+def _lane(**kwargs: object) -> WorktreeLane:
+    base = dict(
+        repo_path="/repo",
+        worktree_path="/repo",
+        branch="feat/x",
+        head_sha="abc123",
+        detached=False,
+        bare=False,
+        dirty_file_count=0,
+        staged_file_count=0,
+        unstaged_file_count=0,
+        untracked_file_count=0,
+        upstream="origin/feat/x",
+        ahead_count=0,
+        behind_count=0,
+    )
+    base.update(kwargs)
+    return WorktreeLane(**base)  # type: ignore[arg-type]
+
+
+def test_dirty_main_flagged() -> None:
+    lane = _lane(branch="main", dirty_file_count=2)
+    assert "dirty_main" in classify_risk_flags(lane)
+    assert "dirty_worktree" not in classify_risk_flags(lane)
+
+
+def test_dirty_master_also_treated_as_main() -> None:
+    lane = _lane(branch="master", dirty_file_count=1)
+    assert "dirty_main" in classify_risk_flags(lane)
+
+
+def test_dirty_feature_worktree_flagged() -> None:
+    lane = _lane(branch="feat/worktree-lane", dirty_file_count=1)
+    flags = classify_risk_flags(lane)
+    assert "dirty_worktree" in flags
+    assert "dirty_main" not in flags
+
+
+def test_detached_head_flagged() -> None:
+    lane = _lane(detached=True, branch=None, upstream=None)
+    assert "detached_head" in classify_risk_flags(lane)
+
+
+def test_no_upstream_flagged_for_branch() -> None:
+    lane = _lane(upstream=None)
+    assert "no_upstream" in classify_risk_flags(lane)
+
+
+def test_no_upstream_not_flagged_for_detached() -> None:
+    lane = _lane(detached=True, branch=None, upstream=None)
+    flags = classify_risk_flags(lane)
+    assert "no_upstream" not in flags
+    assert "detached_head" in flags
+
+
+def test_behind_upstream_flagged() -> None:
+    lane = _lane(behind_count=4)
+    assert "behind_upstream" in classify_risk_flags(lane)
+
+
+def test_not_behind_upstream_not_flagged() -> None:
+    lane = _lane(behind_count=0)
+    assert "behind_upstream" not in classify_risk_flags(lane)
+
+
+def test_staged_changes_flagged() -> None:
+    lane = _lane(staged_file_count=3)
+    assert "staged_changes" in classify_risk_flags(lane)
+
+
+def test_untracked_files_flagged() -> None:
+    lane = _lane(untracked_file_count=2)
+    assert "untracked_files" in classify_risk_flags(lane)
+
+
+def test_missing_head_flagged() -> None:
+    lane = _lane(head_sha=None)
+    assert "missing_head" in classify_risk_flags(lane)
+
+
+def test_missing_head_not_flagged_for_bare() -> None:
+    lane = _lane(bare=True, head_sha=None, upstream=None)
+    assert "missing_head" not in classify_risk_flags(lane)
+
+
+def test_git_state_error_flagged() -> None:
+    lane = _lane(had_git_error=True)
+    assert "git_state_error" in classify_risk_flags(lane)
+
+
+def test_clean_lane_has_no_flags() -> None:
+    lane = _lane()
+    assert classify_risk_flags(lane) == []
+
+
+def test_flags_are_ordered_by_severity() -> None:
+    lane = _lane(
+        branch=None,
+        head_sha=None,
+        detached=True,
+        dirty_file_count=1,
+        staged_file_count=1,
+        untracked_file_count=1,
+        upstream=None,
+        behind_count=2,
+        had_git_error=True,
+    )
+    flags = classify_risk_flags(lane)
+    # Most severe first; detached clears branch so dirty is classified as
+    # dirty_worktree, and detached precludes no_upstream.
+    assert flags == [
+        "git_state_error",
+        "missing_head",
+        "detached_head",
+        "dirty_worktree",
+        "staged_changes",
+        "untracked_files",
+        "behind_upstream",
+    ]

--- a/tests/worktrees/test_service.py
+++ b/tests/worktrees/test_service.py
@@ -1,0 +1,280 @@
+"""Tests for the read-only worktree discovery service.
+
+Uses an injected fake git runner so no subprocess is spawned. The fake runner
+also asserts that only allowed read-only git commands are ever invoked, locking
+in the non-mutation guarantee at test time.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+from guardian.worktrees.model import WorktreeLane
+from guardian.worktrees.service import (
+    GitError,
+    discover_worktree_lanes,
+    resolve_repo_path,
+)
+
+# Allowed read-only commands per the MVP spec. Any other git subcommand would
+# be a mutation and must fail the test.
+ALLOWED_COMMANDS: set[tuple[str, ...]] = {
+    ("worktree", "list", "--porcelain"),
+    ("status", "--short"),
+    ("branch", "--show-current"),
+    ("rev-parse", "HEAD"),
+    ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"),
+    ("rev-list", "--left-right", "--count", "HEAD...@{u}"),
+}
+
+# A responder maps a command signature + cwd to stdout (or raises GitError).
+Responder = Callable[[tuple[str, ...], str], str]
+
+
+class RoutingRunner:
+    """Records calls, asserts only allowed commands run, routes to a responder."""
+
+    def __init__(self, respond: Responder) -> None:
+        self._respond = respond
+        self.calls: list[tuple[tuple[str, ...], str]] = []
+
+    def __call__(self, args: list[str], *, cwd: str) -> str:
+        key = tuple(args)
+        assert (
+            key in ALLOWED_COMMANDS
+        ), f"non-allowed or mutating git command invoked: {key}"
+        self.calls.append((key, cwd))
+        return self._respond(key, cwd)
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# resolve_repo_path
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_repo_path_explicit_wins() -> None:
+    path, source = resolve_repo_path(
+        "/explicit", env={"CODEXIFY_WORKTREE_REPO_PATH": "/from/env"}
+    )
+    assert path == "/explicit"
+    assert source == "query"
+
+
+def test_resolve_repo_path_env_fallback() -> None:
+    path, source = resolve_repo_path(
+        None, env={"CODEXIFY_WORKTREE_REPO_PATH": "/from/env"}
+    )
+    assert path == "/from/env"
+    assert source == "env"
+
+
+def test_resolve_repo_path_dev_default_when_unset() -> None:
+    path, source = resolve_repo_path(None, env={})
+    assert source == "dev_default"
+    assert path
+
+
+# ---------------------------------------------------------------------------
+# discover_worktree_lanes
+# ---------------------------------------------------------------------------
+
+
+def test_discover_collects_state_and_risk_flags(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    main_path = repo / "main"
+    feat_path = repo / "feat"
+    main_path.mkdir()
+    feat_path.mkdir()
+
+    porcelain = (
+        f"worktree {main_path}\n"
+        "HEAD aaa111\n"
+        "branch refs/heads/main\n"
+        "\n"
+        f"worktree {feat_path}\n"
+        "HEAD bbb222\n"
+        "branch refs/heads/feat/lane\n"
+    )
+
+    def respond(args: tuple[str, ...], cwd: str) -> str:
+        if args == ("worktree", "list", "--porcelain"):
+            return porcelain
+        if args == (
+            "branch",
+            "--show-current",
+        ):
+            return "main\n" if cwd == str(main_path) else "feat/lane\n"
+        if args == ("rev-parse", "HEAD"):
+            return "aaa111\n" if cwd == str(main_path) else "bbb222\n"
+        if args == ("status", "--short"):
+            # feat lane is dirty with one staged + one untracked.
+            return "" if cwd == str(main_path) else "M  staged.py\n?? new.py\n"
+        if args == ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
+            # main has upstream and is behind by 2; feat has no upstream.
+            if cwd == str(feat_path):
+                raise GitError("no upstream")
+            return "origin/main\n"
+        if args == ("rev-list", "--left-right", "--count", "HEAD...@{u}"):
+            return "0\t2\n"
+        return ""
+
+    runner = RoutingRunner(respond)
+    discovery = discover_worktree_lanes(str(repo), git_runner=runner)
+    assert discovery.errors == []
+    assert len(discovery.lanes) == 2
+
+    main_lane = next(lane for lane in discovery.lanes if lane.branch == "main")
+    feat_lane = next(lane for lane in discovery.lanes if lane.branch == "feat/lane")
+
+    assert main_lane.dirty_file_count == 0
+    assert main_lane.upstream == "origin/main"
+    assert main_lane.behind_count == 2
+    assert "behind_upstream" in main_lane.risk_flags
+    assert "dirty_main" not in main_lane.risk_flags
+
+    assert feat_lane.dirty_file_count == 2
+    assert feat_lane.staged_file_count == 1
+    assert feat_lane.untracked_file_count == 1
+    assert feat_lane.upstream is None
+    assert "no_upstream" in feat_lane.risk_flags
+    assert "staged_changes" in feat_lane.risk_flags
+    assert "untracked_files" in feat_lane.risk_flags
+    assert "dirty_worktree" in feat_lane.risk_flags
+    assert "git_state_error" not in feat_lane.risk_flags
+
+
+def test_discover_detached_lane(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    detached_path = repo / "detached"
+    detached_path.mkdir()
+
+    porcelain = f"worktree {detached_path}\nHEAD cafe00\ndetached\n"
+
+    def respond(args: tuple[str, ...], cwd: str) -> str:
+        if args == ("worktree", "list", "--porcelain"):
+            return porcelain
+        if args == (
+            "branch",
+            "--show-current",
+        ):
+            return ""  # empty => detached
+        if args == ("rev-parse", "HEAD"):
+            return "cafe00\n"
+        if args == ("status", "--short"):
+            return ""
+        return ""
+
+    runner = RoutingRunner(respond)
+    discovery = discover_worktree_lanes(str(repo), git_runner=runner)
+    assert len(discovery.lanes) == 1
+    lane = discovery.lanes[0]
+    assert lane.detached is True
+    assert lane.branch is None
+    assert "detached_head" in lane.risk_flags
+    assert "no_upstream" not in lane.risk_flags
+    # No upstream rev-parse should be issued for a detached lane.
+    invoked = {call[0] for call in runner.calls}
+    assert (
+        "rev-parse",
+        "--abbrev-ref",
+        "--symbolic-full-name",
+        "@{u}",
+    ) not in invoked
+
+
+def test_discover_missing_worktree_folder_warns_not_crash(
+    tmp_path: Path,
+) -> None:
+    repo = _make_repo(tmp_path)
+    gone_path = repo / "gone"
+
+    porcelain = (
+        f"worktree {gone_path}\n" "HEAD dead00\n" "branch refs/heads/feat/missing\n"
+    )
+
+    def respond(args: tuple[str, ...], cwd: str) -> str:
+        assert args == ("worktree", "list", "--porcelain")
+        return porcelain
+
+    runner = RoutingRunner(respond)
+    discovery = discover_worktree_lanes(str(repo), git_runner=runner)
+    assert discovery.errors == []
+    assert len(discovery.lanes) == 1
+    lane = discovery.lanes[0]
+    assert lane.exists is False
+    assert any("no longer exists" in w for w in discovery.warnings)
+    # Only the porcelain command ran; no per-worktree git inside missing cwd.
+    assert runner.calls == [(("worktree", "list", "--porcelain"), str(repo))]
+
+
+def test_discover_repo_path_does_not_exist(tmp_path: Path) -> None:
+    runner = RoutingRunner(lambda args, cwd: "")
+    discovery = discover_worktree_lanes(str(tmp_path / "missing"), git_runner=runner)
+    assert discovery.lanes == []
+    assert discovery.errors
+    assert "does not exist" in discovery.errors[0]
+    assert runner.calls == []
+
+
+def test_discover_not_a_git_repository(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+
+    def respond(args: tuple[str, ...], cwd: str) -> str:
+        raise GitError("fatal: not a git repository")
+
+    runner = RoutingRunner(respond)
+    discovery = discover_worktree_lanes(str(repo), git_runner=runner)
+    assert discovery.lanes == []
+    assert discovery.errors
+    assert "not a Git repository" in discovery.errors[0]
+
+
+def test_discover_no_worktrees_beyond_main_warns(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+
+    def respond(args: tuple[str, ...], cwd: str) -> str:
+        assert args == ("worktree", "list", "--porcelain")
+        return ""
+
+    runner = RoutingRunner(respond)
+    discovery = discover_worktree_lanes(str(repo), git_runner=runner)
+    assert discovery.lanes == []
+    assert any("no worktrees" in w for w in discovery.warnings)
+
+
+def test_unexpected_git_status_failure_sets_git_state_error(
+    tmp_path: Path,
+) -> None:
+    repo = _make_repo(tmp_path)
+    wt = repo / "wt"
+    wt.mkdir()
+    porcelain = f"worktree {wt}\nHEAD abc\nbranch refs/heads/feat/x\n"
+
+    def respond(args: tuple[str, ...], cwd: str) -> str:
+        if args == ("worktree", "list", "--porcelain"):
+            return porcelain
+        if args == ("status", "--short"):
+            raise GitError("index.lock")
+        if args == (
+            "branch",
+            "--show-current",
+        ):
+            return "feat/x\n"
+        if args == ("rev-parse", "HEAD"):
+            return "abc\n"
+        if args == ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
+            return "origin/feat/x\n"
+        return ""
+
+    runner = RoutingRunner(respond)
+    discovery = discover_worktree_lanes(str(repo), git_runner=runner)
+    lane: WorktreeLane = discovery.lanes[0]
+    assert "git_state_error" in lane.risk_flags

--- a/tests/worktrees/test_status.py
+++ b/tests/worktrees/test_status.py
@@ -1,0 +1,124 @@
+"""Tests for ``git status --short`` and ahead/behind parsing.
+
+Covers the MVP status test matrix: clean, staged, unstaged, modified both
+staged and unstaged, untracked, and mixed. Also covers ahead/behind parsing.
+"""
+
+from __future__ import annotations
+
+from guardian.worktrees.status import parse_ahead_behind, parse_status_short
+
+
+# ---------------------------------------------------------------------------
+# parse_status_short
+# ---------------------------------------------------------------------------
+
+
+def test_clean_status() -> None:
+    counts = parse_status_short("")
+    assert counts.staged == 0
+    assert counts.unstaged == 0
+    assert counts.untracked == 0
+    assert counts.dirty == 0
+
+
+def test_staged_file() -> None:
+    # 'M ' => modified in index, clean in worktree.
+    counts = parse_status_short("M  src/app.py\n")
+    assert counts.staged == 1
+    assert counts.unstaged == 0
+    assert counts.untracked == 0
+    assert counts.dirty == 1
+
+
+def test_unstaged_file() -> None:
+    # ' M' => unmodified in index, modified in worktree.
+    counts = parse_status_short(" M src/app.py\n")
+    assert counts.staged == 0
+    assert counts.unstaged == 1
+    assert counts.untracked == 0
+    assert counts.dirty == 1
+
+
+def test_modified_staged_and_unstaged_file() -> None:
+    # 'MM' => modified in index AND worktree. Counts both, but one dirty file.
+    counts = parse_status_short("MM src/app.py\n")
+    assert counts.staged == 1
+    assert counts.unstaged == 1
+    assert counts.untracked == 0
+    assert counts.dirty == 1
+
+
+def test_untracked_file() -> None:
+    counts = parse_status_short("?? src/new.py\n")
+    assert counts.untracked == 1
+    assert counts.staged == 0
+    assert counts.unstaged == 0
+    assert counts.dirty == 1
+
+
+def test_mixed_staged_unstaged_and_untracked() -> None:
+    porcelain = (
+        "M  staged_only.py\n"
+        " M unstaged_only.py\n"
+        "MM both.py\n"
+        "A  added_staged.py\n"
+        "?? untracked.py\n"
+        "R  renamed.py\n"
+        " D deleted_in_worktree.py\n"
+    )
+    counts = parse_status_short(porcelain)
+    # staged: M, MM, A, R => 4
+    assert counts.staged == 4
+    # unstaged: M(unstaged_only), MM(both), D(deleted_in_worktree) => 3
+    assert counts.unstaged == 3
+    # untracked: ?? => 1
+    assert counts.untracked == 1
+    # dirty lines: every non-empty line => 7
+    assert counts.dirty == 7
+
+
+def test_status_ignores_blank_lines() -> None:
+    counts = parse_status_short("\nM  src/app.py\n\n")
+    assert counts.staged == 1
+    assert counts.dirty == 1
+
+
+def test_status_handles_crlf() -> None:
+    counts = parse_status_short("M  src/app.py\r\n?? new.py\r\n")
+    assert counts.staged == 1
+    assert counts.untracked == 1
+    assert counts.dirty == 2
+
+
+def test_status_too_short_line_is_ignored() -> None:
+    counts = parse_status_short("X\n")
+    assert counts.dirty == 0
+
+
+# ---------------------------------------------------------------------------
+# parse_ahead_behind
+# ---------------------------------------------------------------------------
+
+
+def test_ahead_behind_basic() -> None:
+    ahead, behind = parse_ahead_behind("2\t3\n")
+    assert ahead == 2
+    assert behind == 3
+
+
+def test_ahead_behind_zero_zero() -> None:
+    ahead, behind = parse_ahead_behind("0\t0")
+    assert ahead == 0
+    assert behind == 0
+
+
+def test_ahead_behind_empty_returns_none_tuple() -> None:
+    assert parse_ahead_behind("") == (None, None)
+    assert parse_ahead_behind("   \n") == (None, None)
+
+
+def test_ahead_behind_malformed_returns_none_tuple() -> None:
+    assert parse_ahead_behind("nope") == (None, None)
+    assert parse_ahead_behind("1 2 3") == (None, None)
+    assert parse_ahead_behind("a\tb") == (None, None)


### PR DESCRIPTION
## Summary

Adds the first read-only Worktree Lane MVP for Codexify.

This discovers local git worktrees for a configured repo and reports each as an operator lane with branch, HEAD, dirty/staged/unstaged/untracked counts, upstream, ahead/behind, and risk flags.

## Scope

- Adds read-only worktree discovery package
- Adds worktree lane API routes behind CODEXIFY_ENABLE_WORKTREE_ROUTES
- Preserves supported-profile quarantine behavior
- Adds parser, status, risk flag, service, and route tests

## Safety

- No mutating git commands
- No shell=True
- No file contents or diffs inspected
- Missing folders, upstream, or HEAD degrade into risk flags instead of crashes
- Manifest untouched, route remains dormant until explicitly promoted

## Validation

- 56 worktree tests passed
- ruff check clean
- black --check clean
- py_compile guardian_api.py OK
- Manual smoke against real 10-worktree repo passed

## Known unrelated issue

A pre-existing /health/llm test failure occurs in an environment without an LLM provider and was confirmed on a clean tree. It is not touched by this change.
