### PR TITLE
docs: add dev log batch

### DIFF
--- a/docs/DEV_LOG/2026-05-31/Dev Log - 2026-05-31.md
+++ b/docs/DEV_LOG/2026-05-31/Dev Log - 2026-05-31.md
@@ -1,0 +1,72 @@
+Dev Log - 2026-05-31
+
+Summary
+
+architecture truth-alignment day
+
+Today was mostly about keeping the short-horizon release narrative aligned with the actual supported path. The only committed change in the last 24 hours refreshed the weekly current-state override, which matters because this file is the authoritative interpretation layer for what Codexify is and is not promising right now.
+
+The rest of the day stayed in the truth-surface lane: fresh daily audit artifacts were generated, the current operational state was re-checked, and the worktree still reflected a broader set of in-progress docs, marketing, and delegation work that was not newly committed today. The important part is that the release framing stayed conservative and specific instead of drifting ahead of proof.
+
+What I completed
+
+Current-state refresh
+
+- Refreshed [`docs/architecture/00-current-state.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/00-current-state.md) and [`docs/architecture/README.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/README.md) in commit `65eedff3917c`.
+- Kept the weekly override aligned with the current supported reality: local Docker Compose remains the supported path, the posture is still local-only, and delegation/federation/graph-write surfaces are still explicitly out of the release promise.
+- Tightened the short-horizon interpretation layer so older architecture language does not outrun the live release definition.
+
+Audit and evidence surface
+
+- Generated fresh morning and evening audit artifacts for the 2026-05-31 window.
+- The audit summary stayed clean on the plain CLI path, with `PASS 43`, `WARN 11`, and `FAIL 0`.
+- The JSON probe is still broken, so the audit pipeline is still relying on `text_fallback` instead of the structured path.
+- The weakest signals remained the same: `Federation Readiness`, `Alternate Surface Readiness`, and `Governance Readiness` still need manual review rather than being treated as settled.
+
+Worktree context
+
+- The working tree is still dirty with a broader mix of docs, marketing, frontend, backend, and test changes.
+- None of those were newly committed today, so they should be treated as in-progress context rather than as today’s shipped work.
+- That distinction matters: the day’s actual completed change was the release-truth refresh, not a broad functional delivery.
+
+Important outcome
+
+The supported-path story is no longer just buried in older architecture prose. It now has a current override that explicitly names what is still true, what is not yet true, and what must not be assumed.
+
+That is a small change on paper, but it matters operationally. The system now has a cleaner guardrail against accidental drift in release claims, especially around delegation, federation, and other high-blast-radius surfaces that are still not release-supported.
+
+Commits
+
+- `65eedff3917c` - `docs: refresh weekly current-state override`
+
+Notes
+
+- Evidence today stayed at the docs/audit level; there was no new live runtime proof added.
+- The structured audit probe still fails, so the clean audit result is coming through the plain fallback path.
+- The broader dirty tree suggests substantial in-progress work exists, but it does not belong in today’s completed-log narrative unless it is committed and verified.
+
+Next likely moves
+
+- Reconcile the remaining dirty-tree changes into discrete, truthful commits.
+- Keep the current-state override synced as the release story evolves.
+- Fix the audit JSON probe so structured output becomes reliable again.
+- Recheck the delegation and federation surfaces only when there is fresh proof to support any claim shift.
+
+Closing thought
+
+Today did not expand the product surface. It tightened the boundary around what the product can honestly claim, which is often the more important work when a system is still being hardened.
+
+Narrative Log
+Dev Log - 2026-05-31
+
+This was a truth-maintenance day, not a feature day. The main job was to keep Codexify’s current release story from drifting away from what is actually supported on the ground. That sounds modest, but it is one of the few things that reliably keeps a growing system from becoming misleading.
+
+The committed change was narrow: the weekly current-state override was refreshed in [`docs/architecture/00-current-state.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/00-current-state.md) and [`docs/architecture/README.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/README.md). What changed underneath the surface was not code behavior, but the system’s interpretation of itself. The supported path stayed anchored to local Docker Compose, the local-only posture stayed explicit, and the release narrative kept delegation, federation, and graph-write surfaces outside the promise line.
+
+That mattered because the repo is carrying a lot of adjacent motion right now. The worktree still contains broader changes across docs, marketing, frontend, backend, and tests, but those are not the same thing as completed work for today. The log needed to preserve that distinction. In a system like this, uncommitted context can be useful, but it should not be mistaken for shipped reality.
+
+The audit pass reinforced the same shape. The plain audit CLI path still produced a clean summary, but the JSON probe remains broken, so the structured path is not yet dependable. That keeps the evidence chain honest: the day’s confidence comes from fallback audit output and current-state documentation, not from a fully healthy structured audit pipeline. The weakest areas also remained stable rather than being quietly papered over. Federation, alternate surface readiness, and governance still need manual review, which is exactly the kind of boundary that should stay visible until it is earned away.
+
+So the deeper change today was small but important: the system became a little harder to misread. It now has a fresher, tighter short-horizon contract about what is supported, what is still provisional, and what must not be inferred just because related work exists in the tree. That kind of drift prevention does not look dramatic, but it makes every later claim safer.
+
+What this makes possible next is straightforward: keep turning the dirty tree into discrete, reviewable pieces, repair the structured audit path, and only widen the release story when the proof is there.

--- a/docs/DEV_LOG/2026-06-01/Dev Log - 2026-06-01.md
+++ b/docs/DEV_LOG/2026-06-01/Dev Log - 2026-06-01.md
@@ -1,0 +1,103 @@
+  
+Dev Log - 2026-06-01
+
+Summary
+
+Audit refresh and release-truth alignment day.
+
+The work was fundamentally about keeping the short-horizon truth surface tight: refreshing the daily audits, updating the current-state override on main, and generating a new draft marketing campaign bundle without widening the release claim. This was not a feature-expansion day. It was a day of tightening the system’s story so the repo, the audits, and the release-state doc all pointed at the same reality.
+
+What I completed
+
+Release-truth and current-state alignment
+
+- Refreshed docs/architecture/00-current-state.md with the current operational posture on main.
+- Kept the supported-path narrative narrow: local-first beta hardening, local Docker Compose, local-only provider posture, and no expansion of the release promise.
+- Clarified the live interpretation layer so short-horizon docs stay ahead of older architecture language.
+
+Daily audit refresh
+
+- Regenerated the morning and evening audit artifacts and updated the latest pointers.
+- The audit run stayed in text_fallback mode because the JSON probe still failed, while the plain run completed successfully.
+- The resulting snapshot remained clean on failures, with strong signals in extension boundary, core loop integrity, and primitive stability, and weaker signals around federation and governance readiness.
+
+Marketing draft generation
+
+- Generated CAMPAIGN_2026_06_01_MARKETING_V1 in draft mode for local-first builders.
+- The campaign bundle contains 24 claims, split evenly between marketable and non-marketable claims.
+- The output stays artifact-level and internal: useful for packaging and review, but not evidence of live runtime change.
+
+Important outcome
+
+The system is no longer just accumulating docs. It now has a fresher, more coherent short-horizon truth surface tying together the current-state override, the audit layer, and the campaign artifacts.
+
+That matters because it reduces drift. The repo’s operational story is tighter than it was yesterday, and the release boundary is still being defended instead of being quietly widened by implication.
+
+Commits
+
+- 4c4cb9d364f8 - docs: refresh weekly current-state override
+
+Notes
+
+- The audit JSON probe is still broken, so the plain-text fallback remains the reliable path for this check.
+- This day’s evidence is still artifact-level, not live runtime proof.
+- The marketing bundle is draft-only; no publish or release-side effect was implied by the generated output.
+- I refreshed the automation memory after the run so the next pass has carry-forward context.
+
+Next likely moves
+
+- Re-run the daily audit after the JSON probe is repaired, so the structured path becomes usable again.
+- Keep docs/architecture/00-current-state.md aligned with any new proof, especially if supported-path assumptions drift.
+- Review the draft marketing bundle for claim hygiene before any downstream reuse.
+- Watch for any runtime-proof gap between docs truth and live behavior.
+
+Closing thought
+
+Today was about reducing ambiguity, not adding surface area. The system is a little more trustworthy because the release story, the audit story, and the generated campaign story are pointing at the same constrained reality.
+
+Narrative Log  
+Dev Log - 2026-06-01
+
+It was a truth-surface day.
+
+Not a flashy one. Not a feature day. The work was mostly about making sure the system’s own record stayed honest: refresh the daily audits, keep the current-state override current, and generate the next draft marketing bundle without pretending it said more than it did.
+
+The audit pass set the tone. The JSON probe is still broken, so the plain-text fallback remains the dependable route, but the resulting audit itself was clean enough to be useful. The important part was not the perfection of the toolchain. It was that the outputs still gave a stable read on the system: strong signals in core loop integrity, primitive stability, and extension boundary; weaker signals where federation, alternate surfaces, and governance still deserve caution.
+
+Then the current-state override was refreshed on main. That matters because this repo’s short-horizon reality has to stay explicit. The supported path is still local-first beta hardening with local Docker Compose and local-only provider posture. The doc update did not widen the release promise. It tightened it. That is the point. The system should know what it is, and more importantly, what it is not yet.
+
+The marketing work sat beside that, but it was the same kind of discipline in another form. A new draft campaign bundle was generated for local-first builders, with 24 claims carefully split between marketable and non-marketable material. That output is useful, but only if it stays honest about what is actually proven. Today it stayed inside that boundary. It gave us a structured artifact set without confusing artifact generation for runtime proof.
+
+So the deeper change today was not volume. It was alignment. The repo’s audit layer, release-truth layer, and generated campaign layer are all closer to the same frame of reference now. That lowers drift. It makes the current state easier to trust. And it leaves the next step clear: keep proving the supported path, and keep anything broader explicitly out of the promise until it earns its place.
+
+2 memory citations
+
+memory.mdDocument · MDOpen in
+
+Edited memory.md+8-0
+
+UndoReview
+
+Monday 8:02 PM
+
+  
+
+Custom
+
+5.4-MiniLow
+
+Environment
+
+Changes+1,902-91
+
+Local
+
+codex/add-whooshd-provider
+
+Commit or push
+
+Codex/add whooshd provider
+
+Sources
+
+No sources yet

--- a/docs/DEV_LOG/2026-06-02/Dev Log - 2026-06-02.md
+++ b/docs/DEV_LOG/2026-06-02/Dev Log - 2026-06-02.md
@@ -1,0 +1,62 @@
+Dev Log - 2026-06-02
+
+Summary
+
+Today was a contract hardening and truth-surface maintenance day. The work was less about adding new product surface and more about tightening the system’s operational story: refreshing the daily automation artifacts, updating the short-horizon release-state doc, and making sure the supporting docs and generated records still describe the real supported path.
+
+The day also carried a wider structural pass through the chat/runtime and documentation layers. The changed files show continued work on provider and runtime truth, frontend failure presentation, worker timing, and the supporting audit and teaching exports. The important part is not just that files moved, but that the repo’s current-state narrative was re-anchored around the current supported posture on main.
+
+What I completed
+
+### Daily automation refresh
+
+- Regenerated the daily dev log automation artifacts for both the 2026-06-01 and 2026-06-02 marketing runs.
+- Refreshed the morning and evening audit records and rolled the latest pointers forward.
+- Kept the audit trail internally consistent so the generated artifacts, summary files, and daily pointers agree with one another.
+
+### Release-truth alignment
+
+- Updated `docs/architecture/00-current-state.md` and its supporting README to reflect the current short-horizon operational state.
+- Preserved the distinction between what is supported now and what is still out of scope or not yet proven.
+- Reinforced the local-first beta framing instead of widening the release promise.
+
+### Runtime and contract surface
+
+- Continued work across provider registry, health reporting, protocol tokens, and the chat worker path.
+- Adjusted frontend request/failure presentation and runtime health hooks so timeout and offline states stay legible instead of collapsing into a single generic failure.
+- Kept the chat lifecycle tests, worker timing tests, and protocol contract tests aligned with the evolving runtime contract.
+
+### Documentation and proof surfaces
+
+- Added and refreshed docs around the Guardian work brief flow, the developer guide export, and the job-intelligence proof lane.
+- Regenerated the auxiliary docs and fixtures that support the current architecture and operational narrative.
+- Kept the new material anchored to evidence rather than aspiration.
+
+Important outcome
+
+The system is no longer just carrying scattered proof fragments. It now has enough structured truth in the daily audit trail, release-state doc, and generated support artifacts to explain what main actually supports without overstating it.
+
+Just as importantly, the runtime-facing work keeps moving toward clearer failure classification. Timeout, offline, and provider degradation are being represented more precisely, which makes the system easier to operate and harder to misread. That matters because the supported path is still narrow, and ambiguity at the boundary is expensive.
+
+Commits
+
+- cebdd13f3 - Refresh daily dev log automation artifacts
+- e2e3b2777 - docs: refresh weekly current-state override
+
+Notes
+
+- The strongest evidence from today is still artifact-level and code/test-level; there is no new live-runtime proof in this run.
+- The daily audit output still shows the JSON probe path as conflicted in the working tree, so the plain-text fallback remains the reliable path for now.
+- The work remains intentionally conservative: this was about preserving truth under active change, not expanding the release promise.
+
+Next likely moves
+
+1. Keep the current-state doc aligned with the next supported-path proof.
+2. Finish tightening runtime failure classification in the chat surface.
+3. Continue reconciling audit and generated-artifact workflows so daily logs stay low-friction and trustworthy.
+4. Validate the provider and worker timing changes against the supported local stack.
+5. Trim any remaining drift between docs, tests, and runtime behavior.
+
+Closing thought
+
+This was a day of reducing ambiguity. The repo’s operational story is cleaner now, and the gap between what the code does and what the docs claim is smaller. That is the kind of progress that makes future work safer.

--- a/docs/DEV_LOG/2026-06-03/Dev Log - 2026-06-03.md
+++ b/docs/DEV_LOG/2026-06-03/Dev Log - 2026-06-03.md
@@ -1,0 +1,73 @@
+Dev Log - 2026-06-03
+
+Summary
+
+Architecture truth-alignment day.
+
+The work today was mostly about refreshing the system’s short-horizon truth surfaces rather than adding new runtime capability. I updated the weekly current-state override in the architecture docs, regenerated the morning audit artifacts, and produced a new draft marketing bundle for 2026-06-03. The shape of the day was conservative and useful: keep the documented state aligned with what the repo actually says now, and keep the generated artifacts current without overstating what is proven live.
+
+What I completed
+
+Weekly current-state override refresh
+- Updated [`docs/architecture/00-current-state.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/00-current-state.md) and [`docs/architecture/README.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/README.md) in commit `2014aa0f2`.
+- This kept the short-horizon architecture anchor aligned with the current weekly truth surface instead of letting the docs drift.
+- The change was small, but it matters because this file is treated as the release-truth reference for near-term operational claims.
+
+Daily audit refresh
+- Refreshed the morning audit outputs at [`docs/audits/daily/morning/2026-06-03-audit.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/audits/daily/morning/2026-06-03-audit.md) and [`docs/audits/daily/morning/2026-06-03-audit.json`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/audits/daily/morning/2026-06-03-audit.json), with the latest pointers updated in [`docs/audits/latest.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/audits/latest.md) and [`docs/audits/latest.json`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/audits/latest.json).
+- The JSON probe still failed, so the run remained on `text_fallback`; the plain audit path completed successfully.
+- The audit summary stayed healthy overall: 43 PASS, 11 WARN, 0 FAIL.
+- The weakest signals remained federation readiness, alternate surface readiness, and governance readiness, which is useful because it keeps the risk surface explicit instead of smoothed over.
+
+Marketing draft regeneration
+- Generated a new draft campaign bundle under [`docs/Marketing/generated/CAMPAIGN_2026_06_03_MARKETING_V1/`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/Marketing/generated/CAMPAIGN_2026_06_03_MARKETING_V1/).
+- The bundle is in `draft` approval state with 24 claims, split 12 marketable and 12 non-marketable.
+- This keeps the marketing evidence layer current without pretending the content is approved or live.
+
+Important outcome
+
+The system is getting better at staying honest about its own state.
+
+The architecture anchor no longer sits behind stale weekly assumptions. It now reflects the current override cleanly, so short-term operational truth has a reliable place to land. That matters because a lot of Codexify’s work depends on the difference between what is implemented, what is documented, and what is actually safe to claim.
+
+The audit and marketing outputs also became more disciplined today. The audit stayed artifact-level, with the JSON probe still broken and the text fallback carrying the run. The marketing bundle was regenerated, but it remained explicitly draft-only. That combination is useful: the repo is producing current surfaces without confusing generated evidence for runtime proof.
+
+Commits
+
+- `2014aa0f2` - docs: refresh weekly current-state override
+
+Notes
+
+- The audit JSON path is still broken; the run succeeded via `text_fallback` instead.
+- Today’s marketing bundle is draft-only, not approval-ready.
+- No live runtime proof was added today; the evidence remained doc/artifact level.
+- The uncommitted audit and marketing outputs in the worktree are part of today’s generated state, but they were not committed in the single architecture-doc refresh commit.
+
+Next likely moves
+
+- Fix or triage the audit JSON probe so the fallback path is no longer the default.
+- Decide whether the draft marketing bundle should be promoted, revised, or left as a record-only artifact.
+- Keep the weekly current-state override aligned with any new truth changes before they leak into other docs.
+- If runtime work resumes, validate whether the current state docs still match the actual queue/worker/provider contract.
+
+Closing thought
+
+Today was not about volume. It was about preventing drift. The repo is a little more trustworthy now because the architecture anchor, the audit surface, and the generated campaign artifacts all describe the system more precisely than they did yesterday.
+
+Narrative Log
+Dev Log - 2026-06-03
+
+This was a truth-maintenance day.
+
+Nothing dramatic changed at runtime, and that was part of the point. The work was mostly about keeping the system’s self-description aligned with where it actually stands: the architecture override was refreshed, the daily audit was regenerated, and a new draft marketing bundle was produced for the day. The underlying theme was not feature expansion. It was boundary repair.
+
+The first useful correction was the weekly current-state refresh. Updating [`docs/architecture/00-current-state.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/00-current-state.md) and [`docs/architecture/README.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/README.md) in commit `2014aa0f2` kept the release-truth anchor from drifting away from the actual short-horizon state of the repo. That kind of change is easy to underestimate, but it matters because so much else reads from that surface. If the anchor slips, every downstream claim gets softer.
+
+The daily audit work reinforced the same pattern. The JSON probe is still failing, so the audit run had to fall back to text mode again. That is not ideal, but it is honest, and the plain audit path did complete successfully. The resulting signal was still useful: good overall health, with the weaker areas remaining federation readiness, alternate surface readiness, and governance readiness. That tells us where the uncertainty lives instead of hiding it behind a single green light.
+
+The marketing regeneration was the other piece of the day, but it stayed in the right lane. A new campaign bundle for `CAMPAIGN_2026_06_03_MARKETING_V1` was generated in draft state, with 24 claims split evenly between marketable and non-marketable material. That gives us a fresh evidence bundle without pretending it is approved or ready to publish. The distinction matters. A draft artifact is useful as a record and a working surface; it is not the same thing as a claim we can stand behind externally.
+
+The deeper shift today was simple: the system became a little harder to misread. The docs now better reflect current architecture truth, the audit remains explicit about what is and is not working, and the generated campaign material is clearly separated from any notion of release-level approval. That is not flashy work, but it reduces drift, and reducing drift is how a system becomes trustworthy.
+
+What this makes possible next is straightforward: fix the broken JSON probe, decide what to do with the draft campaign, and keep the current-state anchor tight as the repo evolves.
+::inbox-item{title="Daily dev log drafted from current-state truth" summary="Audit and marketing artifacts are current; review the draft if needed"}

--- a/docs/DEV_LOG/2026-06-04/Dev Log - 2026-06-04.md
+++ b/docs/DEV_LOG/2026-06-04/Dev Log - 2026-06-04.md
@@ -1,0 +1,69 @@
+Dev Log - 2026-06-04
+
+Summary
+
+Release-truth refresh day.
+
+The work was fundamentally about keeping the short-horizon truth surface aligned with what Codexify actually supports right now. The main committed change refreshed the weekly current-state override on `main`, while the rest of the day’s evidence stayed at the artifact layer: new audit snapshots, fresh marketing campaign bundles, and the usual distinction between what is merged, what is generated, and what is still draft-only.
+
+What I completed
+
+Current-state alignment
+- Refreshed `docs/architecture/00-current-state.md` on `main` with the latest short-horizon release truth.
+- Kept the supported-path language tight: local-only beta hardening, not a widened release promise.
+- Preserved the distinction between proven supported reality and areas that still need rechecking as the system evolves.
+
+Audit refresh
+- Regenerated the daily audit surfaces for the morning pass.
+- The JSON audit probe still fails with `NameError: run_git is not defined`, so the plain-text fallback remains the usable path.
+- The text audit still reports strong evidence around core loop integrity, primitive stability, extension boundary, and observability, while federation, alternate surface readiness, and governance remain the weaker/manual-review areas.
+
+Marketing artifact regeneration
+- Generated fresh draft campaign bundles for `CAMPAIGN_2026_06_03_MARKETING_V1` and `CAMPAIGN_2026_06_04_MARKETING_V1`.
+- Kept the campaigns in draft state with claim-ledger outputs instead of implying publish-ready status.
+- The generated history file was updated as part of that pipeline, which makes the artifact trail easier to reconstruct later.
+
+Important outcome
+
+`00-current-state.md` is no longer just a stale note about where the system was headed. It now carries the current release truth for the supported path on `main`, which matters because the repo keeps moving through layered evidence: docs, generated audit artifacts, and runtime-adjacent campaign outputs.
+
+The system also got a cleaner evidence boundary today. The audit and marketing outputs were regenerated, but they stayed correctly labeled as artifact-level proof. That keeps us from confusing generated material with merged runtime capability.
+
+Commits
+
+- `f26925ae5` - `docs: refresh weekly current-state override`
+
+Notes
+
+- The audit JSON path is still broken because `run_git` is undefined inside `scripts/audit_platform_readiness.py`; the plain-text fallback is the current working route.
+- The worktree remains dirty because the audit and marketing artifacts are generated but uncommitted.
+- `docs/Marketing/generated/history/run-history.jsonl` contains merge conflict markers and should be cleaned up separately if it is going to be committed.
+- Evidence today is still mostly code/test/artifact-level rather than live runtime proof.
+
+Next likely moves
+
+- Resolve the audit script JSON probe failure so the structured report works again.
+- Decide whether to commit the generated audit and marketing artifacts or keep them as ephemeral outputs.
+- Clean up the merge conflict markers in `docs/Marketing/generated/history/run-history.jsonl`.
+- Recheck the supported-path proof surface if any runtime-adjacent changes land next.
+
+Closing thought
+
+Today was mostly about truth maintenance. The repo did not gain a flashy new capability, but it did gain a clearer account of what is actually supported, what is only generated, and what still needs manual scrutiny.
+
+Narrative Log
+
+Dev Log - 2026-06-04
+
+This was a release-truth day more than a feature day, and that mattered. The useful work was not in expanding what Codexify claims to do. It was in tightening the record of what the system actually supports right now, and keeping that record aligned with the live direction of `main`.
+
+The anchor point was the weekly current-state refresh in `docs/architecture/00-current-state.md`. That file is only useful if it stays conservative and current, so the real value here was not prose polish. It was keeping the supported path legible: local-only beta hardening, no quiet widening of the release promise, no pretending that artifact generation or docs churn equals runtime proof.
+
+Around that, the audit surfaces were regenerated again. The JSON path is still broken because `run_git` is undefined in the audit script, so the structured report still cannot be trusted. The plain-text fallback remains the usable evidence surface, and it still gives a consistent picture: strong core loop and primitive signals, but federation, alternate surface readiness, and governance still need manual review. That matters because it keeps the repo honest about where it is structurally solid and where it is still cautious territory.
+
+The marketing side followed the same discipline. Draft campaign bundles were generated for June 3 and June 4, but they stayed draft-only, with claim ledgers and review artifacts rather than any implied publish state. That kept the output useful without letting the process overstate maturity. It is a small thing on paper, but it preserves a boundary that matters: generated material is evidence, not proof of release readiness.
+
+What changed underneath the surface is simple. The system now has a cleaner short-horizon truth surface, and the artifacts around it are more explicit about their status. That reduces drift. It reduces the chance that a generated report gets mistaken for shipped reality. And it leaves the next pass with a better base: fix the audit probe, clean up the generated-history conflict markers, and keep the supported-path record aligned with what `main` can actually prove.
+
+
+::inbox-item{title="Refresh release truth and audits" summary="Current-state updated; audit JSON still broken and generated artifacts remain dirty"}

