### PR TITLE
Extract document collaboration event normalizer

### DIFF
--- a/frontend/src/components/editor/__tests__/collaborationEvents.test.ts
+++ b/frontend/src/components/editor/__tests__/collaborationEvents.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "vitest";
+import { normalizeDocumentCollaborationEvent } from "../collaborationEvents";
+
+describe("normalizeDocumentCollaborationEvent", () => {
+  // ── Content updates ──────────────────────────────────────────────────────
+
+  it("normalizes a direct content update to content.update", () => {
+    const input = { type: "update", content: "Direct content", user_id: "user2" };
+    const event = normalizeDocumentCollaborationEvent(input);
+
+    expect(event.kind).toBe("content.update");
+    if (event.kind !== "content.update") return;
+    expect(event.content).toBe("Direct content");
+    expect(event.userId).toBe("user2");
+    expect(event.raw).toBe(input);
+  });
+
+  it("normalizes a payload content update to content.update", () => {
+    const input = {
+      type: "update",
+      payload: { content: "Remote change" },
+      user_id: "user2",
+    };
+    const event = normalizeDocumentCollaborationEvent(input);
+
+    expect(event.kind).toBe("content.update");
+    if (event.kind !== "content.update") return;
+    expect(event.content).toBe("Remote change");
+    expect(event.userId).toBe("user2");
+    expect(event.raw).toBe(input);
+  });
+
+  it("normalizes a payload content update without a user_id", () => {
+    const input = { type: "update", payload: { content: "no author" } };
+    const event = normalizeDocumentCollaborationEvent(input);
+
+    expect(event.kind).toBe("content.update");
+    if (event.kind !== "content.update") return;
+    expect(event.content).toBe("no author");
+    expect(event.userId).toBeUndefined();
+  });
+
+  // ── Presence ─────────────────────────────────────────────────────────────
+
+  it("normalizes direct presence.join with active user IDs", () => {
+    const input = {
+      type: "presence.join",
+      user_id: "user2",
+      active_users: ["user1", "user2"],
+    };
+    const event = normalizeDocumentCollaborationEvent(input);
+
+    expect(event.kind).toBe("presence.join");
+    if (event.kind !== "presence.join") return;
+    expect(event.activeUserIds).toEqual(["user1", "user2"]);
+    expect(event.userId).toBe("user2");
+    expect(event.raw).toBe(input);
+  });
+
+  it("normalizes direct presence.leave with active user IDs", () => {
+    const input = {
+      type: "presence.leave",
+      user_id: "user2",
+      active_users: ["user1"],
+    };
+    const event = normalizeDocumentCollaborationEvent(input);
+
+    expect(event.kind).toBe("presence.leave");
+    if (event.kind !== "presence.leave") return;
+    expect(event.activeUserIds).toEqual(["user1"]);
+    expect(event.userId).toBe("user2");
+    expect(event.raw).toBe(input);
+  });
+
+  // ── Typing (direct) ──────────────────────────────────────────────────────
+
+  it("normalizes direct typing.start", () => {
+    const input = { type: "typing.start", user_id: "user2" };
+    const event = normalizeDocumentCollaborationEvent(input);
+
+    expect(event.kind).toBe("typing.start");
+    if (event.kind !== "typing.start") return;
+    expect(event.userId).toBe("user2");
+    expect(event.raw).toBe(input);
+  });
+
+  it("normalizes direct typing.stop", () => {
+    const input = { type: "typing.stop", user_id: "user2" };
+    const event = normalizeDocumentCollaborationEvent(input);
+
+    expect(event.kind).toBe("typing.stop");
+    if (event.kind !== "typing.stop") return;
+    expect(event.userId).toBe("user2");
+    expect(event.raw).toBe(input);
+  });
+
+  // ── Typing (wrapped envelope) ────────────────────────────────────────────
+
+  it("normalizes wrapped typing.start as typing.start", () => {
+    const input = {
+      type: "update",
+      payload: { type: "typing.start", user_id: "user2" },
+      user_id: "user2",
+    };
+    const event = normalizeDocumentCollaborationEvent(input);
+
+    expect(event.kind).toBe("typing.start");
+    if (event.kind !== "typing.start") return;
+    expect(event.userId).toBe("user2");
+    expect(event.raw).toBe(input);
+  });
+
+  it("normalizes wrapped typing.stop as typing.stop", () => {
+    const input = {
+      type: "update",
+      payload: { type: "typing.stop", user_id: "user2" },
+      user_id: "user2",
+    };
+    const event = normalizeDocumentCollaborationEvent(input);
+
+    expect(event.kind).toBe("typing.stop");
+    if (event.kind !== "typing.stop") return;
+    expect(event.userId).toBe("user2");
+    expect(event.raw).toBe(input);
+  });
+
+  it("does not normalize wrapped typing as a content update", () => {
+    const event = normalizeDocumentCollaborationEvent({
+      type: "update",
+      payload: { type: "typing.start", user_id: "user2" },
+      user_id: "user2",
+    });
+
+    expect(event.kind).not.toBe("content.update");
+    expect(event.kind).toBe("typing.start");
+  });
+
+  // ── Malformed / unknown shapes ───────────────────────────────────────────
+
+  it("normalizes malformed messages to unknown", () => {
+    expect(normalizeDocumentCollaborationEvent(null).kind).toBe("unknown");
+    expect(normalizeDocumentCollaborationEvent(undefined).kind).toBe("unknown");
+    expect(normalizeDocumentCollaborationEvent(42).kind).toBe("unknown");
+    expect(normalizeDocumentCollaborationEvent("update").kind).toBe("unknown");
+    expect(normalizeDocumentCollaborationEvent({}).kind).toBe("unknown");
+    expect(
+      normalizeDocumentCollaborationEvent({ type: "bogus" }).kind
+    ).toBe("unknown");
+  });
+
+  it("normalizes a message without a recognizable type to unknown", () => {
+    const input = { type: "typing.indeterminate", user_id: "user2" };
+    const event = normalizeDocumentCollaborationEvent(input);
+    expect(event.kind).toBe("unknown");
+  });
+
+  it("normalizes direct typing without user_id to unknown", () => {
+    const input = { type: "typing.start" };
+    const event = normalizeDocumentCollaborationEvent(input);
+    expect(event.kind).toBe("unknown");
+  });
+
+  it("normalizes wrapped typing without user_id to unknown", () => {
+    const input = { type: "update", payload: { type: "typing.start" } };
+    const event = normalizeDocumentCollaborationEvent(input);
+    expect(event.kind).toBe("unknown");
+  });
+
+  it("does not mutate the input object", () => {
+    const input = {
+      type: "update",
+      payload: { type: "typing.start", user_id: "user2" },
+      user_id: "user2",
+    };
+    const snapshot = JSON.parse(JSON.stringify(input));
+
+    normalizeDocumentCollaborationEvent(input);
+
+    expect(input).toEqual(snapshot);
+  });
+});

