### PR TITLE
Restore fail-closed CURRENT_LIVE_PROOF manifest integration

### DIFF
--- a/docs/architecture/00-current-state.md
+++ b/docs/architecture/00-current-state.md
@@ -4,7 +4,7 @@ This file is Codexify's canonical short-form source of truth for current operati
 
 ## Last updated
 
-2026-08-02
+2026-08-04
 
 ## Interpretation rule
 
@@ -48,6 +48,7 @@ This file is authoritative for:
 - Do not assume cloud-provider beta support, packaged-desktop replacement of Compose, or a current local runtime without live endpoint and model-inventory proof.
 - Do not assume the private-preview lane is operational; authenticated Whoosh'd and DeepSeek V4 Flash persisted-turn proof remains open.
 - Do not treat a green health check, route acceptance, unit test, proof receipt, or docs contract as end-to-end runtime proof by itself.
+- Do not treat a validator-passing `CURRENT_LIVE_PROOF` manifest as storage, promotion, trusted `latest`, release approval, or proof of the current live Compose runtime without the separately required live execution evidence.
 - Do not assume Hosted Room automatic responses, Luna invocation, ambient presence, cross-node rooms, or release qualification.
 - Do not treat browser, email, federation, graph writes, Continuity/Project Pulse, thread lenses, or P2P video documents as shipped beta behavior.
 - Do not assume failed account-import jobs retry automatically, repair partial writes, deduplicate payloads, or reconstruct missing historical staging.

--- a/docs/architecture/canonical-audit-evidence-contract.md
+++ b/docs/architecture/canonical-audit-evidence-contract.md
@@ -213,10 +213,20 @@ validator. It preserves ordered commands and selected Compose files while
 normalizing unordered claims, relationships, and artifact descriptors. It
 rejects caller-supplied evidence IDs, secret-bearing metadata, unsafe artifact
 paths, inconsistent execution outcomes, unresolved claim references, and
-unsupported live-proof requests. The CLI is stdout-first; an optional output
-path is repository-local, atomic, and non-overwriting unless `--replace` is
-explicit. The producer never executes commands, inspects Docker or services,
-persists evidence, mutates Git, or promotes authority.
+unsupported live-proof requests outside the bounded receipt handoff. For
+`CURRENT_LIVE_PROOF`, it accepts exactly one qualifying `PASS` receipt,
+validates its schema and deterministic ID, preserves the exact receipt bytes
+as a hashed repository-relative artifact, and records explicit
+`derived_from` lineage. It always collects fresh runtime identity for this
+proof class and compares machine, repository, commit, runtime, configuration,
+Compose project, role, and supported-profile identity before assembly.
+Caller metadata cannot disable that collection. Receipt references under
+`supersedes` or `contradicts` fail closed with
+`live_proof_relationship_invalid`; an existing `derived_from` reference is
+retained exactly once. The CLI is stdout-first; an optional output path is
+repository-local, atomic, and non-overwriting unless `--replace` is explicit.
+The producer never executes commands, inspects Docker or services, persists
+evidence, mutates Git, or promotes authority.
 
 A bounded repository-local live proof receipt collector now observes one
 explicitly selected, already-running supported Compose project. It binds the
@@ -227,25 +237,27 @@ schema-validated, secret-safe execution receipt with distinct `PASS`, `FAIL`,
 `BLOCKED`, and `ERROR` outcomes. The subordinate [Canonical Live Proof Receipt
 Contract](./canonical-live-proof-receipt-contract.md) governs this seam. The
 receipt is not accepted canonical evidence, proof storage, promotion approval,
-trusted `latest`, or release approval, and the current manifest producer does
-not consume it.
+trusted `latest`, or release approval. A qualifying `PASS` receipt may now
+support one deterministic `CURRENT_LIVE_PROOF` manifest, but receipt `PASS`
+does not upgrade provisional authority and the manifest remains unpromoted
+evidence.
 
 ## Deferred implementation work
 
-Manifest integration and acceptance of the bounded live receipt, artifact
-collection beyond that receipt, complete canonical manifest production beyond
-the current validated assembly, freshness evaluation, evidence storage,
-cross-record resolution, supersession validation, contradiction resolution,
-pointer storage, promotion receipts, trusted pointers, consumer migration, and
-live VaultNode proof remain separately scoped work. `CURRENT_LIVE_PROOF` is
-still rejected by the manifest producer; other supported proof classes may
-carry nullable runtime fields when static runtime identity is not requested. A
+Artifact collection beyond the receipt, complete canonical manifest
+production beyond the current validated assembly, freshness evaluation,
+evidence storage, cross-record resolution, supersession validation,
+contradiction resolution, pointer storage, promotion receipts, trusted
+pointers, consumer migration, release approval, and live VaultNode proof
+remain separately scoped work. Other supported proof classes may carry
+nullable runtime fields when static runtime identity is not requested. A
 requested static runtime identity must be complete, but it is still not live
-proof without a separately produced receipt, and a receipt is not manifest
-acceptance.
+proof without a separately produced receipt. A receipt and a validator-passing
+manifest remain evidence records; neither is automatic promotion or release
+approval.
 
 ## Non-goals
 
 This contract does not implement producer or consumer migration, a registry,
-pointer, schedule, autonomous audit execution, manifest integration of the
-bounded receipt, release approval, or feature expansion.
+pointer, schedule, autonomous audit execution, evidence storage, promotion,
+trusted `latest`, release approval, or feature expansion.

--- a/docs/architecture/canonical-live-proof-receipt-contract.md
+++ b/docs/architecture/canonical-live-proof-receipt-contract.md
@@ -154,24 +154,34 @@ does not write a registry, manifest, promotion receipt, or trusted pointer.
 
 ## Relationship to canonical evidence
 
-The receipt preserves provenance for a later manifest-integration task. The
-current canonical evidence manifest producer still rejects
-`CURRENT_LIVE_PROOF`; the current canonical evidence schema, producer, and
-validator are unchanged by this seam. A future task must explicitly define how
-a qualifying receipt is attached to a manifest without weakening ADR-041 or
-ADR-042.
+The receipt preserves provenance for the bounded manifest handoff. The
+canonical evidence manifest producer accepts exactly one schema-valid
+`CURRENT_LIVE_PROOF` receipt only when its outcome is `PASS`, its deterministic
+ID matches, its exact source bytes are hash-recorded as an artifact, and all
+machine, repository, commit, runtime, configuration, Compose project, role,
+and supported-profile identities match fresh observations. Runtime identity
+collection is mandatory for this proof class; caller metadata cannot disable
+it. A receipt ID already present under `derived_from` is retained once, while
+the same ID under `supersedes` or `contradicts` fails closed with
+`live_proof_relationship_invalid`.
 
-Still deferred are manifest acceptance of `CURRENT_LIVE_PROOF`, durable evidence
-storage, freshness evaluation, cross-record resolution, supersession and
-contradiction resolution, promotion receipts, trusted pointers, consumer
-migration, and release approval.
+Receipt `PASS` is necessary but insufficient for canonical authority. The
+manifest producer still derives `authority_status` from the existing machine
+and repository candidacy rules, and the resulting manifest is unpromoted
+evidence rather than storage, a freshness decision, a trusted pointer, or
+release approval. The canonical evidence schema and existing validator remain
+the governing validation boundary.
+
+Still deferred are durable evidence storage, freshness evaluation, cross-record
+resolution, supersession and contradiction resolution, promotion receipts,
+trusted pointers, consumer migration, and release approval.
 
 ## Non-goals
 
 This contract does not add Docker lifecycle management, container execution,
 operator-supplied commands, arbitrary probes, chat turns, ingestion proof,
 provider mutation, migration execution, database queries, container logs,
-manifest generation, evidence storage, freshness calculation, trusted
+additional manifest consumers, evidence storage, freshness calculation, trusted
 `latest`, GitHub Actions, or release approval.
 
 ## Related documents

--- a/scripts/audit/generate_canonical_evidence_manifest.py
+++ b/scripts/audit/generate_canonical_evidence_manifest.py
@@ -27,6 +27,10 @@ from scripts.audit.collect_canonical_evidence_identity import (  # noqa: E402
     CollectorError,
     collect_identity,
 )