--- a/docs/DEV_LOG/2026-06-05/Dev Log - 2026-06-05.md
+++ b/docs/DEV_LOG/2026-06-05/Dev Log - 2026-06-05.md
@@ -1,0 +1,70 @@
+Dev Log - 2026-06-05
+
+Summary
+
+docs truth-maintenance day
+
+The work today was mostly about keeping the repo’s documentation surfaces aligned with current state. That meant refreshing the weekly release notes draft, updating the short-horizon architecture truth anchor, and regenerating audit and marketing artifacts so the repo reflects the latest documented posture rather than stale output.
+
+This was not a runtime-shift day. It was a truth-surface day: tightening the written record, keeping release-facing docs in sync, and making sure the generated artifacts for audits and marketing were current across multiple dates without widening scope into code or live verification.
+
+What I completed
+
+Weekly release notes and current-state alignment
+
+- Drafted `CHANGELOG.beta.md` with the weekly release notes material for today.
+- Refreshed `docs/architecture/00-current-state.md` and `docs/architecture/README.md` so the architecture summary stayed aligned with the latest documented position.
+- This kept the short-horizon truth anchor current for anyone reading the repo to understand what is actually supported.
+
+Audit and marketing artifact regeneration
+
+- Regenerated morning and evening audit artifacts for 2026-06-03, 2026-06-04, and 2026-06-05.
+- Refreshed the `latest.md` and `latest.json` audit pointers so the current audit view tracks the newest generated evidence.
+- Regenerated marketing campaign bundles for `CAMPAIGN_2026_06_03_MARKETING_V1`, `CAMPAIGN_2026_06_04_MARKETING_V1`, and `CAMPAIGN_2026_06_05_MARKETING_V1`.
+- Updated the corresponding `run-metadata.json`, `evidence-ledger.json`, ad copy, channel drafts, review notes, core briefs, and infographic specs so the generated campaign outputs are internally consistent.
+
+Important outcome
+
+The system is more structurally honest now, but in the documentation layer rather than the runtime layer. The weekly notes, current-state override, audits, and campaign bundles now point at the same present tense instead of drifting apart.
+
+That matters because the repo’s written surface is often the first thing that signals whether the project is coherent. Today’s work reduced ambiguity there. It did not prove live behavior, but it did improve the credibility of the artifacts people use to reason about the system.
+
+Commits
+
+- `caacad8c5` - `docs: draft weekly release notes`
+- `e10abc126` - `docs: refresh weekly current-state override`
+- `3fee69f9e` - `docs: refresh audit and marketing artifacts`
+
+Notes
+
+- Evidence today is artifact-level, not live runtime proof.
+- The worktree was clean at the end of the run.
+- The audit and marketing outputs cover multiple recent dates, but the value here is consistency of the generated record, not a claim of newly observed runtime behavior.
+
+Next likely moves
+
+1. Turn the refreshed docs state into any needed follow-up release-note or audit edits.
+2. Verify whether the generated marketing bundles need review or approval routing.
+3. Continue keeping `docs/audits/latest.*` and `docs/architecture/00-current-state.md` aligned as the next daily truth anchors.
+4. If runtime work resumes, separate artifact truth from live proof explicitly so the record stays honest.
+
+Closing thought
+
+Today made the repo easier to trust. Not because it changed how the system runs, but because it tightened the documentary boundary around what the system is and what it is not.
+
+Narrative Log
+Dev Log - 2026-06-05
+
+Today was a documentation truth-maintenance day, and that mattered in a quieter way than a feature launch but in a way that still changes how the system is understood. The work was mainly about keeping the written surface of Codexify synchronized: the weekly release notes draft, the current-state architecture snapshot, the daily audits, and the generated marketing bundles all needed to point at the same present tense.
+
+The first piece was the weekly release notes draft. That work does not change the runtime, but it does change the way the repo tells its own story. A release note draft is only useful if it stays close to the actual history, so getting `CHANGELOG.beta.md` updated was part of keeping the project’s memory honest.
+
+The second piece was the current-state override. Refreshing `docs/architecture/00-current-state.md` and `docs/architecture/README.md` matters because those files are the fast read for what the system is currently claiming about itself. That kind of alignment is not cosmetic. It is the difference between a doc set that reflects the present system and one that quietly drifts into stale certainty.
+
+The broader pass was the audit and marketing regeneration. Morning and evening audit artifacts were refreshed across 2026-06-03, 2026-06-04, and 2026-06-05, and the marketing campaign bundles were regenerated for the same run family. That kept the generated record internally consistent: run metadata, evidence ledgers, ad copy, channel variants, review notes, and infographic specs all moved together instead of fragmenting into mismatched versions.
+
+What changed underneath the surface is that the repo’s documentation layer became more trustworthy as a system. Nothing here claimed live proof it did not have. Instead, the work reduced ambiguity, tightened the truth surface, and made it easier to tell which parts of the project are current, which are generated evidence, and which are still just artifact-level records.
+
+That is a small kind of progress, but it is the kind that keeps larger progress from becoming misleading. It leaves the next step clearer: if runtime work returns, it can build on a cleaner documentary baseline instead of compensating for drift.
+
+::inbox-item{title="Refresh Codexify truth surfaces" summary="Daily audits, current-state docs, and generated artifacts are aligned; next runtime proof can build on cleaner records."}

--- a/docs/DEV_LOG/2026-06-07/Dev Log - 2026-06-07.md
+++ b/docs/DEV_LOG/2026-06-07/Dev Log - 2026-06-07.md
@@ -1,0 +1,69 @@
+Dev Log - 2026-06-07
+
+Summary
+
+audit refresh and marketing artifact regeneration day
+
+This was mostly about keeping the truth surface current rather than shipping new runtime behavior. The morning and evening audits were both regenerated through text_fallback because the JSON probe still failed, so the day stayed anchored in the plain audit path that is actually working. In parallel, the 2026-06-07 marketing bundle was generated in draft form, which keeps the campaign evidence ledger moving without overstating proof.
+
+What I completed
+
+Audit refresh and current-state alignment
+
+- Regenerated the daily audit artifacts for morning and evening.
+- Confirmed the audit CLI still lands in text_fallback because audit_platform_readiness.py --json fails while the plain invocation succeeds.
+- The audit summary stayed stable at PASS 43, WARN 11, FAIL 0.
+- The strongest signals remained Extension Boundary, Core Loop Integrity, and Primitive Stability.
+- The weakest signals remained Federation Readiness, Alternate Surface Readiness, and Governance Readiness.
+
+Draft marketing artifact regeneration
+
+- Generated the CAMPAIGN_2026_06_07_MARKETING_V1 bundle in draft mode.
+- The campaign is scoped to local-first builders and currently carries 24 claims.
+- The evidence ledger keeps the claims split between marketable and non-marketable material, which preserves the distinction between public copy and internal anchors.
+
+Repository state
+
+- No commits landed today.
+- The worktree is still dirty from generated audit and marketing artifacts.
+- This is still artifact-level truth maintenance, not live runtime proof.
+
+Important outcome
+
+The system did not get flashier today. It got more honest.
+
+The audit path now has another clean daily snapshot proving that the plain fallback remains the reliable route, even while the JSON probe stays broken. The marketing bundle also moved forward without pretending it had stronger evidence than it does. That matters because the repo is still learning how to describe itself without drifting away from what is actually supported.
+
+Commits
+
+- None today.
+
+Notes
+
+- The JSON audit probe still fails, so the reliable evidence remains the plain-text fallback path.
+- The daily audit continues to report no failures, but several readiness bands still require manual review.
+- The marketing output is draft-only and should be treated as claim organization, not publication-ready proof.
+- Evidence today stayed at the artifact level; there was no live runtime verification added.
+
+Next likely moves
+
+- Repair or replace the JSON audit probe so the structured path becomes usable again.
+- Continue narrowing the gap between audit truth and runtime proof surfaces.
+- Review the draft marketing bundle and decide which claims, if any, are ready for external use.
+- Keep the current-state and audit artifacts synchronized so the daily truth layer stays coherent.
+
+Closing thought
+
+Today was about keeping the system describable under real constraints. That is not decorative work. It is the part that prevents the repo from drifting away from what it can actually support.
+
+Narrative Log
+
+Dev Log - 2026-06-07
+
+This was a quiet but useful day: not a shipping day, more a truth-maintenance day. The main work was to refresh the audit artifacts and generate the latest marketing bundle without inflating what the repo can honestly claim.
+
+The audit side stayed on the plain fallback path. The JSON probe still fails, so the usable signal remains the text_fallback run. That matters because it keeps the daily readiness picture grounded in something that actually executes. The summary did not change in any dramatic way: 43 passes, 11 warnings, 0 failures. The shape of the system is still visible, and the same weak spots continue to show up consistently instead of getting masked by noise.
+
+In parallel, the 2026-06-07 marketing bundle was generated in draft form. That work is easy to misread as promotional, but the real value is more structural: it keeps the claim ledger explicit. The bundle separates what is marketable from what is only internal support, which helps prevent the usual drift where copy outruns proof. In a repo like this, that distinction matters more than polish.
+
+So the day mostly reduced ambiguity. The audits stayed aligned with the current truth of the system, and the marketing output stayed inside its evidence boundaries. Nothing here made the product look bigger than it is, which is the point. It made the system more trustworthy to describe, and that is what lets the next round of work move faster without lying to itself.

--- a/docs/DEV_LOG/2026-06-08/Dev Log - 2026-06-08.md
+++ b/docs/DEV_LOG/2026-06-08/Dev Log - 2026-06-08.md
@@ -1,0 +1,75 @@
+**Dev Log - 2026-06-08**
+
+**Summary**
+
+Docs truth-alignment day.
+
+The work today was fundamentally about keeping Codexify’s short-horizon reality surfaces consistent: the weekly current-state override was refreshed, the morning audit was regenerated, and the marketing evidence bundles for 2026-06-07 and 2026-06-08 were rebuilt in draft state. This was not a runtime feature day. It was a truth-surface day, where the point was to keep release posture, audit signals, and campaign artifacts aligned with what the repo can actually support.
+
+**What I Completed**
+
+**Release truth refresh**
+
+- Refreshed `docs/architecture/00-current-state.md` and `docs/architecture/README.md`.
+- Kept the short-form release truth anchored on the local-first beta hardening posture.
+- Preserved the distinction between what is supported, what is proven, and what is still out of scope.
+
+**Audit refresh**
+
+- Added the 2026-06-08 morning audit in `docs/audits/daily/morning/2026-06-08-audit.md` and its JSON companion.
+- Updated the latest audit pointers so the current audit surface resolves to the new run.
+- The audit still required text_fallback; the JSON probe continued to fail while the plain run succeeded.
+- The summary stayed at PASS 43 / WARN 11 / FAIL 0, with the weakest signals still clustered around federation, alternate surface readiness, and governance readiness.
+
+**Marketing artifact regeneration**
+
+- Regenerated the draft campaign bundle for CAMPAIGN_2026_06_08_MARKETING_V1.
+- Also refreshed the 2026-06-07 campaign bundle in the same commit stream.
+- Kept the bundles in draft approval state with explicit claim accounting and evidence-ledger outputs.
+- This was evidence packaging, not a claim of live validation.
+
+**Important Outcome**
+
+The system is no longer relying on older truth surfaces as implied context. The current-state file, the morning audit, and the marketing bundles now point at the same present-tense posture instead of drifting apart.
+
+That matters because Codexify’s release story is only as trustworthy as the narrowest surface in the chain. Today’s work tightened that chain. The system did not become “more shipped.” It became more honest about what is actually supported, what is only documented, and what still needs proof.
+
+**Commits**
+
+- 40c68321c - docs: refresh weekly current-state override
+- 0653a550f - docs: add 2026-06-08 daily morning audit
+- 2b27b0631 - docs: refresh marketing campaigns for 2026-06-07 and 2026-06-08
+
+**Notes**
+
+- No live runtime proof was added today.
+- The audit still depends on text_fallback because the JSON probe fails.
+- The worktree remains dirty from generated audit and marketing artifacts.
+- Evidence today is artifact-level, not runtime-level.
+
+**Next Likely Moves**
+
+- Refresh the evening audit and keep the latest pointers aligned.
+- Recheck whether the JSON audit probe failure is still isolated or a broader script regression.
+- Continue tightening release-truth docs so the supported path stays explicit.
+- Decide whether any of the generated campaign artifacts should be committed or left as draft evidence only.
+
+**Closing Thought**
+
+Today was about removing ambiguity rather than adding surface area. The repo now tells a cleaner story about its own state, which is a small but real form of operational hardening.
+
+**Narrative Log**
+
+**Dev Log - 2026-06-08**
+
+This was a documentation-heavy day, but not in the trivial sense. It was a day about making the system’s present tense line up with itself.
+
+The first move was the weekly current-state refresh. That file is not decorative in Codexify; it is the short-horizon release truth. Updating it means the repo’s operational story gets another pass through the filter of what is actually supported, what is merely adjacent, and what should stay out of the release promise. That matters more than it sounds, because release truth in a local-first system drifts quietly if nobody keeps reasserting it.
+
+The morning audit followed the same logic. The JSON probe still failed, so the audit stayed on text_fallback, but the plain audit path succeeded and produced the familiar PASS/WARN/FAIL shape. That is not a dramatic result, but it is a useful one. It keeps the repo honest about the difference between a toolchain gap and a system failure. The audit still shows the same weak signals around federation, alternate surface readiness, and governance readiness, which is exactly the kind of residue you want surfaced instead of buried.
+
+Then the marketing artifacts were regenerated for both 2026-06-07 and 2026-06-08. That work sits in a different lane, but it still depends on the same discipline: claims need evidence, evidence needs structure, and structure needs to stay aligned with what the system can actually do. The new bundles are draft state, not shipping proof. That distinction is the point.
+
+By the end of the day, the deeper shift was simple: the repo became harder to misread. The current-state file, the audits, and the draft campaign bundles all point in the same direction now. Nothing flashy changed in runtime behavior, but the system got more legible, and that kind of legibility is part of the product.
+
+What this makes possible next is straightforward: keep the audit chain current, decide what to do with the lingering JSON probe failure, and keep tightening the gap between written posture and proven behavior.

--- a/docs/DEV_LOG/2026-06-09/Dev Log - 2026-06-09.md
+++ b/docs/DEV_LOG/2026-06-09/Dev Log - 2026-06-09.md
@@ -1,0 +1,69 @@
+**Dev Log - 2026-06-09**
+
+**Summary**
+
+Docs-and-truth alignment day. The work was centered on keeping the short-horizon release state honest, refreshing the current-state override, and regenerating audit artifacts so the repo’s operational record stayed aligned with the branch’s actual posture.
+
+This was not a runtime expansion day. The evidence points to release-truth maintenance, audit regeneration, and marketing/audit artifact churn around the supported local-first path. The important part is that the canonical state file still describes the system as local-first beta hardening on `main`, with the supported Compose path and local-only provider posture unchanged.
+
+**What I completed**
+
+**Release-truth refresh**
+
+- Updated `docs/architecture/00-current-state.md` and its companion README in the single commit that landed today.
+- Kept the short-horizon release narrative anchored to the supported local Docker Compose path.
+- Reaffirmed that Whoosh'd remains a local-provider metadata posture, not a new routed provider identity.
+
+**Audit regeneration**
+
+- Refreshed the daily audit surfaces under `docs/audits/`.
+- Regenerated the latest morning and evening audit snapshots plus the top-level `latest` pointers.
+- The audit summary still shows strong evidence for core loop integrity, primitive stability, and extension boundary clarity, while federation and governance remain weaker signals.
+
+**Generated artifacts**
+
+- The worktree also accumulated a large set of generated audit and marketing files.
+- These look like evidence artifacts and campaign outputs, not proof of expanded runtime scope.
+- The main operational takeaway is that the repo’s documentary layer moved more than its runtime layer did.
+
+**Important outcome**
+
+Codexify is no longer relying on stale release language. The current-state file now continues to act as the short-form anchor for what is actually supported, and the audit trail around it was refreshed to match that stance.
+
+The system did not gain a new runtime promise today. What it gained was tighter truth control: the docs, audits, and branch state are more aligned, which reduces drift when people read the repo to understand what is really shipped.
+
+**Commits**
+
+- `d8fa4e964` - `docs: refresh weekly current-state override`
+
+**Notes**
+
+- Evidence this day is mostly docs-level and audit-level, not live runtime proof.
+- The worktree is dirty with many generated audit and marketing artifacts.
+- No new merged runtime scope is visible in the evidence I checked.
+- The audit CLI still uses `text_fallback`; the JSON probe failed, but the plain run succeeded.
+
+**Next likely moves**
+
+1. Recheck whether any of the generated audit artifacts need pruning or consolidation.
+2. Keep the supported-path truth file current if another release-ops or docs refresh lands.
+3. Verify whether the audit churn is still intentional or needs a cleanup pass.
+4. Continue separating docs-only truth maintenance from any future runtime proof work.
+
+**Closing thought**
+
+Today was about tightening the map, not expanding the territory. That matters because a system that can accurately describe its supported state is harder to drift, easier to operate, and safer to extend later.
+
+**Narrative Log - 2026-06-09**
+
+Today felt like a release-truth day more than a feature day. The main work was about keeping Codexify’s public internal record aligned with what the branch actually supports, and making sure the audit surfaces continued to reflect that same constrained reality.
+
+The first important piece was the current-state anchor. `docs/architecture/00-current-state.md` still serves as the short-form source of truth for the present release posture, and today’s commit refreshed that override rather than widening anything. That matters because this repo has to distinguish between documentation momentum and actual supported runtime behavior. The supported path remains local Docker Compose with local-only provider posture. Nothing in today’s evidence suggests that moved.
+
+The second thread was the audit layer. The daily audit snapshots and `latest` pointers were regenerated, which is useful precisely because the repo is in a phase where documentary truth has to stay tightly coupled to operational truth. The audit results still show the stronger surfaces where the system has shape and reliability, and the weaker surfaces where it does not. Federation and governance remain the places that still need manual review, which is the right answer if we’re being honest about the current state.
+
+There was also a lot of generated file churn around audits and marketing outputs. I’m treating that as evidence artifact production, not as proof of broader runtime change. That distinction matters. It keeps us from reading decorative motion as capability growth.
+
+So the deeper shift today was not that the system became more ambitious. It became more legible. The release-truth layer, the audit layer, and the branch state were pulled a little closer together, and that reduces the chance that someone misreads the repo as supporting more than it really does.
+
+That sets up the next phase cleanly: if anything new lands, we’ll have a better baseline for checking whether it is actual runtime progress or just more documentation around the edges.

--- a/docs/DEV_LOG/2026-06-10/Dev Log - 2026-06-10.md
+++ b/docs/DEV_LOG/2026-06-10/Dev Log - 2026-06-10.md
@@ -1,0 +1,72 @@
+**Dev Log - 2026-06-10**
+
+**Summary**
+
+Runtime truth-alignment day.
+
+The work was fundamentally about tightening the local-first supported path around Whoosh’d and making the system’s readiness story match the actual Docker-based runtime instead of older Ollama-era defaults. The day split cleanly into two layers: one docs/current-state refresh to keep the short-horizon release truth current, and one runtime/config pass to align health checks, fallback URLs, and setup defaults with the Whoosh’d bridge on `8000`.
+
+That matters because the supported path is now described more consistently across docs, config, compose, and setup flows. The system is still in beta hardening, but the operational picture is less ambiguous than it was before.
+
+**What I completed**
+
+**Current-state and release truth**
+
+- Refreshed the short-horizon release anchor in `docs/architecture/00-current-state.md` via commit `5da56f81b`.
+- Kept the supported reality framed as local-first beta hardening on `main`, with local Docker Compose still the supported path.
+- Reinforced that release claims should stay bounded to proven runtime behavior, not docs-only or audit-only artifacts.
+
+**Whoosh’d health and readiness reporting**
+
+- Updated the local runtime defaults and fallback paths from `11434` to `8000` in the router, config, setup wizard, compose files, and env templates.
+- Adjusted the local provider description to reflect the Whoosh’d MLX-VLM bridge instead of the older Ollama phrasing.
+- Kept the supported local provider identity as `local`, while making the operator-facing path more truthful and less stale.
+- Improved readiness reporting so the local health surface is closer to the actual bridge the stack expects.
+
+**Support files and operator defaults**
+
+- Synchronized `.env.example`, `.env.template`, `config/supported_profiles/v1-local-core-web-mcp.yaml`, `docker-compose.yml`, and `docker-compose.runtime.yml` with the new base URL assumptions.
+- Kept the setup wizard’s local beta defaults aligned with the same runtime target.
+
+**Important outcome**
+
+Whoosh’d is no longer just a label in docs or metadata. The local path now has enough structural alignment across config, compose, and readiness handling to behave like a coherent supported posture instead of a set of leftover assumptions.
+
+The bigger shift is that the system stopped treating `11434` as the implicit local truth and started converging on `8000` as the actual bridge endpoint. That is a small change on paper, but it removes a lot of hidden drift from setup and health-check behavior.
+
+**Commits**
+
+- `5da56f81b` - `docs: refresh weekly current-state override`
+- `dcbec011b` - `Improve Whooshd health checks and readiness reporting`
+
+**Notes**
+
+- The evidence for the runtime alignment is code/docs-level, not live-runtime proof.
+- The worktree is still dirty with matching runtime/config edits, so some of today’s changes appear to be in-flight rather than fully committed.
+- I did not run tests in this pass.
+- `docs/architecture/00-current-state.md` remains the release-truth anchor for short-horizon claims.
+
+**Next likely moves**
+
+1. Verify the Whoosh’d path live on the supported Compose stack.
+2. Confirm health/readiness responses reflect the new `8000` bridge end to end.
+3. Decide whether the dirty config changes should be committed as a follow-up or were intentionally left for review.
+4. Recheck any operator docs that still mention `11434` so they do not reintroduce drift.
+
+**Closing thought**
+
+Today was mostly about removing mismatch, not adding surface area. The system is easier to reason about now because the operator defaults, the health checks, and the current-state document are pointing at the same local runtime story.
+
+**Narrative Log**
+
+**Dev Log - 2026-06-10**
+
+This was a day of runtime truth alignment more than feature work. The main task was to pull Whoosh’d support into a consistent shape across the places that actually matter when the system boots: config, compose, setup defaults, and the current-state release anchor. The useful part of that work is not the label change itself. It is that the local path stopped depending on stale Ollama-era assumptions and started matching the bridge the stack is meant to use now.
+
+The first piece was the current-state refresh. That document remains the short-horizon truth source, so keeping it current matters more than it would in a normal docs-only repo. It now reflects the local-first beta posture on `main` without overreaching beyond what is actually proven. That keeps release language from drifting ahead of runtime reality.
+
+The second piece was the Whoosh’d health and readiness pass. The router, config defaults, setup wizard, and compose layers all moved together from `11434` to `8000`. That is the kind of change that looks small until it breaks the operator experience if only one layer is updated. Aligning them reduced that fracture. It also made the local provider story more explicit: provider id stays `local`, while the display and base URL now describe the Whoosh’d bridge more honestly.
+
+What changed underneath the surface is that the system became less ambiguous. It is still not a claim of live proof by itself, but it is closer to a single coherent supported path instead of a stack of partially inherited assumptions. That is the kind of work that keeps the rest of the runtime honest.
+
+The next step is straightforward: validate the updated path live, then sweep for any remaining references to the old local endpoint so the drift does not come back through the side door.

