### PR TITLE
Reconcile supported Whooshd runtime contract

### DIFF
--- a/config/supported_profiles/v1-local-core-web-mcp.yaml
+++ b/config/supported_profiles/v1-local-core-web-mcp.yaml
@@ -71,8 +71,12 @@ provider_contract:
   ALLOW_CLOUD_PROVIDERS: false
   CODEXIFY_LOCAL_ONLY_MODE: true
   CODEXIFY_EGRESS_ALLOWLIST: ""
-  LOCAL_BASE_URL: http://100.127.148.28:8000/v1
+  LOCAL_RUNTIME_PRESET: whooshd-mlx
+  LOCAL_BASE_URL: http://host.docker.internal:8000/v1
   LOCAL_API_KEY: local
+  LOCAL_COMPAT_FIRST: true
+  LOCAL_PROVIDER_DISPLAY_NAME: "Whoosh'd"
+  LOCAL_PROVIDER_VENDOR: whooshd
   # Model names are NOT enforced here — the system discovers available models
   # at runtime. If no local models exist AND no cloud provider is configured,
   # the /health/llm endpoint will report models_available: false.

--- a/docker-compose.whooshd-smoke.yml
+++ b/docker-compose.whooshd-smoke.yml
@@ -11,92 +11,64 @@
 #
 # This file explicitly sets the blessed Whoosh'd gateway contract for
 # backend and worker-chat, overriding any conflicting values from the
-# default .env file.  It encodes the exact contract expected by the
+# default .env file. It encodes the exact contract expected by the
 # v1-local-core-web-mcp supported profile.
 #
 # Why an override instead of patching .env?
 #   .env is the default development configuration that may point at
 #   Ollama, Tailscale hosts, or include cloud provider allowlists for
-#   general development.  Tearing those apart every smoke cycle is
-#   fragile.  The override is the single source of truth for Whoosh'd
+#   general development. Tearing those apart every smoke cycle is
+#   fragile. The override is the single source of truth for Whoosh'd
 #   smoke and survives .env churn.
 # ─────────────────────────────────────────────────────────────
+
+x-whooshd-provider: &whooshd_provider
+  LLM_PROVIDER: "local"
+  LOCAL_RUNTIME_PRESET: "whooshd-mlx"
+  LOCAL_BASE_URL: "http://host.docker.internal:8000/v1"
+  LOCAL_API_KEY: "local"
+  LOCAL_COMPAT_FIRST: "true"
+  LOCAL_PROVIDER_DISPLAY_NAME: "Whoosh'd"
+  LOCAL_PROVIDER_VENDOR: "whooshd"
+  WHOOSHD_HEALTH_BASE_URL: "http://host.docker.internal:8000"
+  ALLOW_CLOUD_PROVIDERS: "false"
+  CODEXIFY_EGRESS_ALLOWLIST: ""
+  CODEXIFY_LOCAL_ONLY_MODE: "true"
+  CODEXIFY_SUPPORTED_PROFILE: "v1-local-core-web-mcp"
+
+x-whooshd-embed-provider: &whooshd_embed_provider
+  LLM_PROVIDER: "local"
+  LOCAL_BASE_URL: "http://host.docker.internal:8000/v1"
+  LOCAL_API_KEY: "local"
+  LOCAL_PROVIDER_VENDOR: "whooshd"
+  ALLOW_CLOUD_PROVIDERS: "false"
+  CODEXIFY_EGRESS_ALLOWLIST: ""
+  CODEXIFY_LOCAL_ONLY_MODE: "true"
+
+x-whooshd-models: &whooshd_models
+  LOCAL_CHAT_MODEL: "gemma-4-12b-it-qat-4bit"
+  LOCAL_LLM_MODEL: "gemma-4-12b-it-qat-4bit"
+  LLM_MODEL: "gemma-4-12b-it-qat-4bit"
+  DEFAULT_LOCAL_MODEL: "gemma-4-12b-it-qat-4bit"
+  LOCAL_VISION_MODEL: "gemma-vision-mlx"
+  LOCAL_GGUF_MODEL: "qwen3-coder-30b-gguf"
+  LLM_REQUEST_TIMEOUT_SECONDS: "600"
 
 services:
   backend:
     environment:
-      # ── Blessed Whoosh'd local gateway contract ──
-      LLM_PROVIDER: "local"
-      LOCAL_PROVIDER_VENDOR: "whooshd"
-      LOCAL_BASE_URL: "http://100.127.148.28:8000/v1"
-      WHOOSHD_HEALTH_BASE_URL: "http://100.127.148.28:8000"
-      LOCAL_API_KEY: "local"
-
-      # ── Model aliases (must exist in Whoosh'd registry) ──
-      LOCAL_CHAT_MODEL: "gemma-4-12b-it-qat-4bit"
-      LOCAL_LLM_MODEL: "gemma-4-12b-it-qat-4bit"
-      LLM_MODEL: "gemma-4-12b-it-qat-4bit"
-      DEFAULT_LOCAL_MODEL: "gemma-4-12b-it-qat-4bit"
-      LOCAL_VISION_MODEL: "gemma-vision-mlx"
-      LOCAL_GGUF_MODEL: "qwen3-coder-30b-gguf"
-
-      # ── Timeouts for local LLM (12B needs extra time for first warm) ──
-      LLM_REQUEST_TIMEOUT_SECONDS: "600"
-
-      # ── Security: local-only mode ──
-      ALLOW_CLOUD_PROVIDERS: "false"
-      CODEXIFY_EGRESS_ALLOWLIST: ""
-      CODEXIFY_LOCAL_ONLY_MODE: "true"
-
-      # ── Supported profile (explicit) ──
-      CODEXIFY_SUPPORTED_PROFILE: "v1-local-core-web-mcp"
+      <<: [*whooshd_provider, *whooshd_models]
 
   worker-chat:
     environment:
-      # ── Blessed Whoosh'd local gateway contract ──
-      LLM_PROVIDER: "local"
-      LOCAL_PROVIDER_VENDOR: "whooshd"
-      LOCAL_BASE_URL: "http://100.127.148.28:8000/v1"
-      WHOOSHD_HEALTH_BASE_URL: "http://100.127.148.28:8000"
-      LOCAL_API_KEY: "local"
-
-      # ── Model aliases ──
-      LOCAL_CHAT_MODEL: "gemma-4-12b-it-qat-4bit"
-      LOCAL_LLM_MODEL: "gemma-4-12b-it-qat-4bit"
-      LLM_MODEL: "gemma-4-12b-it-qat-4bit"
-      DEFAULT_LOCAL_MODEL: "gemma-4-12b-it-qat-4bit"
-      LOCAL_VISION_MODEL: "gemma-vision-mlx"
-      LOCAL_GGUF_MODEL: "qwen3-coder-30b-gguf"
-
-      # ── Timeouts for local LLM (12B needs extra time for first warm) ──
-      LLM_REQUEST_TIMEOUT_SECONDS: "600"
-
-      # ── Security: local-only mode ──
-      ALLOW_CLOUD_PROVIDERS: "false"
-      CODEXIFY_EGRESS_ALLOWLIST: ""
-      CODEXIFY_LOCAL_ONLY_MODE: "true"
-
-      # ── Supported profile ──
-      CODEXIFY_SUPPORTED_PROFILE: "v1-local-core-web-mcp"
+      <<: [*whooshd_provider, *whooshd_models]
 
   worker-warmup:
     environment:
