### PR TITLE
Reapply canonical runtime identity with migration integrity guard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Codexify Makefile
 
-.PHONY: all install dev-install test clean lint lint-fix lint-fix-unsafe format check docs docs-diagram-freshness docs-diagram-freshness-strict docs-diagram-freshness-auto docs-diagram-watch docs-diagram-regenerate build check-pytest dossier-collab desktop-dev desktop-build daily-audit morning-audit evening-audit guardian-brief guardian-evidence-packets-validate guardian-evidence-bounded-read guardian-evidence-reducer-dry-run guardian-evidence-reducer-input-bundles-validate guardian-evidence-reducer-input-bundle-dry-run guardian-evidence-packet-generate canonical-audit-evidence-validate canonical-audit-evidence-identity audit-unity audit-risk audit-gates audit-gates-pre-merge audit-gates-pre-release audit-full audit-traps audit-ritual-weekly audit-ritual-monthly audit-ritual-quarterly heartbeat heartbeat-review heartbeat-stage heartbeat-inspect heartbeat-outbox heartbeat-full generate-marketing generate-marketing-automation public-export public-sync
+.PHONY: all install dev-install test clean lint lint-fix lint-fix-unsafe format check docs docs-diagram-freshness docs-diagram-freshness-strict docs-diagram-freshness-auto docs-diagram-watch docs-diagram-regenerate build check-pytest dossier-collab desktop-dev desktop-build daily-audit morning-audit evening-audit guardian-brief guardian-evidence-packets-validate guardian-evidence-bounded-read guardian-evidence-reducer-dry-run guardian-evidence-reducer-input-bundles-validate guardian-evidence-reducer-input-bundle-dry-run guardian-evidence-packet-generate canonical-audit-evidence-validate canonical-audit-evidence-identity canonical-audit-runtime-identity audit-unity audit-risk audit-gates audit-gates-pre-merge audit-gates-pre-release audit-full audit-traps audit-ritual-weekly audit-ritual-monthly audit-ritual-quarterly heartbeat heartbeat-review heartbeat-stage heartbeat-inspect heartbeat-outbox heartbeat-full generate-marketing generate-marketing-automation public-export public-sync
 
 # Python executable
 PYTHON      ?= python
@@ -219,6 +219,11 @@ canonical-audit-evidence-validate:
 
 canonical-audit-evidence-identity:
 	$(PYTHON) scripts/audit/collect_canonical_evidence_identity.py $(if $(repo),--repo "$(repo)",) $(if $(machine_id),--machine-id "$(machine_id)",) $(if $(machine_role),--machine-role "$(machine_role)",) $(if $(authority_basis),--authority-basis "$(authority_basis)",) $(if $(assert_canonical_machine),--assert-canonical-machine,) $(if $(diagnostic_working_path),--diagnostic-working-path,)
+
+canonical-audit-runtime-identity:
+	@test -n "$(compose_file)" || { echo "Usage: make canonical-audit-runtime-identity compose_file=docker-compose.yml audit_project=codexify-audit [serving_project=codexify]" >&2; exit 2; }
+	@test -n "$(audit_project)" || { echo "Usage: make canonical-audit-runtime-identity compose_file=docker-compose.yml audit_project=codexify-audit [serving_project=codexify]" >&2; exit 2; }
+	$(PYTHON) scripts/audit/collect_canonical_runtime_identity.py $(if $(repo),--repo "$(repo)",) --compose-file "$(compose_file)" --audit-project "$(audit_project)" $(if $(serving_project),--serving-project "$(serving_project)",) $(if $(profile_name),--profile-name "$(profile_name)",) $(if $(profiles_dir),--profiles-dir "$(profiles_dir)",) $(if $(migration_dir),--migration-dir "$(migration_dir)",)
 
 # Run local stdout-only Guardian Evidence Packet generator.
 guardian-evidence-packet-generate:

--- a/docs/architecture/00-current-state.md
+++ b/docs/architecture/00-current-state.md
@@ -2,7 +2,7 @@
 This file is Codexify's canonical short-form source of truth for current operational and release state. If it conflicts with older architecture, planning, or roadmap language on short-horizon reality, this file wins.
 
 ## Last updated
-2026-07-10
+2026-07-13
 
 ## Interpretation rule
 This file is authoritative for:
@@ -28,6 +28,7 @@ Codexify is in local-first beta hardening on `main`. The supported path remains 
 - A test-backed repository-local canonical evidence validator now validates one manifest's schema, bounded semantics, artifact hashes, and eligibility; it is local tooling, not runtime proof.
 - Canonical audit producers and consumers have not yet been migrated, and trusted `latest` promotion remains unimplemented.
 - A bounded repository-local identity collector now observes machine and Git identity; it is not runtime proof, does not establish VaultNode authority from hostname, and does not produce or promote canonical evidence. Historical artifacts are not automatically canonical.