--- a/docs/DEV_LOG/2026-06-12/Dev Log - 2026-06-12.md
+++ b/docs/DEV_LOG/2026-06-12/Dev Log - 2026-06-12.md
@@ -1,0 +1,77 @@
+Dev Log - 2026-06-12
+
+Summary
+
+docs-and-artifacts day
+
+Today was mostly about keeping the release-truth layer aligned with the actual `main` state, then capturing the day’s generated campaign artifacts without overstating what they prove. The work was narrow but important: it tightened the short-horizon interpretation of Codexify so the repo’s current supported posture reads cleanly, and it kept the marketing output explicitly inside a draft/evidence-bound frame.
+
+The day did not broaden the release promise. It clarified it. That matters because the repo now has enough moving parts around local-provider setup, operator docs, audit artifacts, and campaign generation that the main risk is drift in the written truth, not just missing code.
+
+What I completed
+
+Release-truth refresh
+
+- Updated `docs/architecture/00-current-state.md` to reflect the current `main` posture more precisely.
+- The first pass captured the Whoosh'd provider preset wiring as the newest shipped change and kept the local-only beta boundary intact.
+- The follow-up pass tightened the language again, clarified the weekly interpretation, and added a stronger pointer in `docs/architecture/README.md` back to `00-current-state.md`.
+- Net effect: the short-horizon docs now read more like an operational boundary marker and less like a loose roadmap note.
+
+Daily audit capture
+
+- Regenerated the daily audit artifacts for the June 12 morning run.
+- The audit remained in `text_fallback` mode because the JSON probe still fails with `NameError: run_git is not defined` in `scripts/audit_platform_readiness.py`.
+- The audit summary stayed stable at PASS 43, WARN 11, FAIL 0.
+- Strongest bands remained Extension Boundary, Core Loop Integrity, and Primitive Stability.
+- Weakest signals remained Federation Readiness, Alternate Surface Readiness, and Governance Readiness.
+
+Campaign artifacts
+
+- Generated a new draft marketing campaign bundle under `docs/Marketing/generated/CAMPAIGN_2026_06_12_MARKETING_V1/`.
+- The campaign brief stays explicitly draft-only and evidence-bound.
+- The campaign materials are useful as internal receipts, but they do not prove runtime support or release readiness.
+- The generated history file was updated to record the campaign run.
+
+Important outcome
+
+`00-current-state.md` is now closer to an actual release-truth anchor than a generalized status page. It reflects the current supported path, the current local-provider posture, and the boundaries that should not be inferred from docs-only artifacts.
+
+The system also stopped pretending that generated marketing materials are proof of capability. Those artifacts now sit in the right place: visible, useful, and clearly non-authoritative about runtime behavior.
+
+Commits
+
+- `56381fbeb` - `docs: refresh weekly current-state override`
+- `3ee11ea5a` - `docs: refresh weekly current-state override`
+
+Notes
+
+- The audit JSON path is still broken by `run_git` not being defined in `scripts/audit_platform_readiness.py`.
+- The audit evidence is repo-local and docs-backed, not live runtime proof.
+- The marketing campaign output is draft-only and should stay framed that way unless later evidence upgrades it.
+- The worktree was dirty outside the commits, so the daily record needs to stay careful about what was committed versus what was generated.
+
+Next likely moves
+
+- Fix the `run_git` failure in `scripts/audit_platform_readiness.py` so the JSON audit path works again.
+- Decide whether the draft campaign bundle should be promoted, revised, or left as internal-only evidence.
+- Keep `docs/architecture/00-current-state.md` synchronized with the next supported-path change on `main`.
+- Recheck the audit outputs after any runtime or docs truth change to confirm the evidence bands still hold.
+
+Closing thought
+
+Today was about tightening the boundary between supported reality and generated output. The repo is healthier when the docs tell the truth first, and the artifacts follow that truth instead of stretching it.
+
+Narrative Log  
+Dev Log - 2026-06-12
+
+This was a truth-alignment day more than a feature day. The work centered on keeping Codexify’s release posture legible while the repo accumulated more local-provider setup, audit output, and campaign-generation artifacts. Nothing here widened the promise. The useful part was making sure the written record did not drift ahead of the system.
+
+The first pass was a refresh of `docs/architecture/00-current-state.md`. That file is supposed to be the short-horizon anchor, so the change mattered less as prose and more as a contract. It now speaks more directly about the Whoosh'd preset wiring as the newest shipped change, while still holding the line that local-only beta hardening is the current phase. The follow-up edit sharpened that interpretation again and added a clearer pointer in the architecture README back to the current-state file. That kind of edit is easy to underread, but it prevents a familiar failure mode in a repo like this: older architecture language slowly outgrowing the present tense.
+
+The daily audit reinforced the same picture. The repo-local evidence was stable enough to keep the same summary bands, but the JSON probe still fails because `run_git` is undefined in `scripts/audit_platform_readiness.py`. That means the audit can still produce a useful text fallback, but part of the automation path remains broken. The important part is not the failure itself; it is that the failure is now clearly bounded. The audit remains honest about what it can prove, and what it cannot.
+
+The other visible thread today was the marketing campaign bundle under `docs/Marketing/generated/CAMPAIGN_2026_06_12_MARKETING_V1/`. Those files are real outputs, but they are not runtime evidence. They are draft receipts, and the campaign brief says as much. That distinction matters because this repo has enough overlapping surfaces that it is easy to overread artifacts as proof. They are useful for internal continuity, but they do not change the release truth.
+
+The deeper shift is small but meaningful: the repo’s documents are becoming more disciplined about saying what is supported, what is only drafted, and what still needs live proof. That makes the system easier to operate. It also makes the next change easier to judge, because the baseline is cleaner.
+
+What this makes possible next is straightforward. We can fix the audit JSON path, keep the release-truth file synchronized, and decide whether the campaign bundle stays internal or gets revised for a later review pass. The important thing is that the repo now has a sharper sense of where its truth lives.

--- a/docs/DEV_LOG/2026-06-14/Dev Log - 2026-06-14.md
+++ b/docs/DEV_LOG/2026-06-14/Dev Log - 2026-06-14.md
@@ -1,0 +1,73 @@
+**Dev Log - 2026-06-14**
+
+**Summary**
+
+truth-alignment day
+
+Today was mostly about tightening the system’s contracts and cleaning up the evidence trail around them. The biggest thread was the Whoosh’d local inference wiring, which kept the project anchored to local-first behavior while making the runtime boundaries and supported paths more explicit. The second thread was the fact-candidate review flow, which turned identity-memory work from an internal pipeline into something users can inspect and act on directly.
+
+What mattered here was not feature count. It was reducing ambiguity: where requests go, how local inference is selected, how memory candidates surface, and what the repo can honestly claim about its current state. The day also ended with a fresh audit pass, which kept the repo-local truth surface current even though the audit itself is still only repo evidence, not live runtime proof.
+
+**What I completed**
+
+**Whoosh’d local inference wiring**
+
+- Kept the local inference path centered on `provider_id: local` and the Whoosh’d sidecar model source.
+- Tightened the supporting runtime and docs seams around the local provider setup.
+- Added smoke and contract coverage so the local path is more explicit about its environment assumptions.
+
+**Fact candidate review flow**
+
+- Added the review flow for memory candidates so identity-memory work can be inspected instead of silently absorbed.
+- Wired the frontend settings surface to the new review path.
+- Added pipeline and review tests so the behavior is defined at the contract level instead of only in the UI.
+
+**Audit refresh and generated artifacts**
+
+- Refreshed the daily audit outputs and related generated artifacts.
+- Kept the current-state evidence aligned with the repo’s actual structure and the strongest scanned domains.
+- Preserved the warning surface around weaker areas like federation readiness and governance readiness instead of smoothing them over.
+
+**Important outcome**
+
+The system is no longer just accumulating capabilities in the background. It now has enough structural truth to expose local inference as a supported path, and enough review surface to make identity-memory changes inspectable rather than implicit.
+
+That matters because the project stopped treating these areas as hidden implementation details. They are becoming legible operating surfaces: local runtime selection, memory review, and audit evidence each have clearer boundaries now. The repo still has weak spots, but the important shift is that the weak spots are visible instead of being masked by generic success language.
+
+**Commits**
+
+- `2dd6e26d8` - `chore(docs): update generated audits and marketing artifacts`
+- `ba0fe6a6` - `feat(memory): add fact candidate review flow`
+- `bf51c64a6` - `feat(local): wire Codexify to Whoosh'd local inference`
+
+**Notes**
+
+- The daily audit selected `text_fallback` because the JSON path still fails with `NameError: run_git is not defined` in `scripts/audit_platform_readiness.py`.
+- The audit result is solid on counts (`PASS 43`, `WARN 11`, `FAIL 0`), but it remains repo-local evidence rather than live runtime proof.
+- Marketing artifacts were regenerated too, but they should stay classified as generated documentation, not operational validation.
+- The weakest structural signals remain federation readiness, alternate surface readiness, and governance readiness.
+
+**Next likely moves**
+
+- Close the JSON probe failure in `scripts/audit_platform_readiness.py`.
+- Tighten runtime evidence for the Whoosh’d local path with a live smoke pass.
+- Keep hardening the memory review flow with clearer UX states and failure handling.
+- Revisit federation and governance gaps only after the local contract surfaces stay stable.
+
+**Closing thought**
+
+Today made the system more honest. The important change was not that it grew larger, but that its boundaries became clearer: local inference, memory review, and audit evidence now read like real operating surfaces instead of loose intentions.
+
+**Narrative Log**
+
+**Dev Log - 2026-06-14**
+
+This was a contract-and-clarity day. The work was less about adding a new surface than about making existing surfaces behave like parts of a real system: local inference, memory review, and audit truth all got sharper edges.
+
+The Whoosh’d wiring mattered because it kept the local-first promise explicit. That path is now more than a vague deployment preference. It is a defined route with supporting config, sidecar behavior, and smoke coverage around the assumptions it depends on. That kind of work does not look flashy, but it is the difference between “we can probably run this locally” and “this is a supported local path we can reason about.”
+
+The fact-candidate review flow pushed in the same direction from the product side. Memory and identity work can get soft very quickly if the system only lets it happen behind the curtain. Surfacing candidate review makes the pipeline inspectable. It gives the user a place to see what the system thinks, accept or reject it, and keep the identity boundary explicit instead of ambient.
+
+The audit refresh tied the day together. It was another reminder that the repo’s truth surface matters as much as the code itself. The audit is strong on the core loop, primitive stability, and extension boundary, but it still exposes the weaker zones plainly: federation, alternate surfaces, and governance are not solved by documentation polish. That honesty is useful. It keeps the team from over-claiming and lets the next round of work stay pointed at the real gaps.
+
+The deeper shift is simple: the system is becoming more trustworthy by becoming more legible. It still has rough edges, but the important parts are starting to declare themselves clearly. That gives us a better base to harden the runtime, tighten failure handling, and keep the architecture aligned with what actually ships.

--- a/docs/DEV_LOG/2026-06-14/Whoosh’d × Codexify Local Inference Signoff — 2026-06-14.md
+++ b/docs/DEV_LOG/2026-06-14/Whoosh’d × Codexify Local Inference Signoff — 2026-06-14.md
@@ -1,0 +1,130 @@
+# Whoosh’d × Codexify Local Inference Signoff — 2026-06-14
+
+Tags: #codexify #whooshd #local-inference #mlx #mlx-vlm #gguf #llama-cpp #async-worker #multimodal #architecture #checkpoint #verified
+
+Today marks the completion of the Whoosh’d × Codexify local inference integration sequence.
+
+The work crossed both repositories but preserved their intended boundary. Whoosh’d remains the standalone local inference gateway. Codexify remains the application layer that owns memory, task orchestration, persona/context routing, Docker smoke configuration, async workers, and user-facing workflows. Codexify talks to Whoosh’d over HTTP only. No Whoosh’d internals were imported into Codexify, and Whoosh’d was not merged into Codexify or added as a Codexify container.
+
+## Verified Runtime Lanes
+
+Whoosh’d now supports and has verified:
+
+- MLX text via `mlx_lm_server`
+    
+- MLX-VLM vision via `mlx_vlm`
+    
+- GGUF inference via `llama.cpp` / `llama-server`
+    
+- OpenAI-compatible chat completion routing
+    
+- Runtime inventory through `/v1/models` and `/api/tags`
+    
+- Runtime health through `/health/runtime`
+    
+
+Codexify has verified local-only inference through Whoosh’d across:
+
+- Sync text: `llama-3.2-3b-mlx` → `mlx_lm_server`
+    
+- Sync vision: `qwen2-vl-2b-mlx` → `mlx_vlm`
+    
+- Sync GGUF: `qwen2.5-0.5b-gguf` → `llama_cpp`
+    
+- Async multimodal: `qwen2-vl-2b-mlx` → `mlx_vlm`
+    
+- Streaming worker lifecycle
+    
+- No cloud fallback
+    
+- Base64 logging safety
+    
+
+The async multimodal path was the final major structural seam. It required preserving structured OpenAI-compatible multimodal content through Codexify’s queued worker path instead of flattening image turns into plain text. The worker now detects image content, preserves the structured payload, selects the vision model, and sends the correct model to Whoosh’d.
+
+## Important Fixes
+
+Codexify-side fixes included:
+
+- Durable Whoosh’d smoke Docker configuration
+    
+- Local-only provider profile enforcement
+    
+- `LOCAL_CHAT_MODEL`, `LOCAL_VISION_MODEL`, and `LOCAL_GGUF_MODEL` handling
+    
+- Vision model source correction
+    
+- GGUF explicit model preservation
+    
+- Structured multimodal task payload preservation
+    
+- Async multimodal worker model resolution
+    
+- Local provider precedence fix so `LOCAL_CHAT_MODEL` beats `LOCAL_LLM_MODEL` for worker async text
+    
+
+Whoosh’d-side fixes and confirmations included:
+
+- Multi-runtime adapter routing
+    
+- Registry-backed model inventory
+    
+- MLX text adapter support
+    
+- MLX-VLM adapter support
+    
+- llama.cpp adapter support
+    
+- Runtime concurrency guardrails
+    
+- Codexify compatibility smoke tests
+    
+- Manual validation reports for MLX, MLX-VLM, and GGUF lanes
+    
+- Confirmation that all configured runtimes can register together in one Whoosh’d process when environment variables are passed in the same execution context
+    
+
+## Commit Checkpoints
+
+Codexify commits:
+
+- `bf51c64a6` — `feat(local): wire Codexify to Whoosh'd local inference`
+    
+- `ba0fe6eaf` — `feat(memory): add fact candidate review flow`
+    
+- `2dd6e26d8` — `chore(docs): update generated audits and marketing artifacts`
+    
+
+Whoosh’d commits:
+
+- `cd6eafe` — `feat(runtime): add multi-runtime routing and adapters`
+    
+- `da20fb4` — `feat(codexify): add local provider compatibility smokes`
+    
+- `c8c34f4` — `docs(validation): add local runtime validation reports`
+    
+
+Both work trees were cleaned and committed. No push was performed at the time of this checkpoint.
+
+## Known Limitation
+
+The first async text task after worker restart can remain in `AWAITING_FIRST_TOKEN` while the MLX model warms. This should be treated as `MODEL_WARMING`, not offline or failed behavior. Sync text works once the model is loaded, and subsequent async text tasks should complete normally after warmup. A future worker-warmup service could preload local models to remove this first-use delay.
+
+GGUF currently requires a separate `llama-server` process. Managed llama-server startup may be added later, but it is not required for the verified integration.
+
+## Why This Matters
+
+This checkpoint turns local inference from an experiment into a usable substrate.
+
+Codexify can now operate through Whoosh’d as a local-first inference layer across text, vision, GGUF, sync, async, and multimodal paths while preserving local-only guarantees and avoiding silent cloud fallback.
+
+The architectural boundary is now clear:
+
+- Whoosh’d is the engine room.
+    
+- Codexify is the memory, workflow, and user-facing cognition layer.
+    
+- The bridge between them is HTTP, model inventory, runtime health, and OpenAI-compatible message structure.
+    
+
+This is the foundation for the next phase of Codexify work: Chronicle, memory, identity-aware workflows, and richer local-first cognition built on top of a verified inference substrate.

--- a/docs/DEV_LOG/2026-06-15/Dev Log - 2026-06-15.md
+++ b/docs/DEV_LOG/2026-06-15/Dev Log - 2026-06-15.md
@@ -1,0 +1,78 @@
+**Dev Log - 2026-06-15**
+
+**Summary**
+
+Contract hardening day.
+
+The day was fundamentally about making Whooshd’s local runtime path more explicit and less fragile. The work tightened the boundary between canonical local configuration and legacy compatibility, then followed through by surfacing catalog mismatches instead of letting them stay implicit. That matters because the system is now closer to telling the truth about its own runtime state, rather than silently accepting a configuration that looks valid until it fails later.
+
+A smaller but still important part of the day was documentation and proof-capture: the current-state docs were refreshed, and a mismatch-handling proof note was written to record what the code now demonstrates. The generated marketing and audit artifacts also landed, but those should be read as repo evidence and not runtime proof.
+
+**What I completed**
+
+**Whooshd local runtime config**
+
+- Standardized the local runtime config so `AI_BACKEND=local` no longer crashes startup.
+- Kept `LLM_PROVIDER=local` and `LOCAL_RUNTIME_PRESET=whooshd-mlx` as the canonical path.
+- Removed `AI_BACKEND` from the setup wizard’s local defaults and readiness normalization.
+- Updated readiness classification so the setup flow checks the right signal instead of overloading backend state.
+- Cleaned up the local example env and compose files to reflect the canonical local configuration.
+
+**Catalog mismatch visibility**
+
+- Surfaced Whooshd catalog inventory mismatches in the router and catalog layers.
+- Added tests around the mismatch path so the failure mode is now explicit instead of latent.
+- Added a proof doc showing the live mismatch behavior that was being exercised.
+
+**Truth alignment and docs**
+
+- Refreshed `docs/architecture/00-current-state.md` and its README pointer to keep the short-horizon truth anchor current.
+- Committed generated marketing and audit artifacts for the day’s campaign runs and audit snapshots.
+- Preserved the distinction between generated evidence and live runtime proof.
+
+**Important outcome**
+
+Whooshd local support is no longer just “present in spirit.” The local path now has a clearer canonical configuration, and the code stops pretending that legacy backend settings are the same thing as the actual local provider contract.
+
+The system also stopped hiding inventory mismatches. That’s the deeper shift: instead of absorbing inconsistency quietly, it now surfaces it in a way that can be tested, documented, and reasoned about. That is a small structural change with real operational value.
+
+**Commits**
+
+- `d06f152dc` - `Standardize Whooshd local runtime config`
+- `004e7e043` - `docs(local): prove Whooshd catalog mismatch handling`
+- `9710ba3ef` - `chore: commit generated marketing and audit artifacts`
+- `d68f38561` - `fix(local): surface Whooshd catalog inventory mismatches`
+- `39a86b56d` - `docs: refresh weekly current-state override`
+
+**Notes**
+
+- The strongest evidence today is code-path and test-level, plus generated audit/marketing artifacts. It should not be described as live runtime validation.
+- The mismatch proof doc records behavior, but it is still documentation of exercised behavior, not a full production runtime claim.
+- The audit and marketing outputs are useful receipts, but they are not the same thing as supported-path runtime proof.
+
+**Next likely moves**
+
+- Verify the local Whooshd startup path end to end with the standardized config.
+- Expand coverage around readiness and mismatch edge cases if any drift remains.
+- Keep the current-state docs aligned with the canonical local-provider contract.
+- Decide whether any legacy `AI_BACKEND` references should be removed more aggressively now that compatibility is preserved in code.
+
+**Closing thought**
+
+Today made the local provider story narrower and more honest. That usually feels like subtraction, but it is how the system becomes easier to operate: fewer ambiguous knobs, clearer failure modes, and less room for configuration drift to masquerade as support.
+
+**Narrative Log**
+
+**Dev Log - 2026-06-15**
+
+It was a contract day more than a feature day. The work settled around one question: what does it mean for Whooshd local inference to be truly supported, rather than merely reachable through old config habits? Most of the changes were about removing ambiguity from that answer.
+
+The first pass tightened the local runtime configuration. `AI_BACKEND=local` now behaves as a legacy compatibility input instead of a startup hazard, while the canonical path stays centered on `LLM_PROVIDER=local` and the Whooshd preset. That shift matters because it moves the system from “this might work if the right combination of flags happens to line up” to a smaller, clearer contract that the setup flow can actually classify.
+
+From there, the work pushed into mismatch visibility. The router and catalog now surface Whooshd inventory mismatches instead of letting them sit as invisible inconsistency. That is the kind of change that does not look dramatic in a diff, but changes how the system fails. A hidden mismatch becomes a named condition. A named condition can be tested, documented, and eventually monitored.
+
+The docs followed the code. `00-current-state.md` was refreshed to keep the short-horizon operational truth in sync, and a proof note was written for the mismatch path. The generated audit and marketing artifacts also landed, but those belong in the evidence trail, not the runtime story. They help document the day, but they do not upgrade the proof level of the system itself.
+
+What changed underneath the surface is simple: the system became more truthful about its own boundaries. Local support is less like a promise and more like a contract. Mismatch handling is less like a surprise and more like a surfaced condition. That makes the next round of work more honest to do, because the foundation is describing reality instead of smoothing it over.
+
+There is still more to validate at runtime, but the shape is better now. The next useful step is to run the standardized local path end to end and keep tightening the boundary between legacy compatibility and the real canonical configuration.

