### PR TITLE
test: exclude Playwright specs from Vitest

### DIFF
--- a/frontend/src/vitest.config.ts
+++ b/frontend/src/vitest.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
     ],
     exclude: [
       "node_modules/**",
+      "tests/playwright/**",
       "components/persona/__tests__/appshell-glass.test.tsx",
       "components/persona/__tests__/appshell-lastview-persist.test.tsx",
       "components/persona/__tests__/theme-toggle-and-storage.test.tsx",


### PR DESCRIPTION
## Summary

Closes #639.

- Adds the explicit Vitest exclusion `tests/playwright/**`.
- Preserves all existing Vitest include patterns and other exclusions.
- Changes only `frontend/src/vitest.config.ts`.

## Validation

- `git diff --check`: passed.
- Vitest resolved collection via the configured project glob: 170 files, 0 under `tests/playwright/`.
- `pnpm exec playwright test --config playwright.config.ts --list`: passed; 12 tests in all 6 Playwright spec files.
- Full Vitest run was attempted, reproduced the existing broad-suite failures, and was stopped after the timing-sensitive suite did not reach a summary. No baseline test or WorkspaceShelfPanel timing behavior was changed.

## Commit

`39b4f3d90410f279b05fee2ef95702f23f2a6cf3`