### PR TITLE
Security: contain content and credential logging

### DIFF
--- a/docs/security/INCIDENT_RESPONSE.md
+++ b/docs/security/INCIDENT_RESPONSE.md
@@ -2,6 +2,9 @@
 
 This playbook defines the Codexify response flow when credentials are exposed in source control, logs, or artifacts.
 
+For the current runtime logging contract and bounded-metadata inventory, see
+[`content-credential-logging.md`](./content-credential-logging.md).
+
 ## 1) Identify Compromised Credentials
 Treat credentials as compromised if they appear in any commit, PR diff, CI artifact, screenshots, or shared logs.
 

--- a/docs/security/content-credential-logging.md
+++ b/docs/security/content-credential-logging.md
@@ -1,0 +1,74 @@
+# Codexify Content and Credential Logging Contract
+
+Status: implemented on `main` by CWC-004. This is an operational logging
+contract; it does not change provider selection, fallback, event payloads,
+transcript persistence, attachment persistence, or control-metadata handling.
+
+## Boundary
+
+Codexify operational logs may contain bounded metadata only:
+
+- task, request, run, thread, turn, message, and event IDs;
+- provider, model, queue, status/status code, endpoint kind, and transport
+  classification;
+- failure class, exception type, timeout class, duration, and bounded counts;
+- content-presence booleans and character/item/byte counts;
+- endpoint identity with URL userinfo, query, and fragment removed.
+
+They must not contain user prompts, assistant output, retrieved or attachment
+contents, tool arguments or output bodies, raw provider request/response
+bodies, authorization headers, API keys, bearer tokens, cookies, session
+secrets, or credential-bearing paths.
+
+`guardian/utils/log_safety.py` installs a process-wide `LogRecord` boundary from
+`guardian/__init__.py`. It sanitizes records before console, file, test, or
+third-party handlers see them. `ScrubFormatter` remains a last-mile defense
+for rendered output and continues the existing credential-path scrub.
+
+Exception records retain the exception type and a bounded failure class, such
+as `timeout`, `connection`, `http`, `parse`, `authorization`, `validation`, or
+`runtime`. Exception messages, tracebacks, response bodies, URLs with query
+secrets, and interpolated argument values are not emitted.
+
+## Discovery inventory and classification
+
+| Surface | Relevant findings | Classification after CWC-004 |
+| --- | --- | --- |
+| `guardian/workers/chat_worker.py` | Worker lifecycle, task/turn/message correlation, persistence and audio diagnostics | IDs, provider/model, status, counts, booleans, and failure classes are safe metadata. The former `raw_output` log is now output length/presence only. |
+| `guardian/core/chat_completion_service.py` | Completion diagnostics, retrieval summaries, prompt/context assembly failures, attachment inference failures | Retrieval is summarized by bounded counts; assistant length is metadata; exception interpolation is sanitized. No prompt or retrieved text is logged. |
+| `guardian/core/ai_router.py` | Local/Groq/OpenAI-compatible/DeepSeek/Alibaba/MiniMax request and HTTP failure paths | Request logs contain provider/model/endpoint identity, status, transport, failure kind, and attempt count. Provider detail/body strings remain runtime error data but do not reach logs. |
+| `guardian/providers/local_ollama.py` and provider clients | Invalid streamed provider frames and response parsing | Raw frame logging was replaced with frame length/presence metadata. Provider response text is returned to the caller but never logged. |
+| `guardian/connectors/github.py`, `guardian/routes/connectors.py`, and Drive auth | Connector identity, document counts, sync failures, OAuth/service-account paths | Owner/repo and counts are bounded metadata. Document bodies, sync results, tokens, and credential paths are not logged. |
+| `guardian/queue/redis_queue.py`, `guardian/queue/task_events.py`, `guardian/queue/turn_lock.py`, and queued workers | Redis/dequeue failures, malformed payloads, retry/terminal visibility | Task IDs, queue/event types, retry counts, and failure classes remain. Payloads, exception messages, and content-bearing fields are sanitized. |
+| `guardian/command_bus/loopback_http_adapter.py`, `guardian/runtime/tools/*`, and WebSocket RPC | Policy warnings, scheduler failures, command/tool execution, RPC failures | Decision/status metadata remains; headers, body, query, tool arguments, results, and exception bodies do not reach logs. |
+| HTTP and exception logging | `guardian/server/app.py` console/file handlers and all installed handlers | Records are sanitized before handlers; rendered output receives a second scrub. `exc_info` is reduced to exception type/failure class. |
+
+## Classification vocabulary
+
+- **Safe metadata:** stable IDs, bounded enumerations, status codes, timing,
+  counts, booleans, provider/model identifiers, and sanitized endpoint identity.
+- **Content-bearing:** prompts, generated text, document/retrieval text,
+  attachment data, raw response/request bodies, tool args/results, and free-form
+  payloads. These are summarized or removed.
+- **Credential-bearing:** authorization headers, bearer/API/session material,
+  cookies, secrets, and credential file paths. These are removed or represented
+  only by a presence boolean.
+- **Potentially unsafe through exception interpolation:** any `exc`, `err`,
+  `detail`, `response`, `body`, `payload`, or validation error. These are
+  represented by type/classification/count metadata; log level does not exempt
+  debug records.
+- **Intentionally security-redacted:** the `LogRecord` boundary, the
+  `ScrubFormatter`, provider error extraction used for runtime responses, and
+  source-level bounded log statements.
+
+## Proof and limits
+
+`tests/security/test_content_credential_logging.py` uses sentinel values to
+prove absence of assistant text, user prompts, provider bodies, credentials and
+authorization material, tool args/output, exception messages, and terminal
+output while preserving task/request/turn correlation and failure metadata.
+
+This is code-path and captured-log proof for the exercised Codexify Python
+process. It is not proof about historical logs, external reverse proxies,
+container runtimes, log collectors, Whoosh'd internals, or uninspected future
+processes. No release claim is widened by this contract.