--- a/docs/DEV_LOG/2026-06-16/Dev Log - 2026-06-16.md
+++ b/docs/DEV_LOG/2026-06-16/Dev Log - 2026-06-16.md
@@ -1,0 +1,99 @@
+Dev Log - 2026-06-16
+
+Summary
+
+runtime truth-alignment day
+
+Today’s work was fundamentally about making Guardian less ambiguous about what the system is actually doing. The core shift was from a coarse online/offline framing toward explicit provider runtime states, paired with request-lifecycle visibility in the chat surface and Command Center. That made the UI and supporting contracts more honest about warming, degraded, generating, and error conditions instead of flattening them into generic “available” language.
+
+The other thread was local-runtime alignment: the Whoosh'd preset stopped claiming an outdated model and was brought back in line with the current inventory. That mattered because the system’s displayed defaults, contract tests, and runtime docs now point at the same thing.
+
+What I completed
+
+Thread contract hardening
+
+- Expanded provider runtime state handling in [`frontend/src/contracts/runtimeTokens.ts`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/frontend/src/contracts/runtimeTokens.ts) so the frontend recognizes the full canonical set: `offline`, `connecting`, `runtime_available`, `model_warming`, `ready`, `generating`, `degraded`, and `error`.
+- Added normalization for legacy values so older `online` / `degraded` / `offline` surfaces still resolve into canonical state without breaking display logic.
+- Reworked provider-state descriptions so each state has operator-facing copy that is distinct and deliberate instead of implying one generic healthy state.
+
+Runtime visual state mapping
+
+- Expanded [`frontend/src/shared/runtimeVisualState.ts`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/frontend/src/shared/runtimeVisualState.ts) so request visual states can account for canonical provider state instead of collapsing `model_warming`, `degraded`, and `generating` into the same presentation path.
+- Kept the mapping explicit about what is terminal, what is blocking, and what should remain informational.
+- Added contract tests in [`frontend/src/contracts/__tests__/runtimeVisualState.test.ts`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/frontend/src/contracts/__tests__/runtimeVisualState.test.ts) to lock the distinctions in place.
+
+Chat surface truthfulness
+
+- Added a read-only runtime status strip to [`frontend/src/features/chat/GuardianChat.tsx`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/frontend/src/features/chat/GuardianChat.tsx).
+- The strip now surfaces provider state and request phase together, which makes it clearer when the system is warming, generating, degraded, or in an error state.
+- Added UI tests in [`frontend/src/features/chat/__tests__/GuardianChat.runtimeState.test.tsx`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/frontend/src/features/chat/__tests__/GuardianChat.runtimeState.test.tsx) to ensure the strip stays informational and does not grow mutation controls.
+
+Command Center observability
+
+- Updated the Command Center run verdict path in [`frontend/src/features/commandCenter/components/HealthOverview.tsx`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/frontend/src/features/commandCenter/components/HealthOverview.tsx) and [`frontend/src/features/commandCenter/commandCenterObservability.ts`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/frontend/src/features/commandCenter/commandCenterObservability.ts) so runtime health can be classified more precisely.
+- This moves the Command Center away from vague health signaling and toward a more legible verdict model.
+
+Local runtime alignment
+
+- Aligned the Whoosh'd local chat model in [`guardian/core/local_runtime_presets.py`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/guardian/core/local_runtime_presets.py) with the current inventory.
+- Kept the corresponding test in [`tests/core/test_local_runtime_presets.py`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/tests/core/test_local_runtime_presets.py) updated so the preset reflects the real default rather than an outdated assumption.
+
+Guardian maturity docs
+
+- Recorded the proof trail for the Guardian maturity program in the `C00`, `C02`, and `C11` campaign docs under [`docs/Campaign/guardian-maturity/`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/Campaign/guardian-maturity/).
+- These docs are supporting evidence, not runtime proof, but they now track the structural work more faithfully.
+
+Important outcome
+
+Guardian is no longer just saying whether the provider is “online” or “offline.” It can now represent a more truthful middle layer: connecting, available but not ready, warming, generating, degraded, and error. That matters because the user-facing surface now has enough structural truth to explain delays and partial failure without pretending they are outages.
+
+The system also stopped carrying a stale local-model assumption. The Whoosh'd preset now matches the inventory the repo is actually using, which reduces drift between config, tests, and the practical default path.
+
+Commits
+
+- `ec1d6974f` - `feat: show Guardian chat runtime state`
+- `f6acbf18f` - `feat: expand Guardian provider runtime visual states`
+- `85931f327` - `fix: align local chat model with Whooshd inventory`
+- `5d5a41ce6` - `feat: show Guardian Command Center run verdict`
+- `4fb2c8846` - `feat: add Guardian Command Center run verdict classifier`
+- `9c5c0e542` - `docs: record Guardian Maturity C02 chat runtime proof`
+- `90d54287e` - `docs: refresh Guardian Maturity C00 truth gate proof`
+- `0c2ef926d` - `docs: record Guardian Maturity C11 route audit proof`
+- `52f4eb81b` - `docs: record Guardian Maturity C00 truth gate proof`
+- `99017e399` - `docs: create Guardian Maturity planning scaffold`
+
+Notes
+
+- Evidence here is code/test/doc level, not live runtime proof.
+- The runtime-status strip is intentionally read-only; it improves legibility without pretending to solve failure conditions.
+- The maturity docs are useful as a proof trail, but they should not be treated as a substitute for runtime validation.
+- The local-model alignment fix is small but important because it removes a stale default that could have quietly skewed operator expectations.
+
+Next likely moves
+
+- Verify the new runtime states against a live Guardian session and confirm the UI copy matches actual provider behavior.
+- Extend the Command Center verdict path if any remaining states still collapse too aggressively.
+- Audit other frontend surfaces that still assume `online` as the only healthy provider state.
+- Keep the maturity proof packs aligned with the new runtime vocabulary.
+- Review whether any backend status emitters still need to be normalized to the new canonical state set.
+
+Closing thought
+
+The day was mostly about removing ambiguity. That kind of work does not look flashy, but it changes how much the system can be trusted under partial failure. Once the UI, the contract layer, and the preset defaults tell the same story, the remaining gaps are easier to see and much harder to hide.
+
+Narrative Log  
+Dev Log - 2026-06-16
+
+This was a day of truth alignment more than feature growth. The work did not add a new product surface so much as it made the existing surfaces say what the system is actually doing. That difference matters. When runtime state is vague, operators fill in the blanks with guesswork. When it is explicit, the system starts to explain itself.
+
+The first correction was at the local-runtime layer. The Whoosh'd preset had drifted away from the current inventory, so the default model was realigned to the model the repo actually expects. That seems small, but it closes a quiet gap between configuration and reality. Once the preset, the test, and the current inventory all agree, the default path stops being a place where stale assumptions can linger.
+
+From there the work moved up the stack into runtime vocabulary. The provider state model was expanded from a blunt healthy/unhealthy shape into a more useful set of canonical states. Connecting, runtime available, warming, generating, degraded, and error are different conditions, and they need different handling. The normalization layer mattered as much as the new states themselves, because older values still exist in the system and need to resolve cleanly without breaking the current display logic.
+
+That contract work paid off in the chat surface. GuardianChat now shows a runtime status strip that pairs provider state with request phase. It stays read-only on purpose. The point is not to create another control surface; it is to make the current one legible. If a model is warming, the UI should say so. If the provider is degraded, the user should not be forced to infer that from a generic loading state. If a request is actively generating, the surface should reflect that too.
+
+The Command Center followed the same logic. The verdict classifier there now has more structure to work with, which makes it a better observability surface instead of a rough health badge. That is the deeper pattern of the day: moving from binary signals to operationally useful distinctions. The system is learning to tell the difference between unavailable, warming, delayed, generating, and broken.
+
+The maturity docs were updated alongside the code, which keeps the proof trail attached to the actual work. That documentation is not runtime evidence, and it should not be treated as such. But it does matter that the repo now records the same truth in its campaign scaffolding that the code is starting to express.
+
+What this makes possible next is straightforward: live verification against the current Guardian session model, a pass over other surfaces that still assume `online` means “healthy enough,” and a check for any backend emitters that still need to be normalized to the canonical state set. The system is more honest now. The next step is to make sure every layer speaks that same honesty consistently.

--- a/docs/DEV_LOG/2026-06-18/Dev Log - 2026-06-18.md
+++ b/docs/DEV_LOG/2026-06-18/Dev Log - 2026-06-18.md
@@ -1,0 +1,65 @@
+Dev Log - 2026-06-18
+
+Summary
+
+contract hardening day
+
+Today was about tightening one receipt-proof seam in Guardian and making the evidence around it harder to misread. The work stayed narrow: receipt readback behavior, the coding work-order route, and the surrounding campaign docs were brought into better alignment so the system says less than it can prove and more of what it can actually guarantee.
+
+What I completed
+
+### Guardian work-order receipt proof
+
+- Hardened the readback proof path for work-order receipts in `guardian/routes/coding_work_orders.py`.
+- Expanded the proof coverage in `tests/routes/test_work_order_result_receipt_readback.py` so the receipt behavior is exercised more explicitly.
+- Updated the C03 coding delegation spine docs:
+    - `docs/Campaign/guardian-maturity/campaigns/C03-coding-delegation-spine/backlog.md`
+    - `docs/Campaign/guardian-maturity/campaigns/C03-coding-delegation-spine/decision-log.md`
+    - `docs/Campaign/guardian-maturity/campaigns/C03-coding-delegation-spine/proof-pack.md`
+
+### Evidence discipline
+
+- The day’s work was proof-hardening, not feature expansion.
+- The docs were used to keep the campaign record in step with the route/test change, not to claim runtime validation.
+- Evidence remains code/test-level only; there was no live runtime proof in today’s material.
+
+Important outcome
+
+The work-order receipt path is no longer just something we expect to behave. It now has a more explicit readback proof trail around it, which matters because this is exactly the kind of seam where systems drift: the receipt exists, but the caller can still misunderstand what was actually confirmed.
+
+The system also got a little more honest about itself. The surrounding campaign docs now track the same boundary the code and test do, so the record does not overstate what was validated. That reduces ambiguity for the next person reading the trail.
+
+Commits
+
+f3e59192f - test: harden Guardian work-order receipt readback proof
+
+Notes
+
+- This was a focused proof-hardening day, not a broad runtime change.
+- The evidence I found is still repo-local and test-backed.
+- I did not see live runtime validation in the day’s artifacts.
+- No unrelated failures surfaced in the commit evidence I checked.
+
+Next likely moves
+
+1. Extend the same proof discipline to adjacent Guardian work-order paths.
+2. Check whether any caller-facing docs need a small truth-alignment pass.
+3. Look for other receipt-like seams where readback and acknowledgment could drift apart.
+4. If needed, add one more targeted test around the nearest neighboring contract.
+
+Closing thought
+
+This was a day of narrowing the gap between “the system did something” and “the system can prove it did something.” That kind of work is unglamorous, but it is what keeps the boundary trustworthy.
+
+Narrative Log  
+Dev Log - 2026-06-18
+
+This was a contract-hardening day in a part of Guardian that matters more than it looks from the outside. The work centered on a work-order receipt path, which is the kind of seam that can quietly accumulate ambiguity if it is not kept under a tight proof discipline.
+
+The main change was to the receipt readback proof around coding work orders. That touched the route itself, the test that reads the result receipt back, and the campaign docs that explain the current state of the work. The important part is not that the code got bigger. It is that the behavior got harder to misinterpret. A receipt path can easily become a source of false confidence if it is only implied rather than verified. Today’s work pushed it back toward explicitness.
+
+The docs update mattered for the same reason. The campaign record now mirrors the same boundary the code and test are enforcing. That keeps the written trail from drifting ahead of the actual proof. In a system like this, that kind of truth alignment is not decoration. It is part of the control surface.
+
+What stands out most is how limited the day was in scope. There was no attempt to broaden the subsystem or add a new abstraction. The work stayed close to the seam that needed attention and improved the evidence around it. That is usually the right move when the risk is not feature absence but contract ambiguity.
+
+What this makes possible next is straightforward: we can apply the same standard to neighboring receipt or acknowledgment paths without first having to clean up the meaning of this one. The system is a little more legible now, and that makes the next correction cheaper.

--- a/docs/DEV_LOG/2026-06-19/Dev Log - 2026-06-19.md
+++ b/docs/DEV_LOG/2026-06-19/Dev Log - 2026-06-19.md
@@ -1,0 +1,75 @@
+Dev Log - 2026-06-19
+
+Summary
+
+contract hardening and workspace composition day
+
+Today was mostly about making the Guardian Operator Workspace legible as a real surface rather than a loose set of campaign artifacts. The day split between composing the read-only card shell in the Command Center, closing out the related proof-pack work, and carrying forward the older observability and receipt-linkage hardening so the runtime story stayed internally consistent.
+
+What I completed
+
+Guardian Operator Workspace composition
+
+- Added the read-only card composition path for the Guardian Operator Workspace inside the Command Center shell.
+- Introduced the lens scaffold that makes the workspace surface explicit instead of implied.
+- Kept the work anchored to the campaign contract, so the UI reflects a constrained operator surface rather than a broad, informal dashboard.
+
+Tool-turn observability closeout
+
+- Closed out the remaining C05 tool-turn observability proof work.
+- The read model, route exposure, and Command Center surface now sit behind a clearer contract boundary.
+- The proof-pack and decision log were updated so the implementation trail matches the actual seam that was hardened.
+
+Receipt and linkage hardening carry-through
+
+- Continued the C03 coding delegation spine closure work around latest receipt linkage and receipt evidence visibility.
+- The fail-closed behavior on linkage failure remains the important part of the story: the system now prefers a hard boundary over ambiguous receipt state.
+- That makes the work-order path more truthful when the latest receipt cannot be trusted.
+
+Important outcome
+
+The Guardian workspace is no longer just a set of linked campaign notes and UI fragments. It now has enough structural shape to read as a deliberate operator surface, with the card composition, observability readouts, and receipt boundaries all pulling in the same direction.
+
+The bigger shift is that ambiguity got pushed out of the critical paths. The system stopped treating some of these seams as documentation-only concepts and started expressing them as enforceable UI and route contracts.
+
+Commits
+
+e2909d07d - docs: close C06-T004 card composition proof  
+6f3596991 - feat: compose Guardian Workspace read-only cards  
+40f90ce4e - docs: record C06-T004 card composition proof  
+4b3cd10df - feat: add Guardian Operator Workspace lens scaffold  
+542d82bfb - feat: expose Guardian tool-turn observability readback  
+2e07bb462 - feat: add Guardian tool-turn observability read model helper  
+e3681ac51 - fix: fail closed on Guardian latest receipt linkage failure
+
+Notes
+
+- Most of today’s evidence is code/test/doc level, not live runtime proof.
+- The proof-pack closures matter here because they keep the campaign trail aligned with the implemented seams.
+- I did not see evidence today that would justify describing the workspace as fully runtime-validated end to end.
+
+Next likely moves
+
+- Tighten the Guardian Operator Workspace surface contract around remaining read-only affordances.
+- Continue closing any loose proof-pack gaps around the tool-turn observability path.
+- Verify whether the receipt-linkage hardening needs any adjacent test coverage for edge cases.
+- Keep the campaign docs aligned with the actual current state so the operator surface does not drift ahead of the code.
+
+Closing thought
+
+Today was about reducing interpretive slack. The system is becoming easier to trust because the UI, routes, and proof artifacts are converging on the same shape instead of telling slightly different stories.
+
+Narrative Log  
+Dev Log - 2026-06-19
+
+This was a contract day more than a feature day. The work moved across a few related seams, but the underlying theme was consistent: make the Guardian operator surface more explicit, and make the boundaries harder to misread.
+
+The clearest change was in the Guardian Operator Workspace. The read-only card composition and lens scaffold turned the Command Center into something that reads like a bounded workspace instead of an open-ended panel collection. That matters because the surface now says what it is. It is not pretending to be a broad control plane; it is a constrained operator view with a defined contract.
+
+The observability work from the earlier tool-turn campaign followed the same logic. The read model helper, route exposure, and Command Center surface had already been pushed into place, and today’s work closed that loop in the docs and proof pack. That kind of cleanup can look secondary from the outside, but it is what keeps the implementation honest. When the proof trail matches the seam, the system is easier to reason about and harder to accidentally overclaim.
+
+The older receipt-linkage hardening carried the same lesson. Failing closed on a missing or untrusted latest receipt is not glamorous, but it removes ambiguity at a point where ambiguity would be expensive. The system would rather refuse to blur the state than pretend it knows more than it does. That is the right bias for a delegated work-order path.
+
+Taken together, the day was about making the operator layer more truthful. The UI became more explicit, the observability path became more legible, and the receipt boundary became less forgiving in the right way. That does not feel flashy, but it is the kind of work that keeps a system from drifting into hand-wavy behavior.
+
+What this makes possible next is straightforward: we can keep tightening the remaining edges without having to re-explain the surface every time. The structure is finally strong enough that the next changes can refine behavior instead of re-establishing what the system is supposed to be.

--- a/docs/DEV_LOG/2026-06-19/ThreadWake Metadata Milestone.md
+++ b/docs/DEV_LOG/2026-06-19/ThreadWake Metadata Milestone.md
@@ -1,0 +1,12 @@
+ThreadWake Metadata Milestone
+Completed June 2026
+
+A safety-first pre-materialization layer for future KV/cache reuse:
+contracts, metadata spine, feasibility boundary, analysis loop,
+read-only visibility, operator runbook, docs index, changelog, and tag.
+
+Engine remains cold by design.
+
+```
+Whoosh’d Current StatusThreadWake metadata milestone complete.Local inference routes validated previously:- MLX text- MLX-VLM vision- GGUF via llama.cpp- OpenAI-compatible chat surface- Codexify local provider integrationCurrent priority:Stabilize Whoosh’d as a usable local inference gateway before deeper KV work.
+```

--- a/docs/DEV_LOG/2026-06-20/Dev Log - 2026-06-20.md
+++ b/docs/DEV_LOG/2026-06-20/Dev Log - 2026-06-20.md
@@ -1,0 +1,89 @@
+Dev Log - 2026-06-20
+
+## Summary
+
+contract hardening day
+
+Today was about tightening the Pi Coder invocation boundary until the system could describe its own evidence cleanly. The work moved from workspace-level composition and receipt tracking into explicit operator evidence, return, and policy decision contracts, with tests and docs closing the loop around those seams.
+
+The important part was not feature growth. It was removing ambiguity about what counts as a valid invocation, what gets returned, and what evidence must exist for the operator layer to be considered sound. That makes the runtime easier to trust, and it narrows the gap between “something happened” and “something was actually proven.”
+
+## What I completed
+
+### Pi Coder contract hardening
+
+- Defined the operator evidence contract for Pi Coder so invocation proof is no longer implicit.
+- Added the return contract, which gives the system a clearer shape for what a completed Pi Coder interaction must emit.
+- Defined the policy decision contract so policy outcomes are represented as a first-class boundary instead of an inferred side effect.
+- Added boundary tests around the receipt artifact contract, which strengthens the evidence trail at the seam where invocation output becomes durable proof.
+- Recorded validation and proof notes alongside the code so the contract work is traceable and not just present in source.
+
+### Guardian workspace closeout context
+
+- The earlier Guardian Workspace proof chain remained relevant context for the day’s work: command-run evidence, tool-turn evidence cards, receipt evidence cards, and final composition proof were already in motion.
+- Today’s Pi Coder work extended that same discipline into a narrower operator contract surface.
+
+## Important Outcome
+
+Pi Coder is no longer just “able to run.” It now has enough structural truth around evidence, return shape, and policy decisions to support reviewable operator behavior.
+
+The system stopped relying on loose assumptions about invocation completion and started requiring explicit contracts at the boundary. That is a small-looking change with a large effect: it makes failures easier to classify, proofs easier to audit, and future runtime work less likely to drift into ambiguity.
+
+## Commits
+
+1c7a386ca - feat: define Pi Coder operator evidence contract  
+b4284b5e8 - docs: record C04-T006 validation closeout  
+c4e63a55f - feat: define Pi Coder result return contract  
+1fc172459 - docs: record C04-T005 policy decision contract proof  
+32b89df06 - feat: define Pi Coder policy decision contract  
+af1ed4776 - docs: record C04-T004 contract verification evidence  
+e38abc8a6 - docs: record C04-T004 receipt artifact contract verification  
+74e137511 - test: add Pi Coder receipt artifact contract boundary tests  
+3cbd4ad8f - docs: record C04-T003 proof matrix evidence  
+9468eeacd - docs: define Pi Coder invocation proof matrix  
+c5c0d5931 - docs: record C04-T002 acceptance contract proof  
+875e5266c - docs: define Pi Coder invocation acceptance contract  
+e4b68e685 - docs: audit Pi Coder invocation boundary seams  
+6a2556daf - docs: select Wave 3 Guardian maturity campaign  
+38547eb77 - docs: close Guardian Operator Workspace campaign  
+d624e1d09 - docs: close Guardian Workspace final composition proof  
+bcdd0e3f3 - docs: add Guardian Workspace final composition proof  
+09ab5f5c8 - docs: record C06-T008 receipt evidence card proof  
+b3e94a4fe - feat: add Guardian Workspace receipt evidence card  
+b52a1de11 - docs: record C06-T007 tool-turn evidence card proof  
+bc3582154 - feat: add Guardian Workspace tool-turn evidence card  
+64cce3fe9 - docs: refresh weekly current-state override  
+fdd9eb9ac - test: close Guardian Workspace command-run evidence proof
+
+## Notes
+
+- The evidence here is code/test/doc level, not live runtime proof.
+- One unrelated dirty file is still present in `frontend/src/contracts/runtimeTokens.ts`; I did not fold it into this log because it does not belong to today’s evidence chain.
+- The day’s work was strongest on contract clarity and proof discipline, not on user-facing runtime validation.
+
+## Next likely moves
+
+1. Extend the Pi Coder contracts into any remaining adjacent invocation seams.
+2. Add or refresh tests for the request-attempt boundary if that surface is still loose.
+3. Verify whether the new contract shapes need matching docs in the current-state or architecture notes.
+4. Separate any unrelated frontend drift before the next evidence-focused pass.
+
+## Closing thought
+
+The main shift today was from implicit behavior to explicit operator truth. That matters because the system can now be audited, extended, and debugged with less guessing about what an invocation actually meant.
+
+Narrative Log
+
+## Dev Log - 2026-06-20
+
+This was a contract-hardening day, and it mattered because the system got more honest about itself.
+
+The work started from the Guardian workspace proof chain that had already been built up around command runs, tool turns, receipt artifacts, and final composition. That context was important, but today’s real move was narrower and more structural: Pi Coder’s operator boundary got explicit evidence and return contracts, then a policy decision contract, then tests that force the receipt artifact seam to behave like a real boundary instead of a loose convention.
+
+What changed underneath the surface is that invocation is no longer being treated as a single opaque success path. The code now separates what the operator must prove, what the return contract must contain, and what the policy decision layer is responsible for. That separation matters because it gives the runtime a better failure vocabulary. If something goes wrong later, we will know whether it broke at evidence formation, policy shape, or receipt persistence instead of collapsing all of that into a generic “did not work.”
+
+The tests are part of the point here. They do not prove live runtime behavior, but they do lock the contract shape in place and keep the evidence seam from drifting. That is a useful kind of work even when it does not look flashy from the outside. It reduces ambiguity, which is one of the few changes that actually compounds in a system like this.
+
+There is still a distinction to keep in mind: this is code/test/doc proof, not live runtime proof. That boundary stayed honest today, and that honesty is valuable. One unrelated frontend file is still dirty in the tree, but it is outside the scope of this log and does not change the story.
+
+What this makes possible next is a cleaner pass through the remaining adjacent seams. The system now has a more explicit operator contract to build on, which means future runtime and observability work can aim at a narrower, more trustworthy target.

