### PR TITLE
Codex/cwc 007 control error contract

### DIFF
--- a/docs/Ops/WHOOSHD_LOCAL_RUNTIME_RUNBOOK.md
+++ b/docs/Ops/WHOOSHD_LOCAL_RUNTIME_RUNBOOK.md
@@ -27,6 +27,32 @@ For the supported local beta path:
 Model availability is live evidence. Codexify should only consider the selected
 model usable when Whoosh'd advertises it through `/v1/models` or `/api/tags`.
 
+## Runtime provenance
+
+Whoosh'd can return bounded `whooshd.runtime.v1` provenance for model inventory
+and successful completions. Codexify accepts the schema only when its required
+runtime, adapter, resolution-source, and execution-mode fields are recognized;
+unknown optional fields are ignored, while malformed known fields are not
+verified. A missing provenance field remains compatible with documented legacy
+Whoosh'd runtimes.
+
+The accepted fields are model aliases and request correlation (`request_id`,
+`requested_model_id`, `advertised_model_id`, `resolved_model_id`, and
+`backend_reported_model_id`), runtime identity, canonical resolution source,
+execution mode, streaming/queue/batch flags, model lifecycle, and
+`whooshd_version`. Codexify carries accepted evidence into the completion
+result and the persisted assistant `extra_meta` key
+`whooshd_runtime_provenance` only after successful terminal proof and message
+persistence. Failed, incomplete, cancelled, or unverified completions do not
+publish successful runtime provenance.
+
+For streaming responses, Whoosh'd uses the additive
+`X-Whooshd-Runtime-Provenance` response header so the established SSE body
+contract remains unchanged. The header and body are parsed from machine-readable
+fields only; human-readable provider messages are never used for runtime
+classification. Provenance is bounded operational metadata and does not prove
+that a live daemon, model, Docker bridge, or external log collector is healthy.
+
 ## Nodes And Boundaries
 
 | Boundary | Responsibility |

--- a/docs/architecture/whooshd-control-plane-v1.md
+++ b/docs/architecture/whooshd-control-plane-v1.md
@@ -1,0 +1,65 @@
+# Whoosh'd Control-Plane v1
+
+This is the Codexify-side interpretation of the bounded
+`whooshd.control.v1` contract. It is implementation and test documentation,
+not proof that a live Whoosh'd daemon has been restarted or that external
+collectors sanitize records.
+
+## Boundary
+
+Whoosh'd-owned responses advertise
+`X-Whooshd-Contract-Version: whooshd.control.v1`. Codexify parses the canonical
+body only when that header is present and exactly supported. The parser reads
+machine fields only: `code`, `http_status`, `retryable`, bounded
+`retry_after_seconds`, `request_id`, and `category`. Unknown optional v1 fields
+are ignored. Missing, mismatched, or unsupported-major headers remain the
+legacy unversioned path; Codexify does not assume v1.
+
+Codexify sends the same contract header on local inference requests. It does
+not forward or classify prompts, generated text, tool values, media, headers,
+or raw provider bodies as contract diagnostics.
+
+## Cross-repository error matrix
+
+| Condition / code | HTTP | Retryable | Retry-After | Codexify mapping | Whoosh'd legacy path |
+|---|---:|:---:|---:|---|---|
+| `invalid_request` | 400 | no | — | request error | unversioned request failure |
+| `unsupported_field` | 400 | no | — | request error | unversioned request failure |
+| `unsupported_capability` | 422 | no | — | request error | unversioned request failure |
+| `contract_version_unsupported` | 400 | no | — | request error | explicit unsupported contract |
+| `model_not_found` | 404 | no | — | local model unavailable | unversioned model/HTTP failure |
+| `model_unavailable` | 503 | yes | — | transport error | unversioned runtime failure |
+| `model_warming` | 425 | yes | 2 seconds bounded | provider HTTP error | unversioned warming/HTTP failure |
+| `model_load_failed` | 500 | no | — | provider HTTP error | unversioned internal failure |
+| `runtime_unavailable` | 503 | yes | — | transport error | unversioned transport failure |
+| `runtime_degraded` | 503 | yes | — | provider HTTP error | unversioned runtime failure |
+| `runner_overloaded` | 429 | yes | 2 seconds bounded | provider HTTP error | existing overload handling |
+| `queue_full` | 429 | yes | 2 seconds bounded | provider HTTP error | existing overload handling |
+| `timeout` | 504 | yes | — | provider timeout | existing timeout handling |
+| `cancelled` | 409 | no | — | provider HTTP error | existing cancellation handling |
+| `context_overflow` | 422 | no | — | request error | existing admission rejection |
+| `upstream_unavailable` | 503 | yes | — | transport error | existing transport failure |
+| `upstream_timeout` | 504 | yes | — | provider timeout | existing timeout failure |
+| `upstream_protocol_error` | 502 | no | — | provider HTTP error | existing upstream failure |
+| `stream_interrupted` | 502 | no | — | provider HTTP error | existing stream failure |
+| `malformed_upstream_response` | 502 | no | — | provider HTTP error | existing parse failure |
+| `internal_error` | 500 | no | — | provider HTTP error | existing internal failure |
+
+`Retry-After` is available in both the body and HTTP header for warming,
+overload, and queue-full errors. Codexify does not automatically retry from
+this contract; existing orchestration policy remains authoritative.
+
+## Streaming terminal rule
+
+When Whoosh'd reports a stream failure after visible output, the canonical
+error is an SSE error event and a successful `[DONE]` event is not fabricated.
+Codexify preserves the established incomplete-stream classification and does
+not fall back after visible output. Successful streams retain their existing
+terminal behavior.
+
+## Proof boundary
+
+Focused parser and adapter tests prove header/body parsing, code-only
+classification, request-ID retention, unknown optional-field tolerance, and
+legacy behavior. Current supported-profile and live daemon behavior remain
+separate proof surfaces and are not widened by this document.

--- a/docs/architecture/whooshd-control-plane-v1.md
+++ b/docs/architecture/whooshd-control-plane-v1.md
@@ -12,8 +12,9 @@ Whoosh'd-owned responses advertise
 body only when that header is present and exactly supported. The parser reads
 machine fields only: `code`, `http_status`, `retryable`, bounded
 `retry_after_seconds`, `request_id`, and `category`. Unknown optional v1 fields
-are ignored. Missing, mismatched, or unsupported-major headers remain the
-legacy unversioned path; Codexify does not assume v1.
+are ignored. A missing response header remains the legacy unversioned path.
+An explicit mismatched or unsupported-major response header is a bounded
+contract failure; Codexify does not route it through legacy fallback.
 
 Codexify sends the same contract header on local inference requests. It does
 not forward or classify prompts, generated text, tool values, media, headers,
@@ -48,6 +49,11 @@ or raw provider bodies as contract diagnostics.
 `Retry-After` is available in both the body and HTTP header for warming,
 overload, and queue-full errors. Codexify does not automatically retry from
 this contract; existing orchestration policy remains authoritative.
+
+On the incoming request side, Whoosh'd preserves missing-header compatibility,
+accepts exact v1, and rejects explicit non-v1 values with
+`contract_version_unsupported` and HTTP 400. The response still advertises v1;
+only a bounded safe version identifier is retained.
 
 ## Streaming terminal rule
 

