### PR TITLE
Advertise first read-only chat capability

### DIFF
--- a/docs/architecture/agent-tool-loop-contract.md
+++ b/docs/architecture/agent-tool-loop-contract.md
@@ -136,3 +136,17 @@ The persisted assistant message keeps the same observability fields in `extra_me
 - No multi-tool orchestration.
 - No bypass of the command bus for tool execution.
 - No widening of the supported beta promise to autonomous coding.
+
+## Stage 2I Ordinary Read-Only Exposure
+
+After effective provider/model resolution and before the first provider
+request, ordinary chat whose `task.tools` is `None` may now receive exactly
+one model-visible ToolSpec: `op::health_health_get` (`GET /health`). Its
+model-facing schema is an empty object with `additionalProperties=false` and
+`maxProperties=0`; the model receives no path, query, header, or body input.
+
+The resolved `task.tools` list is still the exact Stage 1 advertised subset.
+Model visibility does not grant execution authority: a normalized command must
+still match that list before `execute_invoke`, and the one-command hard limit
+is unchanged. Explicit non-empty `task.tools` and explicit `task.tools=[]`
+remain untouched and are never merged with automatic exposure.

--- a/docs/architecture/completion_pipeline.md
+++ b/docs/architecture/completion_pipeline.md
@@ -222,6 +222,31 @@ provider/model identity, terminal status, visible-output state, explicit-termina
 observation, finish reason when available, clean transport completion, bounded
 failure classification, and whether pre-output retry remains permitted.
 
+## Stage 2I capability exposure seam
+
+For ordinary chat with `task.tools is None`, the pipeline resolves the effective
+provider/model first, then evaluates the narrow Stage 2I exposure policy before
+the first provider inference request:
+
+```text
+effective provider/model resolution
+→ capability exposure
+→ task.tools
+→ provider inference
+→ normalization
+→ Stage 1 advertised-subset authority
+→ Command Bus
+```
+
+The only automatic result is `op::health_health_get`, a zero-argument,
+read-only `GET /health` capability. DeepSeek is eligible through its native
+transport. The exact Whoosh'd target additionally requires current Stage 2G
+eligibility; tool-enabled Whoosh'd turns use the existing strict non-streaming
+transport, while ineligible turns preserve ordinary local streaming. Stage
+2F.1b still validates Whoosh'd response identity before Stage 1. No provider
+error is converted into a capability error, and explicit caller-supplied
+`task.tools` values are preserved.
+
 | Completion path | Accepted terminal evidence |
 | --- | --- |
 | Whoosh'd / OpenAI-compatible local stream | `[DONE]`; a finish reason may be retained but does not replace the required marker |

--- a/docs/architecture/proofs/2026-08-10-first-read-only-chat-capability-advertisement-proof.md
+++ b/docs/architecture/proofs/2026-08-10-first-read-only-chat-capability-advertisement-proof.md
@@ -1,0 +1,113 @@
+# First read-only ordinary-chat capability advertisement proof
+
+**Date:** 2026-08-10
+**Campaign stage:** 2I
+**Classification:** architecture-aligned code and deterministic seam proof; no release claim.
+
+## Scope
+
+This receipt records the first automatic ordinary-chat capability exposure:
+`op::health_health_get`, the existing `GET /health` Command Bus command. It
+does not add a user selector, a second capability, a write action, a recursive
+tool loop, a provider-wide `supports_tools` declaration, or a release claim.
+
+## Manifest and least-authority evidence
+
+The live `guardian.guardian_api` FastAPI surface was passed to
+`build_manifest()`. Its current entry is:
+
+| Field | Value |
+| --- | --- |
+| command ID | `op::health_health_get` |
+| method / path | `GET /health` |
+| effect / risk | `read` / `read_only` |
+| idempotency / approval | `safe` / `none` |
+| required path/query/header fields | none |
+| required body | none |
+
+The model-facing ToolSpec is exactly one command with the canonical command ID,
+a health description, and `{ "type": "object", "additionalProperties":
+false, "maxProperties": 0 }`. It intentionally does not mirror Command Bus
+transport buckets, so a model controls no headers, query, body, or path values.
+The canonical execution identity still comes from the current manifest entry.
+
+## Exposure and authority proof
+
+`guardian/tools/chat_exposure.py` contains a fixed one-ID allowlist and also
+verifies the manifest safety facts above. Unknown commands and a modified
+mutating version of the health manifest entry return no exposure. The helper
+does not call `execute_invoke` and never projects the full manifest.
+
+Automatic resolution runs only after effective provider/model resolution and
+only when `task.tools is None`. The resolved list is used both for provider
+advertisement and as the Stage 1 advertised subset. Explicit non-empty lists
+and `task.tools=[]` remain unchanged. An unadvertised proposal still stops at
+Stage 1 with `tool_command_blocked`, no Command Bus call, and no command run.
+
+## Provider proof
+
+- DeepSeek automatically receives the one health tool through its unchanged
+  native alias transport. A deterministic native call executes once, reinjects
+  the result, and returns a final assistant answer with `completed`,
+  `tool_turn_completed`, and a populated `commandRunId`. A model may also
+  return a plain answer without executing the advertised capability.
+- Whoosh'd receives the command only for the exact Stage 2D Gemma target when
+  a current configured-endpoint `/v1/models` `ModelInfo` entry parses through
+  `parse_whooshd_runtime_inventory_entry` and the real Stage 2G projection is
+  `eligible` under explicit exposure permission. The bounded helper retains no
+  raw inventory, model path, or endpoint metadata and performs no runtime
+  mutation or cache write.
+- Missing inventory, missing/mismatched attestation, wrong target, or non-ready
+  state result in no advertisement and preserve the ordinary local streaming
+  path. Stage 2F.1b remains mandatory after a response: a simulated post-request
+  serving-identity change stops before `execute_invoke` even after Stage 2G had
+  exposed the command.
+- Other providers and local runtimes receive no automatic tools.
+
+The existing Stage 2H convergence tests retain the one-command limit for both
+transports. A second decision reaches `limit_reached` / `tool_turn_limit_reached`
+after exactly one invocation. No canonical runtime protocol token changed.
+
+## Files and validation
+
+Changed implementation and test surfaces:
+
+- `guardian/tools/chat_exposure.py`
+- `guardian/core/chat_completion_service.py`
+- `guardian/providers/whooshd_control_plane.py`
+- `tests/core/test_chat_tool_exposure.py`
+- the four architecture documents updated by this receipt
+
+Focused deterministic validation:
+
+```text
+.venv/bin/python -m pytest -q tests/core/test_chat_tool_exposure.py \
+  tests/core/test_chat_completion_service_tool_loop.py \
+  tests/providers/test_tool_turn_transport_convergence.py \
+  tests/providers/test_deepseek_adapter.py \
+  tests/providers/test_whooshd_tool_adapter.py \
+  tests/providers/test_whooshd_qualification.py \
+  tests/providers/test_whooshd_tool_capability.py \
+  tests/command_bus/test_manifest.py tests/core/test_ai_router.py
+```
+
+Result: `158 passed`.
+
+Full-suite, documentation validation, and final diff checks are recorded in the
+task closeout. The repository Ruff baseline currently contains pre-existing
+findings in `chat_completion_service.py`; the new exposure/test files are
+clean, and the edited control-plane file retains its one pre-existing blind
+exception finding with no new lint finding.
+
+## Limitations and next proof
+
+No paid DeepSeek call, provider process start/restart, model replacement, or
+live ordinary-chat provider proof was performed. Deterministic runtime-seam
+tests prove the code path only. The next atomic slice, if separately approved,
+is Stage 2J: live proof of this same capability on already-available qualified
+transports, with no new capability added.
+
+## Commit
+
+Commit ID is recorded in the task closeout; embedding the final commit hash in
+the file it hashes is self-referential and would make the receipt inaccurate.

--- a/docs/architecture/provider-tool-turn-boundary-contract.md
+++ b/docs/architecture/provider-tool-turn-boundary-contract.md
@@ -532,3 +532,24 @@ This proof does not declare every provider transport implemented or qualified,
 does not make loose/free-form JSON a structured transport, and does not change
 ordinary `task.tools`, capability advertisement, Command Bus authority,
 production behavior, or release posture.
+
+## 20. First Ordinary Read-Only Advertisement (Stage 2I)
+
+Stage 2I consumes the Stage 2H semantic convergence seam for exactly one
+production capability: `op::health_health_get` (`GET /health`). After the
+completion runtime resolves its effective provider/model, it may populate an
+otherwise unset `task.tools` with that one canonical command and an empty,
+least-authority model schema. The same list is sent to the provider and remains
+the Stage 1 advertised-subset authority input.
+
+DeepSeek receives the command through its existing opaque native-function
+alias transport. The exact Stage 2D-qualified Whoosh'd target may receive the
+same canonical command through its existing non-streaming strict structured
+transport only when Stage 2G is eligible. All other providers, other local
+runtimes, and ineligible Whoosh'd states remain automatically unadvertised.
+
+Stage 2I neither changes provider adapters nor treats transport eligibility as
+command authority. Whoosh'd Stage 2F.1b still verifies actual response
+provenance before the shared Stage 1 gate, so a stale pre-request eligibility
+snapshot cannot cause an invocation. This is code/test evidence only and adds
+no release-support claim.

--- a/docs/architecture/whooshd-model-tool-capability-boundary.md
+++ b/docs/architecture/whooshd-model-tool-capability-boundary.md
@@ -795,3 +795,19 @@ authorization token. `task.tools` still has no ordinary production producer;
 `ModelCapability.TOOLS`, `RuntimeModel.supports_tools`, and
 `MlxVlmAdapter.supports_tools` remain unchanged. No release-support claim or
 canonical runtime token has been added.
+
+### Stage 2I production consumer — 2026-08-10
+
+Stage 2I is the first production consumer of the Stage 2G projection. It may
+advertise only `op::health_health_get` to the exact qualified target when the
+current `ModelInfo` inventory produces `outcome=eligible` under an explicit
+exposure permission. Codexify reads the configured Whoosh'd `/v1/models`
+surface once per candidate turn, parses only the bounded inventory evidence,
+and retains neither raw inventory nor endpoint/path metadata.
+
+Ineligible inventory, absent or malformed attestation, mismatch, wrong model,
+runtime or adapter, and every non-ready state remain no-tools ordinary local
+chat; the existing streaming path is preserved. Stage 2G remains pre-request
+eligibility evidence. Stage 2F.1b remains mandatory after inference and before
+Stage 1, independently rejecting changed serving identity. This does not
+qualify another model, broaden `supports_tools`, or change release posture.

--- a/guardian/core/chat_completion_service.py
+++ b/guardian/core/chat_completion_service.py
@@ -34,6 +34,7 @@ from guardian.command_bus.contracts import (
     InvokeRequest,
 )
 from guardian.command_bus.invoke import execute_invoke
+from guardian.command_bus.manifest import build_manifest
 from guardian.command_bus.store import CommandBusStore
 from guardian.context.broker import ContextBroker
 from guardian.context.context_directive_resolver import (
@@ -76,6 +77,13 @@ from guardian.providers.whooshd_tool_adapter import (
     build_continuation_messages as build_whooshd_structured_continuation_messages,
     is_qualified_transport_candidate,
 )
+from guardian.providers.whooshd_control_plane import (
+    fetch_whooshd_runtime_inventory_entry,
+)
+from guardian.providers.whooshd_tool_capability import (
+    project_whooshd_tool_capability,
+)
+from guardian.tools.chat_exposure import resolve_ordinary_chat_tools
 from guardian.core.candidate_trace_store import store_candidate_trace
 from guardian.core.completion_terminal import (
     CompletionAttemptResult,
@@ -5096,6 +5104,59 @@ def _authorized_tool_command_ids(task: ChatCompletionTask) -> frozenset[str]:
     )
 
 
+def _resolve_ordinary_chat_tools(
+    *,
+    provider: str,
+    model: str,
+    settings: Any,
+) -> list[dict[str, Any]] | None:
+    """Resolve the Stage 2I subset after the effective target is known."""
+
+    normalized_provider = str(provider or "").strip().lower()
+    provider_vendor = str(
+        getattr(settings, "LOCAL_PROVIDER_VENDOR", "") or ""
+    ).strip().lower()
+    if normalized_provider not in {"deepseek", "local"}:
+        return None
+    if normalized_provider == "local" and provider_vendor != "whooshd":
+        return None
+
+    try:
+        manifest = build_manifest(_command_bus_app())
+    except Exception:
+        logger.warning(
+            "[chat-completion] automatic tool exposure manifest unavailable",
+            exc_info=True,
+        )
+        return None
+
+    whooshd_capability = None
+    if normalized_provider == "local":
+        try:
+            inventory = fetch_whooshd_runtime_inventory_entry(
+                settings,
+                model=model,
+            )
+            whooshd_capability = project_whooshd_tool_capability(
+                inventory=inventory,
+                exposure_allowed=True,
+            )
+        except Exception:
+            logger.warning(
+                "[chat-completion] automatic Whoosh'd tool exposure unavailable",
+                exc_info=True,
+            )
+            return None
+
+    return resolve_ordinary_chat_tools(
+        provider=provider,
+        model=model,
+        provider_vendor=provider_vendor,
+        manifest_commands=manifest.commands,
+        whooshd_capability=whooshd_capability,
+    )
+
+
 def _execute_bounded_tool_turn_completion(
     task: ChatCompletionTask,
     *,
@@ -5614,6 +5675,12 @@ def run_chat_completion_task(
             task.selection_source = "local_vision_env"
 
     settings = get_settings()
+    if task.tools is None:
+        task.tools = _resolve_ordinary_chat_tools(
+            provider=provider,
+            model=model,
+            settings=settings,
+        )
     requested_source_mode = (
         str(getattr(task, "requested_source_mode", "") or "").strip() or None
     )

--- a/guardian/providers/whooshd_control_plane.py
+++ b/guardian/providers/whooshd_control_plane.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, replace
 from typing import Any
+from urllib.parse import urlparse, urlunparse
+
+import requests
 
 WHOOSHD_CONTROL_PLANE_VERSION = "whooshd.control.v1"
 WHOOSHD_CONTROL_VERSION_HEADER = "X-Whooshd-Contract-Version"
@@ -873,3 +876,64 @@ def parse_whooshd_runtime_inventory_entry(
         ),
         resolution_source=resolution_source,
     )
+
+
+def fetch_whooshd_runtime_inventory_entry(
+    settings: Any,
+    *,
+    model: str,
+    timeout_seconds: float = 1.0,
+    request_get: Any = None,
+) -> WhooshdRuntimeInventoryEvidence | None:
+    """Read one current Whoosh'd ``/v1/models`` entry without retaining it.
+
+    Stage 2I needs the full ``ModelInfo`` record because the generic local
+    model discovery seam retains only model names.  This helper is deliberately
+    local-provider scoped, bounded, uncached, and fail-closed.  It returns only
+    the parsed evidence needed by Stage 2G, never the raw payload or endpoint.
+    """
+
+    provider_vendor = str(
+        getattr(settings, "LOCAL_PROVIDER_VENDOR", "") or ""
+    ).strip().lower()
+    if provider_vendor != "whooshd":
+        return None
+    requested_model = str(model or "").strip()
+    base_url = str(getattr(settings, "LOCAL_BASE_URL", "") or "").strip()
+    if not requested_model or not base_url:
+        return None
+
+    parsed = urlparse(base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    path = parsed.path.rstrip("/")
+    if path.endswith("/v1"):
+        path = path[:-3].rstrip("/")
+    inventory_url = urlunparse(
+        (parsed.scheme, parsed.netloc, f"{path}/v1/models", "", "", "")
+    )
+    try:
+        timeout = max(0.1, min(float(timeout_seconds), 5.0))
+    except (TypeError, ValueError):
+        return None
+    fetch = request_get or requests.get
+    try:
+        response = fetch(
+            inventory_url,
+            timeout=timeout,
+            headers={WHOOSHD_CONTROL_VERSION_HEADER: WHOOSHD_CONTROL_PLANE_VERSION},
+        )
+        if not 200 <= int(getattr(response, "status_code", 0)) < 300:
+            return None
+        payload = response.json()
+    except (requests.RequestException, TypeError, ValueError):
+        return None
+
+    entries = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(entries, list):
+        return None
+    for raw_entry in entries:
+        evidence = parse_whooshd_runtime_inventory_entry(raw_entry)
+        if evidence is not None and evidence.invocation_model_id == requested_model:
+            return evidence
+    return None

--- a/guardian/tools/chat_exposure.py
+++ b/guardian/tools/chat_exposure.py
@@ -1,0 +1,127 @@
+"""Narrow Stage 2I exposure policy for ordinary chat tool visibility.
+
+This module decides only whether one existing Command Bus command may be
+shown to a model for one ordinary completion.  It does not execute commands,
+alter command authority, or derive a general manifest projection.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from guardian.command_bus.contracts import CommandSpec
+from guardian.providers.whooshd_tool_capability import (
+    WhooshdToolCapabilityProjection,
+)
+
+HEALTH_COMMAND_ID = "op::health_health_get"
+_WHOOSHD_VENDOR = "whooshd"
+_EMPTY_MODEL_INPUT_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "maxProperties": 0,
+}
+
+
+def _normalized(value: str | None) -> str:
+    return str(value or "").strip().lower()
+
+
+def _find_command(
+    commands: Iterable[CommandSpec | dict[str, Any]],
+) -> CommandSpec | dict[str, Any] | None:
+    for command in commands:
+        if isinstance(command, CommandSpec):
+            command_id = command.command_id
+        elif isinstance(command, dict):
+            command_id = str(command.get("command_id") or "")
+        else:
+            continue
+        if command_id == HEALTH_COMMAND_ID:
+            return command
+    return None
+
+
+def _command_value(command: CommandSpec | dict[str, Any], field: str) -> Any:
+    if isinstance(command, CommandSpec):
+        return getattr(command, field)
+    return command.get(field)
+
+
+def _requires_no_model_arguments(command: CommandSpec | dict[str, Any]) -> bool:
+    input_schema = _command_value(command, "input_schema")
+    if not isinstance(input_schema, dict):
+        return False
+    for bucket in ("path_params", "query", "headers"):
+        schema = input_schema.get(bucket)
+        if not isinstance(schema, dict):
+            return False
+        if schema.get("required") not in (None, []):
+            return False
+        if schema.get("properties") not in (None, {}):
+            return False
+    body = input_schema.get("body")
+    return body in (None, {})
+
+
+def _is_safe_health_command(command: CommandSpec | dict[str, Any]) -> bool:
+    """Defend the fixed allowlist with current-manifest safety facts."""
+
+    return (
+        _command_value(command, "command_id") == HEALTH_COMMAND_ID
+        and _command_value(command, "method") == "GET"
+        and _command_value(command, "path_template") == "/health"
+        and _command_value(command, "effect") == "read"
+        and _command_value(command, "risk") == "read_only"
+        and _command_value(command, "idempotency") == "safe"
+        and _command_value(command, "approval_mode") == "none"
+        and _requires_no_model_arguments(command)
+    )
+
+
+def _model_tool(command: CommandSpec | dict[str, Any]) -> dict[str, Any]:
+    method = str(_command_value(command, "method") or "GET")
+    path_template = str(_command_value(command, "path_template") or "/health")
+    return {
+        "command_id": str(_command_value(command, "command_id")),
+        "description": (
+            f"Read the current Guardian health status ({method} {path_template})."
+        ),
+        "input_schema": dict(_EMPTY_MODEL_INPUT_SCHEMA),
+    }
+
+
+def resolve_ordinary_chat_tools(
+    *,
+    provider: str | None,
+    model: str | None,
+    provider_vendor: str | None,
+    manifest_commands: Iterable[CommandSpec | dict[str, Any]],
+    whooshd_capability: WhooshdToolCapabilityProjection | None = None,
+) -> list[dict[str, Any]] | None:
+    """Return the one Stage 2I tool or no automatic ordinary-chat tools.
+
+    The manifest supplies the canonical command identity and safety facts.  A
+    matching Whoosh'd Stage 2G projection is eligibility evidence only; the
+    returned list is still the exact subset Stage 1 checks later.
+    """
+
+    command = _find_command(manifest_commands)
+    if command is None or not _is_safe_health_command(command):
+        return None
+
+    normalized_provider = _normalized(provider)
+    if normalized_provider == "deepseek":
+        return [_model_tool(command)]
+
+    if (
+        normalized_provider == "local"
+        and _normalized(provider_vendor) == _WHOOSHD_VENDOR
+        and whooshd_capability is not None
+        and whooshd_capability.outcome == "eligible"
+        and whooshd_capability.invocation_model_id == str(model or "").strip()
+    ):
+        return [_model_tool(command)]
+
+    return None

--- a/tests/core/test_chat_tool_exposure.py
+++ b/tests/core/test_chat_tool_exposure.py
@@ -1,0 +1,627 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+
+from guardian.command_bus.manifest import build_manifest
+from guardian.core import chat_completion_service
+from guardian.core.completion_terminal import CompletionTerminalEvidence
+from guardian.protocol_tokens import CompletionTerminalStatus
+from guardian.providers.deepseek_adapter import DeepSeekResponse
+from guardian.providers.whooshd_control_plane import (
+    fetch_whooshd_runtime_inventory_entry,
+    parse_whooshd_runtime_inventory_entry,
+    parse_whooshd_runtime_provenance,
+)
+from guardian.providers.whooshd_qualification import (
+    STAGE_2D_GEMMA_4_12B_IT_QAT_4BIT_RECORD,
+)
+from guardian.providers.whooshd_tool_adapter import WhooshdStructuredResponse
+from guardian.providers.whooshd_tool_capability import (
+    project_whooshd_tool_capability,
+)
+from guardian.routes import health
+from guardian.tasks.types import ChatCompletionTask
+from guardian.tools.chat_exposure import (
+    HEALTH_COMMAND_ID,
+    resolve_ordinary_chat_tools,
+)
+
+
+def _command_bus_app() -> FastAPI:
+    """Use the production health router that the runtime manifest exposes."""
+
+    app = FastAPI()
+    app.include_router(health.router)
+    return app
+
+
+def _manifest_commands() -> list[Any]:
+    return build_manifest(_command_bus_app()).commands
+
+
+def _health_command() -> Any:
+    return next(
+        command
+        for command in _manifest_commands()
+        if command.command_id == HEALTH_COMMAND_ID
+    )
+
+
+def _full_inventory_attestation() -> dict[str, object]:
+    material = STAGE_2D_GEMMA_4_12B_IT_QAT_4BIT_RECORD.material
+    return {
+        "attestation_schema_version": material.attestation_schema_version,
+        "canonicalization_profile": material.canonicalization_profile,
+        "invocation_model_id": material.invocation_model_id,
+        "resolved_model_id": material.resolved_model_id,
+        "artifact_identity": {
+            "kind": material.artifact_identity_kind,
+            "value": material.artifact_identity_value,
+        },
+        "quantization": material.quantization,
+        "runtime_kind": material.runtime_kind,
+        "adapter": {
+            "name": material.adapter_name,
+            "semantic_build": material.adapter_semantic_build,
+        },
+        "whooshd_build_identity": material.whooshd_build_identity,
+        "serving_runtime": {
+            "package": material.serving_runtime_package,
+            "version": material.serving_runtime_version,
+        },
+        "structured_decoder": {
+            "package": material.structured_decoder_package,
+            "version": material.structured_decoder_version,
+        },
+        "tokenizer": {
+            "implementation": material.tokenizer_implementation,
+            "identity_fingerprint": material.tokenizer_identity_fingerprint,
+        },
+        "chat_template_fingerprint": material.chat_template_fingerprint,
+        "tool_template_parser": {
+            "relationship": material.tool_template_parser_relationship,
+            "identity_fingerprint": material.tool_template_parser_identity_fingerprint,
+        },
+        "structured_transport": {
+            "mode": material.structured_transport_mode,
+            "protocol_version": material.structured_transport_protocol_version,
+        },
+        "qualification_protocol_version": material.qualification_protocol_version,
+        "digest_algorithm": STAGE_2D_GEMMA_4_12B_IT_QAT_4BIT_RECORD.digest_algorithm,
+        "attestation_digest": STAGE_2D_GEMMA_4_12B_IT_QAT_4BIT_RECORD.expected_attestation_digest,
+    }
+
+
+def _inventory_entry(
+    *,
+    loaded: bool = True,
+    lifecycle: str = "ready",
+) -> dict[str, object]:
+    return {
+        "id": "gemma-4-12b-it-qat-4bit",
+        "loaded": loaded,
+        "runtime_provenance": {
+            "runtime_kind": "mlx_vlm",
+            "adapter_name": "mlx-vlm",
+            "resolution_source": "authoritative_registry",
+        },
+        "model_lifecycle": lifecycle,
+        "capabilities": ["chat", "streaming", "json", "vision"],
+        "qualification_attestation": _full_inventory_attestation(),
+    }
+
+
+def _matching_response(content: str) -> WhooshdStructuredResponse:
+    material = STAGE_2D_GEMMA_4_12B_IT_QAT_4BIT_RECORD.material
+    provenance = parse_whooshd_runtime_provenance(
+        {
+            "schema_version": "whooshd.runtime.v1",
+            "request_id": "req-stage2i",
+            "requested_model_id": material.invocation_model_id,
+            "advertised_model_id": material.invocation_model_id,
+            "resolved_model_id": material.invocation_model_id,
+            "backend_reported_model_id": material.invocation_model_id,
+            "runtime_kind": material.runtime_kind,
+            "adapter_name": material.adapter_name,
+            "resolution_source": "authoritative_registry",
+            "execution_mode": "managed_sidecar",
+            "streaming": False,
+            "queued": False,
+            "batched": False,
+            "model_lifecycle": "ready",
+            "whooshd_version": "0.1.0rc1",
+            "qualification_attestation": {
+                "attestation_schema_version": material.attestation_schema_version,
+                "canonicalization_profile": material.canonicalization_profile,
+                "digest_algorithm": STAGE_2D_GEMMA_4_12B_IT_QAT_4BIT_RECORD.digest_algorithm,
+                "attestation_digest": STAGE_2D_GEMMA_4_12B_IT_QAT_4BIT_RECORD.expected_attestation_digest,
+                "invocation_model_id": material.invocation_model_id,
+                "resolved_model_id": material.resolved_model_id,
+                "runtime_kind": material.runtime_kind,
+                "adapter_name": material.adapter_name,
+            },
+        }
+    )
+    assert provenance is not None
+    return WhooshdStructuredResponse(
+        content=content,
+        raw_payload={},
+        runtime_provenance=provenance,
+        response_correlation=None,
+        command_id=HEALTH_COMMAND_ID,
+        argument_schema={
+            "type": "object",
+            "additionalProperties": False,
+            "maxProperties": 0,
+        },
+    )
+
+
+def _task(*, provider: str, model: str) -> ChatCompletionTask:
+    task = ChatCompletionTask(
+        user_id="local",
+        task_id="task-stage2i",
+        thread_id=7,
+        provider=provider,
+        model=model,
+        origin="api:chat.complete|turn_id=11111111-1111-4111-8111-111111111111",
+    )
+    task.latest_turn_message_id = 2
+    task.turn_id = "11111111-1111-4111-8111-111111111111"
+    return task
+
+
+def _seed_completion(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    provider: str,
+    model: str,
+    settings: Any,
+) -> None:
+    monkeypatch.setattr(chat_completion_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(chat_completion_service, "_command_bus_app", _command_bus_app)
+    monkeypatch.setattr(
+        chat_completion_service,
+        "build_sanitized_payload_summary",
+        lambda messages, bundle, provider, model, **_kwargs: {
+            "message_count": len(messages),
+            "resolved_provider": provider,
+            "resolved_model": model,
+        },
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "_apply_image_attachment_routing",
+        lambda messages, **_kwargs: (messages, {"image_attachment_count": 0}),
+    )
+    monkeypatch.setattr(
+        chat_completion_service, "_task_routing_debug_metadata", lambda _task: {}
+    )
+
+    async def _build_messages(_task: ChatCompletionTask):
+        return (
+            [{"role": "user", "content": "Check health."}],
+            provider,
+            model,
+            {},
+            None,
+        )
+
+    monkeypatch.setattr(
+        chat_completion_service, "build_messages_for_llm", _build_messages
+    )
+
+
+def test_manifest_health_command_is_exact_safe_and_requires_no_arguments() -> None:
+    command = _health_command()
+
+    assert command.method == "GET"
+    assert command.path_template == "/health"
+    assert command.effect == "read"
+    assert command.risk == "read_only"
+    assert command.idempotency == "safe"
+    assert command.approval_mode == "none"
+    assert command.input_schema == {
+        "path_params": {"type": "object", "properties": {}, "required": []},
+        "query": {"type": "object", "properties": {}, "required": []},
+        "headers": {"type": "object", "properties": {}, "required": []},
+        "body": {},
+    }
+
+
+def test_exposure_allowlist_returns_only_zero_argument_health_for_deepseek() -> None:
+    tools = resolve_ordinary_chat_tools(
+        provider="deepseek",
+        model="deepseek-model",
+        provider_vendor=None,
+        manifest_commands=_manifest_commands(),
+    )
+
+    assert tools == [
+        {
+            "command_id": HEALTH_COMMAND_ID,
+            "description": "Read the current Guardian health status (GET /health).",
+            "input_schema": {
+                "type": "object",
+                "additionalProperties": False,
+                "maxProperties": 0,
+            },
+        }
+    ]
+
+
+def test_exposure_rejects_unknown_and_mutating_manifest_entries() -> None:
+    health_command = _health_command()
+    mutating_health = health_command.model_copy(
+        update={
+            "effect": "write",
+            "risk": "mutating",
+            "approval_mode": "blocked_phase1",
+        }
+    )
+
+    assert (
+        resolve_ordinary_chat_tools(
+            provider="deepseek",
+            model="deepseek-model",
+            provider_vendor=None,
+            manifest_commands=[mutating_health],
+        )
+        is None
+    )
+    assert (
+        resolve_ordinary_chat_tools(
+            provider="deepseek",
+            model="deepseek-model",
+            provider_vendor=None,
+            manifest_commands=[],
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider", "provider_vendor"),
+    [
+        ("openai", None),
+        ("groq", None),
+        ("minimax", None),
+        ("alibaba", None),
+        ("local", "other-runtime"),
+    ],
+)
+def test_other_providers_and_local_runtimes_receive_no_automatic_tools(
+    provider: str,
+    provider_vendor: str | None,
+) -> None:
+    assert (
+        resolve_ordinary_chat_tools(
+            provider=provider,
+            model="unqualified-model",
+            provider_vendor=provider_vendor,
+            manifest_commands=_manifest_commands(),
+        )
+        is None
+    )
+
+
+def test_whooshd_exposure_requires_real_stage_2g_eligibility() -> None:
+    inventory = parse_whooshd_runtime_inventory_entry(_inventory_entry())
+    assert inventory is not None
+    eligible = project_whooshd_tool_capability(
+        inventory=inventory,
+        exposure_allowed=True,
+    )
+
+    tools = resolve_ordinary_chat_tools(
+        provider="local",
+        model="gemma-4-12b-it-qat-4bit",
+        provider_vendor="whooshd",
+        manifest_commands=_manifest_commands(),
+        whooshd_capability=eligible,
+    )
+    assert tools is not None
+    assert [tool["command_id"] for tool in tools] == [HEALTH_COMMAND_ID]
+
+    for ineligible in (
+        project_whooshd_tool_capability(inventory=None, exposure_allowed=True),
+        project_whooshd_tool_capability(
+            inventory=replace(inventory, loaded=False), exposure_allowed=True
+        ),
+        project_whooshd_tool_capability(
+            inventory=replace(inventory, model_lifecycle="warming"),
+            exposure_allowed=True,
+        ),
+        project_whooshd_tool_capability(inventory=inventory, exposure_allowed=False),
+    ):
+        assert (
+            resolve_ordinary_chat_tools(
+                provider="local",
+                model="gemma-4-12b-it-qat-4bit",
+                provider_vendor="whooshd",
+                manifest_commands=_manifest_commands(),
+                whooshd_capability=ineligible,
+            )
+            is None
+        )
+
+
+def test_whooshd_inventory_reader_uses_one_bounded_models_request_and_discards_raw_metadata() -> (
+    None
+):
+    calls: list[dict[str, Any]] = []
+
+    class _Response:
+        status_code = 200
+
+        @staticmethod
+        def json() -> dict[str, Any]:
+            entry = _inventory_entry()
+            entry.update({"path": "/private/model", "endpoint": "http://private"})
+            return {"data": [entry]}
+
+    def _get(url: str, **kwargs: Any) -> _Response:
+        calls.append({"url": url, **kwargs})
+        return _Response()
+
+    evidence = fetch_whooshd_runtime_inventory_entry(
+        SimpleNamespace(
+            LOCAL_PROVIDER_VENDOR="whooshd", LOCAL_BASE_URL="http://127.0.0.1:8000/v1"
+        ),
+        model="gemma-4-12b-it-qat-4bit",
+        request_get=_get,
+    )
+
+    assert evidence is not None
+    assert calls[0]["url"] == "http://127.0.0.1:8000/v1/models"
+    assert calls[0]["timeout"] == 1.0
+    assert "/private/model" not in repr(evidence)
+    assert "http://private" not in repr(evidence)
+
+
+def test_ordinary_deepseek_health_tool_executes_once_and_plain_answer_is_optional(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_completion(
+        monkeypatch,
+        provider="deepseek",
+        model="deepseek-model",
+        settings=SimpleNamespace(LOCAL_PROVIDER_VENDOR=None),
+    )
+    task = _task(provider="deepseek", model="deepseek-model")
+    executions: list[Any] = []
+    provider_tools: list[Any] = []
+
+    monkeypatch.setattr(
+        chat_completion_service,
+        "execute_invoke",
+        lambda *, payload, **_kwargs: (
+            executions.append(payload)
+            or {"run_id": "run-stage2i-deepseek", "status": "completed"}
+        ),
+    )
+
+    def _chat(_messages: list[dict[str, Any]], **kwargs: Any) -> DeepSeekResponse:
+        provider_tools.append(kwargs.get("tools"))
+        if len(provider_tools) == 1:
+            return DeepSeekResponse(
+                content="",
+                reasoning_content=None,
+                tool_calls=[
+                    {
+                        "command_id": HEALTH_COMMAND_ID,
+                        "tool_call_id": "call-health",
+                        "arguments": {},
+                    }
+                ],
+                raw_assistant_message={"role": "assistant", "tool_calls": []},
+                raw_payload={},
+            )
+        return DeepSeekResponse(
+            content="Guardian is healthy.",
+            reasoning_content=None,
+            tool_calls=[],
+            raw_assistant_message={
+                "role": "assistant",
+                "content": "Guardian is healthy.",
+            },
+            raw_payload={},
+        )
+
+    monkeypatch.setattr(chat_completion_service, "chat_with_ai", _chat)
+    result = chat_completion_service.run_chat_completion_task(
+        task, persist_assistant_message=False
+    )
+
+    assert task.tools is not None and [tool["command_id"] for tool in task.tools] == [
+        HEALTH_COMMAND_ID
+    ]
+    assert len(executions) == 1
+    assert executions[0].command_id == HEALTH_COMMAND_ID
+    assert executions[0].arguments.model_dump() == {
+        "path_params": {},
+        "query": {},
+        "headers": {},
+        "body": {},
+    }
+    assert provider_tools[0] == task.tools
+    assert result["assistant_text"] == "Guardian is healthy."
+    assert result["payload_summary"]["toolTurnState"] == "completed"
+    assert result["payload_summary"]["loopStopReason"] == "tool_turn_completed"
+    assert result["payload_summary"]["commandRunId"] == "run-stage2i-deepseek"
+
+
+def test_advertised_deepseek_health_capability_does_not_force_tool_use(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_completion(
+        monkeypatch,
+        provider="deepseek",
+        model="deepseek-model",
+        settings=SimpleNamespace(LOCAL_PROVIDER_VENDOR=None),
+    )
+    task = _task(provider="deepseek", model="deepseek-model")
+    executions: list[Any] = []
+    monkeypatch.setattr(
+        chat_completion_service,
+        "execute_invoke",
+        lambda *, payload, **_kwargs: executions.append(payload),
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "chat_with_ai",
+        lambda *_args, **_kwargs: DeepSeekResponse(
+            content="No health check needed.",
+            reasoning_content=None,
+            tool_calls=[],
+            raw_assistant_message={
+                "role": "assistant",
+                "content": "No health check needed.",
+            },
+            raw_payload={},
+        ),
+    )
+
+    result = chat_completion_service.run_chat_completion_task(
+        task, persist_assistant_message=False
+    )
+
+    assert task.tools is not None
+    assert executions == []
+    assert result["assistant_text"] == "No health check needed."
+    assert result["payload_summary"]["toolTurnState"] == "idle"
+
+
+def test_eligible_whooshd_executes_once_and_stale_response_identity_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = SimpleNamespace(
+        LOCAL_PROVIDER_VENDOR="whooshd", LOCAL_BASE_URL="http://127.0.0.1:8000/v1"
+    )
+    _seed_completion(
+        monkeypatch,
+        provider="local",
+        model="gemma-4-12b-it-qat-4bit",
+        settings=settings,
+    )
+    inventory = parse_whooshd_runtime_inventory_entry(_inventory_entry())
+    assert inventory is not None
+    monkeypatch.setattr(
+        chat_completion_service,
+        "fetch_whooshd_runtime_inventory_entry",
+        lambda _settings, *, model: inventory,
+    )
+    task = _task(provider="local", model="gemma-4-12b-it-qat-4bit")
+    executions: list[Any] = []
+    monkeypatch.setattr(
+        chat_completion_service,
+        "execute_invoke",
+        lambda *, payload, **_kwargs: (
+            executions.append(payload)
+            or {"run_id": "run-stage2i-whooshd", "status": "completed"}
+        ),
+    )
+    calls = 0
+
+    def _chat(
+        _messages: list[dict[str, Any]], **_kwargs: Any
+    ) -> WhooshdStructuredResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return _matching_response(
+                '{"kind":"tool_decision","text":null,"command_id":"op::health_health_get","arguments":{}}'
+            )
+        return _matching_response(
+            '{"kind":"assistant","text":"Guardian is healthy.","command_id":null,"arguments":{}}'
+        )
+
+    monkeypatch.setattr(chat_completion_service, "chat_with_ai", _chat)
+    result = chat_completion_service.run_chat_completion_task(
+        task, persist_assistant_message=False
+    )
+
+    assert task.tools is not None
+    assert len(executions) == 1
+    assert executions[0].command_id == HEALTH_COMMAND_ID
+    assert result["payload_summary"]["toolTurnState"] == "completed"
+
+    stale_task = _task(provider="local", model="gemma-4-12b-it-qat-4bit")
+    stale_calls: list[Any] = []
+    monkeypatch.setattr(
+        chat_completion_service,
+        "execute_invoke",
+        lambda *, payload, **_kwargs: stale_calls.append(payload),
+    )
+    stale_response = _matching_response(
+        '{"kind":"tool_decision","text":null,"command_id":"op::health_health_get","arguments":{}}'
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "chat_with_ai",
+        lambda *_args, **_kwargs: replace(
+            stale_response,
+            runtime_provenance=replace(
+                stale_response.runtime_provenance, resolved_model_id="other-model"
+            ),
+        ),
+    )
+
+    with pytest.raises(Exception, match="provenance"):
+        chat_completion_service.run_chat_completion_task(
+            stale_task, persist_assistant_message=False
+        )
+    assert stale_task.tools is not None
+    assert stale_calls == []
+
+
+def test_ineligible_whooshd_keeps_the_ordinary_streaming_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = SimpleNamespace(
+        LOCAL_PROVIDER_VENDOR="whooshd", LOCAL_BASE_URL="http://127.0.0.1:8000/v1"
+    )
+    _seed_completion(
+        monkeypatch,
+        provider="local",
+        model="gemma-4-12b-it-qat-4bit",
+        settings=settings,
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "fetch_whooshd_runtime_inventory_entry",
+        lambda _settings, *, model: None,
+    )
+    task = _task(provider="local", model="gemma-4-12b-it-qat-4bit")
+    streams: list[Any] = []
+
+    def _stream(*_args: Any, **_kwargs: Any):
+        streams.append(True)
+
+        def _iterator():
+            yield "ordinary local answer"
+            return CompletionTerminalEvidence(
+                status=CompletionTerminalStatus.SUCCESS,
+                visible_output_emitted=True,
+                explicit_provider_terminal_observed=True,
+                finish_reason="stop",
+                transport_ended_cleanly=True,
+                provider="local",
+                model="gemma-4-12b-it-qat-4bit",
+            )
+
+        return _iterator()
+
+    monkeypatch.setattr(chat_completion_service, "stream_local", _stream)
+    result = chat_completion_service.run_chat_completion_task(
+        task, persist_assistant_message=False
+    )
+
+    assert task.tools is None
+    assert streams == [True]
+    assert result["assistant_text"] == "ordinary local answer"


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