--- a/docs/DEV_LOG/2026-06-20/Whoosh’d v0.1.0rc3 is live..md
+++ b/docs/DEV_LOG/2026-06-20/Whoosh’d v0.1.0rc3 is live..md
@@ -1,0 +1,18 @@
+Whoosh’d v0.1.0rc3 is live.
+
+What it is:
+A local-first inference gateway for Apple Silicon and self-hosted AI workflows.
+
+What changed:
+- Runtime readiness smoke layer
+- OpenAI-compatible chat/streaming verification
+- Example env files
+- Smoke scripts
+- ThreadWake metadata milestone
+- README positioning pass
+
+What is intentionally not included:
+- KV reuse
+- Durable snapshots
+- Restore
+- Production backend materialization

--- a/docs/DEV_LOG/2026-06-21/Dev Log - 2026-06-21.md
+++ b/docs/DEV_LOG/2026-06-21/Dev Log - 2026-06-21.md
@@ -1,0 +1,93 @@
+Dev Log - 2026-06-21
+
+Summary
+
+contract hardening day
+
+Today was about tightening the Pi Coder dry-run evidence chain until the system could explain itself cleanly at the contract level. The work moved through the operator surface, API helper, evidence seam, adapter, route wiring, and final evidence rendering, with each step making the dry-run path more explicit and less ambiguous.
+
+The real shift was not feature breadth. It was that the workflow now has a legible chain of custody for operator evidence, with proof artifacts, closeouts, and rendering consistency all lining up. That matters because it separates “this is wired and verified in code/test/doc artifacts” from any claim of live runtime proof.
+
+What I completed
+
+Pi Coder dry-run evidence chain
+
+- Exposed the operator evidence path so the dry-run workflow had a clearer surface to hang on.
+- Added the API helper and evidence seam so the request path could be expressed as a deliberate contract instead of an implicit behavior.
+- Wired the validation flow, adapter, and route together so the dry-run path stayed coherent across layers.
+- Rendered operator evidence at the end of the chain so the proof became visible in a format that could be checked and closed out.
+- Closed the associated proof documents and consistency notes so the record now reflects a completed evidence sequence rather than an in-progress one.
+
+Proof discipline and boundaries
+
+- The evidence here is code/test/doc-level, not live runtime proof.
+- The run stayed honest about that boundary instead of implying production validation that did not happen.
+- An unrelated dirty file in `frontend/src/contracts/runtimeTokens.ts` remained out of scope and was not part of today’s log.
+
+Important outcome
+
+Pi Coder dry-run evidence is no longer just an intention carried by scattered docs and tests. It now has a full contract path that can be named, traced, and rendered.
+
+That is the meaningful change: the system stopped relying on loose proof fragments and started maintaining a structured evidence chain. The result is less ambiguity at the boundary between “implemented” and “documented,” which is exactly where these workflows tend to drift.
+
+Commits
+
+- `71673e8e6` - docs: close Pi Coder dry run operator evidence rendering consistency proof
+- `e61568ded` - test: close Pi Coder dry run operator evidence rendering proof
+- `0675bd2b2` - docs: record C04-T016 rendering proof
+- `825e7c773` - feat: render Pi Coder dry run operator evidence
+- `0b2b9731b` - docs: close Pi Coder dry run route evidence consistency proof
+- `05819877a` - docs: close Pi Coder dry run route evidence proof
+- `3df542f5b` - docs: record C04-T015 route wiring proof
+- `408ddee88` - feat: expose Pi Coder dry run operator evidence
+- `c532f8558` - docs: close Pi Coder dry run evidence adapter consistency proof
+- `6bec8e258` - docs: close Pi Coder dry run evidence adapter proof
+- `1e7ffc2e9` - docs: record C04-T014 evidence adapter proof
+- `6fc146700` - feat: add Pi Coder dry run operator evidence adapter
+- `a5e5170ba` - docs: close Pi Coder dry run evidence seam consistency proof
+- `bab9f4a20` - docs: record Pi Coder dry run evidence seam governance closeout
+- `7673bef45` - docs: record C04-T013 evidence seam proof
+- `b18a05ba1` - docs: define Pi Coder dry run operator evidence seam
+- `c2380a428` - docs: record Pi Coder dry run validation flow governance closeout
+- `30753dce0` - docs: record C04-T012 validation flow proof
+- `a77b3367b` - feat: wire Pi Coder dry run validation flow
+- `9bd9d2ac3` - docs: record Pi Coder dry run API helper governance closeout
+- `a2b395c8a` - docs: record C04-T011-R1 API helper proof
+- `cde458471` - test: close Pi Coder dry run API helper proof
+- `5ca608a15` - docs: record C04-T011 API helper proof
+- `8f617fe5e` - feat: add Pi Coder dry run API helper
+- `17d2a57bc` - docs: close Pi Coder dry run fixture pack proof
+- `035f54e55` - docs: record C04-T010 dry run fixture pack proof
+- `bad0eaf5a` - test: add Pi Coder dry run fixture pack
+- `c02620f9e` - test: close Pi Coder dry run operator surface proof
+- `493d1ca75` - feat: add Pi Coder dry run operator surface
+
+Notes
+
+- Today’s record is intentionally bounded to code/test/doc evidence.
+- I did not treat any of this as live runtime validation.
+- The dirty `frontend/src/contracts/runtimeTokens.ts` file was observed but excluded from the day’s scope.
+
+Next likely moves
+
+- Verify whether the dry-run evidence chain needs a companion runtime check or stays documentation-bound.
+- Refresh the operator-facing contract docs if the new rendering path should become the canonical reference.
+- Decide whether the unrelated `frontend/src/contracts/runtimeTokens.ts` change needs its own cleanup thread.
+- If this chain is now the accepted truth, collapse any redundant proof artifacts into a tighter audit trail.
+
+Closing thought
+
+The day was about turning a loose dry-run path into something structurally honest. That matters because once the evidence chain is explicit, the system becomes easier to trust, easier to audit, and harder to drift.
+
+Narrative Log  
+Dev Log - 2026-06-21
+
+This was a contract-hardening day, and that is the right lens for it. The work around Pi Coder did not introduce a flashy new capability so much as it tightened the shape of the dry-run path until the evidence could be traced cleanly from operator surface to rendered proof.
+
+The sequence matters. First came the operator surface and the API helper, which gave the workflow an explicit entry point instead of an implied one. Then the evidence seam and adapter made that path more legible across the internal boundary where request intent becomes something the system can actually carry. After that, the validation flow and route wiring made sure the path held together as it crossed layers. By the end, operator evidence could be rendered directly, which is a small detail on paper but a big one in practice: it means the proof is visible, not just latent.
+
+What changed underneath the surface is that the dry-run workflow now has a chain of custody. It no longer depends on someone remembering how the pieces fit together. The docs and tests close out the path in a way that makes the record self-consistent, which is often where systems either stay honest or start drifting. That is especially important here because the evidence boundary was kept explicit the whole time. This was code/test/doc-level proof, not live runtime proof, and the log should say that plainly.
+
+There was also restraint in the scope. An unrelated dirty file in `frontend/src/contracts/runtimeTokens.ts` was noted but left out of the story because it did not belong to today’s work. That kind of boundary discipline matters as much as the code itself. It keeps the record usable later, when someone needs to know what actually changed and what merely happened to be present.
+
+What this makes possible next is straightforward: the dry-run path can now be treated as a stable contract surface instead of an ad hoc workflow. From here, the question is whether it stays documentation-bound, gets a companion runtime check, or becomes the canonical operator evidence route. The important part is that the system now has enough structure to answer that question without guesswork.

--- a/docs/DEV_LOG/2026-06-22/Dev Log - 2026-06-22.md
+++ b/docs/DEV_LOG/2026-06-22/Dev Log - 2026-06-22.md
@@ -1,0 +1,77 @@
+**Dev Log - 2026-06-22**
+
+**Summary**
+
+Proof-capture day, mostly around C08 Whooshd runtime context fidelity. The work was about tightening the record around how context is assembled and delivered, and making the evidence chain explicit enough that the system’s current behavior can be defended without leaning on assumptions.
+
+The day was not about shipping new runtime surface area. It was about making the runtime story more truthful: one test proved system-identity delivery for Whooshd context bundles, and the surrounding docs captured the seam inspection, decision points, proof packs, and failure quarantine needed to keep the campaign legible.
+
+**What I completed**
+
+**Whooshd context fidelity**
+
+- Inspected the context assembly seam and recorded the gap analysis in the campaign docs.
+- Added decision-log entries for the assembly and delivery steps so the campaign has a traceable rationale, not just outcomes.
+- Captured proof-pack updates for the assembly seam and the delivery path.
+- Promoted the delivery check into an executable test: `test_whooshd_context_bundle_system_identity_delivery.py`.
+- Marked the relevant backlog items down as the work progressed so the campaign state matched the evidence state.
+
+**Model inventory validation**
+
+- Recorded the core suite rerun and the earlier validation proof for Whooshd model inventory.
+- Quarantined the core suite failures instead of folding them into a success narrative.
+- Kept the proof pack aligned with what was actually observed, not what was hoped for.
+
+**Campaign bookkeeping**
+
+- Updated the campaign docs so the C08 thread now reads as a coherent sequence: seam inspection, decision, proof, rerun, delivery, and closure.
+
+**Important outcome**
+
+The system is no longer just “under review” for context fidelity. It now has a documented seam, a recorded decision trail, and at least one concrete test proving system-identity delivery through the Whooshd context bundle path.
+
+That matters because it turns a vague runtime claim into a bounded, inspectable contract. The day mostly strengthened truth maintenance: what was happening, why it was acceptable, and where the remaining uncertainty was quarantined instead of blurred.
+
+**Commits**
+
+- `cb7288008` - docs: record C08 context delivery decision
+- `ffc7fdadb` - docs: record C08 context delivery proof
+- `1eff82113` - docs: record C08 context delivery proof
+- `345265704` - test: prove Whooshd context identity delivery
+- `5bc937011` - docs: record C08 context assembly decision
+- `dceebe903` - docs: record C08 context assembly seam proof
+- `3e58d21c5` - docs: inspect Whooshd context assembly seams
+- `23dfcbc05` - docs: record Whooshd model inventory core suite rerun
+- `3b2e448e8` - docs: seal Whooshd model inventory validation proof
+- `e9be3d51e` - docs: quarantine Whooshd model inventory core suite failures
+- `b43b7541e` - docs: clarify Whooshd model inventory core suite proof
+- `0a24819f1` - docs: close Whooshd model inventory validation proof
+
+**Notes**
+
+- Evidence today stayed at docs/test level. There was no live runtime proof in the day’s record.
+- The model-inventory thread included a real failure quarantine, so the record is honest about what was validated and what was not.
+- The automation memory write landed in the local Codex memory root because the prompt’s `CODEX_HOME` path was not set in this shell.
+
+**Next likely moves**
+
+- Verify the Whooshd context delivery path in a live runtime session.
+- Decide whether the quarantined model inventory failures need a fix or remain accepted as scoped noise.
+- Expand the proof pack only if the next runtime check exposes a seam that the current docs do not yet cover.
+- Keep the campaign backlog synchronized with any new runtime evidence so the current-state record does not drift.
+
+**Closing thought**
+
+Today made the system easier to trust, not just easier to describe. The main gain was structural honesty: the context path has a clearer contract, the evidence trail is tighter, and the remaining gaps are now named instead of implied.
+
+**Narrative Log - 2026-06-22**
+
+This was a boundary day. Not a flashy feature day, not a broad runtime expansion day, but a day spent making a specific part of the system harder to misread. The work centered on C08 and the Whooshd runtime context fidelity thread, where the important problem was not “can we say something happened,” but “can we show exactly how context is assembled, delivered, and defended.”
+
+The first pass was about the seam itself. The context assembly path got inspected and written down in a way that made the hidden structure visible. That matters more than it looks: once a seam is named, it stops being folklore. It becomes something we can reason about, test against, and revisit without starting from scratch. The decision log entries followed that same logic. They did not add theater. They added traceability.
+
+Then the work moved from inspection into proof. The context assembly and delivery steps were captured in proof packs, and one of the checks became a real test: system-identity delivery for the Whooshd context bundle path. That is the meaningful shift of the day. The system moved from “we believe the bundle carries identity correctly” to “we have an executable check that exercises that claim.” It is still code/test-level evidence, not live runtime proof, but it is no longer just a design intent.
+
+The model inventory thread ran alongside that. There, the right move was not to smooth over the rough edge. The core suite failures were quarantined, the proof was clarified, and the rerun was recorded as rerun evidence rather than quietly folded into success. That kind of bookkeeping is boring in the best way. It keeps the record clean. It prevents a future self from inheriting a false sense of confidence.
+
+By the end of the day, the system was more legible. The C08 campaign now reads like a real engineering sequence: inspect the seam, decide the shape, capture the proof, quarantine the failure, rerun what matters, and close the loop. That is a small amount of surface area, but it changes the quality of the whole record. The next step is obvious: take the strongest of those claims into live runtime and see what still holds when the process stops being purely documentary.

--- a/docs/DEV_LOG/2026-06-23/Dev Log - 2026-06-23.md
+++ b/docs/DEV_LOG/2026-06-23/Dev Log - 2026-06-23.md
@@ -1,0 +1,83 @@
+Dev Log - 2026-06-23
+
+Summary
+
+contract hardening day
+
+Today was about turning Persona Studio V1 from an intended shape into a set of explicit, documented boundaries. The work did not widen the release promise; it tightened it. The system got more truthful about what the Persona Studio surface contains, what it does not contain, and which seams are now proven by tests versus only described in docs.
+
+What I completed
+
+Persona Studio contract and seam definition
+
+- Defined the Persona Studio V1 contract and current-surface seam audit.
+- Captured the bounded surface in the campaign docs so the project now has a clearer line between the intended feature set and the rest of the app.
+- That made the campaign easier to reason about without pretending the whole surface is already settled.
+
+Boundary proof work
+
+- Proved the route navigation boundary.
+- Proved the draft validation boundary.
+- Proved the effective config boundary.
+- Proved the permission retrieval preview boundary.
+- Each test package was paired with a proof doc and decision-log updates, so the evidence trail is explicit instead of implied.
+
+Campaign closeout
+
+- Closed the Persona Studio V1 boundary proof campaign.
+- Updated the campaign backlog as individual proof items landed.
+- Refined the campaign README entries and removed duplicate or stale selection rows after the closeout path became clear.
+
+Important outcome
+
+Persona Studio is no longer just a concept with scattered notes. It now has enough structural truth to behave like a bounded surface inside the project, with the most important contract edges documented and several core behaviors proven at the test level.
+
+The system also became harder to misread. Today’s work reduced the chance that docs, backlog items, and code paths drift apart into different stories about what Persona Studio is supposed to be.
+
+Commits
+
+115783c99 - docs: remove duplicate C09 row  
+d4b72bd72 - docs: clarify C09 selection status  
+0be4d41bf - docs: select C09 after C07 closeout  
+ecf695145 - docs: close Persona Studio V1 boundary proof  
+fd623cfe8 - test: prove Persona Studio permission retrieval boundary  
+bc2d18789 - docs: update C07 backlog for T005  
+e27060a6b - test: prove Persona Studio effective config boundary  
+e128211f8 - test: prove Persona Studio draft validation boundary  
+21f24b6af - docs: update C07 backlog for T003  
+1e98f59c6 - test: prove Persona Studio navigation boundary  
+7d46ef893 - docs: define Persona Studio V1 contract  
+f99f32b8c - docs: audit Persona Studio current seams  
+366dbe881 - docs: remove stale C08 row from README
+
+Notes
+
+- Evidence today is mostly docs plus test-level boundary proof, not live runtime proof.
+- The current-state file still describes Codexify as local-first beta hardening on `main`; nothing today widened that promise.
+- The C09 selection docs were cleaned up after closeout, which suggests the campaign selection state is now less ambiguous.
+- I did not find any unrelated runtime failure that needed to be chased inside this task.
+
+Next likely moves
+
+- Turn the Persona Studio boundary proofs into a single compact release-readiness note.
+- Audit the next adjacent surface for the same kind of contract drift.
+- Keep the campaign README and backlog aligned as any follow-on proof lands.
+- If runtime validation is needed later, add live evidence without widening the supported claim set.
+
+Closing thought
+
+Today mattered because it replaced ambiguity with boundaries. That is not flashy work, but it is the kind that keeps a system honest when the surface area starts to grow.
+
+Narrative Log
+
+Dev Log - 2026-06-23
+
+This was a boundary day. The useful work was not adding a new user-visible flourish, but forcing Persona Studio to become legible as a system with edges. That meant taking a surface that had been described, probed, and partially exercised, and tightening it into something the repo can defend without hand-waving.
+
+The first move was to define the contract and audit the seams. That gave the campaign a stable frame: what Persona Studio V1 is allowed to do, what it is not yet promising, and where the current surface still leaves room for drift. That kind of work does not look dramatic in isolation, but it matters because it stops every later discussion from starting from a foggy premise.
+
+After that, the real value came from boundary proof. Route navigation, draft validation, effective config, and permission retrieval were each turned into explicit test-backed claims. The important shift there is not just that the tests passed. It is that the project now has named evidence for the seams that were previously easy to assume. Each proof narrows the space where accidental behavior can hide.
+
+The closeout work mattered for the same reason. Updating backlog entries, adding decision-log context, and cleaning up the campaign README made the campaign itself more truthful. The project is less likely now to tell three different stories about the same feature: one in docs, one in backlog, and one in code. That consistency is the real gain.
+
+By the end of the day, Persona Studio was not “finished,” but it was materially better bounded. The system stopped being loosely described and started being structurally accounted for. That gives the next round of work a cleaner base: less ambiguity to fight, fewer hidden assumptions to unwind, and a narrower path to prove whatever comes next.