+- A bounded repository-local runtime identity collector now observes the accepted supported profile, explicitly selected Compose definitions, static migration-head identity, and a secret-safe effective configuration hash. It does not inspect Docker, prove service health or execution, establish VaultNode runtime authority, produce a complete manifest, or promote evidence.
 - Existing artifacts remain historical or provisional until revalidated under the new model.
 - Campaign posture remains `HOLD / NEXT_PROOF_NEEDED`; the next implementation slice is VaultNode evidence identity collection or schema-validation integration, not feature expansion.
 

--- a/docs/architecture/canonical-audit-evidence-contract.md
+++ b/docs/architecture/canonical-audit-evidence-contract.md
@@ -184,6 +184,19 @@ identities, and reports bounded repository eligibility reason codes. It is
 observation tooling only: a successful run is not VaultNode proof, canonical
 authority, evidence storage, or promotion approval.
 
+A bounded repository-local runtime identity collector now loads the accepted
+supported profile through `guardian/core/supported_profile.py`, hashes selected
+Compose definitions and the exact profile bytes, resolves the static migration
+head, and emits the canonical runtime identity fields for a later manifest
+producer. Its `effective_config_hash` is SHA-256 over a deterministic JSON
+projection containing only: profile name/version/surface/path/hash and required
+and optional services; ordered selected Compose file paths/hashes/declared
+names/services; explicit audit and optional serving project identifiers;
+normalized service sets; and the migration head. It excludes environment
+values, interpolation output, credentials, database URLs, arbitrary absolute
+paths, and container inspection. It is static observation tooling only: it
+does not establish that Docker or any service is running or healthy.
+
 A repository-local validator now validates one manifest against the existing
 Draft 2020-12 schema, applies bounded single-manifest authority and repository
 consistency checks, verifies repository-relative artifact hashes, and reports
@@ -194,10 +207,11 @@ consumers, or implement trusted `latest`.
 
 ## Deferred implementation work
 
-Runtime and Compose identity, complete manifest production, artifact
-collection/hashing, freshness evaluation, evidence storage, cross-record
-resolution, pointer storage, promotion receipts, trusted pointers, consumer
-migration, and live VaultNode proof remain separately scoped work.
+Live service and Compose runtime inspection, runtime health, complete manifest
+production, artifact collection/hashing, freshness evaluation, evidence
+storage, cross-record resolution, pointer storage, promotion receipts, trusted
+pointers, consumer migration, and live VaultNode proof remain separately
+scoped work.
 
 ## Non-goals
 

--- a/scripts/audit/collect_canonical_runtime_identity.py
+++ b/scripts/audit/collect_canonical_runtime_identity.py
@@ -252,6 +252,9 @@ def _migration_identity(repo_root: Path, migration_dir: str | Path | None) -> tu
     if not revisions:
         return None, {"path": directory.relative_to(repo_root).as_posix(), "head": None}, ["migration_head_missing"]
     referenced = {item for values in down_revisions.values() for item in values}
+    missing_parents = sorted(referenced - set(revisions))
+    if missing_parents:
+        return None, {"path": directory.relative_to(repo_root).as_posix(), "head": None}, ["migration_identity_incomplete"]
     heads = sorted(set(revisions) - referenced)
     if len(heads) == 0:
         return None, {"path": directory.relative_to(repo_root).as_posix(), "head": None}, ["migration_head_missing"]