--- a/guardian/__init__.py
+++ b/guardian/__init__.py
@@ -4,10 +4,14 @@ Guardian package initializer
 Exposes core modules and configuration helpers.
 """
 
+from .utils.log_safety import install_safe_logging
+
+install_safe_logging()
+
 # Expose Imprint Zero façade and full onboarding modules
-from . import imprint_zero
-from .config.core import Config, get_settings, is_cloud_backend
-from .config.system_config import system_config
+from . import imprint_zero  # noqa: E402
+from .config.core import Config, get_settings, is_cloud_backend  # noqa: E402
+from .config.system_config import system_config  # noqa: E402
 
 # from . import imprint_zero_onboarding
 

--- a/guardian/command_bus/loopback_http_adapter.py
+++ b/guardian/command_bus/loopback_http_adapter.py
@@ -16,9 +16,11 @@ from guardian.tools.policy import (
     get_policy_mode,
     is_declared_non_docker_mode,
 )
+from guardian.utils.log_safety import install_safe_logging
 
 _PATH_TOKEN_RE = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
 _FORWARDED_AUTH_HEADERS = ("authorization", "x-api-key", "x-user-id", "cookie")
+install_safe_logging()
 logger = logging.getLogger(__name__)
 
 RECURSION_BLOCKED_PREFIXES = ("/api/guardian/commands/",)

--- a/guardian/connectors/github.py
+++ b/guardian/connectors/github.py
@@ -8,7 +8,10 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
+from guardian.utils.log_safety import install_safe_logging
+
 API_ROOT = "https://api.github.com"
+install_safe_logging()
 LOGGER = logging.getLogger(__name__)
 
 

--- a/guardian/core/ai_router.py
+++ b/guardian/core/ai_router.py
@@ -41,7 +41,9 @@ from guardian.protocol_tokens import (
     GuardianProviderFailureKind,
     GuardianProviderTransportClassification,
 )
+from guardian.utils.log_safety import install_safe_logging
 
+install_safe_logging()
 logger = logging.getLogger(__name__)
 
 _DEFAULT_OPENAI_BASE = "https://api.openai.com"
@@ -2327,10 +2329,16 @@ def call_local(
         )
         attempt_summary = _summarize_local_attempt_failures(attempt_failures)
         detail = f"{detail} Attempted endpoints: {attempt_summary}"
-        if log_exceptions:
-            logger.error(detail)
-        else:
-            logger.warning(detail)
+        log_method = logger.error if log_exceptions else logger.warning
+        log_method(
+            "local inference request failed provider=%s model=%s "
+            "failure_kind=%s transport=%s attempt_count=%s",
+            "local",
+            model,
+            _provider_transport_failure_kind(last_transport_error),
+            _classify_transport_error(last_transport_error),
+            len(attempt_failures),
+        )
         raise HTTPException(
             status_code=502,
             detail=_local_provider_failure_detail(
@@ -2371,10 +2379,16 @@ def call_local(
                 "all supported local endpoints returned HTTP 404"
             ),
         )
-        if log_exceptions:
-            logger.error(detail_payload["message"])
-        else:
-            logger.warning(detail_payload["message"])
+        log_method = logger.error if log_exceptions else logger.warning
+        log_method(
+            "local inference unavailable provider=%s model=%s failure_kind=%s "
+            "status_code=%s attempt_count=%s",
+            "local",
+            model,
+            LOCAL_MODEL_UNAVAILABLE_FAILURE_KIND,
+            404,
+            len(attempt_failures),
+        )
         raise HTTPException(status_code=502, detail=detail_payload)
     else:
         detail = f"Local inference request failed for model '{model}'."
@@ -2382,10 +2396,15 @@ def call_local(
     attempt_summary = _summarize_local_attempt_failures(attempt_failures)
     detail = f"{detail} Attempted endpoints: {attempt_summary}"
 
-    if log_exceptions:
-        logger.error(detail)
-    else:
-        logger.warning(detail)
+    log_method = logger.error if log_exceptions else logger.warning
+    log_method(
+        "local inference request failed provider=%s model=%s failure_kind=%s "
+        "attempt_count=%s",
+        "local",
+        model,
+        "request_failed",
+        len(attempt_failures),
+    )
     raise HTTPException(status_code=502, detail=detail)
 
 
@@ -2729,7 +2748,14 @@ def stream_local(
             )
             summary = _summarize_local_attempt_failures(attempt_failures)
             detail = f"{detail} Attempted endpoints: {summary}"
-            logger.warning(detail)
+            logger.warning(
+                "local streaming inference failed provider=%s model=%s "
+                "failure_kind=%s attempt_count=%s",
+                "local",
+                model,
+                _provider_transport_failure_kind(exc),
+                len(attempt_failures),
+            )
             raise HTTPException(
                 status_code=502,
                 detail=_local_provider_failure_detail(
@@ -2811,11 +2837,13 @@ def call_groq(
     if not (200 <= response.status_code < 300):
         detail = _extract_provider_error_message(response, secret=api_key)
         logger.error(
-            "GROQ backend non-2xx model=%s endpoint=%s status=%s detail=%s",
+            "GROQ backend non-2xx model=%s endpoint=%s status=%s "
+            "failure_kind=%s provider_error_present=%s",
             model,
             url,
             response.status_code,
-            detail,
+            "provider_http_error",
+            bool(detail),
         )
         raise HTTPException(
             status_code=502,
@@ -2937,12 +2965,14 @@ def _call_openai_compatible_chat(
     if not (200 <= response.status_code < 300):
         detail = _extract_provider_error_message(response, secret=clean_api_key)
         logger.error(
-            "%s backend non-2xx model=%s endpoint=%s status=%s detail=%s",
+            "%s backend non-2xx model=%s endpoint=%s status=%s "
+            "failure_kind=%s provider_error_present=%s",
             provider_display_name,
             model,
             url,
             response.status_code,
-            detail,
+            "provider_http_error",
+            bool(detail),
         )
         raise HTTPException(
             status_code=502,

--- a/guardian/core/chat_completion_service.py
+++ b/guardian/core/chat_completion_service.py
@@ -111,6 +111,7 @@ from guardian.queue.redis_queue import (
 )
 from guardian.tasks.types import ChatCompletionTask, TaskLifecycleState
 from guardian.vector.store import VectorStore
+from guardian.utils.log_safety import install_safe_logging
 
 try:  # pragma: no cover - Remote Recall is an optional, gated lane
     from guardian.web.remote_recall import (
@@ -126,6 +127,7 @@ try:  # pragma: no cover - import is runtime-scoped for workspace freshness
 except Exception:  # pragma: no cover - fallback when embedder import fails
     _WorkspaceVectorEmbedder = None
 
+install_safe_logging()
 logger = logging.getLogger(__name__)
 RETRIEVAL_PLAN_TRACE_KEY = "retrieval_plan"
 DEBUG_LATEST_COMPLETION_TASK_ID_METADATA_KEY = "debug_latest_completion_task_id"

--- a/guardian/integrations/google_drive.py
+++ b/guardian/integrations/google_drive.py
@@ -43,7 +43,9 @@ def build_drive_service(logger=None):
         if cpath.exists() and is_service_account(cpath):
             if logger:
                 logger.info(
-                    "Drive auth: using Service Account at %s", str(cpath)
+                    "drive_auth_ready credential_kind=%s path_present=%s",
+                    "service_account",
+                    True,
                 )
             creds = SACredentials.from_service_account_file(
                 str(cpath), scopes=SCOPES
@@ -55,9 +57,11 @@ def build_drive_service(logger=None):
         if token_json.exists():
             if logger:
                 logger.info(
-                    "Drive auth: using OAuth token at %s (client at %s)",
-                    str(token_json),
-                    str(cpath),
+                    "drive_auth_ready credential_kind=%s token_path_present=%s "
+                    "client_path_present=%s",
+                    "oauth",
+                    True,
+                    True,
                 )
             creds = OAuthCredentials.from_authorized_user_file(
                 str(token_json), SCOPES
@@ -74,8 +78,9 @@ def build_drive_service(logger=None):
     if token_json.exists():
         if logger:
             logger.info(
-                "Drive auth: using OAuth token at %s (no client secret provided)",
-                str(token_json),
+                "drive_auth_ready credential_kind=%s token_path_present=%s",
+                "oauth",
+                True,
             )
         creds = OAuthCredentials.from_authorized_user_file(
             str(token_json), SCOPES

--- a/guardian/logging_config.py
+++ b/guardian/logging_config.py
@@ -4,9 +4,13 @@ import logging
 
 import structlog
 
+from guardian.utils.log_safety import install_safe_logging
+
 
 def configure_logging(level: int = logging.INFO) -> None:
+    install_safe_logging()
     logging.basicConfig(level=level, format="%(message)s")
+    install_safe_logging()
     structlog.configure(
         wrapper_class=structlog.make_filtering_bound_logger(level)
     )

--- a/guardian/providers/local_ollama.py
+++ b/guardian/providers/local_ollama.py
@@ -79,7 +79,11 @@ def ollama_stream(
             try:
                 chunk = json.loads(raw_line)
             except json.JSONDecodeError:
-                logger.debug("Skipping non-JSON Ollama line: %r", raw_line)
+                logger.debug(
+                    "ollama_stream_invalid_frame chars=%s content_present=%s",
+                    len(raw_line),
+                    bool(raw_line),
+                )
                 continue
 
             if chunk.get("done"):

--- a/guardian/queue/redis_queue.py
+++ b/guardian/queue/redis_queue.py
@@ -19,7 +19,9 @@ from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
 from guardian.protocol_tokens import ErrorCode
+from guardian.utils.log_safety import install_safe_logging
 
+install_safe_logging()
 logger = logging.getLogger(__name__)
 
 _DEFAULT_REDIS_URL = "redis://redis:6379/0"

--- a/guardian/queue/task_events.py
+++ b/guardian/queue/task_events.py
@@ -16,7 +16,9 @@ from guardian.protocol_tokens import (
 )
 from guardian.queue.redis_queue import _with_reconnect  # type: ignore
 from guardian.queue.redis_queue import get_queue_redis_client
+from guardian.utils.log_safety import install_safe_logging
 
+install_safe_logging()
 logger = logging.getLogger(__name__)
 
 _STREAM_PREFIX = "codexify:task"

--- a/guardian/queue/turn_lock.py
+++ b/guardian/queue/turn_lock.py
@@ -11,7 +11,9 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
 from guardian.queue.redis_queue import _with_reconnect
+from guardian.utils.log_safety import install_safe_logging
 
+install_safe_logging()
 logger = logging.getLogger(__name__)
 
 _DEFAULT_TTL_SECONDS = 180

--- a/guardian/routes/chat.py
+++ b/guardian/routes/chat.py
@@ -114,7 +114,9 @@ from guardian.queue.turn_lock import (
 from guardian.routes.health import _classify_chat_worker_heartbeat
 from guardian.tasks.types import ChatCompletionTask
 from guardian.voice.audio_assets import list_message_audio_assets
+from guardian.utils.log_safety import install_safe_logging
 
+install_safe_logging()
 logger = logging.getLogger(__name__)
 COMPLETION_SERVICE_UNAVAILABLE_MESSAGE = (
     "Completion service unavailable — check Docker/Redis."

--- a/guardian/routes/connectors.py
+++ b/guardian/routes/connectors.py
@@ -25,6 +25,7 @@ from guardian.connectors.external_transport_policy import (
     ExternalPolicyRule,
     evaluate_external_transport_policy,
 )
+from guardian.utils.log_safety import install_safe_logging
 
 # PostgreSQL imports for ingest endpoint
 try:
@@ -33,6 +34,7 @@ try:
 except ImportError:
     psycopg2 = None  # type: ignore
 
+install_safe_logging()
 logger = logging.getLogger(__name__)
 
 # Import shared dependencies from core module (avoids circular imports)
@@ -48,7 +50,10 @@ try:
         require_api_key,
     )
 except ImportError as e:
-    logger.warning(f"[connectors] Import warning: {e}")
+    logger.warning(
+        "[connectors] import failed exception_type=%s",
+        e.__class__.__name__,
+    )
     chatlog_db = None
     require_api_key = lambda x: x
     get_current_user = lambda: "local"

--- a/guardian/runtime/tools/registry.py
+++ b/guardian/runtime/tools/registry.py
@@ -6,6 +6,9 @@ from typing import Any, Dict, List, Tuple
 
 import click
 
+from guardian.utils.log_safety import install_safe_logging
+
+install_safe_logging()
 logger = logging.getLogger(__name__)
 
 # --- Import your roots ---
@@ -249,7 +252,11 @@ def write_tools_manifest(
     tools = generate_tools_manifest()
     with open(path, "w") as f:
         json.dump(tools, f, indent=2)
-    logger.info(f"Wrote tools manifest to {path} with {len(tools)} tools.")
+    logger.info(
+        "tools_manifest_written tools=%s path_present=%s",
+        len(tools),
+        bool(path),
+    )
 
 
 if __name__ == "__main__":

--- a/guardian/runtime/tools/scheduler.py
+++ b/guardian/runtime/tools/scheduler.py
@@ -14,6 +14,9 @@ import threading
 from datetime import datetime, timezone
 from typing import Any, Callable, Optional
 
+from guardian.utils.log_safety import install_safe_logging
+
+install_safe_logging()
 logger = logging.getLogger(__name__)
 
 try:  # pragma: no cover - optional dependency

--- a/guardian/server/app.py
+++ b/guardian/server/app.py
@@ -49,6 +49,13 @@ from guardian.routes.threads import api_router as api_threads_router
 from guardian.routes.threads import router as threads_router
 from guardian.routes.workspace import router as workspace_router
 from guardian.sync.api import router as sync_router
+from guardian.utils.log_safety import (
+    install_safe_logging,
+    sanitize_log_text,
+    sanitize_record,
+)
+
+install_safe_logging()
 
 # --- Rate Limiting Configuration ---
 _rate_limits_env = os.getenv("GUARDIAN_RATE_LIMITS", "100/minute").strip()
@@ -289,11 +296,13 @@ class ScrubFormatter(logging.Formatter):
         return out
 
     def format(self, record: logging.LogRecord) -> str:
-        rendered = super().format(record)
-        if not SCRUB_ENABLED:
-            return rendered
+        # Sanitize the record as well as the rendered string.  The record
+        # boundary protects handlers that do not use this formatter; the
+        # rendered pass preserves the existing path scrub behavior.
+        sanitize_record(record)
+        rendered = sanitize_log_text(super().format(record))
         try:
-            return self._scrub(rendered)
+            return self._scrub(rendered) if SCRUB_ENABLED else rendered
         except Exception:
             # never break logging due to scrubbing
             return rendered

--- a/guardian/utils/log_safety.py
+++ b/guardian/utils/log_safety.py
@@ -1,0 +1,413 @@
+"""Content- and credential-safe logging primitives.
+
+Operational logs are a metadata surface.  This module is deliberately small
+and dependency-free so it can be installed before application-specific loggers
+are created.  It sanitizes records at creation time, which also protects test
+handlers and third-party handlers that do not use Codexify's formatter.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+_REDACTED = "<redacted>"
+_RECORD_SANITIZED_ATTR = "_codexify_log_sanitized"
+
+_SAFE_FIELDS = {
+    "attempt",
+    "attempt_count",
+    "audio_url_present",
+    "acceptance_status",
+    "acceptance_warnings",
+    "assistant_text_length",
+    "bytes",
+    "chars",
+    "concurrency",
+    "content_part_counts",
+    "content_present",
+    "cause_class",
+    "count",
+    "depth",
+    "duration_ms",
+    "endpoint_kind",
+    "error_code",
+    "event_id",
+    "event_type",
+    "exception_type",
+    "execution_continued",
+    "failure_class",
+    "failure_kind",
+    "final_status",
+    "finish_reason",
+    "has_content",
+    "has_images",
+    "http_status",
+    "item_count",
+    "items",
+    "message_count",
+    "message_id",
+    "model",
+    "model_id",
+    "name",
+    "provider",
+    "provider_name",
+    "project_id",
+    "queue",
+    "queue_name",
+    "request_id",
+    "requestid",
+    "retrieval_bundle",
+    "retrieval_query_chars",
+    "run_id",
+    "status",
+    "status_code",
+    "task_event_error_code",
+    "stream",
+    "task_id",
+    "task_type",
+    "thread_id",
+    "timeout",
+    "timeout_seconds",
+    "tool_turn_id",
+    "transport",
+    "transport_classification",
+    "turn_id",
+    "type",
+    "depth_mode",
+    "policy",
+    "selection_source",
+    "source",
+    "user",
+    "user_id",
+    "visibility_scope",
+    "worker",
+}
+
+_UNSAFE_FIELD_RE = re.compile(
+    r"(?i)(?:prompt|content|output|response|body|payload|detail|error|err|"
+    r"exception|exc|header|authorization|bearer|cookie|token|secret|key|"
+    r"argument|args|kwargs|origin|candidate|result|trace|message)"
+)
+_PLACEHOLDER_RE = re.compile(
+    r"%(?:\([^)]+\))?[#0\- +]?\d*(?:\.\d+)?[diouxXeEfFgGcrsa%]"
+)
+_FIELD_RE = re.compile(r"([A-Za-z][A-Za-z0-9_.-]*)\s*(?:=|:)\s*$")
+_AUTH_RE = re.compile(
+    r"(?i)(\b(?:authorization\s*:\s*(?:bearer|basic)|bearer)\s+)[^\s,;]+"
+)
+_COOKIE_RE = re.compile(r"(?i)(\bcookie\s*:\s*)[^\r\n]+")
+_QUERY_RE = re.compile(
+    r"([?&](?:api[_-]?key|token|secret|code|auth|signature)=[^\s&#]+)", re.I
+)
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)(\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|session[_-]?secret|"
+    r"password|client[_-]?secret)\s*[=:]\s*)[^\s,;]+"
+)
+
+_LOG_RECORD_STANDARD_FIELDS = set(
+    logging.LogRecord("_", logging.INFO, __file__, 0, "", (), None).__dict__
+)
+
+_factory_installed = False
+_original_factory = logging.getLogRecordFactory()
+_make_record_installed = False
+_original_make_record = logging.Logger.makeRecord
+
+
+def _field_name(
+    template: str, match_start: int, previous_end: int
+) -> str | None:
+    prefix = template[previous_end:match_start]
+    match = _FIELD_RE.search(prefix)
+    return match.group(1).lower() if match else None
+
+
+def _placeholder_fields(template: str) -> list[str | None]:
+    fields: list[str | None] = []
+    previous_end = 0
+    for match in _PLACEHOLDER_RE.finditer(template):
+        if match.group(0) == "%%":
+            previous_end = match.end()
+            continue
+        fields.append(_field_name(template, match.start(), previous_end))
+        previous_end = match.end()
+    return fields
+
+
+def _safe_url(value: str) -> str:
+    """Keep endpoint identity while dropping userinfo, query, and fragment."""
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return _REDACTED
+    if not parsed.scheme or not parsed.netloc:
+        return _REDACTED
+    try:
+        host = parsed.hostname or ""
+        port = f":{parsed.port}" if parsed.port is not None else ""
+    except ValueError:
+        return _REDACTED
+    return urlunsplit((parsed.scheme, f"{host}{port}", parsed.path, "", ""))[
+        :256
+    ]
+
+
+def _failure_class(exception: BaseException) -> str:
+    name = exception.__class__.__name__.lower()
+    if "timeout" in name:
+        return "timeout"
+    if "connection" in name or "connect" in name:
+        return "connection"
+    if "http" in name or "response" in name or "status" in name:
+        return "http"
+    if "json" in name or "parse" in name or "decode" in name:
+        return "parse"
+    if "permission" in name or "auth" in name:
+        return "authorization"
+    if "validation" in name or "value" in name or "key" in name:
+        return "validation"
+    return "runtime"
+
+
+def exception_metadata(exception: BaseException | None) -> str:
+    """Return exception type/classification without interpolating its message."""
+    if exception is None:
+        return "exception_type=unknown failure_class=unknown"
+    return (
+        f"exception_type={exception.__class__.__name__[:80]} "
+        f"failure_class={_failure_class(exception)}"
+    )
+
+
+def _redacted_summary(value: Any) -> str:
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        size = len(value)
+        return f"{_REDACTED} bytes={size}"
+    if isinstance(value, str):
+        size = len(value)
+    elif isinstance(value, Mapping):
+        size = len(value)
+    elif isinstance(value, Sequence) and not isinstance(
+        value, (str, bytes, bytearray)
+    ):
+        size = len(value)
+    else:
+        size = None
+    if size is None:
+        return _REDACTED
+    return (
+        f"{_REDACTED} chars={size}"
+        if isinstance(value, str)
+        else f"{_REDACTED} items={size}"
+    )
+
+
+def _is_unsafe_field(field: str | None) -> bool:
+    return bool(field and _UNSAFE_FIELD_RE.search(field))
+
+
+def _sanitize_value(value: Any, field: str | None = None) -> Any:
+    normalized_field = field.lower() if field else None
+    if isinstance(value, BaseException):
+        return exception_metadata(value)
+    if normalized_field in {"endpoint", "url", "base_url", "health_base"}:
+        return _safe_url(str(value))
+    if normalized_field in _SAFE_FIELDS:
+        if value is None or isinstance(value, (bool, int, float)):
+            return value
+        if isinstance(value, str):
+            return value.replace("\n", " ").replace("\r", " ")[:256]
+        if isinstance(value, Mapping):
+            if normalized_field == "retrieval_bundle":
+                return {
+                    str(key): _sanitize_value(item, str(key))
+                    for key, item in value.items()
+                    if str(key).lower()
+                    in {
+                        "present",
+                        "semantic",
+                        "memory",
+                        "graph",
+                        "personal_facts",
+                        "verified_personal_facts",
+                        "retrieval_query_chars",
+                    }
+                }
+            return {"items": len(value)}
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            if normalized_field == "content_part_counts":
+                return [int(item) for item in value if isinstance(item, int)][
+                    :32
+                ]
+            return {"items": len(value)}
+        return str(value)[:128]
+    if _is_unsafe_field(normalized_field):
+        return _redacted_summary(value)
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str):
+        return _redacted_summary(value)
+    if isinstance(value, Mapping):
+        return _redacted_summary(value)
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return _redacted_summary(value)
+    if isinstance(value, Sequence):
+        return _redacted_summary(value)
+    return _REDACTED
+
+
+def _sanitize_args(template: Any, args: Any) -> Any:
+    if isinstance(args, Mapping):
+        return {
+            str(key): _sanitize_value(value, str(key))
+            for key, value in args.items()
+        }
+    if not isinstance(args, tuple):
+        return _sanitize_value(args)
+    fields = _placeholder_fields(str(template))
+    sanitized: list[Any] = []
+    field_index = 0
+    for value in args:
+        if field_index < len(fields):
+            field = fields[field_index]
+            field_index += 1
+        else:
+            field = None
+        sanitized.append(_sanitize_value(value, field))
+    return tuple(sanitized)
+
+
+def sanitize_log_text(text: str) -> str:
+    """Apply last-mile secret scrubbing to already-rendered log text."""
+    output = _AUTH_RE.sub(r"\1<redacted>", text)
+    output = _COOKIE_RE.sub(r"\1<redacted>", output)
+    output = _QUERY_RE.sub("<redacted-query>", output)
+    output = _SECRET_ASSIGNMENT_RE.sub(r"\1<redacted>", output)
+    return output
+
+
+def _sanitize_freeform_message(message: Any) -> str:
+    if not isinstance(message, str):
+        return _redacted_summary(message)
+    scrubbed = sanitize_log_text(message)
+    lowered = scrubbed.lower()
+    content_markers = (
+        "raw_output",
+        "prompt=",
+        "content=",
+        "payload=",
+        "response_body",
+        "request_body",
+        "tool_args",
+        "tool_output",
+        "authorization:",
+        "bearer ",
+        "cookie:",
+    )
+    if len(scrubbed) > 200 or any(
+        marker in lowered for marker in content_markers
+    ):
+        return f"log_event={_REDACTED} chars={len(message)}"
+    # A free-form message can itself be a prompt/result.  Preserve only the
+    # conventional static event forms; dynamic callers must use arguments.
+    if not (
+        re.fullmatch(
+            r"\[[A-Za-z0-9_.:-]+\]\s+(?:started|stopped|failed|ready|"
+            r"available|disabled|enabled|cancelled)",
+            scrubbed,
+            re.I,
+        )
+        or re.fullmatch(r"[A-Za-z0-9_.:-]+", scrubbed)
+        or re.fullmatch(
+            r"[A-Za-z0-9_.:-]+\s+(?:started|stopped|failed|ready|available|disabled|enabled|cancelled)",
+            scrubbed,
+            re.I,
+        )
+    ):
+        return f"log_event={_REDACTED} chars={len(message)}"
+    return scrubbed
+
+
+def sanitize_record(
+    record: logging.LogRecord, *, force: bool = False
+) -> logging.LogRecord:
+    if getattr(record, _RECORD_SANITIZED_ATTR, False) and not force:
+        return record
+    original_message = record.msg
+    if record.args:
+        record.args = _sanitize_args(record.msg, record.args)
+    else:
+        record.msg = _sanitize_freeform_message(record.msg)
+
+    if record.exc_info:
+        exception = record.exc_info[1] if len(record.exc_info) > 1 else None
+        suffix = exception_metadata(exception)
+        if record.args:
+            record.msg = f"{record.msg} {suffix}"
+        else:
+            record.msg = f"{record.msg} {suffix}"
+        record.args = _sanitize_args(original_message, record.args)
+        record.exc_info = None
+        record.exc_text = None
+        record.stack_info = None
+
+    for key, value in list(record.__dict__.items()):
+        if key in _LOG_RECORD_STANDARD_FIELDS or key.startswith("_"):
+            continue
+        setattr(record, key, _sanitize_value(value, key))
+
+    setattr(record, _RECORD_SANITIZED_ATTR, True)
+    return record
+
+
+class SafeLogFilter(logging.Filter):
+    """Handler filter for integrations that bypass the installed factory."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        sanitize_record(record, force=True)
+        return True
+
+
+def _safe_record_factory(*args: Any, **kwargs: Any) -> logging.LogRecord:
+    return sanitize_record(_original_factory(*args, **kwargs))
+
+
+def _safe_make_record(
+    logger: logging.Logger, *args: Any, **kwargs: Any
+) -> logging.LogRecord:
+    # Logger.makeRecord applies extra fields after invoking the record factory.
+    # Sanitize again here so content or credential fields cannot bypass it.
+    return sanitize_record(
+        _original_make_record(logger, *args, **kwargs), force=True
+    )
+
+
+def install_safe_logging() -> None:
+    """Install the process-wide record boundary once and protect current handlers."""
+    global _factory_installed, _make_record_installed
+    if not _factory_installed:
+        logging.setLogRecordFactory(_safe_record_factory)
+        _factory_installed = True
+    if not _make_record_installed:
+        logging.Logger.makeRecord = _safe_make_record
+        _make_record_installed = True
+    safe_filter = SafeLogFilter()
+    root = logging.getLogger()
+    for handler in root.handlers:
+        if not any(isinstance(item, SafeLogFilter) for item in handler.filters):
+            handler.addFilter(safe_filter)
+
+
+def bounded_hash(value: Any) -> str:
+    """Return a short correlation hash when a caller explicitly needs one."""
+    encoded = str(value).encode("utf-8", errors="replace")
+    return hashlib.sha256(encoded).hexdigest()[:16]

--- a/guardian/workers/chat_worker.py
+++ b/guardian/workers/chat_worker.py
@@ -89,7 +89,9 @@ from guardian.voice.audio_assets import (
     upsert_message_audio_asset_status,
 )
 from guardian.voice.runtime import assistant_message_audio_autogenerate_enabled
+from guardian.utils.log_safety import install_safe_logging
 
+install_safe_logging()
 logger = logging.getLogger(__name__)
 
 build_guardian_system_prompt = _chat_completion_service.build_guardian_system_prompt
@@ -1814,7 +1816,11 @@ def _run_chat_completion_task_compat(
         payload_summary["final_provider"] = final_provider
         payload_summary["final_model"] = final_model
 
-    logger.debug("[llm] raw_output=%s", assistant_text)
+    logger.debug(
+        "[llm] assistant_output_received chars=%s content_present=%s",
+        len(assistant_text or ""),
+        bool(str(assistant_text or "").strip()),
+    )
     assistant_text = extract_assistant_response(assistant_text)
 
     if not assistant_text.strip():

--- a/guardian/ws/rate_limiter.py
+++ b/guardian/ws/rate_limiter.py
@@ -10,6 +10,9 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
+from guardian.utils.log_safety import install_safe_logging
+
+install_safe_logging()
 logger = logging.getLogger(__name__)
 
 try:

--- a/guardian/ws/router.py
+++ b/guardian/ws/router.py
@@ -26,7 +26,9 @@ from guardian.ws.protocol import (
     parse_request_frame,
 )
 from guardian.ws.rate_limiter import TokenBucketRateLimiter
+from guardian.utils.log_safety import install_safe_logging
 
+install_safe_logging()
 logger = logging.getLogger(__name__)
 
 PAYLOAD_TOO_LARGE_CLOSE_CODE = 4409

--- a/tests/security/test_content_credential_logging.py
+++ b/tests/security/test_content_credential_logging.py
@@ -1,0 +1,154 @@
+"""Negative tests for Codexify's operational logging boundary."""
+
+from __future__ import annotations
+
+import logging
+
+from guardian.utils.log_safety import install_safe_logging
+
+
+def _emit_test_log(
+    level: int, message: str, *args: object, **kwargs: object
+) -> None:
+    install_safe_logging()
+    logging.getLogger("guardian.cwc.logging.test").log(
+        level, message, *args, **kwargs
+    )
+
+
+def test_assistant_and_user_content_are_absent_from_logs(caplog):
+    assistant_text = "ASSISTANT_CONTENT_SENTINEL do not log this response"
+    user_prompt = "USER_PROMPT_SENTINEL do not log this request"
+
+    with caplog.at_level(logging.DEBUG):
+        _emit_test_log(
+            logging.DEBUG,
+            "[llm] assistant_text=%s prompt=%s",
+            assistant_text,
+            user_prompt,
+        )
+
+    assert assistant_text not in caplog.text
+    assert user_prompt not in caplog.text
+
+
+def test_provider_bodies_and_credentials_are_absent_from_logs(caplog):
+    response_body = "PROVIDER_RESPONSE_BODY_SENTINEL"
+    api_key = "API_KEY_SENTINEL"
+    bearer = "BEARER_TOKEN_SENTINEL"
+
+    with caplog.at_level(logging.DEBUG):
+        _emit_test_log(
+            logging.ERROR,
+            "provider response body=%s headers=%s",
+            response_body,
+            {"Authorization": f"Bearer {api_key}", "Cookie": bearer},
+        )
+        _emit_test_log(
+            logging.ERROR,
+            "Authorization: Bearer %s?api_key=%s",
+            bearer,
+            api_key,
+        )
+
+    assert response_body not in caplog.text
+    assert api_key not in caplog.text
+    assert bearer not in caplog.text
+
+
+def test_tool_arguments_and_outputs_are_absent_from_logs(caplog):
+    tool_args = "TOOL_ARGUMENTS_SENTINEL"
+    tool_output = "TOOL_OUTPUT_BODY_SENTINEL"
+
+    with caplog.at_level(logging.DEBUG):
+        _emit_test_log(
+            logging.WARNING,
+            "tool args=%s output=%s",
+            {"query": tool_args},
+            {"body": tool_output},
+        )
+
+    assert tool_args not in caplog.text
+    assert tool_output not in caplog.text
+
+
+def test_exception_diagnostics_are_useful_but_content_free(caplog):
+    exception_secret = "EXCEPTION_CONTENT_SENTINEL"
+
+    with caplog.at_level(logging.DEBUG):
+        try:
+            raise TimeoutError(exception_secret)
+        except TimeoutError:
+            _emit_test_log(
+                logging.ERROR,
+                "provider request failed task_id=%s request_id=%s turn_id=%s",
+                "task-cwc-004",
+                "request-cwc-004",
+                "turn-cwc-004",
+                exc_info=True,
+            )
+
+    assert exception_secret not in caplog.text
+    assert "task-cwc-004" in caplog.text
+    assert "request-cwc-004" in caplog.text
+    assert "turn-cwc-004" in caplog.text
+    assert "exception_type=TimeoutError" in caplog.text
+    assert "failure_class=timeout" in caplog.text
+
+
+def test_terminal_integrity_metadata_keeps_correlation_without_output(caplog):
+    terminal_output = "TERMINAL_OUTPUT_SENTINEL"
+
+    with caplog.at_level(logging.DEBUG):
+        _emit_test_log(
+            logging.ERROR,
+            "[task] failed task_id=%s turn_id=%s failure_kind=%s output=%s",
+            "task-terminal-cwc-004",
+            "turn-terminal-cwc-004",
+            "stream_incomplete",
+            terminal_output,
+        )
+
+    assert terminal_output not in caplog.text
+    assert "task-terminal-cwc-004" in caplog.text
+    assert "turn-terminal-cwc-004" in caplog.text
+    assert "failure_kind=stream_incomplete" in caplog.text
+
+
+def test_url_query_credentials_are_removed_but_endpoint_identity_remains(
+    caplog,
+):
+    with caplog.at_level(logging.DEBUG):
+        _emit_test_log(
+            logging.INFO,
+            "provider request endpoint=%s provider=%s model=%s",
+            "https://provider.example/v1/chat?api_key=URL_SECRET_SENTINEL",
+            "local",
+            "model-cwc-004",
+        )
+
+    assert "URL_SECRET_SENTINEL" not in caplog.text
+    assert "https://provider.example/v1" in caplog.text
+    assert "provider=local" in caplog.text
+    assert "model=model-cwc-004" in caplog.text
+
+
+def test_freeform_and_credential_fields_fail_closed(caplog):
+    freeform_content = "FREEFORM_CONTENT_SENTINEL"
+    extra_secret = "EXTRA_SECRET_SENTINEL"
+
+    with caplog.at_level(logging.DEBUG):
+        _emit_test_log(
+            logging.WARNING,
+            f"[provider] {freeform_content}",
+        )
+        _emit_test_log(
+            logging.ERROR,
+            "credential token=%s",
+            123456789,
+            extra={"api_key": extra_secret},
+        )
+
+    assert freeform_content not in caplog.text
+    assert extra_secret not in caplog.text
+    assert "log_event=<redacted>" in caplog.text


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