--- a/docs/DEV_LOG/2026-06-24/Dev Log - 2026-06-24.md
+++ b/docs/DEV_LOG/2026-06-24/Dev Log - 2026-06-24.md
@@ -1,0 +1,65 @@
+Dev Log - 2026-06-24
+
+Summary
+
+Docs truth-alignment day.
+
+The work was fundamentally about keeping Codexify’s short-horizon release truth aligned with `main` without widening the release promise. The primary change was a refresh of the current-state override so the repo’s operational truth layer reflected the week’s merged contract and operator-surface work accurately, while still stating clearly that the supported path remains local Docker Compose with local-only provider posture.
+
+What I completed
+
+Current-state refresh
+
+- Updated [`docs/architecture/00-current-state.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/00-current-state.md) to `2026-06-24`.
+- Reframed the current phase as local-first beta hardening with contract and operator-surface expansion, not new runtime scope.
+- Added the latest merged work to the “What changed recently” section, including review UI support and OpenAI export conversation import plus Task Prompt Archive.
+- Kept the supported reality section explicit about local-only posture, Whoosh'd support, and the current runtime checks.
+
+Architecture KB entry tightening
+
+- Cleaned up [`docs/architecture/README.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/README.md) so it points people to `00-current-state.md` more directly.
+- Removed repetitive “start here” phrasing and made the entry guidance narrower and easier to scan.
+- Kept the README in its proper role as a KB map, not a source of release truth.
+
+Important outcome
+
+`00-current-state.md` is more authoritative now. It no longer reads like a stale interpretation of last week’s merged work; it reflects the current beta posture and the actual shape of the week’s additions.
+
+The system also became a little harder to misread. The README now sends people to the live operational truth layer faster, which matters because this repo keeps a sharp line between docs, contracts, and runtime proof.
+
+Commits
+
+- `f4277b2e3` - `docs: refresh weekly current-state override`
+
+Notes
+
+- This was a docs-only day.
+- No live runtime proof was added today.
+- The evidence is limited to file-level truth maintenance and commit history.
+- The change is intentionally non-expansive: it clarifies release truth without claiming any new shipped capability.
+
+Next likely moves
+
+1. Keep `00-current-state.md` aligned with the next merged truth change on `main`.
+2. Update adjacent architecture docs if they start drifting from the refreshed current-state language.
+3. Add runtime proof only when a task actually lands a new supported path or operator check.
+4. Keep the README entry path concise so the KB remains easy to navigate.
+
+Closing thought
+
+The main shift today was not feature growth but truth discipline. Codexify’s docs now describe the system more cleanly than before, which lowers the chance that operators, reviewers, or future tasks confuse contract work with shipped runtime capability.
+
+Narrative Log  
+Dev Log - 2026-06-24
+
+Today was a truth-maintenance day. Not a shipping day, not a runtime-expansion day, but the kind of day that matters when a system is getting mature enough that the biggest risk is misreading what is actually true.
+
+The core move was a refresh of `docs/architecture/00-current-state.md`. That file is the short-horizon release gate for this repo, so updating it is less about prose and more about keeping the project honest. The new version now says plainly that Codexify is still in local-first beta hardening on `main`, that the supported path remains the local Docker Compose stack with local-only provider posture, and that the week’s work was mostly contract and operator-surface expansion rather than new runtime scope. That distinction matters. It keeps docs from quietly drifting into a broader promise than the code supports.
+
+The update also captured the specific kinds of merged work that actually landed: collab chat identity contracts, Scout Vault operator-surface baseline docs, personal-facts guardrails with review UI support, Scout endpoint configuration, iOS Scout Vault remote contract docs, the Zac Mac Studio bring-up path, and the OpenAI export conversations import plus Task Prompt Archive. None of that changes the supported runtime boundary by itself, and the refreshed current-state file says so clearly. That is the real engineering value here: the repo can accumulate adjacent capability without blurring the line between documentation, operator support, and shipped behavior.
+
+I also tightened [`docs/architecture/README.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/README.md). It now points people to `00-current-state.md` more directly and with less repetition. That sounds minor, but it reduces the chance that someone lands in the architecture KB and treats structural documentation as release truth. In a repo like this, reducing that kind of ambiguity is part of the work.
+
+What changed underneath the surface is simple: the system became harder to misstate. The docs now separate current-state truth from broader architecture context more cleanly, which helps preserve release discipline as the project continues to add contracts, operator surfaces, and adjacent support paths.
+
+That leaves the next step pretty clear. Keep the current-state layer fresh, keep the KB entry path direct, and only add runtime claims when there is actual proof behind them.

--- a/docs/DEV_LOG/2026-06-25/Dev Log - 2026-06-25.md
+++ b/docs/DEV_LOG/2026-06-25/Dev Log - 2026-06-25.md
@@ -1,0 +1,62 @@
+**Dev Log - 2026-06-25**
+
+**Summary**
+
+docs-only truth-alignment day
+
+Today was about keeping Codexify’s short-horizon truth disciplined. The branch did not pick up new runtime work, so the meaningful task was to keep the operational record aligned with what was actually merged and what was not. That matters here because the project’s release story depends on not letting docs drift ahead of proof.
+
+The only relevant completed work in the current window was yesterday’s docs-truth refresh, which tightened `00-current-state` and entry guidance in the architecture docs. For today, the honest read is that no new code-path or runtime evidence was added, and the log should reflect that boundary instead of inflating it.
+
+**What I completed**
+
+**Truth alignment and release state**
+
+- Kept the daily record anchored to the current-state file rather than inventing forward progress.
+- Preserved the distinction between docs-level contract cleanup and runtime proof.
+- Reconfirmed that the supported local-first beta posture remains the active short-horizon truth.
+
+**Repository evidence check**
+
+- Reviewed the recent commit window and found no June 25 commits in this repo.
+- Confirmed the head commit is still the June 24 docs refresh, not new work from today.
+- Verified there were no working-tree changes to summarize as completed today.
+
+**Important outcome**
+
+The system did not become bigger today. It became more accurately described.
+
+That is still meaningful. `00-current-state` remains the gate for release truth, and today’s record should respect that gate. In practice, that means the repo’s story stays honest: docs can be tightened, but they do not get promoted to runtime proof by proximity.
+
+**Commits**
+
+- No commits recorded today.
+
+**Notes**
+
+- The only recent relevant commit is `f4277b2e3`, but it landed on 2026-06-24, not today.
+- No live runtime proof, test evidence, or code-path changes were added in the current day’s window.
+- This is intentionally a zero-new-work daily log rather than a retrospective of yesterday’s docs refresh.
+
+**Next likely moves**
+
+1. Resume runtime or contract work if new tasks land today.
+2. Keep `00-current-state.md` synchronized with any fresh proof.
+3. Continue separating docs truth from shipped behavior in future logs.
+4. If today stays quiet, carry forward the zero-work boundary explicitly rather than padding it.
+
+**Closing thought**
+
+A clean daily record is part of the system. When nothing new ships, the right move is to say so plainly and keep the boundary intact.
+
+**Narrative Log**
+
+**Dev Log - 2026-06-25**
+
+Today was a quiet day in the repo, and that quiet mattered. The useful work was not a new feature or a new proof path. It was maintaining the discipline of the record itself. Codexify is in a phase where truth drift is more dangerous than silence, so the daily log has to distinguish between what was actually done and what merely remains true from the previous day.
+
+The only nearby change was yesterday’s docs-truth refresh. That work tightened `00-current-state.md` and improved the architecture docs’ entry guidance, which was useful because it kept the current operational story aligned with the merged branch. But that is still yesterday’s work. For June 25, there were no new commits and no new runtime checks to elevate into the day’s record.
+
+That distinction is the point. The system is already in a local-first beta hardening posture, and the supporting documentation only helps if it stays subordinate to the actual runtime and commit evidence. Today reinforced that hierarchy by default rather than by ceremony. No code-path changed, no live proof was added, and the log stayed honest about that.
+
+What this leaves behind is a cleaner boundary. Not a bigger surface, not a flashier release story, just a tighter link between the repo’s state and the words used to describe it. That is the kind of day that prevents future confusion, which is often more valuable than a day that merely adds volume.

--- a/docs/DEV_LOG/2026-06-26/Dev Log - 2026-06-26.md
+++ b/docs/DEV_LOG/2026-06-26/Dev Log - 2026-06-26.md
@@ -1,0 +1,55 @@
+Dev Log - 2026-06-26
+Summary
+An integration and boundary-hardening day. The dominant move was absorbing Zac's group-chat-module branch into main through a dedicated merge-resolution lane, while tightening a personal-facts guardrail in the review UI and closing the documentation loop on the Continuity operator surface. Onboarding substrate for a second collaborator landed as a compact RAG source.
+The day was less about new greenfield code and more about making the tree honest: merging real runtime contributions without widening unsupported claims, enforcing an override contract that was previously bypassable, and writing plain-language truth for an operator surface that already existed.
+What I completed
+Group chat module integration (PR #440)
+Resolved and merged the group-chat-module feature branch into main via chore/resolve-group-chat-module-merge.
+- Brought in group chat support, @luna routing in chat completion and router layers, the atlas route plus a 2D vector-map UI (guardian/routes/atlas.py, webui-basic/index.html), project-scope filtering, namespace-aware retrieval dedup with project fallback, output-token capping, and retrieval diagnostics.
+- Ran a conflict-hotspot inspection first, then validated the merged routing path: pytest tests/core/test_ai_router.py tests/core/test_chat_completion_service_retrieval_query_cleaning.py — 22 passed.
+- The merge is the reason guardian/routes/atlas.py is the active file; the 2D atlas vector map and project-scope picker came in through this lane.
+Personal-facts guardrail hardening
+Enforced a non-empty override reason for blocked fact candidates in FactCandidateReview.tsx.
+- Blocked/promotion-blocked candidates can no longer be force-approved with a blank override note; the save button disables when the override reason is empty and the API call rejects an empty reason client-side.
+- Added a focused test for the empty-override-reason rejection path.
+- Also fixed a real compile blocker in GuardianChatView.swift — six @State declarations (navigationPath, displayedTitle, showRename, renameTitle, renameError, isRenaming) were in use without being declared. That was breaking the iOS Scout build; usage already existed.
+Continuity operator documentation closure
+Created the Continuity Operator Phase Explainer — a human-readable plain-language summary of the six-route test-only Continuity surface.
+- States plainly what exists, what was proven, and what is deliberately unfinished. No new architecture or runtime behavior; it explains the surface that was already live-proven and regression-pinned on 06-25 under the test-continuity profile.
+- Refreshed 00-current-state.md for the weekly override, keeping the supported-beta posture and the continuity quarantine statement intact.
+Collaborator onboarding substrate
+Created docs/collaborators/zac/ — a compact RAG source directory so a second operator's agent can orient without reading the whole architecture corpus.
+- Contains an agent RAG brief, exploration-before-change proposal protocol, a safe/sensitive zone map, a source map, a proposal template, and a copy-paste startup prompt.
+- Explicitly scoped as orientation, not a task backlog, and explicitly subordinate to 00-current-state.md.
+Important outcome
+The personal-facts override path stopped being bypassable. A promotion-blocked candidate used to be force-approvable without a recorded reason; now the UI requires a non-empty override note and the rejection is enforced before the API call. That closes a small but real accountability gap in a guardrail that is meant to protect extracted identity-like facts.
+The group-chat-module merge is the more structurally significant shift: Zac's runtime contributions — group chat, @luna routing, the atlas vector map, and project-scoped retrieval — are now on main rather than stranded on a feature branch. The tree now reflects real integrated work instead of divergent parallel branches.
+Commits
+- 1d15dcca0 - Create continuity operator phase explainer
+- 477d7bead - docs: refresh weekly current-state override
+- fc3d98d71 - Create Zac collaborator RAG source directory
+- 659210183 - Add Zac agent startup prompt
+- 423c75f8d - Merge branch 'main' into chore/resolve-group-chat-module-merge
+- 77db1d197 - Merge pull request #440 from chore/resolve-group-chat-module-merge
+- 7ae51fe69 - fix: enforce non-empty override reason for blocked fact candidates; add missing SwiftUI @State declarations
+- 97e7de1fe - Merge remote-tracking branch 'origin/main' — resolve conflicts in 00-current-state.md and README.md
+Notes
+- Group-chat-module validation was partial. The sync routing tests passed (22), but the async latest-turn retrieval tests were blocked by a missing pytest-asyncio in the active environment — that is environmental, not a merge defect, but it means the async retrieval path is not regression-proven in this environment.
+- Frontend typecheck and vitest could not be fully exercised: the repo-wide tsc fails on pre-existing type gaps (missing React/Node declarations, cypress.config.ts module errors), and vitest is blocked by a missing optional @rollup/rollup-darwin-arm64 native package. These are pre-existing environmental failures, not introduced by today's work, but they mean the frontend side of the merge is evidenced at code/inspection level rather than full green-test level.
+- The Continuity operator work that the explainer summarizes was substantially completed on 06-25; today's contribution is the explainer doc and the current-state refresh, which is docs-level, not new runtime.
+- The override-reason fix is client-side enforcement plus a unit test; it does not by itself prove the backend rejects a server-side empty-override write unless that path is also guarded server-side (worth rechecking).
+- Working tree has one unrelated dirty file (config/supported_profiles/v1-local-core-web-mcp.yaml); left untouched.
+Next likely moves
+- Resolve the pytest-asyncio and rollup native-package environment gaps so the merged async retrieval tests and frontend vitest can run to green — the group-chat-module merge is under-proven until then.
+- Verify server-side enforcement of the blocked-candidate override reason, not just the UI.
+- Decide whether the atlas route and 2D vector map from the merge should be added to the supported-beta claim set or remain operator/experimental — they are currently merged but not in 00-current-state.md as supported.
+- Point Zac's agent at the new RAG source for a first real exploration proposal.
+Closing thought
+A day of integration rather than invention. The meaningful change is that divergent work is now on main, a guardrail that was soft is now hard, and the operator-surface truth is written down for humans. None of it widens the release promise, and that restraint is the point.
+Narrative Log - 2026-06-26
+Today was an integration day — the kind where the value is in reconciling divergent branches and tightening contracts that were quietly loose, rather than in shipping something shiny.
+The largest piece was folding Zac's group-chat-module branch back into main. It had been sitting apart: group chat support, @luna routing through the completion and router layers, an atlas route with a 2D vector-map UI, project-scope filtering, namespace-aware retrieval dedup, and some output-token and diagnostics work. Rather than rebase it carelessly, the move was a deliberate merge-resolution lane — inspect the conflict hotspots first, understand which runtime seams had moved on main, then integrate while preserving the feature history. The routing path validated cleanly. The retrieval-query cleaner validated cleanly. That the file open in the editor right now is guardian/routes/atlas.py is no coincidence: it came in through this merge, carrying the 2D vector map. The structural shift is real — parallel branches are now a single tree again.
+The honest caveat is that the validation was partial. The async retrieval tests couldn't run because pytest-asyncio isn't present in the active environment, and the frontend typecheck and vitest hit pre-existing gaps — missing React/Node type declarations, a broken nested typecheck script, and a missing rollup native binary. None of that was introduced today, but it means the deeper async and frontend sides of the merge stand at code-level evidence rather than full green. That is the kind of gap that doesn't bite until it does, and it's the first thing to close.
+The second thread was smaller but cleaner. The personal-facts review UI had an accountability hole: a fact candidate that the guardrail had marked promotion-blocked could still be force-approved with a blank override note. Today that closed — the save button disables on empty reason, and the path rejects before the API call. It is exactly the sort of unglamorous hardening that matters more than a feature: a boundary that existed on paper now exists in behavior. Alongside it, a genuine compile blocker in the iOS Scout view got fixed — six @State variables were referenced without being declared, which was breaking the Swift build outright.
+Two documentation moves closed the day. The Continuity operator surface — the six-route test-only substrate that was actually built and proven on 06-25 — got a plain-language phase explainer, so a human can read what exists, what was proven, and what is deliberately unfinished without parsing contracts. And 00-current-state.md took its weekly refresh, keeping the supported-beta posture honest and the continuity quarantine explicit. Separately, a compact RAG source directory landed for Zac's agent — orientation, proposal protocol, a safe-and-sensitive zone map, a source index. It's onboarding substrate, not a release promise, and it says so.
+The deeper change underneath all of it: the system became more reconciled. Branches that had drifted are back on main. A guardrail that was advisory is now enforced. Operator truth is written for humans instead of only embedded in contracts. And a second operator can now engage with the codebase through a grounded entry point rather than cold. What this makes possible next is closing the environment-validation gap on the merge, confirming the override contract holds server-side too, and deciding whether the atlas and group-chat surfaces earned their way into the supported-beta claim set or stay experimental.

--- a/docs/DEV_LOG/2026-06-27/Dev Log - 2026-06-27.md
+++ b/docs/DEV_LOG/2026-06-27/Dev Log - 2026-06-27.md
@@ -1,0 +1,109 @@
+Dev Log - 2026-06-27
+
+Summary
+
+Contract hardening day.
+
+Today was mostly about tightening Codexify’s internal doctrine around turn intake and operator surfaces, while keeping release truth explicit. The work did not widen runtime capability so much as remove ambiguity around what the system means, where boundaries sit, and what is still docs-only versus actually shipped.
+
+The shape of the day was conservative in a good way: a current-state refresh, a Guardian operator index, and a set of turn-intake artifacts that define compiler, fixture, and token-domain expectations. There was also a small profile YAML change to add web browsing support. That is a narrow runtime-adjacent change, but the main signal of the day was still structural truth, not feature expansion.
+
+What I completed
+
+Thread contract hardening
+
+- Added a turn-intake compiler architecture contract that defines the governed pre-model intake seam more precisely.
+- Added a turn-intake fixture pack to make the expected intake shapes concrete and reviewable.
+- Added a turn-intake token domain proposal to separate token semantics from runtime implementation.
+- Updated related architecture docs so the contract, fixture pack, and token-domain proposal are linked into the KB front door.
+
+What changed here:
+
+- The intake path is now better named, bounded, and documented.
+- The repo has a clearer line between doctrine and implementation.
+- The docs now reduce the chance of people mistaking a spec artifact for a shipped classifier or router.
+
+Guardian operator index
+
+- Added a Guardian operator index contract as a dedicated architecture reference.
+- Wired that index into the architecture README so it is discoverable from the main entry points.
+
+What changed here:
+
+- Operator-surface documentation is less scattered.
+- The repo now has a stronger front door for Guardian-facing structure without implying new runtime behavior.
+
+Current-state refresh
+
+- Refreshed `docs/architecture/00-current-state.md` to keep short-horizon release truth aligned.
+- Reworded the current supported reality to stay explicit about local-first beta hardening on `main`.
+- Kept the distinction sharp between docs-only doctrine and shipped runtime support.
+
+What changed here:
+
+- The release anchor is cleaner and more resistant to drift.
+- The repo’s short-horizon truth stays grounded in what is actually supported, not what is merely described.
+
+Runtime profile support
+
+- Updated `config/supported_profiles/v1-local-core-web-mcp.yaml` to add web browsing support in the profile set.
+
+What changed here:
+
+- The profile set now reflects that browsing support is part of the local-core web MCP configuration.
+- This is still a small config-level change, but it matters because it makes the supported profile surface more truthful.
+
+Important outcome
+
+The system is less ambiguous than it was at the start of the day.
+
+Turn intake is no longer just an idea floating around in architecture notes. It now has a compiler contract, a fixture pack, and a token-domain proposal that together define the seam with enough structure to discuss it carefully without pretending it is already runtime behavior.
+
+The other important shift is that `00-current-state.md` stayed in charge. The day added doctrine and clarified boundaries, but it did not smuggle those documents into a broader release claim. That kept the repo honest: clearer surfaces, same supported truth.
+
+Commits
+
+- 8a90033e6 - Add turn intake token domain proposal
+- c215aba7a - Add turn intake fixture pack
+- c5901eeec - Add turn intake compiler architecture contract
+- c8703d8ef - adding web browsing support
+- 19f16fd0e - Add Guardian operator index contract
+- df95eb2fb - docs: refresh weekly current-state override
+
+Notes
+
+- Evidence for the day is mostly docs/config-level, not live runtime proof.
+- The turn-intake artifacts should be treated as governed doctrine until a task proves executable behavior.
+- `00-current-state.md` still says the supported path is local-first beta hardening on `main`; nothing today widened that promise.
+- No unrelated failures were surfaced in the evidence I checked.
+
+Next likely moves
+
+- Prove whether the turn-intake contract has an executable path, or keep it explicitly docs-only.
+- Decide whether the token-domain proposal needs a follow-on implementation task or just review.
+- Keep `00-current-state.md` aligned with any future runtime proof so release truth does not drift.
+- Validate whether the new browsing profile should be reflected in adjacent operator docs.
+
+Closing thought
+
+Today mostly removed confusion. That is a real kind of progress: the system now has more precise edges, clearer operator references, and a cleaner distinction between doctrine and shipped capability. That makes the next implementation step easier to trust.
+
+Narrative Log
+
+Dev Log - 2026-06-27
+
+It was a boundary-setting day.
+
+The work did not push Codexify into a new runtime shape. Instead, it made the existing shape easier to trust. That matters because the repo has been carrying a lot of architecture intent, and intent becomes a liability when it is too easy to mistake for proof. Today’s changes pushed back on that in a useful way.
+
+The center of gravity was turn intake. First came the compiler architecture contract, which gave the intake seam a governed description instead of leaving it implicit. Then came the fixture pack, which made the expected shapes tangible enough to inspect. After that came the token-domain proposal, which separated meaning from implementation and made it harder to blur token semantics into runtime claims. Taken together, those three artifacts did not ship the seam, but they did give it a real boundary.
+
+The Guardian operator index fit the same pattern. It did not add a new operational surface so much as organize the one that already exists. That kind of work can look modest from the outside, but it reduces friction in exactly the places where systems drift: discovery, naming, and the gap between where a concept lives and where people look for it.
+
+The current-state refresh was the anchor that kept the day honest. `00-current-state.md` remained the short-horizon source of truth, and the edits kept it aligned with what is actually supported. That prevented the new docs from accidentally inflating the release story. The repo is still in local-first beta hardening on `main`, and that phrasing still matters because it keeps the system from pretending that governed doctrine is the same thing as runtime proof.
+
+There was also a small profile change to add web browsing support. Compared with the architecture work, it was minor, but it still belongs in the day because it adjusted the supported surface in a direct way. The important part is that it stayed small and visible instead of being buried inside a larger, harder-to-audit change.
+
+The deeper change from the day is that the system became easier to reason about. Not faster, not flashier, just more legible. The contracts are more specific. The operator surface is better indexed. The current-state document is still acting like a gate instead of a decoration. That is the kind of progress that prevents future drift.
+
+What this makes possible next is fairly clear: prove the intake seam if that is the next intended step, or keep the new artifacts explicitly in the doctrine lane if runtime work is not ready. Either way, the system now has better scaffolding for the next honest move.

--- a/docs/DEV_LOG/2026-06-28/Dev Log - 2026-06-28.md
+++ b/docs/DEV_LOG/2026-06-28/Dev Log - 2026-06-28.md
@@ -1,0 +1,50 @@
+Dev Log - 2026-06-28
+
+Summary
+
+quiet maintenance day
+
+This was not a shipping day in the tracked Codexify repo. The workspace is clean, and there were no commits or file changes stamped to today, so the honest record is that the system did not move in a way I can prove from the repository alone.
+
+What I completed
+
+Tracked work
+
+- No Codexify commits landed today in this worktree.
+- No files were left modified in the repo.
+- No runtime, test, or docs changes were added that I can attribute to today with confidence.
+
+Important outcome
+
+The main outcome is truthfulness, not output. There is no basis to claim progress beyond a clean workspace and an empty tracked commit trail for the day.
+
+That matters because the daily log stays useful only if it distinguishes actual movement from the absence of movement. Today’s record is a boundary-setting record.
+
+Commits
+
+- None
+
+Notes
+
+- `git status --short` returned clean.
+- `git log --since='2026-06-28 00:00:00'` produced no Codexify commits in this worktree.
+- The last visible local commits are from June 20, 2026, which means any work after that is not represented in the current repository history.
+
+Next likely moves
+
+1. If there was uncommitted work elsewhere, reconcile it into this repo history before the next log run.
+2. If today was intentionally idle, keep the log as-is and carry forward the clean baseline.
+3. If another branch or worktree contains the real work, pull that evidence in before generating the next daily record.
+
+Closing thought
+
+A clean repo with no same-day commits is still a meaningful signal. It tells us there was no verifiable Codexify change to narrate, which is better than inventing momentum.
+
+Narrative Log  
+Dev Log - 2026-06-28
+
+Today reads as a quiet day in the tracked Codexify workspace. There is no commit trail to describe, no modified file set to interpret, and no runtime proof to weigh. In that situation, the right move is not to embellish the gap. It is to preserve the gap as part of the record.
+
+What the repository says, plainly, is that nothing new landed here today. That kind of absence matters more than it looks. It keeps the log honest, and it keeps later comparisons meaningful when real work does resume. A daily record only has value if it can also say when the system held steady.
+
+That leaves the next step simple: either surface work that happened in another branch or worktree, or carry this clean baseline forward into tomorrow. The system did not change today, and that is the change worth recording.

--- a/docs/DEV_LOG/2026-06-29/Dev Log - 2026-06-29.md
+++ b/docs/DEV_LOG/2026-06-29/Dev Log - 2026-06-29.md
@@ -1,0 +1,67 @@
+Dev Log - 2026-06-29
+
+Summary
+
+contract hardening day
+
+Today was about tightening the turn-intake docs into something more explicit and less ambiguous. The work did not widen runtime capability; it made the docs more precise about the boundary between doctrine, machine-readable projection, and actual implementation. That matters because Codexify has been accumulating turn-intake language that can easily drift into implied behavior if it is not pinned down carefully.
+
+The center of gravity was release-truth hygiene. The fixture pack now has a machine-readable projection, and the current-state anchor was updated to say plainly that this projection is still docs/proof-only. That kept the architecture KB aligned with the actual supported path instead of letting a new artifact be mistaken for a live classifier, routing layer, or test harness.
+
+What I completed
+
+Turn-intake fixture projection
+
+- Added a machine-readable projection for the Turn Intake Fixture Pack at [`/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/fixtures/turn-intake-fixtures.v1.json`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/fixtures/turn-intake-fixtures.v1.json).
+- Kept the markdown fixture pack as the human-readable doctrine source.
+- Made the JSON projection explicitly docs/proof-only so it can be reused later without pretending to be runtime evidence.
+
+Release-truth alignment
+
+- Updated [`/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/00-current-state.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/00-current-state.md) to reflect the new machine-readable projection and to state clearly that it is not runtime proof.
+- Kept the active blocker language honest: the turn-intake pipeline and projection remain unproven at runtime.
+- Refreshed the architecture entry points in [`/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/README.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/README.md) so the projection is discoverable without being overstated.
+- Updated the fixture pack and token-domain proposal docs so they point at the new projection while preserving the docs-only boundary.
+
+Important outcome
+
+The system is no longer just carrying turn-intake intent in prose. It now has a machine-readable projection of that intent, which makes the next implementation slice easier to test and less likely to drift.
+
+Just as important, the release truth stayed intact. The new artifact did not get promoted into runtime status by accident. Codexify now has a cleaner seam between “this is the expected shape” and “this is actually shipped.”
+
+Commits
+
+16a684aab - Add turn intake machine-readable fixtures
+
+Notes
+
+- This was docs-only work; no runtime classifier, router, or test harness was proven today.
+- The new JSON projection is LFS-backed, so the commit adds a pointer file rather than an inline fixture payload.
+- Validation here was commit/diff inspection and current-state alignment, not live runtime proof.
+- I also updated the automation memory for the next daily run.
+
+Next likely moves
+
+1. Turn the fixture projection into executable tests once the runtime seam exists.
+2. Add a canonical token registry only if runtime branching actually needs it.
+3. Wire turn-intake contract docs into whatever implementation slice owns classification.
+4. Keep `00-current-state.md` as the release-truth gate if the projection expands.
+
+Closing thought
+
+Today reduced ambiguity more than it added surface area. That is a good trade in Codexify: a machine-readable artifact now exists, but the system still tells the truth about what is and is not live.
+
+Narrative Log  
+Dev Log - 2026-06-29
+
+This was a boundary-setting day.
+
+The work started from a simple but important place: the turn-intake docs had already defined the expected shape of future behavior, but they were still mostly human-readable doctrine. That is useful for design, but it is not enough if the goal is to keep implementation work from drifting. So the day’s real move was to give the fixture pack a machine-readable projection while refusing to let that projection masquerade as runtime proof.
+
+That distinction mattered everywhere. The projection at [`/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/fixtures/turn-intake-fixtures.v1.json`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/fixtures/turn-intake-fixtures.v1.json) makes the turn-intake expectations easier to consume later, but it does not change the fact that Codexify does not yet have a live classifier, routing layer, or executable harness behind it. The docs were adjusted to say exactly that. [`/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/00-current-state.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/00-current-state.md) now names the projection directly and still treats the runtime path as unproven. That keeps release truth from getting stretched by convenience.
+
+The architecture README and the surrounding fixture/token proposal docs were updated in the same spirit. Not to announce a new capability, but to make the documentation stack internally consistent: one place to find the current state, one place to understand the fixture doctrine, one place to see the proposal for token discipline, and one machine-readable artifact that mirrors the examples without pretending to be an implementation. That is the kind of structural work that does not look flashy, but it reduces future ambiguity in a way the system will feel later.
+
+The deeper shift is small but real. Turn-intake is moving from scattered examples toward a more enforceable shape. The system is not smarter yet in runtime terms, but it is harder to misread. That is often what the honest middle of a hardening cycle looks like.
+
+Next, this opens the door to executable tests or a runtime classifier slice, but only once the implementation side is actually ready. For now, the useful outcome is simpler: the docs and the truth layer agree about what exists, what does not, and what still needs to be built.

