### PR TITLE
Make dashboard snapshot viewer aware

### DIFF
--- a/docs/architecture/guardian-dashboard-snapshot-contract.md
+++ b/docs/architecture/guardian-dashboard-snapshot-contract.md
@@ -1,17 +1,41 @@
 # Guardian Dashboard Snapshot Contract
 
-Status: implemented first slice for private-preview operator dashboard.
+Status: implemented viewer-aware slice for private-preview dashboard use.
 
 This contract defines one authenticated, read-only server projection. It does
 not add collaboration persistence, realtime presence, shared notes, mentions,
 host collectors, or collaboration tables.
 
-## Route and ownership
+## Route and dual-authority model
 
 `GET /api/dashboard/snapshot` is Guardian-owned and requires the existing
-`require_api_key` authentication dependency. The route is enabled in the
-local-core and friends/family supported profiles. It is a projection only;
-the existing Guardian health and sensor providers remain the sources of truth.
+`require_api_key` dependency plus a service API key and an authenticated human
+Guardian session. The route is enabled in the local-core and friends/family
+supported profiles. It is a projection only; the existing Guardian health and
+sensor providers remain the sources of truth.
+
+The two authorities are intentionally distinct:
+
+- Service authority is the configured Guardian API key supplied in
+  `X-API-Key`. It proves the trusted service path is allowed to request the
+  projection.
+- Human authority is the signed `gc_session` (or the same Guardian session
+  carried as a bearer token). It determines the current viewer. In
+  private-preview mode, Guardian resolves the signed session through the
+  approved-email allowlist and its server-mapped `admin`/`guest` role policy.
+
+A valid API key without a valid Guardian session is rejected. A valid Guardian
+session without the service API key is rejected. `X-User-Id`, request bodies,
+query parameters, and other caller-controlled identity fields never determine
+the viewer.
+
+Guardian owns identity and authorization. Codexify.Space transports the signed
+session and renders Guardian-owned projections. Codexify.Space must not
+maintain a parallel user authority.
+
+Codexify.Space owns client presentation, not account authority: it may render
+the bounded viewer projection but must not mint identities, map accounts,
+assign roles, or persist a competing account store.
 
 ## Response schema
 
