### PR TITLE
fix(frontend): clear sidebar mechanical type errors

### DIFF
--- a/frontend/src/components/SessionRail/SessionRail.tsx
+++ b/frontend/src/components/SessionRail/SessionRail.tsx
@@ -1,4 +1,4 @@
-import { Plus, X } from "lucide-react";
+import { Plus } from "lucide-react";
 import React from "react";
 
 import type { SessionTab, TabId } from "@/state/session/types";

--- a/frontend/src/components/sidebar/ProjectList.tsx
+++ b/frontend/src/components/sidebar/ProjectList.tsx
@@ -37,7 +37,7 @@ export default function ProjectList({
     async (project: Project) => {
       if (!onDeleteProject) return;
       const projectId = String(project.id);
-      const projectName = cleanSidebarProjectTitle(project as any) || "this project";
+      const projectName = cleanSidebarProjectTitle(project) || "this project";
       const confirmed = window.confirm(
         `Delete project "${projectName}"? This will remove the project and unassign its threads.`
       );
@@ -58,7 +58,7 @@ export default function ProjectList({
         {filtered.map((p) => (
           <ProjectTileCard
             key={p.id}
-            label={cleanSidebarProjectTitle(p as any)}
+            label={cleanSidebarProjectTitle(p)}
             icon={p.icon}
             active={currentId === String(p.id)}
             onClick={() => onPick(String(p.id))}
@@ -98,9 +98,12 @@ function ProjectTileCard({
   const baseIcon = typeof icon === "string" && icon.trim().length <= 2
     ? icon.trim()
     : icon || <FolderOpen className="h-6 w-6" />;
-  const iconNode = React.isValidElement(baseIcon)
-    ? React.cloneElement(baseIcon as React.ReactElement, {
-        className: clsx("project-tile__icon", ((baseIcon as React.ReactElement).props as any)?.className),
+  const iconElement = React.isValidElement(baseIcon)
+    ? (baseIcon as React.ReactElement<{ className?: string }>)
+    : null;
+  const iconNode = iconElement
+    ? React.cloneElement(iconElement, {
+        className: clsx("project-tile__icon", iconElement.props.className),
       })
     : <span className="project-tile__icon">{baseIcon}</span>;
   return (

--- a/frontend/src/components/sidebar/SidebarRoot.tsx
+++ b/frontend/src/components/sidebar/SidebarRoot.tsx
@@ -173,7 +173,7 @@ export default function SidebarRoot({
     if (currentProjectId === null) return "General";
     if (currentProjectId) {
       const proj = projectList.find((p) => String(p.id) === String(currentProjectId));
-      return proj ? cleanSidebarProjectTitle(proj as any) : hookScopeLabel;
+      return proj ? cleanSidebarProjectTitle(proj) : hookScopeLabel;
     }
     return hookScopeLabel;
   }, [currentProjectId, hookScopeLabel, projectList]);
@@ -373,7 +373,7 @@ export default function SidebarRoot({
             new CustomEvent("cfy:toast", {
               detail: {
                 kind: "success",
-                message: `Project "${cleanSidebarProjectTitle(existing as any)}" deleted`,
+                message: `Project "${cleanSidebarProjectTitle(existing)}" deleted`,
               },
             })
           );

--- a/frontend/src/components/sidebar/ThreadList.tsx
+++ b/frontend/src/components/sidebar/ThreadList.tsx
@@ -88,6 +88,7 @@ export default function ThreadList({
   creatingThread,
   className,
 }: ThreadListProps) {
+  void creatingThread;
   return (
     <ThreadPreviewList
       threads={threads}
@@ -107,7 +108,6 @@ export default function ThreadList({
       hasMore={hasMore}
       isLoadingMore={isLoadingMore}
       onLoadMore={onLoadMore}
-      creatingThread={creatingThread}
     />
   );
 }
@@ -291,7 +291,6 @@ function ThreadTileRow({
   onDelete: (threadId: string) => Promise<void>;
 }) {
   const [menuOpen, setMenuOpen] = React.useState(false);
-  const [focusWithin, setFocusWithin] = React.useState(false);
   const [actionBusy, setActionBusy] = React.useState<ThreadAction | null>(null);
   const [hoveredAction, setHoveredAction] = React.useState<ThreadAction | null>(null);
   const menuRef = React.useRef<HTMLDivElement | null>(null);
@@ -444,18 +443,10 @@ function ThreadTileRow({
     ? (isDarkMode ? darkActiveBackground : highlightBg)
     : (isDarkMode ? "var(--panel-sheet)" : "var(--panel-bg)");
 
-  const showActions = active || focusWithin;
   return (
     <div
       data-testid={`thread-row-${thread.id}`}
       className={clsx("relative", className)}
-      onFocusCapture={() => setFocusWithin(true)}
-      onBlurCapture={(event) => {
-        const nextTarget = event.relatedTarget as Node | null;
-        if (!event.currentTarget.contains(nextTarget)) {
-          setFocusWithin(false);
-        }
-      }}
     >
       <TileShell
         as="button"

--- a/frontend/src/components/sidebar/sidebarPresentation.ts
+++ b/frontend/src/components/sidebar/sidebarPresentation.ts
@@ -13,6 +13,16 @@ import codexifyMarkSrc from "@/assets/brands/codexify/codexify-mark.png";
 
 export type SidebarProjectRecord = Project & Record<string, unknown>;
 
+export type SidebarProjectLike = {
+  id?: Project["id"];
+  name?: string;
+  project_id?: Project["id"];
+  project_name?: string;
+  icon?: string;
+  color?: string;
+  metadata?: unknown;
+};
+
 const GENERAL_PROJECT_ALIASES = new Set(["general", "loose threads"]);
 
 const IMPORTED_PROVIDER_PREFIXES = [
@@ -32,22 +42,23 @@ export function isSidebarGeneralProjectName(value: unknown): boolean {
   return GENERAL_PROJECT_ALIASES.has(normalizeText(value).toLowerCase());
 }
 
-function hasImportedProvenance(project: Record<string, unknown>): boolean {
+function hasImportedProvenance(project: SidebarProjectLike): boolean {
+  const record = project as Record<string, unknown>;
   const directMarkers = [
-    project.import_source,
-    project.importSource,
-    project.imported_at,
-    project.importedAt,
-    project.imported_from,
-    project.importedFrom,
-    project.restored_at,
-    project.restoredAt,
-    project.restored_from,
-    project.restoredFrom,
-    project.import_profile,
-    project.importProfile,
-    project.source_thread_id,
-    project.sourceThreadId,
+    record.import_source,
+    record.importSource,
+    record.imported_at,
+    record.importedAt,
+    record.imported_from,
+    record.importedFrom,
+    record.restored_at,
+    record.restoredAt,
+    record.restored_from,
+    record.restoredFrom,
+    record.import_profile,
+    record.importProfile,
+    record.source_thread_id,
+    record.sourceThreadId,
   ];
 
   for (const marker of directMarkers) {
@@ -55,10 +66,9 @@ function hasImportedProvenance(project: Record<string, unknown>): boolean {
     if (typeof marker === "number" && Number.isFinite(marker)) return true;
   }
 
-  const metadata = project.metadata;
+  const metadata = record.metadata;
   if (metadata && typeof metadata === "object") {
-    const meta = metadata as Record<string, unknown>;
-    if (hasImportedProvenance(meta)) return true;
+    if (hasImportedProvenance(metadata as SidebarProjectLike)) return true;
   }
 
   return false;
@@ -76,7 +86,7 @@ function stripImportedProviderPrefix(name: string): string {
 }
 
 export function cleanSidebarProjectTitle(
-  project: Partial<SidebarProjectRecord> & Record<string, unknown>
+  project: SidebarProjectLike
 ): string {
   const rawName = normalizeText(project.name ?? project.project_name ?? "Untitled");
 
@@ -88,21 +98,21 @@ export function cleanSidebarProjectTitle(
   return cleaned || rawName;
 }
 
-export function normalizeSidebarProject<T extends SidebarProjectRecord>(project: T): T {
+export function normalizeSidebarProject<T extends SidebarProjectLike>(project: T): SidebarProjectRecord {
   return {
     ...project,
     id: String(project.id ?? project.project_id ?? ""),
     name: cleanSidebarProjectTitle(project),
-  } as T;
+  };
 }
 
-export function normalizeSidebarProjects<T extends SidebarProjectRecord>(
+export function normalizeSidebarProjects<T extends SidebarProjectLike>(
   projects: readonly T[]
-): T[] {
+): SidebarProjectRecord[] {
   return projects.map(normalizeSidebarProject);
 }
 
-export function selectSidebarGeneralProject<T extends SidebarProjectRecord>(
+export function selectSidebarGeneralProject<T extends SidebarProjectLike>(
   projects: readonly T[]
 ): T | null {
   const candidates = projects.filter((project) => isSidebarGeneralProjectName(project.name));
@@ -110,14 +120,16 @@ export function selectSidebarGeneralProject<T extends SidebarProjectRecord>(
   return candidates[0] ?? null;
 }
 
-export function resolveSidebarGeneralProjectId<T extends SidebarProjectRecord>(
+export function resolveSidebarGeneralProjectId<T extends SidebarProjectLike>(
   projects: readonly T[],
   fallback: string | null = null
 ): string | null {
-  return selectSidebarGeneralProject(projects)?.id ?? fallback;
+  const selected = selectSidebarGeneralProject(projects);
+  const id = selected?.id;
+  return id == null ? fallback : String(id);
 }
 
-export function collapseSidebarGeneralProjectAliases<T extends SidebarProjectRecord>(
+export function collapseSidebarGeneralProjectAliases<T extends SidebarProjectLike>(
   projects: readonly T[]
 ): T[] {
   const seen = new Set<string>();

--- a/frontend/src/components/sidebar/useProjectsCache.ts
+++ b/frontend/src/components/sidebar/useProjectsCache.ts
@@ -62,7 +62,7 @@ function readProjectsCache(): Project[] {
 function writeProjectsCache(list: Project[]) {
   try {
     if (typeof window === "undefined") return;
-    const compact = collapseSidebarGeneralProjectAliases(list as Project[]);
+    const compact = collapseSidebarGeneralProjectAliases(list);
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(compact));
   } catch {
     /* ignore */
@@ -73,12 +73,12 @@ function mergeProjects(primary: Project[], secondary: Project[]): Project[] {
   const seen = new Map<string, Project>();
   const push = (p?: Project) => {
     if (!p) return;
-    const normalized = normalizeSidebarProject(p as any);
+    const normalized = normalizeSidebarProject(p);
     const key = String(normalized.id ?? "");
     const nameKey = `name:${normalized.name}`;
     const existingKey = key || nameKey;
     const previous = seen.get(existingKey);
-    const merged = previous ? normalizeSidebarProject({ ...previous, ...normalized } as any) : normalized;
+    const merged = previous ? normalizeSidebarProject({ ...previous, ...normalized }) : normalized;
     seen.set(existingKey, merged);
   };
   primary.forEach(push);

--- a/frontend/src/components/sidebar/useSidebarThreads.ts
+++ b/frontend/src/components/sidebar/useSidebarThreads.ts
@@ -11,7 +11,6 @@ import {
   isSidebarGeneralProjectName,
   cleanSidebarProjectTitle,
   resolveSidebarThreadBucketId,
-  resolveSidebarGeneralProjectId,
   threadBelongsToGeneral,
   threadMatchesSidebarProvenance,
   type SidebarProvenanceOption,


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