+from scripts.audit.collect_canonical_live_proof_receipt import (  # noqa: E402
+    _receipt_id as compute_receipt_id,
+)
+from scripts.audit.collect_canonical_live_proof_receipt import validate_receipt  # noqa: E402
 from scripts.audit.collect_canonical_runtime_identity import (  # noqa: E402
     RuntimeIdentityError,
     collect_runtime_identity,
@@ -55,6 +59,26 @@ VALID_DISPOSITIONS = {"ACCEPTED", "SUPERSEDED", "CONTRADICTED", "REJECTED"}
 VALID_OUTCOMES = {"PASS", "FAIL", "BLOCKED", "ERROR", "NOT_APPLICABLE"}
 CLAIM_BUCKETS = ("supported", "disproved", "unresolved")
 RELATIONSHIP_BUCKETS = ("supersedes", "contradicts", "derived_from")
+LIVE_PROOF_REASON_CODES = frozenset(
+    {
+        "live_proof_receipt_required",
+        "live_proof_receipt_not_found",
+        "live_proof_receipt_schema_invalid",
+        "live_proof_receipt_id_invalid",
+        "live_proof_receipt_hash_mismatch",
+        "live_proof_receipt_not_pass",
+        "live_proof_machine_identity_mismatch",
+        "live_proof_repository_identity_mismatch",
+        "live_proof_commit_mismatch",
+        "live_proof_runtime_identity_mismatch",
+        "live_proof_effective_config_mismatch",
+        "live_proof_compose_project_mismatch",
+        "live_proof_role_mismatch",
+        "live_proof_profile_mismatch",
+        "live_proof_authority_ineligible",
+        "live_proof_relationship_invalid",
+    }
+)
 SECRET_KEY_RE = re.compile(r"(?i)(password|secret|token|api[_-]?key|private[_-]?key|credential)")
 SECRET_VALUE_RE = re.compile(
     r"(?i)([a-z][a-z0-9+.-]*://[^\s/@]+:[^\s/@]+@|"
@@ -423,6 +447,276 @@ def _write_output(manifest: Mapping[str, Any], output_path: str, root: Path, rep
         raise ProducerError("output_write_failed", "Manifest output could not be written atomically.") from exc
 
 
+def _process_live_proof_receipt(
+    receipt_path_value: str,
+    root: Path,
+    machine_data: Mapping[str, Any],
+    repository_data: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Load, validate, and extract identity from a live proof receipt.
+
+    Returns a dict with keys:
+      receipt, receipt_bytes, receipt_sha256, receipt_id_value,
+      execution, artifact, derived_from_refs.
+
+    Raises ProducerError on any validation failure.
+    """
+    # --- path safety ---
+    relative, path = _safe_relative_path(
+        receipt_path_value, root, code_prefix="live_proof_receipt_path"
+    )
+    # also check lexical (unresolved) path for symlinks
+    lexical = (
+        root / Path(*PurePosixPath(relative).parts)
+        if not PurePosixPath(relative).is_absolute()
+        else Path(relative)
+    )
+    if lexical.is_symlink() or path.is_symlink():
+        raise ProducerError(
+            "live_proof_receipt_path_symlink",
+            "Symlink receipt paths are not accepted.",
+        )
+    if not path.exists():
+        raise ProducerError(
+            "live_proof_receipt_not_found",
+            "Live proof receipt file does not exist.",
+        )
+    if not path.is_file():
+        raise ProducerError(
+            "live_proof_receipt_not_found",
+            "Live proof receipt path is not a regular file.",
+        )
+    # --- exact-byte read ---
+    try:
+        receipt_bytes = path.read_bytes()
+    except OSError as exc:
+        raise ProducerError(
+            "live_proof_receipt_not_found",
+            "Live proof receipt could not be read.",
+        ) from exc
+    receipt_sha256 = hashlib.sha256(receipt_bytes).hexdigest()
+    # --- parse ---
+    try:
+        receipt_text = receipt_bytes.decode("utf-8")
+        receipt = json.loads(receipt_text)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ProducerError(
+            "live_proof_receipt_schema_invalid",
+            "Live proof receipt is not valid UTF-8 JSON.",
+        ) from exc
+    if not isinstance(receipt, dict):
+        raise ProducerError(
+            "live_proof_receipt_schema_invalid",
+            "Live proof receipt must be a JSON object.",
+        )
+    # --- schema validation ---
+    validation = validate_receipt(receipt)
+    if validation["result"] != "pass":
+        raise ProducerError(
+            "live_proof_receipt_schema_invalid",
+            "Live proof receipt failed schema validation.",
+        )
+    # --- field checks ---
+    if receipt.get("schema_version") != "canonical_live_proof_receipt.v1":
+        raise ProducerError(
+            "live_proof_receipt_schema_invalid",
+            "Receipt schema_version is not canonical_live_proof_receipt.v1.",
+        )
+    if receipt.get("proof_class") != "CURRENT_LIVE_PROOF":
+        raise ProducerError(
+            "live_proof_receipt_schema_invalid",
+            "Receipt proof_class is not CURRENT_LIVE_PROOF.",
+        )
+    if receipt.get("execution_outcome") != "PASS":
+        raise ProducerError(
+            "live_proof_receipt_not_pass",
+            "Only PASS receipts qualify for CURRENT_LIVE_PROOF manifest generation.",
+        )
+    # --- receipt identity ---
+    declared_id = receipt.get("receipt_id", "")
+    computed_id = compute_receipt_id(receipt)
+    if declared_id != computed_id:
+        raise ProducerError(
+            "live_proof_receipt_id_invalid",
+            "Declared receipt_id does not match the deterministic receipt identity.",
+        )
+    # --- machine identity comparison ---
+    receipt_machine = receipt.get("machine", {})
+    for field in ("machine_id", "machine_role", "hostname", "authority_basis"):
+        if receipt_machine.get(field) != machine_data.get(field):
+            raise ProducerError(
+                "live_proof_machine_identity_mismatch",
+                f"Receipt machine {field} does not match current observation.",
+            )
+    # --- repository identity comparison ---
+    receipt_repo = receipt.get("repository", {})
+    # commit_sha gets a dedicated reason code
+    if receipt_repo.get("commit_sha") != repository_data.get("commit_sha"):
+        raise ProducerError(
+            "live_proof_commit_mismatch",
+            "Receipt commit does not match the current checked-out commit.",
+        )
+    for field in (
+        "repository_root_identity",
+        "branch",
+        "upstream_sha",
+        "dirty",
+        "worktree_identity",
+    ):
+        if receipt_repo.get(field) != repository_data.get(field):
+            raise ProducerError(
+                "live_proof_repository_identity_mismatch",
+                f"Receipt repository {field} does not match current observation.",
+            )
+    # --- execution mapping ---
+    receipt_commands = receipt.get("commands", [])
+    encoded_commands = [
+        json.dumps(
+            cmd, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+        )
+        for cmd in receipt_commands
+    ]
+    execution = {
+        "suite_id": receipt.get("suite_id", ""),
+        "commands": encoded_commands,
+        "started_at": receipt.get("started_at", ""),
+        "completed_at": receipt.get("completed_at", ""),
+        "exit_code": 0,
+        "summary": f"Current live proof receipt {computed_id}; PASS observation of supported Compose project.",
+    }
+    # --- artifact ---
+    artifact = {
+        "artifact_id": computed_id,
+        "path": relative,
+        "sha256": receipt_sha256,
+        "media_type": "application/json",
+        "artifact_role": "canonical_live_proof_receipt",
+    }
+    # --- lineage ---
+    derived_from_refs = [computed_id]
+    return {
+        "receipt": receipt,
+        "receipt_bytes": receipt_bytes,
+        "receipt_sha256": receipt_sha256,
+        "receipt_id_value": computed_id,
+        "execution": execution,
+        "artifact": artifact,
+        "derived_from_refs": derived_from_refs,
+    }
+
+
+def _compare_runtime_identity(
+    receipt: Mapping[str, Any],
+    runtime_data: Mapping[str, Any],
+    audit_project: str | None,
+    serving_project: str | None,
+) -> None:
+    """Compare receipt runtime/target identity with freshly collected runtime."""
+    receipt_runtime = receipt.get("runtime", {})
+    # compose_project gets dedicated reason code
+    if receipt_runtime.get("compose_project") != runtime_data.get(
+        "compose_project"
+    ):
+        raise ProducerError(
+            "live_proof_compose_project_mismatch",
+            "Receipt compose_project does not match.",
+        )
+    if receipt_runtime.get("supported_profile") != runtime_data.get(
+        "supported_profile"
+    ):
+        raise ProducerError(
+            "live_proof_profile_mismatch",
+            "Receipt supported_profile does not match.",
+        )
+    if receipt_runtime.get("effective_config_hash") != runtime_data.get(
+        "effective_config_hash"
+    ):
+        raise ProducerError(
+            "live_proof_effective_config_mismatch",
+            "Receipt effective_config_hash does not match.",
+        )
+    for field in ("migration_head",):
+        if receipt_runtime.get(field) != runtime_data.get(field):
+            raise ProducerError(
+                "live_proof_runtime_identity_mismatch",
+                f"Receipt runtime {field} does not match.",
+            )
+    # compose_files
+    receipt_files = list(receipt_runtime.get("compose_files") or [])
+    collected_files = list(runtime_data.get("compose_files") or [])
+    if receipt_files != collected_files:
+        raise ProducerError(
+            "live_proof_runtime_identity_mismatch",
+            "Receipt compose_files do not match.",
+        )
+    # service_identities (normalized sorted)
+    receipt_services = sorted(receipt_runtime.get("service_identities") or [])
+    collected_services = sorted(runtime_data.get("service_identities") or [])
+    if receipt_services != collected_services:
+        raise ProducerError(
+            "live_proof_runtime_identity_mismatch",
+            "Receipt service_identities do not match.",
+        )
+    # target comparison
+    receipt_target = receipt.get("target", {})
+    receipt_compose = receipt_target.get("compose_project", "")
+    receipt_audit = receipt_target.get("audit_project", "")
+    receipt_serving = receipt_target.get("serving_project")
+    receipt_role = receipt_target.get("project_role", "")
+    if audit_project is not None and receipt_audit != audit_project:
+        raise ProducerError(
+            "live_proof_compose_project_mismatch",
+            "Receipt audit_project does not match.",
+        )
+    if serving_project is not None and receipt_serving != serving_project:
+        raise ProducerError(
+            "live_proof_compose_project_mismatch",
+            "Receipt serving_project does not match.",
+        )
+    if receipt_role == "audit" and receipt_compose != receipt_audit:
+        raise ProducerError(
+            "live_proof_role_mismatch",
+            "Audit receipt must select the audit project.",
+        )
+    if receipt_role == "serving" and (
+        receipt_serving is None or receipt_compose != receipt_serving
+    ):
+        raise ProducerError(
+            "live_proof_role_mismatch",
+            "Serving receipt must select the serving project.",
+        )
+
+
+def _reject_live_proof_relationship_conflict(
+    value: Any, receipt_id_value: str
+) -> None:
+    """Reject receipt lineage that would conflict with generated derivation."""
+    source = (
+        {bucket: [] for bucket in RELATIONSHIP_BUCKETS}
+        if value is None
+        else dict(_require_mapping(value, "relationship_invalid", "relationships"))
+    )
+    if set(source) != set(RELATIONSHIP_BUCKETS):
+        raise ProducerError(
+            "relationship_invalid",
+            "relationships must contain exactly the supported buckets.",
+        )
+    for bucket in RELATIONSHIP_BUCKETS:
+        entries = source[bucket]
+        if not isinstance(entries, list):
+            raise ProducerError(
+                "relationship_invalid", "relationship buckets must be arrays."
+            )
+        if bucket in {"supersedes", "contradicts"} and any(
+            isinstance(entry, str) and entry.strip() == receipt_id_value
+            for entry in entries
+        ):
+            raise ProducerError(
+                "live_proof_relationship_invalid",
+                "A live proof receipt cannot be superseded or contradicted by its manifest.",
+            )
+
+
 def generate_manifest(
     repo_path: str | Path = ".",
     *,
@@ -455,43 +749,102 @@ def generate_manifest(
     schema_path: str | Path = DEFAULT_SCHEMA_PATH,
     output_path: str | None = None,
     replace: bool = False,
+    live_proof_receipt_path: str | None = None,
 ) -> dict[str, Any]:
     """Return a deterministic producer envelope; never execute proof work."""
     try:
         root = Path(repo_path).expanduser().resolve()
         if not root.is_dir():
-            raise ProducerError("repository_path_invalid", "Repository path is unavailable.")
-        if isinstance(machine_timeout, bool) or not isinstance(machine_timeout, (int, float)) or machine_timeout <= 0:
-            raise ProducerError("machine_timeout_invalid", "machine_timeout must be positive.")
+            raise ProducerError(
+                "repository_path_invalid", "Repository path is unavailable."
+            )
+        if (
+            isinstance(machine_timeout, bool)
+            or not isinstance(machine_timeout, (int, float))
+            or machine_timeout <= 0
+        ):
+            raise ProducerError(
+                "machine_timeout_invalid", "machine_timeout must be positive."
+            )
         if diagnostic_working_path:
-            raise ProducerError("nonportable_absolute_path", "Diagnostic absolute paths are not emitted in manifests.")
+            raise ProducerError(
+                "nonportable_absolute_path",
+                "Diagnostic absolute paths are not emitted in manifests.",
+            )
         supplied = dict(metadata or {})
         _check_secret_values(supplied)
         if evidence_id is not None or "evidence_id" in supplied:
-            raise ProducerError("caller_evidence_id_forbidden", "evidence_id is producer-generated.")
+            raise ProducerError(
+                "caller_evidence_id_forbidden",
+                "evidence_id is producer-generated.",
+            )
         if authority_status is not None or "authority_status" in supplied:
-            raise ProducerError("authority_status_input_forbidden", "authority_status is producer-derived.")
+            raise ProducerError(
+                "authority_status_input_forbidden",
+                "authority_status is producer-derived.",
+            )
         values = {
-            "created_at": created_at if created_at is not None else supplied.get("created_at"),
-            "proof_class": proof_class if proof_class is not None else supplied.get("proof_class"),
-            "freshness_status": freshness_status if freshness_status is not None else supplied.get("freshness_status"),
-            "disposition": disposition if disposition is not None else supplied.get("disposition"),
-            "execution_outcome": execution_outcome if execution_outcome is not None else supplied.get("execution_outcome"),
-            "execution": execution if execution is not None else supplied.get("execution"),
+            "created_at": created_at
+            if created_at is not None
+            else supplied.get("created_at"),
+            "proof_class": proof_class
+            if proof_class is not None
+            else supplied.get("proof_class"),
+            "freshness_status": freshness_status
+            if freshness_status is not None
+            else supplied.get("freshness_status"),
+            "disposition": disposition
+            if disposition is not None
+            else supplied.get("disposition"),
+            "execution_outcome": execution_outcome
+            if execution_outcome is not None
+            else supplied.get("execution_outcome"),
+            "execution": execution
+            if execution is not None
+            else supplied.get("execution"),
             "claims": claims if claims is not None else supplied.get("claims"),
-            "artifacts": artifacts if artifacts is not None else supplied.get("artifacts"),
-            "relationships": relationships if relationships is not None else supplied.get("relationships"),
+            "artifacts": artifacts
+            if artifacts is not None
+            else supplied.get("artifacts"),
+            "relationships": relationships
+            if relationships is not None
+            else supplied.get("relationships"),
         }
         if values["proof_class"] not in VALID_PROOF_CLASSES:
-            raise ProducerError("proof_class_invalid", "proof_class is not accepted vocabulary.")
-        if values["proof_class"] == "CURRENT_LIVE_PROOF":
-            raise ProducerError("live_proof_not_supported", "This producer does not generate CURRENT_LIVE_PROOF.")
+            raise ProducerError(
+                "proof_class_invalid", "proof_class is not accepted vocabulary."
+            )
+        is_live_proof = values["proof_class"] == "CURRENT_LIVE_PROOF"
+        receipt_path = (
+            live_proof_receipt_path
+            if live_proof_receipt_path is not None
+            else supplied.get("live_proof_receipt_path")
+        )
+        if is_live_proof:
+            if (
+                not receipt_path
+                or not isinstance(receipt_path, str)
+                or not receipt_path.strip()
+            ):
+                raise ProducerError(
+                    "live_proof_receipt_required",
+                    "CURRENT_LIVE_PROOF requires live_proof_receipt_path.",
+                )
         if values["freshness_status"] not in VALID_FRESHNESS:
-            raise ProducerError("freshness_status_invalid", "freshness_status is not accepted vocabulary.")
+            raise ProducerError(
+                "freshness_status_invalid",
+                "freshness_status is not accepted vocabulary.",
+            )
         if values["disposition"] not in VALID_DISPOSITIONS:
-            raise ProducerError("disposition_invalid", "disposition is not accepted vocabulary.")
-        normalized_created_at = _normalize_datetime(values["created_at"], "created_at")
-        outcome, normalized_execution = _normalize_execution(values["execution"], values["execution_outcome"])
+            raise ProducerError(
+                "disposition_invalid", "disposition is not accepted vocabulary."
+            )
+        normalized_created_at = _normalize_datetime(
+            values["created_at"], "created_at"
+        )
+        outcome, normalized_execution = _normalize_execution(
+            values["execution"], values["execution_outcome"]
+        )
 
         machine = collect_identity(
             root,
@@ -505,10 +858,17 @@ def generate_manifest(
         machine_data = machine.get("machine")
         repository_data = machine.get("repository")
         eligibility = machine.get("eligibility", {})
-        if not isinstance(machine_data, Mapping) or not isinstance(repository_data, Mapping):
-            raise ProducerError("machine_identity_incomplete", "Machine/Git collector did not return identity fields.")
+        if not isinstance(machine_data, Mapping) or not isinstance(
+            repository_data, Mapping
+        ):
+            raise ProducerError(
+                "machine_identity_incomplete",
+                "Machine/Git collector did not return identity fields.",
+            )
         reason_codes = set(eligibility.get("reason_codes", []))
-        if not eligibility.get("repository_identity_complete") or not machine.get("observation_complete"):
+        if not eligibility.get(
+            "repository_identity_complete"
+        ) or not machine.get("observation_complete"):
             reason_codes.add("repository_identity_incomplete")
             return {
                 "schema_version": RESULT_SCHEMA_VERSION,
@@ -519,9 +879,22 @@ def generate_manifest(
                 "reason_codes": sorted(reason_codes),
             }
 
-        requested_runtime = supplied.get("runtime_identity_requested", runtime_identity_requested)
+        # --- live proof receipt processing ---
+        receipt_bundle: dict[str, Any] | None = None
+        if is_live_proof:
+            receipt_bundle = _process_live_proof_receipt(
+                receipt_path, root, machine_data, repository_data
+            )
+        requested_runtime = (
+            True
+            if is_live_proof
+            else supplied.get("runtime_identity_requested", runtime_identity_requested)
+        )
         if not isinstance(requested_runtime, bool):
-            raise ProducerError("runtime_identity_invalid", "runtime_identity_requested must be boolean.")
+            raise ProducerError(
+                "runtime_identity_invalid",
+                "runtime_identity_requested must be boolean.",
+            )
         runtime_data: Mapping[str, Any] | None = None
         if requested_runtime:
             runtime = collect_runtime_identity(
@@ -547,17 +920,86 @@ def generate_manifest(
                 }
             runtime_data = runtime.get("runtime")
             if not isinstance(runtime_data, Mapping):
-                raise ProducerError("runtime_identity_incomplete", "Runtime collector did not return identity fields.")
+                raise ProducerError(
+                    "runtime_identity_incomplete",
+                    "Runtime collector did not return identity fields.",
+                )
 
-        normalized_artifacts, artifact_ids = _normalize_artifacts(values["artifacts"], root)
-        normalized_claims = _normalize_claims(values["claims"], artifact_ids, normalized_execution["suite_id"])
-        normalized_relationships = _normalize_relationships(values["relationships"])
-        authority_status = "CANONICAL" if (
-            eligibility.get("canonical_machine_candidate") is True
-            and eligibility.get("canonical_repository_candidate") is True
-            and machine_data.get("machine_id") == "vaultnode"
-            and machine_data.get("machine_role") == "canonical_evidence_host"
-        ) else "PROVISIONAL"
+        # --- live proof runtime identity comparison ---
+        if receipt_bundle is not None and runtime_data is not None:
+            _compare_runtime_identity(
+                receipt_bundle["receipt"],
+                runtime_data,
+                audit_project,
+                serving_project,
+            )
+
+        normalized_artifacts, artifact_ids = _normalize_artifacts(
+            values["artifacts"], root
+        )
+        normalized_claims = _normalize_claims(
+            values["claims"], artifact_ids, normalized_execution["suite_id"]
+        )
+        if receipt_bundle is not None:
+            _reject_live_proof_relationship_conflict(
+                values["relationships"], receipt_bundle["receipt_id_value"]
+            )
+        normalized_relationships = _normalize_relationships(
+            values["relationships"]
+        )
+        authority_status = (
+            "CANONICAL"
+            if (
+                eligibility.get("canonical_machine_candidate") is True
+                and eligibility.get("canonical_repository_candidate") is True
+                and machine_data.get("machine_id") == "vaultnode"
+                and machine_data.get("machine_role")
+                == "canonical_evidence_host"
+            )
+            else "PROVISIONAL"
+        )
+        # --- live proof integration: authority agreement, execution, artifact, lineage ---
+        if receipt_bundle is not None:
+            receipt_authority = receipt_bundle["receipt"].get(
+                "authority_status", ""
+            )
+            if receipt_authority != authority_status:
+                raise ProducerError(
+                    "live_proof_authority_ineligible",
+                    "Receipt authority_status must agree with derived manifest authority.",
+                )
+            outcome = "PASS"
+            normalized_execution = receipt_bundle["execution"]
+            # add receipt artifact
+            receipt_artifact = receipt_bundle["artifact"]
+            normalized_artifacts = [receipt_artifact] + normalized_artifacts
+            artifact_ids.add(receipt_artifact["artifact_id"])
+            # add receipt lineage
+            receipt_refs = receipt_bundle["derived_from_refs"]
+            if any(
+                receipt_id in normalized_relationships.get(bucket, [])
+                for bucket in ("supersedes", "contradicts")
+                for receipt_id in receipt_refs
+            ):
+                raise ProducerError(
+                    "live_proof_relationship_invalid",
+                    "A live proof receipt cannot be superseded or contradicted by its manifest.",
+                )
+            existing_derived = set(
+                normalized_relationships.get("derived_from", [])
+            )
+            for ref in receipt_refs:
+                if ref not in existing_derived:
+                    normalized_relationships["derived_from"] = sorted(
+                        list(normalized_relationships["derived_from"]) + [ref]
+                    )
+            # re-normalize claims now that artifact_ids may include the receipt
+            if normalized_claims:
+                normalized_claims = _normalize_claims(
+                    values["claims"],
+                    artifact_ids,
+                    normalized_execution["suite_id"],
+                )
         manifest: dict[str, Any] = {
             "schema_version": MANIFEST_SCHEMA_VERSION,
             "evidence_id": "",
@@ -569,11 +1011,23 @@ def generate_manifest(
             "created_at": normalized_created_at,
             "machine": {
                 field: machine_data[field]
-                for field in ("machine_id", "machine_role", "hostname", "authority_basis")
+                for field in (
+                    "machine_id",
+                    "machine_role",
+                    "hostname",
+                    "authority_basis",
+                )
             },
             "repository": {
                 field: repository_data[field]
-                for field in ("repository_root_identity", "branch", "commit_sha", "upstream_sha", "dirty", "worktree_identity")
+                for field in (
+                    "repository_root_identity",
+                    "branch",
+                    "commit_sha",
+                    "upstream_sha",
+                    "dirty",
+                    "worktree_identity",
+                )
             },
             "runtime": _runtime_manifest(runtime_data),
             "execution": normalized_execution,
@@ -587,7 +1041,10 @@ def generate_manifest(
             for references in normalized_relationships.values()
             for reference in references
         ):
-            raise ProducerError("relationship_self_reference", "A manifest cannot reference its newly generated evidence ID.")
+            raise ProducerError(
+                "relationship_self_reference",
+                "A manifest cannot reference its newly generated evidence ID.",
+            )
         validation = _validate_generated_manifest(manifest, schema_path, root)
         if validation["result"] != "pass":
             reason_codes.add("manifest_validation_failed")
@@ -601,7 +1058,11 @@ def generate_manifest(
             }
         if output_path is not None:
             _write_output(manifest, output_path, root, replace)
-        ineligible = not eligibility.get("canonical_repository_candidate") or values["freshness_status"] != "CURRENT" or values["disposition"] != "ACCEPTED"
+        ineligible = (
+            not eligibility.get("canonical_repository_candidate")
+            or values["freshness_status"] != "CURRENT"
+            or values["disposition"] != "ACCEPTED"
+        )
         return {
             "schema_version": RESULT_SCHEMA_VERSION,
             "producer_version": PRODUCER_VERSION,
@@ -636,6 +1097,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--serving-project")
     parser.add_argument("--migration-dir")
     parser.add_argument("--no-runtime-identity", action="store_true")
+    parser.add_argument(
+        "--live-proof-receipt",
+        help="Repository-relative path to a live proof receipt for CURRENT_LIVE_PROOF manifests.",
+    )
     parser.add_argument("--output")
     parser.add_argument("--replace", action="store_true")
     args = parser.parse_args(argv)
@@ -666,6 +1131,7 @@ def main(argv: list[str] | None = None) -> int:
         metadata=metadata,
         output_path=args.output,
         replace=args.replace,
+        live_proof_receipt_path=args.live_proof_receipt,
     )
     print(json.dumps(result, indent=2, sort_keys=True))
     if result["result"] == "pass":

--- a/tests/audit/test_generate_canonical_evidence_manifest.py
+++ b/tests/audit/test_generate_canonical_evidence_manifest.py
@@ -7,6 +7,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -65,6 +66,9 @@ def make_fixture(tmp_path: Path) -> dict[str, Path]:
     profile_dir.mkdir(parents=True)
     migration_dir.mkdir(parents=True)
     artifact_dir.mkdir(parents=True)
+    (root / ".gitignore").write_text(
+        "live-proof-receipt.json\nreceipt-link.json\n", encoding="utf-8"
+    )
     (profile_dir / "v1-local-core-web-mcp.yaml").write_text(PROFILE, encoding="utf-8")
     compose = root / "docker-compose.yml"
     compose.write_text("name: codexify\nservices:\n  backend: {}\n  db: {}\n  redis: {}\n", encoding="utf-8")
@@ -166,13 +170,13 @@ def test_static_runtime_identity_is_projected_without_live_proof(tmp_path: Path)
     assert result["manifest"]["proof_class"] == "CURRENT_TEST_PROOF"
 
 
-def test_current_live_proof_is_rejected_without_live_inspection(tmp_path: Path) -> None:
+def test_current_live_proof_requires_a_qualifying_receipt(tmp_path: Path) -> None:
     fixture = make_fixture(tmp_path)
     metadata = base_metadata(runtime_requested=True)
     metadata["proof_class"] = "CURRENT_LIVE_PROOF"
     result = generate_manifest(fixture["root"], hostname="fixture-host", metadata=metadata, **runtime_kwargs(fixture))
     assert result["result"] == "error"
-    assert result["reason_codes"] == ["live_proof_not_supported"]
+    assert result["reason_codes"] == ["live_proof_receipt_required"]
 
 
 def test_artifacts_are_hashed_and_claim_references_are_resolved(tmp_path: Path) -> None:
@@ -343,3 +347,868 @@ def test_cli_is_stdout_first_and_uses_stable_json(tmp_path: Path) -> None:
     parsed = json.loads(first.stdout)
     assert parsed["result"] == "pass"
     assert parsed["manifest"]["authority_status"] == "PROVISIONAL"
+# ---------------------------------------------------------------------------
+# Live proof receipt helpers
+# ---------------------------------------------------------------------------
+
+from scripts.audit.collect_canonical_live_proof_receipt import (  # noqa: E402
+    _receipt_id as compute_receipt_id,
+)
+
+
+def _receipt_json(
+    fixture: dict[str, Path],
+    *,
+    authority_status: str = "PROVISIONAL",
+    execution_outcome: str = "PASS",
+    machine_overrides: dict[str, Any] | None = None,
+    repo_overrides: dict[str, Any] | None = None,
+    runtime_overrides: dict[str, Any] | None = None,
+    target_overrides: dict[str, Any] | None = None,
+    receipt_id_override: str | None = None,
+) -> dict[str, Any]:
+    """Build a minimal but valid live proof receipt for a fixture."""
+    root = fixture["root"]
+    head = git(root, "rev-parse", "HEAD")
+    upstream = git(root, "rev-parse", "@{u}")
+    repo_root_id = git(root, "rev-parse", "--show-toplevel")
+    repo_root_id = f"git:{hashlib.sha256(repo_root_id.encode()).hexdigest()}"
+
+    machine = {
+        "machine_id": "local",
+        "machine_role": "provisional_development_host",
+        "hostname": "fixture-host",
+        "authority_basis": "operator_not_asserted",
+    }
+    if machine_overrides:
+        machine.update(machine_overrides)
+
+    repo = {
+        "repository_root_identity": repo_root_id,
+        "branch": "main",
+        "commit_sha": head,
+        "upstream_sha": upstream,
+        "dirty": False,
+        "worktree_identity": f"worktree:{hashlib.sha256(str(root).encode()).hexdigest()}",
+    }
+    if repo_overrides:
+        repo.update(repo_overrides)
+
+    runtime_base = {
+        "supported_profile": "v1-local-core-web-mcp",
+        "effective_config_hash": "e" * 64,
+        "compose_project": "codexify-audit",
+        "compose_files": ["docker-compose.yml"],
+        "migration_head": "head-a",
+        "service_identities": ["backend"],
+        "required_services": ["backend"],
+        "optional_services": ["redis"],
+    }
+    if runtime_overrides:
+        runtime_base.update(runtime_overrides)
+
+    target = {
+        "compose_project": "codexify-audit",
+        "project_role": "audit",
+        "audit_project": "codexify-audit",
+        "serving_project": "codexify-serving",
+        "compose_environment_file": None,
+    }
+    if target_overrides:
+        target.update(target_overrides)
+
+    receipt = {
+        "schema_version": "canonical_live_proof_receipt.v1",
+        "receipt_id": "",
+        "suite_id": "supported_compose_live_health.v1",
+        "proof_class": "CURRENT_LIVE_PROOF",
+        "authority_status": authority_status,
+        "execution_outcome": execution_outcome,
+        "created_at": "2026-07-15T12:00:00Z",
+        "started_at": "2026-07-15T12:00:00Z",
+        "completed_at": "2026-07-15T12:00:05Z",
+        "machine": machine,
+        "repository": repo,
+        "runtime": runtime_base,
+        "target": target,
+        "docker": {"client_version": "27.1.1", "server_version": "27.1.1"},
+        "services": [
+            {
+                "service": "backend",
+                "required": True,
+                "lifecycle": "long_running",
+                "container_identity": "codexify-audit-backend-1",
+                "image_id": "sha256:" + "b" * 64,
+                "image_digest": None,
+                "state": "running",
+                "health_status": "healthy",
+                "exit_code": 0,
+                "observation_result": "PASS",
+                "reason_codes": [],
+            }
+        ],
+        "probes": [
+            {
+                "probe_id": "api_ping",
+                "method": "GET",
+                "path": "/ping",
+                "status_code": 200,
+                "started_at": "2026-07-15T12:00:01Z",
+                "completed_at": "2026-07-15T12:00:01Z",
+                "duration_ms": 1,
+                "outcome": "PASS",
+                "response_body_sha256": hashlib.sha256(b"pong\n").hexdigest(),
+                "projection": {},
+                "reason_codes": [],
+            }
+        ],
+        "commands": [
+            ["docker", "version", "--format", "json"],
+            [
+                "docker",
+                "compose",
+                "-f",
+                "docker-compose.yml",
+                "-p",
+                "codexify-audit",
+                "ps",
+                "--all",
+                "--format",
+                "json",
+            ],
+        ],
+        "reason_codes": [],
+    }
+    if receipt_id_override is not None:
+        receipt["receipt_id"] = receipt_id_override
+    else:
+        receipt["receipt_id"] = compute_receipt_id(receipt)
+    return receipt
+
+
+def write_receipt(
+    fixture: dict[str, Path], **kwargs: Any
+) -> tuple[str, dict[str, Any]]:
+    """Write a receipt to the fixture repo and return the relative path and receipt dict.
+
+    Collects identity AFTER writing so dirty/untracked state matches what the producer sees.
+    Also collects actual runtime identity for accurate comparison.
+    """
+    from scripts.audit.collect_canonical_evidence_identity import (
+        collect_identity,
+    )
+    from scripts.audit.collect_canonical_runtime_identity import (
+        collect_runtime_identity,
+    )
+
+    machine_overrides = kwargs.pop("machine_overrides", None) or {}
+    repo_overrides = kwargs.pop("repo_overrides", None) or {}
+    runtime_overrides = kwargs.pop("runtime_overrides", None) or {}
+    target_overrides = kwargs.pop("target_overrides", None) or {}
+
+    # Build a draft receipt first, write it, then collect identity with receipt present
+    draft = _receipt_json(fixture, **kwargs)
+    receipt_path = fixture["root"] / "live-proof-receipt.json"
+    receipt_path.write_text(
+        json.dumps(draft, indent=2, sort_keys=True), encoding="utf-8"
+    )
+
+    # Now collect identity WITH the receipt file present (repo may be dirty)
+    identity = collect_identity(fixture["root"], hostname="fixture-host")
+    collected_machine = identity.get("machine", {})
+    full_machine = {
+        "machine_id": collected_machine.get("machine_id", "local"),
+        "machine_role": collected_machine.get(
+            "machine_role", "provisional_development_host"
+        ),
+        "hostname": collected_machine.get("hostname", "fixture-host"),
+        "authority_basis": collected_machine.get(
+            "authority_basis", "operator_not_asserted"
+        ),
+    }
+    full_machine.update(machine_overrides)
+
+    collected_repo = identity.get("repository", {})
+    full_repo = {
+        "repository_root_identity": collected_repo.get(
+            "repository_root_identity", ""
+        ),
+        "branch": collected_repo.get("branch", "main"),
+        "commit_sha": collected_repo.get("commit_sha", ""),
+        "upstream_sha": collected_repo.get("upstream_sha", ""),
+        "dirty": collected_repo.get("dirty", False),
+        "worktree_identity": collected_repo.get("worktree_identity", ""),
+    }
+    full_repo.update(repo_overrides)
+
+    # Collect actual runtime identity
+    rt = collect_runtime_identity(
+        fixture["root"],
+        profile_name="v1-local-core-web-mcp",
+        profiles_dir=fixture["profile_dir"],
+        compose_files=["docker-compose.yml"],
+        audit_project="codexify-audit",
+        migration_dir=fixture["migration_dir"],
+    )
+    collected_rt = rt.get("runtime", {})
+    full_runtime = {
+        "supported_profile": collected_rt.get(
+            "supported_profile", "v1-local-core-web-mcp"
+        ),
+        "effective_config_hash": collected_rt.get("effective_config_hash", ""),
+        "compose_project": collected_rt.get(
+            "compose_project", "codexify-audit"
+        ),
+        "compose_files": collected_rt.get(
+            "compose_files", ["docker-compose.yml"]
+        ),
+        "migration_head": collected_rt.get("migration_head", "head-a"),
+        "service_identities": collected_rt.get(
+            "service_identities", ["backend"]
+        ),
+        "required_services": collected_rt.get("compose_identity", {}).get(
+            "required_services", ["backend"]
+        ),
+        "optional_services": collected_rt.get("compose_identity", {}).get(
+            "optional_services", ["redis"]
+        ),
+    }
+    full_runtime.update(runtime_overrides)
+
+    receipt = _receipt_json(
+        fixture,
+        machine_overrides=full_machine,
+        repo_overrides=full_repo,
+        runtime_overrides=full_runtime,
+        target_overrides=target_overrides,
+        **kwargs,
+    )
+    receipt_path.write_text(
+        json.dumps(receipt, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    return "live-proof-receipt.json", receipt
+
+
+def live_proof_metadata(
+    receipt_path: str, *, runtime_requested: bool = True
+) -> dict[str, Any]:
+    return {
+        "created_at": "2026-07-15T12:00:00-04:00",
+        "proof_class": "CURRENT_LIVE_PROOF",
+        "freshness_status": "CURRENT",
+        "disposition": "ACCEPTED",
+        "runtime_identity_requested": runtime_requested,
+        "live_proof_receipt_path": receipt_path,
+        "execution": {
+            "outcome": "PASS",
+            "suite_id": "unused-suite",
+            "commands": ["unused"],
+            "started_at": "2026-07-15T12:00:00Z",
+            "completed_at": "2026-07-15T12:00:05Z",
+            "exit_code": 0,
+            "summary": "placeholder; will be overridden by receipt.",
+        },
+        "claims": {"supported": [], "disproved": [], "unresolved": []},
+        "artifacts": [],
+        "relationships": {
+            "supersedes": [],
+            "contradicts": [],
+            "derived_from": [],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Live proof receipt integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_valid_canonical_pass_receipt_produces_deterministic_manifest(
+    tmp_path: Path,
+) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, receipt = write_receipt(
+        fixture,
+        authority_status="CANONICAL",
+        machine_overrides={
+            "machine_id": "vaultnode",
+            "machine_role": "canonical_evidence_host",
+            "hostname": "fixture-host",
+            "authority_basis": "operator-confirmed-vaultnode",
+        },
+    )
+    kwargs = runtime_kwargs(fixture)
+    metadata = live_proof_metadata(receipt_path)
+    first = generate_manifest(
+        fixture["root"],
+        hostname="fixture-host",
+        metadata=metadata,
+        machine_id="vaultnode",
+        machine_role="canonical_evidence_host",
+        authority_basis="operator-confirmed-vaultnode",
+        assert_canonical_machine=True,
+        **kwargs,
+    )
+    second = generate_manifest(
+        fixture["root"],
+        hostname="fixture-host",
+        metadata=metadata,
+        machine_id="vaultnode",
+        machine_role="canonical_evidence_host",
+        authority_basis="operator-confirmed-vaultnode",
+        assert_canonical_machine=True,
+        **kwargs,
+    )
+    assert first == second
+    assert first["result"] in ("pass", "ineligible")
+    assert first["manifest"] is not None
+    assert first["validation"]["result"] == "pass"
+    assert first["manifest"]["authority_status"] == "CANONICAL"
+    assert first["manifest"]["proof_class"] == "CURRENT_LIVE_PROOF"
+    assert first["manifest"]["execution_outcome"] == "PASS"
+    assert first["manifest"]["execution"]["exit_code"] == 0
+    assert receipt["receipt_id"] in first["manifest"]["execution"]["summary"]
+    # receipt is an artifact
+    artifact = first["manifest"]["artifacts"][0]
+    assert artifact["artifact_id"] == receipt["receipt_id"]
+    assert artifact["artifact_role"] == "canonical_live_proof_receipt"
+    assert artifact["media_type"] == "application/json"
+    assert artifact["path"] == receipt_path
+    # lineage
+    assert (
+        receipt["receipt_id"]
+        in first["manifest"]["relationships"]["derived_from"]
+    )
+    # evidence_id
+    assert first["manifest"]["evidence_id"].startswith("evidence-sha256-")
+
+
+def test_valid_provisional_pass_receipt_produces_provisional_manifest(
+    tmp_path: Path,
+) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, receipt = write_receipt(
+        fixture, authority_status="PROVISIONAL"
+    )
+    kwargs = runtime_kwargs(fixture)
+    metadata = live_proof_metadata(receipt_path)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert result["result"] in ("pass", "ineligible")
+    assert result["manifest"] is not None
+    assert result["manifest"]["authority_status"] == "PROVISIONAL"
+    assert result["manifest"]["proof_class"] == "CURRENT_LIVE_PROOF"
+
+
+def test_missing_receipt_input_fails_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    metadata = base_metadata(runtime_requested=True)
+    metadata["proof_class"] = "CURRENT_LIVE_PROOF"
+    result = generate_manifest(
+        fixture["root"],
+        hostname="fixture-host",
+        metadata=metadata,
+        **runtime_kwargs(fixture),
+    )
+    assert result["result"] == "error"
+    assert "live_proof_receipt_required" in result["reason_codes"]
+
+
+def test_missing_receipt_file_fails_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    metadata = live_proof_metadata("nonexistent-receipt.json")
+    kwargs = runtime_kwargs(fixture)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert result["result"] == "error"
+    assert "live_proof_receipt_not_found" in result["reason_codes"]
+
+
+def test_invalid_json_receipt_fails_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path = fixture["root"] / "bad-receipt.json"
+    receipt_path.write_text("not json", encoding="utf-8")
+    metadata = live_proof_metadata("bad-receipt.json")
+    kwargs = runtime_kwargs(fixture)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert result["result"] == "error"
+    assert "live_proof_receipt_schema_invalid" in result["reason_codes"]
+
+
+def test_schema_invalid_receipt_fails_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt = _receipt_json(fixture)
+    del receipt["machine"]  # remove required field
+    receipt["receipt_id"] = compute_receipt_id(receipt)
+    receipt_path = fixture["root"] / "invalid-receipt.json"
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+    metadata = live_proof_metadata("invalid-receipt.json")
+    kwargs = runtime_kwargs(fixture)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert result["result"] == "error"
+    assert "live_proof_receipt_schema_invalid" in result["reason_codes"]
+
+
+def test_invalid_receipt_id_fails_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, _ = write_receipt(
+        fixture, receipt_id_override="live-proof-receipt-sha256-" + "0" * 64
+    )
+    metadata = live_proof_metadata(receipt_path)
+    kwargs = runtime_kwargs(fixture)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert result["result"] == "error"
+    assert "live_proof_receipt_id_invalid" in result["reason_codes"]
+
+
+def test_receipt_byte_change_changes_manifest_evidence_id(
+    tmp_path: Path,
+) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, _ = write_receipt(fixture)
+    kwargs = runtime_kwargs(fixture)
+    metadata = live_proof_metadata(receipt_path)
+    first = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    # change receipt bytes
+    receipt_file = fixture["root"] / receipt_path
+    receipt = json.loads(receipt_file.read_text(encoding="utf-8"))
+    receipt["reason_codes"] = ["some_reason"]
+    receipt["receipt_id"] = compute_receipt_id(receipt)
+    receipt_file.write_text(json.dumps(receipt), encoding="utf-8")
+    second = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert first["manifest"]["evidence_id"] != second["manifest"]["evidence_id"]
+    assert (
+        first["manifest"]["artifacts"][0]["sha256"]
+        != second["manifest"]["artifacts"][0]["sha256"]
+    )
+
+
+def test_machine_identity_mismatch_fails_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    # receipt has hostname="other-host"; producer collects hostname="fixture-host"
+    receipt_path, _ = write_receipt(
+        fixture, machine_overrides={"hostname": "other-host"}
+    )
+    metadata = live_proof_metadata(receipt_path)
+    kwargs = runtime_kwargs(fixture)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert result["result"] == "error"
+    assert "live_proof_machine_identity_mismatch" in result["reason_codes"]
+
+
+def test_current_live_proof_always_collects_fresh_runtime_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, _ = write_receipt(fixture)
+    original = producer_module.collect_runtime_identity
+    calls: list[object] = []
+
+    def collect_runtime(*args: object, **kwargs: object) -> dict:
+        calls.append((args, kwargs))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(producer_module, "collect_runtime_identity", collect_runtime)
+    for requested in (None, True, False):
+        metadata = live_proof_metadata(receipt_path)
+        if requested is None:
+            metadata.pop("runtime_identity_requested")
+        else:
+            metadata["runtime_identity_requested"] = requested
+        result = generate_manifest(
+            fixture["root"],
+            hostname="fixture-host",
+            metadata=metadata,
+            **runtime_kwargs(fixture),
+        )
+        assert result["manifest"] is not None
+        assert result["validation"]["result"] == "pass"
+    assert len(calls) == 3
+
+
+def test_fresh_runtime_mismatch_fails_even_when_caller_requests_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, _ = write_receipt(fixture)
+    original = producer_module.collect_runtime_identity
+
+    def collect_changed_runtime(*args: object, **kwargs: object) -> dict:
+        result = original(*args, **kwargs)
+        runtime = dict(result["runtime"])
+        runtime["effective_config_hash"] = "f" * 64
+        return {**result, "runtime": runtime}
+
+    monkeypatch.setattr(
+        producer_module, "collect_runtime_identity", collect_changed_runtime
+    )
+    metadata = live_proof_metadata(receipt_path, runtime_requested=True)
+    result = generate_manifest(
+        fixture["root"],
+        hostname="fixture-host",
+        metadata=metadata,
+        **runtime_kwargs(fixture),
+    )
+    assert result["result"] == "error"
+    assert "live_proof_effective_config_mismatch" in result["reason_codes"]
+
+
+def test_incomplete_fresh_runtime_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, _ = write_receipt(fixture)
+
+    def collect_incomplete_runtime(*args: object, **kwargs: object) -> dict:
+        return {
+            "runtime": None,
+            "eligibility": {
+                "runtime_identity_complete": False,
+                "reason_codes": ["runtime_identity_incomplete"],
+            },
+        }
+
+    monkeypatch.setattr(
+        producer_module, "collect_runtime_identity", collect_incomplete_runtime
+    )
+    result = generate_manifest(
+        fixture["root"],
+        hostname="fixture-host",
+        metadata=live_proof_metadata(receipt_path, runtime_requested=False),
+        **runtime_kwargs(fixture),
+    )
+    assert result["result"] == "ineligible"
+    assert "runtime_identity_incomplete" in result["reason_codes"]
+
+
+@pytest.mark.parametrize("bucket", ["supersedes", "contradicts"])
+def test_receipt_lineage_conflict_fails_closed(
+    tmp_path: Path, bucket: str
+) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, receipt = write_receipt(fixture)
+    metadata = live_proof_metadata(receipt_path)
+    metadata["relationships"][bucket] = [receipt["receipt_id"]]
+    result = generate_manifest(
+        fixture["root"],
+        hostname="fixture-host",
+        metadata=metadata,
+        **runtime_kwargs(fixture),
+    )
+    assert result["result"] == "error"
+    assert result["reason_codes"] == ["live_proof_relationship_invalid"]
+
+
+def test_receipt_lineage_conflict_fails_when_also_derived(
+    tmp_path: Path,
+) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, receipt = write_receipt(fixture)
+    metadata = live_proof_metadata(receipt_path)
+    metadata["relationships"] = {
+        "supersedes": [receipt["receipt_id"]],
+        "contradicts": [],
+        "derived_from": [receipt["receipt_id"], "unrelated-evidence"],
+    }
+    result = generate_manifest(
+        fixture["root"],
+        hostname="fixture-host",
+        metadata=metadata,
+        **runtime_kwargs(fixture),
+    )
+    assert result["result"] == "error"
+    assert result["reason_codes"] == ["live_proof_relationship_invalid"]
+
+
+def test_receipt_lineage_is_added_once_and_unrelated_refs_remain(
+    tmp_path: Path,
+) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, receipt = write_receipt(fixture)
+    metadata = live_proof_metadata(receipt_path)
+    metadata["relationships"]["derived_from"] = [
+        receipt["receipt_id"],
+        "unrelated-evidence",
+    ]
+    result = generate_manifest(
+        fixture["root"],
+        hostname="fixture-host",
+        metadata=metadata,
+        **runtime_kwargs(fixture),
+    )
+    assert result["manifest"] is not None
+    derived = result["manifest"]["relationships"]["derived_from"]
+    assert derived.count(receipt["receipt_id"]) == 1
+    assert derived.count("unrelated-evidence") == 1
+
+
+def test_repository_identity_mismatch_fails_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, _ = write_receipt(
+        fixture, repo_overrides={"branch": "other-branch"}
+    )
+    metadata = live_proof_metadata(receipt_path)
+    kwargs = runtime_kwargs(fixture)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert result["result"] == "error"
+    assert "live_proof_repository_identity_mismatch" in result["reason_codes"]
+
+
+def test_commit_mismatch_fails_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, _ = write_receipt(
+        fixture, repo_overrides={"commit_sha": "0" * 40}
+    )
+    metadata = live_proof_metadata(receipt_path)
+    kwargs = runtime_kwargs(fixture)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert result["result"] == "error"
+    assert "live_proof_commit_mismatch" in result["reason_codes"]
+
+
+def test_runtime_identity_mismatch_fails_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, _ = write_receipt(
+        fixture, runtime_overrides={"compose_files": ["other-compose.yml"]}
+    )
+    metadata = live_proof_metadata(receipt_path)
+    kwargs = runtime_kwargs(fixture)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert result["result"] == "error"
+    assert "live_proof_runtime_identity_mismatch" in result["reason_codes"]
+
+
+def test_effective_config_mismatch_fails_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, _ = write_receipt(
+        fixture, runtime_overrides={"effective_config_hash": "f" * 64}
+    )
+    metadata = live_proof_metadata(receipt_path)
+    kwargs = runtime_kwargs(fixture)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert result["result"] == "error"
+    assert "live_proof_effective_config_mismatch" in result["reason_codes"]
+
+
+def test_profile_mismatch_fails_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, _ = write_receipt(
+        fixture, runtime_overrides={"supported_profile": "wrong-profile"}
+    )
+    metadata = live_proof_metadata(receipt_path)
+    kwargs = runtime_kwargs(fixture)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert result["result"] == "error"
+    assert "live_proof_profile_mismatch" in result["reason_codes"]
+
+
+def test_compose_project_mismatch_fails_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, _ = write_receipt(
+        fixture,
+        runtime_overrides={"compose_project": "wrong-project"},
+        target_overrides={"compose_project": "wrong-project"},
+    )
+    metadata = live_proof_metadata(receipt_path)
+    kwargs = runtime_kwargs(fixture)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert result["result"] == "error"
+    assert "live_proof_compose_project_mismatch" in result["reason_codes"]
+
+
+def test_role_mismatch_fails_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, _ = write_receipt(
+        fixture,
+        target_overrides={"project_role": "serving"},
+    )
+    metadata = live_proof_metadata(receipt_path)
+    kwargs = runtime_kwargs(fixture)
+    # audit receipt with serving role is inconsistent
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert result["result"] == "error"
+    assert "live_proof_role_mismatch" in result["reason_codes"]
+
+
+def test_receipt_authority_mismatch_fails_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, _ = write_receipt(
+        fixture, authority_status="CANONICAL"
+    )  # receipt is CANONICAL but machine is not vaultnode
+    metadata = live_proof_metadata(receipt_path)
+    kwargs = runtime_kwargs(fixture)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    # derived authority is PROVISIONAL, receipt says CANONICAL → mismatch
+    assert result["result"] == "error"
+    assert "live_proof_authority_ineligible" in result["reason_codes"]
+
+
+def test_fail_receipt_cannot_become_live_proof(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, _ = write_receipt(fixture, execution_outcome="FAIL")
+    metadata = live_proof_metadata(receipt_path)
+    kwargs = runtime_kwargs(fixture)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert result["result"] == "error"
+    assert "live_proof_receipt_not_pass" in result["reason_codes"]
+
+
+def test_blocked_receipt_cannot_become_live_proof(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, _ = write_receipt(fixture, execution_outcome="BLOCKED")
+    metadata = live_proof_metadata(receipt_path)
+    kwargs = runtime_kwargs(fixture)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert result["result"] == "error"
+    assert "live_proof_receipt_not_pass" in result["reason_codes"]
+
+
+def test_error_receipt_cannot_become_live_proof(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, _ = write_receipt(fixture, execution_outcome="ERROR")
+    metadata = live_proof_metadata(receipt_path)
+    kwargs = runtime_kwargs(fixture)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert result["result"] == "error"
+    assert "live_proof_receipt_not_pass" in result["reason_codes"]
+
+
+def test_absolute_receipt_path_fails_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, _ = write_receipt(fixture)
+    abs_path = str(fixture["root"] / receipt_path)
+    metadata = live_proof_metadata(abs_path)
+    kwargs = runtime_kwargs(fixture)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert result["result"] == "error"
+    assert "live_proof_receipt_path_absolute" in result["reason_codes"]
+
+
+def test_parent_traversal_receipt_path_fails_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    metadata = live_proof_metadata("../outside-receipt.json")
+    kwargs = runtime_kwargs(fixture)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert result["result"] == "error"
+    assert "live_proof_receipt_path_parent_traversal" in result["reason_codes"]
+
+
+def test_symlink_receipt_path_fails_closed(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, _ = write_receipt(fixture)
+    symlink_path = fixture["root"] / "receipt-link.json"
+    symlink_path.symlink_to(fixture["root"] / receipt_path)
+    metadata = live_proof_metadata("receipt-link.json")
+    kwargs = runtime_kwargs(fixture)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert result["result"] == "error"
+    assert "live_proof_receipt_path_symlink" in result["reason_codes"]
+
+
+def test_deterministic_live_proof_output(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, _ = write_receipt(fixture)
+    kwargs = runtime_kwargs(fixture)
+    metadata = live_proof_metadata(receipt_path)
+    first = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    second = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    assert first == second
+    assert first["manifest"]["evidence_id"] == second["manifest"]["evidence_id"]
+
+
+def test_non_live_proof_classes_remain_backward_compatible(
+    tmp_path: Path,
+) -> None:
+    """Existing non-live proof classes continue to work unchanged."""
+    fixture = make_fixture(tmp_path)
+    result = collect(fixture, machine_id="developer-laptop")
+    assert result["result"] == "pass"
+    assert result["manifest"]["proof_class"] == "CURRENT_TEST_PROOF"
+    assert result["manifest"]["execution_outcome"] == "PASS"
+
+
+def test_live_proof_receipt_not_mutated(tmp_path: Path) -> None:
+    fixture = make_fixture(tmp_path)
+    receipt_path, receipt = write_receipt(fixture)
+    receipt_file = fixture["root"] / receipt_path
+    before = receipt_file.read_bytes()
+    kwargs = runtime_kwargs(fixture)
+    metadata = live_proof_metadata(receipt_path)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    after = receipt_file.read_bytes()
+    assert result["result"] in ("pass", "ineligible")
+    assert result["manifest"] is not None
+    assert before == after
+
+
+def test_pass_receipt_cannot_upgrade_provisional_authority(
+    tmp_path: Path,
+) -> None:
+    """A PASS receipt with CANONICAL authority but non-canonical machine must be rejected."""
+    fixture = make_fixture(tmp_path)
+    # Receipt claims CANONICAL, but machine ID is not vaultnode
+    receipt_path, _ = write_receipt(
+        fixture,
+        authority_status="CANONICAL",
+        machine_overrides={
+            "machine_id": "not-vaultnode",
+            "machine_role": "provisional_development_host",
+        },
+    )
+    metadata = live_proof_metadata(receipt_path)
+    kwargs = runtime_kwargs(fixture)
+    result = generate_manifest(
+        fixture["root"], hostname="fixture-host", metadata=metadata, **kwargs
+    )
+    # Machine identity must also match — the machine_id in receipt is "not-vaultnode"
+    # but the producer observes "test-machine" from defaults → machine mismatch
+    assert result["result"] == "error"
+    assert "live_proof_machine_identity_mismatch" in result["reason_codes"]


### PR DESCRIPTION
Closes #675

Corrective successor to #621.
Does not reopen #621.
Restores only the bounded capability reverted from PR #622.

## What changed

- Restored the bounded one-receipt handoff for `CURRENT_LIVE_PROOF` manifests.
- Forces fresh runtime identity collection for every live-proof request; caller metadata cannot disable it.
- Compares machine, repository, commit, runtime, supported profile, effective configuration, Compose project/files, service identities, audit project, serving role, and runtime authority.
- Preserves exact receipt bytes and SHA-256 in the manifest artifact, verifies deterministic receipt/evidence identifiers, and prevents incompatible `supersedes`/`contradicts` lineage.
- Keeps authority provisional unless the separately required machine/repository candidacy permits canonical authority.
- Keeps storage, promotion, trusted-latest selection, release approval, and live VaultNode proof outside this bounded change.
- Preserves non-live manifest behavior.

## Validation

Focused audit and contract checks pass on the task checkout:

- `.venv/bin/python -m pytest -v tests/audit/test_generate_canonical_evidence_manifest.py` — 54 passed
- `.venv/bin/python -m pytest -v tests/audit/test_collect_canonical_live_proof_receipt.py` — 44 passed
- `.venv/bin/python -m pytest -v tests/audit/test_collect_canonical_runtime_identity.py` — 15 passed
- `.venv/bin/python -m pytest -v tests/audit/test_collect_canonical_evidence_identity.py` — 12 passed
- `.venv/bin/python -m pytest -v tests/audit/test_validate_canonical_evidence.py` — 13 passed
- `.venv/bin/python scripts/validate_docs.py` — passed
- targeted Ruff, `py_compile`, and `git diff --check` — passed

The requested aggregate `.venv/bin/python -m pytest -q guardian/tests tests` remains environment/baseline blocked by existing collection failures; it is not represented as a pass. Broad audit Ruff likewise retains 13 pre-existing findings outside the changed files. This PR remains draft pending review and protected CI; it does not claim merged-main or live-runtime proof.