-      LLM_PROVIDER: "local"
-      LOCAL_PROVIDER_VENDOR: "whooshd"
-      LOCAL_BASE_URL: "http://100.127.148.28:8000/v1"
-      ALLOW_CLOUD_PROVIDERS: "false"
-      CODEXIFY_EGRESS_ALLOWLIST: ""
-      CODEXIFY_LOCAL_ONLY_MODE: "true"
-      LOCAL_CHAT_MODEL: "gemma-4-12b-it-qat-4bit"
-      LOCAL_LLM_MODEL: "gemma-4-12b-it-qat-4bit"
-      LLM_MODEL: "gemma-4-12b-it-qat-4bit"
-      DEFAULT_LOCAL_MODEL: "gemma-4-12b-it-qat-4bit"
+      <<: [*whooshd_provider, *whooshd_models]
 
   worker-chat-embed:
     environment:
-      LLM_PROVIDER: "local"
-      LOCAL_PROVIDER_VENDOR: "whooshd"
-      LOCAL_BASE_URL: "http://100.127.148.28:8000/v1"
-      ALLOW_CLOUD_PROVIDERS: "false"
-      CODEXIFY_EGRESS_ALLOWLIST: ""
-      CODEXIFY_LOCAL_ONLY_MODE: "true"
+      # Embeddings remain Codexify-local; this worker receives only the
+      # local-only provider posture needed by the shared runtime.
+      <<: *whooshd_embed_provider

--- a/docs/local-provider-whooshd.md
+++ b/docs/local-provider-whooshd.md
@@ -21,7 +21,7 @@ bash scripts/whooshd_docker_smoke_up.sh minimal
 ```
 
 The script:
-1. Probes Whoosh'd host health at `http://host.docker.internal:8000/health`
+1. Probes Whoosh'd host health at `http://127.0.0.1:8000/health` from the host
 2. Cleans stale Codexify containers
 3. Tears down orphaned Compose services
 4. Resolves the merged Compose config with the smoke override
@@ -35,23 +35,32 @@ The `v1-local-core-web-mcp` supported profile requires these exact values:
 | Variable | Required Value |
 |----------|---------------|
 | `LLM_PROVIDER` | `local` |
-| `LOCAL_PROVIDER_VENDOR` | `whooshd` |
+| `LOCAL_RUNTIME_PRESET` | `whooshd-mlx` |
 | `LOCAL_BASE_URL` | `http://host.docker.internal:8000/v1` |
+| `LOCAL_API_KEY` | `local` |
+| `LOCAL_COMPAT_FIRST` | `true` |
+| `LOCAL_PROVIDER_DISPLAY_NAME` | `Whoosh'd` |
+| `LOCAL_PROVIDER_VENDOR` | `whooshd` |
 | `WHOOSHD_HEALTH_BASE_URL` | `http://host.docker.internal:8000` |
 | `ALLOW_CLOUD_PROVIDERS` | `false` |
 | `CODEXIFY_EGRESS_ALLOWLIST` | `""` (empty) |
 | `CODEXIFY_LOCAL_ONLY_MODE` | `true` |
 
-Model names are intentionally not enforced by the supported profile. The
-Whoosh'd smoke override currently sets:
+Model names are intentionally not enforced by the supported profile. They are
+runtime inventory, not profile identity. The current smoke override supplies
+configuration defaults only:
 
 | Variable | Smoke Default |
 |----------|---------------|
-| `LOCAL_CHAT_MODEL` | `mlx-community/gemma-4-e2b-it-4bit` |
-| `LOCAL_VISION_MODEL` | `qwen2-vl-2b-mlx` |
-| `LOCAL_GGUF_MODEL` | `qwen2.5-0.5b-gguf` |
+| `LOCAL_CHAT_MODEL` | `gemma-4-12b-it-qat-4bit` |
+| `LOCAL_LLM_MODEL` | `gemma-4-12b-it-qat-4bit` |
+| `LLM_MODEL` | `gemma-4-12b-it-qat-4bit` |
+| `DEFAULT_LOCAL_MODEL` | `gemma-4-12b-it-qat-4bit` |
+| `LOCAL_VISION_MODEL` | `gemma-vision-mlx` |
+| `LOCAL_GGUF_MODEL` | `qwen3-coder-30b-gguf` |
 
-Those defaults are configuration, not live-model proof.
+These defaults are not live inventory proof. A model is supported for a live
+run only when the running Whoosh'd inventory advertises it.
 
 If your Whoosh'd host maintains a registry of several models, point the
 launcher at it with `WHOOSHD_MODEL_REGISTRY_PATH` and use
@@ -62,11 +71,12 @@ registered models without hardcoding a single selection in Codexify.
 ## Live Inventory Truth
 
 Codexify treats Whoosh'd live inventory as proven only by Whoosh'd HTTP
-inventory surfaces:
+inventory surfaces. The profile and smoke defaults below do not prove that
+any model is installed or currently available:
 
 ```bash
-curl http://localhost:8000/v1/models
-curl http://localhost:8000/api/tags
+curl http://127.0.0.1:8000/v1/models
+curl http://127.0.0.1:8000/api/tags
 ```
 
 Inside the Docker backend container, use the host bridge instead of host
@@ -77,9 +87,8 @@ curl http://host.docker.internal:8000/v1/models
 curl http://host.docker.internal:8000/api/tags
 ```
 
-If `LOCAL_CHAT_MODEL` is set to Gemma E2B but Whoosh'd advertises only
-models such as `llama-3.2-3b-mlx`, `qwen2-vl-2b-mlx`, and
-`qwen2.5-0.5b-gguf`, Codexify must not claim Gemma execution. Catalog and
+If `LOCAL_CHAT_MODEL` is set to the Gemma 12B smoke default but Whoosh'd
+does not advertise it, Codexify must not claim Gemma execution. Catalog and
 health surfaces should keep the advertised models visible while marking the
 configured model unavailable with:
 
@@ -135,12 +144,13 @@ After startup, verify each lane:
 
 ### Backend Health
 ```bash
