### PR TITLE
Integrate live-proven Stage 2J chat preparation seam

### DIFF
--- a/docs/architecture/proofs/2026-08-11-stage2j-m1-live-closure-proof.md
+++ b/docs/architecture/proofs/2026-08-11-stage2j-m1-live-closure-proof.md
@@ -1,0 +1,286 @@
+# Stage 2J-M1 live closure proof
+
+## Date
+
+2026-08-11
+
+## Verdict
+
+PASS
+
+## Diagnostic Outcome
+
+`LIVE_TOOL_TURN_COMPLETED`
+
+The reconciled Stage 2J mainline candidate at 8248f8a125394bfda18b07d8f0fb31e8b8c0fb4d reproduced the complete ordinary Guardian health-capability tool turn from a runtime directly mounted from that exact source.
+
+This proof validates the M1 mainline candidate. It does not claim that remote origin/main contains M1 until that commit is separately integrated.
+
+## Scope
+
+Proof-only live closure. No runtime implementation, test, Compose, profile, provider, architecture, or `origin/main` change was made. The one permitted initial DeepSeek completion request was issued once; its single same-provider continuation was performed only because the bounded runtime selected the advertised health capability.
+
+## M1 Commit
+
+`8248f8a125394bfda18b07d8f0fb31e8b8c0fb4d`
+
+## M1 Branch
+
+`codex/stage2j-m1-mainline-reconcile`
+
+## M1 Base
+
+`237d5e2d5a0c17ca2b369e364a35c6598d2287d2`
+
+## Remote Main at Proof Time
+
+`origin/main` was fetched and resolved to `237d5e2d5a0c17ca2b369e364a35c6598d2287d2`. M1 is a descendant of that recorded base; no rebase was performed.
+
+## Source Worktree
+
+`/private/tmp/codexify-stage2j-m1-mainline-20260811`
+
+## Source HEAD
+
+Before this receipt, the worktree was clean and at `8248f8a125394bfda18b07d8f0fb31e8b8c0fb4d` on `codex/stage2j-m1-mainline-reconcile`.
+
+## R5D Runtime Equivalence
+
+M1 has no diff from R5D `731f7b27ed037687d56c368f8ff51b02d7417f13` in exactly these governed runtime files:
+
+- `guardian/core/chat_completion_service.py`
+- `guardian/workers/chat_worker.py`
+- `guardian/tools/chat_exposure.py`
+
+The M1 reconciliation commit changes only the preparation seam and its focused tests; it imports no `docs/architecture/proofs/` path.
+
+## Pre-Teardown Runtime Provenance
+
+The prior Tester runtime was intentionally stopped through the supported lifecycle. Its backend was `285e706e0ec5` (healthy; started `2026-08-11T18:18:49.20560718Z`) and its chat worker was `369c32be8318` (started `2026-08-11T18:19:10.471633342Z`). Their Guardian mounts pointed to the designated R5D proof checkout, not M1:
+
+- backend: `/host_mnt/Volumes/Dev_SSD/Codexify-stage2j-r5f-r2-proof/guardian`
+- worker-chat: `/Volumes/Dev_SSD/Codexify-stage2j-r5f-r2-proof/guardian`
+
+The prior db (`04370073000f`), Neo4j (`6e6cb1ff6395`), and Redis (`6039d9b560f6`) were healthy.
+
+## Persistent Volumes Before
+
+Declared Tester volumes present before teardown, with creation identities retained throughout the lifecycle:
+
+- `codexify_tester_pg_data` — `2026-07-25T19:13:17Z`
+- `codexify_tester_neo4j_data` — `2026-07-25T19:13:17Z`
+- `codexify_tester_codexify_cli_home` — `2026-08-11T17:15:30Z`
+- `codexify_tester_codexify_tailscale_test_state` — `2026-07-25T19:13:17Z`
+- `codexify_tester_corepack_cache` — `2026-08-11T17:15:30Z`
+- `codexify_tester_frontend_pnpm_store` — `2026-08-11T17:15:30Z`
+- `codexify_tester_hf_cache` — `2026-08-11T17:15:30Z`
+
+The six pre-existing anonymous Docker volumes also remained present after teardown. No volume removal, `down -v`, prune, or manual volume operation was used.
+
+## Supported Tester Lifecycle
+
+From the M1 source root, the repository-supported `make tester-status`, `make tester-down`, and `make tester-up` wrappers invoked `scripts/ops/codexify_tester.sh`. The existing private `/Volumes/Dev_SSD/Codexify-main/.env.tester` was passed as both `CODEXIFY_TESTER_ENV_FILE` and the base-Compose `CODEXIFY_RUNTIME_ENV_FILE`; no secret file was copied and no provider/profile value was changed.
+
+The initial start attempt stopped during `compose config --quiet` because the base Compose `env_file` setting also requires `CODEXIFY_RUNTIME_ENV_FILE`. It created no container and sent no inference. Supplying that same existing env file to the documented base-Compose input allowed the supported lifecycle to start normally.
+
+## Post-Start Container IDs
+
+- backend: `707c2c95f113` (healthy)
+- worker-chat: `8fdcb63c55bc` (running)
+- db: `b37dd1a7c744` (healthy)
+- neo4j: `573979b1cac4` (healthy)
+- redis: `4f26fb6d9d04` (healthy)
+- frontend: `38fd7032d55a`
+- worker-chat-embed: `5a8a647bfdf7`
+- worker-document-embed: `cd4c56bedcc4`
+- worker-warmup: `5ab9f6407ccf`
+- worker-account-import: `e0602ec3f73a`
+- tailscale-codexify-test: `9a2794906893`
+
+## Backend Mount Provenance
+
+The running backend directly mounts:
+
+- `/private/tmp/codexify-stage2j-m1-mainline-20260811/guardian` to both `/app/guardian` and `/app/codexify`;
+- `/private/tmp/codexify-stage2j-m1-mainline-20260811/backend` to `/app/backend`.
+
+Other Docker Desktop-normalized bind sources under `/host_mnt/private/tmp/codexify-stage2j-m1-mainline-20260811/` correspond to the same M1 source root.
+
+## Worker-Chat Mount Provenance
+
+The running chat worker directly mounts `/host_mnt/private/tmp/codexify-stage2j-m1-mainline-20260811/guardian` to both `/app/guardian` and `/app/codexify`, and `/host_mnt/private/tmp/codexify-stage2j-m1-mainline-20260811/backend` to `/app/backend`. This is Docker Desktop's normalized representation of the M1 source root.
+
+## Persistent Volumes After
+
+The db mounts `codexify_tester_pg_data` at `/var/lib/postgresql/data`; Neo4j mounts `codexify_tester_neo4j_data` at `/data`. Both names and creation identities equal their before values. All seven declared Tester volumes and all six pre-existing anonymous volumes remained present.
+
+## Host / Backend / Worker / M1 / R5D SHA-256 Evidence
+
+Every source listed below has the same SHA-256 in the M1 host checkout, backend container, worker-chat container, M1 Git object, and R5D Git object:
+
+| File | SHA-256 |
+| --- | --- |
+| `guardian/core/chat_completion_service.py` | `a64af62bf9db799948a0f2e1fe6f8c0558f0684abd8a8920973ec6181185bada` |
+| `guardian/workers/chat_worker.py` | `c16e66cab3fc77e6e01eaeae0d81aad7a45ac57fc611daf2898a457f131fbbed` |
+| `guardian/tools/chat_exposure.py` | `627effb46c8a9f8e63efa6feaaeb37f94a60a94494ef3591d3689a617dca3086` |
+
+## Runtime Health Before Inference
+
+`make tester-status` was healthy. `/health` returned HTTP 200 with `status=ok`, `service=core`, `release_hold=true`, and valid profile `v1-whooshd-deepseek-web`; `/health/chat` reported Redis `ok`, a fresh worker heartbeat, and progressing empty queue; `/api/health/llm` was online for the global local lane (`local`, `gemma-4-12b-it-qat-4bit`). The catalog separately showed approved DeepSeek `deepseek-v4-flash` enabled and authorized for this thread-scoped proof.
+
+## Focused Test Results
+
+- `tests/core/test_chat_tool_exposure.py`: 21 passed
+- `guardian/tests/workers/test_chat_worker_completion_semantics.py`: 23 passed (8 existing warnings)
+- `tests/core/test_completion_terminal_integrity.py`: 16 passed
+- M1 exposure/worker/terminal total: 60 passed
+- `tests/core/test_chat_completion_service_tool_loop.py`: 16 passed
+- `tests/core/test_ai_router.py`: 27 passed
+- `tests/providers/test_deepseek_adapter.py`: 8 passed
+- `tests/providers/test_tool_turn_transport_convergence.py`: 21 passed
+- completion loop/router/DeepSeek/convergence total: 72 passed
+- `guardian/tests/core/test_request_correlation.py`: 17 passed (8 existing warnings)
+
+Ruff, Black, and the already-classified profile-trace failures were not broadened into this proof-only slice.
+
+## Proof Account
+
+`stage2jm1p_1786479083`
+
+## Proof Thread
+
+`5060` (fresh ordinary thread)
+
+## Task ID
+
+`34c7216c-8d2e-443d-a6af-a2bec1eed03e`
+
+## Request ID
+
+`req_ef078df111494878904acb573bdff280`
+
+## Provider / Model
+
+Initial and continuation provider/model: `deepseek` / `deepseek-v4-flash`.
+
+## Caller Request Shape
+
+The only completion body was `{}`. It contained no `tools`, `tool_choice`, command ID, tool schema, or forced selection field. The provider/model came from the fresh thread's durable configuration, not caller completion authority.
+
+## Natural-Language Prompt
+
+`Use your available read-only health capability to check Codexify's current service health before answering. Then give me one short sentence summarizing what the health result says. Do not use any other capability.`
+
+## Automatic Tool Exposure
+
+Terminal `payload_summary.toolExposure` recorded:
+
+- `automatic=true`
+- `advertisedToolCount=1`
+- `advertisedToolCommandIds=["op::health_health_get"]`
+
+## Provider Dispatch
+
+The same terminal evidence recorded `providerDispatchToolCount=1` and `providerDispatchToolCommandIds=["op::health_health_get"]`; command IDs were not truncated.
+
+## Initial DeepSeek Decision
+
+The initial native DeepSeek turn selected the sole advertised capability with `{}` arguments. The bounded runtime then recorded `tool_turn_used=true`, generated `toolTurnId=ba62ddc6-82fc-43e6-9a9f-34641fa5521c`, and emitted nonempty `commandRunId=run_5056a86e2ed24fe0`.
+
+## Canonical Normalization
+
+The selected capability normalized to canonical command `op::health_health_get`. This is the only command in both the exact advertised and provider-dispatch sets, and terminal completion recorded the successful bounded command result.
+
+## Stage 1 Authority
+
+Stage 1 admitted only the exact advertised subset: `op::health_health_get`. No caller-supplied authority, unadvertised command, model-provided filesystem authority, or runtime authority was used.
+
+## Command Bus Execution
+
+Exactly one Command Bus invocation executed with `commandRunId=run_5056a86e2ed24fe0` and terminal `command_status=completed`. The governed health capability is read-effect, `read_only` risk, safe-idempotent, and requires no approval. No second command was admitted or executed.
+
+## GET /health Result
+
+The Command Bus health invocation completed and the final continuation truthfully reported: `Codexify's core service is healthy and reporting status **ok**, though a release hold is currently active.` The independently observed pre-inference `/health` response on this same mounted runtime was HTTP 200, `service=core`, `status=ok`, `release_hold=true`.
+
+## Result Reinjection
+
+The bounded turn recorded `tool_turn_used=true`; its command result was reinjected into the DeepSeek continuation path before the final assistant output. The terminal state is `toolTurnState=completed` with `loopStopReason=tool_turn_completed`, not a plain-answer path.
+
+## Provider Continuation
+
+The continuation completed on the same `deepseek` / `deepseek-v4-flash` lane. Terminal execution records attempted and final provider/model as DeepSeek V4 Flash with `fallback_triggered=false`; the terminal provider evidence is successful, explicit, and cleanly ended.
+
+## Final Assistant Persistence
+
+Assistant message `112506` was persisted to thread `5060`. Worker log evidence recorded `assistant_message_persisted`; the authenticated thread readback returned the persisted text exactly as quoted in the health-result section and durable metadata containing the tool-turn identifiers.
+
+## Tool-Turn Observability
+
+- `messageId`: `112505`
+- `requestId`: `req_ef078df111494878904acb573bdff280`
+- `toolTurnId`: `ba62ddc6-82fc-43e6-9a9f-34641fa5521c`
+- `toolTurnState`: `completed`
+- `loopStopReason`: `tool_turn_completed`
+- `commandRunId`: `run_5056a86e2ed24fe0`
+
+The terminal event stream contained one `COMPLETED` state and one distinct attempt ID, `attempt_d40d9f2fcc8245b78f6e1cccaffe8f4e`. The persisted assistant metadata repeats the same request, turn, loop, command-run, final-provider/model, and no-fallback evidence.
+
+Independent CommandRun readback remains unavailable: `/api/guardian/commands/runs/run_5056a86e2ed24fe0` returned `404 command_run_not_found`, and the tool-turn read model returned `500 chat_message_store_unavailable`. This does not contradict the execution: terminal task evidence, the command-run ID, completed tool-turn state, worker persistence record, and persisted assistant metadata are correlated through the existing runtime observability contract.
+
+## Command Count
+
+PASS — exactly 1: `op::health_health_get`.
+
+## Retry Check
+
+PASS — one distinct attempt ID; terminal evidence says `retry_permitted=false`.
+
+## Fallback Check
+
+PASS — `fallback_attempted=false`, `fallback_triggered=false`, and the initial/final provider and model are both `deepseek` / `deepseek-v4-flash`.
+
+## Write Check
+
+PASS — the only command was the read-only health capability; no write command executed.
+
+## Second-Command Check
+
+PASS — one advertised command, one provider-dispatched command, one nonempty command-run ID, and terminal `tool_turn_completed` with no second tool decision.
+
+## What Was Proven
+
+- Exact M1 source, actual backend/worker mounts, and governed runtime bytes match M1 and R5D.
+- Declared PostgreSQL, Neo4j, and other Tester persistent volume identities were preserved through the supported lifecycle.
+- A no-tools/no-`tool_choice` ordinary request caused Guardian-owned automatic exposure, bounded provider dispatch, native DeepSeek selection, canonical Stage 1 admission, exactly one read-only Command Bus health run, reinjection, same-provider continuation, persistence, and completed terminal observability.
+
+## What Was Not Proven
+
+- remote `origin/main` was not modified;
+- M1 was not pushed;
+- M1 was not merged;
+- no Stage 2K repository capability was implemented;
+- no new architecture or authority was introduced.
+
+## ADR Impact
+
+Aligned with existing accepted decisions: ADR-001 (queue acceptance versus execution), ADR-003 (message/request identity), ADR-052 (operator-controlled Whoosh'd/DeepSeek profile), and ADR-061 (capability-oriented authorization boundary). The bounded tool-loop and advertised-subset/provider-translation details remain governed by the existing Agent Tool Loop and Provider Tool-Turn Boundary contracts. No ADR changed.
+
+## Documentation Follow-Through
+
+This receipt is the only documentation change. `00-current-state.md`, README, flows, diagrams, ADRs, and architecture contracts remain untouched pending the separately authorized integration/current-truth slice.
+
+## Validation
+
+- `python3 scripts/validate_docs.py`: passed.
+- `make docs PYTHON=python3`: passed, including diagram freshness.
+- `git diff --check`: passed.
+- Scope checks: only this untracked receipt exists; diffs for `guardian`, `tests`, `frontend`, `config`, all three Compose files, and `docs/architecture/adr` are empty.
+
+## Final Source State
+
+Before staging, the worktree contained only this proof receipt. No runtime source change is authorized or present.
+
+## Commit
+
+This receipt is staged and committed immediately after its final cached-diff validation with the required subject `Prove Stage 2J M1 live closure`; the resulting hash is reported in the task closeout.

--- a/guardian/core/chat_completion_service.py
+++ b/guardian/core/chat_completion_service.py
@@ -1145,6 +1145,7 @@ def _execute_completion_attempt(
     token_callback: Callable[[str], None] | None = None,
     chunk_callback: Callable[[str], None] | None = None,
     cancel_check: Callable[[], bool] | None = None,
+    tool_exposure: dict[str, Any] | None = None,
 ) -> CompletionAttemptResult:
     request_id, _ = normalize_request_id(getattr(task, "request_id", None))
     task.request_id = request_id
@@ -1289,6 +1290,15 @@ def _execute_completion_attempt(
             ),
         )
 