--- a/frontend/src/components/editor/collaborationEvents.ts
+++ b/frontend/src/components/editor/collaborationEvents.ts
@@ -1,0 +1,133 @@
+/**
+ * Document collaboration event normalizer.
+ *
+ * Translates raw WebSocket messages from the `/api/collab/ws/{documentId}`
+ * channel into a single, exhaustive discriminated union so the
+ * `useDocumentCollaboration` hook never needs to re-implement direct-vs-wrapped
+ * envelope parsing inline.
+ *
+ * The backend `ws_collab` handler is known to wrap some non-`update` messages
+ * (notably typing) inside an `{ type: "update", payload: ... }` envelope. This
+ * normalizer treats wrapped typing events as typing, never as content updates.
+ *
+ * Contract:
+ *  - Pure: does not mutate its input, does not import React, and performs no
+ *    I/O, scheduling, or state mutation.
+ *  - Total: any input shape is mapped to exactly one union member; malformed
+ *    or unrecognized shapes collapse to `{ kind: "unknown", raw }`.
+ */
+
+export type NormalizedDocumentCollaborationEvent =
+  | {
+      kind: "content.update";
+      content: string;
+      userId?: string;
+      raw: unknown;
+    }
+  | {
+      kind: "presence.join";
+      activeUserIds: string[];
+      userId?: string;
+      raw: unknown;
+    }
+  | {
+      kind: "presence.leave";
+      activeUserIds: string[];
+      userId?: string;
+      raw: unknown;
+    }
+  | {
+      kind: "typing.start";
+      userId: string;
+      raw: unknown;
+    }
+  | {
+      kind: "typing.stop";
+      userId: string;
+      raw: unknown;
+    }
+  | {
+      kind: "unknown";
+      raw: unknown;
+    };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+export function normalizeDocumentCollaborationEvent(
+  message: unknown
+): NormalizedDocumentCollaborationEvent {
+  if (!isRecord(message)) {
+    return { kind: "unknown", raw: message };
+  }
+
+  const type = typeof message.type === "string" ? message.type : undefined;
+
+  // Wrapped envelope: `{ type: "update", payload: { ... } }`. The backend
+  // `ws_collab` handler may re-wrap non-update messages this way. Typing is
+  // checked before content so wrapped typing never masquerades as an update.
+  if (type === "update" && isRecord(message.payload)) {
+    const payload = message.payload;
+    const payloadType =
+      typeof payload.type === "string" ? payload.type : undefined;
+
+    if (payloadType === "typing.start" || payloadType === "typing.stop") {
+      if (typeof payload.user_id === "string") {
+        return { kind: payloadType, userId: payload.user_id, raw: message };
+      }
+      return { kind: "unknown", raw: message };
+    }
+
+    if (typeof payload.content === "string") {
+      return {
+        kind: "content.update",
+        content: payload.content,
+        userId: optionalString(message.user_id),
+        raw: message,
+      };
+    }
+  }
+
+  // Direct update without a payload wrapper: `{ type: "update", content, user_id }`.
+  if (type === "update") {
+    if (typeof message.content === "string") {
+      return {
+        kind: "content.update",
+        content: message.content,
+        userId: optionalString(message.user_id),
+        raw: message,
+      };
+    }
+  }
+
+  // Presence: join/leave carry the authoritative active-user list.
+  if (type === "presence.join" || type === "presence.leave") {
+    if (isStringArray(message.active_users)) {
+      return {
+        kind: type,
+        activeUserIds: message.active_users,
+        userId: optionalString(message.user_id),
+        raw: message,
+      };
+    }
+  }
+
+  // Direct (unwrapped) typing events.
+  if (type === "typing.start" || type === "typing.stop") {
+    if (typeof message.user_id === "string") {
+      return { kind: type, userId: message.user_id, raw: message };
+    }
+    return { kind: "unknown", raw: message };
+  }
+
+  return { kind: "unknown", raw: message };
+}