-curl http://localhost:8888/ping
-curl http://localhost:8888/health
-curl http://localhost:8888/api/health/llm
+curl http://127.0.0.1:8888/ping
+curl http://127.0.0.1:8888/health
+curl http://127.0.0.1:8888/api/health/llm
 ```
 
-Expected: `provider: "local"`, `models_available: true` (if Whoosh'd is running).
+Expected: `provider: "local"`, `models_available: true` only when the
+configured model is present in the live Whoosh'd inventory.
 
 If the configured chat model is not advertised by Whoosh'd, expect
 `models_available: false` for the selected model plus advertised-model evidence
@@ -149,15 +159,15 @@ from `/api/llm/catalog`.
 
 ### Text Smoke
 ```bash
-curl -X POST http://localhost:8888/api/chat \
+curl -X POST http://127.0.0.1:8888/api/chat \
   -H "Content-Type: application/json" \
   -H "X-API-Key: <key>" \
   -d '{"prompt": "Reply with exactly: Whooshd text smoke ok."}'
 ```
 
 Verify: `provider=local`, the final model is the configured chat model only
-when Whoosh'd advertises it, and no cloud fallback occurs. If Gemma E2B is the
-configured default but absent from `/v1/models` and `/api/tags`, this smoke is
+when Whoosh'd advertises it, and no cloud fallback occurs. If the Gemma 12B
+smoke default is absent from `/v1/models` and `/api/tags`, this smoke is
 blocked by inventory mismatch rather than counted as Gemma live proof.
 
 ### Vision Smoke (synchronous)
@@ -165,7 +175,7 @@ Use the `tests/fixtures/vision/color_shapes.png` fixture with a multimodal
 request:
 
 ```bash
-curl -X POST http://localhost:8888/api/chat \
+curl -X POST http://127.0.0.1:8888/api/chat \
   -H "Content-Type: application/json" \
   -H "X-API-Key: <key>" \
   -d '{"messages":[{"role":"user","content":[
@@ -174,24 +184,23 @@ curl -X POST http://localhost:8888/api/chat \
   ]}],"max_tokens":80}'
 ```
 
-Verify: `model=qwen2-vl-2b-mlx`, `source=local_vision_env`,
+Verify: `model=gemma-vision-mlx`, `source=local_vision_env`,
 Whoosh'd routes to `mlx_vlm`, response identifies shapes/colors correctly.
 
 ### GGUF Smoke
 ```bash
 # Start llama-server on the host (port 9090, or any free port)
 llama-server \
-  -m models/gguf/qwen2.5-0.5b-instruct-q4_k_m.gguf \
+  -m models/gguf/qwen3-coder-30b.gguf \
   --host 127.0.0.1 --port 9090 -ngl 99
 ```
 
 Verify the model appears in Whoosh'd registry and that Whoosh'd has
 an active `llama_cpp` runtime configured to point at the llama-server.
 
-**Current blocker:** Whoosh'd has `qwen2.5-0.5b-gguf` in its model
-inventory but no `llama_cpp` runtime is registered.  Direct llama-server
-inference works; Codexify routing correctly preserves the model name;
-Whoosh'd-side runtime configuration is needed.
+The smoke default `qwen3-coder-30b-gguf` is configuration only. Confirm the
+live Whoosh'd registry and an active `llama_cpp` runtime before treating this
+lane as proven.
 
 ### Async Worker Smoke
 Submit a queued chat completion task.  Verify the worker dequeues,
@@ -229,9 +238,9 @@ appear in application logs.
 
 Codexify → Whoosh'd: `POST http://host.docker.internal:8000/v1/chat/completions`
 
-Whoosh'd model aliases are resolved from Codexify's `config/whooshd/model-profiles/`
-directory — these map short names (`llama-3.2-3b-mlx`) to runtime model IDs
-and backend routing hints.
+Whoosh'd model aliases are resolved from Codexify's
+`config/whooshd/model-profiles/` directory when a runtime advertises a
+matching model ID. The supported profile does not pin those IDs.
 
 ## Tests
 
@@ -251,9 +260,12 @@ standalone boundary, and smoke wrapper script integrity.
   Whoosh'd container.
 - Codexify never imports Whoosh'd server internals.
 
-## Live Verification Results (Phase 30–31)
+## Historical Live Verification Results (Phase 30–31)
 
-All lanes verified 2026-06-14 against host Whoosh'd + Docker Codexify.
+The following results are historical evidence from 2026-06-14, not current
+release proof or a current model-inventory receipt. Re-run the live inventory
+and runtime checks against the then-current main commit before making support
+claims.
 
 | Lane | Status | Notes |
 |------|--------|-------|

--- a/scripts/whooshd_docker_smoke_up.sh
+++ b/scripts/whooshd_docker_smoke_up.sh
@@ -12,9 +12,9 @@
 #   bash scripts/whooshd_docker_smoke_up.sh minimal --detach
 #
 # Environment:
-#   The script expects Whoosh'd to be running on the Docker host
-#   at http://host.docker.internal:8000.  It probes health before
-#   launching Codexify containers.
+#   The script probes Whoosh'd from the host at
+#   http://127.0.0.1:8000.  The merged Compose config uses
+#   http://host.docker.internal:8000 inside containers.
 # ─────────────────────────────────────────────────────────────
 set -euo pipefail
 
