### PR TITLE
Update Whoosh'd local base URL contracts

### DIFF
--- a/config/supported_profiles/v1-local-core-web-mcp.yaml
+++ b/config/supported_profiles/v1-local-core-web-mcp.yaml
@@ -70,7 +70,7 @@ provider_contract:
   ALLOW_CLOUD_PROVIDERS: false
   CODEXIFY_LOCAL_ONLY_MODE: true
   CODEXIFY_EGRESS_ALLOWLIST: ""
-  LOCAL_BASE_URL: http://100.109.4.57:8000/v1
+  LOCAL_BASE_URL: http://host.docker.internal:8000/v1
   LOCAL_API_KEY: local
   # Model names are NOT enforced here — the system discovers available models
   # at runtime. If no local models exist AND no cloud provider is configured,

--- a/docker-compose.whooshd-smoke.yml
+++ b/docker-compose.whooshd-smoke.yml
@@ -28,8 +28,8 @@ services:
       # ── Blessed Whoosh'd local gateway contract ──
       LLM_PROVIDER: "local"
       LOCAL_PROVIDER_VENDOR: "whooshd"
-      LOCAL_BASE_URL: "http://100.109.4.57:8000/v1"
-      WHOOSHD_HEALTH_BASE_URL: "http://100.109.4.57:8000"
+      LOCAL_BASE_URL: "http://100.127.148.28:8000/v1"
+      WHOOSHD_HEALTH_BASE_URL: "http://100.127.148.28:8000"
       LOCAL_API_KEY: "local"
 
       # ── Model aliases (must exist in Whoosh'd registry) ──
@@ -56,8 +56,8 @@ services:
       # ── Blessed Whoosh'd local gateway contract ──
       LLM_PROVIDER: "local"
       LOCAL_PROVIDER_VENDOR: "whooshd"
-      LOCAL_BASE_URL: "http://100.109.4.57:8000/v1"
-      WHOOSHD_HEALTH_BASE_URL: "http://100.109.4.57:8000"
+      LOCAL_BASE_URL: "http://100.127.148.28:8000/v1"
+      WHOOSHD_HEALTH_BASE_URL: "http://100.127.148.28:8000"
       LOCAL_API_KEY: "local"
 
       # ── Model aliases ──
@@ -83,7 +83,7 @@ services:
     environment:
       LLM_PROVIDER: "local"
       LOCAL_PROVIDER_VENDOR: "whooshd"
-      LOCAL_BASE_URL: "http://100.109.4.57:8000/v1"
+      LOCAL_BASE_URL: "http://100.127.148.28:8000/v1"
       ALLOW_CLOUD_PROVIDERS: "false"
       CODEXIFY_EGRESS_ALLOWLIST: ""
       CODEXIFY_LOCAL_ONLY_MODE: "true"
@@ -96,7 +96,7 @@ services:
     environment:
       LLM_PROVIDER: "local"
       LOCAL_PROVIDER_VENDOR: "whooshd"
-      LOCAL_BASE_URL: "http://100.109.4.57:8000/v1"
+      LOCAL_BASE_URL: "http://100.127.148.28:8000/v1"
       ALLOW_CLOUD_PROVIDERS: "false"
       CODEXIFY_EGRESS_ALLOWLIST: ""
       CODEXIFY_LOCAL_ONLY_MODE: "true"

--- a/tests/test_whooshd_smoke_env_contract.py
+++ b/tests/test_whooshd_smoke_env_contract.py
@@ -228,7 +228,7 @@ class TestContractRequiresCorrectLocalBaseUrl:
         profile = _load_supported_profile()
         contract = profile["provider_contract"]
 
-        actual = "http://100.109.4.57:11434"
+        actual = "http://100.127.148.28:11434"
         assert actual != contract["LOCAL_BASE_URL"], (
             "Tailscale IP URL should not match blessed Whoosh'd gateway"
         )


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
