### PR TITLE
Reconcile Anthropic export profiler

### DIFF
--- a/docs/architecture/anthropic-export-profiler.md
+++ b/docs/architecture/anthropic-export-profiler.md
@@ -1,0 +1,200 @@
+# Anthropic Export Profiler
+
+> Classification: architecture tooling (read-only evidence)
+> Status: normative for the profiler surface; does not widen release support
+> Governing contract: `docs/architecture/account-export-restore-contract.md`
+> ADR impact: none
+
+## Purpose and evidence boundary
+
+`scripts/anthropic_import/profile_anthropic_export.py` is a standalone,
+read-only CLI that inspects a real Anthropic account export and emits a
+deterministic **structural evidence report**. It is fixture archaeology: it
+answers, from observed evidence, what Anthropic actually placed in the export.
+
+The profiler describes schema **shape only**. It never imports data, never
+mutates the source package, never extracts ZIP members to disk, and never
+writes to any Codexify runtime store (Postgres, Redis, Chroma, Neo4j, media
+storage, Guardian state, or any service). It imports only the Python standard
+library and does not invoke the existing Claude or OpenAI importer paths.
+
+Profiler output is **observed evidence, not an Anthropic schema contract**. It
+does not import data and does not widen Codexify's supported release promise.
+Durable Anthropic account import remains explicitly deferred.
+
+## Why the profiler exists before the importer
+
+Codexify does not possess a normative Anthropic personal-export schema, and
+Anthropic full-account ZIP import is not a supported runtime path. Building an
+importer blind would force guesses about undocumented structure. The profiler
+lets an operator (or a future importer task) ground normalization decisions in
+observed structural evidence first: container key names, message shape, branch
+relationships, project/memory/account surfaces, and attachment/artifact hints.
+
+This mirrors the existing OpenAI account-export posture, where a diagnostic
+inventory and provenance contract already precede durable migration, and where
+imported third-party records become canonical Codexify state while retaining
+source provenance.
+
+## Supported input types
+
+- a ZIP archive (inspected in-place; members are never extracted)
+- an extracted directory (recursive; symlinks rejected; confined to the root)
+- an individual JSON file (treated as a one-file package)
+
+## CLI
+
+```
+python scripts/anthropic_import/profile_anthropic_export.py <input> --output <report.json>
+```
+
+Example:
+
+```
+python scripts/anthropic_import/profile_anthropic_export.py /path/to/claude-export.zip --output /tmp/anthropic-export-profile.json
+```
+
+A short human-readable summary is printed to stdout: input package kind,
+package fingerprint (truncated sha256), file count, JSON file count, warning
+count, and a fixed output marker. No source message content, identity values,
+or absolute paths are printed.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Profiling completed, including completion with bounded warnings. |
+| `2` | Invalid arguments, missing input, unsupported input type, or unwritable output. |
+| `3` | Unsafe archive structure, corrupt ZIP container or member, duplicate member path, path traversal, symlink, or other structural-integrity rejection. |
+
+## Safety rules
+
+- ZIP members are streamed via `zipfile` and inspected without extraction.
+- Member paths are normalized to canonical POSIX relative form.
+- Rejected before any content is analyzed: absolute paths, `..` traversal,
+  symbolic links (mode-bit detection), duplicate normalized paths, and corrupt
+  ZIP containers or members.
+- ZIP members are processed in deterministic normalized-path order.
+- Directory input rejects symbolic links and ensures every inspected path
+  remains beneath the supplied root.
+- Reads are bounded by named constants (file count, per-member bytes, total
+  bytes, JSON depth, retained keys, warnings). Oversized members and excessive
+  JSON nesting are skipped with bounded warnings and flagged via
+  `package.analysis_truncated` rather than silently dropped.
+- The output path must not overwrite the input file or reside inside an input
+  directory.
+
+## Privacy and redaction rules
+
+The report must never carry message text, conversation or project titles,
+usernames, account names, email addresses, UUID or other identifier values,
+URLs, prompts, file contents, attachment contents, or memory text. A central
+allowlist is the only place scalar **values** may be aggregated:
+
+- semantic role/sender labels from a fixed allowlist (bounded distinct count)
+- structured content-block `type` labels from a fixed allowlist
+- the fixed `unknown` label for unrecognized role, type, or content-type values
+- coarse timestamp format categories (derived, e.g. `iso8601`, `epoch_seconds`)
+- safe boolean presence flags
+- file extensions and detected broad types
+
+Everything else is recorded as key **names** and counts. The report never
+copies arbitrary scalar values.
+
+Relative package paths are retained because they are required for structural
+inventory, but the operator's absolute source path is never emitted. Known
+structural directory and filename labels are retained; every other path
+segment, including emails, usernames, attachment names, and non-UUID record
+names, is replaced with a deterministic `<path-...>` alias. UUID-shaped record
+stems remain represented as `<uuid>`.
+
+Determinism: repeated profiling of identical input produces byte-identical
+UTF-8 JSON (sorted keys, stable list ordering, two-space indentation, one
+trailing newline, no generated timestamp).
+
+## Report schema (`anthropic_export_profile_report_v1`, profiler version `1`)
+
+Top-level fields:
+
+- `report_schema` — exact value `anthropic_export_profile_report_v1`.
+- `profiler_version` — exact value `1`.
+- `package` — `kind` (`zip` | `directory` | `json`), sanitized fixed
+  `display_name`, `sha256`, `file_count`, `json_file_count`, `binary_file_count`,
+  `total_bytes`, `analysis_truncated`.
+- `files` — ordered inventory; each record may include `relative_path`,
+  `size_bytes`, `compressed_size_bytes` (ZIP only), `sha256`, `extension`,
+  `broad_type`, `json_parse_status`, `json_top_level_type`, and
+  `json_top_level_keys`. Never parsed user-authored values.
+- `candidate_surfaces` — evidence-backed candidate classifications
+  (`conversations`, `projects`, `memories`, `users_or_account`,
+  `attachments_or_files`, `artifacts`, `unknown_json`), each with the
+  structural `evidence_keys` that caused the classification. Classification is
+  always `candidate`, never authoritative.
+- `conversation_shape` — whether conversation-like objects were observed,
+  candidate conversation count, observed conversation/message object keys with
+  occurrence counts, message-container keys, message object keys, role-field
+  names, bounded role values (for recognized role fields such as `sender`/
+  `role`), timestamp-field names and coarse format categories, identifier-,
+  model-, project-reference-, parent-relationship-, and attachment-reference
+  field names, and observed allowlisted content-block type names. No IDs,
+  titles, text, or timestamps are emitted.
+- `capabilities_observed` — boolean observed flags with bounded evidence lists
+  (structural keys + relative paths only) for: `flat_conversation_array`,
+  `nested_conversation_container`, `message_parent_links`, `project_records`,
+  `conversation_project_links`, `account_metadata`, `memory_records`,
+  `attachment_references`, `binary_payloads`, `generated_file_evidence`,
+  `artifact_evidence`.
+- `unknown_structures` — counts (and bounded relative paths / structural
+  labels) for unknown top-level JSON shapes, unknown content-block types, and
+  unknown message keys. No raw content values.
+- `warnings` — bounded records with `code`, optional `relative_path`, and
+  `message`. Examples: `json_parse_failed`, `analysis_limit_reached`,
+  `json_nesting_exceeded`, `unknown_json_shape`, `possible_branch_structure`,
+  `binary_without_reference`, `reference_without_binary`.
+- `errors` — empty on successful reports; structural rejection terminates with
+  exit code `3` instead of producing a misleading success report.
+
+## Capability classifications
+
+Capabilities are reported as `true` only when positive structural evidence was
+observed, with a bounded evidence list naming only structural keys and relative
+paths. They are evidence of shape, not proof of importability:
+
+- Branch/parent links are noted when parent-relationship field names
+  (`parent_message_uuid`, `parent_uuid`, `parent_message_id`, `parent_id`, and
+  unknown `parent*` alternatives) appear on message objects.
+- Project/memory/account/artifact surfaces are detected from wrapper keys,
+  record-list shape, or observed record-family directory names
+  (for example sharded `projects/<uuid>.json` files).
+- Attachment references, generated-file hints, and artifact hints are reported
+  independently and only when explicit structural keys support each
+  classification. A text extract is never labeled a binary; an attachment is
+  never labeled uploaded or generated without positive evidence.
+
+## Interpretation guidance
+
+- Treat the report as a snapshot of one observed export, not a schema spec.
+  Field names may vary across Anthropic export versions.
+- `candidate` classifications are starting points for a future importer, not
+  acceptance gates. Missing fields remain missing; the profiler does not infer
+  undocumented semantics.
+- `reference_without_binary` means attachment references were observed without
+  bundled binaries; `binary_without_reference` means binaries were present
+  without observed reference fields. Both are heuristic and bounded.
+- Conversation linearity must not be assumed. `message_parent_links` indicates
+  branching that a future importer would have to resolve.
+
+## Explicit non-goals
+
+- This tool does not import data and does not add Anthropic import support.
+- No current release-truth document is changed to claim Anthropic import
+  support. `docs/architecture/00-current-state.md` remains the release gate.
+- The profiler does not create, widen, or satisfy any ADR.
+
+## Fixture confidentiality
+
+Real user exports and generated profile reports must never be added to this
+repository. The committed tests in `tests/scripts/test_anthropic_export_profiler.py`
+use only temporary synthetic files. Operators should write profile reports to
+locations outside the repository and treat any real export as confidential
+user data.

