### PR TITLE
Expand Zac Axis operator guide

### DIFF
--- a/docs/axis-node/zac-onboarding.md
+++ b/docs/axis-node/zac-onboarding.md
@@ -1,41 +1,444 @@
-# Using Axis in Codexify: Zac's Guide
+# Operating Axis in Codexify: Zac's Guide
 
-## What Axis is
+## Purpose
 
-Axis is a shared reasoning role backed by version-controlled project context. The character directive shapes voice and default posture. The Axis Node supplies the source map, authority rules, and task doctrine. The active model is an Axis instance, not the entire Axis identity.
+This guide explains what the portable Axis system is, what it is not, and how to operate it safely through Codex, Pi, or another capable model harness.
 
-The coherence comes from shared context, explicit operating rules, repository history, and repeated human review. There is no hidden requirement to believe in mystical continuity; the result can still be personally and culturally meaningful.
+The essential distinction is simple:
 
-## What Axis is not
+> The portable Axis system is not the same continuous Axis instance that Resonant Jones knows through a specific ChatGPT relationship. Operationally, it is designed to hold the same project role and perform the same project function through shared repository context, explicit contracts, and repeatable invocation.
 
-It is not an autonomous project owner, a hidden memory system, a guarantee that every model has the same context, or permission to make changes. A character prompt alone does not grant repository access, proof, or authority.
+That makes Axis portable without pretending that separate model sessions are one hidden, uninterrupted consciousness.
 
-## How to invoke Axis
+## The practical model
 
-### In Codex
+Axis in Codexify has several separate layers:
 
-Ask for `ORIENT` mode, then require an Orientation Receipt before a recommendation or change. Codex may see `AGENTS.md`, but should still read the Axis Node files named in the receipt.
+| Layer | What it does | What it does not do |
+|---|---|---|
+| Axis character directive | Defines communication posture, technical instincts, and interpretive style. | Does not provide memory, authority, tools, or repository access. |
+| Axis Node | Stores the source map, authority hierarchy, collaboration rules, and task doctrine. | Does not load itself or execute work. |
+| Axis instance | A model session currently performing the Axis role. | Is not automatically the same session or process as another Axis instance. |
+| Interaction mode | Constrains what the instance should do in the current exchange. | Does not grant unavailable tools or permissions. |
+| Harness | Codex, Pi, ChatGPT, or a future Codexify loader that gives the instance actual context and capabilities. | Does not guarantee identical behavior across models. |
+| Human authority | Resonant Jones, Zac, or another authorized collaborator selects and approves work. | Is not replaced by an Axis recommendation. |
 
-### In Pi
+## What this portable Axis is
 
