### PR TITLE
Fix Guardian evidence generator no-evidence guard

### DIFF
--- a/docs/architecture/guardian-evidence-packet-generator-contract.md
+++ b/docs/architecture/guardian-evidence-packet-generator-contract.md
@@ -326,6 +326,12 @@ release support expansion.
 python3 scripts/guardian/generate_evidence_packet.py docs/architecture/fixtures/guardian-evidence-bounded-read.local-tooling.v1.json --json
 ```
 
+The generator fails closed when bounded-read input contains no usable read
+evidence refs. `pass_with_warnings` is insufficient unless at least one usable
+read evidence ref exists. Supported claims must never have empty
+`evidence_refs`; skipped-only bounded-read input is failure/not-generated, not
+a successful packet.
+
 The static bounded-read result fixture
 `docs/architecture/fixtures/guardian-evidence-bounded-read.local-tooling.v1.json`
 exists and may be used by future packet generator tests only through a separate

--- a/scripts/guardian/generate_evidence_packet.py
+++ b/scripts/guardian/generate_evidence_packet.py
@@ -79,6 +79,14 @@ def main(argv: list[str] | None = None) -> int:
         data = json.loads(args.bounded_read_result.read_text(encoding="utf-8"))
         if data.get("schema_version") != "guardian_evidence_bounded_read_batch_result.v1" or data.get("result") == "fail" or not isinstance(data.get("read_results"), list):
             raise ValueError("bounded-read result is invalid or failed")
+        usable_evidence_refs = [item for item in data["read_results"] if item.get("read_status") == "read" and isinstance(item.get("source_ref"), str) and item["source_ref"].strip()]
+        if not usable_evidence_refs:
+            output = {"schema_version": RESULT_SCHEMA, "generator_contract_version": CONTRACT_VERSION, "bounded_read_result_ref": str(args.bounded_read_result), "result": "fail", "errors": [{"code": "no_usable_evidence_refs", "message": "bounded-read input contains no usable read evidence refs"}], "authority_state": false_authority_state(), "limits": list(LIMITS)}
+            if args.as_json:
+                print(json.dumps(output, indent=2))
+            else:
+                print(output["errors"][0]["message"], file=sys.stderr)
+            return 1
         packet = _packet(data, args.packet_id)
         validation = _validate(packet)
     except (OSError, UnicodeError, json.JSONDecodeError, ValueError, KeyError, TypeError) as exc:

--- a/tests/evidence_packets/test_guardian_evidence_packet_generator.py
+++ b/tests/evidence_packets/test_guardian_evidence_packet_generator.py
@@ -48,6 +48,22 @@ def test_generator_rejects_invalid_inputs(tmp_path: Path) -> None:
     assert proc.returncode == 1
 
 
+def test_generator_fails_closed_when_all_bounded_reads_are_skipped(tmp_path: Path) -> None:
+    data = json.loads((ROOT / INPUT).read_text())
+    for item in data["read_results"]:
+        item["read_status"] = "skipped"
+        item["content_hash"] = None
+        item["content_excerpt"] = None
+    path = tmp_path / "skipped-only.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    proc = subprocess.run(["python3", str(SCRIPT), str(path), "--json"], cwd=ROOT, capture_output=True, text=True, check=False)
+    assert proc.returncode == 1
+    output = json.loads(proc.stdout)
+    assert output["result"] == "fail"
+    assert output["errors"][0] == {"code": "no_usable_evidence_refs", "message": "bounded-read input contains no usable read evidence refs"}
+    assert "packet" not in output
+
+
 def test_generator_docs_are_linked() -> None:
     for path in ("docs/architecture/guardian-evidence-packet-generator-contract.md", "docs/architecture/README.md", "docs/architecture/00-current-state.md"):
         assert "generate_evidence_packet.py" in (ROOT / path).read_text()


### PR DESCRIPTION
## Summary

- Adds the P2 fail-closed guard for local stdout-only Guardian Evidence Packet generation.
- Rejects bounded-read inputs with zero usable read evidence refs using `no_usable_evidence_refs`.
- Adds skipped-only regression coverage and documents the evidence-binding invariant.

## Boundary

- Local generator patch only.
- No packet fixture writes.
- No runtime validator or reducer service.
- No API, UI, database, migration, compose, CI/default gate, ingestion, WorkOrder mutation, Execution Ledger write, Codex Runner, Pi Loop, provider execution, source mutation, receipts, or durable mutation.

## Validation

Reported locally:
- focused generator tests passed
- `git diff --check`
- `python3 scripts/validate_docs.py`
- direct generator invocation returned `pass_with_warnings`

## Reason

PR #530 merged the generator before the P2 follow-up commit reached `main`; this PR carries only the fail-closed evidence-binding fix.