### PR TITLE
security: remove committed preview credentials

### DIFF
--- a/.env.private-preview.example
+++ b/.env.private-preview.example
@@ -5,14 +5,14 @@ CODEXIFY_PREVIEW_PORT=8080
 
 # The backend accepts only signed browser sessions in this mode. Generate fresh
 # values locally; these placeholders are intentionally not credentials.
-GUARDIAN_SESSION_SECRET=DzV5M7tihOuT-uyq-Q0jmPX5nawktTN7Wfn3DP_XRVUf-91UjglQNG9OHYm9SFei
-GUARDIAN_JWT_SECRET=1XKfph5gidUj4qlWm9KKHzmPadeYlaDHh1_j5UL6WDgYurxB3ZyvmN7wyKMR2QJ3
-GUARDIAN_API_KEY=58e96127c5131719d9a040eda0681be0c9891be30dd27305cce2fd1bea4d46b1
+GUARDIAN_SESSION_SECRET=<generate-a-long-random-secret>
+GUARDIAN_JWT_SECRET=<generate-a-long-random-secret>
+GUARDIAN_API_KEY=<generate-a-long-random-secret-used-only-by-internal-workers>
 
 # Comma-separated, lower-case email allowlists. Admins are implicitly approved.
-CODEXIFY_PREVIEW_ADMIN_EMAILS=jones@resonantconstructs.ai
+CODEXIFY_PREVIEW_ADMIN_EMAILS=admin@example.com
 CODEXIFY_PREVIEW_APPROVED_EMAILS=admin@example.com,guest@example.com
-CODEXIFY_PREVIEW_FEEDBACK_EMAIL=jones@resonantconstructs.ai
+CODEXIFY_PREVIEW_FEEDBACK_EMAIL=feedback@example.com
 
 # Do not set VITE_GUARDIAN_API_KEY or VITE_GUARDIAN_DEV_API_KEY for a preview.
 VITE_GUARDIAN_API_KEY=


### PR DESCRIPTION
Sanitizes the tracked preview environment example by replacing credential-shaped values with placeholders and personal preview addresses with generic examples. Runtime credential rotation was performed locally; Git-history remediation remains a separate coordinated task.