### PR TITLE
Remove Zac's last name from Codexify Email campaign

### DIFF
--- a/docs/Campaign/codexify-email-agent-native-campaign-index.md
+++ b/docs/Campaign/codexify-email-agent-native-campaign-index.md
@@ -95,7 +95,7 @@ memory without explicit consent through a governed path.
 
 ### Collaborators remain separate principals
 
-Zac Matariki Snushall, also referred to as Maatariki or Matariki, is a separate
+Zac Matariki, also referred to as Maatariki or Matariki, is a separate
 human collaborator, Codexify engineer, and Resonant Constructs member.
 `maatariki@resonantconstructs.ai` is Zac's Google Workspace mailbox. It is not an
 agent identity, operator test mailbox, alias target, credential source, or
@@ -576,7 +576,7 @@ This index does not authorize or implement:
   retrieval, frontend, or Tauri changes;
 - mailbox, alias, label/filter, OAuth client, app-password, credential, DNS, or MX changes;
 - production mailbox cutover or production correspondence;
-- use, inspection, or modification of Zac Matariki Snushall's mailbox or any
+- use, inspection, or modification of Zac Matariki's mailbox or any
   other collaborator infrastructure;
 - a self-hosted mail server in the initial implementation;
 - autonomous sending or deletion;
@@ -586,7 +586,7 @@ This index does not authorize or implement:
 ## 14. Source evidence
 
 - GitHub Issue #599, including its hosted-provider comments
-- GitHub Issue #600 and the identity correction naming Zac Matariki Snushall
+- GitHub Issue #600 and the identity correction naming Zac Matariki
 - `docs/architecture/00-current-state.md`
 - `docs/architecture/README.md`
 - `docs/architecture/adr/adr-index.md`


### PR DESCRIPTION
## Summary

- remove Zac's last name from all three references in the Codexify Email campaign index
- retain the collaborator identity, consent, and mailbox-isolation boundaries
- leave runtime behavior and current release truth unchanged

## Why

The campaign record did not need Zac's last name to preserve the required identity boundary. This narrows the stored personal identifier while retaining the product and consent contract.

## Validation

- `! rg -n "Snushall" docs`
- campaign content checks for Guardian briefing, user-owned routing, logical mailboxes, Google Workspace, and no runtime behavior
- `python3 scripts/validate_docs.py`
- `git diff --check`
- `git diff --cached --check`
- `git diff --exit-code -- docs/architecture/00-current-state.md`

No automated runtime tests apply.