### PR TITLE
Require explicit canonical machine assertion

### DIFF
--- a/scripts/audit/collect_canonical_evidence_identity.py
+++ b/scripts/audit/collect_canonical_evidence_identity.py
@@ -125,7 +125,8 @@ def collect_identity(
         machine_id != "vaultnode"
         or machine_role != "canonical_evidence_host"
         or not authority_basis.strip()
-        ):
+        or authority_basis.strip() == "operator_not_asserted"
+    ):
         raise CollectorError(
             "canonical_machine_authority_inconsistent",
             "Canonical machine assertion requires compatible explicit authority inputs.",
@@ -181,7 +182,11 @@ def collect_identity(
         "hostname": (hostname.strip().lower().rstrip(".") if hostname is not None else _hostname()),
         "authority_basis": safe_authority_basis,
         "authority_assertion_complete": (
-            machine_id == "vaultnode" and machine_role == "canonical_evidence_host" and bool(authority_basis.strip())
+            assert_canonical_machine
+            and machine_id == "vaultnode"
+            and machine_role == "canonical_evidence_host"
+            and bool(authority_basis.strip())
+            and authority_basis.strip() != "operator_not_asserted"
         ),
     }
     repository: dict[str, Any] = {

--- a/tests/audit/test_collect_canonical_evidence_identity.py
+++ b/tests/audit/test_collect_canonical_evidence_identity.py
@@ -91,8 +91,15 @@ def test_explicit_canonical_machine_inputs_are_required(tmp_path: Path) -> None:
     repo, _ = make_repo(tmp_path)
     provisional = collect(repo, machine_id="vaultnode", machine_role="provisional_development_host")
     assert provisional["eligibility"]["canonical_machine_candidate"] is False
+    unasserted = collect(repo, machine_id="vaultnode", machine_role="canonical_evidence_host")
+    assert unasserted["machine"]["authority_assertion_complete"] is False
+    assert unasserted["eligibility"]["canonical_machine_candidate"] is False
+    assert "canonical_machine_authority_not_asserted" in unasserted["eligibility"]["reason_codes"]
     with pytest.raises(CollectorError) as error:
         collect(repo, machine_id="vaultnode", machine_role="provisional_development_host", assert_canonical_machine=True)
+    assert error.value.code == "canonical_machine_authority_inconsistent"
+    with pytest.raises(CollectorError) as error:
+        collect(repo, machine_id="vaultnode", machine_role="canonical_evidence_host", assert_canonical_machine=True)
     assert error.value.code == "canonical_machine_authority_inconsistent"
     canonical = collect(repo, machine_id="vaultnode", machine_role="canonical_evidence_host", authority_basis="operator-confirmed", assert_canonical_machine=True)
     assert canonical["eligibility"]["canonical_machine_candidate"] is True


### PR DESCRIPTION
## Summary

Follow-up corrective slice for Issue #569 addressing the unresolved P1 review thread from PR #570.

- `authority_assertion_complete` now requires `assert_canonical_machine=True`.
- `operator_not_asserted` cannot qualify as an asserted authority basis.
- Added regression coverage for canonical-looking fields without the explicit assertion flag.

## Validation

- `python -m pytest -v tests/audit/test_collect_canonical_evidence_identity.py` — 12 passed
- `python -m pytest -v tests/audit/test_validate_canonical_evidence.py` — 13 passed
- `python scripts/validate_docs.py` — passed
- `git diff --check` — passed

This remains narrowly scoped to the authority assertion boundary. It does not add runtime proof, manifest production, evidence storage, promotion, trusted pointers, or parent campaign completion.

Refs #569