--- a/scripts/audit/collect_canonical_runtime_identity.py
+++ b/scripts/audit/collect_canonical_runtime_identity.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""Collect static, secret-safe supported-runtime identity.
+
+This collector reads the supported profile, selected Compose definitions, and
+repository migration metadata. It never contacts Docker or a database and
+does not produce a canonical evidence manifest or live-proof claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import re
+import stat
+import sys
+from pathlib import Path, PureWindowsPath
+from typing import Any, Sequence
+
+import yaml
+
+# Keep the CLI importable when invoked by absolute path from outside the repo.
+_SOURCE_ROOT = Path(__file__).resolve().parents[2]
+if str(_SOURCE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SOURCE_ROOT))
+
+from guardian.core.supported_profile import (  # noqa: E402 - CLI bootstrap adds the source root.
+    SupportedProfileError,
+    load_supported_profile,
+)
+
+
+RESULT_SCHEMA_VERSION = "canonical_audit_runtime_identity_result.v1"
+COLLECTOR_VERSION = "canonical_audit_runtime_identity_collector.v1"
+DEFAULT_PROFILE_NAME = "v1-local-core-web-mcp"
+DEFAULT_PROFILES_DIR = "config/supported_profiles"
+DEFAULT_MIGRATIONS_DIR = "guardian/db/migrations/versions"
+PROJECT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+SECRET_INPUT_RE = re.compile(
+    r"(?i)(password|secret|token|api[_-]?key|private[_-]?key|database[_-]?url|"
+    r"postgres(?:ql)?://|mysql://|redis://|://)"
+)
+
+
+class RuntimeIdentityError(Exception):
+    """A bounded, machine-readable collector failure."""
+
+    def __init__(self, code: str, message: str = "") -> None:
+        super().__init__(message or code)
+        self.code = code
+        self.message = message or code
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _is_absolute(value: str) -> bool:
+    return Path(value).is_absolute() or PureWindowsPath(value).is_absolute()
+
+
+def _has_parent_traversal(value: str) -> bool:
+    return ".." in value.replace("\\", "/").split("/")
+
+
+def _safe_project_input(value: str, *, field: str) -> str:
+    normalized = str(value or "").strip().lower()
+    if not normalized or SECRET_INPUT_RE.search(normalized):
+        raise RuntimeIdentityError("forbidden_secret_input", f"Invalid {field} input.")
+    if not PROJECT_NAME_RE.fullmatch(normalized):
+        raise RuntimeIdentityError("compose_project_identity_ambiguous", f"Invalid {field} input.")
+    return normalized
+
+
+def _relative_file(
+    raw: str,
+    repo_root: Path,
+    *,
+    missing_code: str,
+    label: str,
+) -> tuple[str, Path]:
+    value = str(raw or "").strip()
+    if not value:
+        raise RuntimeIdentityError(missing_code, f"{label} is missing.")
+    if _is_absolute(value):
+        raise RuntimeIdentityError("compose_path_absolute", f"{label} must be relative.")
+    if _has_parent_traversal(value):
+        raise RuntimeIdentityError(
+            "compose_path_parent_traversal", f"{label} contains parent traversal."
+        )
+    candidate = (repo_root / value).resolve()
+    try:
+        relative = candidate.relative_to(repo_root.resolve()).as_posix()
+    except ValueError as exc:
+        raise RuntimeIdentityError(
+            "compose_path_outside_repository", f"{label} is outside the repository."
+        ) from exc
+    try:
+        mode = candidate.stat().st_mode
+    except OSError as exc:
+        raise RuntimeIdentityError(missing_code, f"{label} is unavailable.") from exc
+    if not stat.S_ISREG(mode):
+        raise RuntimeIdentityError("compose_file_missing", f"{label} is not a regular file.")
+    return relative, candidate
+
+
+def _load_yaml_file(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            payload = yaml.safe_load(handle)
+    except (OSError, UnicodeError, yaml.YAMLError) as exc:
+        raise RuntimeIdentityError("compose_parse_failed", "YAML could not be parsed safely.") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeIdentityError("compose_parse_failed", "Compose root is not a mapping.")
+    return payload
+
+
+def _normalized_names(raw: Any, *, label: str) -> list[str]:
+    if not isinstance(raw, list):
+        raise RuntimeIdentityError("supported_profile_invalid", f"{label} is invalid.")
+    names = [str(item).strip().lower() for item in raw]
+    if any(not name for name in names):
+        raise RuntimeIdentityError("supported_profile_invalid", f"{label} is invalid.")
+    return sorted(set(names))
+
+
+def _profile_identity(
+    profile_name: str,
+    repo_root: Path,
+    profiles_dir: str | Path | None,
+) -> tuple[dict[str, Any], list[str]]:
+    directory = Path(profiles_dir or DEFAULT_PROFILES_DIR)
+    if not directory.is_absolute():
+        directory = repo_root / directory
+    directory = directory.resolve()
+    try:
+        directory.relative_to(repo_root.resolve())
+    except ValueError as exc:
+        raise RuntimeIdentityError("supported_profile_invalid", "Profile directory is outside the repository.") from exc
+    profile_path = directory / f"{str(profile_name or '').strip()}.yaml"
+    try:
+        relative_path = profile_path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError as exc:
+        raise RuntimeIdentityError("supported_profile_invalid", "Profile path is outside the repository.") from exc
+    if not profile_path.is_file():
+        raise RuntimeIdentityError("supported_profile_missing", "Supported profile file is missing.")
+    try:
+        manifest = load_supported_profile(str(profile_name or ""), profiles_dir=str(directory))
+    except SupportedProfileError as exc:
+        code = "supported_profile_missing" if "not found" in str(exc).lower() else "supported_profile_invalid"
+        raise RuntimeIdentityError(code, "Supported profile could not be resolved.") from exc
+    return (
+        {
+            "name": manifest.name,
+            "version": manifest.version,
+            "surface": manifest.surface,
+            "path": relative_path,
+            "sha256": _sha256(profile_path),
+            "required_services": _normalized_names(list(manifest.required_services), label="required_services"),
+            "optional_services": _normalized_names(list(manifest.optional_services), label="optional_services"),
+        },
+        [],
+    )
+
+
+def _compose_file_identity(relative_path: str, path: Path) -> dict[str, Any]:
+    payload = _load_yaml_file(path)
+    declared_name = payload.get("name")
+    if declared_name is not None:
+        if not isinstance(declared_name, str) or not declared_name.strip():
+            raise RuntimeIdentityError("compose_parse_failed", "Compose project name is invalid.")
+        declared_name = declared_name.strip().lower()
+        if not PROJECT_NAME_RE.fullmatch(declared_name):
+            raise RuntimeIdentityError("compose_project_identity_ambiguous", "Compose project name is invalid.")
+    services = payload.get("services")
+    if not isinstance(services, dict):
+        raise RuntimeIdentityError("compose_parse_failed", "Compose services are invalid.")
+    normalized: dict[str, str] = {}
+    for raw_name in services:
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            raise RuntimeIdentityError("service_identity_conflict", "Compose service name is invalid.")
+        name = raw_name.strip().lower()
+        if name in normalized and normalized[name] != raw_name:
+            raise RuntimeIdentityError("service_identity_conflict", "Compose service names collide after normalization.")
+        normalized[name] = raw_name
+    return {
+        "path": relative_path,
+        "sha256": _sha256(path),
+        "declared_name": declared_name,
+        "services": sorted(normalized),
+    }
+
+
+def _migration_literal(tree: ast.Module, name: str) -> tuple[bool, Any]:
+    found = False
+    value: Any = None
+    for node in tree.body:
+        targets: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        if any(isinstance(target, ast.Name) and target.id == name for target in targets):
+            found = True
+            try:
+                value = ast.literal_eval(node.value)
+            except (ValueError, TypeError, SyntaxError):
+                return True, None
+    return found, value
+
+
+def _migration_identity(repo_root: Path, migration_dir: str | Path | None) -> tuple[str | None, dict[str, Any], list[str]]:
+    directory = Path(migration_dir or DEFAULT_MIGRATIONS_DIR)
+    if not directory.is_absolute():
+        directory = repo_root / directory
+    directory = directory.resolve()
+    try:
+        directory.relative_to(repo_root.resolve())
+    except ValueError as exc:
+        raise RuntimeIdentityError("migration_identity_incomplete", "Migration directory is outside the repository.") from exc
+    if not directory.is_dir():
+        return None, {"path": None, "head": None}, ["migration_head_missing"]
+    revisions: dict[str, str] = {}
+    down_revisions: dict[str, set[str]] = {}
+    for path in sorted(directory.glob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (OSError, UnicodeError, SyntaxError):
+            return None, {"path": directory.relative_to(repo_root).as_posix(), "head": None}, ["migration_identity_incomplete"]
+        revision_found, revision = _migration_literal(tree, "revision")
+        down_found, down_revision = _migration_literal(tree, "down_revision")
+        if not revision_found or not isinstance(revision, str) or not revision.strip() or not down_found:
+            return None, {"path": directory.relative_to(repo_root).as_posix(), "head": None}, ["migration_identity_incomplete"]
+        revision = revision.strip()
+        if revision in revisions:
+            return None, {"path": directory.relative_to(repo_root).as_posix(), "head": None}, ["migration_identity_incomplete"]
+        if down_revision is None:
+            downs: set[str] = set()
+        elif isinstance(down_revision, str):
+            downs = {down_revision.strip()} if down_revision.strip() else set()
+        elif isinstance(down_revision, (tuple, list)) and all(isinstance(item, str) for item in down_revision):
+            downs = {item.strip() for item in down_revision if item.strip()}
+        else:
+            return None, {"path": directory.relative_to(repo_root).as_posix(), "head": None}, ["migration_identity_incomplete"]
+        revisions[revision] = path.name
+        down_revisions[revision] = downs
+    if not revisions:
+        return None, {"path": directory.relative_to(repo_root).as_posix(), "head": None}, ["migration_head_missing"]
+    referenced = {item for values in down_revisions.values() for item in values}
+    heads = sorted(set(revisions) - referenced)
+    if len(heads) == 0:
+        return None, {"path": directory.relative_to(repo_root).as_posix(), "head": None}, ["migration_head_missing"]
+    if len(heads) > 1:
+        return None, {"path": directory.relative_to(repo_root).as_posix(), "head": heads}, ["migration_head_multiple"]
+    return heads[0], {"path": directory.relative_to(repo_root).as_posix(), "head": heads[0]}, []
+
+
+def collect_runtime_identity(
+    repo_root: str | Path = ".",
+    *,
+    profile_name: str = DEFAULT_PROFILE_NAME,
+    profiles_dir: str | Path | None = None,
+    compose_files: Sequence[str] | None = None,
+    audit_project: str | None = None,
+    serving_project: str | None = None,
+    migration_dir: str | Path | None = None,
+) -> dict[str, Any]:
+    """Collect static runtime identity without Docker, database, or mutation."""
+    root = Path(repo_root).expanduser().resolve()
+    if not root.is_dir():
+        raise RuntimeIdentityError("runtime_identity_incomplete", "Repository root is unavailable.")
+    reasons: set[str] = set()
+    try:
+        profile, _ = _profile_identity(profile_name, root, profiles_dir)
+    except RuntimeIdentityError as exc:
+        profile = None
+        reasons.add(exc.code)
+
+    selected = list(compose_files or [])
+    compose_records: list[dict[str, Any]] = []
+    selected_paths: set[str] = set()
+    if not selected:
+        reasons.add("compose_file_missing")
+    else:
+        for raw in selected:
+            try:
+                relative, path = _relative_file(raw, root, missing_code="compose_file_missing", label="Compose file")
+            except RuntimeIdentityError as exc:
+                reasons.add(exc.code)
+                continue
+            if relative in selected_paths:
+                reasons.add("compose_file_duplicate")
+                continue
+            selected_paths.add(relative)
+            try:
+                compose_records.append(_compose_file_identity(relative, path))
+            except RuntimeIdentityError as exc:
+                reasons.add(exc.code)
+
+    declared_names = sorted({record["declared_name"] for record in compose_records if record["declared_name"]})
+    if len(declared_names) > 1:
+        reasons.add("compose_project_identity_ambiguous")
+    explicit_audit = bool(str(audit_project or "").strip())
+    resolved_audit: str | None = None
+    if explicit_audit:
+        try:
+            resolved_audit = _safe_project_input(str(audit_project), field="audit project")
+        except RuntimeIdentityError as exc:
+            reasons.add(exc.code)
+    elif len(declared_names) == 1:
+        resolved_audit = declared_names[0]
+    else:
+        reasons.add("compose_project_identity_ambiguous")
+    resolved_serving: str | None = None
+    if serving_project is not None and str(serving_project).strip():
+        try:
+            resolved_serving = _safe_project_input(str(serving_project), field="serving project")
+        except RuntimeIdentityError as exc:
+            reasons.add(exc.code)
+    if resolved_audit and resolved_serving and resolved_audit == resolved_serving:
+        reasons.add("serving_audit_project_identity_collision")
+
+    declared_services = sorted({service for record in compose_records for service in record["services"]})
+    required_services = profile["required_services"] if profile else []
+    optional_services = profile["optional_services"] if profile else []
+    missing_required = sorted(set(required_services) - set(declared_services))
+    if missing_required:
+        reasons.add("required_service_missing")
+    migration_head, migration_record, migration_reasons = _migration_identity(root, migration_dir)
+    reasons.update(migration_reasons)
+
+    profile_resolved = profile is not None
+    compose_complete = bool(compose_records) and not any(
+        code in reasons
+        for code in (
+            "compose_file_missing",
+            "compose_path_absolute",
+            "compose_path_parent_traversal",
+            "compose_path_outside_repository",
+            "compose_file_duplicate",
+            "compose_parse_failed",
+            "compose_project_identity_ambiguous",
+            "serving_audit_project_identity_collision",
+            "required_service_missing",
+            "service_identity_conflict",
+        )
+    ) and resolved_audit is not None
+    migration_complete = migration_head is not None and not any(
+        code in reasons for code in ("migration_head_missing", "migration_head_multiple", "migration_identity_incomplete")
+    )
+    runtime_complete = profile_resolved and compose_complete and migration_complete and not any(
+        code in reasons for code in ("forbidden_secret_input",)
+    )
+
+    projection: dict[str, Any] | None = None
+    effective_config_hash: str | None = None
+    if runtime_complete:
+        projection = {
+            "profile": profile,
+            "compose": {
+                "files": compose_records,
+                "project": resolved_audit,
+                "serving_project": resolved_serving,
+                "required_services": required_services,
+                "optional_services": optional_services,
+                "declared_services": declared_services,
+            },
+            "migration_head": migration_head,
+        }
+        encoded = json.dumps(projection, ensure_ascii=True, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        effective_config_hash = hashlib.sha256(encoded).hexdigest()
+    if not runtime_complete:
+        reasons.add("runtime_identity_incomplete")
+
+    reasons_list = sorted(reasons)
+    runtime = {
+        "supported_profile": profile["name"] if profile else None,
+        "effective_config_hash": effective_config_hash,
+        "compose_project": resolved_audit,
+        "compose_files": [record["path"] for record in compose_records],
+        "migration_head": migration_head,
+        "service_identities": declared_services,
+        "profile_identity": profile,
+        "compose_identity": {
+            "files": compose_records,
+            "project": resolved_audit,
+            "serving_project": resolved_serving,
+            "required_services": required_services,
+            "optional_services": optional_services,
+            "declared_services": declared_services,
+            "missing_required_services": missing_required,
+        },
+        "migration_identity": migration_record,
+    }
+    return {
+        "schema_version": RESULT_SCHEMA_VERSION,
+        "collector_version": COLLECTOR_VERSION,
+        "observation_complete": runtime_complete,
+        "runtime": runtime,
+        "eligibility": {
+            "supported_profile_resolved": profile_resolved,
+            "compose_identity_complete": compose_complete,
+            "migration_identity_complete": migration_complete,
+            "runtime_identity_complete": runtime_complete,
+            "canonical_runtime_candidate": runtime_complete and explicit_audit and not any(
+                code in reasons for code in ("serving_audit_project_identity_collision",)
+            ),
+            "reason_codes": reasons_list,
+        },
+    }
+
+
+collect_canonical_runtime_identity = collect_runtime_identity
+
+
+def _error_result(error: RuntimeIdentityError) -> dict[str, Any]:
+    return {
+        "schema_version": RESULT_SCHEMA_VERSION,
+        "collector_version": COLLECTOR_VERSION,
+        "observation_complete": False,
+        "eligibility": {"reason_codes": [error.code]},
+        "error": {"code": error.code, "message": error.message},
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Collect static canonical audit runtime identity.")
+    parser.add_argument("--repo", default=".")
+    parser.add_argument("--profile-name", default=DEFAULT_PROFILE_NAME)
+    parser.add_argument("--profiles-dir")
+    parser.add_argument("--compose-file", action="append")
+    parser.add_argument("--audit-project")
+    parser.add_argument("--serving-project")
+    parser.add_argument("--migration-dir")
+    args = parser.parse_args(argv)
+    try:
+        result = collect_runtime_identity(
+            args.repo,
+            profile_name=args.profile_name,
+            profiles_dir=args.profiles_dir,
+            compose_files=args.compose_file,
+            audit_project=args.audit_project,
+            serving_project=args.serving_project,
+            migration_dir=args.migration_dir,
+        )
+    except RuntimeIdentityError as exc:
+        print(json.dumps(_error_result(exc), indent=2, sort_keys=True))
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["observation_complete"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/audit/test_collect_canonical_runtime_identity.py
+++ b/tests/audit/test_collect_canonical_runtime_identity.py
@@ -184,6 +184,19 @@ def test_multiple_migration_heads_fail_closed(tmp_path: Path) -> None:
     assert result["observation_complete"] is False
 
 
+def test_dangling_migration_parent_fails_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    (fixture["migration_dir"] / "a_revision.py").write_text(
+        _migration("head-a", "missing-parent"), encoding="utf-8"
+    )
+    result = collect(fixture)
+    assert "migration_identity_incomplete" in result["eligibility"]["reason_codes"]
+    assert result["eligibility"]["migration_identity_complete"] is False
+    assert result["eligibility"]["runtime_identity_complete"] is False
+    assert result["eligibility"]["canonical_runtime_candidate"] is False
+    assert result["runtime"]["migration_head"] is None
+
+
 def test_profile_and_service_identity_fail_closed(tmp_path: Path) -> None:
     fixture = make_fixture(tmp_path)
     (fixture["profile_dir"] / "v1-local-core-web-mcp.yaml").write_text("name: broken\n", encoding="utf-8")

--- a/tests/audit/test_collect_canonical_runtime_identity.py
+++ b/tests/audit/test_collect_canonical_runtime_identity.py
@@ -1,0 +1,249 @@
+"""Tests for static, secret-safe canonical runtime identity collection."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.audit.collect_canonical_runtime_identity import (
+    RuntimeIdentityError,
+    collect_runtime_identity,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/audit/collect_canonical_runtime_identity.py"
+
+
+PROFILE = """name: v1-local-core-web-mcp
+version: 1
+surface: local-docker-compose-webui
+required_services:
+  - backend
+  - db
+optional_services:
+  - redis
+extension_posture:
+  public: []
+  internal: []
+route_posture:
+  enabled: []
+  internal_only: []
+  quarantined: []
+provider_contract: {}
+criticality:
+  tier0:
+    services: [backend, db]
+    routes: []
+"""
+
+
+def _migration(revision: str, down_revision: str | None = None) -> str:
+    return f'''"""fixture migration."""
+revision = "{revision}"
+down_revision = {down_revision!r}
+'''
+
+
+def make_fixture(tmp_path: Path) -> dict[str, Path]:
+    root = tmp_path / "repo"
+    profile_dir = root / "config" / "supported_profiles"
+    migration_dir = root / "guardian" / "db" / "migrations" / "versions"
+    profile_dir.mkdir(parents=True)
+    migration_dir.mkdir(parents=True)
+    (profile_dir / "v1-local-core-web-mcp.yaml").write_text(PROFILE, encoding="utf-8")
+    compose = root / "docker-compose.yml"
+    compose.write_text(
+        "name: codexify\nservices:\n  backend: {}\n  db: {}\n  redis: {}\n",
+        encoding="utf-8",
+    )
+    override = root / "docker-compose.override.yml"
+    override.write_text("services:\n  worker: {}\n", encoding="utf-8")
+    (migration_dir / "a_revision.py").write_text(_migration("head-a"), encoding="utf-8")
+    return {
+        "root": root,
+        "profile_dir": profile_dir,
+        "migration_dir": migration_dir,
+        "compose": compose,
+        "override": override,
+    }
+
+
+def collect(fixture: dict[str, Path], **kwargs: object) -> dict:
+    return collect_runtime_identity(
+        fixture["root"],
+        profiles_dir=fixture["profile_dir"],
+        compose_files=["docker-compose.yml"],
+        audit_project="codexify-audit",
+        migration_dir=fixture["migration_dir"],
+        **kwargs,
+    )
+
+
+def test_clean_static_identity_is_deterministic_and_non_docker(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    first = collect(fixture, serving_project="codexify")
+    second = collect(fixture, serving_project="codexify")
+    assert first == second
+    assert first["observation_complete"] is True
+    assert first["eligibility"]["canonical_runtime_candidate"] is True
+    assert first["runtime"]["supported_profile"] == "v1-local-core-web-mcp"
+    assert first["runtime"]["migration_head"] == "head-a"
+    assert first["runtime"]["service_identities"] == ["backend", "db", "redis"]
+    assert len(first["runtime"]["effective_config_hash"]) == 64
+    assert str(fixture["root"]) not in json.dumps(first)
+
+
+def test_compose_order_and_bytes_change_effective_identity(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    first = collect(fixture, serving_project="codexify")
+    ordered = collect_runtime_identity(
+        fixture["root"],
+        profiles_dir=fixture["profile_dir"],
+        compose_files=["docker-compose.override.yml", "docker-compose.yml"],
+        audit_project="codexify-audit",
+        serving_project="codexify",
+        migration_dir=fixture["migration_dir"],
+    )
+    reversed_order = collect_runtime_identity(
+        fixture["root"],
+        profiles_dir=fixture["profile_dir"],
+        compose_files=["docker-compose.yml", "docker-compose.override.yml"],
+        audit_project="codexify-audit",
+        serving_project="codexify",
+        migration_dir=fixture["migration_dir"],
+    )
+    assert ordered["runtime"]["effective_config_hash"] != first["runtime"]["effective_config_hash"]
+    assert ordered["runtime"]["effective_config_hash"] != reversed_order["runtime"]["effective_config_hash"]
+    before = first["runtime"]["profile_identity"]["sha256"]
+    (fixture["profile_dir"] / "v1-local-core-web-mcp.yaml").write_text(PROFILE + "\n", encoding="utf-8")
+    changed = collect(fixture, serving_project="codexify")
+    assert changed["runtime"]["profile_identity"]["sha256"] != before
+    assert changed["runtime"]["effective_config_hash"] != first["runtime"]["effective_config_hash"]
+
+
+def test_missing_required_service_fails_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    fixture["compose"].write_text("name: codexify\nservices:\n  backend: {}\n", encoding="utf-8")
+    result = collect(fixture)
+    assert result["observation_complete"] is False
+    assert result["eligibility"]["compose_identity_complete"] is False
+    assert result["eligibility"]["canonical_runtime_candidate"] is False
+    assert "required_service_missing" in result["eligibility"]["reason_codes"]
+
+
+@pytest.mark.parametrize(
+    ("compose_files", "code"),
+    [
+        (["/tmp/compose.yml"], "compose_path_absolute"),
+        (["../compose.yml"], "compose_path_parent_traversal"),
+        (["docker-compose.yml", "./docker-compose.yml"], "compose_file_duplicate"),
+        (["missing.yml"], "compose_file_missing"),
+    ],
+)
+def test_compose_path_safety_reason_codes(tmp_path: Path, compose_files: list[str], code: str) -> None:
+    fixture = make_fixture(tmp_path)
+    result = collect_runtime_identity(
+        fixture["root"],
+        profiles_dir=fixture["profile_dir"],
+        compose_files=compose_files,
+        audit_project="codexify-audit",
+        migration_dir=fixture["migration_dir"],
+    )
+    assert code in result["eligibility"]["reason_codes"]
+    assert result["observation_complete"] is False
+
+
+def test_project_collision_and_secret_input_are_safe(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    collision = collect(fixture, serving_project="codexify-audit")
+    assert "serving_audit_project_identity_collision" in collision["eligibility"]["reason_codes"]
+    secret = collect_runtime_identity(
+        fixture["root"],
+        profiles_dir=fixture["profile_dir"],
+        compose_files=["docker-compose.yml"],
+        audit_project="postgres://user:super-secret@example.invalid/db",
+        migration_dir=fixture["migration_dir"],
+    )
+    encoded = json.dumps(secret)
+    assert "forbidden_secret_input" in secret["eligibility"]["reason_codes"]
+    assert "super-secret" not in encoded
+    assert "postgres://" not in encoded
+
+
+def test_multiple_migration_heads_fail_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    (fixture["migration_dir"] / "b_revision.py").write_text(_migration("head-b"), encoding="utf-8")
+    result = collect(fixture)
+    assert "migration_head_multiple" in result["eligibility"]["reason_codes"]
+    assert result["runtime"]["migration_head"] is None
+    assert result["observation_complete"] is False
+
+
+def test_profile_and_service_identity_fail_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    (fixture["profile_dir"] / "v1-local-core-web-mcp.yaml").write_text("name: broken\n", encoding="utf-8")
+    result = collect(fixture)
+    assert "supported_profile_invalid" in result["eligibility"]["reason_codes"]
+    compose = fixture["root"] / "docker-compose.yml"
+    compose.write_text("name: codexify\nservices:\n  Backend: {}\n  backend: {}\n  db: {}\n", encoding="utf-8")
+    result = collect(fixture)
+    assert "service_identity_conflict" in result["eligibility"]["reason_codes"]
+
+
+def test_no_project_input_is_provisional_incomplete(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    result = collect_runtime_identity(
+        fixture["root"],
+        profiles_dir=fixture["profile_dir"],
+        compose_files=["docker-compose.yml"],
+        migration_dir=fixture["migration_dir"],
+    )
+    assert result["runtime"]["compose_project"] == "codexify"
+    assert result["eligibility"]["canonical_runtime_candidate"] is False
+    assert "compose_project_identity_ambiguous" not in result["eligibility"]["reason_codes"]
+
+
+def test_cli_is_deterministic_and_returns_complete_static_observation(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    args = [
+        sys.executable,
+        str(SCRIPT),
+        "--repo",
+        str(fixture["root"]),
+        "--profiles-dir",
+        str(fixture["profile_dir"]),
+        "--compose-file",
+        "docker-compose.yml",
+        "--audit-project",
+        "codexify-audit",
+        "--serving-project",
+        "codexify",
+        "--migration-dir",
+        str(fixture["migration_dir"]),
+    ]
+    first = subprocess.run(args, check=False, capture_output=True, text=True)
+    second = subprocess.run(args, check=False, capture_output=True, text=True)
+    assert first.returncode == second.returncode == 0
+    assert first.stdout == second.stdout
+    assert str(fixture["root"]) not in first.stdout
+    assert "postgres://" not in first.stdout
+    assert json.loads(first.stdout)["eligibility"]["canonical_runtime_candidate"] is True
+
+
+def test_collector_does_not_mutate_fixture_files(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    tracked = [fixture["compose"], fixture["override"], fixture["profile_dir"] / "v1-local-core-web-mcp.yaml"]
+    before = {path: path.read_bytes() for path in tracked}
+    collect(fixture)
+    assert {path: path.read_bytes() for path in tracked} == before
+
+
+def test_invalid_root_is_fail_closed(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeIdentityError) as error:
+        collect_runtime_identity(tmp_path / "missing", compose_files=["docker-compose.yml"])
+    assert error.value.code == "runtime_identity_incomplete"


### PR DESCRIPTION
## Summary

Conflict-free replacement for the reverted Issue #574 implementation and corrective PR #577.

- Reintroduces the bounded static supported-profile and Compose identity collector.
- Rejects dangling `down_revision` parents with `migration_identity_incomplete`.
- Preserves deterministic secret-safe effective configuration hashing.
- Includes the original isolated tests plus the migration-graph regression.

## Validation

- `python -m pytest -v tests/audit/test_collect_canonical_runtime_identity.py` — 15 passed
- `python -m pytest -v tests/audit/test_collect_canonical_evidence_identity.py` — 12 passed
- `python -m pytest -v tests/audit/test_validate_canonical_evidence.py` — 13 passed
- `python scripts/validate_docs.py` — passed
- `ruff check scripts/audit/collect_canonical_runtime_identity.py tests/audit/test_collect_canonical_runtime_identity.py` — passed
- `git diff --check` — passed

Static-only tooling: no Docker daemon, database, migration execution, health proof, live runtime proof, complete manifest, evidence storage, freshness evaluation, or promotion.

Closes #574