### PR TITLE
Gate Project Pulse resume

### DIFF
--- a/docs/guardian/work-briefs/2026-07-12/project-pulse-resume-gate.md
+++ b/docs/guardian/work-briefs/2026-07-12/project-pulse-resume-gate.md
@@ -1,0 +1,143 @@
+# Project Pulse Resume Gate — 2026-07-12
+
+## Purpose
+
+This gate answers one bounded question: can Project Pulse work resume from
+latest `main` without dirty-state ambiguity? It records repository evidence
+only. It is not Project Pulse implementation, runtime proof, or release
+approval.
+
+## Source documents
+
+- `docs/architecture/00-current-state.md`
+- `docs/architecture/README.md`
+- `docs/architecture/agent-protocol-operations.md`
+- `docs/guardian/work-briefs/2026-07-12/worktree-drift-classification.md`
+- `docs/architecture/project-pulse-read-only-contract.md`
+- `.gitignore`
+- `docs/guardian/work-briefs/.gitignore`
+
+## Recent merged prerequisites
+
+- PR #560: Guardian Work Brief drift classification merged. This records
+  worktree/reporting drift; it does not prove runtime health or Project Pulse
+  readiness.
+- PR #561: generated Guardian Work Brief packet artifacts ignored. This
+  separates generated reporting artifacts from deliberate dated documents; it
+  does not prove runtime health or Project Pulse readiness.
+- PR #564: Guardian Evidence packet dry-run Make target merged. This adds
+  local diagnostics-only tooling; it does not prove runtime health or Project
+  Pulse readiness.
+
+## Current branch and HEAD
+
+- Branch: `codex/project-pulse-resume-gate`
+- HEAD: `12072654e` (`Merge pull request #564 from Resonant-Jones/codex/guardian-evidence-packet-dry-run-make-target`)
+- Base: latest local `main` after `git pull --ff-only`, matching `origin/main`
+- Upstream: not yet configured for this fresh branch
+
+## Worktree status
+
+The ordinary `git status --short --branch --untracked-files=all` probe is
+blocked by the local Git LFS filter attempting to write under
+`/Volumes/Dev_SSD/Codexify-main/.git/lfs/tmp/`. A read-only status probe with
+the LFS filters disabled reports these tracked modifications:
+
+| Path | Observed state | Gate treatment |
+|---|---|---|
+| `tests/audit/fixtures/canonical-evidence.valid.canonical.json` | modified | Unrelated pre-existing LFS checkout drift; preserved and not staged |
+| `tests/audit/fixtures/canonical-evidence.valid.provisional.json` | modified | Unrelated pre-existing LFS checkout drift; preserved and not staged |
+
+No staged changes were reported. `git ls-files --others --exclude-standard`
+reports no unrelated untracked files; the generated packet files are ignored
+and therefore do not appear in that list. The two tracked modifications leave
+the worktree ambiguous enough that Project Pulse work must not resume yet.
+
+## Ignore-rule verification
+
+The required checks produced the following results:
+
+| Path | Result |
+|---|---|
+| `docs/guardian/work-briefs/2026-07-12/axis-brief.md` | ignored by `docs/guardian/work-briefs/.gitignore` |
+| `docs/guardian/work-briefs/2026-07-12/codex-next-task-packet.md` | ignored by `docs/guardian/work-briefs/.gitignore` |
+| `docs/guardian/work-briefs/2026-07-12/decision-log.md` | ignored by `docs/guardian/work-briefs/.gitignore` |
+| `docs/guardian/work-briefs/2026-07-12/truth-ledger.md` | ignored by `docs/guardian/work-briefs/.gitignore` |
+| `docs/guardian/work-briefs/2026-07-12/project-pulse-resume-gate.md` | not ignored; remains trackable |
+
+Generated Guardian Work Brief packet files were not deleted, moved, cleaned,
+or staged.
+
+## Project Pulse context found on `main`
+
+Read-only discovery found one direct Project Pulse contract:
+
+- `docs/architecture/project-pulse-read-only-contract.md` — docs-only future
+  read-only interpretive surface; it explicitly does not implement runtime,
+  routes, migrations, UI, workers, or writes.
+
+The broader Continuity documents contain Project Pulse boundary references and
+future-contract vocabulary. No Project Pulse implementation files, runtime
+routes, UI, storage tables, migrations, workers, or write paths were found by
+the required read-only search.
+
+## Gate classification table
+
+| Evidence | Result | Blocks Project Pulse resume? | Notes |
+|---|---|---:|---|
+| Latest `main` sync | pass | No | Branch was created from `12072654e`, latest `main` after PR #564. |
+| Generated Work Brief ignore behavior | pass | No | Four generated packet names are ignored; this gate document remains trackable. |
+| Worktree cleanliness | fail | Yes | LFS-disabled status exposes two tracked fixture modifications. |
+| Project Pulse existing docs/contracts found | pass | No | A docs-only read-only contract exists; no implementation was found. |
+| Release-truth boundary | pass | No | `00-current-state.md` remains authoritative and the beta surface is unchanged. |
+| Unrelated dirty or untracked files | hold | Yes | Two unrelated tracked LFS fixture modifications remain; no cleanup is authorized here. |
+| Guardian Evidence tooling now merged | pass | No | PR #564 is present on latest `main` as local diagnostics-only tooling. |
+| Recommended next slice | hold | Yes | Resolve the tracked LFS checkout drift before resuming Project Pulse work. |
+
+## Release-truth boundary
+
+`docs/architecture/00-current-state.md` remains authoritative for supported
+install path, active blockers, and release promise.
+
+This resume gate does not prove runtime health. This resume gate does not widen
+the supported beta surface. This resume gate does not approve release
+readiness. This resume gate does not implement Project Pulse.
+
+## Decision
+
+Outcome: hold
+
+The repository has the expected latest `main` prerequisites and a trackable
+gate path, but tracked LFS fixture modifications create unresolved dirty-state
+ambiguity. They must be separately repaired or classified before Project Pulse
+work resumes.
+
+## Recommended next slice
+
+Hold for worktree cleanup
+
+## Non-goals
+
+- No Project Pulse runtime, UI, storage, route, worker, provider, or write-path
+  implementation.
+- No runtime, frontend, backend, scripts, fixtures, tests, Makefile,
+  migrations, database models, Compose files, CI workflows, or unrelated
+  architecture-document changes.
+- No deletion, cleanup, move, stash, or rewrite of generated packet artifacts
+  or unrelated tracked modifications.
+- No release approval, runtime-health claim, or supported-beta expansion.
+
+## Validation results
+
+- Required preflight log, status, ignore checks, and read-only Project Pulse
+  searches: completed.
+- Latest `main` sync: `git checkout main && git pull --ff-only` passed; branch
+  created at `12072654e`.
+- Ignore checks: four generated packet paths ignored; this gate path not
+  ignored.
+- `git diff --check`: pending final validation after this document is written.
+- `test -f` and outcome-line checks: pending final validation after this
+  document is written.
+- `python3 scripts/validate_docs.py`: pending final validation after this
+  document is written.
+- No automated runtime tests apply.


### PR DESCRIPTION
Adds a docs-only Project Pulse resume gate. Outcome is hold because unrelated LFS fixture checkout drift remains. No runtime, UI, backend, tests, Makefile, scripts, fixtures, or Project Pulse implementation changed. Validation passed locally per closeout.