### PR TITLE
Add internal proof profile for live user accent persistence

### DIFF
--- a/config/supported_profiles/v1-user-profile-accent-proof.yaml
+++ b/config/supported_profiles/v1-user-profile-accent-proof.yaml
@@ -1,0 +1,113 @@
+name: v1-user-profile-accent-proof
+version: 1
+surface: internal-proof-only-local-docker-compose-webui
+required_services:
+  - frontend
+  - backend
+  - db
+  - redis
+  - worker-chat
+  - worker-document-embed
+  - migrator
+optional_services:
+  - worker-warmup
+  - neo4j
+  - graph-init
+extension_posture:
+  public:
+    - mcp
+  internal:
+    - command_bus_http
+    - plugin_sdk
+route_posture:
+  enabled:
+    - health
+    - dashboard
+    - admin
+    - chat
+    - simple_chat
+    - api_chat
+    - threads
+    - projects
+    - api_projects
+    - documents
+    - media
+    - personal_facts
+    - migration
+    - embeddings
+    - obsidian
+  internal_only:
+    - coding_work_orders
+    - command_bus
+    - user_profile
+  quarantined:
+    - neo
+    - imprint
+    - system_prompt
+    - system_docs
+    - iddb
+    - backfill
+    - memory
+    - agent
+    - research
+    - share
+    - federation
+    - collaboration
+    - connectors
+    - google_connect
+    - voice
+    - flows
+    - tools
+    - api_tools
+    - exports
+    - codex
+    - devtools
+    - websocket
+    - cron
+    - ui_session
+    - agent_orchestration
+    - agent_orchestration_chat
+provider_contract:
+  LLM_PROVIDER: local
+  ALLOW_CLOUD_PROVIDERS: false
+  CODEXIFY_LOCAL_ONLY_MODE: true
+  CODEXIFY_EGRESS_ALLOWLIST: ""
+  LOCAL_BASE_URL: http://100.127.148.28:8000/v1
+  LOCAL_API_KEY: local
+  # Model names are NOT enforced here — the system discovers available models
+  # at runtime. If no local models exist AND no cloud provider is configured,
+  # the /health/llm endpoint will report models_available: false.
+criticality:
+  tier0:
+    services:
+      - frontend
+      - backend
+      - db
+      - redis
+      - worker-chat
+      - worker-document-embed
+    routes:
+      - health
+      - chat
+      - api_chat
+      - threads
+      - media
+      - documents
+  tier1:
+    services:
+      - migrator
+      - worker-warmup
+    routes:
+      - embeddings
+  tier2:
+    services:
+      - command_bus_http
+      - tts
+      - cron
+      - federation
+    routes:
+      - command_bus
+      - tools
+      - api_tools
+      - websocket
+      - cron

