### PR TITLE
Add Pi Loop Manager adoption contract

### DIFF
--- a/docs/architecture/adr/proposed/041-pi-loop-manager-campaign-runner-gate-graph.md
+++ b/docs/architecture/adr/proposed/041-pi-loop-manager-campaign-runner-gate-graph.md
@@ -1,0 +1,216 @@
+---
+tags:
+  - architecture
+  - adr
+  - campaign-runner
+  - pi-loop-manager
+  - execution-ledger
+  - proposed
+aliases:
+  - ADR-041
+  - Pi Loop Manager Campaign Runner Gate Graph
+---
+
+# ADR-041: Pi Loop Manager Campaign Runner Gate Graph
+
+## Status
+
+Proposed
+
+## Date
+
+2026-07-03
+
+## Context
+
+Campaign Runner now has a bounded Pi Loop Manager v0 dry-run receipt spine. The implementation establishes local loop mechanics for a single task: task spec intake, gate sequencing, provider abstraction, policy checks, artifact emission, validation capture, and final receipt output.
+
+This creates a new execution-adjacent seam that Codexify can eventually adopt as governed evidence for WorkOrder attempts. It must not be treated as a new canonical control plane, autonomous dispatcher, merge authority, or durable runtime truth source.
+
+Codexify already has the Execution Ledger and Campaign Runner governance posture from ADR-028. ADR-028 keeps `campaign_goals`, `campaigns`, `coding_work_orders`, and `campaign_execution_attempts` as the durable planning and evidence surfaces, and explicitly rejects duplicate runtime truth planes, hidden autonomous dispatch, and acceptance/completion collapse.
+
+ADR-036 and ADR-037 further establish that Campaign Runner should use provider adapters rather than hardcoded provider assumptions, and that Pi is a preferred lightweight provider-broker seam when available without becoming Campaign Runner core or a mandatory global runtime.
+
+## Decision
+
+Codexify may adopt Campaign Runner Pi Loop Manager receipts as bounded attempt evidence, not as durable control-plane truth.
+
+The adoption boundary is:
+
+1. Campaign Runner owns local loop mechanics for one bounded task attempt.
+2. Pi Loop Manager owns gate sequencing inside that attempt.
+3. Pi Loop Manager emits receipts, artifacts, validation logs, and handoffs.
+4. Codexify remains the durable authority for WorkOrders, Execution Ledger identity, attempt records, review gates, lifecycle state, and operator-visible truth.
+5. Whoosh'd remains substrate-only and may be used only through a provider adapter or OpenAI-compatible inference surface. It does not gain WorkOrder, ADR, receipt, dispatch, or documentation authority.
+6. Receipts are evidence inputs. They do not directly mutate `coding_work_orders`, trigger dispatch, approve completion, create merge readiness, or bypass human/operator review.
+7. Any future durable ingestion must be implemented as a separate reviewed task that maps receipt fields into Codexify-owned attempt evidence records with explicit lineage.
+
+## Definitions
+
+### Pi Loop Manager
+
+A Campaign Runner-local bounded loop engine for one task attempt. It may plan, create execution packets, call a provider adapter, inspect declared changes, run or capture validation evidence, enforce policy gates, and emit receipts.
+
+### Gate Graph
+
+A sequence of typed gates such as context curation, architecture impact review, ADR policy review, planning, execution, inspection, validation, documentation review, and receipt writing. These gates are policy functions, not autonomous personas.
+
+### Loop Receipt
+
+A bounded artifact produced by Pi Loop Manager that summarizes attempt outcome, stop reason, validation evidence, proposed changed paths, ADR impact, documentation impact, and follow-up recommendations.
+
+### Durable Attempt Evidence
+
+Codexify-owned evidence linked to an Execution Ledger attempt or Guardian run/attempt record. A loop receipt can become part of durable attempt evidence only after explicit ingestion through a governed Codexify path.
+
+## Receipt Trust Boundary
+
+A Pi Loop Manager receipt may support claims about:
+
+- task spec used for the attempt.
+- loop gates that ran.
+- provider adapter selected.
+- stop reason declared by the loop.
+- validation commands captured by the loop.
+- artifacts emitted under the run directory.
+- proposed or provider-declared changed paths.
+- policy classifications made by the loop.
+
+A Pi Loop Manager receipt must not independently prove:
+
+- WorkOrder completion.
+- merge readiness.
+- production readiness.
+- UI-visible completion.
+- live runtime support.
+- database state mutation.
+- successful Codexify ingestion.
+- accepted ADR status.
+- provider truth beyond recorded adapter output.
+- release-surface widening.
+
+## Required Ingestion Fields
+
+A future Codexify ingestion path must preserve, at minimum:
+
+- `task_id`
+- `work_order_id` when available
+- `run_id`
+- `attempt_id` or mapped Codexify attempt identity
+- `loop_status`
+- `stop_reason`
+- `provider_kind`
+- `provider_receipt_ref` when available
+- `gate_receipts`
+- `validation_commands`
+- `validation_outputs` or artifact references
+- `changed_paths`
+- `evidence_refs`
+- `adr_impact`
+- `documentation_impact`
+- `operator_review_required`
+- `follow_up_recommendations`
+- source artifact path or object reference
+- ingestion timestamp
+- ingestion actor or service identity
+
+## Operator Review Gates
+
+Operator review remains required before any Codexify durable or mutating adoption when a receipt indicates or implies:
+
+- UI or UX changes.
+- design token changes.
+- architecture contract changes.
+- runtime state-machine changes.
+- provider or broker boundary changes.
+- queue, worker, lease, or dispatch behavior changes.
+- database/schema changes.
+- identity, memory, persona, or privacy behavior changes.
+- accepted ADR mutation.
+- release-readiness claims.
+- merge automation.
+- autonomous progression.
+
+## Deferred Behavior
+
+This ADR does not approve:
+
+- autonomous dispatch.
+- WorkOrder lifecycle mutation from loop receipts.
+- merge automation.
+- automatic completion acceptance.
+- Command Center mutation controls.
+- Whoosh'd provider integration.
+- patch-applying local execution as a Codexify-supported path.
+- durable receipt ingestion.
+- accepted ADR promotion by agents.
+
+Each deferred behavior requires a separate reviewed task and, where architecture-impacting, ADR alignment.
+
+## Documentation Authority
+
+Campaign Runner may write local run artifacts and handoff documents for loop execution.
+
+Codexify canonical architecture documents, accepted ADRs, current-state docs, design tokens, and operator truth surfaces remain read-only by default for agentic loop outputs unless an explicit task grants authority and review gates are satisfied.
+
+Proposed ADRs and proposed specs may be created under proposal paths, but they are not accepted truth until reviewed and promoted by the operator or an approved governance path.
+
+## Consequences
+
+### Positive
+
+- Keeps the Pi Loop Manager useful without granting it authority it should not hold.
+- Gives Codexify a clean path to ingest loop evidence later.
+- Preserves Campaign Runner as the loop mechanics home.
+- Preserves Codexify as durable orchestration truth.
+- Keeps Whoosh'd as runtime substrate rather than orchestration owner.
+- Prevents receipt production from becoming completion theater.
+
+### Tradeoffs
+
+- Adds a documentation step before runtime integration.
+- Slows mutating automation until receipt semantics are reviewed.
+- Requires future mapping between Campaign Runner receipt shape and Codexify attempt evidence shape.
+- Keeps v0 dry-run evidence useful but intentionally non-authoritative.
+
+## Non-Goals
+
+This ADR does not:
+
+- implement migrations.
+- add routes.
+- add UI.
+- modify Campaign Runner code.
+- modify Whoosh'd code.
+- ingest receipts into Codexify.
+- create new runtime tokens.
+- approve autonomous dispatch.
+- approve merge automation.
+- promote this proposed ADR to accepted status.
+
+## Invariants
+
+- Receipt is evidence, not truth.
+- Acceptance is not completion.
+- Validation output is scoped proof, not global release proof.
+- File artifacts are not durable runtime truth when architecture assigns truth to Postgres-backed stores.
+- Campaign Runner loop mechanics must not bypass Guardian or Execution Ledger boundaries.
+- Provider adapters must remain replaceable.
+- Whoosh'd must remain substrate-only.
+- Operator review gates must remain explicit before mutating adoption.
+- Accepted ADRs must not be mutated by loop output.
+
+## Required Follow-Up Work
+
+1. Add `docs/specs/campaign-runner/PI_LOOP_MANAGER_ADOPTION_CONTRACT.md`.
+2. Review Campaign Runner loop receipt schema against this contract.
+3. Add a future Codexify ingestion design only after field mapping is stable.
+4. Add Command Center read-only visibility only after durable ingestion semantics are approved.
+5. Add provider integrations only through adapter boundaries.
+
+## Links
+
+- ADR-028: Execution Ledger Campaign Runner Contract
+- ADR-036: Campaign Runner Provider Adapter Contract
+- ADR-037: Campaign Runner Pi Provider Broker
+- `docs/specs/campaign-runner/PI_LOOP_MANAGER_ADOPTION_CONTRACT.md`

