### PR TITLE
Contain mobile user message bubbles

### DIFF
--- a/frontend/src/features/chat/components/ChatBubble.tsx
+++ b/frontend/src/features/chat/components/ChatBubble.tsx
@@ -516,10 +516,8 @@ export function ChatBubble({
         overscrollBehavior: "contain",
       }
     : undefined;
-  // Keep padding on the content node itself so collapsed messages still have
-  // inset text when max-height clipping is active.
   const userMessageTextClass = cn(
-    "w-full min-w-0 px-4 py-3 text-left text-sm leading-relaxed whitespace-pre-wrap break-words",
+    "min-w-0 max-w-full text-left text-sm leading-relaxed whitespace-pre-wrap break-words",
     userMessageLooksLikeCode ? "font-mono text-[13px] leading-5" : null
   );
 
@@ -712,10 +710,14 @@ export function ChatBubble({
     >
       {hasVisibleContent ? (
         <div
-          className="max-w-full min-w-0 rounded-[var(--tile-radius)] p-3 shadow-sm"
+          data-testid="chat-user-message-bubble"
+          className={cn(
+            "w-fit max-w-full min-w-0 box-border overflow-hidden rounded-[var(--tile-radius)] px-3 py-2 shadow-sm",
+            isPhoneShell ? "max-w-[calc(100%-var(--shell-gap,10px))]" : null
+          )}
           style={{ background: "var(--accent)", color: "var(--pill-active-text)" }}
         >
-          <div className="flex flex-col gap-2">
+          <div className="flex max-w-full min-w-0 flex-col items-end gap-2">
             {hasDocumentTiles ? (
               <div className="flex w-full flex-col items-end gap-2">
                 {documentTiles.map((tile) => (

--- a/frontend/src/features/chat/components/__tests__/ChatBubble.test.tsx
+++ b/frontend/src/features/chat/components/__tests__/ChatBubble.test.tsx
@@ -323,26 +323,130 @@ describe("ChatBubble", () => {
     expect(container.querySelector(".codexifyCodeBlock")).not.toBeInTheDocument();
   });
 
-  it("left-aligns user message text and keeps it padded within the bubble", () => {
-    const centeredText = `Centered user message ${"x".repeat(1300)}`;
+  it("keeps short phone-shell user messages content-fit inside a bounded bubble", () => {
     const { container } = render(
       <ChatBubble
         isGuardian={false}
+        isPhoneShell
         message={{
-          id: "msg-center-user",
+          id: "msg-short-user",
           authorId: "me",
           authorName: "You",
-          content: centeredText,
+          content: "Hello",
           createdAt: Date.now(),
         }}
       />
     );
 
-    const content = container.querySelector(
-      '[data-testid="guardian-user-message-content"]'
+    const bubble = screen.getByTestId("chat-user-message-bubble");
+    const content = container.querySelector(".whitespace-pre-wrap");
+
+    expect(bubble).toHaveClass(
+      "w-fit",
+      "max-w-full",
+      "min-w-0",
+      "box-border",
+      "overflow-hidden",
+      "px-3",
+      "py-2"
     );
-    expect(content).toHaveClass("text-left", "px-4", "py-3");
+    expect(bubble).toHaveClass("max-w-[calc(100%-var(--shell-gap,10px))]");
+    expect(content).toHaveClass(
+      "min-w-0",
+      "max-w-full",
+      "text-left",
+      "whitespace-pre-wrap",
+      "break-words"
+    );
+    const contentClasses = content?.className.split(/\s+/) ?? [];
+    expect(contentClasses).not.toContain("w-full");
+    expect(contentClasses.some((className) => /^p[xy]-/.test(className))).toBe(false);
     expect(content).not.toHaveClass("text-center");
+  });
+
+  it("keeps uninterrupted phone-shell user content wrapped and bounded", () => {
+    const longToken = "x".repeat(1300);
+    const { container } = render(
+      <ChatBubble
+        isGuardian={false}
+        isPhoneShell
+        message={{
+          id: "msg-long-user",
+          authorId: "me",
+          authorName: "You",
+          content: longToken,
+          createdAt: Date.now(),
+        }}
+      />
+    );
+
+    const bubble = screen.getByTestId("chat-user-message-bubble");
+    const content = screen.getByTestId("guardian-user-message-content");
+
+    expect(bubble).toHaveClass(
+      "w-fit",
+      "max-w-full",
+      "min-w-0",
+      "box-border",
+      "overflow-hidden",
+      "max-w-[calc(100%-var(--shell-gap,10px))]"
+    );
+    expect(content).toHaveClass(
+      "min-w-0",
+      "max-w-full",
+      "text-left",
+      "whitespace-pre-wrap",
+      "break-words"
+    );
+    expect(content).toHaveStyle({
+      overflowWrap: "anywhere",
+      wordBreak: "break-word",
+    });
+  });
+
+  it("keeps a trailing emoji inside the user bubble seam", () => {
+    render(
+      <ChatBubble
+        isGuardian={false}
+        isPhoneShell
+        message={{
+          id: "msg-emoji-user",
+          authorId: "me",
+          authorName: "You",
+          content: "Message ending safely 🎉",
+          createdAt: Date.now(),
+        }}
+      />
+    );
+
+    const bubble = screen.getByTestId("chat-user-message-bubble");
+    expect(bubble).toContainElement(screen.getByText("Message ending safely 🎉"));
+    expect(bubble.querySelector('[style*="position"]')).toBeNull();
+  });
+
+  it("preserves oversized user message expansion and bounded content", () => {
+    const longContent = `Pasted content ${"x".repeat(1300)}`;
+    render(
+      <ChatBubble
+        isGuardian={false}
+        message={{
+          id: "msg-oversized-user",
+          authorId: "me",
+          authorName: "You",
+          content: longContent,
+          createdAt: Date.now(),
+        }}
+      />
+    );
+
+    const content = screen.getByTestId("guardian-user-message-content");
+    const expandButton = screen.getByRole("button", { name: "See more" });
+    expect(content).toHaveStyle({ maxHeight: "224px", overflowY: "hidden" });
+
+    fireEvent.click(expandButton);
+
+    expect(screen.getByRole("button", { name: "Show less" })).toBeInTheDocument();
+    expect(content).toHaveStyle({ maxHeight: "360px", overflowY: "auto" });
   });
 
   it("renders document tiles inline without exposing the full document body", () => {


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