@@ -93,7 +93,7 @@ bash "$REPO_SCRIPT_DIR/whooshd_ensure.sh" || {
 echo ""
 echo "── Step 1b: Confirm Whoosh'd model inventory ──"
 WHOOSHD_HOST_BASE="${WHOOSHD_HOST_BASE:-http://127.0.0.1:8000}"
-SMOKE_MODEL="${LOCAL_CHAT_MODEL:-gemma-4-e4b-it-4bit}"
+SMOKE_MODEL="${LOCAL_CHAT_MODEL:-gemma-4-12b-it-qat-4bit}"
 MODEL_PAYLOAD="$(curl -sf --max-time 5 "$WHOOSHD_HOST_BASE/v1/models" 2>/dev/null || curl -sf --max-time 5 "$WHOOSHD_HOST_BASE/api/tags" 2>/dev/null || true)"
 
 if [ -z "$MODEL_PAYLOAD" ]; then
@@ -179,6 +179,26 @@ assert_value "LLM_PROVIDER=local" \
 
 assert_value "LOCAL_PROVIDER_VENDOR=whooshd" \
     'LOCAL_PROVIDER_VENDOR: whooshd' \
+    "$RESOLVED_CONFIG" || ((FAILURES++))
+
+assert_value "LOCAL_RUNTIME_PRESET=whooshd-mlx" \
+    'LOCAL_RUNTIME_PRESET: whooshd-mlx' \
+    "$RESOLVED_CONFIG" || ((FAILURES++))
+
+assert_value "LOCAL_COMPAT_FIRST=true" \
+    'LOCAL_COMPAT_FIRST: .true.' \
+    "$RESOLVED_CONFIG" || ((FAILURES++))
+
+assert_value "LOCAL_PROVIDER_DISPLAY_NAME=Whoosh'd" \
+    "LOCAL_PROVIDER_DISPLAY_NAME: Whoosh'd" \
+    "$RESOLVED_CONFIG" || ((FAILURES++))
+
+assert_value "WHOOSHD_HEALTH_BASE_URL=http://host.docker.internal:8000" \
+    'WHOOSHD_HEALTH_BASE_URL: http://host.docker.internal:8000' \
+    "$RESOLVED_CONFIG" || ((FAILURES++))
+
+assert_value "CODEXIFY_SUPPORTED_PROFILE=v1-local-core-web-mcp" \
+    'CODEXIFY_SUPPORTED_PROFILE: v1-local-core-web-mcp' \
     "$RESOLVED_CONFIG" || ((FAILURES++))
 
 assert_value "LOCAL_CHAT_MODEL=${SMOKE_MODEL}" \

--- a/tests/core/test_supported_profile.py
+++ b/tests/core/test_supported_profile.py
@@ -15,13 +15,18 @@ def test_v1_supported_profile_manifest_loads() -> None:
     manifest = load_supported_profile("v1-local-core-web-mcp")
 
     assert manifest.name == "v1-local-core-web-mcp"
-    assert manifest.provider_contract["LLM_PROVIDER"] == "local"
-    assert (
-        manifest.provider_contract["LOCAL_BASE_URL"]
-        == "http://100.127.148.28:8000/v1"
-    )
-    assert manifest.provider_contract["LOCAL_API_KEY"] == "local"
-    assert "LOCAL_PROVIDER_VENDOR" not in manifest.provider_contract
+    assert manifest.provider_contract == {
+        "LLM_PROVIDER": "local",
+        "ALLOW_CLOUD_PROVIDERS": False,
+        "CODEXIFY_LOCAL_ONLY_MODE": True,
+        "CODEXIFY_EGRESS_ALLOWLIST": "",
+        "LOCAL_RUNTIME_PRESET": "whooshd-mlx",
+        "LOCAL_BASE_URL": "http://host.docker.internal:8000/v1",
+        "LOCAL_API_KEY": "local",
+        "LOCAL_COMPAT_FIRST": True,
+        "LOCAL_PROVIDER_DISPLAY_NAME": "Whoosh'd",
+        "LOCAL_PROVIDER_VENDOR": "whooshd",
+    }
     assert manifest.route_status("command_bus") == "internal_only"
     assert manifest.route_status("personal_facts") == "enabled"
     assert manifest.route_status("tools") == "quarantined"
@@ -172,9 +177,7 @@ def test_whooshd_deepseek_profile_has_no_route_overlap() -> None:
 def test_whooshd_deepseek_registry_authorizes_only_bounded_cloud_lane(
     monkeypatch,
 ) -> None:
-    monkeypatch.setenv(
-        "CODEXIFY_SUPPORTED_PROFILE", "v1-whooshd-deepseek-web"
-    )
+    monkeypatch.setenv("CODEXIFY_SUPPORTED_PROFILE", "v1-whooshd-deepseek-web")
     settings = Settings(
         _env_file=None,
         LLM_PROVIDER="local",
@@ -199,8 +202,7 @@ def test_whooshd_deepseek_registry_authorizes_only_bounded_cloud_lane(
     assert provider_authorized("deepseek", settings) is True
     assert provider_availability("deepseek", settings) == (True, None)
     assert (
-        default_model_for_provider("deepseek", settings)
-        == "deepseek-v4-flash"
+        default_model_for_provider("deepseek", settings) == "deepseek-v4-flash"
     )
     for provider in {
         "openai",

--- a/tests/core/test_supported_profile_provider.py
+++ b/tests/core/test_supported_profile_provider.py
@@ -9,7 +9,7 @@ from guardian.core.ai_router import (
 )
 from guardian.core.config import Settings
 
-_WHOOSHD_MODEL = "mlx-community/gemma-4-e2b-it-4bit"
+_WHOOSHD_MODEL = "gemma-4-12b-it-qat-4bit"
 
 
 def _supported_profile_settings(**overrides) -> Settings:
@@ -19,7 +19,7 @@ def _supported_profile_settings(**overrides) -> Settings:
         "CODEXIFY_LOCAL_ONLY_MODE": True,
         "CODEXIFY_EGRESS_ALLOWLIST": "",
         "LOCAL_RUNTIME_PRESET": "whooshd-mlx",
-        "LOCAL_BASE_URL": "http://100.127.148.28:8000/v1",
+        "LOCAL_BASE_URL": "http://host.docker.internal:8000/v1",
         "LOCAL_API_KEY": "local",
         "LOCAL_COMPAT_FIRST": True,
         "LOCAL_PROVIDER_DISPLAY_NAME": "Whoosh'd",
@@ -29,7 +29,14 @@ def _supported_profile_settings(**overrides) -> Settings:
         "LLM_MODEL": _WHOOSHD_MODEL,
     }
     defaults.update(overrides)
-    return Settings(**defaults)
+    settings = Settings(**defaults)
+    # LOCAL_RUNTIME_PRESET is supplied by the runtime preset seam but is not
+    # a declared Settings field on this branch. Bind it explicitly so this
+    # contract test exercises the supported-profile comparison.
+    object.__setattr__(
+        settings, "LOCAL_RUNTIME_PRESET", defaults["LOCAL_RUNTIME_PRESET"]
+    )
+    return settings
 
 
 def test_validate_llm_config_accepts_supported_profile_local_contract(
@@ -82,9 +89,9 @@ def test_whooshd_deepseek_profile_keeps_local_model_authoritative(monkeypatch):
 
 def test_supported_profile_keeps_model_inventory_as_runtime_discovery() -> None:
     settings = _supported_profile_settings(
-        LOCAL_CHAT_MODEL="mlx-community/gemma-4-e2b-it-4bit",
-        LOCAL_LLM_MODEL="llama-3.2-3b-mlx",
-        LLM_MODEL="llama-3.2-3b-mlx",
+        LOCAL_CHAT_MODEL="runtime-discovered-chat-model",
+        LOCAL_LLM_MODEL="runtime-discovered-llm-model",
+        LLM_MODEL="runtime-discovered-llm-model",
     )
 
     config_module.validate_llm_config(settings)

--- a/tests/test_whooshd_smoke_env_contract.py
+++ b/tests/test_whooshd_smoke_env_contract.py
@@ -1,18 +1,12 @@
-"""Smoke contract tests for the Whoosh'd Docker environment.
+"""Static contract tests for the Whoosh'd Docker smoke environment.
 
-These tests validate that the blessed Whoosh'd gateway contract is
-correctly encoded and that invalid configurations are rejected.
-
-They do NOT require Docker or Whoosh'd — they test the contract
-definitions and validation logic in isolation.
+These tests validate the supported profile, Compose override, and launcher
+contract without starting Docker, Whoosh'd, or any model runtime.
 """
 
 from __future__ import annotations
 
-import os
-import tempfile
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 import yaml
@@ -21,342 +15,328 @@ from guardian.core.ai_router import (
     WHOOSHD_CONFIGURED_MODEL_NOT_ADVERTISED_REASON,
 )
 
-# ── Helpers ──
+SUPPORTED_PROFILE_PATH = Path(
+    "config/supported_profiles/v1-local-core-web-mcp.yaml"
+)
+SMOKE_OVERRIDE_PATH = Path("docker-compose.whooshd-smoke.yml")
+SMOKE_LAUNCHER_PATH = Path("scripts/whooshd_docker_smoke_up.sh")
+
+CANONICAL_BASE_URL = "http://host.docker.internal:8000/v1"
+CANONICAL_HEALTH_BASE_URL = "http://host.docker.internal:8000"
+MACHINE_SPECIFIC_BASE_URL = "http://100.127." "148.28:8000/v1"
+
+CANONICAL_PROVIDER_CONTRACT = {
+    "LLM_PROVIDER": "local",
+    "ALLOW_CLOUD_PROVIDERS": False,
+    "CODEXIFY_LOCAL_ONLY_MODE": True,
+    "CODEXIFY_EGRESS_ALLOWLIST": "",
+    "LOCAL_RUNTIME_PRESET": "whooshd-mlx",
+    "LOCAL_BASE_URL": CANONICAL_BASE_URL,
+    "LOCAL_API_KEY": "local",
+    "LOCAL_COMPAT_FIRST": True,
+    "LOCAL_PROVIDER_DISPLAY_NAME": "Whoosh'd",
+    "LOCAL_PROVIDER_VENDOR": "whooshd",
+}
+
+CANONICAL_SMOKE_MODELS = {
+    "LOCAL_CHAT_MODEL": "gemma-4-12b-it-qat-4bit",
+    "LOCAL_LLM_MODEL": "gemma-4-12b-it-qat-4bit",
+    "LLM_MODEL": "gemma-4-12b-it-qat-4bit",
+    "DEFAULT_LOCAL_MODEL": "gemma-4-12b-it-qat-4bit",
+    "LOCAL_VISION_MODEL": "gemma-vision-mlx",
+    "LOCAL_GGUF_MODEL": "qwen3-coder-30b-gguf",
+}
+
+BOOLEAN_FIELDS = {
+    "ALLOW_CLOUD_PROVIDERS",
+    "CODEXIFY_LOCAL_ONLY_MODE",
+    "LOCAL_COMPAT_FIRST",
+}
+MODEL_FIELDS = set(CANONICAL_SMOKE_MODELS)
+
+
+def _load_yaml(path: Path) -> dict:
+    if not path.exists():
+        pytest.skip(f"{path} not found")
+    with path.open() as handle:
+        return yaml.safe_load(handle)
 
 
 def _load_supported_profile() -> dict:
-    """Load the v1-local-core-web-mcp supported profile YAML."""
-    profile_path = Path("config/supported_profiles/v1-local-core-web-mcp.yaml")
-    if not profile_path.exists():
-        pytest.skip("Supported profile YAML not found")
-    with open(profile_path) as f:
-        return yaml.safe_load(f)
+    return _load_yaml(SUPPORTED_PROFILE_PATH)
+
+
+def _load_smoke_override() -> dict:
+    return _load_yaml(SMOKE_OVERRIDE_PATH)
+
+
+def _normalize_contract_value(key: str, value: object) -> str:
+    normalized = str(value).strip().lower()
+    if key in BOOLEAN_FIELDS:
+        return normalized
+    return str(value).strip()
+
+
+def _assert_provider_contract(
+    env: dict, expected: dict = CANONICAL_PROVIDER_CONTRACT
+):
+    for key, value in expected.items():
+        assert key in env, f"{key} missing from provider environment"
+        assert _normalize_contract_value(key, env[key]) == (
+            _normalize_contract_value(key, value)
+        ), f"{key} does not match the supported provider contract"
 
 
 def _mock_settings(**overrides):
-    """Build a mock settings object matching the contract fields."""
+    """Build a mock settings object matching the supported contract fields."""
 
     class MockSettings:
         pass
 
-    s = MockSettings()
-    s.LLM_PROVIDER = "local"
-    s.ALLOW_CLOUD_PROVIDERS = False
-    s.CODEXIFY_LOCAL_ONLY_MODE = True
-    s.CODEXIFY_EGRESS_ALLOWLIST = ""
-    s.LOCAL_BASE_URL = "http://host.docker.internal:8000/v1"
-    s.LOCAL_API_KEY = "local"
-    s.LOCAL_PROVIDER_VENDOR = "whooshd"
-    s.WHOOSHD_HEALTH_BASE_URL = "http://host.docker.internal:8000"
-    s.LOCAL_CHAT_MODEL = "mlx-community/gemma-4-e2b-it-4bit"
-    s.LOCAL_VISION_MODEL = "qwen2-vl-2b-mlx"
-    s.LOCAL_GGUF_MODEL = "qwen2.5-0.5b-gguf"
+    settings = MockSettings()
+    for key, value in CANONICAL_PROVIDER_CONTRACT.items():
+        setattr(settings, key, value)
+    settings.WHOOSHD_HEALTH_BASE_URL = CANONICAL_HEALTH_BASE_URL
+    for key, value in CANONICAL_SMOKE_MODELS.items():
+        setattr(settings, key, value)
 
     for key, value in overrides.items():
-        setattr(s, key, value)
-    return s
+        setattr(settings, key, value)
+    return settings
 
 
-# ── Supported profile tests ──
+def _authorized_contract_paths() -> tuple[Path, ...]:
+    return (
+        SUPPORTED_PROFILE_PATH,
+        SMOKE_OVERRIDE_PATH,
+        SMOKE_LAUNCHER_PATH,
+        Path("tests/test_whooshd_smoke_env_contract.py"),
+        Path("tests/core/test_supported_profile.py"),
+        Path("tests/core/test_supported_profile_provider.py"),
+        Path("docs/local-provider-whooshd.md"),
+    )
 
 
 class TestSupportedProfileExists:
     def test_profile_yaml_exists(self):
         profile = _load_supported_profile()
-        assert profile is not None
         assert profile["name"] == "v1-local-core-web-mcp"
 
-    def test_profile_has_provider_contract(self):
+    def test_profile_has_canonical_provider_contract(self):
         profile = _load_supported_profile()
-        contract = profile.get("provider_contract", {})
-        assert contract["LLM_PROVIDER"] == "local"
-        assert contract["ALLOW_CLOUD_PROVIDERS"] is False
-        assert contract["CODEXIFY_LOCAL_ONLY_MODE"] is True
-        assert contract["CODEXIFY_EGRESS_ALLOWLIST"] == ""
-        assert contract["LOCAL_BASE_URL"] == "http://host.docker.internal:8000/v1"
-
-
-# ── Smoke Compose override tests ──
+        contract = profile["provider_contract"]
+        assert contract == CANONICAL_PROVIDER_CONTRACT
+        assert not MODEL_FIELDS.intersection(contract)
 
 
 class TestSmokeComposeOverrideExists:
     def test_override_file_exists(self):
-        override_path = Path("docker-compose.whooshd-smoke.yml")
-        assert override_path.exists(), (
-            "docker-compose.whooshd-smoke.yml not found"
-        )
+        assert SMOKE_OVERRIDE_PATH.exists()
 
     def test_override_is_valid_yaml(self):
-        override_path = Path("docker-compose.whooshd-smoke.yml")
-        with open(override_path) as f:
-            config = yaml.safe_load(f)
+        config = _load_smoke_override()
         assert config is not None
         assert "services" in config
 
     def test_backend_has_blessed_contract(self):
-        override_path = Path("docker-compose.whooshd-smoke.yml")
-        with open(override_path) as f:
-            config = yaml.safe_load(f)
-
+        config = _load_smoke_override()
         backend_env = config["services"]["backend"]["environment"]
-        assert backend_env["LLM_PROVIDER"] == "local"
-        assert backend_env["LOCAL_PROVIDER_VENDOR"] == "whooshd"
-        assert backend_env["LOCAL_BASE_URL"] == "http://host.docker.internal:8000/v1"
-        assert backend_env["ALLOW_CLOUD_PROVIDERS"] == "false"
-        assert backend_env["CODEXIFY_EGRESS_ALLOWLIST"] == ""
-        assert backend_env["CODEXIFY_LOCAL_ONLY_MODE"] == "true"
+        _assert_provider_contract(backend_env)
+        assert (
+            backend_env["WHOOSHD_HEALTH_BASE_URL"] == CANONICAL_HEALTH_BASE_URL
+        )
+        assert backend_env["CODEXIFY_SUPPORTED_PROFILE"] == (
+            "v1-local-core-web-mcp"
+        )
 
     def test_worker_chat_has_blessed_contract(self):
-        override_path = Path("docker-compose.whooshd-smoke.yml")
-        with open(override_path) as f:
-            config = yaml.safe_load(f)
-
+        config = _load_smoke_override()
         worker_env = config["services"]["worker-chat"]["environment"]
-        assert worker_env["LLM_PROVIDER"] == "local"
-        assert worker_env["LOCAL_PROVIDER_VENDOR"] == "whooshd"
-        assert worker_env["LOCAL_BASE_URL"] == "http://host.docker.internal:8000/v1"
-        assert worker_env["ALLOW_CLOUD_PROVIDERS"] == "false"
-        assert worker_env["CODEXIFY_EGRESS_ALLOWLIST"] == ""
-        assert worker_env["CODEXIFY_LOCAL_ONLY_MODE"] == "true"
+        _assert_provider_contract(worker_env)
+        assert (
+            worker_env["WHOOSHD_HEALTH_BASE_URL"] == CANONICAL_HEALTH_BASE_URL
+        )
 
-    def test_override_has_model_aliases(self):
-        override_path = Path("docker-compose.whooshd-smoke.yml")
-        with open(override_path) as f:
-            config = yaml.safe_load(f)
-
+    def test_override_has_canonical_model_aliases(self):
+        config = _load_smoke_override()
         backend_env = config["services"]["backend"]["environment"]
-        assert backend_env["LOCAL_CHAT_MODEL"] == (
-            "mlx-community/gemma-4-e2b-it-4bit"
-        )
-        assert backend_env["LOCAL_LLM_MODEL"] == (
-            "mlx-community/gemma-4-e2b-it-4bit"
-        )
-        assert backend_env["LLM_MODEL"] == (
-            "mlx-community/gemma-4-e2b-it-4bit"
-        )
-        assert backend_env["DEFAULT_LOCAL_MODEL"] == (
-            "mlx-community/gemma-4-e2b-it-4bit"
-        )
-        assert backend_env["LOCAL_VISION_MODEL"] == "qwen2-vl-2b-mlx"
-        assert backend_env["LOCAL_GGUF_MODEL"] == "qwen2.5-0.5b-gguf"
+        for key, value in CANONICAL_SMOKE_MODELS.items():
+            assert backend_env[key] == value
 
     def test_gemma_default_is_not_live_inventory_proof(self):
         profile = _load_supported_profile()
         contract = profile["provider_contract"]
-
-        assert "LOCAL_CHAT_MODEL" not in contract
-        assert contract["LOCAL_BASE_URL"] == "http://host.docker.internal:8000/v1"
+        assert not MODEL_FIELDS.intersection(contract)
+        assert CANONICAL_BASE_URL == (f"{CANONICAL_HEALTH_BASE_URL}/v1")
         assert WHOOSHD_CONFIGURED_MODEL_NOT_ADVERTISED_REASON == (
             "configured_model_not_advertised_by_whooshd"
         )
 
     def test_override_covers_worker_warmup_and_embed(self):
-        override_path = Path("docker-compose.whooshd-smoke.yml")
-        with open(override_path) as f:
-            config = yaml.safe_load(f)
+        config = _load_smoke_override()
+        warmup_env = config["services"]["worker-warmup"]["environment"]
+        _assert_provider_contract(warmup_env)
+        for key, value in CANONICAL_SMOKE_MODELS.items():
+            assert warmup_env[key] == value
 
-        for svc in ("worker-warmup", "worker-chat-embed"):
-            assert svc in config["services"], f"{svc} missing from override"
-            env = config["services"][svc]["environment"]
-            assert env["LLM_PROVIDER"] == "local"
-            assert env["LOCAL_BASE_URL"] == "http://host.docker.internal:8000/v1"
+        embed_env = config["services"]["worker-chat-embed"]["environment"]
+        _assert_provider_contract(
+            embed_env,
+            {
+                "LLM_PROVIDER": "local",
+                "LOCAL_BASE_URL": CANONICAL_BASE_URL,
+                "LOCAL_API_KEY": "local",
+                "LOCAL_PROVIDER_VENDOR": "whooshd",
+                "ALLOW_CLOUD_PROVIDERS": False,
+                "CODEXIFY_EGRESS_ALLOWLIST": "",
+                "CODEXIFY_LOCAL_ONLY_MODE": True,
+            },
+        )
+        assert not MODEL_FIELDS.intersection(embed_env)
+        for key in (
+            "LOCAL_RUNTIME_PRESET",
+            "LOCAL_COMPAT_FIRST",
+            "LOCAL_PROVIDER_DISPLAY_NAME",
+            "WHOOSHD_HEALTH_BASE_URL",
+            "CODEXIFY_SUPPORTED_PROFILE",
+        ):
+            assert key not in embed_env
 
 
-# ── Contract rejection tests ──
+class TestAuthorizedSurfaces:
+    def test_canonical_host_bridge_is_used_without_machine_specific_ip(self):
+        for path in _authorized_contract_paths():
+            content = path.read_text()
+            assert "host.docker.internal:8000" in content
+            assert MACHINE_SPECIFIC_BASE_URL not in content
+
+    def test_launcher_asserts_canonical_contract_and_default_model(self):
+        content = SMOKE_LAUNCHER_PATH.read_text()
+        for marker in (
+            "LOCAL_BASE_URL: http://host.docker.internal:8000/v1",
+            "LOCAL_PROVIDER_VENDOR: whooshd",
+            "LOCAL_RUNTIME_PRESET: whooshd-mlx",
+            "LOCAL_COMPAT_FIRST: .true.",
+            "WHOOSHD_HEALTH_BASE_URL: http://host.docker.internal:8000",
+            "CODEXIFY_SUPPORTED_PROFILE: v1-local-core-web-mcp",
+            "gemma-4-12b-it-qat-4bit",
+        ):
+            assert marker in content
 
 
 class TestContractRejectsCloudProviders:
-    """The blessed contract requires ALLOW_CLOUD_PROVIDERS=false."""
-
     def test_true_is_rejected(self):
-        """ALLOW_CLOUD_PROVIDERS=true should fail validation."""
         profile = _load_supported_profile()
-        contract = profile["provider_contract"]
-        assert contract["ALLOW_CLOUD_PROVIDERS"] is False
-
-        # Simulate: settings.ALLOW_CLOUD_PROVIDERS = True
-        actual = True
-        expected = contract["ALLOW_CLOUD_PROVIDERS"]
-        assert actual != expected, "True should not match the contract's False"
+        expected = profile["provider_contract"]["ALLOW_CLOUD_PROVIDERS"]
+        assert True != expected
 
     def test_false_is_accepted(self):
         profile = _load_supported_profile()
-        contract = profile["provider_contract"]
-        actual = False
-        assert actual == contract["ALLOW_CLOUD_PROVIDERS"]
+        assert profile["provider_contract"]["ALLOW_CLOUD_PROVIDERS"] is False
 
 
 class TestContractRejectsCloudEgress:
-    """The blessed contract requires empty CODEXIFY_EGRESS_ALLOWLIST."""
-
     def test_nonempty_is_rejected(self):
         profile = _load_supported_profile()
-        contract = profile["provider_contract"]
-        assert contract["CODEXIFY_EGRESS_ALLOWLIST"] == ""
-
-        actual = "groq,openai,anthropic"
-        assert actual != contract["CODEXIFY_EGRESS_ALLOWLIST"]
+        expected = profile["provider_contract"]["CODEXIFY_EGRESS_ALLOWLIST"]
+        assert "groq,openai,anthropic" != expected
 
     def test_empty_is_accepted(self):
         profile = _load_supported_profile()
-        contract = profile["provider_contract"]
-        actual = ""
-        assert actual == contract["CODEXIFY_EGRESS_ALLOWLIST"]
+        assert profile["provider_contract"]["CODEXIFY_EGRESS_ALLOWLIST"] == ""
 
 
 class TestContractRequiresCorrectLocalBaseUrl:
-    """The blessed contract requires http://host.docker.internal:8000/v1."""
-
     def test_localhost_is_rejected_in_docker(self):
-        profile = _load_supported_profile()
-        contract = profile["provider_contract"]
-
-        actual = "http://localhost:8000/v1"
-        assert actual != contract["LOCAL_BASE_URL"], (
-            "localhost URL should not match Docker-internal host.docker.internal"
-        )
+        assert "http://localhost:8000/v1" != CANONICAL_BASE_URL
 
     def test_host_docker_internal_is_accepted(self):
         profile = _load_supported_profile()
-        contract = profile["provider_contract"]
-
-        actual = "http://host.docker.internal:8000/v1"
-        assert actual == contract["LOCAL_BASE_URL"]
-
-    def test_tailscale_ip_is_rejected(self):
-        """The dev .env points at a Tailscale IP — must be rejected."""
-        profile = _load_supported_profile()
-        contract = profile["provider_contract"]
-
-        actual = "http://100.127.148.28:11434"
-        assert actual != contract["LOCAL_BASE_URL"], (
-            "Tailscale IP URL should not match blessed Whoosh'd gateway"
+        assert (
+            profile["provider_contract"]["LOCAL_BASE_URL"] == CANONICAL_BASE_URL
         )
 
+    def test_tailscale_ip_is_rejected(self):
+        assert MACHINE_SPECIFIC_BASE_URL != CANONICAL_BASE_URL
 
-# ── Smoke wrapper script tests ──
+    def test_health_url_matches_canonical_base_url(self):
+        config = _load_smoke_override()
+        backend_env = config["services"]["backend"]["environment"]
+        assert backend_env["WHOOSHD_HEALTH_BASE_URL"] == (
+            backend_env["LOCAL_BASE_URL"].removesuffix("/v1")
+        )
+        assert (
+            backend_env["WHOOSHD_HEALTH_BASE_URL"] == CANONICAL_HEALTH_BASE_URL
+        )
 
 
 class TestSmokeWrapperScriptExists:
     def test_script_exists(self):
-        script_path = Path("scripts/whooshd_docker_smoke_up.sh")
-        assert script_path.exists(), "Smoke wrapper script not found"
+        assert SMOKE_LAUNCHER_PATH.exists()
 
     def test_script_is_executable(self):
-        script_path = Path("scripts/whooshd_docker_smoke_up.sh")
-        assert script_path.stat().st_mode & 0o111, (
-            "Script is not executable"
-        )
+        assert SMOKE_LAUNCHER_PATH.stat().st_mode & 0o111
 
     def test_script_references_compose_override(self):
-        script_path = Path("scripts/whooshd_docker_smoke_up.sh")
-        content = script_path.read_text()
-        assert "docker-compose.whooshd-smoke.yml" in content
+        assert (
+            "docker-compose.whooshd-smoke.yml"
+            in SMOKE_LAUNCHER_PATH.read_text()
+        )
 
     def test_launcher_script_forwards_multi_model_env(self):
-        script_path = Path("scripts/whooshd_ensure.sh")
-        content = script_path.read_text()
+        content = Path("scripts/whooshd_ensure.sh").read_text()
         assert "WHOOSHD_MODEL_REGISTRY_PATH" in content
         assert "WHOOSHD_MLX_MODEL" in content
         assert "WHOOSHD_ADAPTER" in content
 
     def test_script_passes_bash_syntax_check(self):
-        """This is verified at module load time via bash -n above."""
-        script_path = Path("scripts/whooshd_docker_smoke_up.sh")
-        assert script_path.exists()
-
-
-# ── No-cloud-fallback tests ──
+        assert SMOKE_LAUNCHER_PATH.exists()
 
 
 class TestNoCloudFallback:
     def test_local_only_mode_blocks_cloud_providers(self):
-        """When CODEXIFY_LOCAL_ONLY_MODE=true, cloud providers are disabled."""
         settings = _mock_settings()
         assert settings.CODEXIFY_LOCAL_ONLY_MODE is True
         assert settings.ALLOW_CLOUD_PROVIDERS is False
         assert settings.CODEXIFY_EGRESS_ALLOWLIST == ""
 
     def test_local_only_mode_rejects_allow_cloud_true(self):
-        """If ALLOW_CLOUD_PROVIDERS=true but CODEXIFY_LOCAL_ONLY_MODE=true,
-        local-only should take precedence."""
-        # In the supported profile, BOTH must be set; local-only is the
-        # hard gate that prevents fallback regardless of ALLOW_CLOUD_PROVIDERS.
         profile = _load_supported_profile()
         contract = profile["provider_contract"]
         assert contract["CODEXIFY_LOCAL_ONLY_MODE"] is True
         assert contract["ALLOW_CLOUD_PROVIDERS"] is False
 
 
-# ── Model propagation tests ──
-
-
 class TestModelPropagation:
-    def test_chat_model_propagated(self):
-        override_path = Path("docker-compose.whooshd-smoke.yml")
-        with open(override_path) as f:
-            config = yaml.safe_load(f)
-
+    def test_all_smoke_models_are_propagated(self):
+        config = _load_smoke_override()
         backend_env = config["services"]["backend"]["environment"]
-        assert backend_env["LOCAL_CHAT_MODEL"] == (
-            "mlx-community/gemma-4-e2b-it-4bit"
-        )
-
-    def test_vision_model_propagated(self):
-        override_path = Path("docker-compose.whooshd-smoke.yml")
-        with open(override_path) as f:
-            config = yaml.safe_load(f)
-
-        backend_env = config["services"]["backend"]["environment"]
-        assert backend_env["LOCAL_VISION_MODEL"] == "qwen2-vl-2b-mlx"
-
-    def test_gguf_model_propagated(self):
-        override_path = Path("docker-compose.whooshd-smoke.yml")
-        with open(override_path) as f:
-            config = yaml.safe_load(f)
-
-        backend_env = config["services"]["backend"]["environment"]
-        assert backend_env["LOCAL_GGUF_MODEL"] == "qwen2.5-0.5b-gguf"
-
-
-# ── Whoosh'd standalone verification ──
+        worker_env = config["services"]["worker-chat"]["environment"]
+        for key, value in CANONICAL_SMOKE_MODELS.items():
+            assert backend_env[key] == value
+            assert worker_env[key] == value
 
 
 class TestWhooshdStaysStandalone:
     def test_no_whooshd_import_in_codexify_routes(self):
-        """Codexify should not import Whoosh'd internals.
-
-        The whooshd_model_profiles module in Codexify is allowed — it
-        provides model ID -> profile metadata mappings and does NOT
-        import the Whoosh'd server package.  We only flag direct imports
-        of an actual 'whooshd' Python package.
-        """
         for check_path in [
             "guardian/guardian_api.py",
             "guardian/core/config.py",
         ]:
-            p = Path(check_path)
-            if p.exists():
-                content = p.read_text()
-                # A direct 'import whooshd' (no suffix) would mean pulling
-                # in the Whoosh'd server runtime — that must not happen.
+            path = Path(check_path)
+            if path.exists():
                 import_lines = [
                     line.strip()
-                    for line in content.splitlines()
-                    if line.strip().startswith(("import whooshd", "from whooshd"))
+                    for line in path.read_text().splitlines()
+                    if line.strip().startswith(
+                        ("import whooshd", "from whooshd")
+                    )
                 ]
-                assert len(import_lines) == 0, (
-                    f"{check_path} imports whooshd internals: {import_lines}"
-                )
+                assert (
+                    not import_lines
+                ), f"{check_path} imports whooshd internals: {import_lines}"
 
     def test_compose_override_does_not_add_whooshd_service(self):
-        """The Whoosh'd container is managed separately, not by our Compose."""
-        override_path = Path("docker-compose.whooshd-smoke.yml")
-        with open(override_path) as f:
-            config = yaml.safe_load(f)
-
-        for svc in config["services"]:
-            assert "whooshd" not in svc.lower(), (
-                f"Service '{svc}' looks like a Whoosh'd container — "
-                "Whoosh'd must remain standalone"
-            )
+        config = _load_smoke_override()
+        for service in config["services"]:
+            assert "whooshd" not in service.lower()


### PR DESCRIPTION
## Summary

Reconciles the supported Whoosh’d runtime contract across the supported profile, Compose smoke override, smoke launcher, focused tests, and operator documentation.

## Root cause

Canonical Whoosh’d surfaces had drifted across endpoint topology, provider metadata, runtime preset, local-only policy, and configured model aliases. The drift caused the prerequisite audit to stop with ten smoke-contract test failures.

## Contract after this repair

- Docker container endpoint uses http://host.docker.internal:8000/v1
- Host health probing remains on local loopback
- Provider identity remains local
- Runtime preset remains whooshd-mlx
- Cloud providers remain disabled
- Supported profile remains model-inventory agnostic
- Smoke aliases remain configuration, not live inventory proof

## Validation

- 75 focused tests passed
- Compose interpolation passed
- Bash validation passed
- Whoosh’d model-profile validation passed
- Documentation validation passed
- Scope and commit hooks passed

## Release boundary

This PR repairs static/test-proven contract drift only. It does not prove live Whoosh’d availability, model inventory, container reachability, supported Compose health, or issue #603 release readiness.

## Next task

Re-run the issue #603 supported-audit readiness prerequisite against the then-current main commit.
