### PR TITLE
feat: add campaign control-plane dry run

### DIFF
--- a/.github/workflows/campaign-control-plane.yml
+++ b/.github/workflows/campaign-control-plane.yml
@@ -1,0 +1,74 @@
+name: Campaign Control Plane Dry Run
+
+on:
+  issues:
+    types: [labeled, unlabeled, edited, reopened]
+  pull_request:
+    types: [opened, edited, synchronize, ready_for_review, converted_to_draft, closed]
+  pull_request_review:
+    types: [submitted, dismissed]
+  workflow_run:
+    workflows: [Guardian CI]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Optional issue number to evaluate
+        required: false
+        type: string
+      pr_number:
+        description: Optional pull request number to evaluate
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  checks: read
+  statuses: read
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: campaign-control-plane-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.workflow_run.pull_requests[0].number || inputs.pr_number || inputs.issue_number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  evaluate:
+    name: Campaign Control Plane Dry Run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout bounded evaluator source
+        uses: actions/checkout@v4
+        with:
+          # Same-repository PRs may validate their candidate evaluator under the
+          # explicitly read-only token. Fork PRs and non-PR events always use
+          # trusted default-branch code.
+          ref: ${{ (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.sha) || github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Evaluate campaign state
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python3 scripts/github/campaign_control_plane.py \
+            --event-path "$GITHUB_EVENT_PATH" \
+            --event-name "$GITHUB_EVENT_NAME" \
+            --event-action "${{ github.event.action || '' }}" \
+            --repository "$GITHUB_REPOSITORY" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --receipt-path "$RUNNER_TEMP/campaign-control-plane-receipt.json" \
+            --summary-path "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload dry-run receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: campaign-control-plane-receipt-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/campaign-control-plane-receipt.json
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/architecture/adr/049-event-driven-campaign-control-plane.md
+++ b/docs/architecture/adr/049-event-driven-campaign-control-plane.md
@@ -1,0 +1,26 @@
+# ADR-049: Event-Driven Campaign Control Plane
+
+## Status
+Accepted
+
+## Context
+Codexify needs a repository-native control-plane substrate that can validate approved issue packets, PR lineage, and merge eligibility without granting an LLM or webhook handler authority to mutate branches or merge code.
+
+## Decision
+1. GitHub-native events are the first control-plane substrate.
+2. Issues are planning and approval records; PRs are implementation and proof records.
+3. Deterministic checks and branch protection outrank model review.
+4. LLM review is advisory only.
+5. The initial control plane is dry-run only.
+6. `workflow_run` scoped to Guardian CI replaces broad `check_suite` handling to avoid recursive control-plane runs.
+7. Agent dispatch, external review invocation, merge enablement, and repository-setting mutation require separate tasks.
+8. A hosted webhook receiver remains deferred until GitHub-native limits are proven insufficient.
+
+## Consequences
+The repository gains an inspectable eligibility receipt and a bounded vocabulary without gaining autonomous execution or merge behavior. Human labels remain explicit authority evidence. Same-repository pull requests may validate candidate evaluator code under an explicitly read-only token with credentials disabled; fork and non-PR events use trusted default-branch code.
+
+## Rejected alternatives
+- `pull_request_target` with checkout of PR code: rejected because it can expose elevated tokens to untrusted code.
+- Automatic merge or auto-merge: rejected for this slice.
+- Comment-based receipts: rejected initially to avoid comment storms and write permissions.
+- Hosted webhook service: deferred as unnecessary infrastructure for the first slice.

--- a/docs/architecture/campaign-control-plane-contract.md
+++ b/docs/architecture/campaign-control-plane-contract.md
@@ -1,0 +1,48 @@
+# Campaign Control Plane Contract
+
+## Status
+Accepted first implementation slice: GitHub-native, deterministic, and dry-run only.
+
+## Authority model
+Human repository authority, branch protection, deterministic checks, and explicit merge-authority evidence outrank model review. Issues are planning and approval records. Pull requests are implementation and proof records. LLM review is advisory and cannot authorize merge.
+
+## Event substrate
+The first substrate is GitHub Actions. It reacts to bounded issue, pull-request, review, Guardian CI `workflow_run`, and manual diagnostic events. `workflow_run` is used instead of `check_suite` because a workflow that reacts to every completed check suite can trigger itself recursively.
+
+## States
+`ineligible`, `eligible_dry_run`, `blocked`, `invalid_packet`, and `missing_lineage`.
+
+## Issue packets
+Child issues must satisfy the Codexify Issue Template Contract and carry `ready-for-agent`. The evaluator parses structured headings, the parent campaign, lane, task kind, files, ownership line, validation, narrow staging and commit commands, closeout fields, board metadata, and source evidence.
+
+## PR lineage
+A PR must link exactly one approved child issue using a supported closing keyword or `Codexify-Child-Issue: #<number>` / `Implements-Issue: #<number>`. Title references do not establish lineage. A parent campaign is not an implementation issue.
+
+## Merge eligibility
+`eligible_dry_run` requires a valid approved child issue, a non-draft open PR, configured successful checks, no active requested-changes review, a branch not known to be behind, in-scope files, a passing privacy sentinel when requested, and the human-applied `merge-authorized` label.
+
+The evaluator never merges, enables auto-merge, updates branches, dismisses reviews, dispatches agents, deploys, or changes repository settings.
+
+## Permissions
+The workflow is read-only: `contents`, `issues`, `pull-requests`, `checks`, and `statuses` are read-only. Same-repository pull requests may check out their candidate head under that read-only token with credentials disabled; fork and non-PR events use trusted default-branch code. No untrusted pull-request code executes with elevated permissions.
+
+## Durable receipt
+Each run writes a JSON receipt to the workflow summary and uploads the same receipt as a native Actions artifact. A deterministic `receipt_key` identifies the logical target and a deterministic `decision_id` makes duplicate evaluations recognizable. Concurrency cancels obsolete in-progress runs. No issue or PR comments are created, so repeated events cannot create a comment storm.
+
+## Scope and privacy
+Scope validation compares changed paths with the child issue's explicit Files list. Privacy scanning is enabled only by the exact issue marker `Privacy sentinel: required`; when enabled, missing patches fail closed and bounded secret-like patterns block eligibility.
+
+## Threat model
+- Issue and PR bodies are untrusted data and never reach shell interpolation.
+- No `pull_request_target` is used.
+- Fork PRs receive no elevated execution path.
+- The workflow token is read-only.
+- Guardian CI completion is observed through `workflow_run` to avoid check-suite recursion.
+- Stale evaluations are bounded by target-scoped concurrency and deterministic decision IDs.
+- Model output is never merge authority.
+
+## Dry-run limitation
+This slice reports eligibility only. It does not dispatch agents, create branches, commit, push, open PRs, invoke external reviewers, mutate labels, merge, enable auto-merge, update branch protection, host a webhook receiver, or implement observability Slice 3.
+
+## Follow-on work
+Agent dispatch, external review invocation, repository mutation, merge enablement, and any hosted receiver require separate issues and architecture review.

--- a/scripts/github/campaign_control_plane.py
+++ b/scripts/github/campaign_control_plane.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""GitHub API adapter for the campaign control-plane dry run."""
+from __future__ import annotations
+import argparse, json, os, sys, urllib.error, urllib.request
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+from campaign_control_plane_core import *
+
+class ControlPlaneError(RuntimeError): pass
+class Client:
+    def __init__(self,repo:str,token:str,api:str): self.repo,self.token,self.api=repo,token,api.rstrip("/")
+    def get(self,path:str)->Any:
+        req=urllib.request.Request(self.api+path,headers={"Accept":"application/vnd.github+json","Authorization":"Bearer "+self.token,"X-GitHub-Api-Version":"2022-11-28","User-Agent":"codexify-campaign-control-plane/1"})
+        try:
+            with urllib.request.urlopen(req,timeout=20) as response: return json.load(response)
+        except (urllib.error.HTTPError,urllib.error.URLError,TimeoutError) as exc: raise ControlPlaneError(f"GitHub API GET failed for {path}: {exc}") from exc
+    def issue(self,n): return self.get(f"/repos/{self.repo}/issues/{n}")
+    def pr(self,n): return self.get(f"/repos/{self.repo}/pulls/{n}")
+    def reviews(self,n): return self.get(f"/repos/{self.repo}/pulls/{n}/reviews?per_page=100")
+    def files(self,n): return self.get(f"/repos/{self.repo}/pulls/{n}/files?per_page=100")
+    def checks(self,sha):
+        out=list(self.get(f"/repos/{self.repo}/commits/{sha}/check-runs?per_page=100").get("check_runs",[]))
+        out += [{"name":x.get("context"),"status":"completed","conclusion":x.get("state")} for x in self.get(f"/repos/{self.repo}/commits/{sha}/status").get("statuses",[])]
+        return out
+
+def packet(raw): return IssuePacket(int(raw.get("number") or 0),str(raw.get("body") or ""),labels(raw.get("labels")),str(raw.get("title") or ""))
+def target(event,payload):
+    if event=="issues": item=payload.get("issue"); return "issue",int(item.get("number")) if isinstance(item,Mapping) else None,item
+    if event in {"pull_request","pull_request_review"}: item=payload.get("pull_request"); return "pull_request",int(item.get("number")) if isinstance(item,Mapping) else None,item
+    if event=="workflow_run":
+        prs=(payload.get("workflow_run") or {}).get("pull_requests") or []; return ("pull_request",int(prs[0]["number"]),None) if prs else ("workflow_run",None,None)
+    if event=="workflow_dispatch":
+        inputs=payload.get("inputs") or {}
+        if inputs.get("pr_number"): return "pull_request",int(inputs["pr_number"]),None
+        if inputs.get("issue_number"): return "issue",int(inputs["issue_number"]),None
+    return "unknown",None,None
+
+def evaluate_event(event,action,repository,payload,token,api):
+    kind,number,embedded=target(event,payload); client=Client(repository,token,api)
+    if kind=="issue" and number:
+        raw=embedded or client.issue(number); result=evaluate_issue(packet(raw)); return result,{"issue_updated_at":raw.get("updated_at"),"approval_label":APPROVAL_LABEL,"packet_errors":list(result.issue_validation.errors if result.issue_validation else ())},kind,number
+    if kind=="pull_request" and number:
+        raw=client.pr(number); refs=parse_linked_issue_numbers(str(raw.get("body") or "")); issues=[packet(client.issue(n)) for n in refs]
+        sha=str((raw.get("head") or {}).get("sha") or ""); checks=client.checks(sha) if sha else []; reviews,files=client.reviews(number),client.files(number)
+        result=evaluate_pr(pr=raw,referenced_issues=issues,checks=checks,reviews=reviews,changed_files=files)
+        evidence={"pr_updated_at":raw.get("updated_at"),"head_sha":sha,"referenced_issue_numbers":list(refs),"required_checks":list(REQUIRED_CHECK_NAMES),"observed_check_names":sorted({str(x.get("name") or x.get("context") or "") for x in checks}),"changed_files":sorted(str(x.get("filename")) for x in files),"fork_pr":bool((raw.get("head") or {}).get("repo",{}).get("fork")),"event_source":event}
+        return result,evidence,kind,number
+    return Evaluation("blocked",("unsupported_event",),(f"event:{event}:{action}",),None,None,None),{"event_source":event},kind,number
+
+def summary(receipt):
+    t=receipt.get("target") or {}; blockers=receipt.get("blocker_codes") or []
+    return "\n".join(["# Campaign Control Plane Dry Run","",f"- **State:** `{receipt.get('state')}`","- **Dry run:** `true`",f"- **Target:** `{t.get('kind')} #{t.get('number')}`",f"- **Linked child issue:** `{receipt.get('linked_child_issue')}`",f"- **Parent campaign:** `{receipt.get('parent_campaign_issue')}`",f"- **Blockers:** {', '.join('`'+x+'`' for x in blockers) if blockers else 'None'}",f"- **Decision ID:** `{receipt.get('decision_id')}`",f"- **Receipt key:** `{receipt.get('receipt_key')}`","","No merge, auto-merge, branch update, agent dispatch, deployment, or repository-setting mutation was performed.","","```json",json.dumps(receipt,indent=2,sort_keys=True),"```",""])
+
+def valid_body():
+    return '''Parent campaign: #625
+## Workflow lane
+`architecture-impact`
+## Task kind
+`implementation`
+## Context
+Bounded.
+## Goal
+Bounded.
+## Files
+- scripts/github/campaign_control_plane.py
+## Ownership
+This change belongs in scripts/github/campaign_control_plane.py
+## Acceptance criteria
+- Deterministic.
+## Non-goals
+- No merge.
+## Validation
+- pytest -q
+## Git commands
+`git add scripts/github/campaign_control_plane.py`
+`git commit -m "feat: add dry run"`
+## Expected closeout
+- Summary of changes
+- Files changed
+- Git commit hash
+- What Axis should add to his KB
+## Board metadata
+- Lane: architecture-impact
+## Source evidence
+- docs/example.md
+'''
+def self_test():
+    issue=IssuePacket(626,valid_body(),(APPROVAL_LABEL,)); assert evaluate_issue(issue).state=="eligible_dry_run"
+    checks=[{"name":n,"status":"completed","conclusion":"success"} for n in REQUIRED_CHECK_NAMES]; pr={"body":"Closes #626","draft":False,"state":"open","mergeable_state":"clean","labels":[{"name":MERGE_AUTHORITY_LABEL}]}
+    assert evaluate_pr(pr=pr,referenced_issues=[issue],checks=checks,reviews=[],changed_files=[{"filename":"scripts/github/campaign_control_plane.py","patch":"+safe"}]).state=="eligible_dry_run"; print("campaign control-plane self-test passed")
+def main(argv:Sequence[str]|None=None)->int:
+    p=argparse.ArgumentParser(description=__doc__); p.add_argument("--self-test",action="store_true"); p.add_argument("--event-path"); p.add_argument("--event-name",default=os.getenv("GITHUB_EVENT_NAME","workflow_dispatch")); p.add_argument("--event-action",default=""); p.add_argument("--repository",default=os.getenv("GITHUB_REPOSITORY","")); p.add_argument("--run-id",default=os.getenv("GITHUB_RUN_ID","local")); p.add_argument("--run-attempt",default=os.getenv("GITHUB_RUN_ATTEMPT","1")); p.add_argument("--api-url",default=os.getenv("GITHUB_API_URL","https://api.github.com")); p.add_argument("--receipt-path"); p.add_argument("--summary-path",default=os.getenv("GITHUB_STEP_SUMMARY")); args=p.parse_args(argv)
+    if args.self_test: self_test(); return 0
+    if not args.event_path or not args.repository: p.error("--event-path and --repository are required outside --self-test")
+    payload=json.loads(Path(args.event_path).read_text()); action=args.event_action or str(payload.get("action") or "")
+    try:
+        token=os.getenv("GITHUB_TOKEN","")
+        if not token: raise ControlPlaneError("GITHUB_TOKEN is required for event evaluation")
+        evaluation,evidence,kind,number=evaluate_event(args.event_name,action,args.repository,payload,token,args.api_url)
+    except ControlPlaneError as exc:
+        evaluation=Evaluation("blocked",("api_error",),(str(exc)[:240],),None,None,None); evidence={"event_source":args.event_name,"api_error":True}; kind,number,_=target(args.event_name,payload)
+    receipt=build_receipt(event_name=args.event_name,event_action=action,repository=args.repository,workflow_run_id=args.run_id,workflow_run_attempt=args.run_attempt,target_kind=kind,target_number=number,evaluation=evaluation,evidence=evidence); text=json.dumps(receipt,indent=2,sort_keys=True)+"\n"
+    Path(args.receipt_path).write_text(text) if args.receipt_path else sys.stdout.write(text)
+    if args.summary_path:
+        with Path(args.summary_path).open("a") as handle: handle.write(summary(receipt))
+    return 0
+if __name__=="__main__": raise SystemExit(main())

--- a/scripts/github/campaign_control_plane_core.py
+++ b/scripts/github/campaign_control_plane_core.py
@@ -63,8 +63,9 @@ def file_specs(body: str) -> tuple[str,...]:
     out=[]
     for raw in section(sections(body),"files").splitlines():
         if not raw.strip().startswith("-"): continue
-        value=raw.strip()[1:].strip().strip("`")
+        value=raw.strip()[1:].strip()
         if value.endswith("(new)"): value=value[:-5].strip()
+        value=value.strip("`")
         value=value.replace("<next-number>","*").replace("<actual-number>","*")
         if value and not value.lower().startswith("report every"): out.append(value)
     return tuple(dict.fromkeys(out))

--- a/scripts/github/campaign_control_plane_core.py
+++ b/scripts/github/campaign_control_plane_core.py
@@ -1,0 +1,171 @@
+"""Pure evaluator for the Codexify campaign control-plane dry run."""
+from __future__ import annotations
+import datetime as dt, fnmatch, hashlib, json, re
+from dataclasses import asdict, dataclass, is_dataclass
+from typing import Any, Mapping, Sequence
+
+SCHEMA_VERSION = "campaign_control_plane_receipt.v1"
+APPROVAL_LABEL = "ready-for-agent"
+MERGE_AUTHORITY_LABEL = "merge-authorized"
+PRIVACY_REQUIRED_MARKER = "privacy sentinel: required"
+STATES = frozenset({"ineligible", "eligible_dry_run", "blocked", "invalid_packet", "missing_lineage"})
+BLOCKER_CODES = frozenset({"issue_not_approved", "issue_packet_invalid", "pr_not_linked_to_issue", "pr_is_draft", "pr_is_closed", "required_checks_missing", "required_checks_failing", "requested_changes_present", "branch_out_of_date", "scope_validation_failed", "privacy_sentinel_failed", "merge_authority_missing", "unsupported_event", "api_error"})
+ALLOWED_LANES = frozenset({"standard", "architecture-impact", "proof", "docs", "marketing", "board-hygiene"})
+REQUIRED_SECTIONS = ("context", "goal", "files", "acceptance criteria", "non-goals", "validation", "expected closeout", "board metadata", "source evidence")
+REQUIRED_CHECK_NAMES = ("Detect Changed Areas", "Backend Tests (Python 3.11)", "alembic-config-sanity", "Frontend Quality", "Migration Contract (Container)")
+SUCCESS_CONCLUSIONS = frozenset({"success", "neutral", "skipped"})
+SECRET_PATTERNS = (re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"), re.compile(r"(?i)\b(?:api[_-]?key|secret|password|token)\s*[:=]\s*['\"][^'\"]{8,}['\"]"), re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"), re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"))
+HEAD_RE = re.compile(r"^#{1,6}\s+(.+?)\s*$", re.M)
+PARENT_RE = re.compile(r"(?im)^\s*Parent campaign:\s*#(\d+)\s*$")
+LANE_RE = re.compile(r"(?im)^\s*(?:Workflow lane|Lane):\s*`?([a-z-]+)`?\s*$")
+TASK_RE = re.compile(r"(?im)^\s*Task kind:\s*`?([a-z-]+)`?\s*$")
+OWN_RE = re.compile(r"(?im)^\s*This change belongs in\s+(.+?)\s*$")
+ADD_RE = re.compile(r"(?im)`?git add\s+[^\n`]+`?")
+COMMIT_RE = re.compile(r"(?im)`?git commit\s+-m\s+['\"][^'\"]+['\"]`?")
+CLOSE_RE = re.compile(r"(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:[\w.-]+/[\w.-]+)?#(\d+)")
+MARKER_RE = re.compile(r"(?im)^\s*(?:Codexify-Child-Issue|Implements-Issue):\s*#(\d+)\s*$")
+
+@dataclass(frozen=True)
+class IssuePacket:
+    number: int; body: str; labels: tuple[str, ...]; title: str = ""
+@dataclass(frozen=True)
+class IssueValidation:
+    valid: bool; approved: bool; errors: tuple[str, ...]; parent_campaign: int | None
+    workflow_lane: str | None; task_kind: str | None; allowed_files: tuple[str, ...]; privacy_required: bool
+@dataclass(frozen=True)
+class Evaluation:
+    state: str; blockers: tuple[str, ...]; details: tuple[str, ...]; linked_child_issue: int | None
+    parent_campaign_issue: int | None; issue_validation: IssueValidation | None
+
+def labels(items: Any) -> tuple[str, ...]:
+    out=[]
+    for item in items or ():
+        name=item if isinstance(item,str) else item.get("name") if isinstance(item,Mapping) else None
+        if isinstance(name,str): out.append(name)
+    return tuple(sorted(set(out)))
+
+def sections(body: str) -> dict[str,str]:
+    hits=list(HEAD_RE.finditer(body or "")); out={}
+    for i,hit in enumerate(hits):
+        name=re.sub(r"\s+"," ",re.sub(r"[`*_]","",hit.group(1)).strip().lower()).rstrip(":")
+        end=hits[i+1].start() if i+1<len(hits) else len(body); out[name]=body[hit.end():end].strip()
+    return out
+
+def section(parts: Mapping[str,str], name: str) -> str:
+    name=name.lower(); return next((v for k,v in parts.items() if k==name or k.startswith(name+" ") or name in k),"")
+
+def field(body: str, parts: Mapping[str,str], inline: re.Pattern[str], heading: str) -> str | None:
+    match=inline.search(body)
+    if match: return match.group(1).lower()
+    value=section(parts,heading).strip(); return value.splitlines()[0].strip("` ").lower() if value else None
+
+def file_specs(body: str) -> tuple[str,...]:
+    out=[]
+    for raw in section(sections(body),"files").splitlines():
+        if not raw.strip().startswith("-"): continue
+        value=raw.strip()[1:].strip().strip("`")
+        if value.endswith("(new)"): value=value[:-5].strip()
+        value=value.replace("<next-number>","*").replace("<actual-number>","*")
+        if value and not value.lower().startswith("report every"): out.append(value)
+    return tuple(dict.fromkeys(out))
+
+def validate_issue_packet(issue: IssuePacket) -> IssueValidation:
+    body=issue.body or ""; parts=sections(body); errors=[]
+    found=PARENT_RE.search(body); parent=int(found.group(1)) if found else None
+    if parent is None: errors.append("missing_parent_campaign")
+    lane=field(body,parts,LANE_RE,"workflow lane")
+    if lane not in ALLOWED_LANES: errors.append("missing_or_invalid_workflow_lane")
+    task=field(body,parts,TASK_RE,"task kind")
+    if not task: errors.append("missing_task_kind")
+    for name in REQUIRED_SECTIONS:
+        if not section(parts,name): errors.append("missing_section:"+name)
+    if not OWN_RE.search(body): errors.append("missing_ownership_line")
+    files=file_specs(body)
+    if not files: errors.append("missing_explicit_files")
+    if not ADD_RE.search(body): errors.append("missing_narrow_git_add")
+    if not COMMIT_RE.search(body): errors.append("missing_git_commit")
+    closeout=section(parts,"expected closeout").lower()
+    for item in ("summary of changes","files changed","git commit hash","what axis should add"):
+        if item not in closeout: errors.append("missing_closeout_field:"+item.replace(" ","_"))
+    return IssueValidation(not errors,APPROVAL_LABEL in issue.labels,tuple(sorted(set(errors))),parent,lane,task,files,PRIVACY_REQUIRED_MARKER in body.lower())
+
+def parse_linked_issue_numbers(body: str) -> tuple[int,...]:
+    return tuple(sorted({*(int(x) for x in CLOSE_RE.findall(body or "")),*(int(x) for x in MARKER_RE.findall(body or ""))}))
+
+def allowed(path: str, specs: Sequence[str]) -> bool:
+    path=path.lstrip("./")
+    for raw in specs:
+        spec=raw.lstrip("./")
+        if (spec.endswith("/") and path.startswith(spec)) or path==spec or (any(c in spec for c in "*?[") and fnmatch.fnmatch(path,spec)): return True
+    return False
+
+def validate_scope(files: Sequence[Mapping[str,Any]], specs: Sequence[str]):
+    bad=tuple(sorted(str(f["filename"]) for f in files if f.get("filename") and not allowed(str(f["filename"]),specs))); return not bad,bad
+
+def validate_privacy(files: Sequence[Mapping[str,Any]], required: bool):
+    if not required: return True,()
+    findings=[]
+    for item in files:
+        path,patch=str(item.get("filename","")),item.get("patch")
+        if patch is None: findings.append("unscannable:"+path)
+        elif any(p.search(str(patch)) for p in SECRET_PATTERNS): findings.append("secret_pattern:"+path)
+    return not findings,tuple(sorted(findings))
+
+def active_requested_changes(reviews: Sequence[Mapping[str,Any]]) -> bool:
+    latest={}
+    for item in reviews:
+        user=item.get("user") or {}; login=str(user.get("login") or item.get("user_login") or "")
+        if not login: continue
+        candidate=(str(item.get("submitted_at") or ""),int(item.get("id") or 0),str(item.get("state") or "").upper())
+        if login not in latest or candidate[:2]>=latest[login][:2]: latest[login]=candidate
+    return any(x[2]=="CHANGES_REQUESTED" for x in latest.values())
+
+def evaluate_checks(checks: Sequence[Mapping[str,Any]], required: Sequence[str]=REQUIRED_CHECK_NAMES):
+    by_name={str(x.get("name") or x.get("context") or ""):x for x in checks}; missing=tuple(x for x in required if x not in by_name); failing=[]
+    for name in required:
+        item=by_name.get(name)
+        if not item: continue
+        if str(item.get("status") or "completed").lower()!="completed" or str(item.get("conclusion") or item.get("state") or "").lower() not in SUCCESS_CONCLUSIONS: failing.append(name)
+    return missing,tuple(failing)
+
+def evaluate_issue(issue: IssuePacket) -> Evaluation:
+    v=validate_issue_packet(issue)
+    if not v.valid: return Evaluation("invalid_packet",("issue_packet_invalid",),v.errors,issue.number,v.parent_campaign,v)
+    if not v.approved: return Evaluation("ineligible",("issue_not_approved",),("missing_label:"+APPROVAL_LABEL,),issue.number,v.parent_campaign,v)
+    return Evaluation("eligible_dry_run",(),(),issue.number,v.parent_campaign,v)
+
+def evaluate_pr(*,pr:Mapping[str,Any],referenced_issues:Sequence[IssuePacket],checks:Sequence[Mapping[str,Any]],reviews:Sequence[Mapping[str,Any]],changed_files:Sequence[Mapping[str,Any]],required_checks:Sequence[str]=REQUIRED_CHECK_NAMES)->Evaluation:
+    refs=set(parse_linked_issue_numbers(str(pr.get("body") or ""))); by={x.number:x for x in referenced_issues}; candidates=[]
+    for n in sorted(refs):
+        if n in by:
+            v=validate_issue_packet(by[n])
+            if v.parent_campaign is not None: candidates.append((by[n],v))
+    if len(candidates)!=1: return Evaluation("missing_lineage",("pr_not_linked_to_issue",),(f"linked_child_count:{len(candidates)}",),None,None,None)
+    child,v=candidates[0]
+    if not v.valid: return Evaluation("invalid_packet",("issue_packet_invalid",),v.errors,child.number,v.parent_campaign,v)
+    blockers=[]; details=[]
+    if not v.approved: blockers.append("issue_not_approved"); details.append("missing_label:"+APPROVAL_LABEL)
+    if pr.get("draft"): blockers.append("pr_is_draft")
+    if str(pr.get("state") or "open").lower()!="open": blockers.append("pr_is_closed")
+    missing,failing=evaluate_checks(checks,required_checks)
+    if missing: blockers.append("required_checks_missing"); details += ["missing_check:"+x for x in missing]
+    if failing: blockers.append("required_checks_failing"); details += ["failing_check:"+x for x in failing]
+    if active_requested_changes(reviews): blockers.append("requested_changes_present")
+    if str(pr.get("mergeable_state") or pr.get("branch_state") or "unknown").lower()=="behind": blockers.append("branch_out_of_date")
+    ok,bad=validate_scope(changed_files,v.allowed_files)
+    if not ok: blockers.append("scope_validation_failed"); details += ["unexpected_file:"+x for x in bad]
+    ok,findings=validate_privacy(changed_files,v.privacy_required)
+    if not ok: blockers.append("privacy_sentinel_failed"); details += list(findings)
+    if MERGE_AUTHORITY_LABEL not in labels(pr.get("labels")): blockers.append("merge_authority_missing"); details.append("missing_label:"+MERGE_AUTHORITY_LABEL)
+    blockers=tuple(sorted(set(blockers))); return Evaluation("blocked" if blockers else "eligible_dry_run",blockers,tuple(sorted(set(details))),child.number,v.parent_campaign,v)
+
+def normal(value: Any) -> Any:
+    if is_dataclass(value): return normal(asdict(value))
+    if isinstance(value,Mapping): return {str(k):normal(v) for k,v in sorted(value.items())}
+    if isinstance(value,(list,tuple,set,frozenset)): return [normal(x) for x in value]
+    return value
+
+def build_receipt(*,event_name:str,event_action:str,repository:str,workflow_run_id:str,workflow_run_attempt:str,target_kind:str,target_number:int|None,evaluation:Evaluation,evidence:Mapping[str,Any])->dict[str,Any]:
+    stable={"event_name":event_name,"event_action":event_action,"repository":repository,"target_kind":target_kind,"target_number":target_number,"evaluation":normal(evaluation),"evidence":normal(evidence)}
+    decision="sha256:"+hashlib.sha256(json.dumps(stable,sort_keys=True,separators=(",",":")).encode()).hexdigest()
+    return {"schema_version":SCHEMA_VERSION,"receipt_key":f"campaign-control-plane:{repository}:{target_kind}:{target_number or 'unknown'}","decision_id":decision,"dry_run":True,"event":{"name":event_name,"action":event_action},"repository":repository,"target":{"kind":target_kind,"number":target_number},"workflow":{"run_id":workflow_run_id,"run_attempt":workflow_run_attempt},"evaluated_at":dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00","Z"),"state":evaluation.state,"blocker_codes":list(evaluation.blockers),"details":list(evaluation.details),"linked_child_issue":evaluation.linked_child_issue,"parent_campaign_issue":evaluation.parent_campaign_issue,"evidence":normal(evidence),"authority":{"model_review_advisory_only":True,"merge_api_called":False,"auto_merge_enabled":False,"branch_updated":False,"repository_settings_mutated":False}}

--- a/tests/scripts/test_campaign_control_plane.py
+++ b/tests/scripts/test_campaign_control_plane.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).parents[2] / "scripts" / "github" / "campaign_control_plane_core.py"
+spec = importlib.util.spec_from_file_location("campaign_control_plane", MODULE_PATH)
+assert spec and spec.loader
+m = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = m
+spec.loader.exec_module(m)
+
+
+def body(*, ownership=True, approved=True, privacy=False):
+    own = "This change belongs in scripts/github/campaign_control_plane.py" if ownership else ""
+    priv = "\nPrivacy sentinel: required" if privacy else ""
+    return f"""Parent campaign: #625
+## Workflow lane
+`architecture-impact`
+## Task kind
+`implementation`
+## Context
+Context.{priv}
+## Goal
+Goal.
+## Files
+- scripts/github/campaign_control_plane.py
+## Ownership
+{own}
+## Acceptance criteria
+- Done.
+## Non-goals
+- No merge.
+## Validation
+- pytest -q
+## Git commands
+`git add scripts/github/campaign_control_plane.py`
+`git commit -m \"feat: dry run\"`
+## Expected closeout
+- Summary of changes
+- Files changed
+- Git commit hash
+- What Axis should add to his KB
+## Board metadata
+- Lane: architecture-impact
+## Source evidence
+- docs/example.md
+"""
+
+
+def issue(labels=(m.APPROVAL_LABEL,), text=None, number=626):
+    return m.IssuePacket(number, text or body(), labels)
+
+
+def checks(conclusion="success"):
+    return [{"name": n, "status": "completed", "conclusion": conclusion} for n in m.REQUIRED_CHECK_NAMES]
+
+
+def pr(**overrides):
+    value = {"body": "Closes #626", "draft": False, "state": "open", "mergeable_state": "clean", "labels": [{"name": m.MERGE_AUTHORITY_LABEL}]}
+    value.update(overrides)
+    return value
+
+
+def evaluate(**kwargs):
+    defaults = dict(pr=pr(), referenced_issues=[issue()], checks=checks(), reviews=[], changed_files=[{"filename": "scripts/github/campaign_control_plane.py", "patch": "+safe"}])
+    defaults.update(kwargs)
+    return m.evaluate_pr(**defaults)
+
+
+def test_valid_approved_issue_packet(): assert m.evaluate_issue(issue()).state == "eligible_dry_run"
+def test_missing_required_section(): assert "issue_packet_invalid" in m.evaluate_issue(issue(text=body().replace("Goal.", ""))).blockers
+def test_missing_ownership_line(): assert "issue_packet_invalid" in m.evaluate_issue(issue(text=body(ownership=False))).blockers
+def test_unapproved_issue(): assert m.evaluate_issue(issue(labels=())).blockers == ("issue_not_approved",)
+def test_correctly_linked_pr(): assert evaluate().state == "eligible_dry_run"
+def test_parent_only_link_is_missing_lineage():
+    campaign = m.IssuePacket(625, "## Goal\nParent campaign record", ())
+    assert m.evaluate_pr(pr=pr(body="Closes #625"), referenced_issues=[campaign], checks=checks(), reviews=[], changed_files=[]).state == "missing_lineage"
+def test_draft_pr(): assert "pr_is_draft" in evaluate(pr=pr(draft=True)).blockers
+def test_missing_required_check(): assert "required_checks_missing" in evaluate(checks=checks()[:-1]).blockers
+def test_failing_required_check(): assert "required_checks_failing" in evaluate(checks=checks("failure")).blockers
+def test_requested_changes(): assert "requested_changes_present" in evaluate(reviews=[{"id": 1, "state": "CHANGES_REQUESTED", "user": {"login": "reviewer"}, "submitted_at": "2026-01-01T00:00:00Z"}]).blockers
+def test_later_approval_clears_requested_changes(): assert "requested_changes_present" not in evaluate(reviews=[{"id": 1, "state": "CHANGES_REQUESTED", "user": {"login": "r"}, "submitted_at": "2026-01-01T00:00:00Z"}, {"id": 2, "state": "APPROVED", "user": {"login": "r"}, "submitted_at": "2026-01-02T00:00:00Z"}]).blockers
+def test_branch_out_of_date(): assert "branch_out_of_date" in evaluate(pr=pr(mergeable_state="behind")).blockers
+def test_scope_failure(): assert "scope_validation_failed" in evaluate(changed_files=[{"filename": "unrelated.txt", "patch": "+x"}]).blockers
+def test_privacy_failure(): assert "privacy_sentinel_failed" in evaluate(referenced_issues=[issue(text=body(privacy=True))], changed_files=[{"filename": "scripts/github/campaign_control_plane.py", "patch": '+ API_KEY="supersecretvalue"'}]).blockers
+def test_missing_merge_authority(): assert "merge_authority_missing" in evaluate(pr=pr(labels=[])).blockers
+def test_fully_eligible_dry_run(): assert evaluate().blockers == ()
+def test_duplicate_event_decision_id_is_stable():
+    ev = evaluate(); args = dict(event_name="pull_request", event_action="synchronize", repository="o/r", workflow_run_id="1", workflow_run_attempt="1", target_kind="pull_request", target_number=7, evaluation=ev, evidence={"head_sha":"abc"})
+    assert m.build_receipt(**args)["decision_id"] == m.build_receipt(**{**args, "workflow_run_id":"2"})["decision_id"]
+def test_untrusted_issue_content_not_executed():
+    text = body().replace("Context.", "Context. $(touch /tmp/pwned) `rm -rf /`")
+    assert m.validate_issue_packet(issue(text=text)).valid
+    assert not Path("/tmp/pwned").exists()
+def test_fork_pr_has_no_special_authority():
+    result = evaluate(pr=pr(head={"repo":{"fork":True}}))
+    assert result.state == "eligible_dry_run"
+def test_title_issue_number_does_not_create_lineage():
+    result = m.evaluate_pr(pr={**pr(body=""), "title":"Fix #626"}, referenced_issues=[issue()], checks=checks(), reviews=[], changed_files=[])
+    assert result.state == "missing_lineage"
+def test_multiple_child_links_are_rejected():
+    result = m.evaluate_pr(pr=pr(body="Closes #626\nCloses #627"), referenced_issues=[issue(number=626), issue(number=627)], checks=checks(), reviews=[], changed_files=[])
+    assert result.state == "missing_lineage"
+
+
+def test_workflow_has_no_elevated_permissions_or_pull_request_target():
+    workflow = (Path(__file__).parents[2] / ".github" / "workflows" / "campaign-control-plane.yml").read_text()
+    assert "pull_request_target" not in workflow
+    assert "contents: write" not in workflow
+    assert "pull-requests: write" not in workflow
+    assert "id-token: write" not in workflow
+    assert "persist-credentials: false" in workflow
+
+
+def test_fork_checkout_falls_back_to_default_branch_expression():
+    workflow = (Path(__file__).parents[2] / ".github" / "workflows" / "campaign-control-plane.yml").read_text()
+    assert "github.event.pull_request.head.repo.full_name == github.repository" in workflow
+    assert "github.event.repository.default_branch" in workflow
+
+
+def test_heading_style_lane_and_task_kind_are_accepted():
+    validation = m.validate_issue_packet(issue())
+    assert validation.workflow_lane == "architecture-impact"
+    assert validation.task_kind == "implementation"
+    assert validation.valid

--- a/tests/scripts/test_campaign_control_plane.py
+++ b/tests/scripts/test_campaign_control_plane.py
@@ -125,3 +125,13 @@ def test_heading_style_lane_and_task_kind_are_accepted():
     assert validation.workflow_lane == "architecture-impact"
     assert validation.task_kind == "implementation"
     assert validation.valid
+
+
+def test_new_file_marker_is_removed_before_markdown_backticks():
+    text = body().replace(
+        "- scripts/github/campaign_control_plane.py",
+        "- `scripts/github/campaign_control_plane.py` (new)",
+    )
+    validation = m.validate_issue_packet(issue(text=text))
+    assert validation.allowed_files == ("scripts/github/campaign_control_plane.py",)
+    assert validation.valid


### PR DESCRIPTION
## Summary

Implements-Issue: #626

This draft adds a bounded GitHub-native campaign control-plane dry run.

It evaluates issue packets, PR lineage, checks, reviews, branch state, file scope, privacy markers, and explicit merge-authority evidence. It does **not** dispatch agents, merge, enable auto-merge, update branches, mutate labels, alter repository settings, deploy, or invoke models.

## Files

- `.github/workflows/campaign-control-plane.yml`
- `scripts/github/campaign_control_plane.py`
- `scripts/github/campaign_control_plane_core.py`
- `tests/scripts/test_campaign_control_plane.py`
- `docs/architecture/campaign-control-plane-contract.md`
- `docs/architecture/adr/049-event-driven-campaign-control-plane.md`

The separate pure-evaluator helper is a candidate implementation detail, not presumed accepted scope. It must either receive explicit architecture acceptance under the issue discovery boundary or be inlined before completion.

## Implemented boundaries

- Canonical states and blocker codes live in one deterministic registry.
- `ready-for-agent` is evaluated as child-issue approval evidence.
- `merge-authorized` is evaluated as explicit human merge-authority evidence, but is never created or mutated here.
- PR lineage requires exactly one child issue through a supported closing keyword or canonical marker; title references do not count.
- Guardian CI completion is observed through `workflow_run`, avoiding recursive `check_suite` handling.
- Workflow permissions are read-only.
- Same-repository PRs may validate candidate evaluator code under an explicitly read-only token with checkout credentials disabled; fork and non-PR events use trusted default-branch code.
- Receipts are written to the workflow summary and uploaded as bounded artifacts. No comments are posted.

## Local validation

- `pytest -q tests/scripts/test_campaign_control_plane.py` — **25 passed** after adding the marked-`(new)` path regression
- `python3 scripts/github/campaign_control_plane.py --self-test` — passed
- Python compilation — passed
- workflow YAML parse — passed
- security sentinel for `pull_request_target`, write permissions, auto-merge, and branch-update tokens — no matches

## Live dry-run receipts

- Run #1 correctly reported missing lineage from noncanonical PR prose.
- Run #2 resolved lineage after adding `Implements-Issue: #626` and exposed a marked-new-file path normalization defect.
- The defect is corrected with a focused regression test; the next receipt is expected to retain only genuine governance and scope blockers.

## Delegation receipt

The two required Pi/DeepSeek advisory passes did **not** occur in this environment.

- Mode attempted: preflight for read-only analysis/review
- Selected model: none
- Exit status: 1
- Result: `ERROR: pi is not installed or not on PATH`
- External-provider acknowledgment: absent and was not set by Codex
- Preserved local receipts: `/mnt/data/codexify-626/delegation/preflight.txt` and `/mnt/data/codexify-626/delegation/post-review-preflight.txt`

Codex continued with deterministic tests and direct repository-grounded review as permitted by the issue failure policy. No DeepSeek opinion is claimed.

## Pending before architecture completion

- Resolve whether the pure evaluator helper is accepted scope or must be inlined.
- Add surgical links to `docs/architecture/README.md` and `docs/architecture/adr/adr-index.md`.
- Run repository-wide `make docs`, `git diff --check`, and exact worktree status/name checks in a full checkout.
- Complete architecture and security review.

`docs/architecture/00-current-state.md` is unchanged.