### PR TITLE
fix: close Whooshd streaming correlation review gaps

### DIFF
--- a/guardian/core/ai_router.py
+++ b/guardian/core/ai_router.py
@@ -2821,6 +2821,7 @@ def stream_local(
                         cancel_check=cancel_check,
                     )
                     candidate_cancel_monitor.start()
+                resp: Optional[requests.Response] = None
                 try:
                     logger.info(
                         "chat.inference.request.built",
@@ -2880,55 +2881,66 @@ def stream_local(
                     attempt_failures.append(f"{url} ({classification}: {exc})")
                     continue
 
-                if candidate_cancel_monitor is not None:
-                    candidate_cancel_monitor.set_response(resp)
-                    cancel_monitor = candidate_cancel_monitor
-
+                # A candidate cancellation monitor must not become the active
+                # monitor until its response is accepted. Rejected candidates
+                # (unsupported endpoints, retryable statuses, or contract errors)
+                # are stopped here so no daemon polling thread survives a later
+                # accepted fallback attempt.
+                accepted = False
                 try:
-                    whooshd_error = parse_whooshd_error(
-                        resp,
-                        include_body=resp.status_code >= 300,
-                    )
-                except WhooshdContractVersionError as exc:
-                    resp.close()
-                    raise _whooshd_contract_version_failure(
-                        settings=settings,
-                        model=model,
-                        endpoint=url,
-                        runtime_policy=runtime_policy,
-                        received_version=exc.received_version,
-                        attempted_endpoints=[
-                            f"{url} (contract_version_unsupported)"
-                        ],
-                        attempted_base_urls=attempted_base_urls,
-                    ) from exc
-                if whooshd_error is not None:
-                    last_whooshd_error = whooshd_error
-                    attempt_failures.append(
-                        f"{url} (HTTP {resp.status_code}: {whooshd_error.code})"
-                    )
-                    resp.close()
-                    continue
-                if resp.status_code == 404:
-                    if is_gateway:
+                    try:
+                        whooshd_error = parse_whooshd_error(
+                            resp,
+                            include_body=resp.status_code >= 300,
+                        )
+                    except WhooshdContractVersionError as exc:
+                        raise _whooshd_contract_version_failure(
+                            settings=settings,
+                            model=model,
+                            endpoint=url,
+                            runtime_policy=runtime_policy,
+                            received_version=exc.received_version,
+                            attempted_endpoints=[
+                                f"{url} (contract_version_unsupported)"
+                            ],
+                            attempted_base_urls=attempted_base_urls,
+                        ) from exc
+                    if whooshd_error is not None:
+                        last_whooshd_error = whooshd_error
                         attempt_failures.append(
-                            f"{url} (HTTP 404: endpoint requires OpenAI-compatible /v1/chat/completions)"
+                            f"{url} (HTTP {resp.status_code}: {whooshd_error.code})"
+                        )
+                    elif resp.status_code == 404:
+                        if is_gateway:
+                            attempt_failures.append(
+                                f"{url} (HTTP 404: endpoint requires OpenAI-compatible /v1/chat/completions)"
+                            )
+                        else:
+                            attempt_failures.append(f"{url} (HTTP 404)")
+                    elif not (200 <= resp.status_code < 300):
+                        detail = _extract_provider_error_message(
+                            resp, secret=api_key
+                        )
+                        attempt_failures.append(
+                            f"{url} (HTTP {resp.status_code}: {detail})"
                         )
                     else:
-                        attempt_failures.append(f"{url} (HTTP 404)")
-                    resp.close()
-                    continue
+                        accepted = True
+                finally:
+                    if not accepted:
+                        if candidate_cancel_monitor is not None:
+                            candidate_cancel_monitor.stop()
+                        if resp is not None:
+                            resp.close()
 
-                if not (200 <= resp.status_code < 300):
-                    detail = _extract_provider_error_message(resp, secret=api_key)
-                    attempt_failures.append(
-                        f"{url} (HTTP {resp.status_code}: {detail})"
-                    )
-                    resp.close()
+                if not accepted:
                     continue
 
                 response = resp
                 response_kind = kind
+                if candidate_cancel_monitor is not None:
+                    candidate_cancel_monitor.set_response(resp)
+                    cancel_monitor = candidate_cancel_monitor
                 break
             if response is not None:
                 break
@@ -3020,6 +3032,7 @@ def stream_local(
             finish_reason: str | None = None
             visible_output_emitted = False
             runtime_provenance: dict[str, Any] | None = None
+            response_correlation: dict[str, Any] | None = None
             parsed_response_provenance: WhooshdRuntimeProvenance | None = None
             response_headers = getattr(response, "headers", {}) or {}
             header_provenance = response_headers.get(
@@ -3040,6 +3053,13 @@ def stream_local(
             )
             if parsed_response_provenance is not None:
                 runtime_provenance = parsed_response_provenance.as_dict()
+            # Capture response correlation independently of runtime provenance so
+            # header-only Whoosh'd request IDs survive even when the upstream did
+            # not emit a bounded runtime-provenance block. Keeps streaming aligned
+            # with the non-streaming path in ``call_local``. An empty mapping is
+            # normalized to ``None`` so absent correlation is never persisted as a
+            # synthesized identifier.
+            response_correlation = parse_whooshd_response_correlation(response) or None
             if callable(cancel_check):
                 if cancel_monitor is None:
                     cancel_monitor = _WhooshdCancellationMonitor(
@@ -3064,6 +3084,7 @@ def stream_local(
                         failure_kind="cancelled",
                         retry_permitted=False,
                         runtime_provenance=runtime_provenance,
+                        response_correlation=response_correlation,
                     )
                 if not raw_line:
                     continue
@@ -3084,6 +3105,7 @@ def stream_local(
                         provider="local",
                         model=model,
                         runtime_provenance=runtime_provenance,
+                        response_correlation=response_correlation,
                     )
                 try:
                     chunk = json.loads(data)
@@ -3099,6 +3121,7 @@ def stream_local(
                         failure_kind="malformed_stream_frame",
                         retry_permitted=not visible_output_emitted,
                         runtime_provenance=runtime_provenance,
+                        response_correlation=response_correlation,
                     )
                 try:
                     parsed_provenance = parse_whooshd_runtime_provenance(
@@ -3124,6 +3147,7 @@ def stream_local(
                             failure_kind="provider_error_frame",
                             retry_permitted=not visible_output_emitted,
                             runtime_provenance=runtime_provenance,
+                            response_correlation=response_correlation,
                         )
                     # OpenAI-compatible SSE or Ollama /api/chat streaming
                     choice = chunk.get("choices", [{}])[0]
@@ -3157,6 +3181,7 @@ def stream_local(
                             provider="local",
                             model=model,
                             runtime_provenance=runtime_provenance,
+                            response_correlation=response_correlation,
                         )
                 except Exception:
                     return CompletionTerminalEvidence(
@@ -3170,6 +3195,7 @@ def stream_local(
                         failure_kind="malformed_stream_frame",
                         retry_permitted=not visible_output_emitted,
                         runtime_provenance=runtime_provenance,
+                        response_correlation=response_correlation,
                     )
             if cancel_monitor and cancel_monitor.cancelled.is_set():
                 return CompletionTerminalEvidence(
@@ -3183,6 +3209,7 @@ def stream_local(
                     failure_kind="cancelled",
                     retry_permitted=False,
                     runtime_provenance=runtime_provenance,
+                    response_correlation=response_correlation,
                 )
             return CompletionTerminalEvidence(
                 status=CompletionTerminalStatus.STREAM_INCOMPLETE,
@@ -3195,6 +3222,7 @@ def stream_local(
                 failure_kind="missing_stream_terminal",
                 retry_permitted=not visible_output_emitted,
                 runtime_provenance=runtime_provenance,
+                response_correlation=response_correlation,
             )
         except req_exc.RequestException as exc:
             if cancel_monitor and cancel_monitor.cancelled.is_set():
@@ -3209,6 +3237,7 @@ def stream_local(
                     failure_kind="cancelled",
                     retry_permitted=False,
                     runtime_provenance=runtime_provenance,
+                    response_correlation=response_correlation,
                 )
             detail = _format_local_connect_error(
                 current_url,

--- a/guardian/core/chat_completion_service.py
+++ b/guardian/core/chat_completion_service.py
@@ -724,6 +724,11 @@ def _execute_completion_attempt(
                 else None
             ),
             attempt_id=attempt_id,
+            response_correlation=(
+                dict(terminal.response_correlation)
+                if isinstance(getattr(terminal, "response_correlation", None), dict)
+                else None
+            ),
         )
 
     try:

--- a/guardian/core/completion_terminal.py
+++ b/guardian/core/completion_terminal.py
@@ -20,6 +20,7 @@ class CompletionTerminalEvidence:
     failure_kind: str | None = None
     retry_permitted: bool = False
     runtime_provenance: dict[str, Any] | None = None
+    response_correlation: dict[str, Any] | None = None
 
     @property
     def successful(self) -> bool:
@@ -45,6 +46,8 @@ class CompletionTerminalEvidence:
         }
         if self.runtime_provenance is not None:
             payload["runtime_provenance"] = dict(self.runtime_provenance)
+        if self.response_correlation is not None:
+            payload["response_correlation"] = dict(self.response_correlation)
         return payload
 
     @classmethod
@@ -69,6 +72,15 @@ class CompletionTerminalEvidence:
             )
             if parsed_provenance is not None:
                 runtime_provenance = parsed_provenance.as_dict()
+        response_correlation = None
+        if raw.get("response_correlation") is not None:
+            from guardian.providers.whooshd_control_plane import (
+                bounded_response_correlation,
+            )
+
+            bounded = bounded_response_correlation(raw.get("response_correlation"))
+            if bounded:
+                response_correlation = bounded
         return cls(
             status=status,
             visible_output_emitted=bool(raw.get("visible_output_emitted")),
@@ -90,6 +102,7 @@ class CompletionTerminalEvidence:
             ),
             retry_permitted=bool(raw.get("retry_permitted")),
             runtime_provenance=runtime_provenance,
+            response_correlation=response_correlation,
         )
 
 

--- a/guardian/providers/whooshd_control_plane.py
+++ b/guardian/providers/whooshd_control_plane.py
@@ -303,6 +303,32 @@ def parse_whooshd_response_correlation(response: Any) -> dict[str, str]:
     return {key: value for key, value in values.items() if value}
 
 
+_RESPONSE_CORRELATION_FIELDS = (
+    "correlation_id",
+    "whooshd_request_id",
+    "codexify_task_id",
+    "codexify_attempt_id",
+)
+
+
+def bounded_response_correlation(values: Any) -> dict[str, str]:
+    """Re-apply the bounded correlation filter to a pre-built mapping.
+
+    Used when correlation metadata crosses a persistence or retry boundary:
+    a stored dict is not trusted merely because it was previously shaped
+    like ``parse_whooshd_response_correlation`` output.
+    """
+
+    if not isinstance(values, dict):
+        return {}
+    bounded: dict[str, str] = {}
+    for field in _RESPONSE_CORRELATION_FIELDS:
+        validated = _safe_correlation_id(values.get(field))
+        if validated:
+            bounded[field] = validated
+    return bounded
+
+
 def merge_whooshd_response_correlation(
     provenance: WhooshdRuntimeProvenance | None,
     response: Any,

--- a/guardian/tests/core/test_request_correlation.py
+++ b/guardian/tests/core/test_request_correlation.py
@@ -7,6 +7,7 @@ import threading
 from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 
 from guardian.core import ai_router
 from guardian.core import chat_completion_service
@@ -413,3 +414,381 @@ def test_response_correlation_accepts_only_bounded_machine_ids():
 
     unsafe = _Response({}, headers={"X-Request-ID": "prompt secret"})
     assert parse_whooshd_response_correlation(unsafe) == {}
+
+
+def _drain_stream(stream):
+    tokens: list[str] = []
+    iterator = iter(stream)
+    while True:
+        try:
+            tokens.append(next(iterator))
+        except StopIteration as stop:
+            return tokens, stop.value
+
+
+_FULL_RUNTIME_PROVENANCE = {
+    "schema_version": "whooshd.runtime.v1",
+    "runtime_kind": "stub",
+    "adapter_name": "stub-adapter",
+    "resolution_source": "configured_stub",
+    "execution_mode": "stub",
+    "streaming": True,
+    "queued": False,
+    "batched": False,
+    "request_id": "whooshd-internal-7",
+}
+_FULL_RUNTIME_PROVENANCE_HEADER = json.dumps(_FULL_RUNTIME_PROVENANCE)
+
+_SSE_OK = [
+    b'data: {"choices":[{"delta":{"content":"ok"}}]}',
+    b"data: [DONE]",
+]
+
+
+def test_stream_local_preserves_header_only_whooshd_request_id(monkeypatch):
+    _prepare_local(monkeypatch)
+
+    def fake_post(url, json, headers, stream, timeout):
+        return _StreamingResponse(
+            _SSE_OK,
+            headers={
+                "X-Whooshd-Request-ID": "whooshd-stream-only",
+                "X-Request-ID": "req-stream-only",
+            },
+        )
+
+    monkeypatch.setattr(ai_router.requests, "post", fake_post)
+
+    tokens, terminal = _drain_stream(
+        stream_local(
+            [{"role": "user", "content": "hi"}],
+            "stub-model",
+            settings=_settings(),
+            request_id="req-stream-only",
+            task_id="task-stream-only",
+            attempt_id="attempt-stream-only",
+        )
+    )
+
+    assert tokens == ["ok"]
+    assert isinstance(terminal, CompletionTerminalEvidence)
+    assert terminal.status is CompletionTerminalStatus.SUCCESS
+    # No runtime provenance block was emitted, so none is synthesized.
+    assert terminal.runtime_provenance is None
+    # Header-only Whoosh'd request ID survives stream termination.
+    assert terminal.response_correlation == {
+        "whooshd_request_id": "whooshd-stream-only",
+        "correlation_id": "req-stream-only",
+    }
+
+
+def test_stream_local_keeps_full_runtime_provenance_and_correlation(monkeypatch):
+    _prepare_local(monkeypatch)
+
+    def fake_post(url, json, headers, stream, timeout):
+        return _StreamingResponse(
+            _SSE_OK,
+            headers={
+                "X-Whooshd-Runtime-Provenance": _FULL_RUNTIME_PROVENANCE_HEADER,
+                "X-Whooshd-Request-ID": "whooshd-stream-full",
+                "X-Request-ID": "req-stream-full",
+            },
+        )
+
+    monkeypatch.setattr(ai_router.requests, "post", fake_post)
+
+    tokens, terminal = _drain_stream(
+        stream_local(
+            [{"role": "user", "content": "hi"}],
+            "stub-model",
+            settings=_settings(),
+            request_id="req-stream-full",
+            task_id="task-stream-full",
+            attempt_id="attempt-stream-full",
+        )
+    )
+
+    assert tokens == ["ok"]
+    assert terminal.status is CompletionTerminalStatus.SUCCESS
+    # Complete provenance continues to be parsed and is not regressed.
+    assert terminal.runtime_provenance is not None
+    assert terminal.runtime_provenance["request_id"] == "whooshd-internal-7"
+    assert terminal.runtime_provenance["whooshd_request_id"] == "whooshd-stream-full"
+    # Independent response correlation is still captured alongside provenance.
+    assert terminal.response_correlation == {
+        "whooshd_request_id": "whooshd-stream-full",
+        "correlation_id": "req-stream-full",
+    }
+
+
+def test_stream_local_does_not_synthesize_correlation_without_headers(monkeypatch):
+    _prepare_local(monkeypatch)
+
+    def fake_post(url, json, headers, stream, timeout):
+        return _StreamingResponse(_SSE_OK)
+
+    monkeypatch.setattr(ai_router.requests, "post", fake_post)
+
+    tokens, terminal = _drain_stream(
+        stream_local(
+            [{"role": "user", "content": "hi"}],
+            "stub-model",
+            settings=_settings(),
+        )
+    )
+
+    assert tokens == ["ok"]
+    assert terminal.status is CompletionTerminalStatus.SUCCESS
+    assert terminal.runtime_provenance is None
+    # No headers means no correlation and no fabricated identifier.
+    assert terminal.response_correlation is None
+
+
+def test_stream_terminal_response_correlation_reaches_completion_attempt(monkeypatch):
+    terminal = CompletionTerminalEvidence(
+        status=CompletionTerminalStatus.SUCCESS,
+        visible_output_emitted=True,
+        explicit_provider_terminal_observed=True,
+        finish_reason="stop",
+        transport_ended_cleanly=True,
+        provider="local",
+        model="stub-model",
+        response_correlation={"whooshd_request_id": "whooshd-plumbing-1"},
+    )
+
+    def fake_stream(*_args, **_kwargs):
+        if False:  # pragma: no cover - keeps this a generator
+            yield ""
+        return terminal
+
+    monkeypatch.setattr(chat_completion_service, "stream_local", fake_stream)
+    task = ChatCompletionTask(
+        task_id="task-plumbing",
+        request_id="req-plumbing",
+        user_id="user-1",
+        thread_id=1,
+    )
+
+    attempt = chat_completion_service._execute_completion_attempt(
+        task=task,
+        messages_for_llm=[{"role": "user", "content": "hi"}],
+        provider="local",
+        model="stub-model",
+        bundle=None,
+    )
+
+    assert attempt.response_correlation == {"whooshd_request_id": "whooshd-plumbing-1"}
+
+
+class _RejectedStreamResponse:
+    """A non-streaming-shaped response used for rejected candidate attempts."""
+
+    def __init__(self, status_code: int, body: dict | None = None):
+        self.status_code = status_code
+        self.text = ""
+        self._body = body or {}
+        self.headers: dict[str, str] = {}
+        self.closed = False
+
+    def json(self):
+        return self._body
+
+    def iter_lines(self, decode_unicode=False):
+        _ = decode_unicode
+        return iter(())
+
+    def close(self):
+        self.closed = True
+
+
+class _RecordingCancelMonitor(ai_router._WhooshdCancellationMonitor):
+    """Records lifecycle calls so tests can prove rejected monitors are stopped."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.stop_calls = 0
+        self.set_response_calls = 0
+
+    def set_response(self, response):
+        self.set_response_calls += 1
+        return super().set_response(response)
+
+    def stop(self):
+        self.stop_calls += 1
+        return super().stop()
+
+    def thread_is_alive(self):
+        return self._thread.is_alive()
+
+
+def _install_recording_monitors(monkeypatch):
+    created: list[_RecordingCancelMonitor] = []
+
+    def factory(**kwargs):
+        monitor = _RecordingCancelMonitor(**kwargs)
+        created.append(monitor)
+        return monitor
+
+    monkeypatch.setattr(ai_router, "_WhooshdCancellationMonitor", factory)
+    return created
+
+
+def _whooshd_vendor_settings():
+    settings = _settings()
+    settings.LOCAL_PROVIDER_VENDOR = "whooshd"
+    return settings
+
+
+def _prepare_local_fallback(monkeypatch):
+    monkeypatch.setattr(
+        ai_router,
+        "resolve_local_execution_model",
+        lambda **_: LocalModelResolution(
+            model="stub-model",
+            source="test",
+            strict=False,
+        ),
+    )
+    # Non-/v1 base so /api/chat and /v1/chat/completions are both candidates.
+    monkeypatch.setattr(
+        ai_router,
+        "_resolve_local_base_candidates",
+        lambda _settings: ["http://whooshd.test"],
+    )
+
+
+def test_rejected_candidate_stops_cancellation_monitor_before_fallback(monkeypatch):
+    _prepare_local_fallback(monkeypatch)
+    created = _install_recording_monitors(monkeypatch)
+    accepted: dict[str, object] = {}
+
+    def fake_post(url, **kwargs):
+        if "/api/chat" in url:
+            return _RejectedStreamResponse(404)
+        accepted["url"] = url
+        return _StreamingResponse(
+            _SSE_OK,
+            headers={"X-Whooshd-Request-ID": "whooshd-accepted-1"},
+        )
+
+    monkeypatch.setattr(ai_router.requests, "post", fake_post)
+
+    tokens, terminal = _drain_stream(
+        stream_local(
+            [{"role": "user", "content": "hi"}],
+            "stub-model",
+            settings=_whooshd_vendor_settings(),
+            request_id="req-fallback-1",
+            task_id="task-fallback-1",
+            attempt_id="attempt-fallback-1",
+            cancel_check=lambda: False,
+        )
+    )
+
+    assert tokens == ["ok"]
+    assert terminal.status is CompletionTerminalStatus.SUCCESS
+    assert accepted["url"].endswith("/v1/chat/completions")
+    # Two candidate monitors were created (one per candidate URL).
+    assert len(created) == 2
+    # Only the accepted response's monitor is promoted via set_response.
+    assert sum(m.set_response_calls for m in created) == 1
+    assert created[1].set_response_calls == 1
+    assert created[0].set_response_calls == 0
+    # Every candidate monitor (rejected + accepted) is stopped, leaving no
+    # daemon polling thread behind after the fallback succeeds.
+    assert all(m.stop_calls >= 1 for m in created)
+    assert all(not m.thread_is_alive() for m in created)
+    # Accepted stream still carries live Whoosh'd correlation.
+    assert terminal.response_correlation == {"whooshd_request_id": "whooshd-accepted-1"}
+
+
+def test_candidate_monitor_stopped_on_transport_exception_before_acceptance(monkeypatch):
+    _prepare_local_fallback(monkeypatch)
+    created = _install_recording_monitors(monkeypatch)
+    accepted: dict[str, object] = {}
+
+    def fake_post(url, **kwargs):
+        if "/api/chat" in url:
+            raise ai_router.req_exc.ConnectionError("boom")
+        accepted["url"] = url
+        return _StreamingResponse(_SSE_OK)
+
+    monkeypatch.setattr(ai_router.requests, "post", fake_post)
+
+    tokens, terminal = _drain_stream(
+        stream_local(
+            [{"role": "user", "content": "hi"}],
+            "stub-model",
+            settings=_whooshd_vendor_settings(),
+            cancel_check=lambda: False,
+        )
+    )
+
+    assert tokens == ["ok"]
+    assert terminal.status is CompletionTerminalStatus.SUCCESS
+    assert accepted["url"].endswith("/v1/chat/completions")
+    assert len(created) == 2
+    # The rejected (exception) candidate never reaches acceptance, and only the
+    # accepted candidate's monitor is promoted.
+    assert created[0].set_response_calls == 0
+    assert created[1].set_response_calls == 1
+    assert all(m.stop_calls >= 1 for m in created)
+    assert all(not m.thread_is_alive() for m in created)
+
+
+def test_candidate_monitor_stopped_on_retryable_status_before_acceptance(monkeypatch):
+    _prepare_local_fallback(monkeypatch)
+    created = _install_recording_monitors(monkeypatch)
+
+    def fake_post(url, **kwargs):
+        if "/api/chat" in url:
+            # Non-2xx, non-404, non-whooshd-error: exercises the generic
+            # retryable-status rejection path.
+            return _RejectedStreamResponse(503, body={"error": "unavailable"})
+        return _StreamingResponse(_SSE_OK)
+
+    monkeypatch.setattr(ai_router.requests, "post", fake_post)
+
+    tokens, terminal = _drain_stream(
+        stream_local(
+            [{"role": "user", "content": "hi"}],
+            "stub-model",
+            settings=_whooshd_vendor_settings(),
+            cancel_check=lambda: False,
+        )
+    )
+
+    assert tokens == ["ok"]
+    assert terminal.status is CompletionTerminalStatus.SUCCESS
+    assert len(created) == 2
+    assert created[0].set_response_calls == 0
+    assert created[1].set_response_calls == 1
+    assert all(m.stop_calls >= 1 for m in created)
+    assert all(not m.thread_is_alive() for m in created)
+
+
+def test_all_rejected_candidates_stop_their_cancellation_monitors(monkeypatch):
+    _prepare_local_fallback(monkeypatch)
+    created = _install_recording_monitors(monkeypatch)
+
+    def fake_post(url, **kwargs):
+        return _RejectedStreamResponse(404)
+
+    monkeypatch.setattr(ai_router.requests, "post", fake_post)
+
+    with pytest.raises(HTTPException):
+        list(
+            stream_local(
+                [{"role": "user", "content": "hi"}],
+                "stub-model",
+                settings=_whooshd_vendor_settings(),
+                cancel_check=lambda: False,
+            )
+        )
+
+    # Every candidate was rejected, so every candidate monitor is stopped and
+    # none is promoted as the active cancellation monitor.
+    assert len(created) >= 1
+    assert all(m.set_response_calls == 0 for m in created)
+    assert all(m.stop_calls >= 1 for m in created)
+    assert all(not m.thread_is_alive() for m in created)


### PR DESCRIPTION
## Summary

Carries the two corrective changes identified during review of #616. The original PR merged before this follow-up commit reached `main`, so this PR contains the isolated repair commit.

## Changes

### Preserve header-only streaming correlation

- Add bounded `response_correlation` terminal evidence with serialization and rehydration validation.
- Capture Whooshd response correlation independently of runtime provenance in `stream_local`.
- Propagate terminal response correlation through `CompletionAttemptResult` so persisted and task-event request correlation retain `X-Whooshd-Request-ID`.
- Keep absent correlation normalized to `None`; no identifiers are synthesized.

### Stop rejected-attempt cancellation monitors

- Promote a candidate monitor only after its response is accepted.
- Stop the candidate monitor and close the response for rejected endpoints, retryable/non-2xx responses, contract-version failures, and transport exceptions.
- Preserve live cancellation behavior for the accepted stream.

## Files changed

- `guardian/core/ai_router.py`
- `guardian/core/chat_completion_service.py`
- `guardian/core/completion_terminal.py`
- `guardian/providers/whooshd_control_plane.py`
- `guardian/tests/core/test_request_correlation.py`

## Validation

- AST parsing and module imports passed.
- Ruff introduced no new errors in edited regions.
- Targeted test suites: **75 passed**.
- `mypy` was unavailable in the validation environment.
- Remaining streaming/profile failures reproduce against the original code and are tied to the existing `LOCAL_BASE_URL` test environment requirement.

## Acceptance

- [x] Header-only streamed Whooshd IDs survive terminal evidence.
- [x] Persisted and task-event correlation retain the Whooshd request ID.
- [x] Full runtime provenance remains supported.
- [x] Missing headers remain valid without synthesized IDs.
- [x] Rejected candidate monitors are stopped.
- [x] Only accepted response monitors are promoted.
- [x] Accepted streams retain live cancellation behavior.
- [x] Regression coverage added.

## ADR impact

None. The evidence field is additive and defaulted; the monitor change corrects lifecycle cleanup without changing an accepted contract.

Closes the two unresolved review findings from #616.