### PR TITLE
[codex] Repair document RAG lifecycle with honest status gating

### DIFF
--- a/frontend/src/components/documents/documentEmbeddingStatus.tsx
+++ b/frontend/src/components/documents/documentEmbeddingStatus.tsx
@@ -48,9 +48,10 @@ function resolveStatusPresentation(raw?: string, embeddingError?: string) {
   if (!key) return null;
 
   const config = STATUS_STYLES[key as keyof typeof STATUS_STYLES];
-  const label = config?.label ?? key.charAt(0).toUpperCase() + key.slice(1);
+  const baseLabel = config?.label ?? key.charAt(0).toUpperCase() + key.slice(1);
   const errorHint = key === "failed" ? resolveErrorHint(embeddingError) : null;
-  const title = errorHint ? `${label} - ${errorHint}` : label;
+  const label = errorHint ? `${baseLabel} - ${errorHint}` : baseLabel;
+  const title = label;
 
   return {
     label,


### PR DESCRIPTION
## Summary
- Restore the uploaded-document lifecycle contract so ready/failed status is the source of truth for retrieval eligibility.
- Make the failure hint visible in the badge text, not only in the tooltip, so operators can see why a document failed.
- Tighten broker/worker regression coverage so unreadied document chunks are excluded from retrieval and the embed worker test fixture reflects the live asset shape.

## Validation
- `.venv/bin/pytest -q guardian/tests/test_document_embed_worker.py tests/core/test_context_broker_depth.py`
- `./node_modules/.bin/vitest run --config vitest.config.ts tests/document_tile_status.spec.tsx components/documents/DocumentsView.interactions.test.tsx components/dashboard/DashboardView.demo-state.test.tsx`
- `git diff --check`

## Notes
- This branch stays scoped to the local-room document RAG lifecycle and does not widen the release promise to Shared Room KB, federation, or participant-node handoff.
- Fixes #464