### PR TITLE
docs: canonicalize imprint ADR as 058

### DIFF
--- a/docs/architecture/adr/013-verified-personal-facts-context-injection.md
+++ b/docs/architecture/adr/013-verified-personal-facts-context-injection.md
@@ -46,7 +46,7 @@ The broker is the authoritative read seam for eligible facts. Prompt assembly co
 ## Governing Contracts
 
 - [Retrieval Policy as Control Plane](./004-retrieval-policy-as-control-plane.md)
-- [Imprint UI Deprecation and Identity Ownership](./005-imprint-ui-deprecation-and-identity-ownership.md)
+- [Imprint UI Deprecation and Identity Ownership](./058-imprint-ui-deprecation-and-identity-ownership.md)
 - [Chat Runtime Contract](../chat-runtime-contract.md)
 - [Data and Storage](../data-and-storage.md)
 

--- a/docs/architecture/adr/058-imprint-ui-deprecation-and-identity-ownership.md
+++ b/docs/architecture/adr/058-imprint-ui-deprecation-and-identity-ownership.md
@@ -9,16 +9,25 @@ tags:
 * persona-studio
 * ownership
   aliases:
-* ADR-005
+* ADR-058
 * Imprint UI Deprecation and Identity Ownership
 
 ---
 
-# ADR-005: Imprint UI Deprecation and Identity Ownership
+# ADR-058: Imprint UI Deprecation and Identity Ownership
 
 ## Status
 
 Proposed
+
+## Canonicalization history
+
+This proposal was originally stored as ADR-005, which collided with the later
+Accepted Runtime Mode and Account Boundary Invariants. Human canonicalization
+retained Runtime Mode as ADR-005 and moved this decision to ADR-058. The move
+changes numeric identity and path only; this proposal remains Proposed.
+Historical references to the former Imprint ADR-005 remain historical evidence
+and must not be reinterpreted as references to Runtime Mode.
 
 ## Date
 

--- a/docs/architecture/adr/adr-index.md
+++ b/docs/architecture/adr/adr-index.md
@@ -35,11 +35,9 @@ Use this note as the local map for all ADRs.
 2. [[002-Dual-State-Machine-Model|ADR-002 Dual State Machine Model]]
 3. [[003-Message-Identity-vs-Request-Identity|ADR-003 Message Identity vs Request Identity]]
 4. [[004-Retrieval-Policy-as-Control-Plane|ADR-004 Retrieval Policy as Control Plane]]
-5. [[005-Imprint-UI-Deprecation-and-Identity-Ownership|ADR-005 Imprint UI Deprecation and Identity Ownership]]
 6. [[006-flow-builder-elicitation-lane|ADR-006 Flow Builder Elicitation Lane]] — upstream spec-building lane for turning tacit expertise into validated workflow structure before execution.
 7. [[010-Self-Extending-Agent-Plugin-System|ADR-010 Self-Extending Agent Plugin System]] — bounded self-extending architecture for generated capabilities, plugin forge flow, and sovereignty boundaries.
-5. [[005-Runtime-Mode-and-Account-Boundary-Invariants|ADR-005 Runtime Mode and Account Boundary Invariants]]
-6. [[005-Imprint-UI-Deprecation-and-Identity-Ownership|ADR-005 Imprint UI Deprecation and Identity Ownership]] — retained as the legacy identity-ownership UI boundary note.
+5. [[005-runtime-mode-and-account-boundary-invariants|ADR-005 Runtime Mode and Account Boundary Invariants]]
 7. [[006-flow-builder-elicitation-lane|ADR-006 Flow Builder Elicitation Lane]] — upstream spec-building lane for turning tacit expertise into validated workflow structure before execution.
 8. [[007-Memory-Graph-Derived-Write-Hook|ADR-007 Memory Graph Derived Write Hook]] — derived graph candidate emission after assistant persistence, kept non-blocking and idempotent.
 9. [[008-Candidate-Trace-Surface|ADR-008 Candidate Trace Surface]] — backend-only candidate-output diagnostic surface, TTL-bound and excluded from export.
@@ -88,6 +86,7 @@ Use this note as the local map for all ADRs.
 48. [[054-browser-host-topology-and-release-ownership|ADR-054 Codexify Browser Host Topology and Release Ownership]] — accepted selection of the `bundled_chromium_electron` Browser Host family with an isolated monorepo-first application/package, retained trusted Tauri shell and Tier 0 extension roles, Guardian authority, and deferred independent-release extraction.
 49. [[055-orthogonal-ui-material-personalization|ADR-055 Orthogonal UI Material Personalization]] — governing decision for additive material axes, cross-theme Surface Temperature, light-only Paper Tone, separate persistence responsibilities, and accessibility-bounded user material expression.
 50. [[055-threadspace-whispermesh-managed-service-boundary|ADR-055 ThreadSpace ↔ WhisperMesh Managed-Service Boundary]] — proposed docs-only authority boundary: Codexify and ThreadSpace own Room sovereignty, grants, and collaboration state, while WhisperMesh Network Assist may issue only narrower, expiring service leases after grant verification; Hosted Rooms and managed processing require separate future decisions.
+51. [[058-imprint-ui-deprecation-and-identity-ownership|ADR-058 Imprint UI Deprecation and Identity Ownership]] — Proposed; renumbered from the duplicate ADR-005 identity during DLG human canonicalization.
 
 ---
 