--- a/docs/architecture/proofs/2026-08-02-user-profile-accent-runtime-activation-proof.md
+++ b/docs/architecture/proofs/2026-08-02-user-profile-accent-runtime-activation-proof.md
@@ -1,0 +1,290 @@
+# User Profile Accent Runtime Activation Proof
+
+## Title
+
+Prove user accent persistence through an internal-only live profile.
+
+## Final Outcome
+
+**go** — the internal-only backend User Profile API was mounted, authenticated,
+validated, and shown to persist the canonical `violet` accent across destruction
+and recreation of the backend process. The value was restored to `default`
+before cleanup.
+
+This is a backend API proof only. It does not widen the supported beta promise.
+
+## Scope
+
+This proof uses the new proof-only supported profile
+`v1-user-profile-accent-proof` and an isolated temporary Postgres database. It
+proves the account-owned `accent_color` contract through the live
+`/api/user/profile` route, including authentication, canonical-token rejection,
+and durable readback after backend replacement.
+
+The default `v1-local-core-web-mcp` profile, migration, route implementation,
+frontend, Chrome extension, persona, memory, provider, queue, worker, and
+release contracts were not changed.
+
+## Repository identity
+
+- Repository: `/Users/chriscastillo/.codex/worktrees/aaba/Codexify-main`
+- Branch: `codex/prove-accent-persistence-live`
+- HEAD: `50721d0f51c4b8c0d61bfb398b733624d22872f4`
+- `origin/main`: `50721d0f51c4b8c0d61bfb398b733624d22872f4`
+- `git merge-base --is-ancestor origin/main HEAD`: PASS
+- `git fetch origin`: PASS after retrying outside the managed sandbox because
+  shared worktree `FETCH_HEAD` metadata was initially not writable
+- Initial worktree: clean
+- Final tracked scope: the three authorized files in this task only
+
+## ADR impact
+
+Classification: **aligned with existing ADR(s)**.
+
+Governing sources:
+
+- ADR-005 Runtime Mode and Account Boundary Invariants
+- Remote Account Access and User Profile Contract
+- Config and Ops supported-profile governance
+- Data and Storage
+- Canonical User Profile accent tokens in `guardian/user_profile_tokens.py`
+
+This proof activates no public route and changes no accepted account, identity,
+schema, or release contract. No new ADR is required.
+
+## Current-truth anchors
+
+- The accent migration and canonical token registry already exist.
+- Existing-row migration preservation was previously proven in the dated
+  existing-instance upgrade proof.
+- `/api/user/profile` exists in backend code but is quarantined by the default
+  supported profile.
+- An `internal_only` supported-profile route is mounted but removed from
+  generated OpenAPI.
+- Chrome extension rehydration and UI persistence remain unproven.
+
+## Invariants checked
+
+- The default supported profile was not changed.
+- The proof profile classifies `user_profile` as `internal_only`.
+- All other route classifications and all services, provider contract,
+  extension posture, and criticality data match the default profile.
+- Route sets do not overlap.
+- Only canonical accent tokens are accepted.
+- Invalid updates do not change the previously persisted valid token.
+- The active application database and its volume were not targeted by
+  migration, seed, profile, or cleanup commands.
+- No `docker compose down -v` was run.
+- No Alembic stamp or manual `alembic_version` edit was used.
+- No Chrome extension or frontend behavior is claimed.
+
+## Proof profile posture
+
+`config/supported_profiles/v1-user-profile-accent-proof.yaml` reports:
+
+- `name`: `v1-user-profile-accent-proof`
+- `surface`: `internal-proof-only-local-docker-compose-webui`
+- `route_status("user_profile")`: `internal_only`
+- Default profile `route_status("user_profile")`: `quarantined`
+- Provider, services, extensions, criticality, and all other route postures:
+  identical to `v1-local-core-web-mcp`
+
+The new profile-contract test also checks that the default profile file is
+byte-for-byte equal to its HEAD version.
+
+## Isolation boundary
+
+- Compose file: `docker-compose.yml`
+- Shared dependencies started: existing `db` and `redis` services only
+- Temporary proof database:
+  `codexify_user_profile_accent_runtime_proof_20260802`
+- Dedicated proof user: `accent-runtime-proof-user-20260802`
+- One-off backend host port: `18888`
+- Active database identity before/after: `Codexify|16384`
+- Active Postgres volume: `codexify_pg_data`
+- Proof database count after cleanup: `0`
+- Proof backend container count after cleanup: `0`
+
+The proof database was created, migrated, seeded with only the named proof user,
+queried, and dropped. The active application database and volumes were not
+modified or destroyed.
+
+The proof-only override supplied the plain `postgresql://` form to the backend
+startup readiness helper, while retaining the SQLAlchemy
+`postgresql+psycopg://` form for `GUARDIAN_DATABASE_URL`. The default provider
+contract was also supplied explicitly because the local `.env` endpoint did not
+match the profile contract. The backend startup environment used the existing
+repository-supported `mock` embedding backend and FAISS vector store only to
+avoid unrelated local SentenceTransformer/Chroma SQLite startup panics. These
+settings were untracked proof-container accommodations; they do not change the
+profile file or claim embedding support.
+
+## Exact commands
+
+The following command classes were run without printing API keys, passwords,
+complete database URLs, session secrets, or other secret material:
+
+```sh
+git fetch origin
+git status --short --branch --untracked-files=all
+git rev-parse HEAD
+git rev-parse origin/main
+
+docker compose -f docker-compose.yml up -d db redis
+docker compose -f docker-compose.yml build backend migrator
+docker compose -f docker-compose.yml run --rm --no-deps \
+  --entrypoint sh backend -lc \
+  'printf "%s" "${GUARDIAN_DATABASE_URL:-${DATABASE_URL:-}}"'
+
+docker compose -f docker-compose.yml exec -T db sh -lc \
+  'dropdb --if-exists -U "$POSTGRES_USER" \
+  codexify_user_profile_accent_runtime_proof_20260802 && \
+  createdb -U "$POSTGRES_USER" \
+  codexify_user_profile_accent_runtime_proof_20260802'
+
+docker compose -f docker-compose.yml run --rm --no-deps \
+  -e DATABASE_URL="$PROOF_DATABASE_URL" \
+  -e GUARDIAN_DATABASE_URL="$PROOF_DATABASE_URL" migrator
+
+docker compose -f docker-compose.yml run -d --no-deps \
+  --service-ports backend
+
+docker rm -f "$PROOF_BACKEND_ID"
+docker compose -f docker-compose.yml run -d --no-deps \
+  --service-ports backend
+
+docker compose -f docker-compose.yml exec -T db sh -lc \
+  'dropdb --if-exists -U "$POSTGRES_USER" \
+  codexify_user_profile_accent_runtime_proof_20260802'
+```
+
+The live probes were fresh Python HTTP-client processes. They asserted health
+profile identity, OpenAPI path absence, authenticated GET/PATCH behavior,
+invalid-token statuses, and post-restart readback.
+
+## Migration result
+
+The normal migrator completed successfully against the temporary database.
+Alembic current reported:
+
+```text
+d0e1f2a3b4c6 (head) (mergepoint)
+```
+
+The existing accent migration and database constraint were therefore present
+on the isolated runtime database before the HTTP proof.
+
+## Health and route-mount result
+
+- `/health`: HTTP 200
+- Health payload identified `v1-user-profile-accent-proof`
+- Backend logs recorded `user_profile` enabled as internal-only
+- Authenticated profile route was reachable through the one-off backend
+
+## OpenAPI internal-only result
+
+`/openapi.json` returned HTTP 200 and did not contain
+`/api/user/profile` in its `paths` mapping.
+
+## Initial profile GET
+
+Authenticated `GET /api/user/profile` returned HTTP 200 with:
+
+```text
+profile.accent_color=default
+```
+
+## Canonical PATCH
+
+Authenticated `PATCH /api/user/profile` with `{"accent_color":"violet"}`
+returned HTTP 200 and `violet`. A subsequent GET in the same process also
+returned `violet`.
+
+## Invalid-token rejection
+
+Both invalid updates were rejected with HTTP 422:
+
+| Payload | Status | Previously persisted value |
+|---|---:|---|
+| `not-a-color` | 422 | `violet` |
+| `linear-gradient(red, blue)` | 422 | `violet` |
+
+The follow-up GET confirmed that rejected requests did not alter the valid
+persisted token.
+
+## Backend restart
+
+The first one-off backend container was destroyed with `docker rm -f` and a new
+one-off backend container was created from the same built backend image and
+proof-only override.
+
+## Post-restart persistence
+
+The fresh HTTP client process returned:
+
+```text
+GET /api/user/profile -> 200, profile.accent_color=violet
+PATCH {"accent_color":"default"} -> 200
+final GET -> 200, profile.accent_color=default
+```
+
+This proves durable backend persistence across backend process replacement.
+
+## Cleanup
+
+- The proof value was restored to `default` before teardown.
+- The proof backend container was removed.
+- The temporary proof database was dropped and verified absent.
+- No proof backend container remained.
+- The active database identity remained `Codexify|16384`.
+- The active volume `codexify_pg_data` remained present.
+- The temporary Compose override was removed.
+- No active application database or volume was destroyed.
+
+## Validation results
+
+Passed:
+
+```text
+.venv/bin/python -m pytest -v \
+  tests/config/test_user_profile_accent_proof_profile.py \
+  tests/core/test_supported_profile.py \
+  tests/contracts/test_user_profile_accent_tokens.py \
+  tests/auth/test_user_profile_session_surface.py
+43 passed, 2 warnings
+
+git diff --check
+```
+
+The system `python3 -m pytest` command was not applicable because that system
+Python had no pytest; the repository `.venv` supplied the requested runtime and
+passed the complete suite.
+
+## Known limitations
+
+- This proves the backend API slice only.
+- The proof used mock embeddings and FAISS in the isolated proof container to
+  bypass unrelated local SentenceTransformer/Chroma startup failures. It does
+  not prove embedding or retrieval behavior.
+- Chrome extension loading, reconnect behavior, selector state, and UI
+  rehydration remain unproven.
+- No release-support or default-beta claim is made.
+- The local `.env` is not shell-source-compatible because an unquoted value
+  caused `source .env` to fail; the named API-key assignment was loaded without
+  printing its value, and the runtime itself loaded Compose-managed env values.
+
+## Documentation follow-through
+
+This dated proof artifact is the only documentation change. The default
+supported profile and `docs/architecture/00-current-state.md` were not updated.
+The proof does not widen the supported beta release promise.
+
+## Next proof
+
+Run a separate internal-only Chrome extension proof covering accent loading,
+selection, reconnect, and second-session rehydration against the proof backend.
+
+## Git commit
+
+The commit hash is recorded in the task closeout because recording it here
+would change the artifact hash.

