### PR TITLE
fix: align proof profile with current local provider contract

### DIFF
--- a/config/supported_profiles/v1-user-profile-accent-proof.yaml
+++ b/config/supported_profiles/v1-user-profile-accent-proof.yaml
@@ -72,8 +72,12 @@ provider_contract:
   ALLOW_CLOUD_PROVIDERS: false
   CODEXIFY_LOCAL_ONLY_MODE: true
   CODEXIFY_EGRESS_ALLOWLIST: ""
-  LOCAL_BASE_URL: http://100.127.148.28:8000/v1
+  LOCAL_RUNTIME_PRESET: whooshd-mlx
+  LOCAL_BASE_URL: http://host.docker.internal:8000/v1
   LOCAL_API_KEY: local
+  LOCAL_COMPAT_FIRST: true
+  LOCAL_PROVIDER_DISPLAY_NAME: "Whoosh'd"
+  LOCAL_PROVIDER_VENDOR: whooshd
   # Model names are NOT enforced here — the system discovers available models
   # at runtime. If no local models exist AND no cloud provider is configured,
   # the /health/llm endpoint will report models_available: false.


### PR DESCRIPTION
## What changed

- Align `v1-user-profile-accent-proof` with the current `v1-local-core-web-mcp` provider contract.
- Preserve the Whoosh'd runtime preset, Docker base URL, compatibility-first flag, and provider identity fields in the proof profile.

## Why

PR #669 was merged while `main` had advanced through PR #670. The merged tree combines the newer default local-provider contract with the older proof profile, causing the backend profile-equivalence test to fail.

## Validation

- `venv/bin/python -m pytest -q tests/config/test_user_profile_accent_proof_profile.py` — 5 passed.
- `git diff --check` — passed for the scoped file.

This is a follow-up to the already-merged PR #669 and intentionally contains only the profile-contract correction.
