### PR TITLE
chore(security): harden trusted remote env handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,7 +107,12 @@ models/
 
 # Local runtime / secrets (DO NOT COMMIT)
 # Local trusted-remote overlay; may carry local/dev session or JWT secrets.
+# Cover the canonical name plus common variant spellings so a rename cannot
+# accidentally re-commit a real overlay. The .example file stays tracked.
 config/trusted-remote.env
+trusted-remote.env
+*.trusted-remote.env
+.env.trusted-remote
 /data/credentials.json
 /data/token.pickle
 /data/trust_registry.json

--- a/docs/architecture/trusted-remote-access-runbook.md
+++ b/docs/architecture/trusted-remote-access-runbook.md
@@ -76,4 +76,41 @@ The trusted-remote overlay is **local-only and must never be committed**. It may
   ```
 
 - Secrets should be regenerated per environment. Treat any previously committed overlay values as expired local/dev material.
-- The guardrail in `scripts/preflight.sh` fails if `config/trusted-remote.env` is ever tracked or staged again.
+- The guardrail in `scripts/preflight.sh` fails if a real overlay (any trusted-remote env variant) is tracked or staged, if the `.example` is missing, or if the `.example` carries obvious secret-looking values.
+
+### Verify the real overlay is ignored
+
+```bash
+git check-ignore -v config/trusted-remote.env
+git ls-files config/trusted-remote.env   # must print nothing
+```
+
+The first command should print the `.gitignore` rule that matches; the second must print nothing (untracked).
+
+### If a real overlay is accidentally staged
+
+```bash
+git restore --staged config/trusted-remote.env
+git status   # confirm it is no longer staged
+```
+
+The file stays on disk; only its staged state is cleared.
+
+### If a real overlay is accidentally committed
+
+1. Remove it from tracking (keeps the local copy):
+
+   ```bash
+   git rm --cached config/trusted-remote.env
+   git commit -m "chore(security): stop tracking trusted remote env overlay"
+   ```
+2. Treat any values that reached history as **expired** — regenerate `GUARDIAN_SESSION_SECRET` / `GUARDIAN_JWT_SECRET` per environment.
+3. History rewriting (`git filter-repo` / BFG) is a separate, high-blast-radius decision and is not part of this runbook. Only consider it if the repo is shared beyond the local machine.
+
+### Run the preflight check
+
+```bash
+bash scripts/preflight.sh
+```
+
+It exits non-zero if a trusted-remote env file is tracked or staged, the `.example` is missing, or the `.example` contains obvious secret-looking values. It passes when only the `.example` is present and the real overlay is ignored.

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -109,21 +109,64 @@ if git rev-parse --show-toplevel >/dev/null 2>&1; then
   fi
 
   # Local trusted-remote overlay must never be tracked or staged. It may carry
-  # local/dev session or JWT signing secrets.
-  overlay="config/trusted-remote.env"
-  overlay_ok=1
-  if git ls-files --error-unmatch "$overlay" >/dev/null 2>&1; then
-    fail "$overlay is tracked but must remain local-only"
-    log "  Remediation: git rm --cached $overlay"
-    overlay_ok=0
+  # local/dev session or JWT secrets. The .example file is the only safe,
+  # tracked artifact.
+  tr_pattern='(^|/)(trusted-remote\.env|.*\.trusted-remote\.env|\.env\.trusted-remote)$'
+  tr_example="config/trusted-remote.env.example"
+  tr_ok=1
+
+  # Tracked real overlay (any variant name)?
+  tracked_real="$(git ls-files | grep -E "$tr_pattern" || true)"
+  if [ -n "$tracked_real" ]; then
+    fail "trusted-remote env file is tracked but must remain local-only:"
+    printf '%s\n' "$tracked_real" | sed 's/^/    /'
+    log "  Remediation: git rm --cached <file>"
+    tr_ok=0
   fi
-  if git diff --cached --name-only -- "$overlay" | grep -q .; then
-    fail "$overlay is staged but must remain local-only"
-    log "  Remediation: git restore --staged $overlay"
-    overlay_ok=0
+
+  # Staged real overlay?
+  staged_real="$(git diff --cached --name-only | grep -E "$tr_pattern" || true)"
+  if [ -n "$staged_real" ]; then
+    fail "trusted-remote env file is staged but must remain local-only:"
+    printf '%s\n' "$staged_real" | sed 's/^/    /'
+    log "  Remediation: git restore --staged <file>"
+    tr_ok=0
   fi
-  if [ "$overlay_ok" -eq 1 ]; then
-    ok "$overlay not tracked or staged (local-only)"
+
+  # Required safe example must exist.
+  if [ ! -f "$tr_example" ]; then
+    fail "$tr_example is missing (required placeholder reference)"
+    log "  Remediation: recreate it with placeholder values only"
+    tr_ok=0
+  fi
+
+  # The example must not carry obvious secret-looking values. The matched
+  # value is intentionally NOT printed in case it really is a secret.
+  if [ -f "$tr_example" ]; then
+    secret_hits="$(awk '
+      {
+        if ($0 ~ /^[[:space:]]*#/) next
+        eq = index($0, "=")
+        if (!eq) next
+        val = substr($0, eq + 1)
+        gsub(/[[:space:]]+$/, "", val)
+        if (val == "") next
+        low = tolower(val)
+        if (low ~ /replace|example|invalid|localhost|127\.0\.0\.1|changeme|placeholder|local-dev|your-|todo|xxxxx/) next
+        if (val ~ /^eyJ/ || val ~ /^(gho_|ghp_|ghs_|ghu_|ghr_|github_pat_|sk-|xox[bp]-)/ || val ~ /^[A-Za-z0-9_\/+=.-]{32,}$/) {
+          print FILENAME ":" FNR ": <redacted value looks like a secret>"
+        }
+      }' "$tr_example" || true)"
+    if [ -n "$secret_hits" ]; then
+      fail "$tr_example may contain a real secret-looking value"
+      printf '%s\n' "$secret_hits" | sed 's/^/    /'
+      log "  Remediation: replace with placeholder values only"
+      tr_ok=0
+    fi
+  fi
+
+  if [ "$tr_ok" -eq 1 ]; then
+    ok "trusted-remote env not tracked/staged; example present and placeholder-only"
   fi
 else
   warn "not in a git repo; skipping clean-tree check"


### PR DESCRIPTION
## Summary

Hardens trusted remote environment handling beyond the initial untracking baseline.

This broadens `.gitignore` coverage for trusted-remote env filename variants, strengthens `scripts/preflight.sh`, and extends the trusted remote access runbook with operator recovery and verification procedures.

## Scope

* Ignore trusted-remote env filename variants
* Strengthen preflight checks for tracked/staged trusted-remote env files
* Add required-example-missing detection
* Add placeholder/example secret-value scanning with redacted output
* Extend trusted remote access runbook with:

  * verify procedure
  * accidentally staged procedure
  * accidentally committed procedure
  * preflight usage

## Safety

* No real env files staged
* No secret values printed
* Example env remains placeholder-only
* Real env remains local, untracked, and ignored
* No app runtime behavior changed
* No Worktree Lane files touched
* No VaultNode files touched
* Route manifests and runtime profiles unchanged

## Validation

* `git diff --check` clean
* `bash -n scripts/preflight.sh` OK
* Ignore rules verified:

  * example env is not ignored
  * real env and trusted-remote variants are ignored
* Secret scanner verified:

  * 0 hits on real example
  * detects JWT / `gho_` / 32-hex fake values
* Preflight state checks:

  * safe state passes trusted-remote block
  * forced staged env fails tracked/staged checks
  * missing example fails required-example check
  * restored safe state passes trusted-remote block

## Known unrelated environment issues

Full preflight still reports pre-existing environmental failures on this machine:

* bare `python` command is missing
* bare `pytest` command is missing
* venv is not active in the current shell

`.venv/bin/python` exists and has pytest available. This task deliberately does not fix interpreter selection or venv activation behavior.