@@ -22,6 +46,13 @@ the existing Guardian health and sensor providers remain the sources of truth.
   "source": {
     "service": "guardian",
     "projection": "canonical_health_and_sensor_telemetry"
+  },
+  "viewer": {
+    "user_id": "<canonical Guardian account id>",
+    "display_name": "<string|null>",
+    "role": "admin|guest",
+    "avatar_url": "<string|null>",
+    "timezone": "<string|null>"
   },
   "health": {
     "core": {},
@@ -53,6 +84,30 @@ the existing Guardian health and sensor providers remain the sources of truth.
 }
 ```
 
+`schema_version` remains `guardian.dashboard.snapshot.v1`. Adding the bounded,
+required viewer projection does not change the stable projection family or its
+telemetry semantics, so this contract does not require a version increment.
+
+## Viewer provenance and isolation
+
+`viewer.user_id` is the canonical Guardian account identity derived from the
+authenticated session. In private-preview mode, it is the normalized approved
+email resolved from the signed session; a supplied `X-User-Id` cannot replace
+it. Chris's approved session resolves Chris's account and the `admin` role;
+Zac's approved session resolves Zac's account and the `guest` role.
+
+`display_name`, `avatar_url`, and `timezone` come only from Guardian's existing
+current-user profile seam. If a canonical authenticated account has no profile
+row, Guardian reuses that seam's lazy profile creation behavior. A viewer can
+receive only the profile for the account derived from that viewer's session.
+
+When private-preview mode is active, `viewer.role` comes from
+`guardian.core.preview_access` and its approved-email policy, not a request
+field or a caller-selected role. Outside private-preview mode, the canonical
+Guardian account role supplies the bounded role value. The response excludes
+password hashes, plaintext passwords, session tokens, API keys, allowlist
+configuration, raw authorization headers, and private account internals.
+
 `health` is composed from the existing health route handlers and heartbeat
 status reader. `host.sensors` is the already-wired `Sensors` provider; this
 route must not create a second collector. `attention` contains a bounded
@@ -65,7 +120,15 @@ realtime presence, or mention delivery.
 
 ## Architecture boundary
 
-This is aligned with ADR-039's operator/user boundary: the route is an
-authenticated operator-owned infrastructure snapshot, not a user identity or
-collaboration surface. It does not widen the supported release claim or imply
-end-to-end runtime completion from health telemetry.
+This is aligned with ADR-039's operator/user boundary and ADR-005's account
+boundary invariants. The route is an authenticated Guardian projection with a
+viewer context, not a parallel identity service, collaboration system, or
+operator-impersonation surface. It does not widen the supported release claim
+or imply end-to-end runtime completion from health telemetry.
+
+The `orientation.notes`, `orientation.presence`, and `orientation.mentions`
+arrays remain empty. Shared notes, presence, mentions, room membership,
+last-seen cursors, collaboration tables, and Codexify.Space frontend integration
+remain deferred. Their absence must not be inferred from the viewer projection,
+and the viewer projection must not weaken account scoping for threads,
+projects, documents, media, or chat.

--- a/guardian/core/dependencies.py
+++ b/guardian/core/dependencies.py
@@ -697,6 +697,56 @@ def verify_api_key(
     raise HTTPException(status_code=401, detail="Invalid API key")
 
 
+def require_service_api_key(
+    x_api_key: Optional[str] = Header(None, alias="X-API-Key"),
+) -> str:
+    """Require a configured static service key without accepting session auth.
+
+    Private-preview routes normally use :func:`require_api_key` to validate a
+    Guardian session.  A route that needs a distinct trusted-service authority
+    can layer this dependency alongside it without changing preview-wide auth
+    behavior.
+    """
+    candidate = _coerce_text(x_api_key)
+    if not candidate:
+        raise HTTPException(status_code=401, detail="Missing API key")
+
+    allowed: List[str] = []
+    try:
+        settings = get_settings()
+        primary = getattr(settings, "GUARDIAN_API_KEY", None)
+        if isinstance(primary, str) and primary.strip():
+            allowed.append(primary.strip())
+        raw_multi = getattr(settings, "GUARDIAN_API_KEYS", None)
+        if isinstance(raw_multi, str) and raw_multi.strip():
+            allowed.extend(
+                token.strip()
+                for token in raw_multi.replace(";", ",").split(",")
+                if token.strip()
+            )
+    except Exception:
+        pass
+
+    env_key = (os.getenv("GUARDIAN_API_KEY") or "").strip()
+    if env_key and env_key not in allowed:
+        allowed.append(env_key)
+
+    if not allowed:
+        logger.error(
+            "GUARDIAN_API_KEY is not configured; set it in .env or the environment."
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Server misconfigured: GUARDIAN_API_KEY is not set",
+        )
+
+    if any(hmac.compare_digest(candidate, allowed_key) for allowed_key in allowed):
+        return candidate
+
+    logger.warning("Unauthorized service API key attempt")
+    raise HTTPException(status_code=401, detail="Invalid API key")
+
+
 def require_api_key(api_key: str = Depends(verify_api_key)) -> str:
     """
     Backward-compatible wrapper around verify_api_key.
@@ -1104,6 +1154,7 @@ __all__ = [
     # Authentication
     "verify_api_key",
     "require_api_key",
+    "require_service_api_key",
     "get_current_user",
     "get_request_user_scope",
     "get_request_user_id",

--- a/guardian/routes/dashboard.py
+++ b/guardian/routes/dashboard.py
@@ -8,14 +8,26 @@ import socket
 from datetime import datetime, timezone
 from typing import Any, Literal
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import Response
 from pydantic import BaseModel, ConfigDict, Field
 
 from guardian.core import dependencies
-from guardian.core.dependencies import require_api_key
+from guardian.core.auth_dependencies import resolve_session_user_id
+from guardian.core.dependencies import (
+    get_request_user_scope,
+    require_api_key,
+    require_service_api_key,
+)
+from guardian.core.preview_access import (
+    ADMIN_ROLE,
+    GUEST_ROLE,
+    is_private_preview,
+    require_preview_principal,
+)
 from guardian.routes import health as health_routes
 from guardian.routes.heartbeat import heartbeat_status
+from guardian.routes.user_profile import resolve_user_profile_owner
 
 
 class DashboardOrientation(BaseModel):
@@ -26,6 +38,18 @@ class DashboardOrientation(BaseModel):
     mentions: list[dict[str, Any]] = Field(default_factory=list)
 
 
+class DashboardViewer(BaseModel):
+    """Bounded current-viewer projection derived from Guardian authority."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    user_id: str
+    display_name: str | None = None
+    role: Literal["admin", "guest"]
+    avatar_url: str | None = None
+    timezone: str | None = None
+
+
 class DashboardSnapshot(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -34,6 +58,7 @@ class DashboardSnapshot(BaseModel):
     )
     generated_at: str
     source: dict[str, str]
+    viewer: DashboardViewer
     health: dict[str, Any]
     runtime: dict[str, Any]
     host: dict[str, Any]
@@ -49,6 +74,51 @@ router = APIRouter(
     tags=["Dashboard"],
     dependencies=[Depends(require_api_key)],
 )
+
+
+def resolve_dashboard_viewer(request: Request) -> DashboardViewer:
+    """Resolve a viewer from the Guardian session, never caller input."""
+    require_service_api_key(request.headers.get("X-API-Key"))
+    if is_private_preview():
+        principal = require_preview_principal(request)
+        user_id = principal.email
+        role = principal.role
+    else:
+        session_user_id = resolve_session_user_id(
+            request.headers.get("Authorization"), request.cookies.get("gc_session")
+        )
+        if not session_user_id:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Dashboard snapshot requires an authenticated Guardian session",
+            )
+        request_scope = get_request_user_scope(request)
+        user_id = str(
+            request_scope.account_id or request_scope.user_id or ""
+        ).strip()
+        if not user_id:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Dashboard snapshot requires a canonical authenticated user",
+            )
+        role = ""
+
+    profile, persisted_role = resolve_user_profile_owner(user_id)
+    if not is_private_preview():
+        role = persisted_role
+    if role not in {ADMIN_ROLE, GUEST_ROLE}:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Canonical user role is invalid",
+        )
+
+    return DashboardViewer(
+        user_id=user_id,
+        display_name=profile.display_name,
+        role=role,
+        avatar_url=profile.avatar_url,
+        timezone=profile.timezone,
+    )
 
 
 def _payload(value: Any) -> dict[str, Any]:
@@ -101,7 +171,10 @@ def _attention_items(health: dict[str, Any]) -> list[dict[str, Any]]:
     return items
 
 
-async def build_dashboard_snapshot(request: Request) -> DashboardSnapshot:
+async def build_dashboard_snapshot(
+    request: Request,
+    viewer: DashboardViewer,
+) -> DashboardSnapshot:
     """Build one server-owned snapshot from canonical Guardian health seams."""
     core = _payload(health_routes.health(request))
     llm = _payload(health_routes.health_llm())
@@ -115,6 +188,7 @@ async def build_dashboard_snapshot(request: Request) -> DashboardSnapshot:
             "service": "guardian",
             "projection": "canonical_health_and_sensor_telemetry",
         },
+        viewer=viewer,
         health=health,
         runtime={
             "provider": llm.get("provider"),
@@ -129,6 +203,9 @@ async def build_dashboard_snapshot(request: Request) -> DashboardSnapshot:
 
 
 @router.get("/snapshot", response_model=DashboardSnapshot)
-async def dashboard_snapshot(request: Request) -> DashboardSnapshot:
+async def dashboard_snapshot(
+    request: Request,
+    viewer: DashboardViewer = Depends(resolve_dashboard_viewer),
+) -> DashboardSnapshot:
     """Return the authenticated, read-only Guardian dashboard snapshot."""
-    return await build_dashboard_snapshot(request)
+    return await build_dashboard_snapshot(request, viewer)

--- a/guardian/routes/user_profile.py
+++ b/guardian/routes/user_profile.py
@@ -96,6 +96,27 @@ def _get_or_create_profile(session, owner_id: str) -> UserProfile:
     return profile
 
 
+def resolve_user_profile_owner(
+    owner_id: str,
+) -> tuple[UserProfileResponse, str]:
+    """Resolve one canonical user's profile and persisted account role.
+
+    This is the shared profile seam for read-only Guardian projections.  It
+    preserves the current route's lazy profile creation behavior and never
+    accepts ownership from request-controlled input.
+    """
+    db = _profile_db()
+    with db.get_session() as session:
+        canonical_owner_id = str(owner_id or "").strip()
+        if not canonical_owner_id:
+            raise HTTPException(status_code=401, detail="Missing authenticated user")
+        user = session.get(User, canonical_owner_id)
+        if user is None:
+            raise HTTPException(status_code=404, detail="user not found")
+        profile = _get_or_create_profile(session, canonical_owner_id)
+        return _profile_payload(profile), str(user.role or "").strip()
+
+
 @router.get("/profile")
 def get_profile(
     request_user_scope: RequestUserScope = Depends(get_request_user_scope),

--- a/tests/routes/test_dashboard_snapshot.py
+++ b/tests/routes/test_dashboard_snapshot.py
@@ -1,36 +1,156 @@
-"""Tests for the authenticated Guardian dashboard snapshot projection."""
+"""Tests for the viewer-aware Guardian dashboard snapshot projection."""
 
 from __future__ import annotations
 
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
+from guardian.core import auth_dependencies as auth_dependencies_module
 from guardian.core import dependencies
+from guardian.core.auth import issue_session_token
+from guardian.core.session_store import SessionStore
+from guardian.db.models import User, UserProfile
 from guardian.routes import dashboard
+from guardian.routes import user_profile as user_profile_routes
 from guardian.routes.heartbeat import HeartbeatStatusResponse
 
-
-def _client() -> TestClient:
-    app = FastAPI()
-    app.include_router(dashboard.router)
-    return TestClient(app)
+_API_KEY = "dashboard-test-key"
+_CHRIS_ID = "chris@resonantconstructs.ai"
+_ZAC_ID = "maatariki@resonantconstructs.ai"
 
 
-def test_dashboard_snapshot_requires_auth(monkeypatch):
-    monkeypatch.setenv("GUARDIAN_API_KEY", "dashboard-test-key")
-    client = _client()
+class _FakeRedis:
+    def __init__(self) -> None:
+        self._strings: dict[str, bytes] = {}
 
-    response = client.get(
-        "/api/dashboard/snapshot", headers={"X-API-Key": "wrong-key"}
-    )
+    def set(
+        self,
+        key: str,
+        value: object,
+        ex: int | None = None,
+        nx: bool = False,
+    ) -> bool | None:
+        if nx and key in self._strings:
+            return None
+        self._strings[key] = str(value).encode("utf-8")
+        _ = ex
+        return True
 
-    assert response.status_code == 401
+    def get(self, key: str) -> bytes | None:
+        return self._strings.get(key)
+
+    def delete(self, key: str) -> int:
+        return 1 if self._strings.pop(key, None) is not None else 0
 
 
-def test_dashboard_snapshot_projects_canonical_telemetry_and_empty_orientation(
-    monkeypatch,
-):
-    monkeypatch.setenv("GUARDIAN_API_KEY", "dashboard-test-key")
+class _DashboardDb:
+    def __init__(self) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite://",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        User.__table__.create(engine)
+        UserProfile.__table__.create(engine)
+        self._session_factory = sessionmaker(
+            bind=engine,
+            autoflush=False,
+            autocommit=False,
+            future=True,
+        )
+
+    @contextmanager
+    def get_session(self):
+        session = self._session_factory()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    def seed_user(
+        self,
+        *,
+        user_id: str,
+        role: str,
+        display_name: str | None = None,
+        avatar_url: str | None = None,
+        timezone_name: str | None = None,
+    ) -> None:
+        with self.get_session() as session:
+            session.add(
+                User(
+                    id=user_id,
+                    username=user_id,
+                    password_hash="non-secret-test-hash",
+                    role=role,
+                    created_at=datetime.now(timezone.utc),
+                )
+            )
+            session.add(
+                UserProfile(
+                    user_id=user_id,
+                    display_name=display_name,
+                    avatar_url=avatar_url,
+                    timezone=timezone_name,
+                )
+            )
+            session.commit()
+
+    def profile_for(self, user_id: str) -> UserProfile | None:
+        with self.get_session() as session:
+            return session.scalar(
+                select(UserProfile).where(UserProfile.user_id == user_id)
+            )
+
+
+def _private_preview_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CODEXIFY_DISABLE_DOTENV", "1")
+    monkeypatch.setenv("GUARDIAN_EXPOSURE_MODE", "private_preview")
+    monkeypatch.setenv("GUARDIAN_SESSION_SECRET", "dashboard-session-secret")
+    monkeypatch.setenv("GUARDIAN_API_KEY", _API_KEY)
+    monkeypatch.setenv("CODEXIFY_PREVIEW_ADMIN_EMAILS", _CHRIS_ID)
+    monkeypatch.setenv("CODEXIFY_PREVIEW_APPROVED_EMAILS", f"{_CHRIS_ID},{_ZAC_ID}")
+
+
+@contextmanager
+def _client(db: _DashboardDb | None = None):
+    session_store = SessionStore(redis_client=_FakeRedis())
+    with (
+        patch.object(
+            auth_dependencies_module,
+            "get_session_store",
+            return_value=session_store,
+        ),
+        patch.object(
+            user_profile_routes,
+            "load_guardian_db_from_env",
+            return_value=db,
+        ),
+    ):
+        app = FastAPI()
+        app.include_router(dashboard.router)
+        with TestClient(app) as client:
+            yield client, session_store
+
+
+def _session_cookie(
+    session_store: SessionStore, user_id: str
+) -> tuple[str, dict[str, str]]:
+    token, _ = issue_session_token(subject=user_id, ttl_seconds=60)
+    session_store.store(token, user_id, 60)
+    return token, {"gc_session": token}
+
+
+def _stub_dashboard_sources(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         dashboard.health_routes,
         "health",
@@ -52,15 +172,87 @@ def test_dashboard_snapshot_projects_canonical_telemetry_and_empty_orientation(
     )
 
     async def heartbeat_fixture():
-        return _heartbeat_fixture()
+        return HeartbeatStatusResponse(latest_date="2026-07-16")
 
     monkeypatch.setattr(dashboard, "heartbeat_status", heartbeat_fixture)
     monkeypatch.setattr(dependencies, "_sensors", None)
 
-    response = _client().get(
-        "/api/dashboard/snapshot",
-        headers={"X-API-Key": "dashboard-test-key"},
+
+def _seed_viewers(db: _DashboardDb) -> None:
+    # Deliberately invert persisted roles: private-preview policy, not a stored
+    # row or caller-controlled field, owns the returned role in this mode.
+    db.seed_user(
+        user_id=_CHRIS_ID,
+        role="guest",
+        display_name="Chris",
+        avatar_url="https://example.com/chris.png",
+        timezone_name="America/New_York",
     )
+    db.seed_user(
+        user_id=_ZAC_ID,
+        role="admin",
+        display_name="Zac",
+        timezone_name="Pacific/Auckland",
+    )
+
+
+@pytest.mark.parametrize("headers", [{"X-API-Key": ""}, {"X-API-Key": "wrong-key"}])
+def test_dashboard_snapshot_rejects_missing_or_wrong_service_key(
+    monkeypatch: pytest.MonkeyPatch,
+    headers: dict[str, str],
+) -> None:
+    _private_preview_env(monkeypatch)
+    with _client() as (client, session_store):
+        _token, cookies = _session_cookie(session_store, _CHRIS_ID)
+        response = client.get(
+            "/api/dashboard/snapshot", headers=headers, cookies=cookies
+        )
+
+    assert response.status_code == 401, response.text
+
+
+def test_dashboard_snapshot_rejects_service_key_without_guardian_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _private_preview_env(monkeypatch)
+    with _client() as (client, _session_store):
+        response = client.get(
+            "/api/dashboard/snapshot", headers={"X-API-Key": _API_KEY}
+        )
+
+    assert response.status_code == 401, response.text
+
+
+def test_dashboard_snapshot_rejects_guardian_session_without_service_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _private_preview_env(monkeypatch)
+    with _client() as (client, session_store):
+        _token, cookies = _session_cookie(session_store, _CHRIS_ID)
+        response = client.get(
+            "/api/dashboard/snapshot",
+            headers={"X-API-Key": ""},
+            cookies=cookies,
+        )
+
+    assert response.status_code == 401, response.text
+
+
+def test_dashboard_snapshot_projects_chris_as_admin_from_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _private_preview_env(monkeypatch)
+    _stub_dashboard_sources(monkeypatch)
+    db = _DashboardDb()
+    _seed_viewers(db)
+
+    with _client(db) as (client, session_store):
+        token, cookies = _session_cookie(session_store, _CHRIS_ID)
+        response = client.get(
+            "/api/dashboard/snapshot",
+            headers={"X-API-Key": _API_KEY, "X-User-Id": _ZAC_ID},
+            cookies=cookies,
+        )
 
     assert response.status_code == 200
     payload = response.json()
@@ -68,6 +260,7 @@ def test_dashboard_snapshot_projects_canonical_telemetry_and_empty_orientation(
         "schema_version",
         "generated_at",
         "source",
+        "viewer",
         "health",
         "runtime",
         "host",
@@ -76,6 +269,14 @@ def test_dashboard_snapshot_projects_canonical_telemetry_and_empty_orientation(
         "orientation",
     }
     assert payload["schema_version"] == "guardian.dashboard.snapshot.v1"
+    assert payload["viewer"] == {
+        "user_id": _CHRIS_ID,
+        "display_name": "Chris",
+        "role": "admin",
+        "avatar_url": "https://example.com/chris.png",
+        "timezone": "America/New_York",
+    }
+    assert payload["viewer"]["user_id"] != _ZAC_ID
     assert payload["health"]["llm"]["model"] == "test-model"
     assert payload["health"]["heartbeat"]["latest_date"] == "2026-07-16"
     assert payload["runtime"] == {
@@ -93,7 +294,72 @@ def test_dashboard_snapshot_projects_canonical_telemetry_and_empty_orientation(
         "mentions": [],
     }
     assert payload["host"]["telemetry_source"] == "guardian.sensors.state.Sensors"
+    assert token not in response.text
+    assert _API_KEY not in response.text
+    assert "non-secret-test-hash" not in response.text
+    assert "CODEXIFY_PREVIEW_APPROVED_EMAILS" not in response.text
 
 
-def _heartbeat_fixture():
-    return HeartbeatStatusResponse(latest_date="2026-07-16")
+def test_dashboard_snapshot_projects_zac_own_profile_and_guest_role(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _private_preview_env(monkeypatch)
+    _stub_dashboard_sources(monkeypatch)
+    db = _DashboardDb()
+    _seed_viewers(db)
+
+    with _client(db) as (client, session_store):
+        _token, chris_cookies = _session_cookie(session_store, _CHRIS_ID)
+        _token, zac_cookies = _session_cookie(session_store, _ZAC_ID)
+        chris_response = client.get(
+            "/api/dashboard/snapshot",
+            headers={"X-API-Key": _API_KEY},
+            cookies=chris_cookies,
+        )
+        zac_response = client.get(
+            "/api/dashboard/snapshot",
+            headers={"X-API-Key": _API_KEY},
+            cookies=zac_cookies,
+        )
+
+    assert chris_response.status_code == 200
+    assert zac_response.status_code == 200
+    assert zac_response.json()["viewer"] == {
+        "user_id": _ZAC_ID,
+        "display_name": "Zac",
+        "role": "guest",
+        "avatar_url": None,
+        "timezone": "Pacific/Auckland",
+    }
+    assert zac_response.json()["viewer"] != chris_response.json()["viewer"]
+    assert zac_response.json()["viewer"]["avatar_url"] != (
+        chris_response.json()["viewer"]["avatar_url"]
+    )
+
+
+def test_dashboard_snapshot_lazily_creates_only_the_session_viewer_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _private_preview_env(monkeypatch)
+    _stub_dashboard_sources(monkeypatch)
+    db = _DashboardDb()
+    db.seed_user(user_id=_CHRIS_ID, role="guest")
+
+    with _client(db) as (client, session_store):
+        _token, cookies = _session_cookie(session_store, _CHRIS_ID)
+        response = client.get(
+            "/api/dashboard/snapshot",
+            headers={"X-API-Key": _API_KEY},
+            cookies=cookies,
+        )
+
+    assert response.status_code == 200
+    assert response.json()["viewer"] == {
+        "user_id": _CHRIS_ID,
+        "display_name": None,
+        "role": "admin",
+        "avatar_url": None,
+        "timezone": None,
+    }
+    assert db.profile_for(_CHRIS_ID) is not None
+    assert db.profile_for(_ZAC_ID) is None


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