--- a/tests/config/test_user_profile_accent_proof_profile.py
+++ b/tests/config/test_user_profile_accent_proof_profile.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from guardian.core.supported_profile import load_supported_profile
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROFILES_DIR = REPO_ROOT / "config" / "supported_profiles"
+DEFAULT_PROFILE_NAME = "v1-local-core-web-mcp"
+PROOF_PROFILE_NAME = "v1-user-profile-accent-proof"
+DEFAULT_PROFILE_PATH = (
+    PROFILES_DIR / f"{DEFAULT_PROFILE_NAME}.yaml"
+)
+
+
+def _profile_route_labels(profile) -> set[str]:
+    return {
+        *profile.enabled_routes,
+        *profile.internal_only_routes,
+        *profile.quarantined_routes,
+    }
+
+
+def _assert_route_sets_do_not_overlap(profile) -> None:
+    enabled = set(profile.enabled_routes)
+    internal_only = set(profile.internal_only_routes)
+    quarantined = set(profile.quarantined_routes)
+    assert not enabled & internal_only
+    assert not enabled & quarantined
+    assert not internal_only & quarantined
+
+
+def test_user_profile_accent_proof_profile_loads() -> None:
+    profile = load_supported_profile(
+        PROOF_PROFILE_NAME,
+        profiles_dir=str(PROFILES_DIR),
+    )
+
+    assert profile.name == PROOF_PROFILE_NAME
+    assert profile.version == 1
+    assert profile.surface == "internal-proof-only-local-docker-compose-webui"
+
+
+def test_user_profile_route_posture_is_internal_only_and_default_is_quarantined() -> None:
+    proof_profile = load_supported_profile(
+        PROOF_PROFILE_NAME,
+        profiles_dir=str(PROFILES_DIR),
+    )
+    default_profile = load_supported_profile(
+        DEFAULT_PROFILE_NAME,
+        profiles_dir=str(PROFILES_DIR),
+    )
+
+    assert proof_profile.route_status("user_profile") == "internal_only"
+    assert default_profile.route_status("user_profile") == "quarantined"
+
+
+def test_default_profile_file_is_unchanged_from_head() -> None:
+    expected = subprocess.check_output(
+        ["git", "show", f"HEAD:config/supported_profiles/{DEFAULT_PROFILE_NAME}.yaml"],
+        cwd=REPO_ROOT,
+    )
+
+    assert DEFAULT_PROFILE_PATH.read_bytes() == expected
+
+
+def test_proof_profile_changes_only_name_surface_and_user_profile_posture() -> None:
+    proof_profile = load_supported_profile(
+        PROOF_PROFILE_NAME,
+        profiles_dir=str(PROFILES_DIR),
+    )
+    default_profile = load_supported_profile(
+        DEFAULT_PROFILE_NAME,
+        profiles_dir=str(PROFILES_DIR),
+    )
+
+    assert proof_profile.version == default_profile.version
+    assert proof_profile.required_services == default_profile.required_services
+    assert proof_profile.optional_services == default_profile.optional_services
+    assert proof_profile.public_extensions == default_profile.public_extensions
+    assert proof_profile.internal_extensions == default_profile.internal_extensions
+    assert proof_profile.provider_contract == default_profile.provider_contract
+    assert proof_profile.criticality == default_profile.criticality
+
+    all_labels = _profile_route_labels(proof_profile) | _profile_route_labels(
+        default_profile
+    )
+    for label in all_labels - {"user_profile"}:
+        assert proof_profile.route_status(label) == default_profile.route_status(
+            label
+        )
+
+
+def test_route_sets_are_disjoint_for_both_profiles() -> None:
+    proof_profile = load_supported_profile(
+        PROOF_PROFILE_NAME,
+        profiles_dir=str(PROFILES_DIR),
+    )
+    default_profile = load_supported_profile(
+        DEFAULT_PROFILE_NAME,
+        profiles_dir=str(PROFILES_DIR),
+    )
+
+    _assert_route_sets_do_not_overlap(proof_profile)
+    _assert_route_sets_do_not_overlap(default_profile)


### PR DESCRIPTION
## Summary

- Add an internal-only supported profile for user profile accent persistence proof.
- Document authenticated API validation, canonical-token rejection, durable persistence across backend restart, and isolated cleanup.
- Add profile contract tests ensuring the default profile and all unrelated route/service postures remain unchanged.

## Testing

- Targeted pytest suite passed: 43 tests.
- `git diff --check` passed.
- Live Docker Compose backend proof passed, including migration, authentication, OpenAPI quarantine, invalid updates, restart persistence, and cleanup.