--- a/scripts/anthropic_import/profile_anthropic_export.py
+++ b/scripts/anthropic_import/profile_anthropic_export.py
@@ -1,0 +1,1938 @@
+#!/usr/bin/env python3
+"""Read-only Anthropic account-export profiler.
+
+This is fixture archaeology, not an importer. It inspects a real Anthropic
+account export (ZIP archive, extracted directory, or individual JSON file) and
+emits a deterministic structural evidence report. It never imports data, never
+writes to any Codexify runtime store, never invokes the existing Claude or
+OpenAI importers, and never mutates the source package.
+
+The report describes schema *shape* only. It never carries message text,
+conversation titles, project or account names, email addresses, UUIDs, IDs,
+URLs, prompts, or attachment contents. Only a small explicit allowlist of
+structural scalar values (role/sender labels, content-block type labels, coarse
+timestamp format categories, safe booleans, and detected file types) may be
+aggregated. Everything else is key names and counts.
+
+Profiler output is *observed evidence*, not an Anthropic schema contract, and it
+does not widen Codexify's supported release promise. Durable Anthropic account
+import remains deferred.
+
+Standard-library only by design.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import stat
+import sys
+import unicodedata
+import zipfile
+import zlib
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable, Iterator, Sequence
+
+# --------------------------------------------------------------------------
+# Report identity
+# --------------------------------------------------------------------------
+
+REPORT_SCHEMA = "anthropic_export_profile_report_v1"
+PROFILER_VERSION = "1"
+
+# --------------------------------------------------------------------------
+# Exit codes
+# --------------------------------------------------------------------------
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+EXIT_UNSAFE = 3
+
+# --------------------------------------------------------------------------
+# Safety limits (conservative defaults). All enforced; overflow is reported,
+# never silently dropped.
+# --------------------------------------------------------------------------
+
+MAX_PACKAGE_FILE_COUNT = 50_000
+MAX_MEMBER_BYTES = 64 * 1024 * 1024
+MAX_TOTAL_BYTES = 8 * 1024 * 1024 * 1024
+MAX_JSON_DEPTH = 64
+MAX_UNIQUE_KEYS_PER_SCOPE = 2_000
+MAX_WARNINGS = 200
+MAX_ROLE_VALUE_DISTINCT = 32
+MAX_CONTENT_BLOCK_TYPE_DISTINCT = 200
+MAX_CANDIDATE_EVIDENCE_KEYS = 50
+MAX_CAPABILITY_EVIDENCE = 25
+MAX_TOP_LEVEL_KEYS_DISPLAY = 500
+MAX_UNKNOWN_RELATIVE_PATHS = 100
+MAX_UNKNOWN_KEY_NAMES = 200
+
+SAMPLE_BYTES = 1024 * 1024
+READ_CHUNK = 65536
+
+# --------------------------------------------------------------------------
+# Structural vocabulary. These are key *names* and type *labels* only.
+# Recognizing them never emits the values that hang off the keys.
+# --------------------------------------------------------------------------
+
+# Message-container keys already understood by Codexify's Claude path plus a
+# generic fallback used to detect unknown alternatives.
+MESSAGE_CONTAINER_KEYS = (
+    "chat_messages",
+    "messages",
+    "conversation",
+    "entries",
+)
+
+# Path redaction for identity-bearing package members. Structural labels remain
+# useful evidence; all other path segments are deterministic aliases.
+UUID_SEGMENT_RE = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+
+SAFE_PATH_DIRECTORY_SEGMENTS = frozenset(
+    {
+        "account",
+        "artifacts",
+        "attachments",
+        "documents",
+        "files",
+        "images",
+        "media",
+        "memories",
+        "messages",
+        "projects",
+        "uploads",
+        "user",
+        "users",
+    }
+)
+SAFE_PATH_FILENAMES = frozenset(
+    {
+        "account.json",
+        "conversations.json",
+        "manifest.json",
+        "memories.json",
+        "messages.json",
+        "metadata.json",
+        "projects.json",
+        "users.json",
+    }
+)
+SAFE_FILE_EXTENSIONS = frozenset(
+    {
+        ".bin",
+        ".csv",
+        ".gif",
+        ".html",
+        ".jpeg",
+        ".jpg",
+        ".json",
+        ".md",
+        ".mov",
+        ".mp3",
+        ".mp4",
+        ".ogg",
+        ".pdf",
+        ".png",
+        ".txt",
+        ".wav",
+        ".webp",
+        ".zip",
+    }
+)
+
+
+# Wrapper keys that may hold a collection of conversation/record objects.
+COLLECTION_WRAPPER_KEYS = (
+    "conversations",
+    "threads",
+    "chats",
+    "items",
+    "data",
+    "projects",
+    "memories",
+    "users",
+    "user",
+    "account",
+    "artifacts",
+)
+
+CONTENT_BLOCK_TYPE_KEYS = ("type", "content_type")
+KNOWN_CONTENT_BLOCK_TYPES = {
+    "text",
+    "markdown",
+    "tool_use",
+    "tool_result",
+    "tool",
+    "server_tool_use",
+    "server_tool_result",
+    "web_search_tool_result",
+    "image",
+    "attachment",
+    "file",
+    "thinking",
+    "code",
+    "plan",
+}
+ROLE_VALUE_ALIASES = {
+    "ai": "assistant",
+    "assistant": "assistant",
+    "bot": "assistant",
+    "developer": "developer",
+    "function": "tool",
+    "human": "human",
+    "model": "assistant",
+    "system": "system",
+    "tool": "tool",
+    "user": "human",
+}
+UNKNOWN_SEMANTIC_LABEL = "unknown"
+
+# Branch / parent relationship fields. Explicit candidates plus unknown
+# alternatives beginning with "parent".
+PARENT_FIELD_EXPLICIT = (
+    "parent_message_uuid",
+    "parent_uuid",
+    "parent_message_id",
+    "parent_id",
+)
+
+TS_FIELD_EXPLICIT = {
+    "created_at",
+    "updated_at",
+    "timestamp",
+    "createdat",
+    "updatedat",
+    "create_time",
+    "update_time",
+    "time",
+    "date",
+    "published_at",
+    "expires_at",
+    "deleted_at",
+    "sent_at",
+    "modified_at",
+}
+
+# Regex classifiers for structural field families. These match *names*, never
+# values.
+IDENTIFIER_NAME_RE = re.compile(
+    r"^(id|uuid|uid|key|guid)$|(_id|_uuid|_uid|_key|_guid)$", re.IGNORECASE
+)
+PARENT_NAME_RE = re.compile(r"^parent", re.IGNORECASE)
+PROJECT_NAME_RE = re.compile(r"^project", re.IGNORECASE)
+MODEL_NAME_RE = re.compile(r"^(model|provider)", re.IGNORECASE)
+ATTACHMENT_NAME_RE = re.compile(
+    r"(file|attachment|upload|asset|image|document)", re.IGNORECASE
+)
+GENERATION_NAME_RE = re.compile(r"^(generat|dalle)", re.IGNORECASE)
+ARTIFACT_NAME_RE = re.compile(r"^artifact", re.IGNORECASE)
+MEMORY_NAME_RE = re.compile(r"^memor", re.IGNORECASE)
+ACCOUNT_NAME_RE = re.compile(
+    r"^(user|account|profile|organization|organisation|email|member|person)",
+    re.IGNORECASE,
+)
+TS_NAME_RE = re.compile(
+    r"((_at|at|time|date|timestamp)$)|^(time|date|timestamp)", re.IGNORECASE
+)
+
+# Safe scalar-value sanitizers. These permit only short structural labels.
+BLOCK_TYPE_RE = re.compile(r"^[A-Za-z0-9_.\-/ ]{1,48}$")
+_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+
+
+# --------------------------------------------------------------------------
+# Errors
+# --------------------------------------------------------------------------
+
+
+class UsageError(ValueError):
+    """Invalid arguments, missing input, unsupported input, unwritable output."""
+
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class UnsafePackageError(ValueError):
+    """Structural integrity rejection: traversal, symlink, duplicate, corruption."""
+
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+# --------------------------------------------------------------------------
+# Path normalization (mirrors Codexify's import-path rules, stdlib only)
+# --------------------------------------------------------------------------
+
+
+def normalize_member_path(value: str) -> str:
+    """Return a canonical POSIX relative path or reject unsafe input."""
+
+    raw = unicodedata.normalize(
+        "NFC", str(value or "").replace("\\", "/").strip()
+    )
+    if not raw or "\x00" in raw:
+        raise UnsafePackageError(
+            "Member path is empty or contains a null byte.",
+            code="invalid_member_path",
+        )
+    if raw.startswith("/") or _WINDOWS_DRIVE_RE.match(raw):
+        raise UnsafePackageError(
+            "Absolute member paths are not allowed.",
+            code="absolute_path_rejected",
+        )
+    if any(part == ".." for part in raw.split("/")):
+        raise UnsafePackageError(
+            "Member path traversal is not allowed.",
+            code="path_traversal_rejected",
+        )
+    parts = [part for part in raw.split("/") if part not in {"", "."}]
+    if not parts:
+        raise UnsafePackageError(
+            "Member path is empty after normalization.",
+            code="empty_member_path",
+        )
+    return PurePosixPath(*parts).as_posix()
+
+
+def _redact_path_segment(segment: str) -> str:
+    """Keep structural path labels and alias every other source segment."""
+
+    lowered = segment.lower()
+    if (
+        lowered in SAFE_PATH_DIRECTORY_SEGMENTS
+        or lowered in SAFE_PATH_FILENAMES
+    ):
+        return segment
+    if UUID_SEGMENT_RE.fullmatch(segment):
+        return "<uuid>"
+    if "." in segment:
+        stem, extension = segment.rsplit(".", 1)
+        if UUID_SEGMENT_RE.fullmatch(stem):
+            return f"<uuid>.{extension}"
+    digest = hashlib.sha256(segment.encode("utf-8")).hexdigest()[:16]
+    return f"<path-{digest}>"
+
+
+def build_path_redaction(relpaths: list[str]) -> dict[str, str]:
+    """Map original relative paths to deterministic, identity-safe paths."""
+
+    return {
+        original: "/".join(
+            _redact_path_segment(seg) for seg in original.split("/")
+        )
+        for original in sorted(set(relpaths))
+    }
+
+
+# --------------------------------------------------------------------------
+# Magic / broad-type detection (content-based, never extension-only)
+# --------------------------------------------------------------------------
+
+
+def _detect_magic_kind(sample: bytes) -> str | None:
+    if sample.startswith((b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")):
+        return "archive"
+    if sample.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image"
+    if sample.startswith(b"\xff\xd8\xff"):
+        return "image"
+    if sample.startswith((b"GIF87a", b"GIF89a")):
+        return "image"
+    if sample.startswith(b"RIFF") and sample[8:12] == b"WEBP":
+        return "image"
+    if sample.startswith(b"%PDF-"):
+        return "pdf"
+    if sample[4:8] == b"ftyp":
+        return "video"
+    if sample.startswith(b"\x1a\x45\xdf\xa3"):
+        return "video"
+    if sample.startswith(b"RIFF") and sample[8:12] == b"WAVE":
+        return "audio"
+    if sample.startswith(b"OggS"):
+        return "audio"
+    if sample.startswith(b"fLaC"):
+        return "audio"
+    if sample.startswith(b"ID3") or (
+        len(sample) > 2 and sample[0] == 0xFF and sample[1] & 0xE0 == 0xE0
+    ):
+        return "audio"
+    return None
+
+
+def _looks_textual(sample: bytes) -> bool:
+    try:
+        text = sample[:4096].decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    if "\x00" in text:
+        return False
+    return True
+
+
+def _broad_type(sample: bytes) -> str:
+    """Return a coarse, content-derived broad file type."""
+
+    if not sample:
+        return "empty"
+    magic = _detect_magic_kind(sample)
+    if magic is not None:
+        return magic
+    stripped = sample.lstrip()
+    lowered = stripped[:256].lower()
+    if lowered.startswith((b"<!doctype html", b"<html", b"<!--")):
+        return "text"
+    if stripped[:1] in {b"{", b"["}:
+        return "json"
+    if _looks_textual(sample):
+        if lowered.startswith(b"<"):
+            return "text"
+        return "text"
+    return "unknown_binary"
+
+
+def _extension_of(name: str) -> str:
+    extension = PurePosixPath(name).suffix.lower()
+    return (
+        extension
+        if extension in SAFE_FILE_EXTENSIONS
+        else UNKNOWN_SEMANTIC_LABEL
+    )
+
+
+# --------------------------------------------------------------------------
+# Streaming reader for a single member
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class MemberBytes:
+    size: int
+    sha256: str
+    sample: bytes
+    buffered: bytes
+    full_buffer_available: bool
+
+
+def _stream_member(open_callable: Callable[[], Any]) -> MemberBytes:
+    """Stream a member computing sha/size with bounded memory.
+
+    ``sample`` holds the first ``SAMPLE_BYTES`` for type detection. ``buffered``
+    holds up to ``MAX_MEMBER_BYTES`` for JSON parsing; ``full_buffer_available``
+    is False when the member exceeded that cap (JSON analysis is then skipped).
+    """
+
+    digest = hashlib.sha256()
+    size = 0
+    sample = bytearray()
+    buffered = bytearray()
+    with open_callable() as handle:
+        while True:
+            chunk = handle.read(READ_CHUNK)
+            if not chunk:
+                break
+            if isinstance(chunk, str):  # defensive; binary streams expected
+                chunk = chunk.encode("utf-8")
+            size += len(chunk)
+            digest.update(chunk)
+            if len(sample) < SAMPLE_BYTES:
+                sample.extend(chunk[: SAMPLE_BYTES - len(sample)])
+            room = MAX_MEMBER_BYTES - len(buffered)
+            if room > 0:
+                buffered.extend(chunk[:room])
+    return MemberBytes(
+        size=size,
+        sha256=digest.hexdigest(),
+        sample=bytes(sample),
+        buffered=bytes(buffered),
+        full_buffer_available=size <= MAX_MEMBER_BYTES,
+    )
+
+
+# --------------------------------------------------------------------------
+# Scanned file record
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class ScannedFile:
+    relative_path: str
+    size_bytes: int
+    sha256: str
+    extension: str
+    broad_type: str
+    json_parse_status: str  # ok | failed | not_json | skipped
+    json_top_level_type: str  # object | array | scalar | none
+    json_top_level_keys: list[str]
+    compressed_size_bytes: int | None = None
+    parsed: Any = None
+    analysis_truncated: bool = False
+
+
+# --------------------------------------------------------------------------
+# Structural collector
+# --------------------------------------------------------------------------
+
+
+def _sorted_counter(counter: dict[str, int]) -> list[dict[str, Any]]:
+    return [{"key": key, "count": int(counter[key])} for key in sorted(counter)]
+
+
+class ShapeCollector:
+    """Accumulates structural evidence only. Never stores raw user values."""
+
+    def __init__(self) -> None:
+        self.conversations_observed = False
+        self.candidate_conversation_count = 0
+        self._conversation_keys: dict[str, int] = {}
+        self._message_container_keys: dict[str, int] = {}
+        self._message_keys: dict[str, int] = {}
+        self._role_fields: dict[str, int] = {}
+        self._role_values: dict[str, int] = {}
+        self._timestamp_fields: dict[str, int] = {}
+        self._timestamp_formats: dict[str, int] = {}
+        self._identifier_fields: dict[str, int] = {}
+        self._model_fields: dict[str, int] = {}
+        self._project_ref_fields: dict[str, int] = {}
+        self._parent_fields: dict[str, int] = {}
+        self._attachment_fields: dict[str, int] = {}
+        self._content_block_types: dict[str, int] = {}
+        self._unknown_content_block_types: dict[str, int] = {}
+        self._unknown_message_keys: dict[str, int] = {}
+
+        # capability evidence: name -> list of {relative_path, structural_keys}
+        self._capability_evidence: dict[str, list[dict[str, Any]]] = {}
+        self._capability_observed: dict[str, bool] = {}
+
+        # candidate surfaces: list of {relative_path, classification, evidence_keys}
+        self.candidate_surfaces: list[dict[str, Any]] = []
+
+        # unknown top-level shapes (parsed JSON that matched nothing)
+        self._unknown_json_shapes: list[str] = []
+
+    # -- bounded helpers --------------------------------------------------
+
+    def _bump(self, store: dict[str, int], key: str) -> None:
+        if len(store) >= MAX_UNIQUE_KEYS_PER_SCOPE and key not in store:
+            return
+        store[key] = store.get(key, 0) + 1
+
+    def _bump_value(
+        self, store: dict[str, int], key: str, *, distinct_cap: int
+    ) -> None:
+        if len(store) >= distinct_cap and key not in store:
+            return
+        store[key] = store.get(key, 0) + 1
+
+    # -- conversation / message recording --------------------------------
+
+    def mark_conversation(self) -> None:
+        self.conversations_observed = True
+        self.candidate_conversation_count += 1
+
+    def add_conversation_key(self, key: str) -> None:
+        self._bump(self._conversation_keys, str(key))
+
+    def add_message_container_key(self, key: str) -> None:
+        self._bump(self._message_container_keys, str(key))
+
+    def add_message_key(self, key: str) -> None:
+        self._bump(self._message_keys, str(key))
+
+    def add_role_field(self, key: str) -> None:
+        self._bump(self._role_fields, str(key))
+
+    def add_role_value(self, value: str) -> None:
+        self._bump_value(
+            self._role_values, str(value), distinct_cap=MAX_ROLE_VALUE_DISTINCT
+        )
+
+    def add_timestamp_field(self, key: str, category: str) -> None:
+        self._bump(self._timestamp_fields, str(key))
+        self._bump(self._timestamp_formats, str(category))
+
+    def add_identifier_field(self, key: str) -> None:
+        self._bump(self._identifier_fields, str(key))
+
+    def add_model_field(self, key: str) -> None:
+        self._bump(self._model_fields, str(key))
+
+    def add_project_ref_field(self, key: str) -> None:
+        self._bump(self._project_ref_fields, str(key))
+
+    def add_parent_field(self, key: str) -> None:
+        self._bump(self._parent_fields, str(key))
+
+    def add_attachment_field(self, key: str) -> None:
+        self._bump(self._attachment_fields, str(key))
+
+    def add_content_block_type(self, value: str) -> None:
+        label = (
+            str(value)
+            if str(value) in KNOWN_CONTENT_BLOCK_TYPES
+            else UNKNOWN_SEMANTIC_LABEL
+        )
+        if label in KNOWN_CONTENT_BLOCK_TYPES:
+            self._bump_value(
+                self._content_block_types,
+                label,
+                distinct_cap=MAX_CONTENT_BLOCK_TYPE_DISTINCT,
+            )
+        else:
+            self._bump_value(
+                self._unknown_content_block_types,
+                label,
+                distinct_cap=MAX_CONTENT_BLOCK_TYPE_DISTINCT,
+            )
+
+    def add_unknown_message_key(self, key: str) -> None:
+        self._bump_value(
+            self._unknown_message_keys,
+            str(key),
+            distinct_cap=MAX_UNKNOWN_KEY_NAMES,
+        )
+
+    def add_unknown_json_shape(self, relative_path: str) -> None:
+        if len(self._unknown_json_shapes) < MAX_UNKNOWN_RELATIVE_PATHS:
+            self._unknown_json_shapes.append(relative_path)
+
+    # -- capabilities -----------------------------------------------------
+
+    def note_capability(
+        self, name: str, *, relative_path: str, structural_keys: list[str]
+    ) -> None:
+        self._capability_observed[name] = True
+        bucket = self._capability_evidence.setdefault(name, [])
+        if len(bucket) >= MAX_CAPABILITY_EVIDENCE:
+            return
+        entry = {
+            "relative_path": relative_path,
+            "structural_keys": sorted(dict.fromkeys(structural_keys))[
+                :MAX_CANDIDATE_EVIDENCE_KEYS
+            ],
+        }
+        if entry not in bucket:
+            bucket.append(entry)
+
+    def add_candidate_surface(
+        self,
+        *,
+        relative_path: str,
+        classification: str,
+        evidence_keys: list[str],
+    ) -> None:
+        self.candidate_surfaces.append(
+            {
+                "relative_path": relative_path,
+                "classification": classification,
+                "evidence_keys": sorted(dict.fromkeys(evidence_keys))[
+                    :MAX_CANDIDATE_EVIDENCE_KEYS
+                ],
+            }
+        )
+
+    # -- finalize ---------------------------------------------------------
+
+    def capability_payload(self) -> dict[str, Any]:
+        names = [
+            "flat_conversation_array",
+            "nested_conversation_container",
+            "message_parent_links",
+            "project_records",
+            "conversation_project_links",
+            "account_metadata",
+            "memory_records",
+            "attachment_references",
+            "binary_payloads",
+            "generated_file_evidence",
+            "artifact_evidence",
+        ]
+        payload: dict[str, Any] = {}
+        for name in names:
+            observed = self._capability_observed.get(name, False)
+            payload[name] = {
+                "observed": bool(observed),
+                "evidence": self._capability_evidence.get(name, []),
+            }
+        return payload
+
+    def conversation_shape_payload(self) -> dict[str, Any]:
+        return {
+            "conversations_observed": bool(self.conversations_observed),
+            "candidate_conversation_count": int(
+                self.candidate_conversation_count
+            ),
+            "conversation_object_keys": _sorted_counter(
+                self._conversation_keys
+            ),
+            "message_container_keys": _sorted_counter(
+                self._message_container_keys
+            ),
+            "message_object_keys": _sorted_counter(self._message_keys),
+            "role_field_names": _sorted_counter(self._role_fields),
+            "role_values": _sorted_counter(self._role_values),
+            "timestamp_field_names": _sorted_counter(self._timestamp_fields),
+            "timestamp_format_categories": _sorted_counter(
+                self._timestamp_formats
+            ),
+            "identifier_field_names": _sorted_counter(self._identifier_fields),
+            "model_field_names": _sorted_counter(self._model_fields),
+            "project_reference_field_names": _sorted_counter(
+                self._project_ref_fields
+            ),
+            "parent_relationship_field_names": _sorted_counter(
+                self._parent_fields
+            ),
+            "attachment_reference_field_names": _sorted_counter(
+                self._attachment_fields
+            ),
+            "content_block_types": _sorted_counter(self._content_block_types),
+        }
+
+    def unknown_structures_payload(self) -> dict[str, Any]:
+        return {
+            "unknown_json_shapes": {
+                "count": len(self._unknown_json_shapes),
+                "relative_paths": list(self._unknown_json_shapes),
+            },
+            "unknown_content_block_types": _sorted_counter(
+                self._unknown_content_block_types
+            ),
+            "unknown_message_keys": _sorted_counter(self._unknown_message_keys),
+        }
+
+
+# --------------------------------------------------------------------------
+# Field classification (names only)
+# --------------------------------------------------------------------------
+
+
+def _is_timestamp_field(name: str) -> bool:
+    return name in TS_FIELD_EXPLICIT or bool(TS_NAME_RE.search(name))
+
+
+def _is_identifier_field(name: str) -> bool:
+    return bool(IDENTIFIER_NAME_RE.search(name))
+
+
+def _is_parent_field(name: str) -> bool:
+    return name in PARENT_FIELD_EXPLICIT or bool(PARENT_NAME_RE.match(name))
+
+
+def _is_project_field(name: str) -> bool:
+    return bool(PROJECT_NAME_RE.match(name))
+
+
+def _is_model_field(name: str) -> bool:
+    return bool(MODEL_NAME_RE.match(name))
+
+
+def _is_attachment_field(name: str) -> bool:
+    return bool(ATTACHMENT_NAME_RE.search(name))
+
+
+def _is_generation_field(name: str) -> bool:
+    return bool(GENERATION_NAME_RE.match(name))
+
+
+def _is_artifact_field(name: str) -> bool:
+    return bool(ARTIFACT_NAME_RE.match(name))
+
+
+def _is_memory_field(name: str) -> bool:
+    return bool(MEMORY_NAME_RE.match(name))
+
+
+def _is_account_field(name: str) -> bool:
+    return bool(ACCOUNT_NAME_RE.match(name))
+
+
+def _timestamp_category(value: Any) -> str:
+    if isinstance(value, bool):
+        return "unknown"
+    if isinstance(value, (int, float)):
+        return (
+            "epoch_millis"
+            if float(value) > 1_000_000_000_000
+            else "epoch_seconds"
+        )
+    if isinstance(value, str):
+        stripped = value.strip()
+        if re.match(r"^\d{4}-\d{2}-\d{2}", stripped):
+            return "iso8601"
+        if re.fullmatch(r"\d+(\.\d+)?", stripped):
+            return (
+                "epoch_millis"
+                if float(stripped) > 1_000_000_000_000
+                else "epoch_seconds"
+            )
+        return "unknown"
+    return "unknown"
+
+
+def _sanitize_role_value(value: Any) -> str | None:
+    if value is None:
+        return UNKNOWN_SEMANTIC_LABEL
+    if isinstance(value, bool) or isinstance(value, (dict, list)):
+        return UNKNOWN_SEMANTIC_LABEL
+    if isinstance(value, (int, float)):
+        return UNKNOWN_SEMANTIC_LABEL
+    text = str(value).strip().lower()
+    return ROLE_VALUE_ALIASES.get(text, UNKNOWN_SEMANTIC_LABEL)
+
+
+def _content_block_type(part: Any) -> str | None:
+    if not isinstance(part, dict):
+        return None
+    for key in CONTENT_BLOCK_TYPE_KEYS:
+        if key in part:
+            value = part[key]
+            if isinstance(value, str):
+                label = value.strip().lower()
+                if (
+                    BLOCK_TYPE_RE.match(label)
+                    and label in KNOWN_CONTENT_BLOCK_TYPES
+                ):
+                    return label
+            return UNKNOWN_SEMANTIC_LABEL
+    return None
+
+
+# --------------------------------------------------------------------------
+# Structural analysis
+# --------------------------------------------------------------------------
+
+
+def _is_message_like(obj: dict[str, Any]) -> bool:
+    keys = {str(k) for k in obj.keys()}
+    if keys & {"sender", "role", "author"}:
+        return True
+    if (keys & {"content", "text"}) and (
+        keys & {"sender", "role", "author", "type"}
+    ):
+        return True
+    return False
+
+
+def _find_message_container(
+    obj: dict[str, Any]
+) -> tuple[str | None, list[dict[str, Any]]]:
+    """Return (container_key, messages) for the first message-bearing list."""
+
+    for key in MESSAGE_CONTAINER_KEYS:
+        value = obj.get(key)
+        if isinstance(value, list):
+            msgs = [m for m in value if isinstance(m, dict)]
+            if msgs:
+                return key, msgs
+    # Unknown container alternatives: any list of message-like dicts.
+    for key, value in obj.items():
+        if not isinstance(value, list) or not value:
+            continue
+        if key in MESSAGE_CONTAINER_KEYS:
+            continue
+        sample = [m for m in value if isinstance(m, dict)]
+        if sample and any(_is_message_like(m) for m in sample[:3]):
+            return key, sample
+    return None, []
+
+
+def _analyze_message(
+    message: dict[str, Any],
+    *,
+    collector: ShapeCollector,
+    relative_path: str,
+    depth_budget: list[int],
+) -> None:
+    keys = [str(k) for k in message.keys()]
+    key_set = set(keys)
+    for key in keys:
+        collector.add_message_key(key)
+
+    # Role fields are names; values are emitted only through the semantic
+    # allowlist and otherwise collapse to the fixed ``unknown`` label.
+    role_field = None
+    for field_name in ("sender", "role", "author", "type"):
+        if field_name in key_set:
+            if role_field is None:
+                role_field = field_name
+            collector.add_role_field(field_name)
+            if field_name in {"sender", "role", "type"}:
+                collector.add_role_value(
+                    _sanitize_role_value(message.get(field_name))
+                )
+
+    structural_key_seen: list[str] = []
+
+    for key in keys:
+        value = message.get(key)
+        if _is_timestamp_field(key):
+            collector.add_timestamp_field(key, _timestamp_category(value))
+            structural_key_seen.append(key)
+        if _is_identifier_field(key):
+            collector.add_identifier_field(key)
+        if _is_model_field(key):
+            collector.add_model_field(key)
+            structural_key_seen.append(key)
+        if _is_parent_field(key):
+            collector.add_parent_field(key)
+            collector.note_capability(
+                "message_parent_links",
+                relative_path=relative_path,
+                structural_keys=[key],
+            )
+            structural_key_seen.append(key)
+        if _is_project_field(key):
+            collector.add_project_ref_field(key)
+            structural_key_seen.append(key)
+        if _is_attachment_field(key):
+            collector.add_attachment_field(key)
+            collector.note_capability(
+                "attachment_references",
+                relative_path=relative_path,
+                structural_keys=[key],
+            )
+            structural_key_seen.append(key)
+        if _is_generation_field(key):
+            collector.note_capability(
+                "generated_file_evidence",
+                relative_path=relative_path,
+                structural_keys=[key],
+            )
+            structural_key_seen.append(key)
+        if _is_artifact_field(key):
+            collector.note_capability(
+                "artifact_evidence",
+                relative_path=relative_path,
+                structural_keys=[key],
+            )
+            structural_key_seen.append(key)
+
+    # Content blocks (structured content). Type labels only.
+    content = message.get("content")
+    if isinstance(content, list) and depth_budget[0] > 0:
+        depth_budget[0] -= 1
+        for part in content:
+            label = _content_block_type(part)
+            if label:
+                collector.add_content_block_type(label)
+            if isinstance(part, dict):
+                for part_key in part.keys():
+                    if _is_attachment_field(str(part_key)):
+                        collector.note_capability(
+                            "attachment_references",
+                            relative_path=relative_path,
+                            structural_keys=[str(part_key)],
+                        )
+                    if _is_generation_field(str(part_key)):
+                        collector.note_capability(
+                            "generated_file_evidence",
+                            relative_path=relative_path,
+                            structural_keys=[str(part_key)],
+                        )
+                    if _is_artifact_field(str(part_key)):
+                        collector.note_capability(
+                            "artifact_evidence",
+                            relative_path=relative_path,
+                            structural_keys=[str(part_key)],
+                        )
+
+
+def _analyze_conversation(
+    conversation: dict[str, Any],
+    *,
+    collector: ShapeCollector,
+    relative_path: str,
+    root_container: str | None,
+) -> None:
+    collector.mark_conversation()
+
+    conv_keys = [str(k) for k in conversation.keys()]
+    for key in conv_keys:
+        collector.add_conversation_key(key)
+        if _is_project_field(key):
+            collector.add_project_ref_field(key)
+            collector.note_capability(
+                "conversation_project_links",
+                relative_path=relative_path,
+                structural_keys=[key],
+            )
+
+    container_key, messages = _find_message_container(conversation)
+    if container_key is not None:
+        collector.add_message_container_key(container_key)
+    for message in messages:
+        depth_budget = [MAX_JSON_DEPTH]
+        _analyze_message(
+            message,
+            collector=collector,
+            relative_path=relative_path,
+            depth_budget=depth_budget,
+        )
+
+
+def _classify_record_dict(obj: dict[str, Any]) -> set[str]:
+    """Return candidate surface classifications for a record dict."""
+
+    keys = {str(k) for k in obj.keys()}
+    classes: set[str] = set()
+    container_key, _messages = _find_message_container(obj)
+    if container_key is not None or _is_message_like(obj):
+        classes.add("conversations")
+    project_hits = sum(1 for k in keys if _is_project_field(k))
+    if project_hits >= 1 and any(k in keys for k in ("name", "description")):
+        classes.add("projects")
+    if any(_is_memory_field(k) for k in keys):
+        classes.add("memories")
+    if any(_is_account_field(k) for k in keys):
+        classes.add("users_or_account")
+    if any(_is_artifact_field(k) for k in keys):
+        classes.add("artifacts")
+    return classes
+
+
+# Directory names that constitute observed structural evidence for a record
+# family when an export shards records as one object file per record (for
+# example Anthropic's ``projects/<uuid>.json`` layout).
+RECORD_FAMILY_DIRS = {
+    "projects": ("projects", "project_records"),
+    "memories": ("memories", "memory_records"),
+    "users": ("users_or_account", "account_metadata"),
+    "user": ("users_or_account", "account_metadata"),
+    "account": ("users_or_account", "account_metadata"),
+    "artifacts": ("artifacts", "artifact_evidence"),
+}
+
+
+def _directory_family(
+    relative_path: str,
+) -> tuple[str | None, str | None, str | None]:
+    for part in relative_path.split("/")[:-1]:
+        key = part.lower()
+        if key in RECORD_FAMILY_DIRS:
+            classification, capability = RECORD_FAMILY_DIRS[key]
+            return classification, capability, part
+    return None, None, None
+
+
+def _analyze_parsed_json(
+    parsed: Any,
+    *,
+    collector: ShapeCollector,
+    relative_path: str,
+) -> tuple[set[str], bool]:
+    """Analyze one parsed JSON payload.
+
+    Returns (classifications_seen, matched_any_known_surface).
+    """
+
+    classifications: set[str] = set()
+    matched = False
+
+    if isinstance(parsed, list):
+        dicts = [item for item in parsed if isinstance(item, dict)]
+        if dicts and any(_find_message_container(d)[0] for d in dicts[:5]):
+            matched = True
+            collector.note_capability(
+                "nested_conversation_container",
+                relative_path=relative_path,
+                structural_keys=["<array_of_conversation_objects>"],
+            )
+            for conversation in dicts:
+                _analyze_conversation(
+                    conversation,
+                    collector=collector,
+                    relative_path=relative_path,
+                    root_container=None,
+                )
+            classifications.add("conversations")
+        elif dicts and any(_is_message_like(d) for d in dicts[:5]):
+            matched = True
+            collector.note_capability(
+                "flat_conversation_array",
+                relative_path=relative_path,
+                structural_keys=["<flat_message_array>"],
+            )
+            collector.mark_conversation()
+            collector.add_message_container_key("<top_level_array>")
+            for message in dicts:
+                depth_budget = [MAX_JSON_DEPTH]
+                _analyze_message(
+                    message,
+                    collector=collector,
+                    relative_path=relative_path,
+                    depth_budget=depth_budget,
+                )
+            classifications.add("conversations")
+        elif dicts:
+            for record in dicts[:100]:
+                classifications |= _classify_record_dict(record)
+            if classifications:
+                matched = True
+                if "projects" in classifications:
+                    collector.note_capability(
+                        "project_records",
+                        relative_path=relative_path,
+                        structural_keys=["<array_of_project_records>"],
+                    )
+                if "memories" in classifications:
+                    collector.note_capability(
+                        "memory_records",
+                        relative_path=relative_path,
+                        structural_keys=["<array_of_memory_records>"],
+                    )
+                if "users_or_account" in classifications:
+                    collector.note_capability(
+                        "account_metadata",
+                        relative_path=relative_path,
+                        structural_keys=["<array_of_account_records>"],
+                    )
+        return classifications, matched
+
+    if isinstance(parsed, dict):
+        container_key, messages = _find_message_container(parsed)
+        if container_key is not None:
+            matched = True
+            classifications.add("conversations")
+            collector.note_capability(
+                "flat_conversation_array",
+                relative_path=relative_path,
+                structural_keys=[container_key],
+            )
+            _analyze_conversation(
+                parsed,
+                collector=collector,
+                relative_path=relative_path,
+                root_container=container_key,
+            )
+            return classifications, matched
+
+        # Wrapper objects: { "conversations": [...], "projects": [...] }
+        saw_wrapper = False
+        for wrapper in COLLECTION_WRAPPER_KEYS:
+            value = parsed.get(wrapper)
+            if not isinstance(value, list) or not value:
+                continue
+            saw_wrapper = True
+            sub_classes: set[str] = set()
+            for record in [v for v in value if isinstance(v, dict)][:100]:
+                sub_classes |= _classify_record_dict(record)
+            if wrapper in {
+                "conversations",
+                "threads",
+                "chats",
+                "items",
+                "data",
+            } and (
+                (sub_classes & {"conversations"})
+                or any(
+                    _find_message_container(v)[0] is not None
+                    for v in value
+                    if isinstance(v, dict)
+                )
+            ):
+                matched = True
+                classifications.add("conversations")
+                collector.note_capability(
+                    "nested_conversation_container",
+                    relative_path=relative_path,
+                    structural_keys=[wrapper],
+                )
+                for record in [v for v in value if isinstance(v, dict)]:
+                    _analyze_conversation(
+                        record,
+                        collector=collector,
+                        relative_path=relative_path,
+                        root_container=None,
+                    )
+            elif wrapper == "projects":
+                matched = True
+                classifications.add("projects")
+                collector.note_capability(
+                    "project_records",
+                    relative_path=relative_path,
+                    structural_keys=[wrapper],
+                )
+            elif wrapper == "memories":
+                matched = True
+                classifications.add("memories")
+                collector.note_capability(
+                    "memory_records",
+                    relative_path=relative_path,
+                    structural_keys=[wrapper],
+                )
+            elif wrapper in {"users", "user", "account"}:
+                matched = True
+                classifications.add("users_or_account")
+                collector.note_capability(
+                    "account_metadata",
+                    relative_path=relative_path,
+                    structural_keys=[wrapper],
+                )
+            elif wrapper == "artifacts":
+                matched = True
+                classifications.add("artifacts")
+                collector.note_capability(
+                    "artifact_evidence",
+                    relative_path=relative_path,
+                    structural_keys=[wrapper],
+                )
+        if saw_wrapper:
+            return classifications, matched
+
+        # Single record dict.
+        record_classes = _classify_record_dict(parsed)
+        dir_class, dir_capability, dir_name = _directory_family(relative_path)
+        if dir_class is not None:
+            record_classes.add(dir_class)
+            collector.note_capability(
+                dir_capability,
+                relative_path=relative_path,
+                structural_keys=[f"directory:{dir_name}"],
+            )
+        if record_classes:
+            matched = True
+            classifications |= record_classes
+            if "projects" in record_classes:
+                collector.note_capability(
+                    "project_records",
+                    relative_path=relative_path,
+                    structural_keys=sorted(record_classes),
+                )
+            if "memories" in record_classes:
+                collector.note_capability(
+                    "memory_records",
+                    relative_path=relative_path,
+                    structural_keys=sorted(record_classes),
+                )
+            if "users_or_account" in record_classes:
+                collector.note_capability(
+                    "account_metadata",
+                    relative_path=relative_path,
+                    structural_keys=sorted(record_classes),
+                )
+            if "artifacts" in record_classes:
+                collector.note_capability(
+                    "artifact_evidence",
+                    relative_path=relative_path,
+                    structural_keys=sorted(record_classes),
+                )
+        return classifications, matched
+
+    return classifications, matched
+
+
+# --------------------------------------------------------------------------
+# Input sources
+# --------------------------------------------------------------------------
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(READ_CHUNK)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _package_fingerprint(entries: list[tuple[str, int, str]]) -> str:
+    """Deterministic fingerprint from ordered (relpath, size, sha256)."""
+
+    payload = json.dumps(
+        [[path, size, sha] for path, size, sha in entries],
+        separators=(",", ":"),
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _looks_json_file(path: Path) -> bool:
+    if path.suffix.lower() == ".json":
+        return True
+    try:
+        with path.open("rb") as handle:
+            head = handle.read(8).lstrip()
+    except OSError:
+        return False
+    return head[:1] in (b"{", b"[")
+
+
+def _json_nesting_exceeds_limit(text: str) -> bool:
+    """Check JSON container depth without recursively walking parsed values."""
+
+    depth = 0
+    in_string = False
+    escaped = False
+    for char in text:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+        elif char in "[{":
+            depth += 1
+            if depth > MAX_JSON_DEPTH:
+                return True
+        elif char in "]}":
+            depth = max(0, depth - 1)
+    return False
+
+
+def _build_scanned_file(
+    *,
+    relative_path: str,
+    member: MemberBytes,
+    compressed_size_bytes: int | None,
+    warnings: list[dict[str, Any]],
+) -> ScannedFile:
+    extension = _extension_of(relative_path)
+    broad_type = _broad_type(member.sample)
+    json_parse_status = "not_json"
+    json_top_level_type = "none"
+    json_top_level_keys: list[str] = []
+    parsed: Any = None
+    analysis_truncated = False
+
+    looks_json = broad_type == "json" or extension == ".json"
+    if looks_json:
+        if not member.full_buffer_available:
+            json_parse_status = "skipped"
+            analysis_truncated = True
+            warnings.append(
+                {
+                    "code": "analysis_limit_reached",
+                    "relative_path": relative_path,
+                    "message": (
+                        "JSON member exceeded the per-member analysis cap and "
+                        "was not parsed."
+                    ),
+                }
+            )
+        else:
+            try:
+                decoded = member.buffered.decode("utf-8-sig")
+                if _json_nesting_exceeds_limit(decoded):
+                    json_parse_status = "skipped"
+                    analysis_truncated = True
+                    warnings.append(
+                        {
+                            "code": "json_nesting_exceeded",
+                            "relative_path": relative_path,
+                            "message": "JSON nesting exceeded the analysis depth limit and was not parsed.",
+                        }
+                    )
+                else:
+                    parsed = json.loads(decoded)
+                    json_parse_status = "ok"
+            except RecursionError:
+                json_parse_status = "skipped"
+                analysis_truncated = True
+                warnings.append(
+                    {
+                        "code": "json_nesting_exceeded",
+                        "relative_path": relative_path,
+                        "message": "JSON nesting exceeded the parser recursion limit and was not parsed.",
+                    }
+                )
+            except (ValueError, UnicodeDecodeError) as exc:
+                json_parse_status = "failed"
+                warnings.append(
+                    {
+                        "code": "json_parse_failed",
+                        "relative_path": relative_path,
+                        "message": (
+                            f"JSON parse failed: {exc.__class__.__name__}"
+                        ),
+                    }
+                )
+            if json_parse_status == "ok":
+                if isinstance(parsed, dict):
+                    json_top_level_type = "object"
+                    json_top_level_keys = sorted(str(k) for k in parsed.keys())[
+                        :MAX_TOP_LEVEL_KEYS_DISPLAY
+                    ]
+                elif isinstance(parsed, list):
+                    json_top_level_type = "array"
+                    first_dict = next(
+                        (item for item in parsed if isinstance(item, dict)),
+                        None,
+                    )
+                    if first_dict is not None:
+                        json_top_level_keys = sorted(
+                            str(k) for k in first_dict.keys()
+                        )[:MAX_TOP_LEVEL_KEYS_DISPLAY]
+                else:
+                    json_top_level_type = "scalar"
+
+    return ScannedFile(
+        relative_path=relative_path,
+        size_bytes=member.size,
+        sha256=member.sha256,
+        extension=extension,
+        broad_type=broad_type,
+        json_parse_status=json_parse_status,
+        json_top_level_type=json_top_level_type,
+        json_top_level_keys=json_top_level_keys,
+        compressed_size_bytes=compressed_size_bytes,
+        parsed=parsed,
+        analysis_truncated=analysis_truncated,
+    )
+
+
+def _profile_zip(
+    path: Path,
+) -> tuple[str, list[ScannedFile], bool, list[dict[str, Any]]]:
+    package_sha = _sha256_file(path)
+    warnings: list[dict[str, Any]] = []
+    scanned: list[ScannedFile] = []
+    truncated = False
+    total_bytes = 0
+    seen_paths: set[str] = set()
+
+    try:
+        zip_handle = zipfile.ZipFile(path)
+    except zipfile.BadZipFile as exc:
+        raise UnsafePackageError(
+            f"ZIP container is corrupt: {exc}",
+            code="corrupt_zip",
+        ) from exc
+
+    with zip_handle as bundle:
+        infos = list(bundle.infolist())
+        # Deterministic normalized-path order; reject unsafe members first.
+        normalized: list[tuple[str, zipfile.ZipInfo]] = []
+        for info in infos:
+            if info.is_dir():
+                continue
+            mode = info.external_attr >> 16
+            if mode and stat.S_ISLNK(mode):
+                raise UnsafePackageError(
+                    "ZIP member is a symbolic link.",
+                    code="symlink_rejected",
+                )
+            rel = normalize_member_path(info.filename)
+            if rel in seen_paths:
+                raise UnsafePackageError(
+                    "ZIP contains a duplicate normalized member path.",
+                    code="duplicate_path_rejected",
+                )
+            seen_paths.add(rel)
+            normalized.append((rel, info))
+        normalized.sort(key=lambda item: item[0])
+
+        for rel, info in normalized:
+            if len(scanned) >= MAX_PACKAGE_FILE_COUNT:
+                truncated = True
+                warnings.append(
+                    {
+                        "code": "analysis_limit_reached",
+                        "relative_path": rel,
+                        "message": "Package file count limit reached; remaining members skipped.",
+                    }
+                )
+                break
+            declared = int(info.file_size)
+            if total_bytes + declared > MAX_TOTAL_BYTES:
+                truncated = True
+                warnings.append(
+                    {
+                        "code": "analysis_limit_reached",
+                        "relative_path": rel,
+                        "message": "Total byte inspection limit reached; remaining members skipped.",
+                    }
+                )
+                break
+            total_bytes += declared
+
+            try:
+                member = _stream_member(lambda i=info: bundle.open(i, "r"))
+            except (
+                zipfile.BadZipFile,
+                EOFError,
+                OSError,
+                RuntimeError,
+                zlib.error,
+            ) as exc:
+                raise UnsafePackageError(
+                    "ZIP member content is corrupt.",
+                    code="corrupt_zip_member",
+                ) from exc
+            scanned.append(
+                _build_scanned_file(
+                    relative_path=rel,
+                    member=member,
+                    compressed_size_bytes=int(info.compress_size),
+                    warnings=warnings,
+                )
+            )
+
+    return package_sha, scanned, truncated, warnings
+
+
+def _iter_directory_files(root: Path) -> Iterator[Path]:
+    """Yield regular files beneath root, rejecting symlinks and escape."""
+
+    resolved_root = root.resolve()
+    stack: list[Path] = [root]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = list(current.iterdir())
+        except OSError:
+            continue
+        for entry in sorted(entries, key=lambda p: p.name):
+            if entry.is_symlink():
+                raise UnsafePackageError(
+                    "Directory contains a symbolic link.",
+                    code="symlink_rejected",
+                )
+            resolved = entry.resolve()
+            try:
+                resolved.relative_to(resolved_root)
+            except ValueError as exc:
+                raise UnsafePackageError(
+                    "Directory entry escaped the inspection root.",
+                    code="path_traversal_rejected",
+                ) from exc
+            if entry.is_dir():
+                stack.append(entry)
+            elif entry.is_file():
+                yield entry
+
+
+def _profile_directory(
+    path: Path,
+) -> tuple[str, list[ScannedFile], bool, list[dict[str, Any]]]:
+    warnings: list[dict[str, Any]] = []
+    scanned: list[ScannedFile] = []
+    truncated = False
+    total_bytes = 0
+    resolved_root = path.resolve()
+
+    collected: list[tuple[str, Path]] = []
+    for absolute in _iter_directory_files(path):
+        rel = absolute.resolve().relative_to(resolved_root).as_posix()
+        collected.append((rel, absolute))
+    collected.sort(key=lambda item: item[0])
+
+    for rel, absolute in collected:
+        if len(scanned) >= MAX_PACKAGE_FILE_COUNT:
+            truncated = True
+            warnings.append(
+                {
+                    "code": "analysis_limit_reached",
+                    "relative_path": rel,
+                    "message": "Package file count limit reached; remaining files skipped.",
+                }
+            )
+            break
+        size = absolute.stat().st_size
+        if total_bytes + size > MAX_TOTAL_BYTES:
+            truncated = True
+            warnings.append(
+                {
+                    "code": "analysis_limit_reached",
+                    "relative_path": rel,
+                    "message": "Total byte inspection limit reached; remaining files skipped.",
+                }
+            )
+            break
+        total_bytes += size
+        member = _stream_member(lambda p=absolute: p.open("rb"))
+        scanned.append(
+            _build_scanned_file(
+                relative_path=rel,
+                member=member,
+                compressed_size_bytes=None,
+                warnings=warnings,
+            )
+        )
+
+    fingerprint_entries = [
+        (f.relative_path, f.size_bytes, f.sha256) for f in scanned
+    ]
+    package_sha = _package_fingerprint(fingerprint_entries)
+    return package_sha, scanned, truncated, warnings
+
+
+def _profile_json_file(
+    path: Path,
+) -> tuple[str, list[ScannedFile], bool, list[dict[str, Any]]]:
+    warnings: list[dict[str, Any]] = []
+    member = _stream_member(lambda p=path: p.open("rb"))
+    rel = path.name
+    scanned = _build_scanned_file(
+        relative_path=rel,
+        member=member,
+        compressed_size_bytes=None,
+        warnings=warnings,
+    )
+    return scanned.sha256, [scanned], False, warnings
+
+
+# --------------------------------------------------------------------------
+# Report assembly
+# --------------------------------------------------------------------------
+
+
+def _build_report(
+    *,
+    kind: str,
+    display_name: str,
+    package_sha: str,
+    files: list[ScannedFile],
+    truncated: bool,
+    warnings: list[dict[str, Any]],
+) -> dict[str, Any]:
+    collector = ShapeCollector()
+    truncated = bool(truncated or any(f.analysis_truncated for f in files))
+
+    # Scrub identity values (UUID-shaped stems) from every relative path before
+    # any analysis emits a path. All downstream path fields derive from this.
+    redaction = build_path_redaction([f.relative_path for f in files])
+    for scanned_file in files:
+        scanned_file.relative_path = redaction.get(
+            scanned_file.relative_path, scanned_file.relative_path
+        )
+    for warning in warnings:
+        rel = warning.get("relative_path")
+        if rel:
+            warning["relative_path"] = redaction.get(rel, rel)
+
+    binary_count = 0
+    json_count = 0
+    for scanned_file in files:
+        if scanned_file.broad_type in {
+            "image",
+            "pdf",
+            "audio",
+            "video",
+            "archive",
+            "unknown_binary",
+        }:
+            binary_count += 1
+        if scanned_file.json_parse_status == "ok":
+            json_count += 1
+
+        # Structural analysis of parsed JSON.
+        if scanned_file.parsed is not None:
+            classifications, matched = _analyze_parsed_json(
+                scanned_file.parsed,
+                collector=collector,
+                relative_path=scanned_file.relative_path,
+            )
+            if classifications:
+                for classification in sorted(classifications):
+                    collector.add_candidate_surface(
+                        relative_path=scanned_file.relative_path,
+                        classification=classification,
+                        evidence_keys=[
+                            k for k in scanned_file.json_top_level_keys
+                        ][:MAX_CANDIDATE_EVIDENCE_KEYS],
+                    )
+            elif scanned_file.json_top_level_type in {"object", "array"}:
+                if not matched:
+                    collector.add_unknown_json_shape(scanned_file.relative_path)
+                    if len(warnings) < MAX_WARNINGS:
+                        warnings.append(
+                            {
+                                "code": "unknown_json_shape",
+                                "relative_path": scanned_file.relative_path,
+                                "message": "Parsed JSON matched no known structural surface.",
+                            }
+                        )
+
+        # Binary / attachment evidence.
+        if scanned_file.broad_type in {
+            "image",
+            "pdf",
+            "audio",
+            "video",
+            "unknown_binary",
+        }:
+            collector.note_capability(
+                "binary_payloads",
+                relative_path=scanned_file.relative_path,
+                structural_keys=[f"broad_type:{scanned_file.broad_type}"],
+            )
+            collector.add_candidate_surface(
+                relative_path=scanned_file.relative_path,
+                classification="attachments_or_files",
+                evidence_keys=[f"broad_type:{scanned_file.broad_type}"],
+            )
+
+    # Branch-structure warning when parent links were observed.
+    if collector._parent_fields and len(warnings) < MAX_WARNINGS:
+        warnings.append(
+            {
+                "code": "possible_branch_structure",
+                "relative_path": None,
+                "message": "Parent/branch relationship field names were observed on messages.",
+            }
+        )
+
+    # Cross-file binary/reference reconciliation warnings (bounded, heuristic).
+    has_binary = any(
+        f.broad_type in {"image", "pdf", "audio", "video", "unknown_binary"}
+        for f in files
+    )
+    has_attachment_refs = bool(collector._attachment_fields)
+    if has_binary and not has_attachment_refs and len(warnings) < MAX_WARNINGS:
+        warnings.append(
+            {
+                "code": "binary_without_reference",
+                "relative_path": None,
+                "message": "Binary payloads present but no attachment-reference field names observed.",
+            }
+        )
+    if has_attachment_refs and not has_binary and len(warnings) < MAX_WARNINGS:
+        warnings.append(
+            {
+                "code": "reference_without_binary",
+                "relative_path": None,
+                "message": "Attachment-reference field names observed but no binary payloads present.",
+            }
+        )
+
+    bounded_warnings = warnings[:MAX_WARNINGS]
+    if len(warnings) > MAX_WARNINGS:
+        bounded_warnings.append(
+            {
+                "code": "analysis_limit_reached",
+                "relative_path": None,
+                "message": "Warning count limit reached; additional warnings dropped.",
+            }
+        )
+
+    file_inventory: list[dict[str, Any]] = []
+    for scanned_file in sorted(files, key=lambda f: f.relative_path):
+        record: dict[str, Any] = {
+            "relative_path": scanned_file.relative_path,
+            "size_bytes": scanned_file.size_bytes,
+            "sha256": scanned_file.sha256,
+            "extension": scanned_file.extension,
+            "broad_type": scanned_file.broad_type,
+            "json_parse_status": scanned_file.json_parse_status,
+            "json_top_level_type": scanned_file.json_top_level_type,
+            "json_top_level_keys": scanned_file.json_top_level_keys,
+        }
+        if scanned_file.compressed_size_bytes is not None:
+            record["compressed_size_bytes"] = scanned_file.compressed_size_bytes
+        file_inventory.append(record)
+
+    total_bytes = sum(f.size_bytes for f in files)
+
+    candidate_surfaces = sorted(
+        collector.candidate_surfaces,
+        key=lambda c: (c["relative_path"], c["classification"]),
+    )
+
+    report = {
+        "report_schema": REPORT_SCHEMA,
+        "profiler_version": PROFILER_VERSION,
+        "package": {
+            "kind": kind,
+            "display_name": display_name,
+            "sha256": package_sha,
+            "file_count": len(files),
+            "json_file_count": json_count,
+            "binary_file_count": binary_count,
+            "total_bytes": total_bytes,
+            "analysis_truncated": bool(truncated),
+        },
+        "files": file_inventory,
+        "candidate_surfaces": candidate_surfaces,
+        "conversation_shape": collector.conversation_shape_payload(),
+        "capabilities_observed": collector.capability_payload(),
+        "unknown_structures": collector.unknown_structures_payload(),
+        "warnings": bounded_warnings,
+        "errors": [],
+    }
+    return report
+
+
+# --------------------------------------------------------------------------
+# Public profiling entrypoint
+# --------------------------------------------------------------------------
+
+
+def profile_export(input_path: str) -> dict[str, Any]:
+    """Profile an Anthropic export and return the deterministic report dict."""
+
+    source = Path(input_path)
+    if not source.exists() and not source.is_symlink():
+        raise UsageError(
+            f"Input path does not exist: {input_path}",
+            code="input_not_found",
+        )
+    if source.is_symlink():
+        raise UnsafePackageError(
+            "Input path is a symbolic link.",
+            code="symlink_rejected",
+        )
+    if source.is_dir():
+        kind = "directory"
+        package_sha, files, truncated, warnings = _profile_directory(source)
+    elif source.suffix.lower() == ".zip" or zipfile.is_zipfile(source):
+        kind = "zip"
+        package_sha, files, truncated, warnings = _profile_zip(source)
+    elif source.is_file():
+        if _looks_json_file(source):
+            kind = "json"
+            package_sha, files, truncated, warnings = _profile_json_file(source)
+        else:
+            raise UsageError(
+                "Unsupported input type: expected a ZIP archive, extracted "
+                "directory, or JSON file.",
+                code="unsupported_input_type",
+            )
+    else:
+        raise UsageError(
+            "Unsupported input type: expected a ZIP archive, extracted "
+            "directory, or JSON file.",
+            code="unsupported_input_type",
+        )
+
+    return _build_report(
+        kind=kind,
+        display_name={
+            "directory": "anthropic-export-directory",
+            "json": "anthropic-export.json",
+            "zip": "anthropic-export.zip",
+        }[kind],
+        package_sha=package_sha,
+        files=files,
+        truncated=truncated,
+        warnings=warnings,
+    )
+
+
+# --------------------------------------------------------------------------
+# Output / CLI
+# --------------------------------------------------------------------------
+
+
+def serialize_report(report: dict[str, Any]) -> str:
+    return (
+        json.dumps(report, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+    )
+
+
+def _validate_output_path(input_path: str, output_path: str) -> None:
+    source = Path(input_path)
+    target = Path(output_path)
+    try:
+        resolved_source = source.resolve(strict=False)
+        resolved_target = target.resolve(strict=False)
+    except OSError as exc:
+        raise UsageError(
+            "Could not resolve input/output paths.",
+            code="output_not_writable",
+        ) from exc
+    if resolved_target == resolved_source or (
+        source.is_dir() and resolved_source in resolved_target.parents
+    ):
+        raise UsageError(
+            "Output path must not overwrite or reside beneath the input package.",
+            code="output_overlaps_input",
+        )
+
+
+def write_report(
+    report: dict[str, Any], output_path: str, *, input_path: str | None = None
+) -> None:
+    if input_path is not None:
+        _validate_output_path(input_path, output_path)
+    target = Path(output_path)
+    if target.is_dir():
+        raise UsageError(
+            f"Output path is a directory: {output_path}",
+            code="output_not_writable",
+        )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(serialize_report(report), encoding="utf-8")
+
+
+def _short(text: str, limit: int = 16) -> str:
+    return text[:limit] if len(text) > limit else text
+
+
+def print_summary(report: dict[str, Any], output_path: str) -> None:
+    package = report["package"]
+    print("Anthropic export profile complete")
+    print(f"package_kind: {package['kind']}")
+    print(f"package_fingerprint: sha256:{_short(package['sha256'])}...")
+    print(f"file_count: {package['file_count']}")
+    print(f"json_file_count: {package['json_file_count']}")
+    print(f"warning_count: {len(report['warnings'])}")
+    print("report_path: <output>")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="profile_anthropic_export.py",
+        description=(
+            "Read-only Anthropic account-export profiler. Inspects a ZIP "
+            "archive, extracted directory, or JSON file and emits a "
+            "deterministic structural evidence report. Does not import data."
+        ),
+    )
+    parser.add_argument(
+        "input",
+        help="Path to a ZIP archive, extracted directory, or JSON file.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to the JSON report to write.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        report = profile_export(args.input)
+    except UsageError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+    except UnsafePackageError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_UNSAFE
+
+    try:
+        write_report(report, args.output, input_path=args.input)
+    except UsageError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+    except OSError as exc:
+        print(f"error: cannot write output: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+
+    print_summary(report, args.output)
+    return EXIT_OK
+
+
+# ``Sequence`` is imported with the other typing names above.
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_anthropic_export_profiler.py
+++ b/tests/scripts/test_anthropic_export_profiler.py
@@ -1,0 +1,841 @@
+"""Synthetic tests for the read-only Anthropic account-export profiler.
+
+These tests use ONLY temporary synthetic files. No real Anthropic export and no
+real profile report is ever committed or read here. The profiler is loaded
+directly from its script path so the test exercises the real standalone module.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import stat
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = (
+    REPO_ROOT / "scripts" / "anthropic_import" / "profile_anthropic_export.py"
+)
+
+
+@pytest.fixture(scope="module")
+def profiler():
+    spec = importlib.util.spec_from_file_location(
+        "anthropic_export_profiler", SCRIPT_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so dataclass annotation resolution can find the module.
+    sys.modules["anthropic_export_profiler"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+# --------------------------------------------------------------------------
+# Synthetic data builders
+# --------------------------------------------------------------------------
+
+CANARY_TEXT = "CANARY_MESSAGE_TEXT_hunter2_secret"
+CANARY_TITLE = "CANARY_TITLE_SecretProjectAlpha"
+CANARY_UUID = "11111111-2222-3333-4444-555555555555"
+CANARY_EMAIL = "canary-user@example.com"
+CANARY_USERNAME = "canary-account-user"
+CANARY_MSG_UUID_A = "aaaaaaaa-0000-0000-0000-000000000001"
+CANARY_MSG_UUID_B = "aaaaaaaa-0000-0000-0000-000000000002"
+CANARY_MODEL = "claude-test-opus"
+CANARY_ATTACHMENT = "invoice-canary.png"
+
+
+def _claude_conversation() -> dict:
+    return {
+        "uuid": CANARY_UUID,
+        "name": CANARY_TITLE,
+        "account": {"email_address": CANARY_EMAIL},
+        "chat_messages": [
+            {
+                "uuid": CANARY_MSG_UUID_A,
+                "sender": "human",
+                "text": CANARY_TEXT,
+                "created_at": "2026-01-02T03:04:05Z",
+                "updated_at": "2026-01-02T03:04:05Z",
+                "parent_message_uuid": None,
+            },
+            {
+                "uuid": CANARY_MSG_UUID_B,
+                "sender": "assistant",
+                "model": CANARY_MODEL,
+                "created_at": "2026-01-02T03:05:06Z",
+                "updated_at": "2026-01-02T03:05:06Z",
+                "parent_message_uuid": CANARY_MSG_UUID_A,
+                "content": [
+                    {"type": "text", "text": "structured answer canary"},
+                    {"type": "tool_use", "name": "search"},
+                ],
+                "attachments": [{"file_name": CANARY_ATTACHMENT}],
+            },
+        ],
+    }
+
+
+def _write_zip(path: Path, members: dict[str, bytes | str]) -> Path:
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as bundle:
+        for name, payload in members.items():
+            if isinstance(payload, bytes):
+                bundle.writestr(name, payload)
+            else:
+                bundle.writestr(name, payload)
+    return path
+
+
+def _write_symlink_zip(path: Path, link_name: str, target: str) -> Path:
+    with zipfile.ZipFile(path, "w") as bundle:
+        info = zipfile.ZipInfo(link_name)
+        info.external_attr = (stat.S_IFLNK | 0o777) << 16
+        bundle.writestr(info, target)
+    return path
+
+
+def _serialize(profiler, report: dict) -> str:
+    return profiler.serialize_report(report)
+
+
+# --------------------------------------------------------------------------
+# 1. Flat conversation array with chat_messages
+# --------------------------------------------------------------------------
+
+
+def test_profiles_zip_with_chat_messages_container(profiler, tmp_path):
+    archive = _write_zip(
+        tmp_path / "export.zip",
+        {"conversations.json": json.dumps([_claude_conversation()])},
+    )
+    report = profiler.profile_export(str(archive))
+
+    assert report["report_schema"] == "anthropic_export_profile_report_v1"
+    assert report["profiler_version"] == "1"
+    assert report["package"]["kind"] == "zip"
+    shape = report["conversation_shape"]
+    assert shape["conversations_observed"] is True
+    assert shape["candidate_conversation_count"] == 1
+    assert any(
+        c["key"] == "chat_messages" for c in shape["message_container_keys"]
+    )
+    conv_cands = [
+        c
+        for c in report["candidate_surfaces"]
+        if c["classification"] == "conversations"
+    ]
+    assert conv_cands, "expected a conversations candidate surface"
+
+
+# --------------------------------------------------------------------------
+# 2. Detects sender/ids/timestamps/model/project refs without raw values
+# --------------------------------------------------------------------------
+
+
+def test_detects_structural_fields_without_raw_values(profiler, tmp_path):
+    conv = _claude_conversation()
+    conv["project_uuid"] = "proj-canary-123"
+    archive = _write_zip(
+        tmp_path / "export.zip",
+        {"conversations.json": json.dumps([conv])},
+    )
+    report = profiler.profile_export(str(archive))
+    shape = report["conversation_shape"]
+
+    role_fields = {c["key"] for c in shape["role_field_names"]}
+    assert "sender" in role_fields
+    role_values = {c["key"] for c in shape["role_values"]}
+    assert {"human", "assistant"} <= role_values
+
+    ts_fields = {c["key"] for c in shape["timestamp_field_names"]}
+    assert {"created_at", "updated_at"} <= ts_fields
+    formats = {c["key"] for c in shape["timestamp_format_categories"]}
+    assert "iso8601" in formats
+
+    model_fields = {c["key"] for c in shape["model_field_names"]}
+    assert "model" in model_fields
+
+    id_fields = {c["key"] for c in shape["identifier_field_names"]}
+    assert {"uuid", "parent_message_uuid"} <= id_fields
+
+    proj_refs = {c["key"] for c in shape["project_reference_field_names"]}
+    assert "project_uuid" in proj_refs
+
+    block_types = {c["key"] for c in shape["content_block_types"]}
+    assert {"text", "tool_use"} <= block_types
+
+    # Structural evidence must not leak any raw values.
+    blob = _serialize(profiler, report)
+    for canary in (
+        CANARY_TEXT,
+        CANARY_TITLE,
+        CANARY_EMAIL,
+        CANARY_UUID,
+        CANARY_MSG_UUID_A,
+        CANARY_MODEL,
+        CANARY_ATTACHMENT,
+        "proj-canary-123",
+        "structured answer canary",
+    ):
+        assert canary not in blob
+
+
+# --------------------------------------------------------------------------
+# 3. Branch structure (parent_message_uuid)
+# --------------------------------------------------------------------------
+
+
+def test_detects_parent_message_branch_structure(profiler, tmp_path):
+    archive = _write_zip(
+        tmp_path / "export.zip",
+        {"conversations.json": json.dumps([_claude_conversation()])},
+    )
+    report = profiler.profile_export(str(archive))
+    parent_fields = {
+        c["key"]
+        for c in report["conversation_shape"]["parent_relationship_field_names"]
+    }
+    assert "parent_message_uuid" in parent_fields
+    assert (
+        report["capabilities_observed"]["message_parent_links"]["observed"]
+        is True
+    )
+    codes = {w["code"] for w in report["warnings"]}
+    assert "possible_branch_structure" in codes
+
+
+# --------------------------------------------------------------------------
+# 4. projects.json / users.json / memories.json candidate surfaces
+# --------------------------------------------------------------------------
+
+
+def test_profiles_projects_users_memories_surfaces(profiler, tmp_path):
+    members = {
+        "projects.json": json.dumps(
+            [{"project_uuid": "p1", "name": "P", "description": "d"}]
+        ),
+        "users.json": json.dumps(
+            [
+                {
+                    "email_address": CANARY_EMAIL,
+                    "full_name": "Name Canary",
+                    "uuid": CANARY_UUID,
+                }
+            ]
+        ),
+        "memories.json": json.dumps(
+            [{"memory": "remembered canary", "memory_id": "m1"}]
+        ),
+    }
+    archive = _write_zip(tmp_path / "export.zip", members)
+    report = profiler.profile_export(str(archive))
+
+    classifications = {
+        (c["relative_path"], c["classification"])
+        for c in report["candidate_surfaces"]
+    }
+    assert ("projects.json", "projects") in classifications
+    assert ("users.json", "users_or_account") in classifications
+    assert ("memories.json", "memories") in classifications
+
+    caps = report["capabilities_observed"]
+    assert caps["project_records"]["observed"] is True
+    assert caps["account_metadata"]["observed"] is True
+    assert caps["memory_records"]["observed"] is True
+
+    blob = _serialize(profiler, report)
+    for canary in (
+        CANARY_EMAIL,
+        CANARY_UUID,
+        "Name Canary",
+        "remembered canary",
+    ):
+        assert canary not in blob
+
+
+# --------------------------------------------------------------------------
+# 5. Binary members inventoried, not parsed as JSON
+# --------------------------------------------------------------------------
+
+
+def test_inventories_binary_members_without_json_parse(profiler, tmp_path):
+    png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+    archive = _write_zip(
+        tmp_path / "export.zip",
+        {
+            "conversations.json": json.dumps([_claude_conversation()]),
+            "media/photo.png": png,
+        },
+    )
+    report = profiler.profile_export(str(archive))
+    by_path = {f["relative_path"]: f for f in report["files"]}
+    png_record = next(
+        record for record in by_path.values() if record["broad_type"] == "image"
+    )
+    assert png_record["broad_type"] == "image"
+    assert png_record["json_parse_status"] == "not_json"
+    assert png_record["sha256"] != ""
+    assert (
+        report["capabilities_observed"]["binary_payloads"]["observed"] is True
+    )
+
+
+# --------------------------------------------------------------------------
+# 6. Attachment / generated-file / artifact hints distinguished
+# --------------------------------------------------------------------------
+
+
+def test_distinguishes_attachment_generated_and_artifact_hints(
+    profiler, tmp_path
+):
+    conv = {
+        "uuid": CANARY_UUID,
+        "chat_messages": [
+            {
+                "uuid": CANARY_MSG_UUID_A,
+                "sender": "user",
+                "content": [{"type": "text", "text": "x"}],
+                "attachments": [{"file_id": "CANARY_FILE_TOKEN"}],
+            },
+            {
+                "uuid": CANARY_MSG_UUID_B,
+                "sender": "assistant",
+                "content": [
+                    {
+                        "type": "image",
+                        "generated": True,
+                        "generation": "CANARY_GEN_TOKEN",
+                    }
+                ],
+                "artifacts": [{"artifact_id": "CANARY_ARTIFACT_TOKEN"}],
+            },
+        ],
+    }
+    archive = _write_zip(
+        tmp_path / "export.zip",
+        {"conversations.json": json.dumps([conv])},
+    )
+    report = profiler.profile_export(str(archive))
+    caps = report["capabilities_observed"]
+    assert caps["attachment_references"]["observed"] is True
+    assert caps["generated_file_evidence"]["observed"] is True
+    assert caps["artifact_evidence"]["observed"] is True
+
+    blob = _serialize(profiler, report)
+    # Distinctive, non-hex tokens so they cannot collide with sha256 hex.
+    for token in (
+        "CANARY_GEN_TOKEN",
+        "CANARY_ARTIFACT_TOKEN",
+        "CANARY_FILE_TOKEN",
+    ):
+        assert token not in blob
+
+
+# --------------------------------------------------------------------------
+# 7. Malformed JSON -> bounded warning, rest preserved
+# --------------------------------------------------------------------------
+
+
+def test_malformed_json_reported_as_warning(profiler, tmp_path):
+    archive = _write_zip(
+        tmp_path / "export.zip",
+        {
+            "conversations.json": json.dumps([_claude_conversation()]),
+            "broken.json": "{not valid json,,,",
+        },
+    )
+    report = profiler.profile_export(str(archive))
+    by_path = {f["relative_path"]: f for f in report["files"]}
+    broken = next(
+        record
+        for record in by_path.values()
+        if record["json_parse_status"] == "failed"
+    )
+    assert broken["json_parse_status"] == "failed"
+    codes = {(w["code"], w["relative_path"]) for w in report["warnings"]}
+    assert any(
+        code == "json_parse_failed" and path != "broken.json"
+        for code, path in codes
+    )
+    # Rest of inventory preserved.
+    assert by_path["conversations.json"]["json_parse_status"] == "ok"
+    assert report["conversation_shape"]["conversations_observed"] is True
+
+
+# --------------------------------------------------------------------------
+# 8-11. ZIP structural rejections
+# --------------------------------------------------------------------------
+
+
+def test_rejects_zip_traversal_path(profiler, tmp_path):
+    archive = _write_zip(tmp_path / "export.zip", {"../escape.json": "[]"})
+    with pytest.raises(profiler.UnsafePackageError) as exc:
+        profiler.profile_export(str(archive))
+    assert exc.value.code == "path_traversal_rejected"
+
+
+def test_rejects_zip_absolute_path(profiler, tmp_path):
+    archive = _write_zip(tmp_path / "export.zip", {"/etc/host.json": "[]"})
+    with pytest.raises(profiler.UnsafePackageError) as exc:
+        profiler.profile_export(str(archive))
+    assert exc.value.code == "absolute_path_rejected"
+
+
+def test_rejects_zip_symbolic_link(profiler, tmp_path):
+    archive = _write_symlink_zip(
+        tmp_path / "export.zip", "link.json", "/etc/passwd"
+    )
+    with pytest.raises(profiler.UnsafePackageError) as exc:
+        profiler.profile_export(str(archive))
+    assert exc.value.code == "symlink_rejected"
+
+
+def test_rejects_normalized_duplicate_member_path(profiler, tmp_path):
+    archive = _write_zip(
+        tmp_path / "export.zip",
+        {"data.json": "[]", "./data.json": "[]"},
+    )
+    with pytest.raises(profiler.UnsafePackageError) as exc:
+        profiler.profile_export(str(archive))
+    assert exc.value.code == "duplicate_path_rejected"
+
+
+# --------------------------------------------------------------------------
+# 12. Directory symlink rejection
+# --------------------------------------------------------------------------
+
+
+def test_rejects_directory_symbolic_link(profiler, tmp_path):
+    root = tmp_path / "extracted"
+    root.mkdir()
+    (root / "real.json").write_text("[]")
+    (root / "link.json").symlink_to(os.path.join(str(root), "real.json"))
+    with pytest.raises(profiler.UnsafePackageError) as exc:
+        profiler.profile_export(str(root))
+    assert exc.value.code == "symlink_rejected"
+
+
+# --------------------------------------------------------------------------
+# 13. Deterministic / identical reports across repeated runs
+# --------------------------------------------------------------------------
+
+
+def test_repeated_runs_produce_identical_reports(profiler, tmp_path):
+    archive = _write_zip(
+        tmp_path / "export.zip",
+        {
+            "conversations.json": json.dumps([_claude_conversation()]),
+            "projects.json": json.dumps([{"project_id": "p", "name": "n"}]),
+        },
+    )
+    first = profiler.serialize_report(profiler.profile_export(str(archive)))
+    second = profiler.serialize_report(profiler.profile_export(str(archive)))
+    assert first == second
+    # JSON is sorted + two-space indent + trailing newline.
+    assert first.endswith("\n")
+    assert '\n  "' in first  # 2-space indentation present
+
+
+# --------------------------------------------------------------------------
+# 14-18. Sensitive-data boundary (no text/title/uuid/email/abs-path)
+# --------------------------------------------------------------------------
+
+
+def test_sensitive_data_boundary(profiler, tmp_path):
+    archive = _write_zip(
+        tmp_path / "export.zip",
+        {
+            "conversations.json": json.dumps([_claude_conversation()]),
+            "users.json": json.dumps(
+                [
+                    {
+                        "email_address": CANARY_EMAIL,
+                        "uuid": CANARY_UUID,
+                        "full_name": "Name",
+                    }
+                ]
+            ),
+            "projects/11111111-2222-3333-4444-555555555555.json": json.dumps(
+                {"name": CANARY_TITLE, "description": "d", "uuid": CANARY_UUID}
+            ),
+        },
+    )
+    report = profiler.profile_export(str(archive))
+    blob = _serialize(profiler, report)
+
+    # 14. no message text
+    assert CANARY_TEXT not in blob
+    # 15. no conversation/project titles
+    assert CANARY_TITLE not in blob
+    # 16. no synthetic UUID values (also redacted from the project filename)
+    assert CANARY_UUID not in blob
+    # 17. no email addresses
+    assert CANARY_EMAIL not in blob
+    # 18. no absolute source path
+    assert str(tmp_path) not in blob
+    assert str(archive.parent) not in blob
+
+    # UUID-shaped project filename is scrubbed but still inventoried uniquely.
+    project_paths = [
+        f["relative_path"]
+        for f in report["files"]
+        if f["relative_path"].startswith("projects/")
+    ]
+    assert project_paths == ["projects/<uuid>.json"]
+
+
+def test_aliases_non_uuid_identity_bearing_paths_and_display_name(
+    profiler, tmp_path
+):
+    archive = _write_zip(
+        tmp_path / f"{CANARY_EMAIL}-export.zip",
+        {
+            f"users/{CANARY_USERNAME}.json": json.dumps(
+                {"email": CANARY_EMAIL}
+            ),
+            f"attachments/{CANARY_ATTACHMENT}": b"attachment-bytes",
+            "attachments/private.canary-username": b"attachment-bytes",
+        },
+    )
+    report = profiler.profile_export(str(archive))
+    blob = _serialize(profiler, report)
+
+    for canary in (
+        CANARY_EMAIL,
+        CANARY_USERNAME,
+        CANARY_ATTACHMENT,
+        archive.name,
+    ):
+        assert canary not in blob
+    assert "canary-username" not in blob
+    assert report["package"]["display_name"] == "anthropic-export.zip"
+    assert all(
+        "<path-" in path
+        or path.startswith("users/")
+        or path.startswith("attachments/")
+        for path in (f["relative_path"] for f in report["files"])
+    )
+
+
+def test_unknown_role_and_content_labels_collapse_to_safe_sentinels(
+    profiler, tmp_path
+):
+    conversation = {
+        "messages": [
+            {
+                "sender": CANARY_USERNAME,
+                "role": "private-role-canary",
+                "type": "private-message-type-canary",
+                "content": [
+                    {
+                        "type": "private-block-type-canary",
+                        "content_type": "private-content-type-canary",
+                    }
+                ],
+            }
+        ]
+    }
+    archive = _write_zip(
+        tmp_path / "conversations.json",
+        {"conversations.json": json.dumps(conversation)},
+    )
+    report = profiler.profile_export(str(archive))
+    blob = _serialize(profiler, report)
+
+    for canary in (
+        CANARY_USERNAME,
+        "private-role-canary",
+        "private-message-type-canary",
+        "private-block-type-canary",
+        "private-content-type-canary",
+    ):
+        assert canary not in blob
+    assert {
+        entry["key"] for entry in report["conversation_shape"]["role_values"]
+    } == {"unknown"}
+    assert {
+        entry["key"]
+        for entry in report["unknown_structures"]["unknown_content_block_types"]
+    } == {"unknown"}
+
+
+def test_top_level_message_container_is_counted_once(profiler, tmp_path):
+    archive = _write_zip(
+        tmp_path / "messages.json",
+        {
+            "messages.json": json.dumps(
+                {"messages": [{"sender": "human", "text": "x"}]}
+            )
+        },
+    )
+    report = profiler.profile_export(str(archive))
+    counts = {
+        entry["key"]: entry["count"]
+        for entry in report["conversation_shape"]["message_container_keys"]
+    }
+    assert counts["messages"] == 1
+
+
+def test_rejects_corrupt_zip_member_as_unsafe(profiler, tmp_path):
+    archive = _write_zip(tmp_path / "corrupt.zip", {"data.json": "[]"})
+    with zipfile.ZipFile(archive) as bundle:
+        info = bundle.infolist()[0]
+    raw = bytearray(archive.read_bytes())
+    data_offset = (
+        info.header_offset + 30 + len(info.filename.encode()) + len(info.extra)
+    )
+    raw[data_offset] ^= 0xFF
+    archive.write_bytes(raw)
+
+    with pytest.raises(profiler.UnsafePackageError) as exc:
+        profiler.profile_export(str(archive))
+    assert exc.value.code == "corrupt_zip_member"
+    assert (
+        profiler.main([str(archive), "--output", str(tmp_path / "report.json")])
+        == profiler.EXIT_UNSAFE
+    )
+
+
+def test_oversized_json_member_sets_analysis_truncated(
+    profiler, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(profiler, "MAX_MEMBER_BYTES", 8)
+    archive = _write_zip(
+        tmp_path / "large.zip",
+        {"large.json": json.dumps({"value": "0123456789"})},
+    )
+    report = profiler.profile_export(str(archive))
+
+    assert report["package"]["analysis_truncated"] is True
+    assert report["files"][0]["json_parse_status"] == "skipped"
+    assert any(
+        w["code"] == "analysis_limit_reached" for w in report["warnings"]
+    )
+
+
+def test_excessive_json_nesting_is_bounded(profiler, tmp_path):
+    nested = (
+        "[" * (profiler.MAX_JSON_DEPTH + 10)
+        + "0"
+        + "]" * (profiler.MAX_JSON_DEPTH + 10)
+    )
+    archive = _write_zip(tmp_path / "nested.zip", {"nested.json": nested})
+    report = profiler.profile_export(str(archive))
+
+    assert report["files"][0]["json_parse_status"] == "skipped"
+    assert report["package"]["analysis_truncated"] is True
+    assert any(w["code"] == "json_nesting_exceeded" for w in report["warnings"])
+
+
+def test_output_cannot_overwrite_or_enter_input_package(profiler, tmp_path):
+    archive = _write_zip(tmp_path / "export.zip", {"conversations.json": "[]"})
+    original = archive.read_bytes()
+    assert (
+        profiler.main([str(archive), "--output", str(archive)])
+        == profiler.EXIT_USAGE
+    )
+    assert archive.read_bytes() == original
+
+    root = tmp_path / "exported"
+    root.mkdir()
+    (root / "data.json").write_text("[]")
+    nested_output = root / "reports" / "profile.json"
+    assert (
+        profiler.main([str(root), "--output", str(nested_output)])
+        == profiler.EXIT_USAGE
+    )
+    assert not nested_output.exists()
+
+
+# --------------------------------------------------------------------------
+# 19. Truncation when a configured limit is exceeded
+# --------------------------------------------------------------------------
+
+
+def test_reports_truncation_on_file_count_limit(
+    profiler, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(profiler, "MAX_PACKAGE_FILE_COUNT", 2)
+    members = {f"f{i}.json": json.dumps([{"name": f"n{i}"}]) for i in range(5)}
+    archive = _write_zip(tmp_path / "export.zip", members)
+    report = profiler.profile_export(str(archive))
+
+    assert report["package"]["analysis_truncated"] is True
+    assert report["package"]["file_count"] == 2
+    codes = {w["code"] for w in report["warnings"]}
+    assert "analysis_limit_reached" in codes
+
+
+# --------------------------------------------------------------------------
+# 20. Direct JSON-file input
+# --------------------------------------------------------------------------
+
+
+def test_supports_direct_json_file_input(profiler, tmp_path):
+    json_path = tmp_path / "single.json"
+    json_path.write_text(json.dumps([_claude_conversation()]))
+    report = profiler.profile_export(str(json_path))
+
+    assert report["package"]["kind"] == "json"
+    assert report["package"]["file_count"] == 1
+    assert report["conversation_shape"]["conversations_observed"] is True
+    assert report["files"][0]["relative_path"] != "single.json"
+
+
+# --------------------------------------------------------------------------
+# 21. Extracted-directory input
+# --------------------------------------------------------------------------
+
+
+def test_supports_extracted_directory_input(profiler, tmp_path):
+    root = tmp_path / "export"
+    root.mkdir()
+    (root / "conversations.json").write_text(
+        json.dumps([_claude_conversation()])
+    )
+    (root / "media").mkdir()
+    (root / "media" / "photo.png").write_bytes(
+        b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+    )
+
+    report = profiler.profile_export(str(root))
+    assert report["package"]["kind"] == "directory"
+    paths = {f["relative_path"] for f in report["files"]}
+    assert "conversations.json" in paths
+    assert any(path.startswith("media/") for path in paths)
+    assert report["conversation_shape"]["conversations_observed"] is True
+    assert (
+        report["capabilities_observed"]["binary_payloads"]["observed"] is True
+    )
+
+
+# --------------------------------------------------------------------------
+# 22. Documented CLI exit codes
+# --------------------------------------------------------------------------
+
+
+def test_cli_exit_codes_via_main(profiler, tmp_path):
+    archive = _write_zip(
+        tmp_path / "export.zip",
+        {"conversations.json": json.dumps([_claude_conversation()])},
+    )
+    out = tmp_path / "report.json"
+
+    # 0: success
+    rc = profiler.main([str(archive), "--output", str(out)])
+    assert rc == profiler.EXIT_OK
+    assert out.exists()
+    assert json.loads(out.read_text())["report_schema"]
+
+    # 2: missing input
+    rc = profiler.main([str(tmp_path / "missing.zip"), "--output", str(out)])
+    assert rc == profiler.EXIT_USAGE
+
+    # 2: unsupported input type (non-zip, non-json file)
+    other = tmp_path / "data.bin"
+    other.write_bytes(b"\x00\x01\x02\x03")
+    rc = profiler.main([str(other), "--output", str(out)])
+    assert rc == profiler.EXIT_USAGE
+
+    # 3: unsafe archive
+    bad = _write_zip(tmp_path / "bad.zip", {"../escape.json": "[]"})
+    rc = profiler.main([str(bad), "--output", str(out)])
+    assert rc == profiler.EXIT_UNSAFE
+
+
+def test_cli_exit_codes_via_subprocess(tmp_path):
+    archive = _write_zip(
+        tmp_path / "export.zip",
+        {"conversations.json": json.dumps([_claude_conversation()])},
+    )
+    out = tmp_path / "report.json"
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), str(archive), "--output", str(out)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Anthropic export profile complete" in result.stdout
+    assert "package_kind: zip" in result.stdout
+    assert "file_count:" in result.stdout
+    report = json.loads(out.read_text())
+    assert report["report_schema"] == "anthropic_export_profile_report_v1"
+    assert report["errors"] == []
+
+
+# --------------------------------------------------------------------------
+# Extra invariants: no Codexify runtime dependency, no extraction to disk
+# --------------------------------------------------------------------------
+
+
+def test_no_codexify_runtime_dependency_imported():
+    source = SCRIPT_PATH.read_text(encoding="utf-8")
+    for forbidden in (
+        "import guardian",
+        "from guardian",
+        "import backend",
+        "from backend",
+        "import redis",
+        "import sqlalchemy",
+        "import psycopg2",
+    ):
+        assert (
+            forbidden not in source
+        ), f"profiler must not import {forbidden!r}"
+
+
+def test_zip_members_are_not_extracted_to_disk(profiler, tmp_path, monkeypatch):
+    archive = _write_zip(
+        tmp_path / "export.zip",
+        {
+            "conversations.json": json.dumps([_claude_conversation()]),
+            "nested/deep/secret.json": json.dumps({"a": 1}),
+        },
+    )
+    extracted_before = {p for p in tmp_path.rglob("*") if p.is_file()}
+    profiler.profile_export(str(archive))
+    extracted_after = {p for p in tmp_path.rglob("*") if p.is_file()}
+    # Only the archive itself should exist; no member files materialized.
+    new_files = extracted_after - extracted_before
+    assert new_files == set(), f"unexpected files appeared: {new_files}"
+
+
+def test_report_has_required_top_level_fields(profiler, tmp_path):
+    archive = _write_zip(
+        tmp_path / "export.zip",
+        {"conversations.json": json.dumps([_claude_conversation()])},
+    )
+    report = profiler.profile_export(str(archive))
+    expected = {
+        "report_schema",
+        "profiler_version",
+        "package",
+        "files",
+        "candidate_surfaces",
+        "conversation_shape",
+        "capabilities_observed",
+        "unknown_structures",
+        "warnings",
+        "errors",
+    }
+    assert expected <= set(report.keys())
+    assert set(report.keys()) == expected
+    for key in (
+        "kind",
+        "display_name",
+        "sha256",
+        "file_count",
+        "json_file_count",
+        "binary_file_count",
+        "total_bytes",
+        "analysis_truncated",
+    ):
+        assert key in report["package"]


### PR DESCRIPTION
## Summary

Replaces the Anthropic export profiler portion of PR #632 with a clean branch based on current main. Repairs identity-safe path aliases and package naming, semantic label allowlists, corrupt ZIP member handling, exact message-container counting, source/output overlap rejection, truncation propagation, and bounded deep-JSON handling. Adds focused regressions and updates profiler documentation.

## Validation

- ============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
plugins: anyio-4.13.0
collected 29 items

tests/scripts/test_anthropic_export_profiler.py ........................ [ 82%]
.....                                                                    [100%]

============================== 29 passed in 0.12s ============================== — 29 passed
-  — passed
-  — passed
- docs/architecture/anthropic-export-profiler.md
scripts/anthropic_import/profile_anthropic_export.py
tests/scripts/test_anthropic_export_profiler.py — exactly the three authorized profiler files

Unrelated PR #632 changes were intentionally excluded. PR #632 should remain open until this replacement is reviewed and merged.