### PR TITLE
Unify Persona Studio badges with panel border styling

### DIFF
--- a/frontend/src/features/personaStudio/PersonaPreviewPanel.tsx
+++ b/frontend/src/features/personaStudio/PersonaPreviewPanel.tsx
@@ -394,7 +394,6 @@ export default function PersonaPreviewPanel({ profile }: PersonaPreviewPanelProp
                       <div className="flex items-center justify-between gap-2">
                         <div className="flex flex-wrap items-center gap-2">
                           <Badge
-                            variant="outline"
                             className="px-2 py-1 text-[10px] uppercase tracking-[0.14em]"
                             style={{ borderColor: "var(--panel-border)" }}
                           >
@@ -431,7 +430,6 @@ export default function PersonaPreviewPanel({ profile }: PersonaPreviewPanelProp
                             <div className="flex flex-wrap items-center justify-between gap-2">
                               <div className="flex flex-wrap items-center gap-2">
                                 <Badge
-                                  variant="outline"
                                   className="px-2 py-1 text-[10px] uppercase tracking-[0.14em]"
                                   style={{ borderColor: "var(--panel-border)" }}
                                 >
@@ -445,7 +443,6 @@ export default function PersonaPreviewPanel({ profile }: PersonaPreviewPanelProp
                                 </div>
                               </div>
                               <Badge
-                                variant="outline"
                                 className="px-2 py-1 text-[10px] uppercase tracking-[0.14em]"
                                 style={{ borderColor: "var(--panel-border)" }}
                               >
@@ -626,10 +623,9 @@ export default function PersonaPreviewPanel({ profile }: PersonaPreviewPanelProp
                             >
                               <div className="flex flex-wrap items-center justify-between gap-2">
                                 <div className="flex flex-wrap items-center gap-2">
-                                  <Badge
-                                    variant="outline"
-                                    className="px-2 py-1 text-[10px] uppercase tracking-[0.14em]"
-                                    style={{ borderColor: "var(--panel-border)" }}
+                                    <Badge
+                                      className="px-2 py-1 text-[10px] uppercase tracking-[0.14em]"
+                                      style={{ borderColor: "var(--panel-border)" }}
                                   >
                                     Turn {turnNumber}
                                   </Badge>

--- a/frontend/src/features/personaStudio/PersonaStudioPage.tsx
+++ b/frontend/src/features/personaStudio/PersonaStudioPage.tsx
@@ -384,7 +384,6 @@ function ToolsEditor({
           {config.tools.pinnedTools.map((tool) => (
             <Badge
               key={tool}
-              variant="outline"
               className="px-2 py-1 text-xs"
               style={{ borderColor: "var(--panel-border)" }}
             >
@@ -419,7 +418,6 @@ function ToolsEditor({
           {config.tools.allowedTools.map((tool) => (
             <Badge
               key={tool}
-              variant="outline"
               className="px-2 py-1 text-xs"
               style={{ borderColor: "var(--panel-border)" }}
             >
@@ -454,7 +452,6 @@ function ToolsEditor({
           {config.tools.skills.map((skill) => (
             <Badge
               key={skill}
-              variant="outline"
               className="px-2 py-1 text-xs"
               style={{ borderColor: "var(--panel-border)" }}
             >
@@ -945,7 +942,7 @@ export default function PersonaStudioPage() {
               >
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div className="space-y-1" />
-                  <Badge variant="outline" className="px-2 py-1 text-[10px] uppercase tracking-[0.14em]" style={{ borderColor: "var(--panel-border)" }}>
+                  <Badge className="px-2 py-1 text-[10px] uppercase tracking-[0.14em]" style={{ borderColor: "var(--panel-border)" }}>
                     {activeTab}
                   </Badge>
                 </div>

--- a/frontend/src/features/personaStudio/components/DiagnosticsPanel.tsx
+++ b/frontend/src/features/personaStudio/components/DiagnosticsPanel.tsx
@@ -56,7 +56,6 @@ export default function DiagnosticsPanel({
       <div className="flex items-center justify-between text-xs">
         <span style={{ color: "var(--muted)" }}>Save Status</span>
         <Badge
-          variant="outline"
           className="text-xs"
           style={{
             borderColor:

--- a/frontend/src/features/personaStudio/components/PersonaVoicePanel.tsx
+++ b/frontend/src/features/personaStudio/components/PersonaVoicePanel.tsx
@@ -311,7 +311,6 @@ export default function PersonaVoicePanel({
           {currentProvider ? (
             <div className="flex flex-wrap items-center gap-2">
               <Badge
-                variant="outline"
                 className="px-2 py-1 text-[10px] uppercase tracking-[0.14em]"
                 style={{
                   borderColor: "var(--panel-border)",
@@ -320,7 +319,6 @@ export default function PersonaVoicePanel({
                 {currentProvider.classification}
               </Badge>
               <Badge
-                variant="outline"
                 className="px-2 py-1 text-[10px] uppercase tracking-[0.14em]"
                 style={badgeTone(currentProvider)}
               >
@@ -383,21 +381,18 @@ export default function PersonaVoicePanel({
               {currentProvider ? (
                 <>
                   <Badge
-                    variant="outline"
                     className="px-2 py-1 text-[10px] uppercase tracking-[0.14em]"
                     style={{ borderColor: "var(--panel-border)" }}
                   >
                     preset voices {currentProvider.capabilities.presetVoices ? "yes" : "no"}
                   </Badge>
                   <Badge
-                    variant="outline"
                     className="px-2 py-1 text-[10px] uppercase tracking-[0.14em]"
                     style={{ borderColor: "var(--panel-border)" }}
                   >
                     preview {currentProvider.capabilities.preview ? "yes" : "no"}
                   </Badge>
                   <Badge
-                    variant="outline"
                     className="px-2 py-1 text-[10px] uppercase tracking-[0.14em]"
                     style={{ borderColor: "var(--panel-border)" }}
                   >
@@ -406,7 +401,6 @@ export default function PersonaVoicePanel({
                 </>
               ) : (
                 <Badge
-                  variant="outline"
                   className="px-2 py-1 text-[10px] uppercase tracking-[0.14em]"
                   style={{ borderColor: "var(--panel-border)" }}
                 >

--- a/frontend/src/features/personaStudio/components/StudioGuidePanel.tsx
+++ b/frontend/src/features/personaStudio/components/StudioGuidePanel.tsx
@@ -36,14 +36,12 @@ export default function StudioGuidePanel({
           </div>
           <div className="flex flex-wrap gap-2">
             <Badge
-              variant="outline"
               className="px-2 py-1 text-[10px] uppercase tracking-[0.14em]"
               style={{ borderColor: "var(--panel-border)" }}
             >
               {hasDraft ? "Draft aware" : "No draft selected"}
             </Badge>
             <Badge
-              variant="outline"
               className="px-2 py-1 text-[10px] uppercase tracking-[0.14em]"
               style={{ borderColor: "var(--panel-border)" }}
             >
@@ -74,7 +72,6 @@ export default function StudioGuidePanel({
                   <p className="text-sm leading-6 text-[var(--muted)]">{card.summary}</p>
                 </div>
                 <Badge
-                  variant="outline"
                   className="px-2 py-1 text-[10px] uppercase tracking-[0.14em]"
                   style={{ borderColor: "var(--panel-border)" }}
                 >
@@ -95,7 +92,6 @@ export default function StudioGuidePanel({
                   {card.evidence.map((item) => (
                     <Badge
                       key={`${card.id}-${item}`}
-                      variant="outline"
                       className="px-2 py-1 text-[10px] uppercase tracking-[0.14em]"
                       style={{ borderColor: "var(--panel-border)" }}
                     >


### PR DESCRIPTION
## Summary
- Removed `variant="outline"` from Persona Studio badges so they consistently use the shared panel-border styling.
- Applied the same badge treatment across preview, voice, diagnostics, guide, tools, and active-tab surfaces.
- Keeps the local Persona Studio UI visually aligned without changing behavior.

## Testing
- Not run (not requested)