--- a/docs/knowledge-graph/nodes/codexify:doc:architecture:adr-index.json
+++ b/docs/knowledge-graph/nodes/codexify:doc:architecture:adr-index.json
@@ -17,7 +17,7 @@
   ],
   "lifecycle_state": "active",
   "freshness": {
-    "state": "current",
+    "state": "stale",
     "verified_at": "2026-08-08T13:54:04Z",
     "verified_commit": "157d0279f80ed2db377873f9bd225a4c8d493c53",
     "triggers": [
@@ -25,7 +25,7 @@
       "an indexed ADR review posture changes",
       "the documented ADR graph or reading order changes"
     ],
-    "reason": "Verified as the canonical ADR routing surface at the Phase 1 base."
+    "reason": "ADR Index source changed during the human-approved ADR-005 to ADR-058 canonicalization and requires committed-revision re-verification."
   },
   "disposition": "accepted",
   "evidence_class": "documented-contract",
@@ -77,7 +77,7 @@
     "created_at": "2026-04-14T20:56:05Z",
     "effective_from": "2026-04-14T20:56:05Z"
   },
-  "content_hash": "e273efcbf095d0f2ae7b83e1f4909c4ba9260d80011b8c9763864356b1430503",
+  "content_hash": "3e6b633efd660236902d53a922cba9f6cf6e42044058e2da4fe447a7664a00f3",
   "relations": [],
   "governing_adr_posture": "not_applicable"
 }

--- a/docs/knowledge-graph/nodes/codexify:doc:architecture:current-state.json
+++ b/docs/knowledge-graph/nodes/codexify:doc:architecture:current-state.json
@@ -17,7 +17,7 @@
   ],
   "lifecycle_state": "active",
   "freshness": {
-    "state": "current",
+    "state": "stale",
     "verified_at": "2026-08-08T13:54:04Z",
     "verified_commit": "157d0279f80ed2db377873f9bd225a4c8d493c53",
     "triggers": [
@@ -26,7 +26,7 @@
       "active blockers, priorities, or the audited implementation tip change"
     ],
     "window_days": 7,
-    "reason": "Verified against the canonical weekly current-state refresh at the Phase 1 base."
+    "reason": "Canonical current-state source changed after the recorded verification boundary; source-byte integrity is synchronized, and semantic freshness requires later committed-revision re-verification."
   },
   "disposition": "accepted",
   "evidence_class": "documented-contract",
@@ -73,7 +73,7 @@
     "created_at": "2026-03-11T13:30:22Z",
     "effective_from": "2026-08-08T00:00:00Z"
   },
-  "content_hash": "229231d17e9df7861c2fb406a075c1646bce6d92ec1d56848cb241bc934bc14b",
+  "content_hash": "a7b7315aaf6b350820145bb92e2e8c314fdbc0fc51a5dde8f9b6433139c732f8",
   "relations": [],
   "governing_adr_posture": "not_applicable"
 }

--- a/docs/knowledge-graph/nodes/codexify:doc:architecture:kb-entrypoint.json
+++ b/docs/knowledge-graph/nodes/codexify:doc:architecture:kb-entrypoint.json
@@ -15,7 +15,7 @@
   ],
   "lifecycle_state": "active",
   "freshness": {
-    "state": "current",
+    "state": "stale",
     "verified_at": "2026-08-08T13:54:04Z",
     "verified_commit": "157d0279f80ed2db377873f9bd225a4c8d493c53",
     "triggers": [
@@ -23,7 +23,7 @@
       "listed subsystem ownership or change-location paths change",
       "the current-state routing boundary changes"
     ],
-    "reason": "Verified against the canonical KB routing refresh and listed source anchors at the Phase 1 base."
+    "reason": "Architecture KB source and freshness-invalidating architecture anchors changed after the recorded verification boundary; source-byte integrity is synchronized, and semantic freshness requires later committed-revision re-verification."
   },
   "disposition": "accepted",
   "evidence_class": "documented-contract",
@@ -95,7 +95,7 @@
     "created_at": "2026-02-17T16:32:37Z",
     "effective_from": "2026-02-17T16:32:37Z"
   },
-  "content_hash": "e61efdd0cbbd43e078078d2a871a685b210f3c2b419cb780c41727dc99a6dcc0",
+  "content_hash": "11f859bc21f2efdfa6f84ce1ad752d00ace208c7bac734eea46680bbd775307b",
   "relations": [],
   "governing_adr_posture": "not_applicable"
 }


### PR DESCRIPTION
## Summary

- Repairs DLG source-hash drift for the current-state and architecture-KB entrypoint nodes; both are explicitly stale pending later committed semantic re-verification.
- Renumbers the Proposed Imprint UI decision from ADR-005 to ADR-058, preserving its date, posture, and substantive doctrine.
- Repairs ADR-013's Imprint governing-contract link so it resolves to canonical ADR-058.
- Updates ADR Index routing and its living DLG node without changing runtime or release claims.

## Validation

- `python3 scripts/knowledge_graph/validate_and_generate_dlg.py validate` — pass (9 nodes, 8 edges, 9 source hashes, 6 live ADR-number collisions)
- `python3 -m pytest -v tests/architecture` — 394 passed
- `python3 scripts/knowledge_graph/generate_representative_arps.py validate` — 4/4
- `make docs PYTHON=python3` — pass
- `git diff --check` — pass

## Boundaries

- ADR-058 remains Proposed.
- The frozen Phase 3A snapshot remains unchanged and records its historical seven-collision calibration state.
- No runtime behavior or release claim changed.