### PR TITLE
Fix post-merge CI checkout failures

### DIFF
--- a/.github/workflows/architecture-contracts.yml
+++ b/.github/workflows/architecture-contracts.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           lfs: true
 
       - name: Verify tracked paths are valid

--- a/.gitignore
+++ b/.gitignore
@@ -209,6 +209,9 @@ chatgpt-conversation.json
 .codex/
 .codexify/coding-artifacts/
 
+# Local Git worktrees
+.worktrees/
+
 # Local/vendor checkouts
 MiniMax-MCP-main/
 


### PR DESCRIPTION
## Summary

Repairs the two CI failures exposed after PR #692 merged.

## Changes

- Remove the accidentally tracked `.worktrees/render-relay-codexify` gitlink. It had no matching `.gitmodules` URL, which caused `actions/checkout` to fail while running its internal recursive submodule cleanup.
- Ignore `.worktrees/` so local Git worktrees cannot be staged again accidentally.
- Set `fetch-depth: 0` for Architecture Contracts. Those tests resolve historical commits and baseline blobs, so the default shallow checkout (`fetch-depth: 1`) cannot satisfy their contract.

## Why not the suggested workflow cleanup workaround?

The Campaign Control Plane checkout fails inside the `actions/checkout` step itself, before a following cleanup step could execute. Removing the invalid gitlink is the root fix.

## Validation basis

- Job `94148945989`: checkout logs report `No url found for submodule path '.worktrees/render-relay-codexify' in .gitmodules`.
- Architecture Contracts job `94148938799`: test failures report `freshness_anchor_history_unavailable`, `verified_commit_unknown`, and inability to resolve historical blob `236798ba...:docs/knowledge-graph/generated/document-graph.json` under the shallow clone.

No application/runtime behavior is changed.