### PR TITLE
Add canonical audit evidence validator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Codexify Makefile
 
-.PHONY: all install dev-install test clean lint lint-fix lint-fix-unsafe format check docs docs-diagram-freshness docs-diagram-freshness-strict docs-diagram-freshness-auto docs-diagram-watch docs-diagram-regenerate build check-pytest dossier-collab desktop-dev desktop-build daily-audit morning-audit evening-audit guardian-brief guardian-evidence-packets-validate guardian-evidence-bounded-read guardian-evidence-reducer-dry-run guardian-evidence-reducer-input-bundles-validate guardian-evidence-reducer-input-bundle-dry-run guardian-evidence-packet-generate audit-unity audit-risk audit-gates audit-gates-pre-merge audit-gates-pre-release audit-full audit-traps audit-ritual-weekly audit-ritual-monthly audit-ritual-quarterly heartbeat heartbeat-review heartbeat-stage heartbeat-inspect heartbeat-outbox heartbeat-full generate-marketing generate-marketing-automation public-export public-sync
+.PHONY: all install dev-install test clean lint lint-fix lint-fix-unsafe format check docs docs-diagram-freshness docs-diagram-freshness-strict docs-diagram-freshness-auto docs-diagram-watch docs-diagram-regenerate build check-pytest dossier-collab desktop-dev desktop-build daily-audit morning-audit evening-audit guardian-brief guardian-evidence-packets-validate guardian-evidence-bounded-read guardian-evidence-reducer-dry-run guardian-evidence-reducer-input-bundles-validate guardian-evidence-reducer-input-bundle-dry-run guardian-evidence-packet-generate canonical-audit-evidence-validate audit-unity audit-risk audit-gates audit-gates-pre-merge audit-gates-pre-release audit-full audit-traps audit-ritual-weekly audit-ritual-monthly audit-ritual-quarterly heartbeat heartbeat-review heartbeat-stage heartbeat-inspect heartbeat-outbox heartbeat-full generate-marketing generate-marketing-automation public-export public-sync
 
 # Python executable
 PYTHON      ?= python
@@ -211,6 +211,11 @@ guardian-brief:
 # Validate GuardianEvidencePacket fixtures locally.
 guardian-evidence-packets-validate:
 	python3 scripts/guardian/validate_evidence_packets.py --json
+
+# Validate one canonical audit evidence manifest without generating or promoting it.
+canonical-audit-evidence-validate:
+	@test -n "$(manifest)" || { echo "Usage: make canonical-audit-evidence-validate manifest=path/to/manifest.json" >&2; exit 2; }
+	$(PYTHON) scripts/audit/validate_canonical_evidence.py "$(manifest)" --json
 
 # Run local stdout-only Guardian Evidence Packet generator.
 guardian-evidence-packet-generate:

--- a/docs/architecture/00-current-state.md
+++ b/docs/architecture/00-current-state.md
@@ -25,7 +25,9 @@ Codexify is in local-first beta hardening on `main`. The supported path remains 
 ## Phase 2 canonical evidence model
 
 - ADR-042 and `schemas/audit/canonical-audit-evidence.schema.json` now define the intended canonical audit evidence model.
+- A test-backed repository-local canonical evidence validator now validates one manifest's schema, bounded semantics, artifact hashes, and eligibility; it is local tooling, not runtime proof.
 - Canonical audit producers and consumers have not yet been migrated, and trusted `latest` promotion remains unimplemented.
+- No VaultNode identity collector exists yet; historical artifacts are not automatically canonical.
 - Existing artifacts remain historical or provisional until revalidated under the new model.
 - Campaign posture remains `HOLD / NEXT_PROOF_NEEDED`; the next implementation slice is VaultNode evidence identity collection or schema-validation integration, not feature expansion.
 

--- a/docs/architecture/canonical-audit-evidence-contract.md
+++ b/docs/architecture/canonical-audit-evidence-contract.md
@@ -174,6 +174,16 @@ failure/blockage and lineage, surface stale coverage, distinguish latest
 observation from latest proven baseline, and never promote evidence merely from
 timestamp, location, or generated prose.
 
