### PR TITLE
Revert live-proof receipt manifest integration

### DIFF
--- a/docs/architecture/00-current-state.md
+++ b/docs/architecture/00-current-state.md
@@ -16,7 +16,6 @@ This file is authoritative for:
 Codexify is in local-first beta hardening on `main`. The supported path remains the local Docker Compose stack with local-only provider posture. Recent `main` changes are mostly release cleanup, health/probing fixes, UI polish, and release-truth documentation, plus email implementation-target inspection work that does not widen runtime support.
 
 ## What changed recently
-- Integrated live-proof receipts into canonical evidence manifest generation; qualifying `PASS` receipts now support deterministic `CURRENT_LIVE_PROOF` manifests with receipt identity preserved as hashed evidence and explicit lineage. The generated manifest remains unpromoted; durable storage, cross-record freshness, and trusted `latest` remain deferred.
 - Added an email implementation-target inspection and campaign index on `main`; this is planning and target mapping only.
 - Removed the legacy document generation UI from the frontend.
 - Fixed mobile composer viewport settling.

--- a/docs/architecture/canonical-audit-evidence-contract.md
+++ b/docs/architecture/canonical-audit-evidence-contract.md
@@ -227,36 +227,25 @@ schema-validated, secret-safe execution receipt with distinct `PASS`, `FAIL`,
 `BLOCKED`, and `ERROR` outcomes. The subordinate [Canonical Live Proof Receipt
 Contract](./canonical-live-proof-receipt-contract.md) governs this seam. The
 receipt is not accepted canonical evidence, proof storage, promotion approval,
-trusted `latest`, or release approval.
-
-The manifest producer now accepts an optional `live_proof_receipt_path` for
-`CURRENT_LIVE_PROOF` proof class. A qualifying canonical `PASS` receipt supports
-deterministic `CURRENT_LIVE_PROOF` manifest generation. The receipt is loaded,
-validated against its schema, and verified for correct `receipt_id`, schema
-version, proof class, and `PASS` outcome. Machine, repository, runtime, and
-target identity are compared against freshly collected observations. Receipt
-authority must agree with derived manifest authority. A `PASS` receipt cannot
-upgrade provisional authority to canonical. The receipt's exact bytes are
-represented as a hashed manifest artifact with `application/json` media type
-and `canonical_live_proof_receipt` role. Receipt lineage is explicit in
-`relationships.derived_from`. The generated manifest remains unpromoted
-evidence: durable storage, cross-record freshness, supersession, contradiction
-resolution, promotion receipts, trusted `latest`, consumer migration, and
-release approval remain deferred.
+trusted `latest`, or release approval, and the current manifest producer does
+not consume it.
 
 ## Deferred implementation work
 
-Artifact collection beyond the live receipt, freshness evaluation, evidence
-storage, cross-record resolution, supersession validation, contradiction
-resolution, pointer storage, promotion receipts, trusted pointers, consumer
-migration, and live VaultNode proof remain separately scoped work.
-`CURRENT_LIVE_PROOF` now requires a valid `PASS` receipt; other supported proof
-classes continue to carry nullable runtime fields when static runtime identity
-is not requested and use the existing explicit execution metadata path.
-A receipt is not manifest acceptance.
+Manifest integration and acceptance of the bounded live receipt, artifact
+collection beyond that receipt, complete canonical manifest production beyond
+the current validated assembly, freshness evaluation, evidence storage,
+cross-record resolution, supersession validation, contradiction resolution,
+pointer storage, promotion receipts, trusted pointers, consumer migration, and
+live VaultNode proof remain separately scoped work. `CURRENT_LIVE_PROOF` is
+still rejected by the manifest producer; other supported proof classes may
+carry nullable runtime fields when static runtime identity is not requested. A
+requested static runtime identity must be complete, but it is still not live
+proof without a separately produced receipt, and a receipt is not manifest
+acceptance.
 
 ## Non-goals
 
 This contract does not implement producer or consumer migration, a registry,
-pointer, schedule, autonomous audit execution, release approval, or feature
-expansion.
+pointer, schedule, autonomous audit execution, manifest integration of the
+bounded receipt, release approval, or feature expansion.

--- a/docs/architecture/canonical-live-proof-receipt-contract.md
+++ b/docs/architecture/canonical-live-proof-receipt-contract.md
@@ -154,17 +154,17 @@ does not write a registry, manifest, promotion receipt, or trusted pointer.
 
 ## Relationship to canonical evidence
 
-The receipt preserves provenance as an intermediate proof artifact. The
-manifest producer now accepts a qualifying `PASS` receipt via
-`live_proof_receipt_path` for `CURRENT_LIVE_PROOF` manifest generation.
-Receipt bytes and identity are preserved as hashed manifest evidence with
-explicit lineage. Receipt `PASS` is necessary but not sufficient for canonical
-authority; a `PASS` receipt cannot upgrade provisional authority. The
-generated manifest remains unpromoted evidence.
+The receipt preserves provenance for a later manifest-integration task. The
+current canonical evidence manifest producer still rejects
+`CURRENT_LIVE_PROOF`; the current canonical evidence schema, producer, and
+validator are unchanged by this seam. A future task must explicitly define how
+a qualifying receipt is attached to a manifest without weakening ADR-041 or
+ADR-042.
 
-Still deferred are durable evidence storage, freshness evaluation,
-cross-record resolution, supersession and contradiction resolution, promotion
-receipts, trusted `latest`, consumer migration, and release approval.
+Still deferred are manifest acceptance of `CURRENT_LIVE_PROOF`, durable evidence
+storage, freshness evaluation, cross-record resolution, supersession and
+contradiction resolution, promotion receipts, trusted pointers, consumer
+migration, and release approval.
 
 ## Non-goals
 

--- a/scripts/audit/collect_canonical_live_proof_receipt.py
+++ b/scripts/audit/collect_canonical_live_proof_receipt.py
@@ -995,16 +995,6 @@ def validate_receipt(
     }
 
 
-def receipt_projection(receipt: Mapping[str, Any]) -> dict[str, Any]:
-    """Public canonical receipt identity projection (excludes receipt_id)."""
-    return _receipt_projection(receipt)
-
-
-def receipt_id(receipt: Mapping[str, Any]) -> str:
-    """Public deterministic receipt identity from the canonical projection."""
-    return _receipt_id(receipt)
-
-
 def _output_destination(root: Path, output_path: str) -> Path:
     raw = str(output_path or "").strip().replace("\\", "/")
     if not raw or Path(raw).is_absolute() or PureWindowsPath(raw).is_absolute():

--- a/scripts/audit/generate_canonical_evidence_manifest.py
+++ b/scripts/audit/generate_canonical_evidence_manifest.py
@@ -27,10 +27,6 @@ from scripts.audit.collect_canonical_evidence_identity import (  # noqa: E402
     CollectorError,
     collect_identity,
 )
