### PR TITLE
Fix remote-auth thread ownership payload

### DIFF
--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -77,7 +77,10 @@ import type { RagTraceResponse } from "@/types/rag";
 import { fetchSystemPromptSummary, type PromptCostStatus, type SystemPromptSummary } from "@/imprint/api";
 import { logOnce } from "@/lib/logging/logOnce";
 import { useAuthState } from "@/lib/authState";
-import { getRuntimeConfigHydrationState } from "@/lib/runtimeConfig";
+import {
+  getRuntimeConfigHydrationState,
+  getRuntimeConfigSync,
+} from "@/lib/runtimeConfig";
 import {
   describeModelCapability,
   isChatSelectableModel,
@@ -3102,7 +3105,7 @@ export function GuardianChat({
         return effectiveThreadId;
       }
 
-      const normalizedUserId = CANONICAL_SINGLE_USER_ID;
+      const runtimeConfig = getRuntimeConfigSync();
       const originTabId = options?.tabId ?? activeSessionTabIdRef.current;
       const firstLine = bodyText.trim().split(/\n+/)[0] ?? "";
       const provisionalTitle = firstLine.slice(0, 60) || NEW_THREAD_TITLE;
@@ -3112,11 +3115,14 @@ export function GuardianChat({
       const createThreadEndpoint = buildChatThreadsPath();
 
       try {
-        const resp = await api.post(createThreadEndpoint, {
+        const createThreadPayload = {
           title: provisionalTitle,
-          user_id: normalizedUserId,
           metadata,
-        });
+          ...(runtimeConfig.authMode === "remote"
+            ? {}
+            : { user_id: CANONICAL_SINGLE_USER_ID }),
+        };
+        const resp = await api.post(createThreadEndpoint, createThreadPayload);
         const response = resp ?? {};
         const resolution = resolveBackendThreadIdFromResponse(response, {
           endpoint: `POST ${createThreadEndpoint}`,

--- a/frontend/src/features/chat/__tests__/GuardianChat.test.tsx
+++ b/frontend/src/features/chat/__tests__/GuardianChat.test.tsx
@@ -45,6 +45,9 @@ const authState = vi.hoisted(() => ({
   status: "authenticated" as const,
   token: "test-token",
 }));
+const runtimeConfigState = vi.hoisted(() => ({
+  authMode: "local" as "local" | "remote",
+}));
 
 type MockGuardianEventSource = EventTarget & {
   url: string;
@@ -262,6 +265,21 @@ vi.mock("@/lib/authState", () => ({
   useAuthState: () => authState,
 }));
 
+vi.mock("@/lib/runtimeConfig", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/runtimeConfig")>(
+    "@/lib/runtimeConfig"
+  );
+
+  return {
+    ...actual,
+    getRuntimeConfigHydrationState: () => "ready",
+    getRuntimeConfigSync: () => ({
+      ...actual.getRuntimeConfigSync(),
+      authMode: runtimeConfigState.authMode,
+    }),
+  };
+});
+
 vi.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenu: ({ children }: any) => <div>{children}</div>,
   DropdownMenuTrigger: ({ children, asChild, ...props }: any) => {
@@ -446,6 +464,7 @@ describe("GuardianChat inference rail", () => {
     authState.ready = true;
     authState.status = "authenticated";
     authState.token = "test-token";
+    runtimeConfigState.authMode = "local";
     try {
       window.localStorage.setItem("cfy.voice.playbackEnabled", "");
       window.localStorage.setItem("cfy.voice.turnEnabled", "");
@@ -822,6 +841,63 @@ describe("GuardianChat inference rail", () => {
       ).not.toBeInTheDocument();
     }
   );
+
+  it("omits the local user id when creating a thread in remote auth mode", async () => {
+    runtimeConfigState.authMode = "remote";
+    renderChat("draft-thread", {
+      userName: "Resonant Jones",
+    });
+
+    apiMock.post.mockImplementation(async (url: string, body?: any) => {
+      if (url === "/api/chat/threads") {
+        expect(body).toEqual(
+          expect.objectContaining({
+            title: "hello",
+            metadata: expect.any(Object),
+          })
+        );
+        expect(body).not.toHaveProperty("user_id");
+        return createApiResponse(
+          { thread_id: 2, thread: { id: 2, title: "New Thread" } },
+          201
+        );
+      }
+      if (url === "/chat/2/messages") {
+        return createApiResponse(
+          {
+            ok: true,
+            thread: { id: 2, title: "New Thread" },
+            message: { id: 456, thread_id: 2 },
+          },
+          200
+        );
+      }
+      if (url === "/chat/2/complete") {
+        return createApiResponse({ task_id: "task-123" }, 200);
+      }
+      return createApiResponse({}, 200);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("composer-send"));
+    });
+    await advanceTimers(100);
+
+    await waitFor(() => {
+      expect(apiMock.post).toHaveBeenCalledWith(
+        "/api/chat/threads",
+        expect.objectContaining({
+          title: "hello",
+          metadata: expect.any(Object),
+        })
+      );
+    });
+
+    const createThreadCall = apiMock.post.mock.calls.find(
+      ([url]) => url === "/api/chat/threads"
+    );
+    expect(createThreadCall?.[1]).not.toHaveProperty("user_id");
+  });
 
   it("surfaces sanitized diagnostics when the create-thread response lacks a thread id", async () => {
     renderChat("draft-thread", {


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