--- a/docs/specs/campaign-runner/PI_LOOP_MANAGER_ADOPTION_CONTRACT.md
+++ b/docs/specs/campaign-runner/PI_LOOP_MANAGER_ADOPTION_CONTRACT.md
@@ -1,0 +1,324 @@
+# Pi Loop Manager Adoption Contract
+
+## Status
+
+Draft contract for proposed ADR-041.
+
+## Purpose
+
+Define how Codexify may treat Campaign Runner Pi Loop Manager v0 outputs without confusing local loop receipts with durable Codexify control-plane truth.
+
+This contract exists before any mutating runtime integration. It is intentionally conservative.
+
+## Scope
+
+This contract covers:
+
+- Campaign Runner Pi Loop Manager receipts.
+- Codexify receipt review and future ingestion boundaries.
+- WorkOrder / Execution Ledger ownership.
+- trust limits for dry-run and future execution receipts.
+- operator review gates before durable or mutating adoption.
+- explicit deferrals for dispatch, merge automation, and autonomous progression.
+
+This contract does not implement runtime behavior.
+
+## System Ownership
+
+| Surface | Owner | Authority |
+|---|---|---|
+| Pi Loop Manager | Campaign Runner | Bounded local loop mechanics for one task attempt |
+| Loop receipts | Campaign Runner output, Codexify evidence input | Evidence only until ingested through a governed Codexify path |
+| WorkOrders | Codexify | Durable atomic task identity and lifecycle |
+| Execution Ledger attempts | Codexify | Durable attempt evidence and review linkage |
+| Guardian-mediated execution | Codexify | Governed execution boundary |
+| Command Center | Codexify | Operator-visible truth surface |
+| Whoosh'd | Whoosh'd | Optional inference/runtime substrate only |
+
+## Adoption Rule
+
+Codexify may reference Pi Loop Manager receipts as attempt evidence.
+
+Codexify must not treat Pi Loop Manager receipts as direct authority to:
+
+- mutate WorkOrder state.
+- approve completion.
+- mark work as merge-ready.
+- dispatch downstream work.
+- widen release claims.
+- bypass Guardian mediation.
+- bypass operator review.
+- mutate accepted ADRs or canonical docs.
+
+## Receipt-As-Evidence Semantics
+
+A receipt can be used as evidence for a bounded attempt only when it preserves source lineage and artifact references.
+
+A receipt can say:
+
+- what task spec was used.
+- what gates ran.
+- what provider adapter was invoked.
+- what status the loop returned.
+- why the loop stopped.
+- what validation commands were captured.
+- what artifacts were emitted.
+- what paths were provider-declared or proposed as changed.
+- whether operator review is required.
+
+A receipt cannot, by itself, say:
+
+- the WorkOrder is complete.
+- the code is merged.
+- the product is release-ready.
+- live runtime support is proven.
+- a UI receipt was shown to the operator.
+- accepted architecture changed.
+- durable Codexify state changed.
+
+## Receipt Classification
+
+Codexify should classify incoming loop receipts using the following dimensions:
+
+```text
+receipt_mode:
+  dry_run
+  patch_producing
+  local_execution
+  durable_ingested
+```
+
+```text
+receipt_trust_level:
+  artifact_only
+  validation_captured
+  validation_passed
+  operator_reviewed
+  durable_evidence_ingested
+```
+
+```text
+receipt_actionability:
+  observe_only
+  review_required
+  follow_up_work_order_candidate
+  ingestion_candidate
+```
+
+For Pi Loop Manager v0, the expected classification is:
+
+```yaml
+receipt_mode: dry_run
+receipt_trust_level: validation_captured
+receipt_actionability: review_required
+```
+
+## Required Receipt Fields
+
+A Codexify-compatible loop receipt should include:
+
+```yaml
+task_id: string
+work_order_id: string | null
+run_id: string
+attempt: integer | null
+loop_status: string
+stop_reason: string
+provider_kind: string
+provider_receipt_ref: string | null
+gate_receipts: list
+validation_commands: list
+validation_outputs: list | artifact refs
+changed_paths: list
+evidence_refs: list
+adr_impact: string
+documentation_impact: string
+operator_review_required: boolean
+follow_up_recommendations: list
+artifact_root: string
+ingestion_timestamp: string | null
+ingestion_actor: string | null
+```
+
+If fields are missing, the receipt may still be preserved as an artifact, but it should not be treated as durable attempt evidence without an explicit review decision.
+
+## Gate Receipt Expectations
+
+Each gate receipt should preserve:
+
+```yaml
+gate_id: string
+gate_status: string
+summary: string
+evidence_refs: list
+changed_paths: list
+adr_impact: string
+documentation_impact: string
+next_gate: string | null
+stop_reason: string | null
+```
+
+Gate failures or ambiguous gate state should fail closed to `review_required` or `blocked` at the Codexify adoption boundary.
+
+## WorkOrder Mapping
+
+A future ingestion path may map loop receipt fields to Codexify surfaces as follows:
+
+| Loop receipt field | Codexify target | Notes |
+|---|---|---|
+| `work_order_id` | `coding_work_orders.id` | Must already exist or require operator mapping |
+| `run_id` | Guardian / attempt lineage | Must not replace WorkOrder identity |
+| `loop_status` | attempt evidence status | Must not directly mutate WorkOrder lifecycle |
+| `stop_reason` | attempt evidence reason | Should use canonical token review before runtime visibility |
+| `validation_outputs` | durable attempt evidence artifact refs | Preserve raw logs or stable artifact pointers |
+| `operator_review_required` | review gate signal | Must not auto-resolve |
+| `follow_up_recommendations` | follow-up WorkOrder candidates | Must remain candidates until accepted |
+
+## Lifecycle Boundary
+
+Pi Loop Manager output may support a future review decision, but it must not directly transition WorkOrders.
+
+Allowed future interpretation:
+
+```text
+loop receipt passed
+  -> proof review candidate
+  -> operator or governed review evaluates evidence
+  -> Codexify may record durable attempt evidence
+```
+
+Forbidden interpretation:
+
+```text
+loop receipt passed
+  -> WorkOrder complete
+  -> merge ready
+  -> downstream dispatch
+```
+
+## Operator Review Gates
+
+Operator review is required before Codexify accepts or acts on receipts involving:
+
+- UI or UX changes.
+- design token changes.
+- public-facing copy changes.
+- accepted ADR changes.
+- architecture contract changes.
+- runtime state-machine changes.
+- database/schema changes.
+- provider/broker boundary changes.
+- queue, worker, lease, or dispatch behavior changes.
+- identity, memory, persona, or privacy behavior changes.
+- release-readiness claims.
+- merge automation.
+- autonomous progression.
+
+## Documentation Authority
+
+Receipts and handoffs may point to proposed documentation.
+
+They may not promote proposed documentation to canonical truth.
+
+Agent-generated docs should be classified as:
+
+```text
+operational artifact
+handoff
+proposal
+canonical change request
+```
+
+Canonical docs remain read-only by default:
+
+- accepted ADRs.
+- `docs/architecture/00-current-state.md`.
+- runtime contracts.
+- design tokens.
+- release-readiness docs.
+- operator truth doctrine.
+
+## Provider Boundary
+
+Pi Loop Manager must call providers through adapters.
+
+Codexify adoption must not assume a direct provider identity unless the receipt records it.
+
+Whoosh'd may serve as an OpenAI-compatible inference substrate through an adapter, but Whoosh'd must not gain authority over:
+
+- WorkOrders.
+- Execution Ledger attempts.
+- ADR policy.
+- documentation authority.
+- dispatch.
+- merge readiness.
+- completion review.
+
+## Validation Boundary
+
+Validation evidence proves only what was actually checked.
+
+Dry-run validation proves the loop can produce and classify evidence. It does not prove applied code changes unless the loop actually applies patches and runs validation against the mutated workspace.
+
+Validation outputs should record:
+
+- command.
+- exit code.
+- stdout/stderr or artifact reference.
+- run location.
+- timestamp when available.
+- whether the command was declared by the task spec or suggested by the loop.
+
+Suggested commands may be useful, but only executed and recorded commands count as evidence.
+
+## Deferrals
+
+The following remain deferred until separate reviewed tasks exist:
+
+1. Patch-applying local execution.
+2. Real provider adapter beyond stub/manual handoff.
+3. Whoosh'd/OpenAI-compatible provider adapter.
+4. Codexify durable receipt ingestion.
+5. WorkOrder lifecycle mutation from receipts.
+6. Command Center read-only receipt visibility.
+7. Command Center mutation controls.
+8. autonomous dispatch.
+9. merge automation.
+10. accepted ADR promotion by agents.
+
+## Minimal Future Ingestion Flow
+
+A future ingestion path should follow this shape:
+
+```text
+Campaign Runner loop receipt
+  -> Codexify ingestion endpoint or worker
+  -> schema validation
+  -> WorkOrder identity resolution
+  -> artifact reference preservation
+  -> attempt evidence record creation
+  -> proof review state set to pending
+  -> Command Center read-only visibility
+```
+
+The ingestion path should not perform completion acceptance, merge readiness, or dispatch.
+
+## Acceptance Criteria For This Contract
+
+This contract is sufficient for the next implementation slice when:
+
+- the receipt-as-evidence rule is explicit.
+- WorkOrder and Execution Ledger ownership remain in Codexify.
+- required receipt fields are listed.
+- trust limits are documented.
+- operator review gates are listed.
+- Whoosh'd remains substrate-only.
+- dispatch, merge automation, and autonomous progression are explicitly deferred.
+- no runtime behavior is implemented by this document.
+
+## Recommended Next Tasks
+
+1. Review the Campaign Runner Pi Loop Manager v0 receipt schema against Required Receipt Fields.
+2. Add a Codexify proof-only fixture using a sample loop receipt.
+3. Draft a future ingestion task that stores receipt artifacts as attempt evidence without mutating WorkOrder lifecycle.
+4. Add Command Center read-only receipt visibility only after ingestion semantics are approved.


### PR DESCRIPTION
## Summary

Adds the Codexify adoption boundary for Campaign Runner's Pi Loop Manager v0 dry-run receipt spine.

This PR adds two docs-only artifacts:

- `docs/architecture/adr/proposed/041-pi-loop-manager-campaign-runner-gate-graph.md`
- `docs/specs/campaign-runner/PI_LOOP_MANAGER_ADOPTION_CONTRACT.md`

## Key boundaries

- Pi Loop Manager receipts are evidence, not durable control-plane truth.
- Campaign Runner owns bounded local loop mechanics.
- Codexify remains owner of WorkOrders, Execution Ledger identity, attempt evidence, lifecycle state, and operator-visible truth.
- Whoosh'd remains optional substrate-only provider infrastructure.
- Receipt production does not imply completion, merge readiness, dispatch, or autonomous progression.

## Explicit deferrals

This PR does not implement:

- runtime behavior
- migrations
- routes
- Command Center UI
- durable receipt ingestion
- WorkOrder lifecycle mutation
- autonomous dispatch
- merge automation
- Whoosh'd provider integration
- accepted ADR promotion

## Validation

Docs-only change. No runtime validation required.

## ADR impact

Proposal created. No accepted ADRs mutated.