### PR TITLE
Add canonical evidence identity collector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Codexify Makefile
 
-.PHONY: all install dev-install test clean lint lint-fix lint-fix-unsafe format check docs docs-diagram-freshness docs-diagram-freshness-strict docs-diagram-freshness-auto docs-diagram-watch docs-diagram-regenerate build check-pytest dossier-collab desktop-dev desktop-build daily-audit morning-audit evening-audit guardian-brief guardian-evidence-packets-validate guardian-evidence-bounded-read guardian-evidence-reducer-dry-run guardian-evidence-reducer-input-bundles-validate guardian-evidence-reducer-input-bundle-dry-run guardian-evidence-packet-generate canonical-audit-evidence-validate audit-unity audit-risk audit-gates audit-gates-pre-merge audit-gates-pre-release audit-full audit-traps audit-ritual-weekly audit-ritual-monthly audit-ritual-quarterly heartbeat heartbeat-review heartbeat-stage heartbeat-inspect heartbeat-outbox heartbeat-full generate-marketing generate-marketing-automation public-export public-sync
+.PHONY: all install dev-install test clean lint lint-fix lint-fix-unsafe format check docs docs-diagram-freshness docs-diagram-freshness-strict docs-diagram-freshness-auto docs-diagram-watch docs-diagram-regenerate build check-pytest dossier-collab desktop-dev desktop-build daily-audit morning-audit evening-audit guardian-brief guardian-evidence-packets-validate guardian-evidence-bounded-read guardian-evidence-reducer-dry-run guardian-evidence-reducer-input-bundles-validate guardian-evidence-reducer-input-bundle-dry-run guardian-evidence-packet-generate canonical-audit-evidence-validate canonical-audit-evidence-identity audit-unity audit-risk audit-gates audit-gates-pre-merge audit-gates-pre-release audit-full audit-traps audit-ritual-weekly audit-ritual-monthly audit-ritual-quarterly heartbeat heartbeat-review heartbeat-stage heartbeat-inspect heartbeat-outbox heartbeat-full generate-marketing generate-marketing-automation public-export public-sync
 
 # Python executable
 PYTHON      ?= python
@@ -216,6 +216,9 @@ guardian-evidence-packets-validate:
 canonical-audit-evidence-validate:
 	@test -n "$(manifest)" || { echo "Usage: make canonical-audit-evidence-validate manifest=path/to/manifest.json" >&2; exit 2; }
 	$(PYTHON) scripts/audit/validate_canonical_evidence.py "$(manifest)" --json
+
+canonical-audit-evidence-identity:
+	$(PYTHON) scripts/audit/collect_canonical_evidence_identity.py $(if $(repo),--repo "$(repo)",) $(if $(machine_id),--machine-id "$(machine_id)",) $(if $(machine_role),--machine-role "$(machine_role)",) $(if $(authority_basis),--authority-basis "$(authority_basis)",) $(if $(assert_canonical_machine),--assert-canonical-machine,) $(if $(diagnostic_working_path),--diagnostic-working-path,)
 
 # Run local stdout-only Guardian Evidence Packet generator.
 guardian-evidence-packet-generate:

--- a/docs/architecture/00-current-state.md
+++ b/docs/architecture/00-current-state.md
@@ -27,7 +27,7 @@ Codexify is in local-first beta hardening on `main`. The supported path remains 
 - ADR-042 and `schemas/audit/canonical-audit-evidence.schema.json` now define the intended canonical audit evidence model.
 - A test-backed repository-local canonical evidence validator now validates one manifest's schema, bounded semantics, artifact hashes, and eligibility; it is local tooling, not runtime proof.
 - Canonical audit producers and consumers have not yet been migrated, and trusted `latest` promotion remains unimplemented.
-- No VaultNode identity collector exists yet; historical artifacts are not automatically canonical.
+- A bounded repository-local identity collector now observes machine and Git identity; it is not runtime proof, does not establish VaultNode authority from hostname, and does not produce or promote canonical evidence. Historical artifacts are not automatically canonical.
 - Existing artifacts remain historical or provisional until revalidated under the new model.
 - Campaign posture remains `HOLD / NEXT_PROOF_NEEDED`; the next implementation slice is VaultNode evidence identity collection or schema-validation integration, not feature expansion.
 