--- a/docs/kb/codexify-for-whooshd.md
+++ b/docs/kb/codexify-for-whooshd.md
@@ -8,6 +8,10 @@ The bounded cross-repository HTTP error contract is documented separately in
 [Whoosh'd Control-Plane v1](../architecture/whooshd-control-plane-v1.md).
 That document is implementation/test evidence, not live-daemon proof.
 
+Missing response-version headers remain the legacy compatibility path. An
+explicit non-v1 response version is a contract failure and must not enter the
+legacy fallback parser.
+
 Every claim is tagged with a confidence level:
 - `confirmed` — backed by live code, architecture docs, or runtime proofs
 - `inferred` — reasonable deduction from available evidence but not explicitly stated

--- a/docs/kb/codexify-for-whooshd.md
+++ b/docs/kb/codexify-for-whooshd.md
@@ -4,6 +4,10 @@
 
 This document captures everything Whoosh'd needs to know about Codexify in order to serve it well as a high-throughput MLX inference backend. It is extracted from Codexify's own architecture docs, runtime contracts, worker code, and operational surfaces.
 
+The bounded cross-repository HTTP error contract is documented separately in
+[Whoosh'd Control-Plane v1](../architecture/whooshd-control-plane-v1.md).
+That document is implementation/test evidence, not live-daemon proof.
+
 Every claim is tagged with a confidence level:
 - `confirmed` — backed by live code, architecture docs, or runtime proofs
 - `inferred` — reasonable deduction from available evidence but not explicitly stated

--- a/guardian/core/ai_router.py
+++ b/guardian/core/ai_router.py
@@ -38,6 +38,7 @@ from guardian.providers.deepseek_adapter import (
 from guardian.providers.whooshd_control_plane import (
     WHOOSHD_CONTROL_PLANE_VERSION,
     WHOOSHD_CONTROL_VERSION_HEADER,
+    WhooshdContractVersionError,
     WhooshdErrorDiagnostic,
     parse_whooshd_error,
     provider_failure_kind as whooshd_provider_failure_kind,
@@ -1404,6 +1405,43 @@ def _local_provider_failure_detail(
     return detail
 
 
+def _whooshd_contract_version_failure(
+    *,
+    settings: Settings,
+    model: str,
+    endpoint: str,
+    runtime_policy: LocalRuntimePolicy,
+    received_version: str,
+    attempted_endpoints: list[str] | None = None,
+    attempted_base_urls: list[str] | None = None,
+) -> HTTPException:
+    """Build a bounded failure for an explicitly unsupported provider version."""
+
+    code = "contract_version_unsupported"
+    return HTTPException(
+        status_code=502,
+        detail=_local_provider_failure_detail(
+            settings=settings,
+            model=model,
+            endpoint=endpoint,
+            failure_kind=whooshd_provider_failure_kind(code),
+            message="Whoosh'd control-plane version is unsupported.",
+            provider_error=code,
+            runtime_policy=runtime_policy,
+            attempted_endpoints=attempted_endpoints,
+            attempted_base_urls=attempted_base_urls,
+            whooshd_error={
+                "contract_version": WHOOSHD_CONTROL_PLANE_VERSION,
+                "code": code,
+                "http_status": 400,
+                "retryable": False,
+                "category": "request_contract",
+                "received_version": received_version,
+            },
+        ),
+    )
+
+
 def _image_turn_vision_unsupported_detail(
     *,
     provider: str,
@@ -2294,7 +2332,20 @@ def call_local(
                 continue
 
             last_transport_url = url
-            whooshd_error = parse_whooshd_error(resp)
+            try:
+                whooshd_error = parse_whooshd_error(resp)
+            except WhooshdContractVersionError as exc:
+                raise _whooshd_contract_version_failure(
+                    settings=settings,
+                    model=model,
+                    endpoint=url,
+                    runtime_policy=runtime_policy,
+                    received_version=exc.received_version,
+                    attempted_endpoints=[
+                        f"{url} (contract_version_unsupported)"
+                    ],
+                    attempted_base_urls=attempted_base_urls,
+                ) from exc
             if whooshd_error is not None:
                 last_whooshd_error = whooshd_error
                 attempt_failures.append(
@@ -2588,7 +2639,21 @@ def stream_local(
                     attempt_failures.append(f"{url} ({classification}: {exc})")
                     continue
 
-                whooshd_error = parse_whooshd_error(resp)
+                try:
+                    whooshd_error = parse_whooshd_error(resp)
+                except WhooshdContractVersionError as exc:
+                    resp.close()
+                    raise _whooshd_contract_version_failure(
+                        settings=settings,
+                        model=model,
+                        endpoint=url,
+                        runtime_policy=runtime_policy,
+                        received_version=exc.received_version,
+                        attempted_endpoints=[
+                            f"{url} (contract_version_unsupported)"
+                        ],
+                        attempted_base_urls=attempted_base_urls,
+                    ) from exc
                 if whooshd_error is not None:
                     last_whooshd_error = whooshd_error
                     attempt_failures.append(

--- a/guardian/core/ai_router.py
+++ b/guardian/core/ai_router.py
@@ -35,6 +35,13 @@ from guardian.providers.deepseek_adapter import (
     normalize_tool_calls as normalize_deepseek_tool_calls,
     parse_response as parse_deepseek_response,
 )
+from guardian.providers.whooshd_control_plane import (
+    WHOOSHD_CONTROL_PLANE_VERSION,
+    WHOOSHD_CONTROL_VERSION_HEADER,
+    WhooshdErrorDiagnostic,
+    parse_whooshd_error,
+    provider_failure_kind as whooshd_provider_failure_kind,
+)
 from guardian.protocol_tokens import (
     CompletionTerminalStatus,
     ErrorCode,
@@ -1362,6 +1369,7 @@ def _local_provider_failure_detail(
     transport_classification: str | None = None,
     attempted_endpoints: list[str] | None = None,
     attempted_base_urls: list[str] | None = None,
+    whooshd_error: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     detail = _provider_failure_detail(
         provider="local",
@@ -1391,6 +1399,8 @@ def _local_provider_failure_detail(
             reason=_summarize_local_attempt_failures(list(attempted_endpoints or []))
             or message,
         )
+    if whooshd_error:
+        detail["whooshd_error"] = dict(whooshd_error)
     return detail
 
 
@@ -2166,6 +2176,7 @@ def call_local(
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
+        WHOOSHD_CONTROL_VERSION_HEADER: WHOOSHD_CONTROL_PLANE_VERSION,
     }
     payload: Dict[str, Any] = {
         "model": model,
@@ -2215,6 +2226,7 @@ def call_local(
     attempt_failures: list[str] = []
     attempted_base_urls: list[str] = []
     last_transport_error: req_exc.RequestException | None = None
+    last_whooshd_error: WhooshdErrorDiagnostic | None = None
     last_transport_url: str = ""
 
     for base_url in base_urls:
@@ -2281,6 +2293,14 @@ def call_local(
                 attempt_failures.append(f"{url} ({classification}: {exc})")
                 continue
 
+            last_transport_url = url
+            whooshd_error = parse_whooshd_error(resp)
+            if whooshd_error is not None:
+                last_whooshd_error = whooshd_error
+                attempt_failures.append(
+                    f"{url} (HTTP {resp.status_code}: {whooshd_error.code})"
+                )
+                continue
             if resp.status_code == 404:
                 if is_gateway:
                     attempt_failures.append(
@@ -2320,6 +2340,25 @@ def call_local(
                 f"{url} (response did not include assistant content)"
             )
 
+    if last_whooshd_error is not None:
+        detail = (
+            f"Whoosh'd request failed with {last_whooshd_error.code}."
+        )
+        raise HTTPException(
+            status_code=502,
+            detail=_local_provider_failure_detail(
+                settings=settings,
+                model=model,
+                endpoint=last_transport_url or (base_urls[-1] if base_urls else ""),
+                failure_kind=whooshd_provider_failure_kind(last_whooshd_error.code),
+                message=detail,
+                provider_error=last_whooshd_error.code,
+                runtime_policy=runtime_policy,
+                attempted_endpoints=attempt_failures,
+                attempted_base_urls=attempted_base_urls,
+                whooshd_error=last_whooshd_error.as_dict(),
+            ),
+        )
     if last_transport_error is not None:
         detail = _format_local_connect_error(
             last_transport_url,
@@ -2439,6 +2478,7 @@ def stream_local(
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
+        WHOOSHD_CONTROL_VERSION_HEADER: WHOOSHD_CONTROL_PLANE_VERSION,
     }
     payload: Dict[str, Any] = {
         "model": model,
@@ -2477,6 +2517,7 @@ def stream_local(
     attempt_failures: list[str] = []
     attempted_base_urls: list[str] = []
     last_transport_error: req_exc.RequestException | None = None
+    last_whooshd_error: WhooshdErrorDiagnostic | None = None
 
     try:
         for base_url in base_urls:
@@ -2547,6 +2588,14 @@ def stream_local(
                     attempt_failures.append(f"{url} ({classification}: {exc})")
                     continue
 
+                whooshd_error = parse_whooshd_error(resp)
+                if whooshd_error is not None:
+                    last_whooshd_error = whooshd_error
+                    attempt_failures.append(
+                        f"{url} (HTTP {resp.status_code}: {whooshd_error.code})"
+                    )
+                    resp.close()
+                    continue
                 if resp.status_code == 404:
                     if is_gateway:
                         attempt_failures.append(
@@ -2572,6 +2621,26 @@ def stream_local(
                 break
 
         if response is None:
+            if last_whooshd_error is not None:
+                raise HTTPException(
+                    status_code=502,
+                    detail=_local_provider_failure_detail(
+                        settings=settings,
+                        model=model,
+                        endpoint=current_url,
+                        failure_kind=whooshd_provider_failure_kind(
+                            last_whooshd_error.code
+                        ),
+                        message=(
+                            f"Whoosh'd request failed with {last_whooshd_error.code}."
+                        ),
+                        provider_error=last_whooshd_error.code,
+                        runtime_policy=runtime_policy,
+                        attempted_endpoints=attempt_failures,
+                        attempted_base_urls=attempted_base_urls,
+                        whooshd_error=last_whooshd_error.as_dict(),
+                    ),
+                )
             if last_transport_error is not None:
                 detail = _format_local_connect_error(
                     current_url,

--- a/guardian/core/ai_router.py
+++ b/guardian/core/ai_router.py
@@ -38,9 +38,12 @@ from guardian.providers.deepseek_adapter import (
 from guardian.providers.whooshd_control_plane import (
     WHOOSHD_CONTROL_PLANE_VERSION,
     WHOOSHD_CONTROL_VERSION_HEADER,
+    WHOOSHD_RUNTIME_PROVENANCE_HEADER,
     WhooshdContractVersionError,
     WhooshdErrorDiagnostic,
+    WhooshdRuntimeProvenance,
     parse_whooshd_error,
+    parse_whooshd_runtime_provenance,
     provider_failure_kind as whooshd_provider_failure_kind,
 )
 from guardian.protocol_tokens import (
@@ -127,11 +130,13 @@ class ProviderResponse(str):
         raw_payload: Any | None = None,
         content_blocks: Any | None = None,
         provider: str | None = None,
+        runtime_provenance: WhooshdRuntimeProvenance | None = None,
     ):
         obj = super().__new__(cls, text or "")
         obj.raw_payload = raw_payload  # type: ignore[attr-defined]
         obj.content_blocks = content_blocks  # type: ignore[attr-defined]
         obj.provider = provider  # type: ignore[attr-defined]
+        obj.runtime_provenance = runtime_provenance  # type: ignore[attr-defined]
         return obj
 
 
@@ -279,6 +284,7 @@ class NormalizedCompletionOutput:
     tool_call_id: str | None = None
     tool_call_count: int = 0
     raw_assistant_message: dict[str, Any] | None = None
+    runtime_provenance: WhooshdRuntimeProvenance | None = None
 
 
 def _coerce_tool_arguments(raw: Any) -> dict[str, Any]:
@@ -440,6 +446,7 @@ def normalize_completion_output(
 
     if isinstance(output, ProviderResponse):
         provider = getattr(output, "provider", None)
+        runtime_provenance = getattr(output, "runtime_provenance", None)
         raw_payload = getattr(output, "raw_payload", None)
         content_blocks = getattr(output, "content_blocks", None)
         candidate = None
@@ -483,6 +490,7 @@ def normalize_completion_output(
             raw_payload=raw_payload,
             content_blocks=content_blocks,
             provider=provider,
+            runtime_provenance=runtime_provenance,
         )
 
     if isinstance(output, dict):
@@ -2372,20 +2380,39 @@ def call_local(
                 attempt_failures.append(f"{url} (invalid JSON: {exc})")
                 continue
 
+            runtime_provenance = parse_whooshd_runtime_provenance(
+                data.get("runtime_provenance")
+            ) if isinstance(data, dict) else None
+
             # Ollama /api/chat format
             if isinstance(data.get("message"), dict) and "content" in data["message"]:
-                return data["message"]["content"]
+                return ProviderResponse(
+                    data["message"]["content"],
+                    raw_payload=data,
+                    provider="local",
+                    runtime_provenance=runtime_provenance,
+                )
 
             # Ollama /api/generate format
             if "response" in data and isinstance(data.get("response"), str):
-                return data.get("response") or ""
+                return ProviderResponse(
+                    data.get("response") or "",
+                    raw_payload=data,
+                    provider="local",
+                    runtime_provenance=runtime_provenance,
+                )
 
             # OpenAI-compatible format
             choices = data.get("choices")
             if isinstance(choices, list) and choices:
                 message = choices[0].get("message")
                 if isinstance(message, dict) and "content" in message:
-                    return message.get("content") or ""
+                    return ProviderResponse(
+                        message.get("content") or "",
+                        raw_payload=data,
+                        provider="local",
+                        runtime_provenance=runtime_provenance,
+                    )
 
             attempt_failures.append(
                 f"{url} (response did not include assistant content)"
@@ -2771,6 +2798,20 @@ def stream_local(
         try:
             finish_reason: str | None = None
             visible_output_emitted = False
+            runtime_provenance: dict[str, Any] | None = None
+            response_headers = getattr(response, "headers", {}) or {}
+            header_provenance = response_headers.get(
+                WHOOSHD_RUNTIME_PROVENANCE_HEADER
+            )
+            if header_provenance:
+                try:
+                    parsed_header = parse_whooshd_runtime_provenance(
+                        json.loads(str(header_provenance))
+                    )
+                except Exception:
+                    parsed_header = None
+                if parsed_header is not None:
+                    runtime_provenance = parsed_header.as_dict()
             for raw_line in response.iter_lines(decode_unicode=False):
                 if not raw_line:
                     continue
@@ -2790,6 +2831,7 @@ def stream_local(
                         transport_ended_cleanly=True,
                         provider="local",
                         model=model,
+                        runtime_provenance=runtime_provenance,
                     )
                 try:
                     chunk = json.loads(data)
@@ -2804,8 +2846,16 @@ def stream_local(
                         model=model,
                         failure_kind="malformed_stream_frame",
                         retry_permitted=not visible_output_emitted,
+                        runtime_provenance=runtime_provenance,
                     )
                 try:
+                    parsed_provenance = parse_whooshd_runtime_provenance(
+                        chunk.get("runtime_provenance")
+                        if isinstance(chunk, dict)
+                        else None
+                    )
+                    if parsed_provenance is not None:
+                        runtime_provenance = parsed_provenance.as_dict()
                     if isinstance(chunk.get("error"), (dict, str)):
                         return CompletionTerminalEvidence(
                             status=CompletionTerminalStatus.PROVIDER_ERROR,
@@ -2817,6 +2867,7 @@ def stream_local(
                             model=model,
                             failure_kind="provider_error_frame",
                             retry_permitted=not visible_output_emitted,
+                            runtime_provenance=runtime_provenance,
                         )
                     # OpenAI-compatible SSE or Ollama /api/chat streaming
                     choice = chunk.get("choices", [{}])[0]
@@ -2849,6 +2900,7 @@ def stream_local(
                             transport_ended_cleanly=True,
                             provider="local",
                             model=model,
+                            runtime_provenance=runtime_provenance,
                         )
                 except Exception:
                     return CompletionTerminalEvidence(
@@ -2861,6 +2913,7 @@ def stream_local(
                         model=model,
                         failure_kind="malformed_stream_frame",
                         retry_permitted=not visible_output_emitted,
+                        runtime_provenance=runtime_provenance,
                     )
             return CompletionTerminalEvidence(
                 status=CompletionTerminalStatus.STREAM_INCOMPLETE,
@@ -2872,6 +2925,7 @@ def stream_local(
                 model=model,
                 failure_kind="missing_stream_terminal",
                 retry_permitted=not visible_output_emitted,
+                runtime_provenance=runtime_provenance,
             )
         except req_exc.RequestException as exc:
             detail = _format_local_connect_error(

--- a/guardian/core/chat_completion_service.py
+++ b/guardian/core/chat_completion_service.py
@@ -669,7 +669,15 @@ def _execute_completion_attempt(
             terminal = terminal.with_visible_output(visible_output_emitted)
         if not terminal.successful:
             raise CompletionTerminalError(terminal)
-        return CompletionAttemptResult("".join(collected), terminal)
+        return CompletionAttemptResult(
+            "".join(collected),
+            terminal,
+            runtime_provenance=(
+                dict(terminal.runtime_provenance)
+                if isinstance(getattr(terminal, "runtime_provenance", None), dict)
+                else None
+            ),
+        )
 
     try:
         output = chat_with_ai(
@@ -699,7 +707,16 @@ def _execute_completion_attempt(
         model=model,
         finish_reason=_provider_output_finish_reason(output),
     )
-    return CompletionAttemptResult(output, terminal)
+    output_provenance = getattr(output, "runtime_provenance", None)
+    return CompletionAttemptResult(
+        output,
+        terminal,
+        runtime_provenance=(
+            output_provenance.as_dict()
+            if hasattr(output_provenance, "as_dict")
+            else None
+        ),
+    )
 
 
 async def _build_messages_for_llm_compat(
@@ -4384,6 +4401,7 @@ def _execute_bounded_tool_turn_completion(
         tool_turn_state_value: str,
         loop_stop_reason_value: str,
         terminal_evidence: CompletionTerminalEvidence,
+        runtime_provenance: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         payload_summary = dict(base_payload_summary or {})
         payload_summary.update(
@@ -4455,6 +4473,8 @@ def _execute_bounded_tool_turn_completion(
             payload_summary["command_error"] = command_error
         if execution is not None:
             payload_summary["execution"] = execution
+        if runtime_provenance is not None:
+            payload_summary["runtime_provenance"] = dict(runtime_provenance)
         result = _tool_turn_completion_result(
             task=task,
             assistant_text=assistant_text,
@@ -4474,6 +4494,8 @@ def _execute_bounded_tool_turn_completion(
         )
         result["terminal_evidence"] = terminal_evidence.as_dict()
         payload_summary["terminal_evidence"] = terminal_evidence.as_dict()
+        if runtime_provenance is not None:
+            result["runtime_provenance"] = dict(runtime_provenance)
         return result
 
     first_attempt = _execute_completion_attempt(
@@ -4504,6 +4526,14 @@ def _execute_bounded_tool_turn_completion(
             tool_turn_state_value=ToolTurnState.IDLE.value,
             loop_stop_reason_value=ToolLoopStopReason.PLAIN_ANSWER.value,
             terminal_evidence=first_attempt.terminal,
+            runtime_provenance=(
+                first_attempt.runtime_provenance
+                or (
+                    normalized_first_output.runtime_provenance.as_dict()
+                    if normalized_first_output.runtime_provenance is not None
+                    else None
+                )
+            ),
         )
 
     tool_turn_id = str(uuid.uuid4())
@@ -4661,6 +4691,14 @@ def _execute_bounded_tool_turn_completion(
         tool_turn_state_value=tool_turn_state,
         loop_stop_reason_value=loop_stop_reason,
         terminal_evidence=second_attempt.terminal,
+        runtime_provenance=(
+            second_attempt.runtime_provenance
+            or (
+                normalized_second_output.runtime_provenance.as_dict()
+                if normalized_second_output.runtime_provenance is not None
+                else None
+            )
+        ),
     )
     if provider == "deepseek":
         result["_provider_replay_state"] = {
@@ -5048,6 +5086,9 @@ def run_chat_completion_task(
     )
     provider_replay_state = result.get("_provider_replay_state")
     result.pop("_provider_replay_state", None)
+    completion_runtime_provenance = result.get("runtime_provenance")
+    if not isinstance(completion_runtime_provenance, dict):
+        completion_runtime_provenance = None
     assistant_text = str(result.get("assistant_text") or "")
     _log_completion_diagnostics(
         task=task,
@@ -5217,6 +5258,7 @@ def run_chat_completion_task(
         "loopStopReason": payload_summary.get("loop_stop_reason"),
         "commandRunId": payload_summary.get("command_run_id"),
         "tool_loop": dict(payload_summary.get("tool_loop") or {}),
+        "runtime_provenance": completion_runtime_provenance,
     }
     if isinstance(trace, dict):
         result["latest_turn_message_id"] = trace.get("latest_turn_message_id")
@@ -5291,9 +5333,20 @@ def run_chat_completion_task(
         "assistant",
         assistant_text,
         extra_meta=(
-            {"provider_replay_state": provider_replay_state}
-            if provider == "deepseek" and isinstance(provider_replay_state, dict)
-            else None
+            {
+                **(
+                    {"provider_replay_state": provider_replay_state}
+                    if provider == "deepseek"
+                    and isinstance(provider_replay_state, dict)
+                    else {}
+                ),
+                **(
+                    {"whooshd_runtime_provenance": completion_runtime_provenance}
+                    if completion_runtime_provenance is not None
+                    else {}
+                ),
+            }
+            or None
         ),
     )
     result["message_id"] = message_id

--- a/guardian/core/completion_terminal.py
+++ b/guardian/core/completion_terminal.py
@@ -19,6 +19,7 @@ class CompletionTerminalEvidence:
     model: str
     failure_kind: str | None = None
     retry_permitted: bool = False
+    runtime_provenance: dict[str, Any] | None = None
 
     @property
     def successful(self) -> bool:
@@ -29,7 +30,7 @@ class CompletionTerminalEvidence:
 
     def as_dict(self) -> dict[str, Any]:
         """Return bounded metadata; response content is deliberately absent."""
-        return {
+        payload = {
             "status": self.status.value,
             "visible_output_emitted": self.visible_output_emitted,
             "explicit_provider_terminal_observed": (
@@ -42,6 +43,9 @@ class CompletionTerminalEvidence:
             "failure_kind": self.failure_kind,
             "retry_permitted": self.retry_permitted,
         }
+        if self.runtime_provenance is not None:
+            payload["runtime_provenance"] = dict(self.runtime_provenance)
+        return payload
 
     @classmethod
     def from_dict(cls, raw: Any) -> "CompletionTerminalEvidence | None":
@@ -51,6 +55,20 @@ class CompletionTerminalEvidence:
             status = CompletionTerminalStatus(str(raw.get("status") or ""))
         except ValueError:
             return None
+        runtime_provenance = None
+        if isinstance(raw.get("runtime_provenance"), dict):
+            # Re-apply the provider boundary when evidence crosses a
+            # persistence or retry boundary.  Stored metadata is not trusted
+            # merely because it was previously shaped like a dict.
+            from guardian.providers.whooshd_control_plane import (
+                parse_whooshd_runtime_provenance,
+            )
+
+            parsed_provenance = parse_whooshd_runtime_provenance(
+                raw["runtime_provenance"]
+            )
+            if parsed_provenance is not None:
+                runtime_provenance = parsed_provenance.as_dict()
         return cls(
             status=status,
             visible_output_emitted=bool(raw.get("visible_output_emitted")),
@@ -71,6 +89,7 @@ class CompletionTerminalEvidence:
                 else None
             ),
             retry_permitted=bool(raw.get("retry_permitted")),
+            runtime_provenance=runtime_provenance,
         )
 
 
@@ -78,6 +97,7 @@ class CompletionTerminalEvidence:
 class CompletionAttemptResult:
     output: Any
     terminal: CompletionTerminalEvidence
+    runtime_provenance: dict[str, Any] | None = None
 
 
 class CompletionTerminalError(RuntimeError):

--- a/guardian/providers/whooshd_control_plane.py
+++ b/guardian/providers/whooshd_control_plane.py
@@ -1,0 +1,134 @@
+"""Codexify-side reader for the versioned Whoosh'd control-plane contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+WHOOSHD_CONTROL_PLANE_VERSION = "whooshd.control.v1"
+WHOOSHD_CONTROL_VERSION_HEADER = "X-Whooshd-Contract-Version"
+
+_ERROR_CODES = frozenset(
+    {
+        "invalid_request",
+        "unsupported_field",
+        "unsupported_capability",
+        "contract_version_unsupported",
+        "model_not_found",
+        "model_unavailable",
+        "model_warming",
+        "model_load_failed",
+        "runtime_unavailable",
+        "runtime_degraded",
+        "runner_overloaded",
+        "queue_full",
+        "timeout",
+        "cancelled",
+        "context_overflow",
+        "upstream_unavailable",
+        "upstream_timeout",
+        "upstream_protocol_error",
+        "stream_interrupted",
+        "malformed_upstream_response",
+        "internal_error",
+    }
+)
+
+
+@dataclass(frozen=True)
+class WhooshdErrorDiagnostic:
+    """Content-free canonical error metadata consumed by Guardian."""
+
+    contract_version: str
+    code: str
+    http_status: int
+    retryable: bool
+    retry_after_seconds: float | None
+    request_id: str | None
+    category: str | None
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "contract_version": self.contract_version,
+            "code": self.code,
+            "http_status": self.http_status,
+            "retryable": self.retryable,
+        }
+        if self.retry_after_seconds is not None:
+            payload["retry_after_seconds"] = self.retry_after_seconds
+        if self.request_id:
+            payload["request_id"] = self.request_id
+        if self.category:
+            payload["category"] = self.category
+        return payload
+
+
+def _header(response: Any, name: str) -> str | None:
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return None
+    value = headers.get(name) or headers.get(name.lower())
+    return str(value).strip()[:80] if value else None
+
+
+def parse_whooshd_error(response: Any) -> WhooshdErrorDiagnostic | None:
+    """Parse a v1 error only when the response explicitly declares v1.
+
+    A missing or unknown version is intentionally treated as legacy rather
+    than guessed to be v1.  The response body is never copied into the
+    diagnostic; only bounded machine fields are retained.
+    """
+
+    if _header(response, WHOOSHD_CONTROL_VERSION_HEADER) != WHOOSHD_CONTROL_PLANE_VERSION:
+        return None
+    try:
+        body = response.json()
+    except Exception:
+        return None
+    if not isinstance(body, dict):
+        return None
+    envelope = body.get("error") if isinstance(body.get("error"), dict) else body
+    if not isinstance(envelope, dict):
+        return None
+    code = str(envelope.get("code") or "").strip()
+    if code not in _ERROR_CODES:
+        return None
+    try:
+        http_status = int(envelope.get("http_status") or response.status_code)
+    except (TypeError, ValueError):
+        http_status = int(getattr(response, "status_code", 502) or 502)
+    retry_after = envelope.get("retry_after_seconds")
+    try:
+        retry_after_value = (
+            max(0.0, min(float(retry_after), 60.0))
+            if retry_after is not None
+            else None
+        )
+    except (TypeError, ValueError):
+        retry_after_value = None
+    request_id = envelope.get("request_id")
+    category = envelope.get("category")
+    return WhooshdErrorDiagnostic(
+        contract_version=WHOOSHD_CONTROL_PLANE_VERSION,
+        code=code,
+        http_status=http_status,
+        retryable=bool(envelope.get("retryable")),
+        retry_after_seconds=retry_after_value,
+        request_id=str(request_id)[:128] if request_id else None,
+        category=str(category)[:80] if category else None,
+    )
+
+
+def provider_failure_kind(code: str) -> str:
+    """Map v1 codes into Guardian's existing provider failure categories."""
+
+    if code in {"timeout", "upstream_timeout"}:
+        return "provider_timeout"
+    if code in {"upstream_unavailable", "runtime_unavailable", "model_unavailable"}:
+        return "transport_error"
+    if code in {"invalid_request", "unsupported_field", "unsupported_capability"}:
+        return "request_error"
+    if code == "model_not_found":
+        return "local_model_unavailable"
+    return "provider_http_error"

--- a/guardian/providers/whooshd_control_plane.py
+++ b/guardian/providers/whooshd_control_plane.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -34,6 +35,17 @@ _ERROR_CODES = frozenset(
         "internal_error",
     }
 )
+_VERSION_RE = re.compile(r"^whooshd\.control\.v[0-9]+$")
+
+
+class WhooshdContractVersionError(ValueError):
+    """An explicitly declared, unsupported Whoosh'd response version."""
+
+    code = "contract_version_unsupported"
+
+    def __init__(self, received_version: str):
+        self.received_version = received_version
+        super().__init__(self.code)
 
 
 @dataclass(frozen=True)
@@ -68,20 +80,32 @@ def _header(response: Any, name: str) -> str | None:
     headers = getattr(response, "headers", None)
     if headers is None:
         return None
-    value = headers.get(name) or headers.get(name.lower())
-    return str(value).strip()[:80] if value else None
+    if name in headers:
+        value = headers.get(name)
+    else:
+        value = headers.get(name.lower())
+    if value is None:
+        return None
+    candidate = str(value).strip()
+    if len(candidate) > 80 or not _VERSION_RE.fullmatch(candidate):
+        return "invalid"
+    return candidate
 
 
 def parse_whooshd_error(response: Any) -> WhooshdErrorDiagnostic | None:
     """Parse a v1 error only when the response explicitly declares v1.
 
-    A missing or unknown version is intentionally treated as legacy rather
-    than guessed to be v1.  The response body is never copied into the
+    A missing version is intentionally treated as legacy rather than guessed
+    to be v1. An explicit non-v1 version raises a bounded contract error so it
+    cannot enter legacy fallback. The response body is never copied into the
     diagnostic; only bounded machine fields are retained.
     """
 
-    if _header(response, WHOOSHD_CONTROL_VERSION_HEADER) != WHOOSHD_CONTROL_PLANE_VERSION:
+    response_version = _header(response, WHOOSHD_CONTROL_VERSION_HEADER)
+    if response_version is None:
         return None
+    if response_version != WHOOSHD_CONTROL_PLANE_VERSION:
+        raise WhooshdContractVersionError(response_version)
     try:
         body = response.json()
     except Exception:
@@ -127,7 +151,12 @@ def provider_failure_kind(code: str) -> str:
         return "provider_timeout"
     if code in {"upstream_unavailable", "runtime_unavailable", "model_unavailable"}:
         return "transport_error"
-    if code in {"invalid_request", "unsupported_field", "unsupported_capability"}:
+    if code in {
+        "invalid_request",
+        "unsupported_field",
+        "unsupported_capability",
+        "contract_version_unsupported",
+    }:
         return "request_error"
     if code == "model_not_found":
         return "local_model_unavailable"

--- a/guardian/providers/whooshd_control_plane.py
+++ b/guardian/providers/whooshd_control_plane.py
@@ -9,6 +9,8 @@ from typing import Any
 
 WHOOSHD_CONTROL_PLANE_VERSION = "whooshd.control.v1"
 WHOOSHD_CONTROL_VERSION_HEADER = "X-Whooshd-Contract-Version"
+WHOOSHD_RUNTIME_PROVENANCE_SCHEMA = "whooshd.runtime.v1"
+WHOOSHD_RUNTIME_PROVENANCE_HEADER = "X-Whooshd-Runtime-Provenance"
 
 _ERROR_CODES = frozenset(
     {
@@ -36,6 +38,44 @@ _ERROR_CODES = frozenset(
     }
 )
 _VERSION_RE = re.compile(r"^whooshd\.control\.v[0-9]+$")
+_SAFE_RUNTIME_KINDS = frozenset(
+    {"stub", "mlx_lm", "mlx_lm_server", "mlx_vlm", "llama_cpp"}
+)
+_SAFE_RESOLUTION_SOURCES = frozenset(
+    {
+        "authoritative_registry",
+        "external_route",
+        "format_heuristic",
+        "loaded_model_match",
+        "configured_stub",
+        "single_runtime_compatibility",
+        "stub_only_compatibility",
+    }
+)
+_SAFE_EXECUTION_MODES = frozenset(
+    {"in_process", "managed_sidecar", "external_sidecar", "stub"}
+)
+_SAFE_LIFECYCLE_STATES = frozenset(
+    {"unloaded", "warming", "ready", "generating", "degraded", "failed"}
+)
+_RUNTIME_FIELD_NAMES = (
+    "request_id",
+    "requested_model_id",
+    "advertised_model_id",
+    "resolved_model_id",
+    "backend_reported_model_id",
+    "runtime_kind",
+    "adapter_name",
+    "resolution_source",
+    "execution_mode",
+    "streaming",
+    "queued",
+    "batched",
+    "model_lifecycle",
+    "whooshd_version",
+)
+_PRIVATE_OR_URL_RE = re.compile(r"(?:^[/~]|^[A-Za-z]:[\\/]|://|[?&#])")
+_SAFE_RUNTIME_TEXT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$")
 
 
 class WhooshdContractVersionError(ValueError):
@@ -74,6 +114,129 @@ class WhooshdErrorDiagnostic:
         if self.category:
             payload["category"] = self.category
         return payload
+
+
+@dataclass(frozen=True)
+class WhooshdRuntimeProvenance:
+    """Content-free runtime evidence accepted from Whoosh'd v1 responses."""
+
+    schema_version: str
+    request_id: str | None
+    requested_model_id: str | None
+    advertised_model_id: str | None
+    resolved_model_id: str | None
+    backend_reported_model_id: str | None
+    runtime_kind: str
+    adapter_name: str
+    resolution_source: str
+    execution_mode: str
+    streaming: bool
+    queued: bool
+    batched: bool
+    model_lifecycle: str | None
+    whooshd_version: str | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in {
+                "schema_version": self.schema_version,
+                "request_id": self.request_id,
+                "requested_model_id": self.requested_model_id,
+                "advertised_model_id": self.advertised_model_id,
+                "resolved_model_id": self.resolved_model_id,
+                "backend_reported_model_id": self.backend_reported_model_id,
+                "runtime_kind": self.runtime_kind,
+                "adapter_name": self.adapter_name,
+                "resolution_source": self.resolution_source,
+                "execution_mode": self.execution_mode,
+                "streaming": self.streaming,
+                "queued": self.queued,
+                "batched": self.batched,
+                "model_lifecycle": self.model_lifecycle,
+                "whooshd_version": self.whooshd_version,
+            }.items()
+            if value is not None
+        }
+
+
+def parse_whooshd_runtime_provenance(raw: Any) -> WhooshdRuntimeProvenance | None:
+    """Accept only the bounded, recognized runtime provenance schema."""
+    if not isinstance(raw, dict):
+        return None
+    if raw.get("schema_version") != WHOOSHD_RUNTIME_PROVENANCE_SCHEMA:
+        return None
+
+    def _text(name: str, *, required: bool = False) -> str | None:
+        value = raw.get(name)
+        if value is None and not required:
+            return None
+        if not isinstance(value, str):
+            return None
+        value = value.strip()
+        if not value or len(value) > 256 or not _SAFE_RUNTIME_TEXT_RE.fullmatch(value):
+            return None
+        if _PRIVATE_OR_URL_RE.search(value):
+            return None
+        return value
+
+    runtime_kind = _text("runtime_kind", required=True)
+    adapter_name = _text("adapter_name", required=True)
+    resolution_source = _text("resolution_source", required=True)
+    execution_mode = _text("execution_mode", required=True)
+    if (
+        runtime_kind not in _SAFE_RUNTIME_KINDS
+        or resolution_source not in _SAFE_RESOLUTION_SOURCES
+        or execution_mode not in _SAFE_EXECUTION_MODES
+    ):
+        return None
+
+    text_values = {
+        name: _text(name)
+        for name in _RUNTIME_FIELD_NAMES
+        if name
+        not in {
+            "runtime_kind",
+            "adapter_name",
+            "resolution_source",
+            "execution_mode",
+            "streaming",
+            "queued",
+            "batched",
+            "model_lifecycle",
+        }
+    }
+    lifecycle = _text("model_lifecycle")
+    if lifecycle is not None and lifecycle not in _SAFE_LIFECYCLE_STATES:
+        return None
+    bool_values: dict[str, bool] = {}
+    for name in ("streaming", "queued", "batched"):
+        value = raw.get(name, False)
+        if not isinstance(value, bool):
+            return None
+        bool_values[name] = value
+    if raw.get("model_lifecycle") is not None and lifecycle is None:
+        return None
+    for name, value in text_values.items():
+        if raw.get(name) is not None and value is None:
+            return None
+    return WhooshdRuntimeProvenance(
+        schema_version=WHOOSHD_RUNTIME_PROVENANCE_SCHEMA,
+        request_id=text_values["request_id"],
+        requested_model_id=text_values["requested_model_id"],
+        advertised_model_id=text_values["advertised_model_id"],
+        resolved_model_id=text_values["resolved_model_id"],
+        backend_reported_model_id=text_values["backend_reported_model_id"],
+        runtime_kind=runtime_kind,
+        adapter_name=adapter_name,
+        resolution_source=resolution_source,
+        execution_mode=execution_mode,
+        streaming=bool_values["streaming"],
+        queued=bool_values["queued"],
+        batched=bool_values["batched"],
+        model_lifecycle=lifecycle,
+        whooshd_version=text_values["whooshd_version"],
+    )
 
 
 def _header(response: Any, name: str) -> str | None:

--- a/guardian/tests/workers/test_chat_worker_completion_semantics.py
+++ b/guardian/tests/workers/test_chat_worker_completion_semantics.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock
 from fastapi import HTTPException
 
 from guardian.core.config import Settings
+from guardian.core.ai_router import ProviderResponse
+from guardian.providers.whooshd_control_plane import parse_whooshd_runtime_provenance
 from guardian.tasks.types import ChatCompletionTask
 from guardian.workers import chat_worker
 
@@ -582,6 +584,68 @@ def test_completion_result_includes_execution_metadata_without_fallback(
         "fallback_triggered": False,
         "tool_turn_used": False,
     }
+
+
+def test_runtime_provenance_persists_after_successful_completion(monkeypatch):
+    mock_db = MagicMock()
+    mock_db.create_message.return_value = 323
+    monkeypatch.setattr(chat_worker.dependencies, "chatlog_db", mock_db)
+    monkeypatch.setattr(chat_worker, "_embed_message", lambda *a, **k: None)
+    persisted_extra_meta: dict[str, object] = {}
+    monkeypatch.setattr(
+        chat_worker,
+        "_persist_message_extra_meta",
+        lambda **kwargs: persisted_extra_meta.update(kwargs) or True,
+    )
+
+    async def _build_messages(_task):
+        return (
+            [{"role": "user", "content": "hello"}],
+            "groq",
+            "qwen3.5:27b",
+            {},
+            None,
+            None,
+            {},
+        )
+
+    monkeypatch.setattr(chat_worker, "_build_messages_for_llm", _build_messages)
+    provenance = parse_whooshd_runtime_provenance(
+        {
+            "schema_version": "whooshd.runtime.v1",
+            "request_id": "request-22",
+            "runtime_kind": "stub",
+            "adapter_name": "stub",
+            "resolution_source": "configured_stub",
+            "execution_mode": "stub",
+            "model_lifecycle": "ready",
+        }
+    )
+    monkeypatch.setattr(
+        chat_worker._chat_completion_service,
+        "chat_with_ai",
+        lambda *_a, **_k: ProviderResponse(
+            "ready", provider="groq", runtime_provenance=provenance
+        ),
+    )
+
+    result = chat_worker._run_chat_completion_task_compat(
+        ChatCompletionTask(
+            user_id="local",
+            thread_id=1,
+            provider="groq",
+            model="qwen3.5:27b",
+            selection_source="explicit",
+        )
+    )
+
+    assert result["runtime_provenance"]["request_id"] == "request-22"
+    assert (
+        persisted_extra_meta["payload"]["whooshd_runtime_provenance"][
+            "runtime_kind"
+        ]
+        == "stub"
+    )
 
 
 def test_explicit_provider_failure_does_not_rescue(monkeypatch):

--- a/guardian/workers/chat_worker.py
+++ b/guardian/workers/chat_worker.py
@@ -1940,6 +1940,10 @@ def _run_chat_completion_task_compat(
         "payload_summary": payload_summary,
     }
     if isinstance(completion_result, dict):
+        if isinstance(completion_result.get("runtime_provenance"), dict):
+            result["runtime_provenance"] = dict(
+                completion_result["runtime_provenance"]
+            )
         helper_tool_loop_execution = completion_result.get("execution")
         helper_payload_summary = completion_result.get("payload_summary")
         helper_trace = completion_result.get("trace")
@@ -2100,6 +2104,7 @@ def _run_chat_completion_task_compat(
                 "model": final_model,
                 "execution": execution,
                 "tool_loop_execution": result.get("tool_loop_execution"),
+                "whooshd_runtime_provenance": result.get("runtime_provenance"),
                 **tool_loop_observability,
             },
         )
@@ -2134,6 +2139,7 @@ def _run_chat_completion_task_compat(
                 ),
                 "execution": execution,
                 "tool_loop_execution": result.get("tool_loop_execution"),
+                "whooshd_runtime_provenance": result.get("runtime_provenance"),
                 **tool_loop_observability,
             },
         )

--- a/tests/providers/test_whooshd_control_plane.py
+++ b/tests/providers/test_whooshd_control_plane.py
@@ -1,0 +1,164 @@
+"""Focused Codexify tests for the versioned Whoosh'd control plane."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import HTTPException
+
+import guardian.core.ai_router as ai_router
+from guardian.core.config import Settings
+import guardian.core.supported_profile as supported_profile
+from guardian.providers.whooshd_control_plane import (
+    WHOOSHD_CONTROL_PLANE_VERSION,
+    WHOOSHD_CONTROL_VERSION_HEADER,
+    parse_whooshd_error,
+    provider_failure_kind,
+)
+
+
+class _Response:
+    def __init__(self, body: dict, *, version: str | None = WHOOSHD_CONTROL_PLANE_VERSION):
+        self.status_code = int(body.get("http_status", 503))
+        self.headers = {}
+        if version is not None:
+            self.headers[WHOOSHD_CONTROL_VERSION_HEADER] = version
+        self.content = json.dumps(body).encode("utf-8")
+        self._body = body
+
+    def json(self):
+        return self._body
+
+
+def test_v1_header_and_body_are_parsed_without_content_fields():
+    response = _Response(
+        {
+            "contract_version": WHOOSHD_CONTROL_PLANE_VERSION,
+            "code": "model_warming",
+            "http_status": 425,
+            "retryable": True,
+            "retry_after_seconds": 2,
+            "request_id": "req-42",
+            "category": "model_runtime",
+            "message": "prompt-secret-generated-secret",
+            "details": {"body": "upstream-response-secret"},
+            "optional_future_field": "ignored",
+        }
+    )
+
+    diagnostic = parse_whooshd_error(response)
+
+    assert diagnostic is not None
+    assert diagnostic.contract_version == WHOOSHD_CONTROL_PLANE_VERSION
+    assert diagnostic.code == "model_warming"
+    assert diagnostic.http_status == 425
+    assert diagnostic.retryable is True
+    assert diagnostic.retry_after_seconds == 2.0
+    assert diagnostic.request_id == "req-42"
+    assert diagnostic.category == "model_runtime"
+    serialized = json.dumps(diagnostic.as_dict())
+    assert "prompt-secret-generated-secret" not in serialized
+    assert "upstream-response-secret" not in serialized
+    assert "optional_future_field" not in serialized
+
+
+@pytest.mark.parametrize(
+    "version",
+    [None, "whooshd.control.v0", "whooshd.control.v2"],
+)
+def test_missing_mismatched_and_unsupported_versions_remain_legacy(version):
+    response = _Response(
+        {
+            "code": "runtime_unavailable",
+            "http_status": 503,
+            "retryable": True,
+        },
+        version=version,
+    )
+
+    assert parse_whooshd_error(response) is None
+
+
+@pytest.mark.parametrize(
+    ("code", "expected"),
+    [
+        ("timeout", "provider_timeout"),
+        ("upstream_timeout", "provider_timeout"),
+        ("runtime_unavailable", "transport_error"),
+        ("model_unavailable", "transport_error"),
+        ("model_not_found", "local_model_unavailable"),
+        ("unsupported_field", "request_error"),
+        ("unsupported_capability", "request_error"),
+    ],
+)
+def test_codexify_classifies_from_machine_readable_code_only(code, expected):
+    assert provider_failure_kind(code) == expected
+
+
+def test_legacy_unversioned_response_is_not_assumed_to_be_v1():
+    response = _Response(
+        {
+            "code": "runtime_unavailable",
+            "message": "legacy response body may be provider-defined",
+        },
+        version=None,
+    )
+
+    assert parse_whooshd_error(response) is None
+
+
+def test_call_local_sends_v1_header_and_uses_code_not_body(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def _post(url, *, json, headers, timeout):
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return _Response(
+            {
+                "contract_version": WHOOSHD_CONTROL_PLANE_VERSION,
+                "code": "runtime_unavailable",
+                "http_status": 503,
+                "retryable": True,
+                "request_id": "turn-9",
+                "message": "prompt-body-sentinel",
+                "details": {"response": "provider-body-sentinel"},
+            }
+        )
+
+    monkeypatch.setattr(ai_router.requests, "post", _post)
+    monkeypatch.setattr(
+        supported_profile,
+        "get_active_supported_profile",
+        lambda: None,
+    )
+    settings = Settings(
+        LLM_PROVIDER="local",
+        CODEXIFY_LOCAL_ONLY_MODE=True,
+        ALLOW_CLOUD_PROVIDERS=False,
+        CODEXIFY_EGRESS_ALLOWLIST="",
+        LOCAL_BASE_URL="http://host.docker.internal:8000/v1",
+        LOCAL_LLM_MODEL="gemma-3-4b-it",
+        LOCAL_CHAT_MODEL="gemma-3-4b-it",
+        DEFAULT_LOCAL_MODEL="gemma-3-4b-it",
+        LLM_MODEL="gemma-3-4b-it",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        ai_router.call_local(
+            [{"role": "user", "content": "prompt-input-sentinel"}],
+            "gemma-3-4b-it",
+            settings=settings,
+        )
+
+    assert captured["headers"][WHOOSHD_CONTROL_VERSION_HEADER] == WHOOSHD_CONTROL_PLANE_VERSION
+    detail = exc.value.detail
+    assert detail["failure_kind"] == "transport_error"
+    assert detail["provider_error"] == "runtime_unavailable"
+    assert detail["whooshd_error"]["request_id"] == "turn-9"
+    serialized = json.dumps(detail)
+    assert "prompt-body-sentinel" not in serialized
+    assert "provider-body-sentinel" not in serialized
+    assert "prompt-input-sentinel" not in serialized

--- a/tests/providers/test_whooshd_control_plane.py
+++ b/tests/providers/test_whooshd_control_plane.py
@@ -13,6 +13,7 @@ import guardian.core.supported_profile as supported_profile
 from guardian.providers.whooshd_control_plane import (
     WHOOSHD_CONTROL_PLANE_VERSION,
     WHOOSHD_CONTROL_VERSION_HEADER,
+    WhooshdContractVersionError,
     parse_whooshd_error,
     provider_failure_kind,
 )
@@ -63,21 +64,39 @@ def test_v1_header_and_body_are_parsed_without_content_fields():
     assert "optional_future_field" not in serialized
 
 
-@pytest.mark.parametrize(
-    "version",
-    [None, "whooshd.control.v0", "whooshd.control.v2"],
-)
-def test_missing_mismatched_and_unsupported_versions_remain_legacy(version):
+def test_missing_version_remains_legacy():
     response = _Response(
         {
             "code": "runtime_unavailable",
             "http_status": 503,
             "retryable": True,
         },
-        version=version,
+        version=None,
     )
 
     assert parse_whooshd_error(response) is None
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["whooshd.control.v0", "whooshd.control.v2", "malformed-secret", "x" * 200],
+)
+def test_explicit_non_v1_version_fails_without_legacy_fallback(version):
+    response = _Response(
+        {
+            "code": "runtime_unavailable",
+            "http_status": 503,
+            "retryable": True,
+            "message": "response-body-secret",
+        },
+        version=version,
+    )
+
+    with pytest.raises(WhooshdContractVersionError) as exc:
+        parse_whooshd_error(response)
+
+    assert exc.value.received_version in {"whooshd.control.v0", "whooshd.control.v2", "invalid"}
+    assert "response-body-secret" not in str(exc.value)
 
 
 @pytest.mark.parametrize(
@@ -90,6 +109,7 @@ def test_missing_mismatched_and_unsupported_versions_remain_legacy(version):
         ("model_not_found", "local_model_unavailable"),
         ("unsupported_field", "request_error"),
         ("unsupported_capability", "request_error"),
+        ("contract_version_unsupported", "request_error"),
     ],
 )
 def test_codexify_classifies_from_machine_readable_code_only(code, expected):
@@ -162,3 +182,51 @@ def test_call_local_sends_v1_header_and_uses_code_not_body(monkeypatch):
     assert "prompt-body-sentinel" not in serialized
     assert "provider-body-sentinel" not in serialized
     assert "prompt-input-sentinel" not in serialized
+
+
+def test_call_local_explicit_future_version_is_a_bounded_contract_failure(monkeypatch):
+    calls: list[str] = []
+
+    def _post(url, *, json, headers, timeout):
+        _ = (json, headers, timeout)
+        calls.append(url)
+        return _Response(
+            {
+                "http_status": 503,
+                "message": "provider-response-secret",
+                "details": {"body": "response-body-secret"},
+            },
+            version="whooshd.control.v2",
+        )
+
+    monkeypatch.setattr(ai_router.requests, "post", _post)
+    monkeypatch.setattr(supported_profile, "get_active_supported_profile", lambda: None)
+    settings = Settings(
+        LLM_PROVIDER="local",
+        CODEXIFY_LOCAL_ONLY_MODE=True,
+        ALLOW_CLOUD_PROVIDERS=False,
+        CODEXIFY_EGRESS_ALLOWLIST="",
+        LOCAL_BASE_URL="http://host.docker.internal:8000/v1",
+        LOCAL_LLM_MODEL="gemma-3-4b-it",
+        LOCAL_CHAT_MODEL="gemma-3-4b-it",
+        DEFAULT_LOCAL_MODEL="gemma-3-4b-it",
+        LLM_MODEL="gemma-3-4b-it",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        ai_router.call_local(
+            [{"role": "user", "content": "prompt-secret"}],
+            "gemma-3-4b-it",
+            settings=settings,
+        )
+
+    assert len(calls) == 1
+    assert exc.value.status_code == 502
+    detail = exc.value.detail
+    assert detail["failure_kind"] == "request_error"
+    assert detail["provider_error"] == "contract_version_unsupported"
+    assert detail["whooshd_error"]["received_version"] == "whooshd.control.v2"
+    serialized = json.dumps(detail)
+    assert "provider-response-secret" not in serialized
+    assert "response-body-secret" not in serialized
+    assert "prompt-secret" not in serialized

--- a/tests/providers/test_whooshd_control_plane.py
+++ b/tests/providers/test_whooshd_control_plane.py
@@ -14,7 +14,9 @@ from guardian.providers.whooshd_control_plane import (
     WHOOSHD_CONTROL_PLANE_VERSION,
     WHOOSHD_CONTROL_VERSION_HEADER,
     WhooshdContractVersionError,
+    WHOOSHD_RUNTIME_PROVENANCE_SCHEMA,
     parse_whooshd_error,
+    parse_whooshd_runtime_provenance,
     provider_failure_kind,
 )
 
@@ -128,6 +130,63 @@ def test_legacy_unversioned_response_is_not_assumed_to_be_v1():
     assert parse_whooshd_error(response) is None
 
 
+def test_runtime_provenance_accepts_known_fields_and_ignores_unknown_values():
+    provenance = parse_whooshd_runtime_provenance(
+        {
+            "schema_version": WHOOSHD_RUNTIME_PROVENANCE_SCHEMA,
+            "request_id": "request-9",
+            "requested_model_id": "requested/model",
+            "advertised_model_id": "advertised-model",
+            "resolved_model_id": "resolved-model",
+            "backend_reported_model_id": "backend-model",
+            "runtime_kind": "mlx_lm_server",
+            "adapter_name": "mlx-lm-server",
+            "resolution_source": "authoritative_registry",
+            "execution_mode": "managed_sidecar",
+            "streaming": False,
+            "queued": True,
+            "batched": False,
+            "model_lifecycle": "ready",
+            "whooshd_version": "0.1.0rc1",
+            "prompt": "prompt-sentinel",
+            "generated_output": "output-sentinel",
+            "private_path": "/Users/private/model.gguf",
+            "endpoint": "http://user:token@example.test/v1?api_key=secret",
+        }
+    )
+
+    assert provenance is not None
+    assert provenance.request_id == "request-9"
+    assert provenance.runtime_kind == "mlx_lm_server"
+    serialized = json.dumps(provenance.as_dict())
+    assert "prompt-sentinel" not in serialized
+    assert "output-sentinel" not in serialized
+    assert "/Users/private/model.gguf" not in serialized
+    assert "api_key=secret" not in serialized
+
+
+def test_malformed_runtime_provenance_is_not_verified():
+    assert parse_whooshd_runtime_provenance(
+        {
+            "schema_version": "whooshd.runtime.v2",
+            "runtime_kind": "stub",
+            "adapter_name": "stub",
+            "resolution_source": "stub_only_compatibility",
+            "execution_mode": "stub",
+        }
+    ) is None
+    assert parse_whooshd_runtime_provenance(
+        {
+            "schema_version": WHOOSHD_RUNTIME_PROVENANCE_SCHEMA,
+            "runtime_kind": "stub",
+            "adapter_name": "stub",
+            "resolution_source": "stub_only_compatibility",
+            "execution_mode": "stub",
+            "queued": "not-a-bool",
+        }
+    ) is None
+
+
 def test_call_local_sends_v1_header_and_uses_code_not_body(monkeypatch):
     captured: dict[str, object] = {}
 
@@ -230,3 +289,56 @@ def test_call_local_explicit_future_version_is_a_bounded_contract_failure(monkey
     assert "provider-response-secret" not in serialized
     assert "response-body-secret" not in serialized
     assert "prompt-secret" not in serialized
+
+
+def test_call_local_success_retains_bounded_runtime_provenance(monkeypatch):
+    body = {
+        "http_status": 200,
+        "id": "chatcmpl-1",
+        "model": "backend-model",
+        "choices": [
+            {"message": {"role": "assistant", "content": "assistant-output"}}
+        ],
+        "runtime_provenance": {
+            "schema_version": WHOOSHD_RUNTIME_PROVENANCE_SCHEMA,
+            "request_id": "request-11",
+            "requested_model_id": "requested-model",
+            "advertised_model_id": "advertised-model",
+            "resolved_model_id": "resolved-model",
+            "backend_reported_model_id": "backend-model",
+            "runtime_kind": "stub",
+            "adapter_name": "stub",
+            "resolution_source": "configured_stub",
+            "execution_mode": "stub",
+            "streaming": False,
+            "queued": False,
+            "batched": False,
+            "model_lifecycle": "ready",
+            "prompt": "prompt-secret",
+        },
+    }
+
+    monkeypatch.setattr(ai_router.requests, "post", lambda *a, **k: _Response(body))
+    monkeypatch.setattr(supported_profile, "get_active_supported_profile", lambda: None)
+    settings = Settings(
+        LLM_PROVIDER="local",
+        CODEXIFY_LOCAL_ONLY_MODE=True,
+        ALLOW_CLOUD_PROVIDERS=False,
+        CODEXIFY_EGRESS_ALLOWLIST="",
+        LOCAL_BASE_URL="http://host.docker.internal:8000/v1",
+        LOCAL_LLM_MODEL="gemma-3-4b-it",
+        LOCAL_CHAT_MODEL="gemma-3-4b-it",
+        DEFAULT_LOCAL_MODEL="gemma-3-4b-it",
+        LLM_MODEL="gemma-3-4b-it",
+    )
+
+    output = ai_router.call_local(
+        [{"role": "user", "content": "prompt-input-secret"}],
+        "gemma-3-4b-it",
+        settings=settings,
+    )
+    normalized = ai_router.normalize_completion_output(output)
+    assert normalized.runtime_provenance is not None
+    assert normalized.runtime_provenance.request_id == "request-11"
+    assert "prompt-secret" not in json.dumps(normalized.runtime_provenance.as_dict())
+    assert "assistant-output" not in json.dumps(normalized.runtime_provenance.as_dict())


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