--- a/docs/DEV_LOG/2026-06-30/Dev Log - 2026-06-30.md
+++ b/docs/DEV_LOG/2026-06-30/Dev Log - 2026-06-30.md
@@ -1,0 +1,73 @@
+Dev Log - 2026-06-30
+
+Summary
+
+contract hardening day
+
+Today was mostly about turning future behavior into explicit contracts and making the current-state record keep pace with that work. The repo did not grow a new runtime feature surface; it gained clearer boundaries around how shared presence should be understood, and clearer language for how chat transport can fail without implying provider failure or request loss.
+
+What I completed
+
+Shared presence contract
+
+- Defined the Shared Presence Protocol as a docs-only future capability, with explicit non-goals and boundary language.
+- Separated presence from identity, control, and provenance so the concept stays permissioned and auditable instead of collapsing into a vague collaboration layer.
+- Added a structured participant and surface model, plus a candidate event vocabulary, without claiming runtime support.
+
+Chat transport visibility and stream recovery
+
+- Added ADR-038 for transport visibility state and adaptive stream recovery.
+- Established a third conceptual plane for chat turns: transport visibility, distinct from provider runtime state and request execution state.
+- Clarified that recovery means re-observing the original attempt, not replaying or duplicating the assistant turn.
+
+Current-state alignment
+
+- Refreshed `docs/architecture/00-current-state.md` to reflect the new contract work and to keep the release boundary explicit.
+- Kept the docs honest about what is still only guidance or proposal, especially around turn-intake and transport recovery.
+
+Important outcome
+
+The system is no longer describing shared presence or stream recovery as loose ideas. It now has named contracts, named boundaries, and named non-goals.
+
+That matters because it reduces drift. The docs now separate future capability from shipped behavior more cleanly, and they make room for later implementation without pretending the implementation already exists.
+
+The biggest shift is that visibility problems are now treated as their own class of failure. Chat can stall, recover, or appear to drop without that being conflated with provider state or request success. That is a better foundation for honest UX and for later recovery logic.
+
+Commits
+
+- `74491f8fc` - `Define Shared Presence Protocol contract`
+- `65fb99887` - `docs: add chat transport recovery contract`
+- `20e3b2923` - `docs: refresh weekly current-state override`
+
+Notes
+
+- This was docs and contract work only; there is no live runtime proof attached to these changes.
+- The shared presence document is explicitly future-facing and does not widen the supported beta surface.
+- The chat recovery ADR is about observation recovery, not request replay.
+- I did not see unrelated runtime failures in the evidence I reviewed.
+
+Next likely moves
+
+- Turn the transport visibility contract into follow-up implementation specs for stall timers, reconnect behavior, and duplicate suppression.
+- Translate the shared presence proposal into a narrower implementation sequence with explicit phase boundaries.
+- Keep `00-current-state.md` aligned with any future runtime proof so docs do not outrun reality.
+- Recheck the release boundary if any of these contracts start touching shipped behavior.
+
+Closing thought
+
+Today made the system more legible before it made it more capable. That is the right order for work like this: first define the boundary, then build inside it.
+
+Narrative Log  
+Dev Log - 2026-06-30
+
+This was a contract day, and that mattered. The work did not add a flashy new runtime path. It made the system more precise about what kinds of coordination it is willing to describe, and what kinds of failure it must be able to name before it can handle them.
+
+The first piece was the Shared Presence Protocol. That document does not claim implementation. It does something more valuable at this stage: it defines the shape of the future without smuggling it into the present. Presence is now separated from identity, control, and provenance. That sounds formal, but it is the difference between a clean permissioned model and an ambiguous collaboration idea that would be hard to enforce later.
+
+The second piece was the chat transport recovery ADR. This is the kind of distinction that only becomes obvious after a few partial-failure incidents. A stream can look dead while the backend is still working. A completion can arrive later without the request having failed. If those realities are not separated, the UI and the runtime start lying to each other. The ADR introduces transport visibility as its own state plane so the system can talk honestly about observation loss without turning it into provider failure or request replay.
+
+The current-state refresh tied those threads back to the release boundary. That matters because the repo now has more doctrine, and doctrine only helps if the short-horizon source of truth keeps saying the same thing. The current-state doc stays clear that these are contracts and proposals, not shipped behavior. That keeps the system from drifting into self-congratulation.
+
+The deeper change from the day is simple: ambiguity got removed from the vocabulary. Shared presence now has a boundary. Stream recovery now has a failure model. The current-state doc now reflects both. That gives the next implementation work something solid to stand on, instead of asking runtime code to invent the contract after the fact.
+
+What this makes possible next is narrower and better: follow-up specs for actual recovery behavior, and a staged implementation path for shared presence that can be built without re-litigating the fundamentals.

--- a/docs/DEV_LOG/2026-07-01/Dev Log - 2026-07-01.md
+++ b/docs/DEV_LOG/2026-07-01/Dev Log - 2026-07-01.md
@@ -1,0 +1,50 @@
+Dev Log - 2026-07-01
+
+Summary
+
+release-truth alignment day
+
+Today was mostly about tightening the line between what Codexify says is supported and what is only documented, proposed, or quarantined. The work did not widen the runtime surface. It made the current-state anchor more accurate, more explicit, and harder to misread.
+
+The main change was a weekly refresh of `docs/architecture/00-current-state.md` and a small front-door update in `docs/architecture/README.md`. That kept the KB entry point aligned with the current release posture and made sure docs-only contracts like shared presence, chat transport recovery, and thread lenses stay clearly separated from shipped runtime behavior.
+
+What I completed
+
+Current-state refresh
+
+- Updated [`docs/architecture/00-current-state.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/00-current-state.md) to `2026-07-01`.
+- Refined the phase language to reflect that recent work is centered on docs-first operator routing, release-truth refreshes, and future-facing contracts.
+- Added explicit guardrails that shared presence, chat transport recovery, and thread lenses are docs-only, not supported runtime surfaces.
+- Tightened the weekly priorities so docs-only contracts stay separated from shipped runtime claims.
+
+Architecture front door
+
+- Updated [`docs/architecture/README.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/README.md) to point release-truth questions more directly at `00-current-state.md`.
+- Kept the architecture KB entry path aligned with the current truth hierarchy instead of letting older structure pages carry too much interpretive weight.
+
+Important outcome
+
+`00-current-state.md` is now a little harder to drift away from. The system did not gain new runtime capability today, but it did gain a cleaner boundary around what counts as current truth.
+
+That matters because docs-only contracts can easily start sounding like shipped features if the language gets loose. Today’s update kept that from happening. The supported release promise stayed narrow, and the KB now says that more plainly.
+
+Commits
+
+- `60f204d1c` - `docs: refresh weekly current-state override`
+
+Notes
+
+- This was a docs-only day. There was no runtime evidence to claim beyond the updated release-truth documents.
+- The evidence level here is documentation truth, not live execution proof.
+- No unrelated failures or blocked validations surfaced in this run.
+
+Next likely moves
+
+1. Keep `00-current-state.md` synced with any new merged docs-only contracts.
+2. Watch for any docs language that starts implying runtime support before `main` proves it.
+3. Continue separating supported beta paths from aspirational contract work in the KB.
+4. Refresh the operator-facing README front door again if the release-truth hierarchy changes.
+
+Closing thought
+
+The useful shift today was not feature growth. It was truth maintenance. Codexify’s release story stayed narrow on purpose, and the docs now reflect that with less ambiguity.

--- a/docs/DEV_LOG/2026-07-02/Dev Log - 2026-07-02.md
+++ b/docs/DEV_LOG/2026-07-02/Dev Log - 2026-07-02.md
@@ -1,0 +1,62 @@
+**Dev Log - 2026-07-02**
+
+**Summary**
+
+Release-truth alignment day.
+
+The work was fundamentally about keeping Codexify’s short-horizon truth tight. The only landed change today was a docs refresh to the weekly current-state override, which kept the release story, supported path, and docs-only contracts from drifting apart. This was not a runtime-shipping day; it was a truth-maintenance day.
+
+**What I completed**
+
+**Current-state refresh**
+
+- Refreshed `docs/architecture/00-current-state.md` so the current operational story stays explicit about what is supported on `main`.
+- Tightened the separation between supported runtime reality and docs-only contracts.
+- Kept the release promise narrow: local-only beta path remains the supported baseline, and the newer contract language stays clearly marked as non-runtime unless proven otherwise.
+
+**Docs routing cleanup**
+
+- Updated `docs/architecture/README.md` alongside the current-state refresh.
+- Kept the architecture front door aligned with the current truth anchor instead of letting older language imply broader runtime support than exists.
+
+**Important outcome**
+
+`main` did not gain new runtime surface today, and that is the point. The system became more honest about what is actually supported, what is only documented, and what still needs proof.
+
+The docs stopped implying movement that had not happened. That matters because Codexify’s release truth depends on keeping docs, operator routing, and runtime evidence in the same lane.
+
+**Commits**
+
+- `7ecec7916` - `docs: refresh weekly current-state override`
+
+**Notes**
+
+- Evidence level today was docs-level only.
+- No live runtime proof landed.
+- The repo was clean at the time of review.
+- No unrelated failures surfaced during this pass.
+
+**Next likely moves**
+
+1. Recheck `main` against the current-state anchor if new runtime work lands.
+2. Keep docs-only contracts clearly separated from shipped support claims.
+3. Preserve the narrow local-only beta story unless runtime proof changes it.
+4. Revisit operator routing if the supported path changes again.
+
+**Closing thought**
+
+The day was small in surface area but meaningful in discipline. Codexify is still governed by the same release truth, and today’s work made that truth easier to trust.
+
+**Narrative Log**
+
+**Dev Log - 2026-07-02**
+
+Today was a release-truth day rather than a feature day. The work did not add new runtime behavior, and it did not need to. What changed was the clarity of the record: the current-state docs and architecture front door were brought back into alignment so the supported path on `main` stays narrow, explicit, and believable.
+
+The center of gravity was the weekly current-state override refresh. That file is the short-horizon anchor for what Codexify is actually promising right now, so the job was to make sure it still reflected the real system instead of letting docs drift into aspiration. The update kept the local-only beta posture intact, left docs-only contracts in their proper lane, and preserved the distinction between what is supported and what is still just described.
+
+The companion README update mattered in the same way. It did not change the runtime, but it did keep the operator-facing entry point from telling a looser story than the current-state anchor. That kind of alignment is easy to overlook, but it is the difference between a repo that merely contains documentation and a repo that can be trusted to describe its own release boundary.
+
+What the day really produced was a cleaner boundary. Codexify did not become more flashy. It became more precise about itself. The system stopped implying unsupported truth and started holding the line on what has actually been proven on `main`.
+
+That leaves the next step clear: keep watching for drift, and only widen the release story when runtime proof justifies it.

--- a/docs/DEV_LOG/2026-07-03/Dev Log - 2026-07-03.md
+++ b/docs/DEV_LOG/2026-07-03/Dev Log - 2026-07-03.md
@@ -1,0 +1,50 @@
+Dev Log - 2026-07-03
+
+Summary
+
+docs-truth alignment day
+
+Today was about tightening the short-horizon record rather than expanding runtime surface. The work stayed focused on release truth: refreshing the current-state anchor, keeping the architecture front door pointed at the right source, and making sure the docs match what `main` actually says about the system right now.
+
+This was not a feature day. It was a truth-maintenance day. The value came from removing drift between the KB entry points and the current release narrative so operators reading the repo get the same answer from the first page they open.
+
+What I completed
+
+Current-state refresh
+
+- Updated `docs/architecture/00-current-state.md` to `2026-07-03`.
+- Reframed the weekly status so it reflects incremental `main`line movement instead of implying a phase change.
+- Added the latest release-truth bullets around document RAG gating, chat transcript pagination, and the new Guardian/shared-presence contract docs.
+- Tightened the “not yet true” section so docs-only contracts stay clearly separated from shipped runtime behavior.
+
+Architecture entry-point cleanup
+
+- Nudged `docs/architecture/README.md` so readers are directed to `00-current-state.md` first.
+- Kept the KB front door aligned with the live truth layer instead of letting it drift toward a generic architecture overview.
+
+Important outcome
+
+`00-current-state.md` is now carrying the current release story more precisely. It no longer reads like a stale weekly snapshot; it reads like an active operational gate for what is and is not part of the supported promise.
+
+The system also got a little harder to misread. The architecture README now sends people to the truth anchor first, which reduces the chance that someone treats structural docs as if they were release proof.
+
+Commits
+
+- `4f9e65d1c` - `docs: refresh weekly current-state override`
+
+Notes
+
+- Evidence here is docs-level only. No runtime proof was added or claimed.
+- The worktree was clean after the commit; there were no unrelated local changes to account for.
+- This was intentionally narrow: one truth-anchor refresh, one entry-point adjustment.
+
+Next likely moves
+
+1. Recheck any docs that still describe Guardian/shared-presence behavior too loosely.
+2. Verify whether the weekly current-state wording should also be mirrored in other operator-facing docs.
+3. Continue keeping docs-only contracts separated from shipped runtime claims.
+4. If the week’s runtime work continues, refresh the release-truth anchor again rather than letting it age.
+
+Closing thought
+
+The day was small in surface area but useful in effect: it made the repo easier to trust. The main thing that changed was not capability, but clarity about capability, and that is often what keeps a local-first system honest.

--- a/docs/DEV_LOG/2026-07-04/Dev Log - 2026-07-04.md
+++ b/docs/DEV_LOG/2026-07-04/Dev Log - 2026-07-04.md
@@ -1,0 +1,45 @@
+Dev Log - 2026-07-04
+
+Summary
+
+quiet maintenance day
+
+There was no recorded Codexify implementation work today. The repo stayed clean, and there were no commits in the `2026-07-04` window to anchor a substantive build log. That matters because it keeps the daily record honest: no invented progress, no inflated claims, just a clean statement that today did not add release-truth changes.
+
+What I completed
+
+No recorded work
+
+- No new commits landed today.
+- No working tree changes were present.
+- No docs, runtime, or contract updates were captured in the repo for this date.
+
+Important outcome
+
+The system did not move today, and that is worth recording plainly. There is nothing to overstate and nothing to retrofit into progress.
+
+Notes
+
+- Evidence available in the repo for this date was limited to a clean working tree and no commit activity.
+- No live runtime proof, test proof, or documentation changes were available to summarize.
+- This log should be treated as a no-op day unless an external task summary provides additional work not reflected in git.
+
+Next likely moves
+
+- Resume the next Codexify task with current repo state as the baseline.
+- Check whether any architecture or docs updates were completed outside git and need to be captured separately.
+- Continue from the last recorded release-truth update if a new task lands.
+
+Closing thought
+
+Today preserved the record rather than changing the system. That still matters: a truthful log keeps the next real change legible.
+
+Narrative Log
+
+Dev Log - 2026-07-04
+
+This was a quiet day in Codexify terms. The repository did not show new commits, and the working tree stayed clean, so there was no technical change to narrate beyond the absence of change itself. That is still useful signal. It means the daily record remains anchored to actual work instead of being padded to sound active.
+
+No contract work landed, no runtime surfaces shifted, and no documentation changed the short-horizon truth. In a system that cares about release truth and boundary discipline, that kind of emptiness is better than a decorative summary. It tells us the log can stay precise when there is nothing to report.
+
+What this makes possible next is simple: the next real task can start from a clean baseline without ambiguity about what changed today. That keeps the system easier to reason about and the record easier to trust.

--- a/docs/DEV_LOG/2026-07-05/Dev Log - 2026-07-05.md
+++ b/docs/DEV_LOG/2026-07-05/Dev Log - 2026-07-05.md
@@ -1,0 +1,64 @@
+Dev Log - 2026-07-05
+
+Summary
+
+docs truth-alignment day
+
+Today was about keeping the short-horizon release record honest. The work was not about new runtime behavior or shipped features. It was a controlled refresh of the architecture truth layer so the repo’s current-state docs still match the present posture of Codexify on `main`.
+
+The important part is that the release story stayed narrow and explicit. The current supported path remains the local Docker Compose stack with a local-only provider posture, and the docs were updated to reflect the latest status without widening the promise set.
+
+What I completed
+
+Current-state refresh
+
+- Updated `docs/architecture/00-current-state.md` to reflect the latest short-horizon release truth.
+- Kept the release posture framed as stable and incremental rather than implying a new phase.
+- Reworded the recent-changes section so it reflects the actual current emphasis: Persona Studio cleanup, document RAG status hints, and newly landed contract docs.
+- Preserved the boundary between what is documented and what is actually proven runtime behavior.
+
+Architecture entrypoint alignment
+
+- Updated `docs/architecture/README.md` so it still points people to `00-current-state.md` first for release-truth questions.
+- Kept the KB front door consistent with the newer current-state date.
+
+Important outcome
+
+`00-current-state.md` is now a better short-horizon anchor for what Codexify actually is right now. It no longer reads like an older snapshot.
+
+The system also stayed honest about scope. The docs reflect release truth, but they do not pretend that docs-only contracts or recent cleanups are runtime proof.
+
+Commits
+
+- e2b1a6b1d - docs: refresh weekly current-state override
+
+Notes
+
+- This was docs-only work.
+- No runtime tests were run or needed.
+- No live validation or production proof was added.
+- The evidence here is documentation-level only, not runtime-level.
+- `git status` was clean at the time of review.
+
+Next likely moves
+
+- Recheck any downstream docs that reference the older current-state wording.
+- Keep `00-current-state.md` aligned with the next real `main` shift.
+- If runtime changes land next, separate their proof from doc refreshes more explicitly.
+- Audit adjacent architecture pages for any stale release-truth phrasing.
+
+Closing thought
+
+This kind of work matters because the system’s trustworthiness depends on the docs staying in lockstep with reality. The change was small, but it tightened the boundary between current truth and older narrative.
+
+Narrative Log - 2026-07-05
+
+Today was a truth-maintenance day. Not a feature day, not a runtime proof day, and not a validation-heavy day. The work was narrower than that: I refreshed Codexify’s current-state documentation so the repo’s short-horizon release story still matches where the system actually is.
+
+The center of gravity was `docs/architecture/00-current-state.md`. That file is the release-truth anchor, so even small wording drift matters. I updated the date, adjusted the “current phase” language to make the posture sound stable rather than transitional, and rewrote the recent-changes section so it reflects the real emphasis of the week: Persona Studio cleanup, document RAG gating and status hints, and the fact that the contract docs landed on `main`. The point was not to celebrate those items, but to make sure the repository’s most authoritative summary stayed precise.
+
+I also kept `docs/architecture/README.md` aligned with that anchor. That matters because the README is the front door for people looking for current architecture truth, and if it lags even slightly, the repo starts teaching the wrong instincts. This was a small edit, but it kept the entry path coherent: if someone wants release-readiness or short-horizon status, they get pointed to the right file first.
+
+What changed underneath the surface is simple: the docs stopped carrying yesterday’s shape of the system and started reflecting today’s. That is mostly invisible work, but it prevents drift. It keeps future conversations honest, and it protects the boundary between what is actually supported, what is merely documented, and what still needs runtime proof.
+
+There was no live verification to report here, which is itself part of the record. This was documentation-level alignment only. The next useful move is to keep that truth layer synchronized as the actual `main` posture changes, and to separate future runtime proof from doc refreshes so the record stays clean.

--- a/docs/DEV_LOG/2026-07-06/Dev Log - 2026-07-06.md
+++ b/docs/DEV_LOG/2026-07-06/Dev Log - 2026-07-06.md
@@ -1,0 +1,62 @@
+Dev Log - 2026-07-06
+
+Summary
+
+Docs truth-alignment day.
+
+This was a narrow release-truth maintenance pass. The work did not add runtime behavior; it tightened the short-horizon operational record so the current-state docs continue to reflect the supported path, the active blockers, and what has or has not actually landed on `main`.
+
+What I completed
+
+Release truth refresh
+
+- Updated [`docs/architecture/00-current-state.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/00-current-state.md) to advance the short-horizon truth anchor to `2026-07-06`.
+- Added the explicit note that no merged `main` changes landed since the last audit.
+- Kept the supported-path boundary intact: local-only beta, Compose-first, and no new runtime promise implied.
+
+Architecture KB entrypoint alignment
+
+- Updated [`docs/architecture/README.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/README.md) to match the same date refresh.
+- Kept the KB front door pointed at `00-current-state.md` as the release-truth source of record.
+- Preserved the distinction between architecture guidance and shipped runtime behavior.
+
+Important outcome
+
+The current-state file is now explicitly synchronized to today’s audit window. That matters because it prevents stale release language from drifting forward just because the repo changed around it.
+
+This was not a feature day. It was a truth-maintenance day. The system did not gain new behavior, but it did get a cleaner statement of what remains supported and what does not.
+
+Commits
+
+bc361b0b - docs: refresh weekly current-state override
+
+Notes
+
+- Evidence level is docs-only.
+- No runtime proof, tests, or live validation were part of this change.
+- The update was intentionally narrow: no unrelated files were touched.
+- $CODEX_HOME was not set in the shell during the memory write, so the automation memory was written to the user-level Codex automation path instead.
+
+Next likely moves
+
+1. Recheck whether any `main`-merged changes should move the current-state bullets again.
+2. Continue keeping `00-current-state.md` and the KB front door in lockstep.
+3. Refresh any downstream release notes or daily audit artifacts that cite the current-state date.
+4. If runtime work landed separately, verify whether the supported-path language needs another update.
+
+Closing thought
+
+The day’s change was small, but it kept the release record honest. In this repo, that is not cosmetic work; it is part of keeping the system trustworthy.
+
+Narrative Log  
+Dev Log - 2026-07-06
+
+Today was a truth-alignment day.
+
+The actual work was small and deliberate: I refreshed the architecture current-state anchor and made sure the KB entrypoint still points back to it as the source of short-horizon release truth. Nothing about the runtime changed. What changed was the clarity of the record. The docs now say, plainly, that no merged `main` changes landed since the last audit, which matters because this repo treats release claims as something to keep under discipline, not something to let drift.
+
+That kind of maintenance can look minor from the outside, but it does real work inside a system like this. `00-current-state.md` is not just a note; it is the short-form contract for what is currently supported, what remains blocked, and what should not be inferred from planning language. Updating it keeps the boundary intact between shipped reality and adjacent intent. Updating the architecture README at the same time keeps the front door aligned with that same truth layer instead of letting the navigation page get ahead of the record.
+
+There was no feature landing, no runtime proof, and no validation run to narrate. This was documentation work, but it was the kind that protects the meaning of everything else. The day was about preventing stale language from quietly becoming false confidence. That is a small shift in text and a meaningful shift in discipline.
+
+What this makes possible next is straightforward: the next time `main` actually moves, the current-state file can absorb that change cleanly, and anything downstream that depends on it will have a reliable anchor again.