--- a/docs/architecture/canonical-audit-evidence-contract.md
+++ b/docs/architecture/canonical-audit-evidence-contract.md
@@ -176,19 +176,28 @@ timestamp, location, or generated prose.
 
 ## Implementation status
 
+A bounded repository-local identity collector now observes normalized machine
+facts and Git repository identity for a later manifest producer. It accepts
+the existing `machine_role` vocabulary, keeps explicit authority inputs
+separate from observed hostname facts, emits portable repository/worktree
+identities, and reports bounded repository eligibility reason codes. It is
+observation tooling only: a successful run is not VaultNode proof, canonical
+authority, evidence storage, or promotion approval.
+
 A repository-local validator now validates one manifest against the existing
 Draft 2020-12 schema, applies bounded single-manifest authority and repository
 consistency checks, verifies repository-relative artifact hashes, and reports
-canonical eligibility. It is local tooling only: it does not accept or promote
-evidence, collect host identity, compare declared values with live Git or
-runtime state, resolve cross-record supersession or contradiction, migrate
-producers or consumers, or implement trusted `latest`.
+canonical eligibility. It remains local tooling only: it does not accept or
+promote evidence, produce a complete manifest, collect runtime or Compose
+identity, execute proof, store evidence, compare records, migrate producers or
+consumers, or implement trusted `latest`.
 
 ## Deferred implementation work
 
-VaultNode identity capture, semantic validation, producer emission, hashing,
-freshness evaluation, pointer storage/promotion receipts, migration of existing
-artifacts, and consumer integration remain separately scoped work.
+Runtime and Compose identity, complete manifest production, artifact
+collection/hashing, freshness evaluation, evidence storage, cross-record
+resolution, pointer storage, promotion receipts, trusted pointers, consumer
+migration, and live VaultNode proof remain separately scoped work.
 
 ## Non-goals
 