+## Implementation status
+
+A repository-local validator now validates one manifest against the existing
+Draft 2020-12 schema, applies bounded single-manifest authority and repository
+consistency checks, verifies repository-relative artifact hashes, and reports
+canonical eligibility. It is local tooling only: it does not accept or promote
+evidence, collect host identity, compare declared values with live Git or
+runtime state, resolve cross-record supersession or contradiction, migrate
+producers or consumers, or implement trusted `latest`.
+
 ## Deferred implementation work
 
 VaultNode identity capture, semantic validation, producer emission, hashing,

--- a/scripts/audit/validate_canonical_evidence.py
+++ b/scripts/audit/validate_canonical_evidence.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Validate one canonical audit evidence manifest without mutating repository state."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path, PureWindowsPath
+from typing import Any
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+
+RESULT_SCHEMA_VERSION = "canonical_audit_evidence_validation_result.v1"
+VALIDATOR_VERSION = "canonical_audit_evidence_validator.v1"
+DEFAULT_REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCHEMA_PATH = (
+    DEFAULT_REPO_ROOT / "schemas/audit/canonical-audit-evidence.schema.json"
+)
+_FORMAT_CHECKER = FormatChecker()
+
+
+def _relative_reference(path: Path, repo_root: Path) -> str:
+    """Return a portable reference without exposing an absolute local path."""
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except (OSError, ValueError):
+        return path.name or "manifest.json"
+
+
+def _json_path(parts: Any) -> str:
+    return "$" + "".join(
+        f"[{part}]" if isinstance(part, int) else "." + str(part)
+        for part in parts
+    )
+
+
+def _is_absolute(value: str) -> bool:
+    return Path(value).is_absolute() or PureWindowsPath(value).is_absolute()
+
+
+def _has_parent_traversal(value: str) -> bool:
+    return ".." in value.replace("\\", "/").split("/")
+
+
+def _issue(
+    severity: str, code: str, path: str, message: str, remediation_hint: str
+) -> dict[str, str]:
+    return {
+        "issue_id": "",
+        "severity": severity,
+        "code": code,
+        "path": path,
+        "message": message,
+        "remediation_hint": remediation_hint,
+    }
+
+
+def _finalize_issues(issues: list[dict[str, str]]) -> list[dict[str, str]]:
+    ordered = sorted(
+        issues,
+        key=lambda item: (item["path"], item["code"], item["message"], item["severity"]),
+    )
+    for number, item in enumerate(ordered, start=1):
+        item["issue_id"] = f"issue-{number:04d}"
+    return ordered
+
+
+def _value(manifest: dict[str, Any], *path: str) -> Any:
+    current: Any = manifest
+    for part in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current
+
+
+def _validate_semantics(manifest: dict[str, Any], issues: list[dict[str, str]]) -> None:
+    authority = manifest.get("authority_status")
+    machine_id = _value(manifest, "machine", "machine_id")
+    machine_role = _value(manifest, "machine", "machine_role")
+    if authority == "CANONICAL":
+        if machine_id != "vaultnode":
+            issues.append(_issue("error", "canonical_machine_id_invalid", "$.machine.machine_id", "Canonical evidence must declare machine_id 'vaultnode'.", "Use the canonical VaultNode machine identifier."))
+        if machine_role != "canonical_evidence_host":
+            issues.append(_issue("error", "canonical_machine_role_invalid", "$.machine.machine_role", "Canonical evidence must declare role 'canonical_evidence_host'.", "Use the canonical evidence host role."))
+        if _value(manifest, "repository", "branch") != "main":
+            issues.append(_issue("error", "canonical_branch_invalid", "$.repository.branch", "Canonical evidence must declare branch 'main'.", "Record the evaluated main branch."))
+        if _value(manifest, "repository", "dirty") is not False:
+            issues.append(_issue("error", "canonical_worktree_dirty", "$.repository.dirty", "Canonical evidence must declare a clean worktree.", "Set dirty to false only for a clean evaluated worktree."))
+        if _value(manifest, "repository", "commit_sha") != _value(manifest, "repository", "upstream_sha"):
+            issues.append(_issue("error", "canonical_commit_upstream_mismatch", "$.repository", "Canonical evidence requires matching commit_sha and upstream_sha.", "Record matching accepted main commit identities."))
+
+        for field in ("repository_root_identity", "worktree_identity"):
+            value = _value(manifest, "repository", field)
+            path = f"$.repository.{field}"
+            if isinstance(value, str) and _is_absolute(value):
+                issues.append(_issue("error", "portable_identity_absolute", path, "Canonical repository identity must be portable and non-absolute.", "Use a repository-relative portable identity."))
+            if isinstance(value, str) and _has_parent_traversal(value):
+                issues.append(_issue("error", "portable_identity_parent_traversal", path, "Canonical repository identity must not contain parent traversal.", "Use a normalized repository-relative identity."))
+
+    if manifest.get("proof_class") == "CURRENT_LIVE_PROOF":
+        runtime = manifest.get("runtime")
+        required = ("supported_profile", "effective_config_hash", "compose_project", "compose_files", "migration_head", "service_identities")
+        incomplete = not isinstance(runtime, dict)
+        if isinstance(runtime, dict):
+            incomplete = any(
+                runtime.get(field) is None or runtime.get(field) == [] or runtime.get(field) == ""
+                for field in required
+            )
+        if incomplete:
+            issues.append(_issue("error", "live_runtime_identity_incomplete", "$.runtime", "CURRENT_LIVE_PROOF requires complete non-empty runtime identity.", "Provide all required supported-profile, configuration, Compose, migration, and service identity fields."))
+
+
+def _validate_artifacts(
+    manifest: dict[str, Any], repo_root: Path, issues: list[dict[str, str]]
+) -> None:
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list):
+        return
+    root = repo_root.resolve()
+    for index, artifact in enumerate(artifacts):
+        if not isinstance(artifact, dict):
+            continue
+        path_value = artifact.get("path")
+        location = f"$.artifacts[{index}].path"
+        if not isinstance(path_value, str):
+            continue
+        if _is_absolute(path_value):
+            issues.append(_issue("error", "artifact_path_absolute", location, "Artifact paths must be repository-relative.", "Use a repository-relative artifact path."))
+            continue
+        if _has_parent_traversal(path_value):
+            issues.append(_issue("error", "artifact_path_parent_traversal", location, "Artifact paths must not contain parent traversal.", "Use a normalized repository-relative artifact path."))
+            continue
+        candidate = (root / path_value).resolve()
+        try:
+            candidate.relative_to(root)
+        except ValueError:
+            issues.append(_issue("error", "artifact_path_outside_repo", location, "Artifact path resolves outside the repository root.", "Reference an artifact contained by the selected repository root."))
+            continue
+        if not candidate.is_file():
+            issues.append(_issue("error", "artifact_missing", location, "Declared artifact is missing.", "Add the artifact or correct its repository-relative path."))
+            continue
+        digest = hashlib.sha256()
+        with candidate.open("rb") as artifact_file:
+            for chunk in iter(lambda: artifact_file.read(1024 * 1024), b""):
+                digest.update(chunk)
+        if artifact.get("sha256") != digest.hexdigest():
+            issues.append(_issue("error", "artifact_hash_mismatch", f"$.artifacts[{index}].sha256", "Declared artifact SHA-256 does not match artifact bytes.", "Update the immutable record with the artifact's lowercase SHA-256."))
+
+
+def validate_manifest(
+    manifest_path: str | Path,
+    schema_path: str | Path = DEFAULT_SCHEMA_PATH,
+    repo_root: str | Path = DEFAULT_REPO_ROOT,
+) -> dict[str, Any]:
+    """Validate one manifest using only its declared contents and local artifacts."""
+    manifest_file = Path(manifest_path)
+    schema_file = Path(schema_path)
+    root = Path(repo_root)
+    issues: list[dict[str, str]] = []
+    manifest: dict[str, Any] | None = None
+    schema_valid = False
+
+    try:
+        raw_manifest = manifest_file.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        issues.append(_issue("error", "manifest_read_error", "$", "Manifest could not be read as UTF-8.", "Provide a readable UTF-8 JSON manifest."))
+    else:
+        try:
+            parsed = json.loads(raw_manifest)
+        except json.JSONDecodeError:
+            issues.append(_issue("error", "manifest_json_invalid", "$", "Manifest is not valid JSON.", "Correct the JSON syntax."))
+        else:
+            if not isinstance(parsed, dict):
+                issues.append(_issue("error", "manifest_root_invalid", "$", "Manifest root must be a JSON object.", "Use an object as the JSON document root."))
+            else:
+                manifest = parsed
+
+    schema: dict[str, Any] | None = None
+    try:
+        schema = json.loads(schema_file.read_text(encoding="utf-8"))
+        Draft202012Validator.check_schema(schema)
+    except (OSError, UnicodeDecodeError):
+        issues.append(_issue("error", "schema_read_error", "$", "Canonical schema could not be read as UTF-8.", "Provide the hydrated canonical audit evidence schema."))
+    except Exception:
+        code = "schema_invalid"
+        issues.append(_issue("error", code, "$", "Canonical schema is invalid.", "Repair the schema in its governing task before validation."))
+
+    if manifest is not None and schema is not None:
+        validator = Draft202012Validator(schema, format_checker=_FORMAT_CHECKER)
+        for error in sorted(validator.iter_errors(manifest), key=lambda err: (_json_path(err.absolute_path), err.message)):
+            issues.append(_issue("error", "schema_validation_error", _json_path(error.absolute_path), error.message, "Correct the manifest to satisfy the canonical Draft 2020-12 schema."))
+        _validate_semantics(manifest, issues)
+        _validate_artifacts(manifest, root, issues)
+
+    issues = _finalize_issues(issues)
+    schema_valid = manifest is not None and schema is not None and not any(
+        issue["code"] == "schema_validation_error" for issue in issues
+    )
+    semantic_valid = manifest is not None and not any(
+        issue["code"].startswith("canonical_")
+        or issue["code"].startswith("portable_identity_")
+        or issue["code"] == "live_runtime_identity_incomplete"
+        for issue in issues
+    )
+    artifact_integrity_valid = manifest is not None and not any(
+        issue["code"].startswith("artifact_") for issue in issues
+    )
+    eligibility_reasons: list[str] = []
+    if not schema_valid:
+        eligibility_reasons.append("schema_invalid")
+    if not semantic_valid:
+        eligibility_reasons.append("semantic_validation_failed")
+    if not artifact_integrity_valid:
+        eligibility_reasons.append("artifact_integrity_failed")
+    if manifest is None or manifest.get("authority_status") != "CANONICAL":
+        eligibility_reasons.append("authority_status_not_canonical")
+    if _value(manifest or {}, "machine", "machine_id") != "vaultnode":
+        eligibility_reasons.append("machine_not_vaultnode")
+    if _value(manifest or {}, "machine", "machine_role") != "canonical_evidence_host":
+        eligibility_reasons.append("machine_role_not_canonical_evidence_host")
+    if manifest is None or manifest.get("freshness_status") != "CURRENT":
+        eligibility_reasons.append("freshness_not_current")
+    if manifest is None or manifest.get("disposition") != "ACCEPTED":
+        eligibility_reasons.append("disposition_not_accepted")
+    canonical_eligible = not eligibility_reasons
+    return {
+        "schema_version": RESULT_SCHEMA_VERSION,
+        "validator_version": VALIDATOR_VERSION,
+        "validated_manifest_ref": _relative_reference(manifest_file, root),
+        "result": "pass" if not issues else "fail",
+        "schema_valid": schema_valid,
+        "semantic_valid": semantic_valid,
+        "artifact_integrity_valid": artifact_integrity_valid,
+        "canonical_eligible": canonical_eligible,
+        "issue_count": len(issues),
+        "issues": issues,
+        "eligibility_reasons": eligibility_reasons,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate one canonical audit evidence manifest.")
+    parser.add_argument("manifest_path")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    parser.add_argument("--schema", default=str(DEFAULT_SCHEMA_PATH))
+    parser.add_argument("--repo-root", default=str(DEFAULT_REPO_ROOT))
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args(argv)
+    result = validate_manifest(args.manifest_path, args.schema, args.repo_root)
+    if args.as_json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    elif not args.quiet:
+        print(f"Canonical audit evidence validation {result['result']}: {result['validated_manifest_ref']} ({result['issue_count']} issue(s))")
+        for issue in result["issues"]:
+            print(f"  [{issue['severity']}] {issue['code']} at {issue['path']}: {issue['message']}")
+    if any(issue["code"] in {"schema_read_error", "schema_invalid"} for issue in result["issues"]):
+        return 2
+    return 0 if result["result"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/audit/fixtures/artifacts/sample-proof.txt
+++ b/tests/audit/fixtures/artifacts/sample-proof.txt
@@ -1,0 +1,1 @@
+Canonical audit evidence fixture artifact.

--- a/tests/audit/fixtures/canonical-evidence.valid.canonical.json
+++ b/tests/audit/fixtures/canonical-evidence.valid.canonical.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d34291a0d5d480be4c098f7681fbacd766f1b142231c5c22aa5943db643f011
+size 1440

--- a/tests/audit/fixtures/canonical-evidence.valid.provisional.json
+++ b/tests/audit/fixtures/canonical-evidence.valid.provisional.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7f08b0c9061f9f6368be7f0a053a3c2443b9db91143bf5985de35dde85be7d6
+size 1464

--- a/tests/audit/test_validate_canonical_evidence.py
+++ b/tests/audit/test_validate_canonical_evidence.py
@@ -1,0 +1,163 @@
+"""Tests for the repository-local canonical audit evidence validator."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from scripts.audit.validate_canonical_evidence import validate_manifest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA = ROOT / "schemas/audit/canonical-audit-evidence.schema.json"
+SCRIPT = ROOT / "scripts/audit/validate_canonical_evidence.py"
+FIXTURES = ROOT / "tests/audit/fixtures"
+CANONICAL = FIXTURES / "canonical-evidence.valid.canonical.json"
+PROVISIONAL = FIXTURES / "canonical-evidence.valid.provisional.json"
+
+
+def _manifest(path: Path = CANONICAL) -> dict:
+    return json.loads(path.read_text())
+
+
+def _write(tmp_path: Path, value: object) -> Path:
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(value), encoding="utf-8")
+    return path
+
+
+def _validate(path: Path) -> dict:
+    return validate_manifest(path, SCHEMA, ROOT)
+
+
+def _codes(result: dict) -> set[str]:
+    return {issue["code"] for issue in result["issues"]}
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, str(SCRIPT), *args], capture_output=True, text=True)
+
+
+def test_schema_is_valid_draft_2020_12() -> None:
+    Draft202012Validator.check_schema(json.loads(SCHEMA.read_text()))
+
+
+def test_valid_canonical_is_pass_and_eligible() -> None:
+    result = _validate(CANONICAL)
+    assert result["result"] == "pass"
+    assert result["canonical_eligible"] is True
+    assert result["artifact_integrity_valid"] is True
+
+
+def test_valid_provisional_passes_but_is_ineligible() -> None:
+    result = _validate(PROVISIONAL)
+    assert result["result"] == "pass"
+    assert result["canonical_eligible"] is False
+    assert "authority_status_not_canonical" in result["eligibility_reasons"]
+
+
+def test_malformed_json_and_non_object_root_fail(tmp_path: Path) -> None:
+    malformed = tmp_path / "broken.json"
+    malformed.write_text("{", encoding="utf-8")
+    assert "manifest_json_invalid" in _codes(_validate(malformed))
+    assert "manifest_root_invalid" in _codes(_validate(_write(tmp_path, [])))
+
+
+def test_schema_errors_include_stable_json_path(tmp_path: Path) -> None:
+    manifest = _manifest()
+    del manifest["execution"]
+    result = _validate(_write(tmp_path, manifest))
+    issue = next(issue for issue in result["issues"] if issue["code"] == "schema_validation_error")
+    assert issue["path"] == "$"
+
+
+def test_canonical_authority_and_repository_rules(tmp_path: Path) -> None:
+    cases = [
+        ("machine_id", "other", "canonical_machine_id_invalid"),
+        ("machine_role", "provisional_development_host", "canonical_machine_role_invalid"),
+        ("branch", "feature", "canonical_branch_invalid"),
+        ("dirty", True, "canonical_worktree_dirty"),
+        ("upstream_sha", "fedcba9876543210fedcba9876543210fedcba98", "canonical_commit_upstream_mismatch"),
+    ]
+    for field, value, code in cases:
+        manifest = _manifest()
+        target = manifest["machine"] if field.startswith("machine") else manifest["repository"]
+        target[field] = value
+        assert code in _codes(_validate(_write(tmp_path, manifest)))
+
+
+def test_live_runtime_requires_complete_identity_and_other_proof_can_be_null(tmp_path: Path) -> None:
+    manifest = _manifest()
+    manifest["proof_class"] = "CURRENT_LIVE_PROOF"
+    assert "live_runtime_identity_incomplete" in _codes(_validate(_write(tmp_path, manifest)))
+    assert _validate(CANONICAL)["semantic_valid"] is True
+
+
+def test_artifact_errors_fail_closed(tmp_path: Path) -> None:
+    cases = [
+        ("missing.txt", "artifact_missing"),
+        ("/tmp/proof.txt", "artifact_path_absolute"),
+        ("../proof.txt", "artifact_path_parent_traversal"),
+    ]
+    for path, code in cases:
+        manifest = _manifest()
+        manifest["artifacts"][0]["path"] = path
+        assert code in _codes(_validate(_write(tmp_path, manifest)))
+    manifest = _manifest()
+    manifest["artifacts"][0]["sha256"] = "0" * 64
+    assert "artifact_hash_mismatch" in _codes(_validate(_write(tmp_path, manifest)))
+
+
+def test_symlink_escape_fails(tmp_path: Path) -> None:
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside", encoding="utf-8")
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "escape.txt").symlink_to(outside)
+    manifest = _manifest()
+    manifest["artifacts"][0]["path"] = "escape.txt"
+    assert "artifact_path_outside_repo" in _codes(validate_manifest(_write(tmp_path, manifest), SCHEMA, root))
+
+
+def test_stale_or_nonaccepted_canonical_records_are_ineligible(tmp_path: Path) -> None:
+    for field, value in (("freshness_status", "STALE"), ("disposition", "REJECTED"), ("disposition", "SUPERSEDED")):
+        manifest = _manifest()
+        manifest[field] = value
+        result = _validate(_write(tmp_path, manifest))
+        assert result["result"] == "pass"
+        assert result["canonical_eligible"] is False
+
+
+def test_failure_outcomes_remain_eligible_observations(tmp_path: Path) -> None:
+    for outcome in ("FAIL", "BLOCKED", "ERROR"):
+        manifest = _manifest()
+        manifest["execution_outcome"] = outcome
+        result = _validate(_write(tmp_path, manifest))
+        assert result["result"] == "pass"
+        assert result["canonical_eligible"] is True
+
+
+def test_result_and_cli_json_are_deterministic(tmp_path: Path) -> None:
+    manifest = _manifest()
+    manifest["machine"]["machine_id"] = "other"
+    manifest["artifacts"][0]["path"] = "../missing.txt"
+    path = _write(tmp_path, manifest)
+    assert _validate(path) == _validate(path)
+    first, second = _run(str(path), "--json"), _run(str(path), "--json")
+    assert first.returncode == second.returncode == 1
+    assert first.stdout == second.stdout
+    issues = json.loads(first.stdout)["issues"]
+    assert [issue["issue_id"] for issue in issues] == [f"issue-{i:04d}" for i in range(1, len(issues) + 1)]
+
+
+def test_cli_exit_codes_and_human_output_are_safe(tmp_path: Path) -> None:
+    assert _run(str(CANONICAL), "--json").returncode == 0
+    failed = _run(str(_write(tmp_path, {"schema_version": "bad"})), "--json")
+    assert failed.returncode == 1
+    assert _run().returncode == 2
+    human = _run(str(CANONICAL))
+    assert str(ROOT) not in human.stdout


### PR DESCRIPTION
Closes #558

## Summary

Adds a deterministic repository-local validator for the canonical audit evidence contract defined by ADR-041 and ADR-042.

The validator provides:

- Draft 2020-12 JSON Schema validation
- bounded single-manifest semantic validation
- canonical eligibility classification
- repository-relative artifact path and SHA-256 verification
- deterministic CLI and machine-readable output
- canonical and provisional fixtures
- focused test coverage
- a Make target
- narrow current-truth documentation updates

## Validation

- `.venv/bin/python -m pytest -v tests/audit/test_validate_canonical_evidence.py`
  - 13 passed
- Canonical fixture CLI validation
  - passed
- Provisional fixture CLI validation
  - passed
- `make PYTHON=.venv/bin/python canonical-audit-evidence-validate ...`
  - passed
- `make guardian-evidence-packets-validate`
  - passed with pre-existing warnings only
- `python3 scripts/validate_docs.py`
  - passed
- `git diff --check`
  - passed

## Boundaries

This does not implement:

- VaultNode identity collection
- evidence generation
- producer or consumer migration
- evidence acceptance or promotion
- trusted `latest`
- live-runtime proof
- cross-record supersession or contradiction resolution

## ADR impact

Aligned with ADR-041 and ADR-042. No new ADR required.