--- a/frontend/src/components/editor/useDocumentCollaboration.ts
+++ b/frontend/src/components/editor/useDocumentCollaboration.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { WsClient } from "@/lib/wsClient";
+import { normalizeDocumentCollaborationEvent } from "./collaborationEvents";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -198,35 +199,25 @@ export function useDocumentCollaboration({
     };
 
     client.on("message", (data: any) => {
-      if (data?.type === "update") {
-        const payload = data.payload ?? data;
+      const event = normalizeDocumentCollaborationEvent(data);
 
-        // Typing events may arrive wrapped in an update envelope from the
-        // backend ws_collab handler. Route them before checking for content.
-        if (
-          (payload?.type === "typing.start" ||
-            payload?.type === "typing.stop") &&
-          typeof payload?.user_id === "string"
-        ) {
-          if (payload.type === "typing.start") {
-            handleRemoteTypingStart(payload.user_id);
-          } else {
-            handleRemoteTypingStop(payload.user_id);
-          }
-          return;
-        }
-
-        if (payload?.content !== undefined) {
-          onRemoteContentUpdate(payload.content);
-        }
-      } else if (data?.type === "presence.join" && Array.isArray(data?.active_users)) {
-        rebuildPresence(data.active_users);
-      } else if (data?.type === "presence.leave" && Array.isArray(data?.active_users)) {
-        rebuildPresence(data.active_users);
-      } else if (data?.type === "typing.start" && typeof data?.user_id === "string") {
-        handleRemoteTypingStart(data.user_id);
-      } else if (data?.type === "typing.stop" && typeof data?.user_id === "string") {
-        handleRemoteTypingStop(data.user_id);
+      switch (event.kind) {
+        case "content.update":
+          onRemoteContentUpdate(event.content);
+          break;
+        case "presence.join":
+        case "presence.leave":
+          rebuildPresence(event.activeUserIds);
+          break;
+        case "typing.start":
+          handleRemoteTypingStart(event.userId);
+          break;
+        case "typing.stop":
+          handleRemoteTypingStop(event.userId);
+          break;
+        case "unknown":
+        default:
+          break;
       }
     });
 


### PR DESCRIPTION
## Summary

Extracts document-collaboration message interpretation out of the `useDocumentCollaboration` hook into a single pure, React-free normalizer (`collaborationEvents.ts`) before adding richer presence / cursor event types.

The backend `ws_collab` handler is known to wrap non-`update` messages (notably typing) inside an `{ type: "update", payload: ... }` envelope. The hook handled this inline after the wrapped-typing fix, but that parsing was local and easy to duplicate incorrectly as new event types land. This PR introduces one explicit, testable parser seam.

## Changes

- **`frontend/src/components/editor/collaborationEvents.ts`** (new) — `NormalizedDocumentCollaborationEvent` discriminated union + `normalizeDocumentCollaborationEvent()`. Pure: no input mutation, no React dependency, no I/O, timers, or state. Wrapped typing is checked **before** content so it never masquerades as a content update; malformed / missing-`user_id` shapes collapse to `{ kind: "unknown", raw }`.
- **`frontend/src/components/editor/__tests__/collaborationEvents.test.ts`** (new) — 15 unit tests covering direct + payload content updates, presence join/leave, direct + wrapped typing, wrapped-typing-is-not-content, malformed→unknown, missing-`user_id`→unknown, and input-not-mutated.
- **`frontend/src/components/editor/useDocumentCollaboration.ts`** — inline direct-vs-wrapped parsing replaced by an exhaustive `switch` over `event.kind`. Behavior unchanged: content updates still call `onRemoteContentUpdate`; presence join/leave still rebuilds `activeUsers`; typing start/stop still updates `typingUsers`; typing from the current user is ignored; 3000ms expiry and reset-on-repeat preserved; timer cleanup intact; outgoing `sendContentUpdate` / `notifyTyping` / `stopTyping` payloads untouched.

## Behavior preserved

Wrapped `{ type:"update", payload:{ type:"typing.start", user_id } }` still normalizes to `typing.start` (priority over content) and **never** calls `onRemoteContentUpdate` — i.e. wrapped typing events still do not overwrite editor content.

## Validation

Run from repo root via \`pnpm --dir frontend test\`:

| Suite | Result |
| --- | --- |
| \`collaborationEvents\` | 15 passed |
| \`useDocumentCollaboration\` | 32 passed |
| \`CollaborativeNote\` | 20 passed |
| \`wsClient\` | 31 passed |
| \`git diff --check\` | clean |

Frontend-only: no backend / server-route / schema / migration / share-link / annotation / cursor / GuardianChat changes.

## Notes

- This is the only unmerged collaboration commit on this branch; the prior collab slices (resilient `WsClient`, hook extraction, typing indicator, typing-broadcast proof, wrapped-typing fix) are already on `main`.
- Deliberate in-scope tightening: `content.update` now requires \`typeof content === "string"\` to match the \`(content: string) => void\` callback contract; all existing tests send string content.