### PR TITLE
Add document collaboration cursor presence

### DIFF
--- a/frontend/src/components/editor/CollaborativeNote.tsx
+++ b/frontend/src/components/editor/CollaborativeNote.tsx
@@ -80,9 +80,11 @@ export function CollaborativeNote({
     accessDenied,
     activeUsers,
     typingUsers,
+    cursorUsers,
     sendContentUpdate,
     notifyTyping,
     stopTyping,
+    sendCursorPosition,
   } = useDocumentCollaboration({
     documentId,
     userId,
@@ -239,6 +241,21 @@ export function CollaborativeNote({
             </span>
           )}
 
+          {/* Cursor presence indicator */}
+          {cursorUsers.length > 0 && (
+            <span
+              style={{
+                fontSize: 11,
+                color: "var(--text-subtle)",
+                fontStyle: "italic",
+              }}
+            >
+              {cursorUsers.length === 1
+                ? `User ${cursorUsers[0].user_id} cursor at ${cursorUsers[0].position}`
+                : `${cursorUsers.length} collaborator cursors active`}
+            </span>
+          )}
+
           {/* Permission lock indicator */}
           {!permissions?.can_edit && (
             <div
@@ -382,6 +399,15 @@ export function CollaborativeNote({
       <textarea
         value={content}
         onChange={(e: any) => handleChange(e.target.value)}
+        onSelect={(e: any) =>
+          sendCursorPosition(e.target.selectionStart as number)
+        }
+        onClick={(e: any) =>
+          sendCursorPosition(e.target.selectionStart as number)
+        }
+        onKeyUp={(e: any) =>
+          sendCursorPosition(e.target.selectionStart as number)
+        }
         disabled={permissions?.can_edit === false}
         placeholder={
           permissions?.can_edit === false

--- a/frontend/src/components/editor/__tests__/CollaborativeNote.test.tsx
+++ b/frontend/src/components/editor/__tests__/CollaborativeNote.test.tsx
@@ -591,14 +591,228 @@ describe("CollaborativeNote", () => {
       });
     });
 
-    // Content must not change — typing events have no 'content' field
-    const textarea = screen.getByPlaceholderText(
-      /Start typing/i
-    ) as HTMLTextAreaElement;
-    expect(textarea.value).toBe("Existing text");
-  });
+      // Content must not change — typing events have no 'content' field
+      const textarea = screen.getByPlaceholderText(
+        /Start typing/i
+      ) as HTMLTextAreaElement;
+      expect(textarea.value).toBe("Existing text");
+    });
 
-  // ── Cleanup ─────────────────────────────────────────────────────────────
+    // ── Cursor presence ────────────────────────────────────────────────────
+
+    it("textarea selection sends cursor position through the hook path", async () => {
+      render(
+        <CollaborativeNote
+          documentId="doc1"
+          threadId={1}
+          userId="user1"
+          initialContent=""
+        />
+      );
+
+      await act(async () => {
+        latestWs().simulateOpen();
+      });
+
+      const textarea = screen.getByPlaceholderText(
+        /Start typing/i
+      ) as HTMLTextAreaElement;
+
+      await act(async () => {
+        fireEvent.select(textarea);
+      });
+
+      const cursorMsgs = latestWs().sentMessages.filter(
+        (m: any) => m.type === "cursor.position"
+      );
+      expect(cursorMsgs.length).toBeGreaterThanOrEqual(1);
+      expect(cursorMsgs[cursorMsgs.length - 1].user_id).toBe("user1");
+      expect(typeof cursorMsgs[cursorMsgs.length - 1].position).toBe("number");
+    });
+
+    it("textarea click sends cursor position through the hook path", async () => {
+      render(
+        <CollaborativeNote
+          documentId="doc1"
+          threadId={1}
+          userId="user1"
+          initialContent=""
+        />
+      );
+
+      await act(async () => {
+        latestWs().simulateOpen();
+      });
+
+      const textarea = screen.getByPlaceholderText(
+        /Start typing/i
+      ) as HTMLTextAreaElement;
+
+      await act(async () => {
+        fireEvent.click(textarea);
+      });
+
+      const cursorMsgs = latestWs().sentMessages.filter(
+        (m: any) => m.type === "cursor.position"
+      );
+      expect(cursorMsgs.length).toBeGreaterThanOrEqual(1);
+      expect(cursorMsgs[cursorMsgs.length - 1].user_id).toBe("user1");
+    });
+
+    it("textarea key-up sends cursor position through the hook path", async () => {
+      render(
+        <CollaborativeNote
+          documentId="doc1"
+          threadId={1}
+          userId="user1"
+          initialContent=""
+        />
+      );
+
+      await act(async () => {
+        latestWs().simulateOpen();
+      });
+
+      const textarea = screen.getByPlaceholderText(
+        /Start typing/i
+      ) as HTMLTextAreaElement;
+
+      await act(async () => {
+        fireEvent.keyUp(textarea, { key: "a" });
+      });
+
+      const cursorMsgs = latestWs().sentMessages.filter(
+        (m: any) => m.type === "cursor.position"
+      );
+      expect(cursorMsgs.length).toBeGreaterThanOrEqual(1);
+      expect(cursorMsgs[cursorMsgs.length - 1].user_id).toBe("user1");
+    });
+
+    it("wrapped backend cursor event renders the cursor-presence indicator", async () => {
+      render(
+        <CollaborativeNote
+          documentId="doc1"
+          threadId={1}
+          userId="user1"
+          initialContent=""
+        />
+      );
+
+      await act(async () => {
+        latestWs().simulateOpen();
+      });
+
+      await act(async () => {
+        latestWs().simulateMessage({
+          type: "update",
+          payload: { type: "cursor.position", user_id: "user2", position: 5 },
+          user_id: "user2",
+        });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/User user2 cursor at 5/)).toBeInTheDocument();
+      });
+    });
+
+    it("cursor presence expires and hides", async () => {
+      render(
+        <CollaborativeNote
+          documentId="doc1"
+          threadId={1}
+          userId="user1"
+          initialContent=""
+        />
+      );
+
+      await act(async () => {
+        latestWs().simulateOpen();
+      });
+
+      await act(async () => {
+        latestWs().simulateMessage({
+          type: "update",
+          payload: { type: "cursor.position", user_id: "user2", position: 5 },
+          user_id: "user2",
+        });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/User user2 cursor at 5/)).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(5_100);
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText(/cursor/)).not.toBeInTheDocument();
+      });
+    });
+
+    it("wrapped cursor event does not overwrite editor content", async () => {
+      render(
+        <CollaborativeNote
+          documentId="doc1"
+          threadId={1}
+          userId="user1"
+          initialContent="Existing text"
+        />
+      );
+
+      await act(async () => {
+        latestWs().simulateOpen();
+      });
+
+      await act(async () => {
+        latestWs().simulateMessage({
+          type: "update",
+          payload: { type: "cursor.position", user_id: "user2", position: 3 },
+          user_id: "user2",
+        });
+      });
+
+      const textarea = screen.getByPlaceholderText(
+        /Start typing/i
+      ) as HTMLTextAreaElement;
+      expect(textarea.value).toBe("Existing text");
+    });
+
+    it("multiple remote cursor users show collaborators count", async () => {
+      render(
+        <CollaborativeNote
+          documentId="doc1"
+          threadId={1}
+          userId="user1"
+          initialContent=""
+        />
+      );
+
+      await act(async () => {
+        latestWs().simulateOpen();
+      });
+
+      await act(async () => {
+        latestWs().simulateMessage({
+          type: "cursor.position",
+          user_id: "user2",
+          position: 1,
+        });
+        latestWs().simulateMessage({
+          type: "cursor.position",
+          user_id: "user3",
+          position: 2,
+        });
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/2 collaborator cursors active/)
+        ).toBeInTheDocument();
+      });
+    });
+
+    // ── Cleanup ─────────────────────────────────────────────────────────────
 
   it("cleans up on unmount", async () => {
     const { unmount } = render(

--- a/frontend/src/components/editor/__tests__/collaborationEvents.test.ts
+++ b/frontend/src/components/editor/__tests__/collaborationEvents.test.ts
@@ -135,6 +135,80 @@ describe("normalizeDocumentCollaborationEvent", () => {
     expect(event.kind).toBe("typing.start");
   });
 
+  // ── Cursor position ──────────────────────────────────────────────────────
+
+  it("normalizes a direct cursor.position", () => {
+    const input = { type: "cursor.position", user_id: "user2", position: 7 };
+    const event = normalizeDocumentCollaborationEvent(input);
+
+    expect(event.kind).toBe("cursor.position");
+    if (event.kind !== "cursor.position") return;
+    expect(event.userId).toBe("user2");
+    expect(event.position).toBe(7);
+    expect(event.raw).toBe(input);
+  });
+
+  it("normalizes a wrapped cursor.position", () => {
+    const input = {
+      type: "update",
+      payload: { type: "cursor.position", user_id: "user2", position: 12 },
+      user_id: "user2",
+    };
+    const event = normalizeDocumentCollaborationEvent(input);
+
+    expect(event.kind).toBe("cursor.position");
+    if (event.kind !== "cursor.position") return;
+    expect(event.userId).toBe("user2");
+    expect(event.position).toBe(12);
+    expect(event.raw).toBe(input);
+  });
+
+  it("does not normalize wrapped cursor as a content update", () => {
+    const event = normalizeDocumentCollaborationEvent({
+      type: "update",
+      payload: { type: "cursor.position", user_id: "user2", position: 3 },
+      user_id: "user2",
+    });
+
+    expect(event.kind).not.toBe("content.update");
+    expect(event.kind).toBe("cursor.position");
+  });
+
+  it("normalizes a cursor event missing user_id to unknown", () => {
+    const event = normalizeDocumentCollaborationEvent({
+      type: "cursor.position",
+      position: 3,
+    });
+    expect(event.kind).toBe("unknown");
+  });
+
+  it("normalizes a cursor event with negative position to unknown", () => {
+    const event = normalizeDocumentCollaborationEvent({
+      type: "cursor.position",
+      user_id: "user2",
+      position: -1,
+    });
+    expect(event.kind).toBe("unknown");
+  });
+
+  it("normalizes a cursor event with non-number position to unknown", () => {
+    const event = normalizeDocumentCollaborationEvent({
+      type: "cursor.position",
+      user_id: "user2",
+      position: "five",
+    });
+    expect(event.kind).toBe("unknown");
+  });
+
+  it("normalizes a wrapped cursor with invalid position to unknown", () => {
+    const event = normalizeDocumentCollaborationEvent({
+      type: "update",
+      payload: { type: "cursor.position", user_id: "user2", position: NaN },
+      user_id: "user2",
+    });
+    expect(event.kind).toBe("unknown");
+  });
+
   // ── Malformed / unknown shapes ───────────────────────────────────────────
 
   it("normalizes malformed messages to unknown", () => {

--- a/frontend/src/components/editor/__tests__/useDocumentCollaboration.test.tsx
+++ b/frontend/src/components/editor/__tests__/useDocumentCollaboration.test.tsx
@@ -747,6 +747,275 @@ describe("useDocumentCollaboration", () => {
     });
   });
 
+  describe("cursor presence", () => {
+    it("sendCursorPosition() sends cursor.position with user_id, position, and timestamp", async () => {
+      const { result } = render(defaultOptions());
+
+      await act(async () => {
+        latestWs().simulateOpen();
+        result.current.sendCursorPosition(7);
+      });
+
+      const cursorMsgs = latestWs().sentMessages.filter(
+        (m: any) => m.type === "cursor.position"
+      );
+      expect(cursorMsgs.length).toBeGreaterThanOrEqual(1);
+      const last = cursorMsgs[cursorMsgs.length - 1];
+      expect(last.user_id).toBe("user1");
+      expect(last.position).toBe(7);
+      expect(last.timestamp).toBeDefined();
+    });
+
+    it("sendCursorPosition() does not send when disconnected", async () => {
+      const { result } = render(defaultOptions());
+
+      // Do not open — socket is still connecting
+      await act(async () => {
+        result.current.sendCursorPosition(7);
+      });
+
+      const cursorMsgs = latestWs().sentMessages.filter(
+        (m: any) => m.type === "cursor.position"
+      );
+      expect(cursorMsgs.length).toBe(0);
+    });
+
+    it("sendCursorPosition() does not send invalid positions", async () => {
+      const { result } = render(defaultOptions());
+
+      await act(async () => {
+        latestWs().simulateOpen();
+      });
+
+      await act(async () => {
+        result.current.sendCursorPosition(-1);
+        result.current.sendCursorPosition(Number.NaN);
+        result.current.sendCursorPosition("five" as any);
+        result.current.sendCursorPosition(Number.POSITIVE_INFINITY);
+      });
+
+      const cursorMsgs = latestWs().sentMessages.filter(
+        (m: any) => m.type === "cursor.position"
+      );
+      expect(cursorMsgs.length).toBe(0);
+    });
+
+    it("direct incoming cursor.position adds a remote cursor user", async () => {
+      const { result } = render(defaultOptions());
+
+      await act(async () => {
+        latestWs().simulateOpen();
+      });
+
+      await act(async () => {
+        latestWs().simulateMessage({
+          type: "cursor.position",
+          user_id: "user2",
+          position: 4,
+          timestamp: new Date().toISOString(),
+        });
+      });
+
+      expect(result.current.cursorUsers).toHaveLength(1);
+      expect(result.current.cursorUsers[0].user_id).toBe("user2");
+      expect(result.current.cursorUsers[0].position).toBe(4);
+    });
+
+    it("wrapped incoming cursor.position adds a remote cursor user", async () => {
+      const { result } = render(defaultOptions());
+
+      await act(async () => {
+        latestWs().simulateOpen();
+      });
+
+      await act(async () => {
+        latestWs().simulateMessage({
+          type: "update",
+          payload: {
+            type: "cursor.position",
+            user_id: "user2",
+            position: 9,
+          },
+          user_id: "user2",
+        });
+      });
+
+      expect(result.current.cursorUsers).toHaveLength(1);
+      expect(result.current.cursorUsers[0].user_id).toBe("user2");
+      expect(result.current.cursorUsers[0].position).toBe(9);
+    });
+
+    it("direct incoming cursor.position updates an existing cursor user's position", async () => {
+      const { result } = render(defaultOptions());
+
+      await act(async () => {
+        latestWs().simulateOpen();
+      });
+
+      await act(async () => {
+        latestWs().simulateMessage({
+          type: "cursor.position",
+          user_id: "user2",
+          position: 1,
+        });
+      });
+
+      await act(async () => {
+        latestWs().simulateMessage({
+          type: "cursor.position",
+          user_id: "user2",
+          position: 8,
+        });
+      });
+
+      expect(result.current.cursorUsers).toHaveLength(1);
+      expect(result.current.cursorUsers[0].position).toBe(8);
+    });
+
+    it("cursor events from the current user are ignored", async () => {
+      const { result } = render(defaultOptions({ userId: "user1" }));
+
+      await act(async () => {
+        latestWs().simulateOpen();
+      });
+
+      await act(async () => {
+        latestWs().simulateMessage({
+          type: "cursor.position",
+          user_id: "user1",
+          position: 3,
+        });
+      });
+
+      expect(result.current.cursorUsers).toHaveLength(0);
+    });
+
+    it("cursor users auto-expire after 5000ms", async () => {
+      const { result } = render(defaultOptions());
+
+      await act(async () => {
+        latestWs().simulateOpen();
+      });
+
+      await act(async () => {
+        latestWs().simulateMessage({
+          type: "cursor.position",
+          user_id: "user2",
+          position: 2,
+        });
+      });
+
+      expect(result.current.cursorUsers).toHaveLength(1);
+
+      await act(async () => {
+        vi.advanceTimersByTime(5_100);
+      });
+
+      expect(result.current.cursorUsers).toHaveLength(0);
+    });
+
+    it("repeated cursor events reset the expiry timer", async () => {
+      const { result } = render(defaultOptions());
+
+      await act(async () => {
+        latestWs().simulateOpen();
+      });
+
+      await act(async () => {
+        latestWs().simulateMessage({
+          type: "cursor.position",
+          user_id: "user2",
+          position: 1,
+        });
+      });
+
+      // Advance 4s — not past expiry yet
+      await act(async () => {
+        vi.advanceTimersByTime(4_000);
+      });
+
+      // Another cursor event resets the timer
+      await act(async () => {
+        latestWs().simulateMessage({
+          type: "cursor.position",
+          user_id: "user2",
+          position: 5,
+        });
+      });
+
+      // Advance another 4s — still within the reset window
+      await act(async () => {
+        vi.advanceTimersByTime(4_000);
+      });
+
+      expect(result.current.cursorUsers).toHaveLength(1);
+
+      // Advance past full expiry
+      await act(async () => {
+        vi.advanceTimersByTime(1_100);
+      });
+
+      expect(result.current.cursorUsers).toHaveLength(0);
+    });
+
+    it("cleans up cursor timers on unmount", async () => {
+      const { result, unmount } = render(defaultOptions());
+
+      await act(async () => {
+        latestWs().simulateOpen();
+      });
+
+      await act(async () => {
+        latestWs().simulateMessage({
+          type: "cursor.position",
+          user_id: "user2",
+          position: 2,
+        });
+      });
+
+      expect(result.current.cursorUsers).toHaveLength(1);
+
+      // Unmount before expiry — should not throw
+      unmount();
+
+      // Advance past expiry — timers should have been cleared, no state updates
+      await act(async () => {
+        vi.advanceTimersByTime(6_000);
+      });
+    });
+
+    it("cursor presence does not interfere with typing or content updates", async () => {
+      const onRemoteContentUpdate = vi.fn();
+      const { result } = render(defaultOptions({ onRemoteContentUpdate }));
+
+      await act(async () => {
+        latestWs().simulateOpen();
+      });
+
+      await act(async () => {
+        latestWs().simulateMessage({
+          type: "update",
+          payload: { content: "content still flows" },
+          user_id: "user2",
+        });
+        latestWs().simulateMessage({
+          type: "cursor.position",
+          user_id: "user3",
+          position: 6,
+        });
+        latestWs().simulateMessage({
+          type: "typing.start",
+          user_id: "user2",
+        });
+      });
+
+      expect(onRemoteContentUpdate).toHaveBeenCalledWith("content still flows");
+      expect(result.current.cursorUsers).toHaveLength(1);
+      expect(result.current.cursorUsers[0].user_id).toBe("user3");
+      expect(result.current.typingUsers).toHaveLength(1);
+    });
+  });
+
   describe("sendContentUpdate", () => {
     it("sends the update payload when connected and editable", async () => {
       const { result } = render(defaultOptions({ canEdit: true }));

--- a/frontend/src/components/editor/collaborationEvents.ts
+++ b/frontend/src/components/editor/collaborationEvents.ts
@@ -47,6 +47,12 @@ export type NormalizedDocumentCollaborationEvent =
       raw: unknown;
     }
   | {
+      kind: "cursor.position";
+      userId: string;
+      position: number;
+      raw: unknown;
+    }
+  | {
       kind: "unknown";
       raw: unknown;
     };
@@ -61,6 +67,10 @@ function isStringArray(value: unknown): value is string[] {
 
 function optionalString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
+}
+
+function isFiniteNonNegativeNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
 }
 
 export function normalizeDocumentCollaborationEvent(
@@ -83,6 +93,21 @@ export function normalizeDocumentCollaborationEvent(
     if (payloadType === "typing.start" || payloadType === "typing.stop") {
       if (typeof payload.user_id === "string") {
         return { kind: payloadType, userId: payload.user_id, raw: message };
+      }
+      return { kind: "unknown", raw: message };
+    }
+
+    if (payloadType === "cursor.position") {
+      if (
+        typeof payload.user_id === "string" &&
+        isFiniteNonNegativeNumber(payload.position)
+      ) {
+        return {
+          kind: "cursor.position",
+          userId: payload.user_id,
+          position: payload.position,
+          raw: message,
+        };
       }
       return { kind: "unknown", raw: message };
     }
@@ -125,6 +150,22 @@ export function normalizeDocumentCollaborationEvent(
   if (type === "typing.start" || type === "typing.stop") {
     if (typeof message.user_id === "string") {
       return { kind: type, userId: message.user_id, raw: message };
+    }
+    return { kind: "unknown", raw: message };
+  }
+
+  // Direct (unwrapped) cursor events.
+  if (type === "cursor.position") {
+    if (
+      typeof message.user_id === "string" &&
+      isFiniteNonNegativeNumber(message.position)
+    ) {
+      return {
+        kind: "cursor.position",
+        userId: message.user_id,
+        position: message.position,
+        raw: message,
+      };
     }
     return { kind: "unknown", raw: message };
   }

--- a/frontend/src/components/editor/useDocumentCollaboration.ts
+++ b/frontend/src/components/editor/useDocumentCollaboration.ts
@@ -7,6 +7,8 @@ import { normalizeDocumentCollaborationEvent } from "./collaborationEvents";
 export type PresenceUser = {
   user_id: string;
   color: string;
+  /** Cursor offset for cursor-presence users; undefined for active/typing users. */
+  position?: number;
 };
 
 export type UseDocumentCollaborationOptions = {
@@ -33,12 +35,16 @@ export type UseDocumentCollaborationResult = {
   activeUsers: PresenceUser[];
   /** Users who are currently typing (remote only, never includes current user). */
   typingUsers: PresenceUser[];
+  /** Remote users with an active cursor position (auto-expires after 5s). */
+  cursorUsers: PresenceUser[];
   /** Send a local content update to all other clients in the session. */
   sendContentUpdate: (content: string) => void;
   /** Signal that the current user is actively typing. */
   notifyTyping: () => void;
   /** Signal that the current user has stopped typing. */
   stopTyping: () => void;
+  /** Broadcast the current user's cursor position to the session. */
+  sendCursorPosition: (position: number) => void;
 };
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -53,6 +59,9 @@ const USER_COLORS = [
 
 /** Typing indicator auto-expires after this many milliseconds. */
 const TYPING_EXPIRY_MS = 3_000;
+
+/** Cursor presence auto-expires after this many milliseconds. */
+const CURSOR_EXPIRY_MS = 5_000;
 
 // ─── URL construction ────────────────────────────────────────────────────────
 
@@ -87,10 +96,12 @@ export function useDocumentCollaboration({
   const [accessDenied, setAccessDenied] = useState(false);
   const [activeUsers, setActiveUsers] = useState<PresenceUser[]>([]);
   const [typingUsers, setTypingUsers] = useState<PresenceUser[]>([]);
+  const [cursorUsers, setCursorUsers] = useState<PresenceUser[]>([]);
 
   const clientRef = useRef<WsClient | null>(null);
   const userColorMapRef = useRef<Map<string, string>>(new Map());
   const typingTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const cursorTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
   // Assign stable colours to user IDs
   const assignColor = useCallback((uid: string): string => {
@@ -166,6 +177,51 @@ export function useDocumentCollaboration({
     [removeTypingUser],
   );
 
+  // ── Cursor handlers ────────────────────────────────────────────────────
+
+  const removeCursorUser = useCallback((uid: string) => {
+    const timers = cursorTimersRef.current;
+    const timer = timers.get(uid);
+    if (timer) {
+      clearTimeout(timer);
+      timers.delete(uid);
+    }
+
+    setCursorUsers((prev) => prev.filter((u) => u.user_id !== uid));
+  }, []);
+
+  const addCursorUser = useCallback(
+    (uid: string, position: number) => {
+      if (uid === userId) return;
+
+      // Clear any existing expiry timer for this user
+      const timers = cursorTimersRef.current;
+      const existing = timers.get(uid);
+      if (existing) clearTimeout(existing);
+
+      setCursorUsers((prev) => {
+        const others = prev.filter((u) => u.user_id !== uid);
+        return [...others, { user_id: uid, color: assignColor(uid), position }];
+      });
+
+      // Auto-expire after CURSOR_EXPIRY_MS
+      timers.set(
+        uid,
+        setTimeout(() => {
+          removeCursorUser(uid);
+        }, CURSOR_EXPIRY_MS)
+      );
+    },
+    [assignColor, userId],
+  );
+
+  const handleRemoteCursorPosition = useCallback(
+    (uid: string, position: number) => {
+      addCursorUser(uid, position);
+    },
+    [addCursorUser],
+  );
+
   // Connect / reconnect when dependencies change
   useEffect(() => {
     const wsUrl = buildCollabWsUrl(documentId, authToken);
@@ -215,6 +271,9 @@ export function useDocumentCollaboration({
         case "typing.stop":
           handleRemoteTypingStop(event.userId);
           break;
+        case "cursor.position":
+          handleRemoteCursorPosition(event.userId, event.position);
+          break;
         case "unknown":
         default:
           break;
@@ -232,6 +291,11 @@ export function useDocumentCollaboration({
       const timers = typingTimersRef.current;
       timers.forEach((timer) => clearTimeout(timer));
       timers.clear();
+
+      // Clean up cursor timers
+      const cursorTimers = cursorTimersRef.current;
+      cursorTimers.forEach((timer) => clearTimeout(timer));
+      cursorTimers.clear();
 
       client.disconnect();
       clientRef.current = null;
@@ -272,13 +336,31 @@ export function useDocumentCollaboration({
     });
   };
 
+  const sendCursorPosition = (position: number) => {
+    if (
+      typeof position !== "number" ||
+      !Number.isFinite(position) ||
+      position < 0
+    ) {
+      return;
+    }
+    clientRef.current?.send({
+      type: "cursor.position",
+      user_id: userId,
+      position,
+      timestamp: new Date().toISOString(),
+    });
+  };
+
   return {
     isConnected,
     accessDenied,
     activeUsers,
     typingUsers,
+    cursorUsers,
     sendContentUpdate,
     notifyTyping,
     stopTyping,
+    sendCursorPosition,
   };
 }


### PR DESCRIPTION
## Summary

Adds lightweight cursor presence to the document collaboration editor, reusing the existing `collaborationEvents.ts` normalizer and the `useDocumentCollaboration` seam. No new event parser.

## Changes

- `collaborationEvents.ts`: added `cursor.position` to the `NormalizedDocumentCollaborationEvent` union and recognition of both direct `{ type: "cursor.position", user_id, position }` and backend-wrapped `{ type: "update", payload: { type: "cursor.position", ... } }` shapes. Position must be a finite non-negative number; missing/`invalid` `user_id` or `position` normalizes to `unknown`. Wrapped cursor events normalize as cursor, never as `content.update`. Parser stays pure (no React / state / timers / I/O).
- `useDocumentCollaboration.ts`: added `cursorUsers: PresenceUser[]` and `sendCursorPosition(position)`. Outgoing `cursor.position` sends only when connected and on a valid non-negative finite position. Incoming events update `cursorUsers` (same stable color model as active/typing users), ignore the current user, auto-expire after 5000ms, and reset their expiry timer on repeat; cursor timers are cleared on unmount. `PresenceUser` gained optional `position`.
- `CollaborativeNote.tsx`: emits `sendCursorPosition(selectionStart)` on textarea `onSelect` / `onClick` / `onKeyUp`; renders a minimal status-region indicator — `User <id> cursor at <pos>` (or `<count> collaborator cursors active`) — using only CSS variables (no hex colors, no overlay ghosts in the textarea).

## Scope / non-goals

- Frontend-only; reuses the existing WebSocket path and normalizer.
- No backend code, routes, schema, migrations, share-links, annotations, role-scope, global provider, GuardianChat, or `protocol_tokens.py` changes.
- Cursor presence is status-region only — no visual overlay ghost rendering (deferred follow-up).

## Validation

Run in the dedicated worktree off `cab83c1ab` (post PR #521), from repo root via `pnpm --dir frontend test`:

| Suite | Result |
| --- | --- |
| `collaborationEvents` | 22 passed |
| `useDocumentCollaboration` | 43 passed |
| `CollaborativeNote` | 27 passed |
| `wsClient` | 31 passed |
| `git diff --check` | clean |

All 123 tests pass. Confirmed: wrapped cursor events do not overwrite editor content; invalid positions are not sent; current-user cursor events are ignored; 5000ms expiry + repeat-reset behave correctly.

## Notes

- Source: local commit `017eb4254be47d783a918ddb6215d48835639ab7` on `codex/document-cursor-presence`.
- Base observed at branch creation: `cab83c1ab` (main after PR #521).
- Flagged draft for review of the cursor + remote-auth/identity boundary surface before merge.