### PR TITLE
Fix canonical evidence validator CI inputs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,8 @@ codex_runner/schemas/*.json -filter -diff -merge text
 
 # Golden marketing fixtures must remain plaintext JSON for deterministic tests
 tests/fixtures/marketing/golden/**/*.json -filter -diff -merge text
+
+# Canonical audit validator inputs are small deterministic source files, not LFS artifacts.
+schemas/audit/canonical-audit-evidence.schema.json -filter -diff -merge text
+tests/audit/fixtures/canonical-evidence.valid.canonical.json -filter -diff -merge text
+tests/audit/fixtures/canonical-evidence.valid.provisional.json -filter -diff -merge text

--- a/backend/requirements-ci.txt
+++ b/backend/requirements-ci.txt
@@ -33,3 +33,4 @@ neomodel
 # Lightweight retrieval helpers used by deterministic tests.
 markdownify
 rank-bm25
+jsonschema==4.25.0

--- a/schemas/audit/canonical-audit-evidence.schema.json
+++ b/schemas/audit/canonical-audit-evidence.schema.json
@@ -1,3 +1,164 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:38f2afaeb983e6268376eede40bc36ef3390abf9dce207c6f19df5f48295bef3
-size 6998
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schemas/audit/canonical-audit-evidence.schema.json",
+  "title": "Canonical Audit Evidence Manifest",
+  "description": "Shape and vocabulary contract for immutable Codexify audit and proof observations. Semantic promotion checks require future implementation.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "evidence_id",
+    "authority_status",
+    "proof_class",
+    "freshness_status",
+    "disposition",
+    "execution_outcome",
+    "created_at",
+    "machine",
+    "repository",
+    "runtime",
+    "execution",
+    "claims",
+    "artifacts",
+    "relationships"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "minLength": 1 },
+    "evidence_id": { "type": "string", "minLength": 1 },
+    "authority_status": { "type": "string", "enum": ["CANONICAL", "PROVISIONAL"] },
+    "proof_class": { "type": "string", "enum": ["CURRENT_LIVE_PROOF", "CURRENT_TEST_PROOF", "HISTORICAL_LIVE_PROOF", "IMPLEMENTED_UNPROVEN", "PARTIAL_VERTICAL_SLICE", "DOCS_ONLY", "BLOCKED", "UNKNOWN"] },
+    "freshness_status": { "type": "string", "enum": ["CURRENT", "STALE"] },
+    "disposition": { "type": "string", "enum": ["ACCEPTED", "SUPERSEDED", "CONTRADICTED", "REJECTED"] },
+    "execution_outcome": { "type": "string", "enum": ["PASS", "FAIL", "BLOCKED", "ERROR", "NOT_APPLICABLE"] },
+    "created_at": { "type": "string", "format": "date-time" },
+    "machine": { "$ref": "#/$defs/machine" },
+    "repository": { "$ref": "#/$defs/repository" },
+    "runtime": { "$ref": "#/$defs/runtime" },
+    "execution": { "$ref": "#/$defs/execution" },
+    "claims": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["supported", "disproved", "unresolved"],
+      "properties": {
+        "supported": { "type": "array", "items": { "$ref": "#/$defs/claim" } },
+        "disproved": { "type": "array", "items": { "$ref": "#/$defs/claim" } },
+        "unresolved": { "type": "array", "items": { "$ref": "#/$defs/claim" } }
+      }
+    },
+    "artifacts": { "type": "array", "items": { "$ref": "#/$defs/artifact" } },
+    "relationships": { "$ref": "#/$defs/relationships" }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "authority_status": { "const": "CANONICAL" }
+        },
+        "required": ["authority_status"]
+      },
+      "then": {
+        "properties": {
+          "machine": {
+            "properties": {
+              "machine_id": { "const": "vaultnode" },
+              "machine_role": { "const": "canonical_evidence_host" }
+            }
+          },
+          "repository": {
+            "properties": {
+              "branch": { "const": "main" },
+              "dirty": { "const": false }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "machine": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["machine_id", "machine_role", "hostname", "authority_basis"],
+      "properties": {
+        "machine_id": { "type": "string", "minLength": 1 },
+        "machine_role": { "type": "string", "enum": ["canonical_evidence_host", "provisional_development_host"] },
+        "hostname": { "type": "string", "minLength": 1 },
+        "authority_basis": { "type": "string", "minLength": 1 }
+      }
+    },
+    "repository": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository_root_identity", "branch", "commit_sha", "upstream_sha", "dirty", "worktree_identity"],
+      "properties": {
+        "repository_root_identity": { "type": "string", "minLength": 1, "pattern": "^(?!/).+" },
+        "branch": { "type": "string", "minLength": 1 },
+        "commit_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "upstream_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "dirty": { "type": "boolean" },
+        "worktree_identity": { "type": "string", "minLength": 1 },
+        "diagnostic_working_path": { "type": "string", "minLength": 1 }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["supported_profile", "effective_config_hash", "compose_project", "compose_files", "migration_head", "service_identities"],
+      "properties": {
+        "supported_profile": { "type": ["string", "null"], "minLength": 1 },
+        "effective_config_hash": { "type": ["string", "null"], "pattern": "^[0-9a-f]{64}$" },
+        "compose_project": { "type": ["string", "null"], "minLength": 1 },
+        "compose_files": { "type": ["array", "null"], "items": { "type": "string", "minLength": 1 } },
+        "migration_head": { "type": ["string", "null"], "minLength": 1 },
+        "service_identities": { "type": ["array", "null"], "items": { "type": "string", "minLength": 1 } }
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["suite_id", "commands", "started_at", "completed_at", "exit_code", "summary"],
+      "properties": {
+        "suite_id": { "type": "string", "minLength": 1 },
+        "commands": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "started_at": { "type": "string", "format": "date-time" },
+        "completed_at": { "type": "string", "format": "date-time" },
+        "exit_code": { "type": ["integer", "null"], "minimum": 0 },
+        "summary": { "type": "string", "minLength": 1 }
+      }
+    },
+    "claim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["claim_id", "statement", "scope", "evidence_refs", "reason"],
+      "properties": {
+        "claim_id": { "type": "string", "minLength": 1 },
+        "statement": { "type": "string", "minLength": 1 },
+        "scope": { "type": "string", "minLength": 1 },
+        "evidence_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "reason": { "type": "string", "minLength": 1 }
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifact_id", "path", "sha256", "media_type", "artifact_role"],
+      "properties": {
+        "artifact_id": { "type": "string", "minLength": 1 },
+        "path": { "type": "string", "minLength": 1, "pattern": "^(?!/).+" },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "media_type": { "type": "string", "minLength": 1 },
+        "artifact_role": { "type": "string", "minLength": 1 }
+      }
+    },
+    "relationships": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["supersedes", "contradicts", "derived_from"],
+      "properties": {
+        "supersedes": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "contradicts": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "derived_from": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+      }
+    }
+  }
+}

--- a/tests/audit/fixtures/canonical-evidence.valid.canonical.json
+++ b/tests/audit/fixtures/canonical-evidence.valid.canonical.json
@@ -1,3 +1,17 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d34291a0d5d480be4c098f7681fbacd766f1b142231c5c22aa5943db643f011
-size 1440
+{
+  "schema_version": "canonical_audit_evidence.v1",
+  "evidence_id": "fixture-canonical-001",
+  "authority_status": "CANONICAL",
+  "proof_class": "CURRENT_TEST_PROOF",
+  "freshness_status": "CURRENT",
+  "disposition": "ACCEPTED",
+  "execution_outcome": "PASS",
+  "created_at": "2026-07-12T00:00:00Z",
+  "machine": {"machine_id": "vaultnode", "machine_role": "canonical_evidence_host", "hostname": "redacted", "authority_basis": "ADR-041"},
+  "repository": {"repository_root_identity": "codexify", "branch": "main", "commit_sha": "0123456789abcdef0123456789abcdef01234567", "upstream_sha": "0123456789abcdef0123456789abcdef01234567", "dirty": false, "worktree_identity": "audit"},
+  "runtime": {"supported_profile": null, "effective_config_hash": null, "compose_project": null, "compose_files": null, "migration_head": null, "service_identities": null},
+  "execution": {"suite_id": "fixture", "commands": ["fixture"], "started_at": "2026-07-12T00:00:00Z", "completed_at": "2026-07-12T00:00:01Z", "exit_code": 0, "summary": "Controlled fixture only."},
+  "claims": {"supported": [], "disproved": [], "unresolved": []},
+  "artifacts": [{"artifact_id": "sample-proof", "path": "tests/audit/fixtures/artifacts/sample-proof.txt", "sha256": "1db8575603ddda3de79b8a024b8511834c6e3666658cf28d8ed3755a6d835fa8", "media_type": "text/plain", "artifact_role": "fixture"}],
+  "relationships": {"supersedes": [], "contradicts": [], "derived_from": []}
+}

--- a/tests/audit/fixtures/canonical-evidence.valid.provisional.json
+++ b/tests/audit/fixtures/canonical-evidence.valid.provisional.json
@@ -1,3 +1,17 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c7f08b0c9061f9f6368be7f0a053a3c2443b9db91143bf5985de35dde85be7d6
-size 1464
+{
+  "schema_version": "canonical_audit_evidence.v1",
+  "evidence_id": "fixture-provisional-001",
+  "authority_status": "PROVISIONAL",
+  "proof_class": "CURRENT_TEST_PROOF",
+  "freshness_status": "CURRENT",
+  "disposition": "ACCEPTED",
+  "execution_outcome": "PASS",
+  "created_at": "2026-07-12T00:00:00Z",
+  "machine": {"machine_id": "developer-laptop", "machine_role": "provisional_development_host", "hostname": "redacted", "authority_basis": "ADR-041"},
+  "repository": {"repository_root_identity": "codexify", "branch": "feature", "commit_sha": "0123456789abcdef0123456789abcdef01234567", "upstream_sha": "fedcba9876543210fedcba9876543210fedcba98", "dirty": true, "worktree_identity": "development"},
+  "runtime": {"supported_profile": null, "effective_config_hash": null, "compose_project": null, "compose_files": null, "migration_head": null, "service_identities": null},
+  "execution": {"suite_id": "fixture", "commands": ["fixture"], "started_at": "2026-07-12T00:00:00Z", "completed_at": "2026-07-12T00:00:01Z", "exit_code": 0, "summary": "Controlled fixture only."},
+  "claims": {"supported": [], "disproved": [], "unresolved": []},
+  "artifacts": [{"artifact_id": "sample-proof", "path": "tests/audit/fixtures/artifacts/sample-proof.txt", "sha256": "1db8575603ddda3de79b8a024b8511834c6e3666658cf28d8ed3755a6d835fa8", "media_type": "text/plain", "artifact_role": "fixture"}],
+  "relationships": {"supersedes": [], "contradicts": [], "derived_from": []}
+}


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