+    provider_tools = (
+        getattr(task, "tools", None) if provider in {"deepseek", "local"} else None
+    )
+    if tool_exposure is not None:
+        _record_provider_dispatch_tool_exposure(
+            tool_exposure,
+            tools=provider_tools,
+        )
+
     try:
         output = chat_with_ai(
             messages_for_llm,
@@ -1299,9 +1309,7 @@ def _execute_completion_attempt(
                     "provider": provider,
                     "reasoning_mode": reasoning_mode,
                     "temperature": temperature,
-                    "tools": getattr(task, "tools", None)
-                    if provider in {"deepseek", "local"}
-                    else None,
+                    "tools": provider_tools,
                     "settings": settings,
                     "prompt_meta": (
                         (bundle or {}).get("_prompt_meta")
@@ -5092,6 +5100,96 @@ async def build_messages_for_llm(
     return messages_for_llm, provider, model, bundle, trace
 
 
+_TOOL_EXPOSURE_COMMAND_ID_CAP = 16
+_TOOL_EXPOSURE_COMMAND_ID_MAX_LENGTH = 256
+_TOOL_EXPOSURE_COMMAND_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9:._-]*")
+
+
+def _bounded_tool_exposure_command_ids(
+    tools: Any,
+) -> tuple[int, list[str], bool]:
+    """Return canonical command IDs suitable for durable observability only."""
+
+    if not isinstance(tools, list):
+        return 0, [], False
+
+    command_ids: set[str] = set()
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        command_id = str(tool.get("command_id") or "").strip()
+        if (
+            not command_id
+            or len(command_id) > _TOOL_EXPOSURE_COMMAND_ID_MAX_LENGTH
+            or _TOOL_EXPOSURE_COMMAND_ID_RE.fullmatch(command_id) is None
+        ):
+            continue
+        command_ids.add(command_id)
+
+    ordered_command_ids = sorted(command_ids)
+    return (
+        len(ordered_command_ids),
+        ordered_command_ids[:_TOOL_EXPOSURE_COMMAND_ID_CAP],
+        len(ordered_command_ids) > _TOOL_EXPOSURE_COMMAND_ID_CAP,
+    )
+
+
+def _build_tool_exposure_evidence(
+    *,
+    automatic: bool,
+    tools: Any,
+) -> dict[str, Any]:
+    """Build the bounded, provider-neutral Stage 2I exposure observation."""
+
+    count, command_ids, command_ids_truncated = _bounded_tool_exposure_command_ids(
+        tools
+    )
+    return {
+        "automatic": bool(automatic),
+        "advertisedToolCount": count,
+        "advertisedToolCommandIds": command_ids,
+        "providerDispatchToolCount": 0,
+        "providerDispatchToolCommandIds": [],
+        "commandIdsTruncated": command_ids_truncated,
+    }
+
+
+def _record_provider_dispatch_tool_exposure(
+    tool_exposure: dict[str, Any],
+    *,
+    tools: Any,
+) -> None:
+    """Snapshot the canonical list supplied to the initial provider dispatch."""
+
+    count, command_ids, command_ids_truncated = _bounded_tool_exposure_command_ids(
+        tools
+    )
+    tool_exposure["providerDispatchToolCount"] = count
+    tool_exposure["providerDispatchToolCommandIds"] = command_ids
+    tool_exposure["commandIdsTruncated"] = bool(
+        tool_exposure.get("commandIdsTruncated") or command_ids_truncated
+    )
+
+
+def _tool_exposure_payload(tool_exposure: dict[str, Any]) -> dict[str, Any]:
+    """Copy only the bounded evidence fields into durable payload summaries."""
+
+    return {
+        "automatic": bool(tool_exposure.get("automatic")),
+        "advertisedToolCount": int(tool_exposure.get("advertisedToolCount") or 0),
+        "advertisedToolCommandIds": list(
+            tool_exposure.get("advertisedToolCommandIds") or []
+        ),
+        "providerDispatchToolCount": int(
+            tool_exposure.get("providerDispatchToolCount") or 0
+        ),
+        "providerDispatchToolCommandIds": list(
+            tool_exposure.get("providerDispatchToolCommandIds") or []
+        ),
+        "commandIdsTruncated": bool(tool_exposure.get("commandIdsTruncated")),
+    }
+
+
 def _authorized_tool_command_ids(task: ChatCompletionTask) -> frozenset[str]:
     tools = getattr(task, "tools", None)
     if not isinstance(tools, list):
@@ -5157,6 +5255,28 @@ def _resolve_ordinary_chat_tools(
     )
 
 
+def _prepare_chat_tool_exposure(
+    task: ChatCompletionTask,
+    *,
+    provider: str,
+    model: str,
+    settings: Any,
+) -> dict[str, Any]:
+    """Resolve the canonical advertised subset and its bounded evidence."""
+
+    automatic_tool_exposure = task.tools is None
+    if automatic_tool_exposure:
+        task.tools = _resolve_ordinary_chat_tools(
+            provider=provider,
+            model=model,
+            settings=settings,
+        )
+    return _build_tool_exposure_evidence(
+        automatic=automatic_tool_exposure,
+        tools=task.tools,
+    )
+
+
 def _execute_bounded_tool_turn_completion(
     task: ChatCompletionTask,
     *,
@@ -5166,6 +5286,7 @@ def _execute_bounded_tool_turn_completion(
     bundle: dict[str, Any] | None,
     trace: dict[str, Any] | None,
     base_payload_summary: dict[str, Any],
+    tool_exposure: dict[str, Any],
     token_callback: Callable[[str], None] | None = None,
     chunk_callback: Callable[[str], None] | None = None,
     cancel_check: Callable[[], bool] | None = None,
@@ -5213,6 +5334,7 @@ def _execute_bounded_tool_turn_completion(
         response_correlation: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         payload_summary = dict(base_payload_summary or {})
+        payload_summary["toolExposure"] = _tool_exposure_payload(tool_exposure)
         payload_summary.update(
             build_sanitized_payload_summary(
                 current_messages,
@@ -5326,6 +5448,7 @@ def _execute_bounded_tool_turn_completion(
         token_callback=token_callback,
         chunk_callback=chunk_callback,
         cancel_check=cancel_check,
+        tool_exposure=tool_exposure,
     )
     normalized_first_output = normalize_completion_output(first_attempt.output)
     if normalized_first_output.kind != "tool_decision":
@@ -5675,12 +5798,12 @@ def run_chat_completion_task(
             task.selection_source = "local_vision_env"
 
     settings = get_settings()
-    if task.tools is None:
-        task.tools = _resolve_ordinary_chat_tools(
-            provider=provider,
-            model=model,
-            settings=settings,
-        )
+    tool_exposure = _prepare_chat_tool_exposure(
+        task,
+        provider=provider,
+        model=model,
+        settings=settings,
+    )
     requested_source_mode = (
         str(getattr(task, "requested_source_mode", "") or "").strip() or None
     )
@@ -5813,6 +5936,7 @@ def run_chat_completion_task(
             ),
         }
     )
+    payload_summary["toolExposure"] = _tool_exposure_payload(tool_exposure)
     payload_summary.update(routing_debug_metadata)
     if isinstance(trace, dict):
         trace = dict(trace)
@@ -5933,6 +6057,7 @@ def run_chat_completion_task(
         bundle=bundle,
         trace=trace,
         base_payload_summary=payload_summary,
+        tool_exposure=tool_exposure,
         token_callback=token_callback,
         chunk_callback=chunk_callback,
         cancel_check=cancel_check,

--- a/guardian/tests/workers/test_chat_worker_completion_semantics.py
+++ b/guardian/tests/workers/test_chat_worker_completion_semantics.py
@@ -649,6 +649,130 @@ def test_completion_result_includes_execution_metadata_without_fallback(
     }
 
 
+def test_worker_uses_canonical_tool_preparation_and_forwards_its_exact_evidence(
+    monkeypatch,
+):
+    task = ChatCompletionTask(
+        user_id="local",
+        thread_id=1,
+        provider="deepseek",
+        model="deepseek-v4-flash",
+        selection_source="explicit",
+    )
+    health_tool = {"command_id": "op::health_health_get"}
+    prepared_tool_exposure = {
+        "automatic": True,
+        "advertisedToolCount": 1,
+        "advertisedToolCommandIds": ["op::health_health_get"],
+        "providerDispatchToolCount": 0,
+        "providerDispatchToolCommandIds": [],
+        "commandIdsTruncated": False,
+    }
+    captured: dict[str, object] = {}
+    command_bus_calls: list[object] = []
+
+    async def _build_messages(_task):
+        return (
+            [{"role": "user", "content": "Check health."}],
+            "deepseek",
+            "deepseek-v4-flash",
+            {},
+            {"source_mode": "project", "effective_policy": None},
+        )
+
+    def _prepare(completion_task, *, provider, model, settings):
+        captured["prepare_task"] = completion_task
+        captured["prepare_provider"] = provider
+        captured["prepare_model"] = model
+        captured["prepare_settings"] = settings
+        completion_task.tools = [health_tool]
+        return prepared_tool_exposure
+
+    def _execute(_task, **kwargs):
+        captured["tool_exposure"] = kwargs["tool_exposure"]
+        return {
+            "assistant_text": "Codexify is healthy.",
+            "payload_summary": {
+                "toolExposure": dict(kwargs["tool_exposure"]),
+                "toolTurnState": "idle",
+                "loopStopReason": "plain_answer",
+                "commandRunId": None,
+            },
+            "execution": {
+                "attempted_provider": "deepseek",
+                "attempted_model": "deepseek-v4-flash",
+                "final_provider": "deepseek",
+                "final_model": "deepseek-v4-flash",
+                "fallback_triggered": False,
+                "tool_turn_used": False,
+            },
+            "terminal_evidence": successful_non_stream_terminal(
+                provider="deepseek",
+                model="deepseek-v4-flash",
+            ).as_dict(),
+        }
+
+    monkeypatch.setattr(chat_worker, "_build_messages_for_llm", _build_messages)
+    monkeypatch.setattr(chat_worker, "get_settings", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        chat_worker._chat_completion_service,
+        "_prepare_chat_tool_exposure",
+        _prepare,
+    )
+    monkeypatch.setattr(
+        chat_worker._chat_completion_service,
+        "_resolve_ordinary_chat_tools",
+        lambda **_kwargs: pytest.fail(
+            "worker must not resolve ordinary-chat tools directly"
+        ),
+    )
+    monkeypatch.setattr(
+        chat_worker._chat_completion_service,
+        "_execute_bounded_tool_turn_completion",
+        _execute,
+    )
+    monkeypatch.setattr(
+        chat_worker._chat_completion_service,
+        "execute_invoke",
+        lambda *_args, **_kwargs: command_bus_calls.append(True),
+    )
+    monkeypatch.setattr(
+        chat_worker._chat_completion_service,
+        "_normalize_completion_image_routing_truth",
+        lambda **_kwargs: (0, "none", "none"),
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "require_successful_terminal",
+        lambda _result: successful_non_stream_terminal(
+            provider="deepseek",
+            model="deepseek-v4-flash",
+        ),
+    )
+    monkeypatch.setattr(
+        chat_worker,
+        "build_provider_truth",
+        lambda provider, _settings, **kwargs: {"provider": provider, **kwargs},
+    )
+
+    result = chat_worker._run_chat_completion_task_compat(
+        task,
+        persist_assistant_message=False,
+    )
+
+    assert captured["prepare_task"] is task
+    assert captured["prepare_provider"] == "deepseek"
+    assert captured["prepare_model"] == "deepseek-v4-flash"
+    assert task.tools == [health_tool]
+    assert captured["tool_exposure"] is prepared_tool_exposure
+    assert result["assistant_text"] == "Codexify is healthy."
+    assert result["payload_summary"]["toolExposure"] == prepared_tool_exposure
+    assert result["payload_summary"]["toolTurnState"] == "idle"
+    assert result["payload_summary"]["loopStopReason"] == "plain_answer"
+    assert result["payload_summary"]["commandRunId"] is None
+    assert command_bus_calls == []
+
+
 def test_runtime_provenance_persists_after_successful_completion(monkeypatch):
     mock_db = MagicMock()
     mock_db.create_message.return_value = 323

--- a/guardian/workers/chat_worker.py
+++ b/guardian/workers/chat_worker.py
@@ -1643,6 +1643,12 @@ def _run_chat_completion_task_compat(
             },
         )
     settings = get_settings()
+    tool_exposure = _chat_completion_service._prepare_chat_tool_exposure(
+        task,
+        provider=provider,
+        model=model,
+        settings=settings,
+    )
     turn_id = _extract_turn_id(task)
     requested_provider = _normalize_provider_override(
         getattr(task, "requested_provider", None)
@@ -1737,6 +1743,7 @@ def _run_chat_completion_task_compat(
                 bundle=bundle,
                 trace=trace,
                 base_payload_summary=payload_summary,
+                tool_exposure=tool_exposure,
                 token_callback=_token_bridge,
                 chunk_callback=_chunk_bridge,
                 cancel_check=cancel_check,

--- a/tests/core/test_chat_tool_exposure.py
+++ b/tests/core/test_chat_tool_exposure.py
@@ -454,6 +454,14 @@ def test_ordinary_deepseek_health_tool_executes_once_and_plain_answer_is_optiona
     assert result["payload_summary"]["toolTurnState"] == "completed"
     assert result["payload_summary"]["loopStopReason"] == "tool_turn_completed"
     assert result["payload_summary"]["commandRunId"] == "run-stage2i-deepseek"
+    assert result["payload_summary"]["toolExposure"] == {
+        "automatic": True,
+        "advertisedToolCount": 1,
+        "advertisedToolCommandIds": [HEALTH_COMMAND_ID],
+        "providerDispatchToolCount": 1,
+        "providerDispatchToolCommandIds": [HEALTH_COMMAND_ID],
+        "commandIdsTruncated": False,
+    }
 
 
 def test_advertised_deepseek_health_capability_does_not_force_tool_use(
@@ -495,6 +503,270 @@ def test_advertised_deepseek_health_capability_does_not_force_tool_use(
     assert executions == []
     assert result["assistant_text"] == "No health check needed."
     assert result["payload_summary"]["toolTurnState"] == "idle"
+    assert result["payload_summary"]["loopStopReason"] == "plain_answer"
+    assert result["payload_summary"]["commandRunId"] is None
+    assert result["payload_summary"]["toolExposure"] == {
+        "automatic": True,
+        "advertisedToolCount": 1,
+        "advertisedToolCommandIds": [HEALTH_COMMAND_ID],
+        "providerDispatchToolCount": 1,
+        "providerDispatchToolCommandIds": [HEALTH_COMMAND_ID],
+        "commandIdsTruncated": False,
+    }
+
+
+def test_prepare_chat_tool_exposure_resolves_automatic_deepseek_health(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = _task(provider="deepseek", model="deepseek-v4-flash")
+    health_tool = {
+        "command_id": HEALTH_COMMAND_ID,
+        "description": "Read health.",
+        "input_schema": {"type": "object"},
+    }
+    resolver_calls: list[dict[str, Any]] = []
+
+    def _resolve(**kwargs: Any) -> list[dict[str, Any]]:
+        resolver_calls.append(kwargs)
+        return [health_tool]
+
+    monkeypatch.setattr(
+        chat_completion_service,
+        "_resolve_ordinary_chat_tools",
+        _resolve,
+    )
+
+    evidence = chat_completion_service._prepare_chat_tool_exposure(
+        task,
+        provider="deepseek",
+        model="deepseek-v4-flash",
+        settings=SimpleNamespace(),
+    )
+
+    assert len(resolver_calls) == 1
+    assert resolver_calls[0]["provider"] == "deepseek"
+    assert resolver_calls[0]["model"] == "deepseek-v4-flash"
+    assert task.tools == [health_tool]
+    assert evidence == {
+        "automatic": True,
+        "advertisedToolCount": 1,
+        "advertisedToolCommandIds": [HEALTH_COMMAND_ID],
+        "providerDispatchToolCount": 0,
+        "providerDispatchToolCommandIds": [],
+        "commandIdsTruncated": False,
+    }
+
+
+def test_prepare_chat_tool_exposure_preserves_explicit_empty_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = _task(provider="deepseek", model="deepseek-v4-flash")
+    task.tools = []
+    monkeypatch.setattr(
+        chat_completion_service,
+        "_resolve_ordinary_chat_tools",
+        lambda **_kwargs: pytest.fail("explicit tools must not be resolved"),
+    )
+
+    evidence = chat_completion_service._prepare_chat_tool_exposure(
+        task,
+        provider="deepseek",
+        model="deepseek-v4-flash",
+        settings=SimpleNamespace(),
+    )
+
+    assert task.tools == []
+    assert evidence["automatic"] is False
+    assert evidence["advertisedToolCount"] == 0
+    assert evidence["advertisedToolCommandIds"] == []
+
+
+def test_prepare_chat_tool_exposure_preserves_explicit_nonempty_subset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = _task(provider="deepseek", model="deepseek-v4-flash")
+    explicit_tools = [{"command_id": "op::caller_selected"}]
+    task.tools = explicit_tools
+    monkeypatch.setattr(
+        chat_completion_service,
+        "_resolve_ordinary_chat_tools",
+        lambda **_kwargs: pytest.fail("explicit tools must not be resolved"),
+    )
+
+    evidence = chat_completion_service._prepare_chat_tool_exposure(
+        task,
+        provider="deepseek",
+        model="deepseek-v4-flash",
+        settings=SimpleNamespace(),
+    )
+
+    assert task.tools is explicit_tools
+    assert evidence["automatic"] is False
+    assert evidence["advertisedToolCount"] == 1
+    assert evidence["advertisedToolCommandIds"] == ["op::caller_selected"]
+
+
+def test_prepare_chat_tool_exposure_records_automatic_ineligible_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = _task(provider="groq", model="unqualified-model")
+    resolver_calls: list[dict[str, Any]] = []
+
+    def _resolve(**kwargs: Any) -> None:
+        resolver_calls.append(kwargs)
+        return None
+
+    monkeypatch.setattr(
+        chat_completion_service,
+        "_resolve_ordinary_chat_tools",
+        _resolve,
+    )
+
+    evidence = chat_completion_service._prepare_chat_tool_exposure(
+        task,
+        provider="groq",
+        model="unqualified-model",
+        settings=SimpleNamespace(),
+    )
+
+    assert len(resolver_calls) == 1
+    assert task.tools is None
+    assert evidence["automatic"] is True
+    assert evidence["advertisedToolCount"] == 0
+    assert evidence["advertisedToolCommandIds"] == []
+
+
+def test_explicit_empty_tools_remain_empty_and_are_observed_as_nonautomatic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_completion(
+        monkeypatch,
+        provider="deepseek",
+        model="deepseek-model",
+        settings=SimpleNamespace(LOCAL_PROVIDER_VENDOR=None),
+    )
+    task = _task(provider="deepseek", model="deepseek-model")
+    task.tools = []
+    provider_tools: list[Any] = []
+    executions: list[Any] = []
+    monkeypatch.setattr(
+        chat_completion_service,
+        "execute_invoke",
+        lambda *, payload, **_kwargs: executions.append(payload),
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "chat_with_ai",
+        lambda *_args, **kwargs: (
+            provider_tools.append(kwargs.get("tools"))
+            or DeepSeekResponse(
+                content="Plain answer.",
+                reasoning_content=None,
+                tool_calls=[],
+                raw_assistant_message={"role": "assistant", "content": "Plain answer."},
+                raw_payload={},
+            )
+        ),
+    )
+
+    result = chat_completion_service.run_chat_completion_task(
+        task, persist_assistant_message=False
+    )
+
+    assert task.tools == []
+    assert provider_tools == [[]]
+    assert executions == []
+    assert result["payload_summary"]["toolExposure"] == {
+        "automatic": False,
+        "advertisedToolCount": 0,
+        "advertisedToolCommandIds": [],
+        "providerDispatchToolCount": 0,
+        "providerDispatchToolCommandIds": [],
+        "commandIdsTruncated": False,
+    }
+
+
+def test_automatic_unsupported_provider_records_no_exposure_or_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_completion(
+        monkeypatch,
+        provider="groq",
+        model="unsupported-model",
+        settings=SimpleNamespace(LOCAL_PROVIDER_VENDOR=None),
+    )
+    task = _task(provider="groq", model="unsupported-model")
+    provider_tools: list[Any] = []
+    monkeypatch.setattr(
+        chat_completion_service,
+        "chat_with_ai",
+        lambda *_args, **kwargs: provider_tools.append(kwargs.get("tools"))
+        or "Plain answer.",
+    )
+
+    result = chat_completion_service.run_chat_completion_task(
+        task, persist_assistant_message=False
+    )
+
+    assert task.tools is None
+    assert provider_tools == [None]
+    assert result["payload_summary"]["toolExposure"] == {
+        "automatic": True,
+        "advertisedToolCount": 0,
+        "advertisedToolCommandIds": [],
+        "providerDispatchToolCount": 0,
+        "providerDispatchToolCommandIds": [],
+        "commandIdsTruncated": False,
+    }
+
+
+def test_tool_exposure_evidence_is_bounded_and_contains_no_tool_payloads() -> None:
+    tools = [
+        {
+            "command_id": f"op::read_{index:02d}",
+            "description": "private description",
+            "input_schema": {"type": "object", "properties": {"secret": {}}},
+            "arguments": {"secret": "do-not-record"},
+            "messages": ["do-not-record"],
+        }
+        for index in range(17)
+    ]
+    evidence = chat_completion_service._build_tool_exposure_evidence(
+        automatic=True,
+        tools=tools,
+    )
+    chat_completion_service._record_provider_dispatch_tool_exposure(
+        evidence,
+        tools=tools,
+    )
+    payload = chat_completion_service._tool_exposure_payload(evidence)
+
+    assert payload["advertisedToolCount"] == 17
+    assert payload["providerDispatchToolCount"] == 17
+    assert len(payload["advertisedToolCommandIds"]) == 16
+    assert len(payload["providerDispatchToolCommandIds"]) == 16
+    assert payload["commandIdsTruncated"] is True
+    assert set(payload) == {
+        "automatic",
+        "advertisedToolCount",
+        "advertisedToolCommandIds",
+        "providerDispatchToolCount",
+        "providerDispatchToolCommandIds",
+        "commandIdsTruncated",
+    }
+    rendered = repr(payload)
+    for forbidden in (
+        "description",
+        "input_schema",
+        "parameters",
+        "arguments",
+        "messages",
+        "payload",
+        "credential",
+        "reasoning_content",
+        "do-not-record",
+    ):
+        assert forbidden not in rendered
 
 
 def test_eligible_whooshd_executes_once_and_stale_response_identity_blocks(

--- a/tests/core/test_completion_terminal_integrity.py
+++ b/tests/core/test_completion_terminal_integrity.py
@@ -294,6 +294,14 @@ def test_tool_loop_obeys_terminal_gate(monkeypatch):
             bundle={},
             trace={},
             base_payload_summary={},
+            tool_exposure={
+                "automatic": False,
+                "advertisedToolCount": 0,
+                "advertisedToolCommandIds": [],
+                "providerDispatchToolCount": 0,
+                "providerDispatchToolCommandIds": [],
+                "commandIdsTruncated": False,
+            },
         )
 
 


### PR DESCRIPTION
## Stage 2J mainline integration

- Integration base: `237d5e2d5a0c17ca2b369e364a35c6598d2287d2` (`origin/main` at integration start)
- M1 implementation source: `8248f8a125394bfda18b07d8f0fb31e8b8c0fb4d`
- M1P live proof: `b9d3471bebd15f15c2a1645c4dd56d14a4683b0d` (`LIVE_TOOL_TURN_COMPLETED`)
- Integration commit: `8fe5a4d8c9a0aedcc14b25c70074becb246e059e`

This is a semantic transplant, not a historical-branch merge. It integrates exactly six paths: the accepted M1 implementation/test delta plus the M1P live-closure receipt.

The three governed runtime files remain byte-identical to the live-proven M1 tuple. No new capability, authority, provider, schema, runtime configuration, or release semantics is introduced. No provider inference was executed during M2.

Validation passed:

- `60 passed` — exposure, worker, and terminal suites
- `72 passed` — completion loop, router, DeepSeek, and transport convergence suites
- `17 passed` — request correlation
- Python compilation, docs validation, diagram freshness, and diff checks

The completed M1P proof established automatic exposure, native DeepSeek selection, advertised-subset admission, exactly one read-only health Command Bus invocation, reinjection, same-provider continuation, persistence, completed observability, and no retry/fallback/write/second command.
