### PR TITLE
Handle malformed bounded read entries

### DIFF
--- a/docs/architecture/guardian-evidence-packet-generator-contract.md
+++ b/docs/architecture/guardian-evidence-packet-generator-contract.md
@@ -332,6 +332,13 @@ read evidence ref exists. Supported claims must never have empty
 `evidence_refs`; skipped-only bounded-read input is failure/not-generated, not
 a successful packet.
 
+The generator fails closed when `read_results` contains a non-object entry
+(e.g. `null`). Malformed bounded-read input must produce bounded diagnostics,
+not Python tracebacks. The generator emits a `malformed_read_result_entry`
+error code, exits 1, and does not emit a packet. Non-object `read_results`
+entries must never produce a successful packet. Supported claims must still
+never have empty `evidence_refs`.
+
 The static bounded-read result fixture
 `docs/architecture/fixtures/guardian-evidence-bounded-read.local-tooling.v1.json`
 exists and may be used by future packet generator tests only through a separate

--- a/scripts/guardian/generate_evidence_packet.py
+++ b/scripts/guardian/generate_evidence_packet.py
@@ -79,6 +79,14 @@ def main(argv: list[str] | None = None) -> int:
         data = json.loads(args.bounded_read_result.read_text(encoding="utf-8"))
         if data.get("schema_version") != "guardian_evidence_bounded_read_batch_result.v1" or data.get("result") == "fail" or not isinstance(data.get("read_results"), list):
             raise ValueError("bounded-read result is invalid or failed")
+        for i, item in enumerate(data["read_results"]):
+            if not isinstance(item, dict):
+                output = {"schema_version": RESULT_SCHEMA, "generator_contract_version": CONTRACT_VERSION, "bounded_read_result_ref": str(args.bounded_read_result), "result": "fail", "errors": [{"code": "malformed_read_result_entry", "message": "bounded-read input contains a non-object read_results entry"}], "authority_state": false_authority_state(), "limits": list(LIMITS)}
+                if args.as_json:
+                    print(json.dumps(output, indent=2))
+                else:
+                    print(output["errors"][0]["message"], file=sys.stderr)
+                return 1
         usable_evidence_refs = [item for item in data["read_results"] if item.get("read_status") == "read" and isinstance(item.get("source_ref"), str) and item["source_ref"].strip()]
         if not usable_evidence_refs:
             output = {"schema_version": RESULT_SCHEMA, "generator_contract_version": CONTRACT_VERSION, "bounded_read_result_ref": str(args.bounded_read_result), "result": "fail", "errors": [{"code": "no_usable_evidence_refs", "message": "bounded-read input contains no usable read evidence refs"}], "authority_state": false_authority_state(), "limits": list(LIMITS)}
@@ -89,7 +97,7 @@ def main(argv: list[str] | None = None) -> int:
             return 1
         packet = _packet(data, args.packet_id)
         validation = _validate(packet)
-    except (OSError, UnicodeError, json.JSONDecodeError, ValueError, KeyError, TypeError) as exc:
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError, KeyError, TypeError, AttributeError) as exc:
         print(f"generator error: {exc}", file=sys.stderr)
         return 1
     output = {"schema_version": RESULT_SCHEMA, "generator_contract_version": CONTRACT_VERSION, "bounded_read_result_ref": str(args.bounded_read_result), "packet": packet, "packet_validation_result": validation, "authority_state": false_authority_state(), "diagnostics": {"source_ref_read_policy": "reads bounded-read result only; does not read source_ref targets", "evidence_ref_count": len(packet["raw_evidence_refs"]), "claim_count": len(packet["claim_ledger"]), "uncertainty_count": len(packet["uncertainty"]), "forbidden_interpretation_count": len(packet["forbidden_interpretations"]), "contradiction_count": 0, "omitted_source_count": len(packet["uncertainty"]), "bounded_read_result": data["result"]}, "limits": list(LIMITS)}

--- a/tests/evidence_packets/test_guardian_evidence_packet_generator.py
+++ b/tests/evidence_packets/test_guardian_evidence_packet_generator.py
@@ -64,6 +64,20 @@ def test_generator_fails_closed_when_all_bounded_reads_are_skipped(tmp_path: Pat
     assert "packet" not in output
 
 
+def test_generator_fails_closed_on_non_object_read_results_entry(tmp_path: Path) -> None:
+    data = json.loads((ROOT / INPUT).read_text())
+    data["read_results"].insert(1, None)
+    path = tmp_path / "malformed-entry.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    proc = subprocess.run(["python3", str(SCRIPT), str(path), "--json"], cwd=ROOT, capture_output=True, text=True, check=False)
+    assert proc.returncode == 1
+    output = json.loads(proc.stdout)
+    assert output["result"] == "fail"
+    assert output["errors"][0]["code"] == "malformed_read_result_entry"
+    assert "packet" not in output
+    assert "Traceback" not in proc.stderr
+
+
 def test_generator_docs_are_linked() -> None:
     for path in ("docs/architecture/guardian-evidence-packet-generator-contract.md", "docs/architecture/README.md", "docs/architecture/00-current-state.md"):
         assert "generate_evidence_packet.py" in (ROOT / path).read_text()


### PR DESCRIPTION
## Summary

- Fixes local stdout-only Guardian Evidence Packet generator malformed-input handling.
- Rejects non-object entries in `read_results` with controlled `malformed_read_result_entry` diagnostics.
- Adds regression coverage and documents the bounded-diagnostics invariant.

## Boundary

- Local generator patch only.
- No packet fixture writes.
- No runtime validator or reducer service.
- No API, UI, database, migration, compose, CI/default gate, ingestion, WorkOrder mutation, Execution Ledger write, Codex Runner, Pi Loop, provider execution, source mutation, receipts, or durable mutation.

## Validation

Reported locally:
- `git diff --check`
- direct generator invocation returned `pass_with_warnings`
- focused generator tests: 5/5 pass
- `python3 scripts/validate_docs.py`
- all five Guardian Make targets
- packet and input-bundle validators
- full PR regression pytest matrix
- bridge static suite

## Reason

PR #532 merged the no-evidence guard before this malformed-entry follow-up commit reached `main`; this PR carries only the non-object `read_results` fail-closed fix.