### PR TITLE
Fail closed on dangling migration parents

### DIFF
--- a/scripts/audit/collect_canonical_runtime_identity.py
+++ b/scripts/audit/collect_canonical_runtime_identity.py
@@ -252,6 +252,9 @@ def _migration_identity(repo_root: Path, migration_dir: str | Path | None) -> tu
     if not revisions:
         return None, {"path": directory.relative_to(repo_root).as_posix(), "head": None}, ["migration_head_missing"]
     referenced = {item for values in down_revisions.values() for item in values}
+    missing_parents = sorted(referenced - set(revisions))
+    if missing_parents:
+        return None, {"path": directory.relative_to(repo_root).as_posix(), "head": None}, ["migration_identity_incomplete"]
     heads = sorted(set(revisions) - referenced)
     if len(heads) == 0:
         return None, {"path": directory.relative_to(repo_root).as_posix(), "head": None}, ["migration_head_missing"]

--- a/tests/audit/test_collect_canonical_runtime_identity.py
+++ b/tests/audit/test_collect_canonical_runtime_identity.py
@@ -184,6 +184,19 @@ def test_multiple_migration_heads_fail_closed(tmp_path: Path) -> None:
     assert result["observation_complete"] is False
 
 
+def test_dangling_migration_parent_fails_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    (fixture["migration_dir"] / "a_revision.py").write_text(
+        _migration("head-a", "missing-parent"), encoding="utf-8"
+    )
+    result = collect(fixture)
+    assert "migration_identity_incomplete" in result["eligibility"]["reason_codes"]
+    assert result["eligibility"]["migration_identity_complete"] is False
+    assert result["eligibility"]["runtime_identity_complete"] is False
+    assert result["eligibility"]["canonical_runtime_candidate"] is False
+    assert result["runtime"]["migration_head"] is None
+
+
 def test_profile_and_service_identity_fail_closed(tmp_path: Path) -> None:
     fixture = make_fixture(tmp_path)
     (fixture["profile_dir"] / "v1-local-core-web-mcp.yaml").write_text("name: broken\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

Corrective follow-up for Issue #574 and PR #575.

- Rejects migration graphs whose `down_revision` references an undiscovered revision.
- Reports stable `migration_identity_incomplete`.
- Prevents runtime identity completeness and canonical runtime candidacy.
- Adds a regression test for a dangling migration parent.

## Validation

- `python -m pytest -v tests/audit/test_collect_canonical_runtime_identity.py` — 15 passed
- `python -m pytest -v tests/audit/test_collect_canonical_evidence_identity.py` — 12 passed
- `python -m pytest -v tests/audit/test_validate_canonical_evidence.py` — 13 passed
- `python scripts/validate_docs.py` — passed
- `ruff check scripts/audit/collect_canonical_runtime_identity.py tests/audit/test_collect_canonical_runtime_identity.py` — passed
- `git diff --check` — passed

This remains a narrow static migration-metadata integrity correction. It does not add Docker inspection, database access, migration execution, live proof, manifest production, storage, freshness, or promotion.

Closes #574