--- a/scripts/audit/collect_canonical_evidence_identity.py
+++ b/scripts/audit/collect_canonical_evidence_identity.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Collect bounded machine and Git identity for a future audit manifest.
+
+This module observes local identity only. It does not produce an evidence
+manifest, execute a proof, or mutate Git or filesystem state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import socket
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+
+RESULT_SCHEMA_VERSION = "canonical_audit_evidence_identity_result.v1"
+COLLECTOR_VERSION = "canonical_audit_evidence_identity_collector.v1"
+DEFAULT_TIMEOUT_SECONDS = 5.0
+VALID_MACHINE_ROLES = {
+    "canonical_evidence_host",
+    "provisional_development_host",
+}
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class CollectorError(Exception):
+    """A stable, user-safe collector failure."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def _safe_text(value: str) -> str:
+    """Keep subprocess errors bounded and free of environment-like content."""
+    text = " ".join(value.split())
+    text = re.sub(r"(?i)(https?://)([^/@\s]+):[^/@\s]+@", r"\1[redacted]@", text)
+    text = re.sub(r"(?i)(token|password|secret|api[_-]?key)\s*[=:]\s*\S+", r"\1=[redacted]", text)
+    return text[:240]
+
+
+def _hostname() -> str:
+    value = socket.gethostname().strip().lower().rstrip(".")
+    if not value:
+        raise CollectorError("machine_identity_incomplete", "Hostname is empty.")
+    return value
+
+
+def _run_git(repo_path: Path, args: Sequence[str], timeout: float) -> str:
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(repo_path), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            shell=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise CollectorError("git_command_timeout", "A Git identity probe timed out.") from exc
+    except OSError as exc:
+        raise CollectorError("git_command_failed", "Git could not be executed.") from exc
+    if completed.returncode != 0:
+        detail = _safe_text(completed.stderr or completed.stdout)
+        raise CollectorError(
+            "git_command_failed",
+            f"A Git identity probe failed{': ' + detail if detail else '.'}",
+        )
+    return completed.stdout.strip()
+
+
+def _try_git(repo_path: Path, args: Sequence[str], timeout: float) -> tuple[str | None, str | None]:
+    try:
+        return _run_git(repo_path, args, timeout), None
+    except CollectorError as exc:
+        return None, exc.code
+
+
+def _portable_remote_identity(remotes: list[str], commit_sha: str) -> str:
+    safe: list[str] = []
+    for remote in remotes:
+        value = remote.strip()
+        if "@" in value and "://" in value:
+            value = re.sub(r"(://)[^/@]+@", r"\1", value)
+        if "@" in value and "://" not in value and ":" in value:
+            value = value.split("@", 1)[-1]
+        safe.append(value)
+    basis = "\n".join(sorted(safe)) or f"local:{commit_sha}"
+    return f"git:{hashlib.sha256(basis.encode('utf-8')).hexdigest()}"
+
+
+def _portable_worktree_identity(common_dir: str, commit_sha: str) -> str:
+    # The common-dir path is intentionally reduced to a stable Git object.
+    # It is an identity token, not a disclosed local path.
+    basis = f"git-common-dir:{Path(common_dir).name}:{commit_sha}"
+    return f"worktree:{hashlib.sha256(basis.encode('utf-8')).hexdigest()}"
+
+
+def collect_identity(
+    repo_path: str | Path = ".",
+    *,
+    machine_id: str = "local",
+    machine_role: str = "provisional_development_host",
+    authority_basis: str = "operator_not_asserted",
+    assert_canonical_machine: bool = False,
+    diagnostic_working_path: bool = False,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    hostname: str | None = None,
+) -> dict[str, Any]:
+    """Return a JSON-serializable, deterministic identity observation."""
+    if machine_role not in VALID_MACHINE_ROLES:
+        raise CollectorError("invalid_machine_role", "Machine role is not accepted vocabulary.")
+    if not machine_id.strip() or not authority_basis.strip():
+        raise CollectorError(
+            "authority_fields_incomplete",
+            "machine_id and authority_basis must be non-empty.",
+        )
+    if assert_canonical_machine and (
+        machine_id != "vaultnode"
+        or machine_role != "canonical_evidence_host"
+        or not authority_basis.strip()
+        ):
+        raise CollectorError(
+            "canonical_machine_authority_inconsistent",
+            "Canonical machine assertion requires compatible explicit authority inputs.",
+        )
+    safe_machine_id = _safe_text(machine_id.strip())
+    safe_authority_basis = _safe_text(authority_basis.strip())
+
+    selected = Path(repo_path).expanduser()
+    if not selected.exists() or not selected.is_dir():
+        raise CollectorError("path_not_git_worktree", "Path is not a directory in a Git worktree.")
+    selected = selected.resolve()
+    root_text, root_error = _try_git(selected, ["rev-parse", "--show-toplevel"], timeout)
+    if root_text is None:
+        raise CollectorError("path_not_git_worktree", "Path is not inside a Git worktree.")
+    root = Path(root_text).resolve()
+
+    commit_sha, _ = _try_git(selected, ["rev-parse", "HEAD^{commit}"], timeout)
+    if commit_sha is None or not SHA_RE.fullmatch(commit_sha.lower()):
+        raise CollectorError("repository_identity_incomplete", "Checked-out commit SHA is incomplete.")
+    commit_sha = commit_sha.lower()
+    symbolic_head, _ = _try_git(selected, ["symbolic-ref", "--quiet", "--short", "HEAD"], timeout)
+    branch = symbolic_head if symbolic_head else "DETACHED_HEAD"
+    status = _run_git(selected, ["status", "--porcelain=v1", "-z", "--untracked-files=all"], timeout)
+    dirty = bool(status)
+    common_dir = _run_git(selected, ["rev-parse", "--git-common-dir"], timeout)
+    remotes_raw = _run_git(selected, ["remote", "-v"], timeout)
+    remote_lines = [line for line in remotes_raw.splitlines() if line.strip()]
+    remote_refs = sorted({line.split()[1] for line in remote_lines if len(line.split()) >= 2})
+    upstream_ref, upstream_error = _try_git(
+        selected, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"], timeout
+    )
+    configured_upstream = False
+    if upstream_ref is None and symbolic_head:
+        configured_upstream = bool(
+            _try_git(selected, ["config", "--get", f"branch.{symbolic_head}.remote"], timeout)[0]
+            and _try_git(selected, ["config", "--get", f"branch.{symbolic_head}.merge"], timeout)[0]
+        )
+    upstream_sha: str | None = None
+    upstream_resolution_error: str | None = None
+    if upstream_ref is not None:
+        upstream_sha, upstream_resolution_error = _try_git(
+            selected, ["rev-parse", "@{upstream}^{commit}"], timeout
+        )
+        if upstream_sha is not None:
+            upstream_sha = upstream_sha.lower()
+            if not SHA_RE.fullmatch(upstream_sha):
+                upstream_sha = None
+                upstream_resolution_error = "repository_identity_incomplete"
+
+    machine = {
+        "machine_id": safe_machine_id,
+        "machine_role": machine_role,
+        "hostname": (hostname.strip().lower().rstrip(".") if hostname is not None else _hostname()),
+        "authority_basis": safe_authority_basis,
+        "authority_assertion_complete": (
+            machine_id == "vaultnode" and machine_role == "canonical_evidence_host" and bool(authority_basis.strip())
+        ),
+    }
+    repository: dict[str, Any] = {
+        "repository_root_identity": _portable_remote_identity(remote_refs, commit_sha),
+        "branch": branch,
+        "commit_sha": commit_sha,
+        "upstream_ref": upstream_ref,
+        "upstream_sha": upstream_sha,
+        "dirty": dirty,
+        "worktree_identity": _portable_worktree_identity(common_dir, commit_sha),
+    }
+    if diagnostic_working_path:
+        repository["diagnostic_working_path"] = str(selected)
+
+    reason_codes: list[str] = []
+    if not machine["authority_assertion_complete"]:
+        reason_codes.append("canonical_machine_authority_not_asserted")
+    if symbolic_head is None:
+        reason_codes.append("detached_head")
+    if branch != "main":
+        reason_codes.append("wrong_branch")
+    if dirty:
+        reason_codes.append("dirty_worktree")
+    if upstream_ref is None and not configured_upstream:
+        reason_codes.append("missing_upstream")
+    if upstream_ref is None and configured_upstream:
+        reason_codes.append("unresolved_upstream")
+    if upstream_ref is not None and upstream_sha is None:
+        reason_codes.append("unresolved_upstream")
+    if upstream_sha is not None and upstream_sha != commit_sha:
+        reason_codes.append("commit_upstream_mismatch")
+    if upstream_error == "git_command_timeout" or upstream_resolution_error == "git_command_timeout":
+        reason_codes.append("git_command_timeout")
+    if upstream_error == "git_command_failed" or upstream_resolution_error == "git_command_failed":
+        reason_codes.append("git_command_failed")
+    reason_codes = sorted(set(reason_codes))
+
+    repository_identity_complete = bool(
+        branch
+        and SHA_RE.fullmatch(commit_sha)
+        and upstream_ref
+        and upstream_sha
+        and SHA_RE.fullmatch(upstream_sha)
+    )
+    canonical_repository_candidate = repository_identity_complete and not any(
+        code in reason_codes
+        for code in ("detached_head", "wrong_branch", "dirty_worktree", "missing_upstream", "unresolved_upstream", "commit_upstream_mismatch")
+    )
+    observation_complete = repository_identity_complete and bool(machine["hostname"])
+    return {
+        "schema_version": RESULT_SCHEMA_VERSION,
+        "collector_version": COLLECTOR_VERSION,
+        "observation_complete": observation_complete,
+        "machine": machine,
+        "repository": repository,
+        "eligibility": {
+            "repository_identity_complete": repository_identity_complete,
+            "canonical_repository_candidate": canonical_repository_candidate,
+            "canonical_machine_candidate": bool(machine["authority_assertion_complete"]),
+            "reason_codes": reason_codes,
+        },
+    }
+
+
+# Descriptive public alias for callers that prefer the task-level name.
+collect_canonical_evidence_identity = collect_identity
+
+
+def _error_result(exc: CollectorError) -> dict[str, Any]:
+    return {
+        "schema_version": RESULT_SCHEMA_VERSION,
+        "collector_version": COLLECTOR_VERSION,
+        "observation_complete": False,
+        "error": {"code": exc.code, "message": exc.message},
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Collect bounded canonical audit evidence identity.")
+    parser.add_argument("--repo", default=".", help="Repository or directory inside a Git worktree.")
+    parser.add_argument("--machine-id", default="local")
+    parser.add_argument("--machine-role", default="provisional_development_host")
+    parser.add_argument("--authority-basis", default="operator_not_asserted")
+    parser.add_argument("--assert-canonical-machine", action="store_true")
+    parser.add_argument("--diagnostic-working-path", action="store_true")
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    args = parser.parse_args(argv)
+    if args.timeout <= 0:
+        parser.error("--timeout must be positive")
+    try:
+        result = collect_identity(
+            args.repo,
+            machine_id=args.machine_id,
+            machine_role=args.machine_role,
+            authority_basis=args.authority_basis,
+            assert_canonical_machine=args.assert_canonical_machine,
+            diagnostic_working_path=args.diagnostic_working_path,
+            timeout=args.timeout,
+        )
+    except CollectorError as exc:
+        print(json.dumps(_error_result(exc), indent=2, sort_keys=True))
+        return 2 if exc.code in {"path_not_git_worktree", "git_command_failed", "git_command_timeout", "invalid_machine_role", "authority_fields_incomplete", "canonical_machine_authority_inconsistent"} else 1
+    print(json.dumps(result, indent=2, sort_keys=True))
+    eligible = result["eligibility"]
+    only_provisional_reason = eligible["reason_codes"] == [
+        "canonical_machine_authority_not_asserted"
+    ]
+    return 0 if result["observation_complete"] and (
+        eligible["canonical_repository_candidate"] or only_provisional_reason
+    ) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/audit/test_collect_canonical_evidence_identity.py
+++ b/tests/audit/test_collect_canonical_evidence_identity.py
@@ -1,0 +1,146 @@
+"""Focused tests for the bounded canonical evidence identity collector."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.audit.collect_canonical_evidence_identity import (
+    CollectorError,
+    collect_identity,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/audit/collect_canonical_evidence_identity.py"
+
+
+def run_git(repo: Path, *args: str) -> str:
+    result = subprocess.run(["git", "-C", str(repo), *args], check=True, text=True, capture_output=True)
+    return result.stdout.strip()
+
+
+def make_repo(tmp_path: Path, *, branch: str = "main") -> tuple[Path, Path]:
+    repo = tmp_path / "repo"
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+    subprocess.run(["git", "init", "-b", branch, str(repo)], check=True, capture_output=True)
+    run_git(repo, "config", "user.email", "test@example.invalid")
+    run_git(repo, "config", "user.name", "Test User")
+    (repo / "tracked.txt").write_text("identity\n", encoding="utf-8")
+    run_git(repo, "add", "tracked.txt")
+    run_git(repo, "commit", "-m", "fixture")
+    run_git(repo, "remote", "add", "origin", str(remote))
+    run_git(repo, "push", "-u", "origin", branch)
+    return repo, remote
+
+
+def collect(repo: Path, **kwargs: object) -> dict:
+    return collect_identity(repo, hostname="fixture-host", **kwargs)
+
+
+def test_clean_main_matching_upstream_is_deterministic_and_candidate(tmp_path: Path) -> None:
+    repo, _ = make_repo(tmp_path)
+    first = collect(repo, machine_id="local-test")
+    second = collect(repo, machine_id="local-test")
+    assert first == second
+    assert first["observation_complete"] is True
+    assert first["eligibility"]["repository_identity_complete"] is True
+    assert first["eligibility"]["canonical_repository_candidate"] is True
+    assert first["eligibility"]["canonical_machine_candidate"] is False
+    assert "canonical_machine_authority_not_asserted" in first["eligibility"]["reason_codes"]
+    assert str(repo) not in json.dumps(first)
+
+
+@pytest.mark.parametrize(
+    ("case", "expected"),
+    [
+        ("dirty", "dirty_worktree"),
+        ("detached", "detached_head"),
+        ("wrong_branch", "wrong_branch"),
+        ("missing_upstream", "missing_upstream"),
+        ("unresolved_upstream", "unresolved_upstream"),
+        ("mismatch", "commit_upstream_mismatch"),
+    ],
+)
+def test_ineligible_repository_states_are_visible(tmp_path: Path, case: str, expected: str) -> None:
+    repo, remote = make_repo(tmp_path)
+    if case == "dirty":
+        (repo / "tracked.txt").write_text("changed\n", encoding="utf-8")
+    elif case == "detached":
+        run_git(repo, "checkout", "--detach", "HEAD")
+    elif case == "wrong_branch":
+        run_git(repo, "checkout", "-b", "feature")
+    elif case == "missing_upstream":
+        run_git(repo, "branch", "--unset-upstream")
+    elif case == "unresolved_upstream":
+        run_git(repo, "config", "branch.main.merge", "refs/heads/missing")
+    elif case == "mismatch":
+        (repo / "tracked.txt").write_text("new commit\n", encoding="utf-8")
+        run_git(repo, "commit", "-am", "local divergence")
+    result = collect(repo)
+    assert expected in result["eligibility"]["reason_codes"]
+    assert result["eligibility"]["canonical_repository_candidate"] is False
+
+
+def test_explicit_canonical_machine_inputs_are_required(tmp_path: Path) -> None:
+    repo, _ = make_repo(tmp_path)
+    provisional = collect(repo, machine_id="vaultnode", machine_role="provisional_development_host")
+    assert provisional["eligibility"]["canonical_machine_candidate"] is False
+    with pytest.raises(CollectorError) as error:
+        collect(repo, machine_id="vaultnode", machine_role="provisional_development_host", assert_canonical_machine=True)
+    assert error.value.code == "canonical_machine_authority_inconsistent"
+    canonical = collect(repo, machine_id="vaultnode", machine_role="canonical_evidence_host", authority_basis="operator-confirmed", assert_canonical_machine=True)
+    assert canonical["eligibility"]["canonical_machine_candidate"] is True
+
+
+def test_invalid_role_and_non_worktree_fail_closed(tmp_path: Path) -> None:
+    with pytest.raises(CollectorError) as error:
+        collect_identity(tmp_path, machine_role="made_up_role")
+    assert error.value.code == "invalid_machine_role"
+    with pytest.raises(CollectorError) as error:
+        collect_identity(tmp_path, hostname="fixture-host")
+    assert error.value.code == "path_not_git_worktree"
+
+
+def test_diagnostic_path_is_explicit_and_remote_credentials_are_not_emitted(tmp_path: Path) -> None:
+    repo, _ = make_repo(tmp_path)
+    run_git(repo, "remote", "set-url", "origin", "https://user:super-secret@example.invalid/org/repo.git")
+    result = collect(repo, diagnostic_working_path=True)
+    encoded = json.dumps(result)
+    assert result["repository"]["diagnostic_working_path"] == str(repo)
+    assert "super-secret" not in encoded
+    assert "user:" not in encoded
+
+
+def test_collection_does_not_mutate_git_state_or_tracked_contents(tmp_path: Path) -> None:
+    repo, _ = make_repo(tmp_path)
+    before = {
+        "head": run_git(repo, "rev-parse", "HEAD"),
+        "refs": run_git(repo, "show-ref"),
+        "status": run_git(repo, "status", "--porcelain=v1"),
+        "tracked": (repo / "tracked.txt").read_bytes(),
+    }
+    collect(repo)
+    after = {
+        "head": run_git(repo, "rev-parse", "HEAD"),
+        "refs": run_git(repo, "show-ref"),
+        "status": run_git(repo, "status", "--porcelain=v1"),
+        "tracked": (repo / "tracked.txt").read_bytes(),
+    }
+    assert after == before
+
+
+def test_cli_exit_codes_and_stable_json(tmp_path: Path) -> None:
+    repo, _ = make_repo(tmp_path)
+    args = [sys.executable, str(SCRIPT), "--repo", str(repo), "--machine-id", "local-test"]
+    first = subprocess.run(args, check=False, capture_output=True, text=True)
+    second = subprocess.run(args, check=False, capture_output=True, text=True)
+    assert first.returncode == second.returncode == 0
+    assert first.stdout == second.stdout
+    parsed = json.loads(first.stdout)
+    assert parsed["schema_version"] == "canonical_audit_evidence_identity_result.v1"


### PR DESCRIPTION
## Summary

Implements the bounded identity-collection seam for Issue #569.

- Collects normalized machine facts and explicit authority inputs.
- Collects portable Git repository/worktree identity without mutation or fetch.
- Emits deterministic reason codes and provisional/candidate observations.
- Adds isolated temporary-repository coverage and the local Make target.
- Updates current-state and canonical evidence contract documentation.

## Validation

- `python -m pytest -v tests/audit/test_collect_canonical_evidence_identity.py` — 12 passed
- `python -m pytest -v tests/audit/test_validate_canonical_evidence.py` — 13 passed
- `python scripts/validate_docs.py` — passed
- `git diff --check` — passed

This remains repository tooling only. It does not produce complete manifests, inspect runtime or Compose identity, execute proof suites, persist evidence, promote evidence, update trusted pointers, or claim VaultNode authority from hostname.

Closes #569