--- a/docs/DEV_LOG/2026-07-07/Dev Log - 2026-07-07.md
+++ b/docs/DEV_LOG/2026-07-07/Dev Log - 2026-07-07.md
@@ -1,0 +1,59 @@
+Dev Log - 2026-07-07
+
+Summary
+
+Docs alignment day.
+
+Today was about keeping Codexify’s short-horizon truth anchored to the current-state docs rather than letting the narrative drift. The work was small in code terms but important in release terms: it refreshed the weekly operational baseline and tightened the guidance around where current-state interpretation should start.
+
+What I completed
+
+Current-state refresh
+
+- Updated `docs/architecture/00-current-state.md` to reflect the new date and keep the release-truth anchor current.
+- Reworded the current phase language so it stays crisp: local-first beta hardening on `main`, with no new shipped phase implied.
+
+Architecture entrypoint cleanup
+
+- Adjusted `docs/architecture/README.md` so the front door to the architecture KB points cleanly at `00-current-state.md` as the first stop for release-truth questions.
+- This reduced ambiguity in how humans and agents should enter the architecture docs when they need short-horizon reality.
+
+Important outcome
+
+`00-current-state.md` is now less likely to be read as stale or overextended. The system did not gain new runtime capability today, but it did gain a cleaner truth boundary: the current-state doc remains the place where release posture is asserted, and the README now steers readers there without extra wording.
+
+This mattered because release truth is part of the product surface here. When the docs drift, downstream reasoning drifts with them.
+
+Commits
+
+f114a9881 - docs: refresh weekly current-state override
+
+Notes
+
+- This was a docs-only day; there is no runtime proof to report.
+- No dirty worktree was present.
+- The evidence here is entirely document-level and commit-level, not live-system validation.
+- The main limitation is that this work clarifies truth, but does not change behavior.
+
+Next likely moves
+
+- Reconcile any other architecture docs that may still lag the refreshed current-state wording.
+- Check whether the weekly audit or release notes need the same truth-alignment pass.
+- Continue using `00-current-state.md` as the release gate for any new claims.
+
+Closing thought
+
+The system got a little more honest today. Nothing flashy changed, but the boundary around what Codexify currently is and is not became clearer, and that is the kind of maintenance that keeps a release narrative trustworthy.
+
+Narrative Log  
+Dev Log - 2026-07-07
+
+This was a quiet truth-maintenance day. The work was small, but it mattered because Codexify’s architecture docs are part of the operating system for how the project reasons about itself. If those docs drift, the rest of the stack starts to inherit that drift in planning, reviews, and release language.
+
+The main job was to refresh the short-horizon state anchor. `docs/architecture/00-current-state.md` was updated so the current phase reads cleanly as local-first beta hardening on `main`, with no suggestion that a new shipped phase has arrived. That is a narrow change, but it is the kind of narrowness that matters: it keeps release truth from inflating beyond what has actually landed.
+
+I also tightened the entrypoint language in `docs/architecture/README.md`. The goal there was not to add more documentation, but to make the path into the documentation more disciplined. When someone needs current-state interpretation or release-readiness context, they should land on `00-current-state.md` first, without detouring through phrasing that softens its authority.
+
+The deeper shift is that the documentation now points more directly at the place where truth is maintained. That does not change runtime behavior, and it does not claim any new capability. It does, however, make the system easier to trust. The architecture docs now behave a little more like a control surface and a little less like a loose collection of notes.
+
+What this makes possible next is straightforward: future work can keep using the current-state file as the release gate without having to mentally discount stale wording. That reduces drift, and in a project like this, reducing drift is real progress.

--- a/docs/DEV_LOG/2026-07-08/Dev Log - 2026-07-08.md
+++ b/docs/DEV_LOG/2026-07-08/Dev Log - 2026-07-08.md
@@ -1,0 +1,62 @@
+**Dev Log - 2026-07-08**
+
+**Summary**
+
+Docs and contract-alignment day.
+
+The work was fundamentally about tightening the repository’s written truth: refreshing the current-state anchor and adding a reusable module-ownership skill so future changes have a clearer boundary model. This was not runtime expansion work. It was structural cleanup aimed at reducing ambiguity in how Codexify work should be scoped, owned, and described.
+
+**What I completed**
+
+**Current-state alignment**
+
+- Refreshed [`docs/architecture/00-current-state.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/00-current-state.md) to keep the short-horizon release truth aligned with the current local-first beta posture.
+- Kept the distinction clear between what is genuinely supported on `main` and what is only documented or under contract.
+
+**Module ownership skill**
+
+- Added the `module-ownership` skill under [`docs/skills/module-ownership/SKILL.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/skills/module-ownership/SKILL.md).
+- Added its companion OpenAI agent metadata in [`docs/skills/module-ownership/agents/openai.yaml`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/skills/module-ownership/agents/openai.yaml).
+- Added the ownership matrix reference template in [`docs/skills/module-ownership/references/ownership-matrix-template.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/skills/module-ownership/references/ownership-matrix-template.md).
+
+**Important outcome**
+
+Codexify is a little less ambiguous now.
+
+The current-state doc keeps the release story pinned to the real supported path, while the new module-ownership skill gives future work a cleaner way to decide where behavior belongs. That matters because a lot of repo drift starts as boundary drift, and boundary drift becomes release-truth drift if it is left unchecked.
+
+This was not a flashy day. It was a truth-maintenance day. The system now has a slightly better spine for saying what is owned, what is shared, and what should stay out of a given module.
+
+**Commits**
+
+- `a53710b52` - `docs(skills): add module ownership skill`
+- `608aba305` - `docs: refresh weekly current-state override`
+
+**Notes**
+
+- The evidence for today is documentation-level, not runtime-level.
+- There were uncommitted deletions in the working tree under `docs/skills/module-ownership/`; I did not change them.
+- No automated runtime validation was applicable for the work captured here.
+
+**Next likely moves**
+
+1. Reconcile the uncommitted `module-ownership` deletions with the intended doc state.
+2. Apply the ownership pattern to the next boundary-sensitive Codexify change.
+3. Keep `00-current-state.md` aligned with any new supported-path claims only after proof lands on `main`.
+4. Add or refresh adjacent docs if another module boundary needs a similarly explicit owner map.
+
+**Closing thought**
+
+The repo did not become more capable today in the runtime sense. It became more governable. That is still useful work, because clearer ownership and tighter release truth prevent accidental inflation of what the system can honestly claim.
+
+**Narrative Log - 2026-07-08**
+
+This was a quiet but meaningful day. The system did not gain a new runtime path, and that is part of the point. The work was about narrowing ambiguity: keeping the short-horizon truth anchor current and giving future changes a sharper model for module ownership and boundaries.
+
+The first piece was the current-state refresh. That doc is the place where Codexify says, without ornament, what is actually supported right now and what is still only documentation or intent. Keeping that current matters because the repository has a growing contract surface, and the easiest way for a project to drift is to let its written promises get ahead of its proof. This update kept the supported local-first beta story pinned to the real operational posture.
+
+The second piece was the new `module-ownership` skill. That is a small addition, but it carries a useful discipline: one behavior, one owner; thin composition layers; explicit shared contracts; clear privileged boundaries. In practice, that gives future work a better way to answer a question the codebase keeps asking anyway: what belongs here, what belongs somewhere else, and what should never cross this seam in the first place.
+
+The day’s deeper shift is that Codexify is becoming easier to govern by construction. The repository now has a slightly stronger vocabulary for boundary decisions, and the release-truth doc still sits in its proper role as the short-horizon gate on claims. That does not sound dramatic, but it is the kind of maintenance that keeps systems honest.
+
+What this makes possible next is straightforward: the next boundary-sensitive change can be scoped against a clearer ownership model, and any future release claim can be checked against a current truth anchor that is less likely to drift.

--- a/docs/DEV_LOG/2026-07-09/**Dev Log - 2026-07-09**.md
+++ b/docs/DEV_LOG/2026-07-09/**Dev Log - 2026-07-09**.md
@@ -1,0 +1,75 @@
+**Dev Log - 2026-07-09**
+
+**Summary**
+
+Contract hardening day.
+
+The work today was mostly about tightening what Codexify says is true versus what it can actually prove. One commit pushed the current-state guidance forward, and another front-loaded the README so the release-truth anchor is harder to miss. In parallel, I added a mounted live-validate proof note and a static contract test that keeps that proof inside a validate-only boundary.
+
+The real shape of the day was not feature expansion. It was evidence discipline: making the docs point more directly at the current-state source, and capturing a live operator proof attempt that is honest about where the containerized bridge still fails.
+
+**What I completed**
+
+**Release-truth alignment**
+
+- Updated [`docs/architecture/00-current-state.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/00-current-state.md) to refresh the weekly current-state override.
+- Updated [`docs/architecture/README.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/README.md) so the current-state guidance is surfaced earlier.
+- The result is less ambiguity about where short-horizon operational truth lives.
+
+**Mounted live-validate proof boundary**
+
+- Added [`docs/architecture/guardian-codex-runner-command-bus-live-validate-mounted-proof.md`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/docs/architecture/guardian-codex-runner-command-bus-live-validate-mounted-proof.md).
+- The note records a validate-only live operator proof against the mounted Codex Runner path.
+- It explicitly stays out of orchestration, write paths, UI proof, and Codexify ingestion.
+- The proof is honest about the failure mode: the backend container can see the mount, but `codexrun` is not on PATH inside the container.
+
+**Static contract coverage**
+
+- Added [`tests/codex_runner_bridge/test_live_validate_mounted_proof.py`](/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify/tests/codex_runner_bridge/test_live_validate_mounted_proof.py).
+- The test locks the document to the validate-only boundary and checks that the mounted proof references the right command and cross-links.
+- This is code/test-level enforcement, not live runtime proof.
+
+**Important outcome**
+
+The current-state anchor is now harder to overlook, which matters because it is the short-horizon truth gate for this repo.
+
+The mounted live-validate proof also moved from vague intent to a concrete failure record. The system now has a documented, bounded attempt that confirms mount visibility and isolates the next blocker: the container runtime still lacks the `codexrun` executable.
+
+That is a meaningful shift. The day did not prove more capability. It reduced uncertainty about what is mounted, what is reachable, and what remains missing.
+
+**Commits**
+
+- `c19d61153` - `docs: front-load current-state readme guidance`
+- `bc79470d3` - `docs: refresh weekly current-state override`
+
+**Notes**
+
+- The mounted proof note and static test are still uncommitted in the worktree.
+- Evidence here is code/doc/test-level plus a live operator proof note. It is not live runtime success.
+- The proof failed for a concrete environment reason: `codexrun` was not installed on PATH inside the backend container.
+- No unrelated failures surfaced beyond that container/runtime gap.
+
+**Next likely moves**
+
+- Install or expose `codexrun` inside the backend container, then rerun the mounted validate-only proof.
+- Decide whether the mounted proof note should be committed as-is or revised after the next runtime attempt.
+- Keep current-state wording aligned with any follow-up proof outcome.
+- If the container fix lands, add a narrower success/fail proof split so the boundary stays explicit.
+
+**Closing thought**
+
+Today made the system more truthful before it made it more capable. That is usually the right order. The repo now points more clearly at current truth, and the proof trail is sharper about what is mounted, what is blocked, and what still needs to be installed.
+
+**Narrative Log - 2026-07-09**
+
+This was a contract and evidence day, not a feature day. The useful work was mostly about removing drift between what Codexify says is current truth and what it can actually show. That kind of work is quiet, but it matters because it keeps the system from accumulating confident stories that outpace reality.
+
+The first part of the day tightened the release-truth surface. I refreshed the weekly current-state override and then front-loaded the README guidance so the short-horizon anchor is easier to find. That is small on the surface, but it changes behavior downstream: fewer people will wander into stale assumptions when the repo’s own front door points them back to the current-state file first.
+
+The second part of the day was more operational. I added a mounted live-validate proof document for the Guardian Codex Runner bridge and paired it with a static contract test that keeps the proof in bounds. The important thing there is not just the existence of the document. It is the boundary language. The note stays validate-only, names what it does not attempt, and refuses to smuggle orchestration or ingestion claims into a proof that did not earn them.
+
+The live attempt itself was useful precisely because it failed in a specific way. The backend container can see the Codex Runner mount, which means the filesystem visibility problem is no longer the blocker. What remains is more concrete: `codexrun` is not available on PATH inside the container. That is a narrower, more actionable failure than the earlier ambiguity, and it gives the next step a real target.
+
+So the deeper shift today was not capability gain. It was drift reduction. The docs now steer more directly at current truth, and the proof trail now separates mount visibility from executable availability. The system stopped speaking in broad terms and started naming its actual boundary conditions.
+
+That makes the next move clearer. The next useful step is to fix the container runtime exposure for `codexrun`, rerun the mounted validate-only proof, and keep the evidence trail as strict as it was today.

--- a/docs/DEV_LOG/2026-07-10/Dev Log - 2026-07-10.md
+++ b/docs/DEV_LOG/2026-07-10/Dev Log - 2026-07-10.md
@@ -1,0 +1,89 @@
+Dev Log - 2026-07-10
+
+Summary
+
+architecture truth-alignment day
+
+Today was mostly about turning Guardian evidence handling into a contract-backed system instead of a loose set of scripts. The work moved through the full chain: canonical audit evidence, VaultNode authority, bounded reads, reducer input bundles, packet generation, fixtures, and Make targets. The result is less ambiguity at each boundary and a clearer path from source evidence to validated output.
+
+A smaller but important parallel track tightened the collaboration layer in the editor and chat flow. Event normalization, cursor presence, and thread-ownership payload fixes made multi-user state less brittle and less implicit. That matters because ownership and collaboration semantics need to stay legible once more than one actor is in the loop.
+
+What I completed
+
+Guardian evidence pipeline hardening
+
+- Defined the canonical audit evidence contract and schema, then updated current-state docs so the repo has a named authority for evidence shape instead of relying on informal expectations.
+- Added the VaultNode canonical machine and audit authority contract, which gave the system a clearer trust and ownership boundary.
+- Built out the bounded-read path with a contract, reader, fixture, and Make target so evidence can be read in a constrained way and verified against the expected local-tooling shape.
+- Added the reducer input bundle contract, static validator, batch validator, dry-run loader, and Make targets so reducer inputs are now checked before they are treated as valid.
+- Added the packet generator contract, generator, malformed-entry handling, generated fixture, and Make target so packet creation is now reproducible and testable instead of implicit.
+- Updated the architecture docs and tests throughout so the contracts, fixtures, and command entrypoints stay aligned.
+
+Collaboration and ownership fixes
+
+- Extracted the document collaboration event normalizer and added cursor presence handling so collaboration state is represented more explicitly.
+- Fixed multi-user thread creation ownership and remote-auth thread ownership payload handling so the owning identity is carried more correctly through chat flows.
+- Expanded the related tests so the collaboration and ownership paths are less likely to drift silently.
+
+Important outcome
+
+Guardian evidence is no longer just a sequence of scripts. It now has enough structural truth to be named, bounded, validated, reduced, and generated against explicit contracts.
+
+That shift matters because it moves the system from "works if you know the sequence" to "works because the sequence is enforced." The collaboration side made the same kind of move at a smaller scale: ownership and cursor presence are now less accidental and more legible.
+
+Commits
+
+- 063bd1afe - Extract document collaboration event normalizer
+- 58b86f3d5 - Add Guardian evidence reducer input bundle validator
+- 62db7502d - Fix remote-auth thread ownership payload
+- 9f5befc2e - Add Guardian evidence reducer input bundle batch validator
+- 1a126cf26 - Add Guardian evidence reducer input bundle Make target
+- 3e7422269 - Keep reducer input bundle make target JSON parseable
+- b91204ed0 - Add Guardian evidence reducer input bundle loader contract
+- d51863163 - Fix multi-user thread creation ownership
+- fac2595cd - Add Guardian evidence reducer input bundle dry-run loader
+- 795eeebca - Add Guardian evidence reducer input bundle dry-run Make target
+- 4c686e76b - Add Guardian evidence packet generator contract
+- 0303b25a8 - Add Guardian evidence bounded read contract
+- c14431b9b - Add Guardian evidence bounded reader
+- f8be1665f - docs: define VaultNode canonical audit authority
+- 017eb4254 - Add document collaboration cursor presence
+- 4c3e17325 - Add Guardian evidence bounded read Make target
+- 1159171f0 - Add Guardian evidence bounded read fixture
+- bb4b65218 - docs: define canonical audit evidence contract
+- 44349c351 - Add Guardian evidence packet generator
+- 0a91a4ee9 - Add Guardian evidence packet generator
+- d5a2567d8 - Handle malformed bounded read entries
+- c0f2c8fbd - Add Guardian evidence packet generator Make target
+- aaa8b3480 - Add Guardian evidence generated packet fixture
+
+Notes
+
+- The evidence here is still code/test-level; I did not verify a live runtime path in this pass.
+- The worktree still has an uncommitted demo-prep slice in `Makefile` and `scripts/demo/`; I left it out of the completed-work record because it is not committed yet.
+- No unrelated failures were established from the material I reviewed.
+
+Next likely moves
+
+- Validate the Guardian evidence pipeline end to end with the new bounded-read, reducer-input, and generator entrypoints.
+- Reconcile the uncommitted demo-prep slice and decide whether it belongs in the same daily record or a follow-up commit.
+- Tighten the current-state docs if any of the new contracts should be promoted into shorter operational truth.
+- Run a focused test pass on the collaboration/ownership paths to confirm the payload fixes hold under existing scenarios.
+
+Closing thought
+
+The day was mostly about removing hidden assumptions. The system now has more explicit boundaries around evidence and collaboration state, which makes it easier to trust, easier to test, and harder to drift.
+
+The work paid down ambiguity rather than adding surface area, and that is the kind of progress that compounds.
+
+Narrative Log
+
+Dev Log - 2026-07-10
+
+Today was a contract-hardening day, and it showed in the shape of the work. Most of the energy went into Guardian evidence handling, where the repo moved from a set of procedural steps toward a more explicit chain of authority. First came the canonical audit evidence contract and the VaultNode authority layer, then the bounded-read contract and reader, then the reducer input bundle contracts, validators, dry-run loader, and Make targets, and finally the packet generator, malformed-entry handling, and fixtures. Each piece narrowed the gap between "we know how this is supposed to work" and "the system can actually enforce it."
+
+What mattered underneath the surface was not just the addition of files or tests. It was the removal of guesswork. Evidence now has a declared shape. Reads are bounded. Reducer inputs are validated before they are trusted. Generated packets are reproducible. The documentation and tests were updated alongside the code so the contracts do not drift into being ornamental.
+
+In parallel, there was a smaller but still important cleanup in the collaboration layer. The document collaboration event normalizer was extracted, cursor presence was made explicit, and the thread ownership payload bugs were fixed in both multi-user creation and remote-auth flows. That work is less visible than the Guardian pipeline, but it solves the same kind of problem: if identity and state are going to matter, they need to be carried cleanly through the system instead of inferred after the fact.
+
+The deeper shift today was toward structural truth. The system stopped depending on implicit knowledge and started encoding more of its own rules. That is what makes the day matter: not that more code exists, but that the code is now more honest about what it expects and what it guarantees.

--- a/docs/DEV_LOG/Weekly-Log copy/2026-04-05 to 2026-04-10.md
+++ b/docs/DEV_LOG/Weekly-Log copy/2026-04-05 to 2026-04-10.md
@@ -1,0 +1,144 @@
+# Weekly Narrative Brief
+
+## Codexify Weekly Update
+
+This week was a **hardening week**.
+
+The strongest progress was not in flashy new surface area, but in making Codexify more truthful, more bounded, and more usable under real operating conditions.
+
+### What improved
+
+#### 1. Identity and retrieval got stricter
+
+We tightened the rules around **where context comes from**, **how retrieval is allowed to widen**, and **what identity boundaries must remain intact**.
+
+That included work on:
+
+- provenance filtering
+    
+- imprint prompt tracing
+    
+- verified personal-facts injection into deep context assembly
+    
+- identity-boundary evaluation coverage
+    
+- supported-path retrieval proof maintenance
+    
+
+The effect is simple: Codexify is getting better at staying grounded in the right scope instead of quietly smearing context across threads, projects, or identity layers.
+
+#### 2. Import and restoration paths became more resilient
+
+This week also improved the reliability of imported content and restoration behavior.
+
+That included:
+
+- batched ChatGPT import embedding retries
+    
+- startup sweep behavior for import catch-up
+    
+- restoring imported projects with cleaner native titles
+    
+- built-in help ingest at Guardian startup
+    
+
+This continues the broader direction of making Codexify feel less like a fragile prototype and more like a durable local knowledge workspace.
+
+#### 3. The operator shell became more stable
+
+A significant portion of the week went into frontend shell polish and navigation stability.
+
+That included:
+
+- moving Settings into the utility gear entrypoint
+    
+- jump-to-latest support
+    
+- mobile shell profile work
+    
+- refined mobile nav behavior
+    
+- workspace summon behavior improvements
+    
+- settings dock/layout fixes and anchoring work
+    
+
+This is important because Codexify is no longer just being shaped as a chat pane. It is being shaped as an **operator surface** that has to remain legible while people move between chat, workspace, settings, imprint/persona controls, and document flows.
+
+#### 4. Audit and proof surfaces stayed in sync
+
+We also refreshed daily and weekly audit material, added new ritual/review generators, and kept the evidence pack current as the system moved.
+
+That matters because release readiness in Codexify should not be inferred from vibes. It should be argued from proof surfaces, supported-path validation, and explicit quarantine boundaries.
+
+---
+
+## What this means
+
+The system moved further toward:
+
+- **bounded retrieval**
+    
+- **explicit provenance**
+    
+- **cleaner identity separation**
+    
+- **stronger import durability**
+    
+- **more stable shell behavior across desktop and mobile**
+    
+
+In short:
+
+**Codexify is becoming a more disciplined local cognitive workspace, not just a more featureful one.**
+
+---
+
+## Current release posture
+
+The release promise is still intentionally narrow.
+
+We are still treating the supported path as:
+
+- local Docker Compose
+    
+- local-only provider posture
+    
+- validated chat -> worker -> persistence loop
+    
+- validated upload -> parse -> embed -> retrieve path
+    
+
+Some surfaces continue to advance behind the curtain, but they are **not automatically part of the beta promise** just because code exists for them.
+
+That includes areas like:
+
+- personal facts as a supported beta surface
+    
+- delegation/autonomous execution as a released promise
+    
+- internal operator surfaces being treated as public beta surface by default
+    
+
+That restraint is deliberate. The goal is to keep the promise truthful while the system hardens.
+
+---
+
+## Bottom line
+
+This week improved **trustworthiness more than spectacle**.
+
+The machine got better at:
+
+- staying inside the right boundaries
+    
+- preserving provenance
+    
+- recovering imported knowledge
+    
+- maintaining shell stability
+    
+- keeping audit language aligned with runtime reality
+    
+
+That is the kind of week that makes later expansion safer.


### PR DESCRIPTION
## Summary
- add the batch of Dev Log markdown files for 2026-05-31 through 2026-07-10
- add the weekly dev log copy file

## Notes
- docs-only change
- branch is clean and pushed