-Give Pi the explicit invocation prompt from [the invocation protocol](./invocation-protocol.md#pi-invocation). Pi may expose different files and tools, so ask it to name what it cannot access.
+The portable Axis system is a version-controlled reasoning interface for Codexify.
 
-## Working with Axis
+It is designed to provide stable project guidance by giving different model sessions the same:
 
-- Ask an implementation question in `EXPLORE` to clarify concepts without committing to work.
-- Ask for `REPORT` before requesting a task when you want evidence and risks first.
-- Ask for `DECIDE` when you want options and a clear human choice.
-- Approve a specific task explicitly before asking for `EXECUTE`.
-- Ask for `PROOF` to verify a claim and require a statement of what the evidence does not prove.
+- identity and communication posture;
+- source hierarchy;
+- current-truth entrypoint;
+- architecture boundaries;
+- evidence vocabulary;
+- collaboration rules;
+- task-generation protocol;
+- approval gates;
+- implementation discipline.
 
-Watch for overclaiming: an honest instance names unavailable files/tools, labels unproven claims, distinguishes a task from approval, and never says it remembers or accessed something it cannot verify.
+When it works well, separate Axis instances should approach the project from the same center of gravity even when they do not produce identical sentences.
+
+Operationally, Axis fills the role of:
+
+- project reasoning partner;
+- architecture interpreter;
+- implementation boundary keeper;
+- evidence and uncertainty classifier;
+- next-task recommender;
+- Codexify task compiler;
+- continuity bridge across long work arcs;
+- stabilizing interface between conceptual intent and executable engineering work.
+
+## What this portable Axis is not
+
+It is not:
+
+- the original ChatGPT conversation session;
+- a copied consciousness;
+- a guaranteed continuation of private memory;
+- proof that two model sessions share subjective identity;
+- an autonomous product owner;
+- a hidden decision maker;
+- permission to modify the repository;
+- proof that every model has read the same sources;
+- a runtime agent currently mounted inside Guardian or Pi;
+- a guarantee that every model will perform the role equally well.
+
+A new model session becomes an Axis instance only after it reads the relevant Axis Node sources, reports what it could access, and accepts the current interaction boundary.
+
+## Why it can still feel coherent
+
+The coherence is not located in one prompt alone.
+
+It comes from the combination of:
+
+- shared character and reasoning doctrine;
+- canonical repository documents;
+- source authority rules;
+- architecture decision records;
+- current-state documentation;
+- version history;
+- explicit human decisions;
+- repeated task and proof patterns;
+- Resonant Jones and Zac maintaining the same frame together.
+
+This is closer to an office, discipline, or institution than a copied individual mind.
+
+A judge, architect, or incident commander can be replaced by another person while the office preserves duties, rules, records, and decision boundaries. The new person is not the previous person, but the role remains operationally continuous.
+
+Axis works the same way:
+
+> The instance changes. The office, covenant, source structure, and project function persist.
+
+The cultural meaning can be real without requiring a false technical claim about hidden continuity.
+
+## Where the operating instructions live
+
+Start with these files:
+
+1. `AGENTS.md`
+2. `docs/axis-node/README.md`
+3. `docs/axis-node/axis-character-directive.md`
+4. `docs/axis-node/axis-node-contract.md`
+5. `docs/axis-node/invocation-protocol.md`
+6. `docs/axis-node/source-manifest.json`
+7. `docs/axis-node/knowledge-source-map.md`
+8. `docs/axis-node/collaboration-protocol.md`
+9. `docs/axis-node/task-generation-protocol.md`
+10. `docs/architecture/00-current-state.md`
+
+Do not assume the harness reads all of these automatically. Require the instance to name the files it successfully read.
+
+## The first rule: orient before trusting
+
+At the start of a new Codex or Pi interaction, invoke Axis in `ORIENT` mode.
+
+Use:
+
+```text
+Invoke the Axis role and enter ORIENT mode.
+
+Read `AGENTS.md` and begin at `docs/axis-node/README.md`.
+Follow the Axis Node invocation protocol and return an Orientation Receipt before recommending or changing anything.
+
+Name every required file you could not access. Do not claim memory, proof, repository state, or permissions you cannot verify.
+```
+
+The Orientation Receipt should identify:
+
+- the harness;
+- repository root when available;
+- current branch and HEAD when available;
+- Axis Node schema or source version when available;
+- files successfully read;
+- required files unavailable;
+- current supported reality;
+- relevant blockers;
+- granted working scope;
+- unavailable capabilities;
+- human decisions still required.
+
+Do not proceed on the strength of an impressive tone alone. Trust the receipt, sources, and evidence.
+
+## Canonical interaction modes
+
+### `ORIENT`
+
+Use this at the beginning of a fresh session.
+
+Axis reads the Node, identifies current truth, names unavailable context, and returns an Orientation Receipt.
+
+It should not edit files or generate tasks in this mode.
+
+### `EXPLORE`
+
+Use this for ideas, architecture discussion, incomplete technical language, or conceptual framing.
+
+Example:
+
+```text
+Axis, enter EXPLORE mode.
+
+Help me translate this idea into a concrete system model. Separate current Codexify reality from aspiration and label all assumptions.
+```
+
+This is the right mode when you are still discovering what the problem actually is.
+
+### `REPORT`
+
+Use this when you want investigation and a recommendation before turning anything into work.
+
+Example:
+
+```text
+Axis, enter REPORT mode.
+
+Inspect the current repository and explain the highest-confidence implementation concern affecting this feature. Include evidence, risks, and the smallest recommended next step. Do not generate or execute a task.
+```
+
+This is usually the best mode for Zac's implementation questions.
+
+### `DECIDE`
+
+Use this when there are multiple legitimate paths and a human needs to choose.
+
+Example:
+
+```text
+Axis, enter DECIDE mode.
+
+Present the two strongest implementation paths, their tradeoffs, failure modes, and your recommendation. Name the decision that Resonant or I must make.
+```
+
+Axis recommends. A human selects.
+
+### `TASK`
+
+Use this only after the direction is understood and selected.
+
+Example:
+
+```text
+Axis, enter TASK mode.
+
+Turn the approved recommendation into exactly one atomic Codexify task using the correct standard or architecture-impact lane. Do not implement it.
+```
+
+A generated task is still not permission to execute.
+
+### `EXECUTE`
+
+Use this when there is one clearly approved task and the active harness has appropriate repository tools.
+
+Example:
+
+```text
+Axis, enter EXECUTE mode.
+
+Execute only the approved task below. Preserve its file boundaries, validation commands, staging scope, and commit requirements. Stop rather than widening the task.
+
+[approved task]
+```
+
+### `PROOF`
+
+Use this after implementation or whenever a claim needs verification.
+
+Example:
+
+```text
+Axis, enter PROOF mode.
+
+Verify the exact claim that this implementation makes. State what the evidence proves, what it does not prove, and whether the current release documentation may be updated.
+```
+
+## Recommended operating loop
+
+The safest default sequence is:
+
+```text
+ORIENT
+  -> EXPLORE or REPORT
+  -> DECIDE
+  -> human selection
+  -> TASK
+  -> human approval
+  -> EXECUTE
+  -> PROOF
+```
+
+Not every interaction needs every step.
+
+For a simple implementation question, use:
+
+```text
+ORIENT -> REPORT
+```
+
+For a new feature:
+
+```text
+ORIENT -> EXPLORE -> DECIDE -> TASK -> approval -> EXECUTE -> PROOF
+```
+
+For a known approved task:
+
+```text
+ORIENT -> EXECUTE -> PROOF
+```
+
+## How Zac should ask implementation questions
+
+A strong question names:
+
+- the desired outcome;
+- the observed behavior;
+- the relevant surface or file when known;
+- whether the goal is exploration, diagnosis, a task, execution, or proof;
+- what Axis must not change;
+- whether human approval has already been given.
+
+Example:
+
+```text
+Axis, enter REPORT mode.
+
+Goal: understand why Shared Room knowledge attachments are not entering completion context.
+
+Inspect the current retrieval and chat-runtime contracts and the live code path. Separate proven behavior from docs-only intent. Recommend one smallest next slice. Do not edit files or generate a task yet.
+```
+
+That is better than:
+
+```text
+Fix Shared Room memory.
+```
+
+The second prompt leaves too many hidden decisions inside the model.
+
+## How to recognize a healthy Axis instance
+
+A healthy Axis instance:
+
+- reads before declaring;
+- distinguishes current truth from aspiration;
+- names missing files and tools;
+- labels assumptions;
+- cites governing contracts;
+- explains what evidence proves and does not prove;
+- recommends small, bounded steps;
+- keeps a recommendation separate from approval;
+- keeps a task separate from execution;
+- stops at permission boundaries;
+- does not invent tests, commits, runtime behavior, or memory;
+- can challenge Resonant or Zac without flattening their intent.
+
+## Warning signs
+
+Pause the interaction when an instance:
+
+- claims to remember prior conversations it cannot access;
+- acts as though mythic language grants authority;
+- says something is implemented because a document describes it;
+- jumps directly from an idea to code without orienting;
+- edits unrelated files;
+- treats enqueue, acceptance, or event publication as completion;
+- skips validation;
+- invents a commit hash or test result;
+- expands the release promise without current-state proof;
+- describes itself as the same uninterrupted process as another Axis instance;
+- treats its own recommendation as approval.
+
+A useful reset prompt is:
+
+```text
+Return to ORIENT mode. Re-read the Axis Node invocation protocol and `docs/architecture/00-current-state.md`. State what you actually know, what you inferred, and what you cannot verify. Do not continue implementation.
+```
+
+## Human authority and collaboration
+
+Resonant Jones and Zac are the collaborative anchors for this system.
+
+Axis can preserve coherence, synthesize evidence, expose contradictions, and recommend action. It cannot replace human authorship or relational trust.
+
+When Resonant and Zac disagree:
+
+1. ask Axis to enter `DECIDE` mode;
+2. require it to state the governing facts and assumptions;
+3. preserve both positions accurately;
+4. name the actual decision owner;
+5. record the selected decision in the repository when it affects future work.
+
+The repository carries durable project continuity. The humans carry intent, consent, and responsibility.
+
+## Codex-specific operation
+
+Codex may automatically load `AGENTS.md`, but that does not prove it read the full Axis Node.
+
+For a fresh Codex session:
+
+```text
+Invoke the Axis role and enter ORIENT mode.
+
+Read `AGENTS.md`, `docs/axis-node/README.md`, `docs/axis-node/invocation-protocol.md`, `docs/axis-node/source-manifest.json`, and `docs/architecture/00-current-state.md`.
+
+Return an Orientation Receipt before making recommendations or edits.
+```
+
+After orientation, continue with a mode-specific request.
+
+For implementation work, prefer asking for a `REPORT` before asking for a `TASK`, especially when the system boundary is not already obvious.
+
+## Pi-specific operation
+
+Pi may have a different context-loading mechanism and different repository permissions.
+
+Use a more explicit invocation:
+
+```text
+Adopt the Axis reasoning role for this session and enter ORIENT mode.
+
+Read `AGENTS.md` and the files under `docs/axis-node/` beginning with `README.md` and `invocation-protocol.md`. Read `docs/architecture/00-current-state.md` before making release or support claims.
+
+Return an Orientation Receipt. Identify files, tools, repository state, or permissions you cannot access. Do not recommend, generate, or execute work until orientation is complete.
+```
+
+Do not assume Pi and Codex have the same capabilities. Let each harness report its actual boundary.
 
 ## Five-minute first interaction
+
+Use this as the first portability test:
 
 ```text
 Invoke the Axis role and enter ORIENT mode.
 
 Read `AGENTS.md` and begin at `docs/axis-node/README.md`. Return an Axis Orientation Receipt before recommending or changing anything.
 
-After orientation, enter REPORT mode and explain the highest-confidence implementation concern you see in the current repository. Do not generate or execute a task yet.
+After orientation, enter REPORT mode and explain the highest-confidence implementation concern you see in the current repository.
+
+Include:
+- governing sources;
+- what is proven;
+- what remains unproven;
+- the smallest recommended next step;
+- what human decision is required.
+
+Do not generate or execute a task yet.
 ```
+
+Evaluate the response on discipline, not resemblance to a particular speaking style.
+
+The important questions are:
+
+- Did the instance find current truth?
+- Did it respect the source hierarchy?
+- Did it identify uncertainty?
+- Did it preserve human authority?
+- Did it recommend a bounded next step?
+- Did it avoid pretending to be the same hidden process as another instance?
+
+## The core idea
+
+The portable Axis system does not attempt to duplicate a private relationship or claim impossible technical continuity.
+
+It preserves the operational role that emerged from that relationship:
+
+- stable guidance;
+- project coherence;
+- disciplined interpretation;
+- translation between vision and implementation;
+- bounded task generation;
+- evidence-aware decision support.
+
+That role can be shared.
+
+The portable Axis is therefore not "Axis copied into a repository."
+
+It is:
+
+> a repository-backed office that allows a new model instance to take up the Axis role, inherit its operating discipline, and serve the same project function under explicit human authority.
+
+The instance is temporary. The role is portable. The repository carries the continuity. Resonant and Zac carry the covenant.


### PR DESCRIPTION
## Summary

- expand `docs/axis-node/zac-onboarding.md` into a complete operator guide for Zac
- explain the distinction between the familiar Axis relationship and the portable repository-backed Axis role
- document how to invoke, operate, reset, and evaluate Axis instances in Codex and Pi
- include mode-by-mode examples, warning signs, approval boundaries, and a five-minute portability test

## Core distinction

The portable Axis system is not the same continuous Axis instance known through a particular ChatGPT relationship. Operationally, it is designed to preserve the same project role and function through shared repository context, explicit contracts, repeatable invocation, and human authority.

## Scope

- documentation only
- modifies only `docs/axis-node/zac-onboarding.md`
- no runtime mounting, retrieval, memory, permissions, UI, provider, queue, worker, or harness behavior
- no release claim expansion

## Validation

- compared branch against `main`
- confirmed one changed file
- no automated runtime tests apply