-from scripts.audit.collect_canonical_live_proof_receipt import (  # noqa: E402
-    receipt_id as compute_receipt_id,
-)
-from scripts.audit.collect_canonical_live_proof_receipt import validate_receipt
 from scripts.audit.collect_canonical_runtime_identity import (  # noqa: E402
     RuntimeIdentityError,
     collect_runtime_identity,
@@ -39,6 +35,7 @@ from scripts.audit.validate_canonical_evidence import (  # noqa: E402
     DEFAULT_SCHEMA_PATH,
     validate_manifest,
 )
+
 
 RESULT_SCHEMA_VERSION = "canonical_audit_evidence_manifest_result.v1"
 PRODUCER_VERSION = "canonical_audit_evidence_manifest_producer.v1"
@@ -58,29 +55,7 @@ VALID_DISPOSITIONS = {"ACCEPTED", "SUPERSEDED", "CONTRADICTED", "REJECTED"}
 VALID_OUTCOMES = {"PASS", "FAIL", "BLOCKED", "ERROR", "NOT_APPLICABLE"}
 CLAIM_BUCKETS = ("supported", "disproved", "unresolved")
 RELATIONSHIP_BUCKETS = ("supersedes", "contradicts", "derived_from")
-LIVE_PROOF_REASON_CODES = frozenset(
-    {
-        "live_proof_receipt_required",
-        "live_proof_receipt_not_found",
-        "live_proof_receipt_schema_invalid",
-        "live_proof_receipt_id_invalid",
-        "live_proof_receipt_hash_mismatch",
-        "live_proof_receipt_not_pass",
-        "live_proof_machine_identity_mismatch",
-        "live_proof_repository_identity_mismatch",
-        "live_proof_commit_mismatch",
-        "live_proof_runtime_identity_mismatch",
-        "live_proof_effective_config_mismatch",
-        "live_proof_compose_project_mismatch",
-        "live_proof_role_mismatch",
-        "live_proof_profile_mismatch",
-        "live_proof_authority_ineligible",
-        "live_proof_relationship_invalid",
-    }
-)
-SECRET_KEY_RE = re.compile(
-    r"(?i)(password|secret|token|api[_-]?key|private[_-]?key|credential)"
-)
+SECRET_KEY_RE = re.compile(r"(?i)(password|secret|token|api[_-]?key|private[_-]?key|credential)")
 SECRET_VALUE_RE = re.compile(
     r"(?i)([a-z][a-z0-9+.-]*://[^\s/@]+:[^\s/@]+@|"
     r"(?:postgres(?:ql)?|mysql|mariadb|redis|rediss|mongodb(?:\+srv)?|sqlite|mssql|oracle|amqp|nats)://|"
@@ -99,14 +74,8 @@ class ProducerError(Exception):
 
 def _safe_text(value: Any) -> str:
     text = " ".join(str(value).split())
-    text = re.sub(
-        r"(?i)(https?://)([^/@\s]+):[^/@\s]+@", r"\1[redacted]@", text
-    )
-    text = re.sub(
-        r"(?i)(token|password|secret|api[_-]?key)\s*[=:]\s*\S+",
-        r"\1=[redacted]",
-        text,
-    )
+    text = re.sub(r"(?i)(https?://)([^/@\s]+):[^/@\s]+@", r"\1[redacted]@", text)
+    text = re.sub(r"(?i)(token|password|secret|api[_-]?key)\s*[=:]\s*\S+", r"\1=[redacted]", text)
     return text[:240]
 
 
@@ -124,19 +93,13 @@ def _error_envelope(code: str, message: str) -> dict[str, Any]:
 
 def _normalize_datetime(value: Any, field: str) -> str:
     if not isinstance(value, str) or not value.strip():
-        raise ProducerError(
-            f"{field}_invalid", f"{field} must be an explicit date-time."
-        )
+        raise ProducerError(f"{field}_invalid", f"{field} must be an explicit date-time.")
     try:
         parsed = dt.datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
     except ValueError as exc:
-        raise ProducerError(
-            f"{field}_invalid", f"{field} is not a valid date-time."
-        ) from exc
+        raise ProducerError(f"{field}_invalid", f"{field} is not a valid date-time.") from exc
     if parsed.tzinfo is None:
-        raise ProducerError(
-            f"{field}_invalid", f"{field} must include a timezone."
-        )
+        raise ProducerError(f"{field}_invalid", f"{field} must include a timezone.")
     parsed = parsed.astimezone(dt.timezone.utc)
     if parsed.microsecond:
         return parsed.isoformat(timespec="microseconds").replace("+00:00", "Z")
@@ -147,18 +110,13 @@ def _check_secret_values(value: Any) -> None:
     if isinstance(value, Mapping):
         for key, item in value.items():
             if SECRET_KEY_RE.search(str(key)):
-                raise ProducerError(
-                    "forbidden_secret_input",
-                    "Secret-bearing metadata is not accepted.",
-                )
+                raise ProducerError("forbidden_secret_input", "Secret-bearing metadata is not accepted.")
             _check_secret_values(item)
     elif isinstance(value, (list, tuple)):
         for item in value:
             _check_secret_values(item)
     elif isinstance(value, str) and SECRET_VALUE_RE.search(value):
-        raise ProducerError(
-            "forbidden_secret_input", "Secret-bearing metadata is not accepted."
-        )
+        raise ProducerError("forbidden_secret_input", "Secret-bearing metadata is not accepted.")
 
 
 def _require_mapping(value: Any, code: str, label: str) -> Mapping[str, Any]:
@@ -173,234 +131,113 @@ def _normalize_execution(
 ) -> tuple[str, dict[str, Any]]:
     execution = dict(_require_mapping(value, "execution_invalid", "execution"))
     declared_outcome = execution.pop("outcome", None)
-    if (
-        declared_outcome is not None
-        and execution_outcome is not None
-        and declared_outcome != execution_outcome
-    ):
-        raise ProducerError(
-            "execution_outcome_inconsistent",
-            "Execution outcome inputs disagree.",
-        )
-    outcome = (
-        declared_outcome if declared_outcome is not None else execution_outcome
-    )
+    if declared_outcome is not None and execution_outcome is not None and declared_outcome != execution_outcome:
+        raise ProducerError("execution_outcome_inconsistent", "Execution outcome inputs disagree.")
+    outcome = declared_outcome if declared_outcome is not None else execution_outcome
     if outcome not in VALID_OUTCOMES:
-        raise ProducerError(
-            "execution_invalid", "execution outcome is not accepted vocabulary."
-        )
-    required = (
-        "suite_id",
-        "commands",
-        "started_at",
-        "completed_at",
-        "exit_code",
-        "summary",
-    )
+        raise ProducerError("execution_invalid", "execution outcome is not accepted vocabulary.")
+    required = ("suite_id", "commands", "started_at", "completed_at", "exit_code", "summary")
     if set(execution) != set(required):
-        raise ProducerError(
-            "execution_invalid",
-            "execution fields are incomplete or unsupported.",
-        )
-    if (
-        not isinstance(execution["suite_id"], str)
-        or not execution["suite_id"].strip()
-    ):
+        raise ProducerError("execution_invalid", "execution fields are incomplete or unsupported.")
+    if not isinstance(execution["suite_id"], str) or not execution["suite_id"].strip():
         raise ProducerError("execution_invalid", "suite_id must be non-empty.")
     commands = execution["commands"]
-    if (
-        not isinstance(commands, list)
-        or not commands
-        or any(
-            not isinstance(command, str) or not command.strip()
-            for command in commands
-        )
+    if not isinstance(commands, list) or not commands or any(
+        not isinstance(command, str) or not command.strip() for command in commands
     ):
-        raise ProducerError(
-            "execution_invalid",
-            "commands must be a non-empty ordered list of strings.",
-        )
-    if (
-        not isinstance(execution["summary"], str)
-        or not execution["summary"].strip()
-    ):
+        raise ProducerError("execution_invalid", "commands must be a non-empty ordered list of strings.")
+    if not isinstance(execution["summary"], str) or not execution["summary"].strip():
         raise ProducerError("execution_invalid", "summary must be non-empty.")
     normalized = {
         "suite_id": execution["suite_id"].strip(),
         "commands": [command.strip() for command in commands],
-        "started_at": _normalize_datetime(
-            execution["started_at"], "execution_started_at"
-        ),
-        "completed_at": _normalize_datetime(
-            execution["completed_at"], "execution_completed_at"
-        ),
+        "started_at": _normalize_datetime(execution["started_at"], "execution_started_at"),
+        "completed_at": _normalize_datetime(execution["completed_at"], "execution_completed_at"),
         "exit_code": execution["exit_code"],
         "summary": execution["summary"].strip(),
     }
-    started = dt.datetime.fromisoformat(
-        normalized["started_at"].replace("Z", "+00:00")
-    )
-    completed = dt.datetime.fromisoformat(
-        normalized["completed_at"].replace("Z", "+00:00")
-    )
+    started = dt.datetime.fromisoformat(normalized["started_at"].replace("Z", "+00:00"))
+    completed = dt.datetime.fromisoformat(normalized["completed_at"].replace("Z", "+00:00"))
     if completed < started:
-        raise ProducerError(
-            "execution_invalid", "completed_at must not precede started_at."
-        )
+        raise ProducerError("execution_invalid", "completed_at must not precede started_at.")
     exit_code = normalized["exit_code"]
-    if exit_code is not None and (
-        isinstance(exit_code, bool)
-        or not isinstance(exit_code, int)
-        or exit_code < 0
-    ):
-        raise ProducerError(
-            "execution_invalid",
-            "exit_code must be null or a non-negative integer.",
-        )
+    if exit_code is not None and (isinstance(exit_code, bool) or not isinstance(exit_code, int) or exit_code < 0):
+        raise ProducerError("execution_invalid", "exit_code must be null or a non-negative integer.")
     if outcome == "PASS" and exit_code != 0:
-        raise ProducerError(
-            "execution_outcome_inconsistent", "PASS requires exit_code 0."
-        )
+        raise ProducerError("execution_outcome_inconsistent", "PASS requires exit_code 0.")
     if outcome in {"FAIL", "ERROR"} and (exit_code is None or exit_code == 0):
-        raise ProducerError(
-            "execution_outcome_inconsistent",
-            f"{outcome} requires a non-zero exit_code.",
-        )
+        raise ProducerError("execution_outcome_inconsistent", f"{outcome} requires a non-zero exit_code.")
     if outcome in {"BLOCKED", "NOT_APPLICABLE"} and exit_code is not None:
-        raise ProducerError(
-            "execution_outcome_inconsistent",
-            f"{outcome} cannot claim executed exit_code.",
-        )
+        raise ProducerError("execution_outcome_inconsistent", f"{outcome} cannot claim executed exit_code.")
     return outcome, normalized
 
 
-def _safe_relative_path(
-    raw: Any, root: Path, *, code_prefix: str, allow_absolute: bool = False
-) -> tuple[str, Path]:
+def _safe_relative_path(raw: Any, root: Path, *, code_prefix: str, allow_absolute: bool = False) -> tuple[str, Path]:
     if not isinstance(raw, str) or not raw.strip():
-        raise ProducerError(
-            f"{code_prefix}_invalid",
-            "Path must be a non-empty repository-relative string.",
-        )
+        raise ProducerError(f"{code_prefix}_invalid", "Path must be a non-empty repository-relative string.")
     value = raw.strip().replace("\\", "/")
-    is_absolute = (
-        Path(value).is_absolute() or PureWindowsPath(value).is_absolute()
-    )
+    is_absolute = Path(value).is_absolute() or PureWindowsPath(value).is_absolute()
     if is_absolute and not allow_absolute:
-        raise ProducerError(
-            f"{code_prefix}_absolute", "Absolute paths are not accepted."
-        )
+        raise ProducerError(f"{code_prefix}_absolute", "Absolute paths are not accepted.")
     if is_absolute:
         candidate = Path(value).expanduser().resolve()
         try:
             relative = candidate.relative_to(root.resolve()).as_posix()
         except ValueError as exc:
-            raise ProducerError(
-                f"{code_prefix}_outside_repository",
-                "Path resolves outside the repository.",
-            ) from exc
+            raise ProducerError(f"{code_prefix}_outside_repository", "Path resolves outside the repository.") from exc
         return relative, candidate
     parts = PurePosixPath(value).parts
     if ".." in parts:
-        raise ProducerError(
-            f"{code_prefix}_parent_traversal",
-            "Parent traversal is not accepted.",
-        )
+        raise ProducerError(f"{code_prefix}_parent_traversal", "Parent traversal is not accepted.")
     relative = PurePosixPath(value).as_posix()
     candidate = (root / Path(*PurePosixPath(relative).parts)).resolve()
     try:
         candidate.relative_to(root.resolve())
     except ValueError as exc:
-        raise ProducerError(
-            f"{code_prefix}_outside_repository",
-            "Path resolves outside the repository.",
-        ) from exc
+        raise ProducerError(f"{code_prefix}_outside_repository", "Path resolves outside the repository.") from exc
     return relative, candidate
 
 
 def _load_metadata(path_value: str, root: Path) -> dict[str, Any]:
-    _, path = _safe_relative_path(
-        path_value, root, code_prefix="input_path", allow_absolute=True
-    )
+    _, path = _safe_relative_path(path_value, root, code_prefix="input_path", allow_absolute=True)
     try:
         raw = path.read_text(encoding="utf-8")
         parsed = json.loads(raw)
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise ProducerError(
-            "input_read_failed",
-            "Structured producer input could not be read as UTF-8 JSON.",
-        ) from exc
+        raise ProducerError("input_read_failed", "Structured producer input could not be read as UTF-8 JSON.") from exc
     if not isinstance(parsed, dict):
-        raise ProducerError(
-            "input_invalid", "Structured producer input must be a JSON object."
-        )
+        raise ProducerError("input_invalid", "Structured producer input must be a JSON object.")
     _check_secret_values(parsed)
     return parsed
 
 
-def _normalize_claims(
-    value: Any, artifact_ids: set[str], suite_id: str
-) -> dict[str, list[dict[str, Any]]]:
-    source = (
-        {bucket: [] for bucket in CLAIM_BUCKETS}
-        if value is None
-        else dict(_require_mapping(value, "claim_invalid", "claims"))
-    )
+def _normalize_claims(value: Any, artifact_ids: set[str], suite_id: str) -> dict[str, list[dict[str, Any]]]:
+    source = {bucket: [] for bucket in CLAIM_BUCKETS} if value is None else dict(_require_mapping(value, "claim_invalid", "claims"))
     if set(source) != set(CLAIM_BUCKETS):
-        raise ProducerError(
-            "claim_invalid",
-            "claims must contain exactly the supported claim buckets.",
-        )
+        raise ProducerError("claim_invalid", "claims must contain exactly the supported claim buckets.")
     seen: set[str] = set()
     result: dict[str, list[dict[str, Any]]] = {}
     for bucket in CLAIM_BUCKETS:
         entries = source[bucket]
         if not isinstance(entries, list):
-            raise ProducerError(
-                "claim_invalid", "claim buckets must be arrays."
-            )
+            raise ProducerError("claim_invalid", "claim buckets must be arrays.")
         normalized: list[dict[str, Any]] = []
         for entry in entries:
             item = dict(_require_mapping(entry, "claim_invalid", "claim"))
-            required = {
-                "claim_id",
-                "statement",
-                "scope",
-                "evidence_refs",
-                "reason",
-            }
-            if set(item) != required or any(
-                not isinstance(item[field], str) or not item[field].strip()
-                for field in required - {"evidence_refs"}
-            ):
-                raise ProducerError(
-                    "claim_invalid", "claim fields are incomplete or invalid."
-                )
+            required = {"claim_id", "statement", "scope", "evidence_refs", "reason"}
+            if set(item) != required or any(not isinstance(item[field], str) or not item[field].strip() for field in required - {"evidence_refs"}):
+                raise ProducerError("claim_invalid", "claim fields are incomplete or invalid.")
             claim_id = item["claim_id"].strip()
             if claim_id in seen:
-                raise ProducerError(
-                    "claim_id_duplicate", "claim_id values must be unique."
-                )
+                raise ProducerError("claim_id_duplicate", "claim_id values must be unique.")
             seen.add(claim_id)
             refs = item["evidence_refs"]
-            if (
-                not isinstance(refs, list)
-                or not refs
-                or any(
-                    not isinstance(ref, str) or not ref.strip() for ref in refs
-                )
-            ):
-                raise ProducerError(
-                    "claim_invalid",
-                    "claim evidence_refs must be non-empty strings.",
-                )
+            if not isinstance(refs, list) or not refs or any(not isinstance(ref, str) or not ref.strip() for ref in refs):
+                raise ProducerError("claim_invalid", "claim evidence_refs must be non-empty strings.")
             normalized_refs = sorted({ref.strip() for ref in refs})
             for ref in normalized_refs:
                 if ref not in artifact_ids and ref != f"execution:{suite_id}":
-                    raise ProducerError(
-                        "claim_evidence_reference_unresolved",
-                        "claim evidence_refs must resolve to an artifact or execution suite.",
-                    )
+                    raise ProducerError("claim_evidence_reference_unresolved", "claim evidence_refs must resolve to an artifact or execution suite.")
             normalized.append(
                 {
                     "claim_id": claim_id,
@@ -410,134 +247,72 @@ def _normalize_claims(
                     "reason": item["reason"].strip(),
                 }
             )
-        result[bucket] = sorted(
-            normalized,
-            key=lambda item: (
-                item["claim_id"],
-                json.dumps(item, sort_keys=True, separators=(",", ":")),
-            ),
-        )
+        result[bucket] = sorted(normalized, key=lambda item: (item["claim_id"], json.dumps(item, sort_keys=True, separators=(",", ":"))))
     return result
 
 
 def _normalize_relationships(value: Any) -> dict[str, list[str]]:
-    source = (
-        {bucket: [] for bucket in RELATIONSHIP_BUCKETS}
-        if value is None
-        else dict(
-            _require_mapping(value, "relationship_invalid", "relationships")
-        )
-    )
+    source = {bucket: [] for bucket in RELATIONSHIP_BUCKETS} if value is None else dict(_require_mapping(value, "relationship_invalid", "relationships"))
     if set(source) != set(RELATIONSHIP_BUCKETS):
-        raise ProducerError(
-            "relationship_invalid",
-            "relationships must contain exactly the supported buckets.",
-        )
+        raise ProducerError("relationship_invalid", "relationships must contain exactly the supported buckets.")
     seen: dict[str, str] = {}
     result: dict[str, list[str]] = {}
     for bucket in RELATIONSHIP_BUCKETS:
         entries = source[bucket]
         if not isinstance(entries, list):
-            raise ProducerError(
-                "relationship_invalid", "relationship buckets must be arrays."
-            )
+            raise ProducerError("relationship_invalid", "relationship buckets must be arrays.")
         normalized: list[str] = []
         for entry in entries:
             if not isinstance(entry, str) or not entry.strip():
-                raise ProducerError(
-                    "relationship_invalid",
-                    "relationship references must be non-empty strings.",
-                )
+                raise ProducerError("relationship_invalid", "relationship references must be non-empty strings.")
             reference = entry.strip()
             if reference in seen:
                 if seen[reference] == bucket:
-                    raise ProducerError(
-                        "relationship_duplicate",
-                        "relationship references must be unique within a bucket.",
-                    )
-                raise ProducerError(
-                    "relationship_bucket_conflict",
-                    "A relationship reference cannot occupy incompatible buckets.",
-                )
+                    raise ProducerError("relationship_duplicate", "relationship references must be unique within a bucket.")
+                raise ProducerError("relationship_bucket_conflict", "A relationship reference cannot occupy incompatible buckets.")
             seen[reference] = bucket
             normalized.append(reference)
         result[bucket] = sorted(normalized)
     return result
 
 
-def _normalize_artifacts(
-    value: Any, root: Path
-) -> tuple[list[dict[str, Any]], set[str]]:
+def _normalize_artifacts(value: Any, root: Path) -> tuple[list[dict[str, Any]], set[str]]:
     if value is None:
         return [], set()
     if not isinstance(value, list):
-        raise ProducerError(
-            "artifact_descriptor_invalid", "artifacts must be an array."
-        )
+        raise ProducerError("artifact_descriptor_invalid", "artifacts must be an array.")
     records: list[dict[str, Any]] = []
     artifact_ids: set[str] = set()
     artifact_paths: set[str] = set()
     for descriptor in value:
-        item = dict(
-            _require_mapping(
-                descriptor, "artifact_descriptor_invalid", "artifact descriptor"
-            )
-        )
+        item = dict(_require_mapping(descriptor, "artifact_descriptor_invalid", "artifact descriptor"))
         required = {"artifact_id", "path", "media_type", "artifact_role"}
         if set(item) != required:
-            raise ProducerError(
-                "artifact_descriptor_invalid",
-                "artifact descriptors must contain id, path, media type, and role only.",
-            )
-        if any(
-            not isinstance(item[field], str) or not item[field].strip()
-            for field in required
-        ):
-            raise ProducerError(
-                "artifact_descriptor_invalid",
-                "artifact descriptor fields must be non-empty strings.",
-            )
+            raise ProducerError("artifact_descriptor_invalid", "artifact descriptors must contain id, path, media type, and role only.")
+        if any(not isinstance(item[field], str) or not item[field].strip() for field in required):
+            raise ProducerError("artifact_descriptor_invalid", "artifact descriptor fields must be non-empty strings.")
         artifact_id = item["artifact_id"].strip()
         if artifact_id in artifact_ids:
-            raise ProducerError(
-                "artifact_id_duplicate", "artifact_id values must be unique."
-            )
+            raise ProducerError("artifact_id_duplicate", "artifact_id values must be unique.")
         raw_path = item["path"].strip().replace("\\", "/")
-        if (
-            not Path(raw_path).is_absolute()
-            and not PureWindowsPath(raw_path).is_absolute()
-            and ".." not in PurePosixPath(raw_path).parts
-        ):
+        if not Path(raw_path).is_absolute() and not PureWindowsPath(raw_path).is_absolute() and ".." not in PurePosixPath(raw_path).parts:
             lexical_path = root / Path(*PurePosixPath(raw_path).parts)
             if lexical_path.is_symlink():
-                raise ProducerError(
-                    "artifact_symlink_escape",
-                    "Symlink artifacts are not accepted.",
-                )
-        relative, path = _safe_relative_path(
-            item["path"], root, code_prefix="artifact_path"
-        )
+                raise ProducerError("artifact_symlink_escape", "Symlink artifacts are not accepted.")
+        relative, path = _safe_relative_path(item["path"], root, code_prefix="artifact_path")
         if relative in artifact_paths:
-            raise ProducerError(
-                "artifact_path_duplicate", "artifact paths must be unique."
-            )
+            raise ProducerError("artifact_path_duplicate", "artifact paths must be unique.")
         if not path.exists():
-            raise ProducerError(
-                "artifact_missing", "Declared artifact is missing."
-            )
+            raise ProducerError("artifact_missing", "Declared artifact is missing.")
         if not path.is_file():
-            raise ProducerError(
-                "artifact_not_file", "Declared artifact is not a regular file."
-            )
+            raise ProducerError("artifact_not_file", "Declared artifact is not a regular file.")
         digest = hashlib.sha256()
         try:
             with path.open("rb") as handle:
                 for chunk in iter(lambda: handle.read(1024 * 1024), b""):
                     digest.update(chunk)
         except OSError as exc:
-            raise ProducerError(
-                "artifact_read_failed", "Declared artifact could not be read."
-            ) from exc
+            raise ProducerError("artifact_read_failed", "Declared artifact could not be read.") from exc
         artifact_ids.add(artifact_id)
         artifact_paths.add(relative)
         records.append(
@@ -549,10 +324,7 @@ def _normalize_artifacts(
                 "artifact_role": item["artifact_role"].strip(),
             }
         )
-    return (
-        sorted(records, key=lambda item: (item["artifact_id"], item["path"])),
-        artifact_ids,
-    )
+    return sorted(records, key=lambda item: (item["artifact_id"], item["path"])), artifact_ids
 
 
 def _runtime_manifest(runtime: Mapping[str, Any] | None) -> dict[str, Any]:
@@ -590,14 +362,7 @@ def _evidence_projection(manifest: Mapping[str, Any]) -> dict[str, Any]:
         "machine": manifest["machine"],
         "repository": {
             field: manifest["repository"][field]
-            for field in (
-                "repository_root_identity",
-                "branch",
-                "commit_sha",
-                "upstream_sha",
-                "dirty",
-                "worktree_identity",
-            )
+            for field in ("repository_root_identity", "branch", "commit_sha", "upstream_sha", "dirty", "worktree_identity")
         },
         "runtime": manifest["runtime"],
         "execution": manifest["execution"],
@@ -608,36 +373,20 @@ def _evidence_projection(manifest: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _evidence_id(manifest: Mapping[str, Any]) -> str:
-    payload = json.dumps(
-        _evidence_projection(manifest),
-        ensure_ascii=True,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("utf-8")
+    payload = json.dumps(_evidence_projection(manifest), ensure_ascii=True, separators=(",", ":"), sort_keys=True).encode("utf-8")
     return f"evidence-sha256-{hashlib.sha256(payload).hexdigest()}"
 
 
-def _validate_generated_manifest(
-    manifest: dict[str, Any], schema_path: str | Path, repo_root: Path
-) -> dict[str, Any]:
+def _validate_generated_manifest(manifest: dict[str, Any], schema_path: str | Path, repo_root: Path) -> dict[str, Any]:
     temporary_path: Path | None = None
     try:
-        with tempfile.NamedTemporaryFile(
-            "w", encoding="utf-8", suffix=".json", delete=False
-        ) as handle:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".json", delete=False) as handle:
             temporary_path = Path(handle.name)
-            json.dump(
-                manifest, handle, ensure_ascii=False, indent=2, sort_keys=True
-            )
+            json.dump(manifest, handle, ensure_ascii=False, indent=2, sort_keys=True)
             handle.write("\n")
-        validation = validate_manifest(
-            temporary_path, schema_path=schema_path, repo_root=repo_root
-        )
+        validation = validate_manifest(temporary_path, schema_path=schema_path, repo_root=repo_root)
     except OSError as exc:
-        raise ProducerError(
-            "manifest_validation_failed",
-            "Temporary manifest validation file could not be created.",
-        ) from exc
+        raise ProducerError("manifest_validation_failed", "Temporary manifest validation file could not be created.") from exc
     finally:
         if temporary_path is not None:
             try:
@@ -648,35 +397,19 @@ def _validate_generated_manifest(
     return validation
 
 
-def _write_output(
-    manifest: Mapping[str, Any], output_path: str, root: Path, replace: bool
-) -> None:
-    relative, destination = _safe_relative_path(
-        output_path, root, code_prefix="output_path", allow_absolute=True
-    )
+def _write_output(manifest: Mapping[str, Any], output_path: str, root: Path, replace: bool) -> None:
+    relative, destination = _safe_relative_path(output_path, root, code_prefix="output_path", allow_absolute=True)
     lexical_destination = root / Path(*PurePosixPath(relative).parts)
     if lexical_destination.is_symlink():
-        raise ProducerError(
-            "output_path_invalid", "Symlink output paths are not accepted."
-        )
+        raise ProducerError("output_path_invalid", "Symlink output paths are not accepted.")
     if destination.exists() and not replace:
-        raise ProducerError(
-            "output_exists", "Output exists; pass --replace to replace it."
-        )
+        raise ProducerError("output_exists", "Output exists; pass --replace to replace it.")
     destination.parent.mkdir(parents=True, exist_ok=True)
     temporary_path: Path | None = None
     try:
-        with tempfile.NamedTemporaryFile(
-            "w",
-            encoding="utf-8",
-            dir=destination.parent,
-            prefix=f".{destination.name}.",
-            delete=False,
-        ) as handle:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=destination.parent, prefix=f".{destination.name}.", delete=False) as handle:
             temporary_path = Path(handle.name)
-            json.dump(
-                manifest, handle, ensure_ascii=False, indent=2, sort_keys=True
-            )
+            json.dump(manifest, handle, ensure_ascii=False, indent=2, sort_keys=True)
             handle.write("\n")
             handle.flush()
             os.fsync(handle.fileno())
@@ -687,250 +420,7 @@ def _write_output(
                 temporary_path.unlink()
             except OSError:
                 pass
-        raise ProducerError(
-            "output_write_failed",
-            "Manifest output could not be written atomically.",
-        ) from exc
-
-
-def _process_live_proof_receipt(
-    receipt_path_value: str,
-    root: Path,
-    machine_data: Mapping[str, Any],
-    repository_data: Mapping[str, Any],
-) -> dict[str, Any]:
-    """Load, validate, and extract identity from a live proof receipt.
-
-    Returns a dict with keys:
-      receipt, receipt_bytes, receipt_sha256, receipt_id_value,
-      execution, artifact, derived_from_refs.
-
-    Raises ProducerError on any validation failure.
-    """
-    # --- path safety ---
-    relative, path = _safe_relative_path(
-        receipt_path_value, root, code_prefix="live_proof_receipt_path"
-    )
-    # also check lexical (unresolved) path for symlinks
-    lexical = (
-        root / Path(*PurePosixPath(relative).parts)
-        if not PurePosixPath(relative).is_absolute()
-        else Path(relative)
-    )
-    if lexical.is_symlink() or path.is_symlink():
-        raise ProducerError(
-            "live_proof_receipt_path_symlink",
-            "Symlink receipt paths are not accepted.",
-        )
-    if not path.exists():
-        raise ProducerError(
-            "live_proof_receipt_not_found",
-            "Live proof receipt file does not exist.",
-        )
-    if not path.is_file():
-        raise ProducerError(
-            "live_proof_receipt_not_found",
-            "Live proof receipt path is not a regular file.",
-        )
-    # --- exact-byte read ---
-    try:
-        receipt_bytes = path.read_bytes()
-    except OSError as exc:
-        raise ProducerError(
-            "live_proof_receipt_not_found",
-            "Live proof receipt could not be read.",
-        ) from exc
-    receipt_sha256 = hashlib.sha256(receipt_bytes).hexdigest()
-    # --- parse ---
-    try:
-        receipt_text = receipt_bytes.decode("utf-8")
-        receipt = json.loads(receipt_text)
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise ProducerError(
-            "live_proof_receipt_schema_invalid",
-            "Live proof receipt is not valid UTF-8 JSON.",
-        ) from exc
-    if not isinstance(receipt, dict):
-        raise ProducerError(
-            "live_proof_receipt_schema_invalid",
-            "Live proof receipt must be a JSON object.",
-        )
-    # --- schema validation ---
-    validation = validate_receipt(receipt)
-    if validation["result"] != "pass":
-        raise ProducerError(
-            "live_proof_receipt_schema_invalid",
-            "Live proof receipt failed schema validation.",
-        )
-    # --- field checks ---
-    if receipt.get("schema_version") != "canonical_live_proof_receipt.v1":
-        raise ProducerError(
-            "live_proof_receipt_schema_invalid",
-            "Receipt schema_version is not canonical_live_proof_receipt.v1.",
-        )
-    if receipt.get("proof_class") != "CURRENT_LIVE_PROOF":
-        raise ProducerError(
-            "live_proof_receipt_schema_invalid",
-            "Receipt proof_class is not CURRENT_LIVE_PROOF.",
-        )
-    if receipt.get("execution_outcome") != "PASS":
-        raise ProducerError(
-            "live_proof_receipt_not_pass",
-            "Only PASS receipts qualify for CURRENT_LIVE_PROOF manifest generation.",
-        )
-    # --- receipt identity ---
-    declared_id = receipt.get("receipt_id", "")
-    computed_id = compute_receipt_id(receipt)
-    if declared_id != computed_id:
-        raise ProducerError(
-            "live_proof_receipt_id_invalid",
-            "Declared receipt_id does not match the deterministic receipt identity.",
-        )
-    # --- machine identity comparison ---
-    receipt_machine = receipt.get("machine", {})
-    for field in ("machine_id", "machine_role", "hostname", "authority_basis"):
-        if receipt_machine.get(field) != machine_data.get(field):
-            raise ProducerError(
-                "live_proof_machine_identity_mismatch",
-                f"Receipt machine {field} does not match current observation.",
-            )
-    # --- repository identity comparison ---
-    receipt_repo = receipt.get("repository", {})
-    # commit_sha gets a dedicated reason code
-    if receipt_repo.get("commit_sha") != repository_data.get("commit_sha"):
-        raise ProducerError(
-            "live_proof_commit_mismatch",
-            "Receipt commit does not match the current checked-out commit.",
-        )
-    for field in (
-        "repository_root_identity",
-        "branch",
-        "upstream_sha",
-        "dirty",
-        "worktree_identity",
-    ):
-        if receipt_repo.get(field) != repository_data.get(field):
-            raise ProducerError(
-                "live_proof_repository_identity_mismatch",
-                f"Receipt repository {field} does not match current observation.",
-            )
-    # --- execution mapping ---
-    receipt_commands = receipt.get("commands", [])
-    encoded_commands = [
-        json.dumps(
-            cmd, ensure_ascii=True, separators=(",", ":"), sort_keys=True
-        )
-        for cmd in receipt_commands
-    ]
-    execution = {
-        "suite_id": receipt.get("suite_id", ""),
-        "commands": encoded_commands,
-        "started_at": receipt.get("started_at", ""),
-        "completed_at": receipt.get("completed_at", ""),
-        "exit_code": 0,
-        "summary": f"Current live proof receipt {computed_id}; PASS observation of supported Compose project.",
-    }
-    # --- artifact ---
-    artifact = {
-        "artifact_id": computed_id,
-        "path": relative,
-        "sha256": receipt_sha256,
-        "media_type": "application/json",
-        "artifact_role": "canonical_live_proof_receipt",
-    }
-    # --- lineage ---
-    derived_from_refs = [computed_id]
-    return {
-        "receipt": receipt,
-        "receipt_bytes": receipt_bytes,
-        "receipt_sha256": receipt_sha256,
-        "receipt_id_value": computed_id,
-        "execution": execution,
-        "artifact": artifact,
-        "derived_from_refs": derived_from_refs,
-    }
-
-
-def _compare_runtime_identity(
-    receipt: Mapping[str, Any],
-    runtime_data: Mapping[str, Any],
-    audit_project: str | None,
-    serving_project: str | None,
-) -> None:
-    """Compare receipt runtime/target identity with freshly collected runtime."""
-    receipt_runtime = receipt.get("runtime", {})
-    # compose_project gets dedicated reason code
-    if receipt_runtime.get("compose_project") != runtime_data.get(
-        "compose_project"
-    ):
-        raise ProducerError(
-            "live_proof_compose_project_mismatch",
-            "Receipt compose_project does not match.",
-        )
-    if receipt_runtime.get("supported_profile") != runtime_data.get(
-        "supported_profile"
-    ):
-        raise ProducerError(
-            "live_proof_profile_mismatch",
-            "Receipt supported_profile does not match.",
-        )
-    if receipt_runtime.get("effective_config_hash") != runtime_data.get(
-        "effective_config_hash"
-    ):
-        raise ProducerError(
-            "live_proof_effective_config_mismatch",
-            "Receipt effective_config_hash does not match.",
-        )
-    for field in ("migration_head",):
-        if receipt_runtime.get(field) != runtime_data.get(field):
-            raise ProducerError(
-                "live_proof_runtime_identity_mismatch",
-                f"Receipt runtime {field} does not match.",
-            )
-    # compose_files
-    receipt_files = list(receipt_runtime.get("compose_files") or [])
-    collected_files = list(runtime_data.get("compose_files") or [])
-    if receipt_files != collected_files:
-        raise ProducerError(
-            "live_proof_runtime_identity_mismatch",
-            "Receipt compose_files do not match.",
-        )
-    # service_identities (normalized sorted)
-    receipt_services = sorted(receipt_runtime.get("service_identities") or [])
-    collected_services = sorted(runtime_data.get("service_identities") or [])
-    if receipt_services != collected_services:
-        raise ProducerError(
-            "live_proof_runtime_identity_mismatch",
-            "Receipt service_identities do not match.",
-        )
-    # target comparison
-    receipt_target = receipt.get("target", {})
-    receipt_compose = receipt_target.get("compose_project", "")
-    receipt_audit = receipt_target.get("audit_project", "")
-    receipt_serving = receipt_target.get("serving_project")
-    receipt_role = receipt_target.get("project_role", "")
-    if audit_project is not None and receipt_audit != audit_project:
-        raise ProducerError(
-            "live_proof_compose_project_mismatch",
-            "Receipt audit_project does not match.",
-        )
-    if serving_project is not None and receipt_serving != serving_project:
-        raise ProducerError(
-            "live_proof_compose_project_mismatch",
-            "Receipt serving_project does not match.",
-        )
-    if receipt_role == "audit" and receipt_compose != receipt_audit:
-        raise ProducerError(
-            "live_proof_role_mismatch",
-            "Audit receipt must select the audit project.",
-        )
-    if receipt_role == "serving" and (
-        receipt_serving is None or receipt_compose != receipt_serving
-    ):
-        raise ProducerError(
-            "live_proof_role_mismatch",
-            "Serving receipt must select the serving project.",
-        )
+        raise ProducerError("output_write_failed", "Manifest output could not be written atomically.") from exc
 
 
 def generate_manifest(
@@ -965,102 +455,43 @@ def generate_manifest(
     schema_path: str | Path = DEFAULT_SCHEMA_PATH,
     output_path: str | None = None,
     replace: bool = False,
-    live_proof_receipt_path: str | None = None,
 ) -> dict[str, Any]:
     """Return a deterministic producer envelope; never execute proof work."""
     try:
         root = Path(repo_path).expanduser().resolve()
         if not root.is_dir():
-            raise ProducerError(
-                "repository_path_invalid", "Repository path is unavailable."
-            )
-        if (
-            isinstance(machine_timeout, bool)
-            or not isinstance(machine_timeout, (int, float))
-            or machine_timeout <= 0
-        ):
-            raise ProducerError(
-                "machine_timeout_invalid", "machine_timeout must be positive."
-            )
+            raise ProducerError("repository_path_invalid", "Repository path is unavailable.")
+        if isinstance(machine_timeout, bool) or not isinstance(machine_timeout, (int, float)) or machine_timeout <= 0:
+            raise ProducerError("machine_timeout_invalid", "machine_timeout must be positive.")
         if diagnostic_working_path:
-            raise ProducerError(
-                "nonportable_absolute_path",
-                "Diagnostic absolute paths are not emitted in manifests.",
-            )
+            raise ProducerError("nonportable_absolute_path", "Diagnostic absolute paths are not emitted in manifests.")
         supplied = dict(metadata or {})
         _check_secret_values(supplied)
         if evidence_id is not None or "evidence_id" in supplied:
-            raise ProducerError(
-                "caller_evidence_id_forbidden",
-                "evidence_id is producer-generated.",
-            )
+            raise ProducerError("caller_evidence_id_forbidden", "evidence_id is producer-generated.")
         if authority_status is not None or "authority_status" in supplied:
-            raise ProducerError(
-                "authority_status_input_forbidden",
-                "authority_status is producer-derived.",
-            )
+            raise ProducerError("authority_status_input_forbidden", "authority_status is producer-derived.")
         values = {
-            "created_at": created_at
-            if created_at is not None
-            else supplied.get("created_at"),
-            "proof_class": proof_class
-            if proof_class is not None
-            else supplied.get("proof_class"),
-            "freshness_status": freshness_status
-            if freshness_status is not None
-            else supplied.get("freshness_status"),
-            "disposition": disposition
-            if disposition is not None
-            else supplied.get("disposition"),
-            "execution_outcome": execution_outcome
-            if execution_outcome is not None
-            else supplied.get("execution_outcome"),
-            "execution": execution
-            if execution is not None
-            else supplied.get("execution"),
+            "created_at": created_at if created_at is not None else supplied.get("created_at"),
+            "proof_class": proof_class if proof_class is not None else supplied.get("proof_class"),
+            "freshness_status": freshness_status if freshness_status is not None else supplied.get("freshness_status"),
+            "disposition": disposition if disposition is not None else supplied.get("disposition"),
+            "execution_outcome": execution_outcome if execution_outcome is not None else supplied.get("execution_outcome"),
+            "execution": execution if execution is not None else supplied.get("execution"),
             "claims": claims if claims is not None else supplied.get("claims"),
-            "artifacts": artifacts
-            if artifacts is not None
-            else supplied.get("artifacts"),
-            "relationships": relationships
-            if relationships is not None
-            else supplied.get("relationships"),
+            "artifacts": artifacts if artifacts is not None else supplied.get("artifacts"),
+            "relationships": relationships if relationships is not None else supplied.get("relationships"),
         }
         if values["proof_class"] not in VALID_PROOF_CLASSES:
-            raise ProducerError(
-                "proof_class_invalid", "proof_class is not accepted vocabulary."
-            )
-        is_live_proof = values["proof_class"] == "CURRENT_LIVE_PROOF"
-        receipt_path = (
-            live_proof_receipt_path
-            if live_proof_receipt_path is not None
-            else supplied.get("live_proof_receipt_path")
-        )
-        if is_live_proof:
-            if (
-                not receipt_path
-                or not isinstance(receipt_path, str)
-                or not receipt_path.strip()
-            ):
-                raise ProducerError(
-                    "live_proof_receipt_required",
-                    "CURRENT_LIVE_PROOF requires live_proof_receipt_path.",
-                )
+            raise ProducerError("proof_class_invalid", "proof_class is not accepted vocabulary.")
+        if values["proof_class"] == "CURRENT_LIVE_PROOF":
+            raise ProducerError("live_proof_not_supported", "This producer does not generate CURRENT_LIVE_PROOF.")
         if values["freshness_status"] not in VALID_FRESHNESS:
-            raise ProducerError(
-                "freshness_status_invalid",
-                "freshness_status is not accepted vocabulary.",
-            )
+            raise ProducerError("freshness_status_invalid", "freshness_status is not accepted vocabulary.")
         if values["disposition"] not in VALID_DISPOSITIONS:
-            raise ProducerError(
-                "disposition_invalid", "disposition is not accepted vocabulary."
-            )
-        normalized_created_at = _normalize_datetime(
-            values["created_at"], "created_at"
-        )
-        outcome, normalized_execution = _normalize_execution(
-            values["execution"], values["execution_outcome"]
-        )
+            raise ProducerError("disposition_invalid", "disposition is not accepted vocabulary.")
+        normalized_created_at = _normalize_datetime(values["created_at"], "created_at")
+        outcome, normalized_execution = _normalize_execution(values["execution"], values["execution_outcome"])
 
         machine = collect_identity(
             root,
@@ -1074,17 +505,10 @@ def generate_manifest(
         machine_data = machine.get("machine")
         repository_data = machine.get("repository")
         eligibility = machine.get("eligibility", {})
-        if not isinstance(machine_data, Mapping) or not isinstance(
-            repository_data, Mapping
-        ):
-            raise ProducerError(
-                "machine_identity_incomplete",
-                "Machine/Git collector did not return identity fields.",
-            )
+        if not isinstance(machine_data, Mapping) or not isinstance(repository_data, Mapping):
+            raise ProducerError("machine_identity_incomplete", "Machine/Git collector did not return identity fields.")
         reason_codes = set(eligibility.get("reason_codes", []))
-        if not eligibility.get(
-            "repository_identity_complete"
-        ) or not machine.get("observation_complete"):
+        if not eligibility.get("repository_identity_complete") or not machine.get("observation_complete"):
             reason_codes.add("repository_identity_incomplete")
             return {
                 "schema_version": RESULT_SCHEMA_VERSION,
@@ -1095,28 +519,9 @@ def generate_manifest(
                 "reason_codes": sorted(reason_codes),
             }
 
-        # --- live proof receipt processing ---
-        receipt_bundle: dict[str, Any] | None = None
-        if is_live_proof:
-            receipt_bundle = _process_live_proof_receipt(
-                receipt_path, root, machine_data, repository_data
-            )
-            # receipt authority must agree with freshly derived manifest authority
-            receipt_authority = receipt_bundle["receipt"].get(
-                "authority_status", ""
-            )
-            # forced runtime identity for live proof comparison
-            if not runtime_identity_requested:
-                runtime_identity_requested = True
-
-        requested_runtime = supplied.get(
-            "runtime_identity_requested", runtime_identity_requested
-        )
+        requested_runtime = supplied.get("runtime_identity_requested", runtime_identity_requested)
         if not isinstance(requested_runtime, bool):
-            raise ProducerError(
-                "runtime_identity_invalid",
-                "runtime_identity_requested must be boolean.",
-            )
+            raise ProducerError("runtime_identity_invalid", "runtime_identity_requested must be boolean.")
         runtime_data: Mapping[str, Any] | None = None
         if requested_runtime:
             runtime = collect_runtime_identity(
@@ -1142,73 +547,17 @@ def generate_manifest(
                 }
             runtime_data = runtime.get("runtime")
             if not isinstance(runtime_data, Mapping):
-                raise ProducerError(
-                    "runtime_identity_incomplete",
-                    "Runtime collector did not return identity fields.",
-                )
+                raise ProducerError("runtime_identity_incomplete", "Runtime collector did not return identity fields.")
 
-        # --- live proof runtime identity comparison ---
-        if receipt_bundle is not None and runtime_data is not None:
-            _compare_runtime_identity(
-                receipt_bundle["receipt"],
-                runtime_data,
-                audit_project,
-                serving_project,
-            )
-
-        normalized_artifacts, artifact_ids = _normalize_artifacts(
-            values["artifacts"], root
-        )
-        normalized_claims = _normalize_claims(
-            values["claims"], artifact_ids, normalized_execution["suite_id"]
-        )
-        normalized_relationships = _normalize_relationships(
-            values["relationships"]
-        )
-        authority_status = (
-            "CANONICAL"
-            if (
-                eligibility.get("canonical_machine_candidate") is True
-                and eligibility.get("canonical_repository_candidate") is True
-                and machine_data.get("machine_id") == "vaultnode"
-                and machine_data.get("machine_role")
-                == "canonical_evidence_host"
-            )
-            else "PROVISIONAL"
-        )
-        # --- live proof integration: authority agreement, execution, artifact, lineage ---
-        if receipt_bundle is not None:
-            receipt_authority = receipt_bundle["receipt"].get(
-                "authority_status", ""
-            )
-            if receipt_authority != authority_status:
-                raise ProducerError(
-                    "live_proof_authority_ineligible",
-                    "Receipt authority_status must agree with derived manifest authority.",
-                )
-            outcome = "PASS"
-            normalized_execution = receipt_bundle["execution"]
-            # add receipt artifact
-            receipt_artifact = receipt_bundle["artifact"]
-            normalized_artifacts = [receipt_artifact] + normalized_artifacts
-            artifact_ids.add(receipt_artifact["artifact_id"])
-            # add receipt lineage
-            receipt_refs = receipt_bundle["derived_from_refs"]
-            existing_derived = set(
-                normalized_relationships.get("derived_from", [])
-            )
-            for ref in receipt_refs:
-                if ref not in existing_derived:
-                    normalized_relationships["derived_from"] = sorted(
-                        list(normalized_relationships["derived_from"]) + [ref]
-                    )
-            # re-normalize claims now that artifact_ids may include the receipt
-            if normalized_claims:
-                normalized_claims = _normalize_claims(
-                    values["claims"],
-                    artifact_ids,
-                    normalized_execution["suite_id"],
-                )
+        normalized_artifacts, artifact_ids = _normalize_artifacts(values["artifacts"], root)
+        normalized_claims = _normalize_claims(values["claims"], artifact_ids, normalized_execution["suite_id"])
+        normalized_relationships = _normalize_relationships(values["relationships"])
+        authority_status = "CANONICAL" if (
+            eligibility.get("canonical_machine_candidate") is True
+            and eligibility.get("canonical_repository_candidate") is True
+            and machine_data.get("machine_id") == "vaultnode"
+            and machine_data.get("machine_role") == "canonical_evidence_host"
+        ) else "PROVISIONAL"
         manifest: dict[str, Any] = {
             "schema_version": MANIFEST_SCHEMA_VERSION,
             "evidence_id": "",
@@ -1220,23 +569,11 @@ def generate_manifest(
             "created_at": normalized_created_at,
             "machine": {
                 field: machine_data[field]
-                for field in (
-                    "machine_id",
-                    "machine_role",
-                    "hostname",
-                    "authority_basis",
-                )
+                for field in ("machine_id", "machine_role", "hostname", "authority_basis")
             },
             "repository": {
                 field: repository_data[field]
-                for field in (
-                    "repository_root_identity",
-                    "branch",
-                    "commit_sha",
-                    "upstream_sha",
-                    "dirty",
-                    "worktree_identity",
-                )
+                for field in ("repository_root_identity", "branch", "commit_sha", "upstream_sha", "dirty", "worktree_identity")
             },
             "runtime": _runtime_manifest(runtime_data),
             "execution": normalized_execution,
@@ -1250,10 +587,7 @@ def generate_manifest(
             for references in normalized_relationships.values()
             for reference in references
         ):
-            raise ProducerError(
-                "relationship_self_reference",
-                "A manifest cannot reference its newly generated evidence ID.",
-            )
+            raise ProducerError("relationship_self_reference", "A manifest cannot reference its newly generated evidence ID.")
         validation = _validate_generated_manifest(manifest, schema_path, root)
         if validation["result"] != "pass":
             reason_codes.add("manifest_validation_failed")
@@ -1267,11 +601,7 @@ def generate_manifest(
             }
         if output_path is not None:
             _write_output(manifest, output_path, root, replace)
-        ineligible = (
-            not eligibility.get("canonical_repository_candidate")
-            or values["freshness_status"] != "CURRENT"
-            or values["disposition"] != "ACCEPTED"
-        )
+        ineligible = not eligibility.get("canonical_repository_candidate") or values["freshness_status"] != "CURRENT" or values["disposition"] != "ACCEPTED"
         return {
             "schema_version": RESULT_SCHEMA_VERSION,
             "producer_version": PRODUCER_VERSION,
@@ -1290,19 +620,11 @@ generate_canonical_evidence_manifest = generate_manifest
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(
-        description="Generate one bounded canonical audit evidence manifest."
-    )
+    parser = argparse.ArgumentParser(description="Generate one bounded canonical audit evidence manifest.")
     parser.add_argument("--repo", default=".")
-    parser.add_argument(
-        "--metadata-input",
-        required=True,
-        help="Repository-relative JSON input for explicit evidence metadata.",
-    )
+    parser.add_argument("--metadata-input", required=True, help="Repository-relative JSON input for explicit evidence metadata.")
     parser.add_argument("--machine-id", default="local")
-    parser.add_argument(
-        "--machine-role", default="provisional_development_host"
-    )
+    parser.add_argument("--machine-role", default="provisional_development_host")
     parser.add_argument("--authority-basis", default="operator_not_asserted")
     parser.add_argument("--assert-canonical-machine", action="store_true")
     parser.add_argument("--diagnostic-working-path", action="store_true")
@@ -1314,10 +636,6 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--serving-project")
     parser.add_argument("--migration-dir")
     parser.add_argument("--no-runtime-identity", action="store_true")
-    parser.add_argument(
-        "--live-proof-receipt",
-        help="Repository-relative path to a live proof receipt for CURRENT_LIVE_PROOF manifests.",
-    )
     parser.add_argument("--output")
     parser.add_argument("--replace", action="store_true")
     args = parser.parse_args(argv)
@@ -1348,7 +666,6 @@ def main(argv: list[str] | None = None) -> int:
         metadata=metadata,
         output_path=args.output,
         replace=args.replace,
-        live_proof_receipt_path=args.live_proof_receipt,
     )
     print(json.dumps(result, indent=2, sort_keys=True))
     if result["result"] == "pass":

--- a/tests/audit/test_generate_canonical_evidence_manifest.py
+++ b/tests/audit/test_generate_canonical_evidence_manifest.py
@@ -7,12 +7,12 @@ import json
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
 
 import pytest
 
 import scripts.audit.generate_canonical_evidence_manifest as producer_module
 from scripts.audit.generate_canonical_evidence_manifest import generate_manifest
+
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts/audit/generate_canonical_evidence_manifest.py"
@@ -41,12 +41,7 @@ criticality:
 
 
 def git(repo: Path, *args: str) -> str:
-    result = subprocess.run(
-        ["git", "-C", str(repo), *args],
-        check=True,
-        text=True,
-        capture_output=True,
-    )
+    result = subprocess.run(["git", "-C", str(repo), *args], check=True, text=True, capture_output=True)
     return result.stdout.strip()
 
 
@@ -60,14 +55,8 @@ down_revision = {down_revision!r}
 def make_fixture(tmp_path: Path) -> dict[str, Path]:
     root = tmp_path / "repo"
     remote = tmp_path / "remote.git"
-    subprocess.run(
-        ["git", "init", "--bare", str(remote)], check=True, capture_output=True
-    )
-    subprocess.run(
-        ["git", "init", "-b", "main", str(root)],
-        check=True,
-        capture_output=True,
-    )
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+    subprocess.run(["git", "init", "-b", "main", str(root)], check=True, capture_output=True)
     git(root, "config", "user.email", "test@example.invalid")
     git(root, "config", "user.name", "Test User")
     profile_dir = root / "config" / "supported_profiles"
@@ -76,28 +65,14 @@ def make_fixture(tmp_path: Path) -> dict[str, Path]:
     profile_dir.mkdir(parents=True)
     migration_dir.mkdir(parents=True)
     artifact_dir.mkdir(parents=True)
-    (profile_dir / "v1-local-core-web-mcp.yaml").write_text(
-        PROFILE, encoding="utf-8"
-    )
+    (profile_dir / "v1-local-core-web-mcp.yaml").write_text(PROFILE, encoding="utf-8")
     compose = root / "docker-compose.yml"
-    compose.write_text(
-        "name: codexify\nservices:\n  backend: {}\n  db: {}\n  redis: {}\n",
-        encoding="utf-8",
-    )
-    (migration_dir / "a_revision.py").write_text(
-        migration("head-a"), encoding="utf-8"
-    )
+    compose.write_text("name: codexify\nservices:\n  backend: {}\n  db: {}\n  redis: {}\n", encoding="utf-8")
+    (migration_dir / "a_revision.py").write_text(migration("head-a"), encoding="utf-8")
     artifact = artifact_dir / "proof.txt"
     artifact.write_text("fixture proof\n", encoding="utf-8")
-    gitignore = root / ".gitignore"
-    gitignore.write_text(
-        "live-proof-receipt.json\nreceipt-link.json\n", encoding="utf-8"
-    )
     metadata_path = root / "manifest-input.json"
-    metadata_path.write_text(
-        json.dumps(base_metadata(runtime_requested=False), indent=2) + "\n",
-        encoding="utf-8",
-    )
+    metadata_path.write_text(json.dumps(base_metadata(runtime_requested=False), indent=2) + "\n", encoding="utf-8")
     git(root, "add", ".")
     git(root, "commit", "-m", "fixture")
     git(root, "remote", "add", "origin", str(remote))
@@ -131,11 +106,7 @@ def base_metadata(*, runtime_requested: bool = True) -> dict:
         },
         "claims": {"supported": [], "disproved": [], "unresolved": []},
         "artifacts": [],
-        "relationships": {
-            "supersedes": [],
-            "contradicts": [],
-            "derived_from": [],
-        },
+        "relationships": {"supersedes": [], "contradicts": [], "derived_from": []},
     }
 
 
@@ -158,9 +129,7 @@ def runtime_kwargs(fixture: dict[str, Path]) -> dict[str, object]:
     }
 
 
-def test_provisional_manifest_is_deterministic_and_validated(
-    tmp_path: Path,
-) -> None:
+def test_provisional_manifest_is_deterministic_and_validated(tmp_path: Path) -> None:
     fixture = make_fixture(tmp_path)
     first = collect(fixture, machine_id="developer-laptop")
     second = collect(fixture, machine_id="developer-laptop")
@@ -173,9 +142,7 @@ def test_provisional_manifest_is_deterministic_and_validated(
     assert str(fixture["root"]) not in json.dumps(first)
 
 
-def test_explicit_canonical_machine_and_eligible_repository_are_derived(
-    tmp_path: Path,
-) -> None:
+def test_explicit_canonical_machine_and_eligible_repository_are_derived(tmp_path: Path) -> None:
     fixture = make_fixture(tmp_path)
     result = collect(
         fixture,
@@ -189,43 +156,26 @@ def test_explicit_canonical_machine_and_eligible_repository_are_derived(
     assert result["validation"]["canonical_eligible"] is True
 
 
-def test_static_runtime_identity_is_projected_without_live_proof(
-    tmp_path: Path,
-) -> None:
+def test_static_runtime_identity_is_projected_without_live_proof(tmp_path: Path) -> None:
     fixture = make_fixture(tmp_path)
     metadata = base_metadata(runtime_requested=True)
-    result = generate_manifest(
-        fixture["root"],
-        hostname="fixture-host",
-        metadata=metadata,
-        **runtime_kwargs(fixture),
-    )
+    result = generate_manifest(fixture["root"], hostname="fixture-host", metadata=metadata, **runtime_kwargs(fixture))
     assert result["result"] == "pass"
-    assert (
-        result["manifest"]["runtime"]["supported_profile"]
-        == "v1-local-core-web-mcp"
-    )
+    assert result["manifest"]["runtime"]["supported_profile"] == "v1-local-core-web-mcp"
     assert result["manifest"]["runtime"]["migration_head"] == "head-a"
     assert result["manifest"]["proof_class"] == "CURRENT_TEST_PROOF"
 
 
-def test_live_proof_without_receipt_path_fails_closed(tmp_path: Path) -> None:
+def test_current_live_proof_is_rejected_without_live_inspection(tmp_path: Path) -> None:
     fixture = make_fixture(tmp_path)
     metadata = base_metadata(runtime_requested=True)
     metadata["proof_class"] = "CURRENT_LIVE_PROOF"
-    result = generate_manifest(
-        fixture["root"],
-        hostname="fixture-host",
-        metadata=metadata,
-        **runtime_kwargs(fixture),
-    )
+    result = generate_manifest(fixture["root"], hostname="fixture-host", metadata=metadata, **runtime_kwargs(fixture))
     assert result["result"] == "error"
-    assert result["reason_codes"] == ["live_proof_receipt_required"]
+    assert result["reason_codes"] == ["live_proof_not_supported"]
 
 
-def test_artifacts_are_hashed_and_claim_references_are_resolved(
-    tmp_path: Path,
-) -> None:
+def test_artifacts_are_hashed_and_claim_references_are_resolved(tmp_path: Path) -> None:
     fixture = make_fixture(tmp_path)
     metadata = base_metadata(runtime_requested=False)
     metadata["artifacts"] = [
@@ -249,55 +199,32 @@ def test_artifacts_are_hashed_and_claim_references_are_resolved(
         "disproved": [],
         "unresolved": [],
     }
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata
-    )
+    result = generate_manifest(fixture["root"], hostname="fixture-host", metadata=metadata)
     assert result["result"] == "pass"
     artifact = result["manifest"]["artifacts"][0]
     assert artifact["sha256"] == hashlib.sha256(b"fixture proof\n").hexdigest()
-    assert result["manifest"]["claims"]["supported"][0]["evidence_refs"] == [
-        "execution:fixture-suite",
-        "proof-a",
-    ]
+    assert result["manifest"]["claims"]["supported"][0]["evidence_refs"] == ["execution:fixture-suite", "proof-a"]
 
 
-def test_generated_evidence_ids_are_valid_lineage_references(
-    tmp_path: Path,
-) -> None:
+def test_generated_evidence_ids_are_valid_lineage_references(tmp_path: Path) -> None:
     fixture = make_fixture(tmp_path)
     first = collect(fixture)
     first_id = first["manifest"]["evidence_id"]
     second_metadata = base_metadata(runtime_requested=False)
-    second_metadata["relationships"] = {
-        "supersedes": [],
-        "contradicts": [],
-        "derived_from": [first_id],
-    }
-    second = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=second_metadata
-    )
+    second_metadata["relationships"] = {"supersedes": [], "contradicts": [], "derived_from": [first_id]}
+    second = generate_manifest(fixture["root"], hostname="fixture-host", metadata=second_metadata)
     assert second["result"] == "pass"
     assert second["manifest"]["relationships"]["derived_from"] == [first_id]
     assert second["manifest"]["evidence_id"] != first_id
 
 
-def test_only_the_newly_generated_id_is_rejected_as_self_reference(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_only_the_newly_generated_id_is_rejected_as_self_reference(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     fixture = make_fixture(tmp_path)
     generated_id = "evidence-sha256-" + "a" * 64
-    monkeypatch.setattr(
-        producer_module, "_evidence_id", lambda manifest: generated_id
-    )
+    monkeypatch.setattr(producer_module, "_evidence_id", lambda manifest: generated_id)
     metadata = base_metadata(runtime_requested=False)
-    metadata["relationships"] = {
-        "supersedes": [],
-        "contradicts": [],
-        "derived_from": [generated_id],
-    }
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata
-    )
+    metadata["relationships"] = {"supersedes": [], "contradicts": [], "derived_from": [generated_id]}
+    result = generate_manifest(fixture["root"], hostname="fixture-host", metadata=metadata)
     assert result["result"] == "error"
     assert result["reason_codes"] == ["relationship_self_reference"]
 
@@ -305,68 +232,17 @@ def test_only_the_newly_generated_id_is_rejected_as_self_reference(
 @pytest.mark.parametrize(
     ("field", "value", "reason"),
     [
-        (
-            "execution",
-            {
-                "outcome": "PASS",
-                "suite_id": "fixture-suite",
-                "commands": ["fixture"],
-                "started_at": "2026-07-13T15:00:00Z",
-                "completed_at": "2026-07-13T15:00:01Z",
-                "exit_code": 1,
-                "summary": "bad",
-            },
-            "execution_outcome_inconsistent",
-        ),
-        (
-            "artifacts",
-            [
-                {
-                    "artifact_id": "proof-a",
-                    "path": "../outside.txt",
-                    "media_type": "text/plain",
-                    "artifact_role": "proof",
-                }
-            ],
-            "artifact_path_parent_traversal",
-        ),
-        (
-            "claims",
-            {
-                "supported": [
-                    {
-                        "claim_id": "bad",
-                        "statement": "bad",
-                        "scope": "fixture",
-                        "evidence_refs": ["summary-only"],
-                        "reason": "bad",
-                    }
-                ],
-                "disproved": [],
-                "unresolved": [],
-            },
-            "claim_evidence_reference_unresolved",
-        ),
-        (
-            "relationships",
-            {
-                "supersedes": ["same"],
-                "contradicts": ["same"],
-                "derived_from": [],
-            },
-            "relationship_bucket_conflict",
-        ),
+        ("execution", {"outcome": "PASS", "suite_id": "fixture-suite", "commands": ["fixture"], "started_at": "2026-07-13T15:00:00Z", "completed_at": "2026-07-13T15:00:01Z", "exit_code": 1, "summary": "bad"}, "execution_outcome_inconsistent"),
+        ("artifacts", [{"artifact_id": "proof-a", "path": "../outside.txt", "media_type": "text/plain", "artifact_role": "proof"}], "artifact_path_parent_traversal"),
+        ("claims", {"supported": [{"claim_id": "bad", "statement": "bad", "scope": "fixture", "evidence_refs": ["summary-only"], "reason": "bad"}], "disproved": [], "unresolved": []}, "claim_evidence_reference_unresolved"),
+        ("relationships", {"supersedes": ["same"], "contradicts": ["same"], "derived_from": []}, "relationship_bucket_conflict"),
     ],
 )
-def test_invalid_metadata_fails_closed(
-    tmp_path: Path, field: str, value: object, reason: str
-) -> None:
+def test_invalid_metadata_fails_closed(tmp_path: Path, field: str, value: object, reason: str) -> None:
     fixture = make_fixture(tmp_path)
     metadata = base_metadata(runtime_requested=False)
     metadata[field] = value
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata
-    )
+    result = generate_manifest(fixture["root"], hostname="fixture-host", metadata=metadata)
     assert result["result"] == "error"
     assert result["reason_codes"] == [reason]
 
@@ -379,9 +255,7 @@ def test_invalid_metadata_fails_closed(
         "mysql://user:password@db.example.invalid/audit",
     ],
 )
-def test_secret_input_is_rejected_and_not_echoed(
-    tmp_path: Path, secret_value: str
-) -> None:
+def test_secret_input_is_rejected_and_not_echoed(tmp_path: Path, secret_value: str) -> None:
     fixture = make_fixture(tmp_path)
     metadata = base_metadata(runtime_requested=False)
     metadata["execution"]["summary"] = f"Observed {secret_value} during a test."
@@ -390,22 +264,12 @@ def test_secret_input_is_rejected_and_not_echoed(
     assert secret_value not in json.dumps(result)
 
 
-def test_secret_database_url_in_claim_is_rejected_and_not_echoed(
-    tmp_path: Path,
-) -> None:
+def test_secret_database_url_in_claim_is_rejected_and_not_echoed(tmp_path: Path) -> None:
     fixture = make_fixture(tmp_path)
     secret_value = "postgresql://user:password@db.example.invalid/audit"
     metadata = base_metadata(runtime_requested=False)
     metadata["claims"] = {
-        "supported": [
-            {
-                "claim_id": "secret",
-                "statement": secret_value,
-                "scope": "fixture",
-                "evidence_refs": ["execution:fixture-suite"],
-                "reason": "not accepted",
-            }
-        ],
+        "supported": [{"claim_id": "secret", "statement": secret_value, "scope": "fixture", "evidence_refs": ["execution:fixture-suite"], "reason": "not accepted"}],
         "disproved": [],
         "unresolved": [],
     }
@@ -414,9 +278,7 @@ def test_secret_database_url_in_claim_is_rejected_and_not_echoed(
     assert secret_value not in json.dumps(result)
 
 
-def test_diagnostic_working_path_is_rejected_as_nonportable(
-    tmp_path: Path,
-) -> None:
+def test_diagnostic_working_path_is_rejected_as_nonportable(tmp_path: Path) -> None:
     fixture = make_fixture(tmp_path)
     result = collect(fixture, diagnostic_working_path=True)
     assert result["result"] == "error"
@@ -425,17 +287,11 @@ def test_diagnostic_working_path_is_rejected_as_nonportable(
 
 def test_caller_evidence_id_is_rejected(tmp_path: Path) -> None:
     fixture = make_fixture(tmp_path)
-    result = generate_manifest(
-        fixture["root"],
-        metadata=base_metadata(runtime_requested=False),
-        evidence_id="caller-selected",
-    )
+    result = generate_manifest(fixture["root"], metadata=base_metadata(runtime_requested=False), evidence_id="caller-selected")
     assert result["reason_codes"] == ["caller_evidence_id_forbidden"]
 
 
-def test_repository_identity_incompleteness_is_fail_closed(
-    tmp_path: Path,
-) -> None:
+def test_repository_identity_incompleteness_is_fail_closed(tmp_path: Path) -> None:
     fixture = make_fixture(tmp_path)
     git(fixture["root"], "branch", "--unset-upstream")
     result = collect(fixture)
@@ -461,727 +317,6 @@ def test_producer_does_not_mutate_git_or_tracked_files(tmp_path: Path) -> None:
     }
     assert result["result"] == "pass"
     assert before == after
-
-
-# ---------------------------------------------------------------------------
-# Live proof receipt helpers
-# ---------------------------------------------------------------------------
-
-from scripts.audit.collect_canonical_live_proof_receipt import (  # noqa: E402
-    receipt_id as compute_receipt_id,
-)
-
-
-def _receipt_json(
-    fixture: dict[str, Path],
-    *,
-    authority_status: str = "PROVISIONAL",
-    execution_outcome: str = "PASS",
-    machine_overrides: dict[str, Any] | None = None,
-    repo_overrides: dict[str, Any] | None = None,
-    runtime_overrides: dict[str, Any] | None = None,
-    target_overrides: dict[str, Any] | None = None,
-    receipt_id_override: str | None = None,
-) -> dict[str, Any]:
-    """Build a minimal but valid live proof receipt for a fixture."""
-    root = fixture["root"]
-    head = git(root, "rev-parse", "HEAD")
-    upstream = git(root, "rev-parse", "@{u}")
-    repo_root_id = git(root, "rev-parse", "--show-toplevel")
-    repo_root_id = f"git:{hashlib.sha256(repo_root_id.encode()).hexdigest()}"
-
-    machine = {
-        "machine_id": "local",
-        "machine_role": "provisional_development_host",
-        "hostname": "fixture-host",
-        "authority_basis": "operator_not_asserted",
-    }
-    if machine_overrides:
-        machine.update(machine_overrides)
-
-    repo = {
-        "repository_root_identity": repo_root_id,
-        "branch": "main",
-        "commit_sha": head,
-        "upstream_sha": upstream,
-        "dirty": False,
-        "worktree_identity": f"worktree:{hashlib.sha256(str(root).encode()).hexdigest()}",
-    }
-    if repo_overrides:
-        repo.update(repo_overrides)
-
-    runtime_base = {
-        "supported_profile": "v1-local-core-web-mcp",
-        "effective_config_hash": "e" * 64,
-        "compose_project": "codexify-audit",
-        "compose_files": ["docker-compose.yml"],
-        "migration_head": "head-a",
-        "service_identities": ["backend"],
-        "required_services": ["backend"],
-        "optional_services": ["redis"],
-    }
-    if runtime_overrides:
-        runtime_base.update(runtime_overrides)
-
-    target = {
-        "compose_project": "codexify-audit",
-        "project_role": "audit",
-        "audit_project": "codexify-audit",
-        "serving_project": "codexify-serving",
-        "compose_environment_file": None,
-    }
-    if target_overrides:
-        target.update(target_overrides)
-
-    receipt = {
-        "schema_version": "canonical_live_proof_receipt.v1",
-        "receipt_id": "",
-        "suite_id": "supported_compose_live_health.v1",
-        "proof_class": "CURRENT_LIVE_PROOF",
-        "authority_status": authority_status,
-        "execution_outcome": execution_outcome,
-        "created_at": "2026-07-15T12:00:00Z",
-        "started_at": "2026-07-15T12:00:00Z",
-        "completed_at": "2026-07-15T12:00:05Z",
-        "machine": machine,
-        "repository": repo,
-        "runtime": runtime_base,
-        "target": target,
-        "docker": {"client_version": "27.1.1", "server_version": "27.1.1"},
-        "services": [
-            {
-                "service": "backend",
-                "required": True,
-                "lifecycle": "long_running",
-                "container_identity": "codexify-audit-backend-1",
-                "image_id": "sha256:" + "b" * 64,
-                "image_digest": None,
-                "state": "running",
-                "health_status": "healthy",
-                "exit_code": 0,
-                "observation_result": "PASS",
-                "reason_codes": [],
-            }
-        ],
-        "probes": [
-            {
-                "probe_id": "api_ping",
-                "method": "GET",
-                "path": "/ping",
-                "status_code": 200,
-                "started_at": "2026-07-15T12:00:01Z",
-                "completed_at": "2026-07-15T12:00:01Z",
-                "duration_ms": 1,
-                "outcome": "PASS",
-                "response_body_sha256": hashlib.sha256(b"pong\n").hexdigest(),
-                "projection": {},
-                "reason_codes": [],
-            }
-        ],
-        "commands": [
-            ["docker", "version", "--format", "json"],
-            [
-                "docker",
-                "compose",
-                "-f",
-                "docker-compose.yml",
-                "-p",
-                "codexify-audit",
-                "ps",
-                "--all",
-                "--format",
-                "json",
-            ],
-        ],
-        "reason_codes": [],
-    }
-    if receipt_id_override is not None:
-        receipt["receipt_id"] = receipt_id_override
-    else:
-        receipt["receipt_id"] = compute_receipt_id(receipt)
-    return receipt
-
-
-def write_receipt(
-    fixture: dict[str, Path], **kwargs: Any
-) -> tuple[str, dict[str, Any]]:
-    """Write a receipt to the fixture repo and return the relative path and receipt dict.
-
-    Collects identity AFTER writing so dirty/untracked state matches what the producer sees.
-    Also collects actual runtime identity for accurate comparison.
-    """
-    from scripts.audit.collect_canonical_evidence_identity import (
-        collect_identity,
-    )
-    from scripts.audit.collect_canonical_runtime_identity import (
-        collect_runtime_identity,
-    )
-
-    machine_overrides = kwargs.pop("machine_overrides", None) or {}
-    repo_overrides = kwargs.pop("repo_overrides", None) or {}
-    runtime_overrides = kwargs.pop("runtime_overrides", None) or {}
-    target_overrides = kwargs.pop("target_overrides", None) or {}
-
-    # Build a draft receipt first, write it, then collect identity with receipt present
-    draft = _receipt_json(fixture, **kwargs)
-    receipt_path = fixture["root"] / "live-proof-receipt.json"
-    receipt_path.write_text(
-        json.dumps(draft, indent=2, sort_keys=True), encoding="utf-8"
-    )
-
-    # Now collect identity WITH the receipt file present (repo may be dirty)
-    identity = collect_identity(fixture["root"], hostname="fixture-host")
-    collected_machine = identity.get("machine", {})
-    full_machine = {
-        "machine_id": collected_machine.get("machine_id", "local"),
-        "machine_role": collected_machine.get(
-            "machine_role", "provisional_development_host"
-        ),
-        "hostname": collected_machine.get("hostname", "fixture-host"),
-        "authority_basis": collected_machine.get(
-            "authority_basis", "operator_not_asserted"
-        ),
-    }
-    full_machine.update(machine_overrides)
-
-    collected_repo = identity.get("repository", {})
-    full_repo = {
-        "repository_root_identity": collected_repo.get(
-            "repository_root_identity", ""
-        ),
-        "branch": collected_repo.get("branch", "main"),
-        "commit_sha": collected_repo.get("commit_sha", ""),
-        "upstream_sha": collected_repo.get("upstream_sha", ""),
-        "dirty": collected_repo.get("dirty", False),
-        "worktree_identity": collected_repo.get("worktree_identity", ""),
-    }
-    full_repo.update(repo_overrides)
-
-    # Collect actual runtime identity
-    rt = collect_runtime_identity(
-        fixture["root"],
-        profile_name="v1-local-core-web-mcp",
-        profiles_dir=fixture["profile_dir"],
-        compose_files=["docker-compose.yml"],
-        audit_project="codexify-audit",
-        migration_dir=fixture["migration_dir"],
-    )
-    collected_rt = rt.get("runtime", {})
-    full_runtime = {
-        "supported_profile": collected_rt.get(
-            "supported_profile", "v1-local-core-web-mcp"
-        ),
-        "effective_config_hash": collected_rt.get("effective_config_hash", ""),
-        "compose_project": collected_rt.get(
-            "compose_project", "codexify-audit"
-        ),
-        "compose_files": collected_rt.get(
-            "compose_files", ["docker-compose.yml"]
-        ),
-        "migration_head": collected_rt.get("migration_head", "head-a"),
-        "service_identities": collected_rt.get(
-            "service_identities", ["backend"]
-        ),
-        "required_services": collected_rt.get("compose_identity", {}).get(
-            "required_services", ["backend"]
-        ),
-        "optional_services": collected_rt.get("compose_identity", {}).get(
-            "optional_services", ["redis"]
-        ),
-    }
-    full_runtime.update(runtime_overrides)
-
-    receipt = _receipt_json(
-        fixture,
-        machine_overrides=full_machine,
-        repo_overrides=full_repo,
-        runtime_overrides=full_runtime,
-        target_overrides=target_overrides,
-        **kwargs,
-    )
-    receipt_path.write_text(
-        json.dumps(receipt, indent=2, sort_keys=True), encoding="utf-8"
-    )
-    return "live-proof-receipt.json", receipt
-
-
-def live_proof_metadata(
-    receipt_path: str, *, runtime_requested: bool = True
-) -> dict[str, Any]:
-    return {
-        "created_at": "2026-07-15T12:00:00-04:00",
-        "proof_class": "CURRENT_LIVE_PROOF",
-        "freshness_status": "CURRENT",
-        "disposition": "ACCEPTED",
-        "runtime_identity_requested": runtime_requested,
-        "live_proof_receipt_path": receipt_path,
-        "execution": {
-            "outcome": "PASS",
-            "suite_id": "unused-suite",
-            "commands": ["unused"],
-            "started_at": "2026-07-15T12:00:00Z",
-            "completed_at": "2026-07-15T12:00:05Z",
-            "exit_code": 0,
-            "summary": "placeholder; will be overridden by receipt.",
-        },
-        "claims": {"supported": [], "disproved": [], "unresolved": []},
-        "artifacts": [],
-        "relationships": {
-            "supersedes": [],
-            "contradicts": [],
-            "derived_from": [],
-        },
-    }
-
-
-# ---------------------------------------------------------------------------
-# Live proof receipt integration tests
-# ---------------------------------------------------------------------------
-
-
-def test_valid_canonical_pass_receipt_produces_deterministic_manifest(
-    tmp_path: Path,
-) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt_path, receipt = write_receipt(
-        fixture,
-        authority_status="CANONICAL",
-        machine_overrides={
-            "machine_id": "vaultnode",
-            "machine_role": "canonical_evidence_host",
-            "hostname": "fixture-host",
-            "authority_basis": "operator-confirmed-vaultnode",
-        },
-    )
-    kwargs = runtime_kwargs(fixture)
-    metadata = live_proof_metadata(receipt_path)
-    first = generate_manifest(
-        fixture["root"],
-        hostname="fixture-host",
-        metadata=metadata,
-        machine_id="vaultnode",
-        machine_role="canonical_evidence_host",
-        authority_basis="operator-confirmed-vaultnode",
-        assert_canonical_machine=True,
-        **kwargs,
-    )
-    second = generate_manifest(
-        fixture["root"],
-        hostname="fixture-host",
-        metadata=metadata,
-        machine_id="vaultnode",
-        machine_role="canonical_evidence_host",
-        authority_basis="operator-confirmed-vaultnode",
-        assert_canonical_machine=True,
-        **kwargs,
-    )
-    assert first == second
-    assert first["result"] in ("pass", "ineligible")
-    assert first["manifest"] is not None
-    assert first["validation"]["result"] == "pass"
-    assert first["manifest"]["authority_status"] == "CANONICAL"
-    assert first["manifest"]["proof_class"] == "CURRENT_LIVE_PROOF"
-    assert first["manifest"]["execution_outcome"] == "PASS"
-    assert first["manifest"]["execution"]["exit_code"] == 0
-    assert receipt["receipt_id"] in first["manifest"]["execution"]["summary"]
-    # receipt is an artifact
-    artifact = first["manifest"]["artifacts"][0]
-    assert artifact["artifact_id"] == receipt["receipt_id"]
-    assert artifact["artifact_role"] == "canonical_live_proof_receipt"
-    assert artifact["media_type"] == "application/json"
-    assert artifact["path"] == receipt_path
-    # lineage
-    assert (
-        receipt["receipt_id"]
-        in first["manifest"]["relationships"]["derived_from"]
-    )
-    # evidence_id
-    assert first["manifest"]["evidence_id"].startswith("evidence-sha256-")
-
-
-def test_valid_provisional_pass_receipt_produces_provisional_manifest(
-    tmp_path: Path,
-) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt_path, receipt = write_receipt(
-        fixture, authority_status="PROVISIONAL"
-    )
-    kwargs = runtime_kwargs(fixture)
-    metadata = live_proof_metadata(receipt_path)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert result["result"] in ("pass", "ineligible")
-    assert result["manifest"] is not None
-    assert result["manifest"]["authority_status"] == "PROVISIONAL"
-    assert result["manifest"]["proof_class"] == "CURRENT_LIVE_PROOF"
-
-
-def test_missing_receipt_input_fails_closed(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    metadata = base_metadata(runtime_requested=True)
-    metadata["proof_class"] = "CURRENT_LIVE_PROOF"
-    result = generate_manifest(
-        fixture["root"],
-        hostname="fixture-host",
-        metadata=metadata,
-        **runtime_kwargs(fixture),
-    )
-    assert result["result"] == "error"
-    assert "live_proof_receipt_required" in result["reason_codes"]
-
-
-def test_missing_receipt_file_fails_closed(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    metadata = live_proof_metadata("nonexistent-receipt.json")
-    kwargs = runtime_kwargs(fixture)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert result["result"] == "error"
-    assert "live_proof_receipt_not_found" in result["reason_codes"]
-
-
-def test_invalid_json_receipt_fails_closed(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt_path = fixture["root"] / "bad-receipt.json"
-    receipt_path.write_text("not json", encoding="utf-8")
-    metadata = live_proof_metadata("bad-receipt.json")
-    kwargs = runtime_kwargs(fixture)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert result["result"] == "error"
-    assert "live_proof_receipt_schema_invalid" in result["reason_codes"]
-
-
-def test_schema_invalid_receipt_fails_closed(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt = _receipt_json(fixture)
-    del receipt["machine"]  # remove required field
-    receipt["receipt_id"] = compute_receipt_id(receipt)
-    receipt_path = fixture["root"] / "invalid-receipt.json"
-    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
-    metadata = live_proof_metadata("invalid-receipt.json")
-    kwargs = runtime_kwargs(fixture)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert result["result"] == "error"
-    assert "live_proof_receipt_schema_invalid" in result["reason_codes"]
-
-
-def test_invalid_receipt_id_fails_closed(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt_path, _ = write_receipt(
-        fixture, receipt_id_override="live-proof-receipt-sha256-" + "0" * 64
-    )
-    metadata = live_proof_metadata(receipt_path)
-    kwargs = runtime_kwargs(fixture)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert result["result"] == "error"
-    assert "live_proof_receipt_id_invalid" in result["reason_codes"]
-
-
-def test_receipt_byte_change_changes_manifest_evidence_id(
-    tmp_path: Path,
-) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt_path, _ = write_receipt(fixture)
-    kwargs = runtime_kwargs(fixture)
-    metadata = live_proof_metadata(receipt_path)
-    first = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    # change receipt bytes
-    receipt_file = fixture["root"] / receipt_path
-    receipt = json.loads(receipt_file.read_text(encoding="utf-8"))
-    receipt["reason_codes"] = ["some_reason"]
-    receipt["receipt_id"] = compute_receipt_id(receipt)
-    receipt_file.write_text(json.dumps(receipt), encoding="utf-8")
-    second = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert first["manifest"]["evidence_id"] != second["manifest"]["evidence_id"]
-    assert (
-        first["manifest"]["artifacts"][0]["sha256"]
-        != second["manifest"]["artifacts"][0]["sha256"]
-    )
-
-
-def test_machine_identity_mismatch_fails_closed(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    # receipt has hostname="other-host"; producer collects hostname="fixture-host"
-    receipt_path, _ = write_receipt(
-        fixture, machine_overrides={"hostname": "other-host"}
-    )
-    metadata = live_proof_metadata(receipt_path)
-    kwargs = runtime_kwargs(fixture)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert result["result"] == "error"
-    assert "live_proof_machine_identity_mismatch" in result["reason_codes"]
-
-
-def test_repository_identity_mismatch_fails_closed(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt_path, _ = write_receipt(
-        fixture, repo_overrides={"branch": "other-branch"}
-    )
-    metadata = live_proof_metadata(receipt_path)
-    kwargs = runtime_kwargs(fixture)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert result["result"] == "error"
-    assert "live_proof_repository_identity_mismatch" in result["reason_codes"]
-
-
-def test_commit_mismatch_fails_closed(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt_path, _ = write_receipt(
-        fixture, repo_overrides={"commit_sha": "0" * 40}
-    )
-    metadata = live_proof_metadata(receipt_path)
-    kwargs = runtime_kwargs(fixture)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert result["result"] == "error"
-    assert "live_proof_commit_mismatch" in result["reason_codes"]
-
-
-def test_runtime_identity_mismatch_fails_closed(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt_path, _ = write_receipt(
-        fixture, runtime_overrides={"compose_files": ["other-compose.yml"]}
-    )
-    metadata = live_proof_metadata(receipt_path)
-    kwargs = runtime_kwargs(fixture)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert result["result"] == "error"
-    assert "live_proof_runtime_identity_mismatch" in result["reason_codes"]
-
-
-def test_effective_config_mismatch_fails_closed(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt_path, _ = write_receipt(
-        fixture, runtime_overrides={"effective_config_hash": "f" * 64}
-    )
-    metadata = live_proof_metadata(receipt_path)
-    kwargs = runtime_kwargs(fixture)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert result["result"] == "error"
-    assert "live_proof_effective_config_mismatch" in result["reason_codes"]
-
-
-def test_profile_mismatch_fails_closed(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt_path, _ = write_receipt(
-        fixture, runtime_overrides={"supported_profile": "wrong-profile"}
-    )
-    metadata = live_proof_metadata(receipt_path)
-    kwargs = runtime_kwargs(fixture)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert result["result"] == "error"
-    assert "live_proof_profile_mismatch" in result["reason_codes"]
-
-
-def test_compose_project_mismatch_fails_closed(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt_path, _ = write_receipt(
-        fixture,
-        runtime_overrides={"compose_project": "wrong-project"},
-        target_overrides={"compose_project": "wrong-project"},
-    )
-    metadata = live_proof_metadata(receipt_path)
-    kwargs = runtime_kwargs(fixture)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert result["result"] == "error"
-    assert "live_proof_compose_project_mismatch" in result["reason_codes"]
-
-
-def test_role_mismatch_fails_closed(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt_path, _ = write_receipt(
-        fixture,
-        target_overrides={"project_role": "serving"},
-    )
-    metadata = live_proof_metadata(receipt_path)
-    kwargs = runtime_kwargs(fixture)
-    # audit receipt with serving role is inconsistent
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert result["result"] == "error"
-    assert "live_proof_role_mismatch" in result["reason_codes"]
-
-
-def test_receipt_authority_mismatch_fails_closed(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt_path, _ = write_receipt(
-        fixture, authority_status="CANONICAL"
-    )  # receipt is CANONICAL but machine is not vaultnode
-    metadata = live_proof_metadata(receipt_path)
-    kwargs = runtime_kwargs(fixture)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    # derived authority is PROVISIONAL, receipt says CANONICAL → mismatch
-    assert result["result"] == "error"
-    assert "live_proof_authority_ineligible" in result["reason_codes"]
-
-
-def test_fail_receipt_cannot_become_live_proof(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt_path, _ = write_receipt(fixture, execution_outcome="FAIL")
-    metadata = live_proof_metadata(receipt_path)
-    kwargs = runtime_kwargs(fixture)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert result["result"] == "error"
-    assert "live_proof_receipt_not_pass" in result["reason_codes"]
-
-
-def test_blocked_receipt_cannot_become_live_proof(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt_path, _ = write_receipt(fixture, execution_outcome="BLOCKED")
-    metadata = live_proof_metadata(receipt_path)
-    kwargs = runtime_kwargs(fixture)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert result["result"] == "error"
-    assert "live_proof_receipt_not_pass" in result["reason_codes"]
-
-
-def test_error_receipt_cannot_become_live_proof(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt_path, _ = write_receipt(fixture, execution_outcome="ERROR")
-    metadata = live_proof_metadata(receipt_path)
-    kwargs = runtime_kwargs(fixture)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert result["result"] == "error"
-    assert "live_proof_receipt_not_pass" in result["reason_codes"]
-
-
-def test_absolute_receipt_path_fails_closed(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt_path, _ = write_receipt(fixture)
-    abs_path = str(fixture["root"] / receipt_path)
-    metadata = live_proof_metadata(abs_path)
-    kwargs = runtime_kwargs(fixture)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert result["result"] == "error"
-    assert "live_proof_receipt_path_absolute" in result["reason_codes"]
-
-
-def test_parent_traversal_receipt_path_fails_closed(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    metadata = live_proof_metadata("../outside-receipt.json")
-    kwargs = runtime_kwargs(fixture)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert result["result"] == "error"
-    assert "live_proof_receipt_path_parent_traversal" in result["reason_codes"]
-
-
-def test_symlink_receipt_path_fails_closed(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt_path, _ = write_receipt(fixture)
-    symlink_path = fixture["root"] / "receipt-link.json"
-    symlink_path.symlink_to(fixture["root"] / receipt_path)
-    metadata = live_proof_metadata("receipt-link.json")
-    kwargs = runtime_kwargs(fixture)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert result["result"] == "error"
-    assert "live_proof_receipt_path_symlink" in result["reason_codes"]
-
-
-def test_deterministic_live_proof_output(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt_path, _ = write_receipt(fixture)
-    kwargs = runtime_kwargs(fixture)
-    metadata = live_proof_metadata(receipt_path)
-    first = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    second = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    assert first == second
-    assert first["manifest"]["evidence_id"] == second["manifest"]["evidence_id"]
-
-
-def test_non_live_proof_classes_remain_backward_compatible(
-    tmp_path: Path,
-) -> None:
-    """Existing non-live proof classes continue to work unchanged."""
-    fixture = make_fixture(tmp_path)
-    result = collect(fixture, machine_id="developer-laptop")
-    assert result["result"] == "pass"
-    assert result["manifest"]["proof_class"] == "CURRENT_TEST_PROOF"
-    assert result["manifest"]["execution_outcome"] == "PASS"
-
-
-def test_live_proof_receipt_not_mutated(tmp_path: Path) -> None:
-    fixture = make_fixture(tmp_path)
-    receipt_path, receipt = write_receipt(fixture)
-    receipt_file = fixture["root"] / receipt_path
-    before = receipt_file.read_bytes()
-    kwargs = runtime_kwargs(fixture)
-    metadata = live_proof_metadata(receipt_path)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    after = receipt_file.read_bytes()
-    assert result["result"] in ("pass", "ineligible")
-    assert result["manifest"] is not None
-    assert before == after
-
-
-def test_pass_receipt_cannot_upgrade_provisional_authority(
-    tmp_path: Path,
-) -> None:
-    """A PASS receipt with CANONICAL authority but non-canonical machine must be rejected."""
-    fixture = make_fixture(tmp_path)
-    # Receipt claims CANONICAL, but machine ID is not vaultnode
-    receipt_path, _ = write_receipt(
-        fixture,
-        authority_status="CANONICAL",
-        machine_overrides={
-            "machine_id": "not-vaultnode",
-            "machine_role": "provisional_development_host",
-        },
-    )
-    metadata = live_proof_metadata(receipt_path)
-    kwargs = runtime_kwargs(fixture)
-    result = generate_manifest(
-        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
-    )
-    # Machine identity must also match — the machine_id in receipt is "not-vaultnode"
-    # but the producer observes "test-machine" from defaults → machine mismatch
-    assert result["result"] == "error"
-    assert "live_proof_machine_identity_mismatch" in result["reason_codes"]
 
 
 def test_cli_is_stdout_first_and_uses_stable_json(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Reverts the implementation merged by PR #622 while preserving the later Project Pulse documentation and proof fixture merged by PR #623.

## Why

PR #622 merged despite a failed Guardian CI run and an architecture review disposition of changes required. Two fail-closed defects remained unresolved:

- `CURRENT_LIVE_PROOF` metadata could disable fresh runtime comparison.
- A receipt ID could appear across conflicting relationship buckets without emitting `live_proof_relationship_invalid`.

This rollback restores the six files touched by #622 to their pre-#622 state, except that `docs/architecture/00-current-state.md` retains the unrelated #623 Project Pulse entry.

## Scope

- Restore the pre-#622 canonical evidence contract.
- Restore the pre-#622 live-proof receipt contract.
- Restore the pre-#622 collector and manifest producer behavior.
- Restore the pre-#622 focused test suite.
- Remove only the #622 release-truth bullet from `00-current-state.md`.
- Preserve PR #623 and all unrelated later work.

## Validation

- Branch is one commit ahead of current `main` and zero commits behind.
- Diff is limited to the six files changed by PR #622.
- `00-current-state.md` preserves the later Project Pulse exact-ID fixture entry.
- CI and review should complete before merge.

Reverts #622.