### PR TITLE
Integrate project repository authority

### DIFF
--- a/docs/architecture/proofs/2026-08-12-stage2k1-repository-binding-authority-proof.md
+++ b/docs/architecture/proofs/2026-08-12-stage2k1-repository-binding-authority-proof.md
@@ -1,0 +1,277 @@
+# Stage 2K.1 RepositoryBinding Authority Proof
+
+## Date
+
+2026-08-12
+
+## Verdict
+
+`PROVEN-TEST` — Stage 2K.1 establishes the scoped storage and internal
+authority layer only. It does not establish a repository discovery, import,
+chat, provider, or supported-runtime capability.
+
+## Diagnostic Outcome
+
+`STAGE2K1_COMPLETED`
+
+## Original Stage 2K-R1 Commit
+
+`ca861c47411c8571aff86125ae52526ecdb4d6f9`
+
+## Stage 2K-R1 Replay Commit
+
+`61ea03c52c75785c7269575ce87cafd67542612a`
+
+## Branch/Worktree
+
+- Branch: `codex/stage2k1-repository-binding-authority`
+- Worktree: `/private/tmp/codexify-stage2k1-repository-binding-authority`
+
+## Remote Main at Start
+
+`origin/main` resolved to
+`a36a8286e0cd7ca7ac035bd1273b38c804bc6317`, the issuance SHA. The Stage
+2K-R1 replay commit has that revision as its merge base.
+
+## Remote Main Reconciliation
+
+`git fetch origin` completed before implementation continuation. `origin/main`
+remained at the issuance SHA, with no later relevant authority or storage
+boundary change to reconcile. ADR-065 and the repository-onboarding authority
+contract are present through the accepted R1 replay rather than a remote-main
+advancement.
+
+## Governing ADRs
+
+- ADR-065, Guardian-Managed Repository Onboarding Boundary — primary.
+- ADR-061, Capability-Oriented Mesh Architecture — binding storage is not
+  capability advertisement or execution authority.
+- ADR-005, account scoping and user isolation.
+- ADR-020 and ADR-024, Guardian-issued filesystem scope and the distinction
+  between connected source evidence and authorized access.
+
+## ADR Impact
+
+`Aligned with existing ADR(s)`. No ADR was changed. The implementation adds
+the accepted, internal `Account -> Project -> RepositoryBinding -> working-tree
+root` resolution seam without widening any capability or release claim.
+
+## Current Truth Before
+
+- Projects were durable Postgres records with canonical account ownership.
+- No durable `RepositoryBinding` table or Project repository authority existed.
+- `WorkspaceRootManager.detect_project_root()` and worktree/env paths were
+  convenience or campaign machinery, not Project authority.
+- `General` was a default Project only, without implicit filesystem authority.
+- No repository scanner, import/link route, `repository.search`, ordinary-chat
+  repository capability, or model filesystem authority existed.
+
+## Pre-Task Alembic Head
+
+`c1a2b3c4d5e6`
+
+## Ancestral Continuity Revision Confirmation
+
+`e8d1f2a3b4c5` was verified ancestral to the new head. It is not a second
+parent of the Stage 2K.1 migration.
+
+## RepositoryBinding Migration Revision
+
+`6e2b9c4a7d1f`
+
+## RepositoryBinding Down Revision
+
+`c1a2b3c4d5e6`
+
+## Post-Task Alembic Head
+
+`6e2b9c4a7d1f` is the sole Alembic head.
+
+## Migration Graph Regression Update
+
+The existing uniqueness/lineage regression retains all historical assertions,
+adds the RepositoryBinding direct-parent assertion, and advances the sole-head
+assertion from `c1a2b3c4d5e6` to `6e2b9c4a7d1f`. No historical migration was
+rewritten and no merge migration was created.
+
+## Guardian Projects Directory Configuration
+
+`guardian.core.config.Settings` now declares exactly the canonical
+`CODEXIFY_GUARDIAN_PROJECTS_DIR` operator/instance setting. It has no
+compatibility aliases and Settings import creates no directory.
+
+## Guardian Projects Directory Default Resolution
+
+An unset or blank setting resolves to no managed root and callers that need a
+managed root fail closed. The resolver requires an explicitly configured
+absolute path, expands and canonicalizes it, rejects a file, and only creates
+the directory when an authority-side caller explicitly requests creation. It
+does not derive a root from cwd, `DATA_STORAGE_PATH`, the application checkout,
+home, or a container default.
+
+## RepositoryBinding Schema
+
+The `repository_bindings` table stores an opaque binding ID, non-null
+`project_id` with `ON DELETE CASCADE`, constrained `source_class`, canonical
+absolute root, active flag, bounded JSONB provenance, and timestamps. It has a
+Postgres partial unique index on `project_id WHERE is_active IS TRUE`; inactive
+history may coexist. The migration has no backfill or Project mutation.
+
+## Project Ownership Resolution
+
+Internal creation and resolution load the Project, compare its canonical
+`user_id` with the authenticated account, and fail closed on a missing Project
+or ownership mismatch. The caller transaction is flushed but never committed
+by binding creation.
+
+## Managed Root Containment
+
+`guardian_managed` working-tree roots must be canonical children of the
+configured Guardian Projects Directory. Equal-to-root, traversal, and symlink
+escape cases fail closed. Managed child paths derive only from immutable Project
+IDs; names do not participate in filesystem identity.
+
+## External Linked Root Behavior
+
+`external_linked` bindings may validate a canonical Git working-tree root
+outside the Guardian Projects Directory. They remain account/Project scoped and
+must still be explicitly active bindings.
+
+## Git Working-Tree Validation
+
+Validation canonicalizes the requested path, requires an existing directory,
+and runs only argv-based `git -C <root> rev-parse --show-toplevel` with
+`GIT_OPTIONAL_LOCKS=0` and a bounded timeout. It accepts standard checkouts and
+valid linked worktrees, while rejecting missing paths, non-Git directories,
+stale worktrees, and nested subdirectories whose Git top level differs from the
+requested root.
+
+## Active Binding Cardinality
+
+Creation rejects a Project with an existing active binding. The database partial
+unique index independently enforces at most one active binding per Project.
+
+## Missing Binding Failure
+
+Repository-less Projects, including `General`, remain valid. Resolution fails
+closed when no active binding exists.
+
+## Ambiguous Binding Failure
+
+The resolver rejects more than one active binding instead of selecting one.
+The database prevents this state through its partial unique index; resolver
+coverage preserves the fail-closed behavior for inconsistent historical or
+manually corrupted data.
+
+## Invalid/Stale Root Failure
+
+Resolution fails closed when a stored path is absent, no longer an exact Git
+working-tree root, no longer canonical, or escapes the managed root for its
+source class.
+
+## Explicit No-Fallback Proof
+
+The authority module contains no `detect_project_root()` or
+`WorkspaceRootManager` use and does not read
+`CODEXIFY_WORKTREE_REPO_PATH`. Unit coverage proves no cwd fallback and a
+relative configured directory is rejected rather than cwd-resolved.
+
+## General Project Behavior
+
+No migration or helper creates a binding for an existing Project or `General`.
+Unit coverage confirms a Project named `General` has no implicit authority.
+
+## Unit Test Results
+
+`pytest -v tests/core/test_repository_authority.py` — `32 passed`.
+
+The suite uses temporary Git repositories and linked worktrees, never the
+Codexify checkout as test authority. It covers deterministic directory
+resolution, identity-derived managed paths, symlink/traversal escape, exact Git
+root validation, ownership, source classes, active/inactive/ambiguous binding
+states, no-fallback assertions, bounded provenance, and no implicit commit.
+
+## Migration Round-Trip Results
+
+`TEST_DATABASE_URL=... pytest -v tests/migration/test_repository_bindings_migration.py`
+— `1 passed` against a newly started disposable Postgres 15 container and a
+uniquely named temporary database. The test upgraded from
+`c1a2b3c4d5e6`, proved the new table absent at baseline, preserved an existing
+User/Project, upgraded to `6e2b9c4a7d1f`, verified columns/FK/check/partial
+index/no backfill, exercised active and inactive cardinality behavior,
+downgraded to baseline, and upgraded to head again.
+
+## Existing Project Preservation
+
+The round-trip test records the pre-existing Project fields before upgrade,
+proves no binding was auto-created, verifies the Project unchanged after
+upgrade and after downgrade, and then re-upgrades the schema.
+
+## Alembic Graph Test Results
+
+`pytest -v tests/migration/test_alembic_revision_uniqueness.py` — `1 passed`.
+
+`python -m alembic -c backend/alembic.ini heads` reported only
+`6e2b9c4a7d1f (head)`.
+
+## Architecture Test Results
+
+`pytest -v tests/architecture` — `394 passed`.
+
+Scoped Project regressions also passed:
+
+`pytest -v tests/core/test_repository_authority.py tests/migration/test_alembic_revision_uniqueness.py tests/routes/test_projects_routes.py tests/routes/test_projects_account_scope.py tests/routes/test_route_user_scoping_invariant.py`
+— `59 passed`.
+
+## Docs Validation
+
+`python3 scripts/validate_docs.py` — passed.
+
+`make docs PYTHON=python3` — passed, including the diagram-freshness check.
+
+## What Was Proven
+
+- Durable, account-scoped Project-to-working-tree binding storage exists with
+  a single active-binding invariant.
+- Guardian-managed and external-linked source classes remain distinct.
+- Internal creation and resolution fail closed across ownership, cardinality,
+  path containment, and exact Git-root validation boundaries.
+- The migration upgrades and downgrades an existing Project database without
+  adding a binding or altering that Project.
+- The Alembic graph remains single-headed at the expected revision.
+
+## What Was Not Proven
+
+- No external repository scanner exists.
+- No coding-agent discovery exists.
+- No automatic import/link flow exists.
+- No repository files are moved, copied, cloned, initialized, or deleted.
+- No Project creation route creates repositories.
+- No `repository.search` command exists.
+- No ordinary-chat repository capability exists.
+- No model receives filesystem authority.
+- No provider inference occurred.
+- No supported runtime was restarted.
+
+## Documentation Follow-Through
+
+This receipt is the authorized documentation follow-through. ADR-065, the ADR
+index, repository-onboarding contract, `00-current-state.md`, and
+`data-and-storage.md` were intentionally not modified.
+
+## Final File Scope
+
+- `guardian/core/config.py`
+- `guardian/core/repository_authority.py`
+- `guardian/db/models.py`
+- `guardian/db/migrations/versions/6e2b9c4a7d1f_add_repository_bindings.py`
+- `tests/core/test_repository_authority.py`
+- `tests/migration/test_repository_bindings_migration.py`
+- `tests/migration/test_alembic_revision_uniqueness.py`
+- `docs/architecture/proofs/2026-08-12-stage2k1-repository-binding-authority-proof.md`
+
+## Commit
+
+Implementation commit: `6101fc0ef` (`Establish Project repository binding authority`).
+The proof receipt is committed separately after its final documentation
+validation.

--- a/guardian/core/config.py
+++ b/guardian/core/config.py
@@ -476,6 +476,18 @@ class Settings(BaseSettings):
         default=None,
         description="Primary Postgres connection URL for Guardian chatlog DB.",
     )
+    CODEXIFY_GUARDIAN_PROJECTS_DIR: str | None = Field(
+        default=None,
+        description=(
+            "Stage 2K.1 (ADR-065): explicit operator/instance setting for the "
+            "Guardian Projects Directory that hosts guardian_managed "
+            "RepositoryBindings. When unset, repository-backed Project "
+            "creation is unavailable with needs_configuration; no cwd, source "
+            "checkout, home, or container fallback is permitted. Canonical "
+            "filesystem resolution occurs in repository_authority.py and does "
+            "not create directories at Settings import time."
+        ),
+    )
     DATA_STORAGE_PATH: str = Field(
         default="./data", description="Path for MemoryOS data storage."
     )

--- a/guardian/core/repository_authority.py
+++ b/guardian/core/repository_authority.py
@@ -1,0 +1,674 @@
+"""Project-to-RepositoryBinding authority (Stage 2K.1 / ADR-065).
+
+Guardian-owned durable Project-to-Git-working-tree authority. Repository
+authority is derived, never model-supplied. Guardian Projects Directory is
+configuration-owned. There is no cwd fallback, no nearest ``.git``
+fallback, no ``CODEXIFY_WORKTREE_REPO_PATH`` fallback, no worktree
+query-path authority, no application-checkout fallback, and no startup
+filesystem scan.
+
+This module deliberately exposes authority-side types only. It is NOT a
+chat/tool/provider payload. Future capability advertisement (Stage 2K.5)
+and repository.search (Stage 2K.4) consume its typed results; they do not
+receive raw absolute roots or mounts.
+
+ADR-065 invariants enforced here:
+
+- Repository authority is Guardian-derived, never model-supplied.
+- Guardian Projects Directory is configuration-owned.
+- One Project has at most one active RepositoryBinding.
+- Repository-less Projects remain valid.
+- ``General`` receives no implicit RepositoryBinding.
+- Project display names are not filesystem identity.
+- Absolute repository roots remain authority-side data.
+- ``guardian_managed`` roots remain beneath Guardian Projects Directory.
+- ``external_linked`` roots may remain outside Guardian Projects Directory.
+- symlink/path escape fails closed.
+- missing roots fail closed.
+- non-Git roots fail closed.
+- nested subdirectories are not silently promoted to repository roots.
+- ambiguous bindings fail closed.
+- account/Project ownership mismatch fails closed.
+- inactive bindings grant no authority.
+- ``discovery_candidate`` is not binding authority.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from guardian.core.config import Settings, get_settings
+from guardian.db.models import (
+    Project,
+    REPOSITORY_BINDING_SOURCE_CLASS_EXTERNAL_LINKED,
+    REPOSITORY_BINDING_SOURCE_CLASS_GUARDIAN_MANAGED,
+    RepositoryBinding,
+)
+
+# Canonical configuration key per ADR-065. Unset → fail closed.
+GUARDIAN_PROJECTS_DIR_CONFIG_KEY = "CODEXIFY_GUARDIAN_PROJECTS_DIR"
+
+# Source-class vocabulary (ADR-065). ``discovery_candidate`` is intentionally
+# absent — it is not an active RepositoryBinding source class.
+SOURCE_CLASS_GUARDIAN_MANAGED = REPOSITORY_BINDING_SOURCE_CLASS_GUARDIAN_MANAGED
+SOURCE_CLASS_EXTERNAL_LINKED = REPOSITORY_BINDING_SOURCE_CLASS_EXTERNAL_LINKED
+BINDING_SOURCE_CLASSES: tuple[str, ...] = (
+    SOURCE_CLASS_GUARDIAN_MANAGED,
+    SOURCE_CLASS_EXTERNAL_LINKED,
+)
+DISCOVERY_CANDIDATE_CLASS = "discovery_candidate"
+
+# Bounded subprocess budget for the read-only git top-level probe.
+DEFAULT_GIT_VALIDATION_TIMEOUT_SECONDS = 15.0
+
+# RepositoryBinding provenance is evidence only. Keep this first storage
+# slice intentionally narrow so it cannot become a side channel for secrets,
+# prompts, repository contents, or discovery output.
+PROVENANCE_ALLOWED_KEYS = frozenset(
+    {
+        "registration_source",
+        "operation_class",
+        "authority_context",
+    }
+)
+PROVENANCE_MAX_CONTEXT_ITEMS = 8
+PROVENANCE_MAX_KEY_LENGTH = 64
+PROVENANCE_MAX_VALUE_LENGTH = 256
+PROVENANCE_MAX_SERIALIZED_BYTES = 2048
+
+
+class RepositoryAuthorityError(Exception):
+    """Base class for Stage 2K.1 authority failures."""
+
+
+class GuardianProjectsDirectoryUnconfigured(RepositoryAuthorityError):
+    """``CODEXIFY_GUARDIAN_PROJECTS_DIR`` is unset or empty."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "CODEXIFY_GUARDIAN_PROJECTS_DIR is not configured; "
+            "repository-backed Project authority is unavailable."
+        )
+
+
+class GuardianProjectsDirectoryNotDirectory(RepositoryAuthorityError):
+    """The configured root exists but is not a directory."""
+
+
+class GuardianProjectsDirectoryNotAbsolute(RepositoryAuthorityError):
+    """The configured Guardian Projects Directory is relative."""
+
+
+class GuardianProjectsDirectoryOutsideAllowedRoot(
+    RepositoryAuthorityError
+):
+    """A managed-root candidate is not contained beneath the configured root."""
+
+
+class ManagedRootSymlinkEscape(RepositoryAuthorityError):
+    """A managed-root candidate escapes via symlink or traversal."""
+
+
+class GitValidationError(RepositoryAuthorityError):
+    """The read-only git working-tree probe failed."""
+
+
+class InvalidRepositoryRoot(GitValidationError):
+    """The candidate path is not an exact Git working-tree root."""
+
+
+class NestedRepositoryRejected(InvalidRepositoryRoot):
+    """The candidate path is a subdirectory inside an existing Git root."""
+
+
+class AccountProjectMismatch(RepositoryAuthorityError):
+    """The authenticated account does not own the requested Project."""
+
+
+class ProjectNotFound(RepositoryAuthorityError):
+    """The requested Project does not exist."""
+
+
+class UnsupportedSourceClass(RepositoryAuthorityError):
+    """The proposed source class is not a binding-eligible class."""
+
+
+class ActiveBindingAlreadyExists(RepositoryAuthorityError):
+    """The Project already has an active RepositoryBinding."""
+
+
+class BindingResolutionFailed(RepositoryAuthorityError):
+    """No single active RepositoryBinding could be resolved for the Project."""
+
+
+class InvalidRepositoryBindingProvenance(RepositoryAuthorityError):
+    """Binding provenance exceeds the narrow authority-side evidence contract."""
+
+
+@dataclass(frozen=True)
+class ResolvedRepositoryBinding:
+    """Authority-side result type. Not a chat/tool/provider payload."""
+
+    binding_id: str
+    project_id: int
+    source_class: str
+    canonical_root: Path
+
+    def __post_init__(self) -> None:
+        if not self.binding_id:
+            raise ValueError("binding_id is required")
+        if self.source_class not in BINDING_SOURCE_CLASSES:
+            raise ValueError(
+                f"source_class must be one of {BINDING_SOURCE_CLASSES!r}"
+            )
+        if not isinstance(self.canonical_root, Path):
+            raise ValueError("canonical_root must be a Path")
+
+
+def _resolve_symlink_aware(path: Path) -> Path:
+    """Resolve ``path`` strictly and return an absolute Path.
+
+    Falls back to ``Path.resolve(strict=False)`` when ``strict=True`` raises
+    ``FileNotFoundError``. The loose path is still normalized and symlinks
+    above existing components are resolved.
+    """
+    try:
+        return path.resolve(strict=True)
+    except (FileNotFoundError, RuntimeError):
+        return path.resolve(strict=False)
+
+
+def _read_configured_projects_dir(
+    settings: Settings | None,
+) -> str | None:
+    if settings is None:
+        settings = get_settings()
+    raw = getattr(settings, GUARDIAN_PROJECTS_DIR_CONFIG_KEY, None)
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    if not text:
+        return None
+    return text
+
+
+def resolve_guardian_projects_directory(
+    *,
+    settings: Settings | None = None,
+    create: bool = False,
+) -> Path | None:
+    """Resolve the canonical Guardian Projects Directory path.
+
+    Returns the absolute, symlink-resolved path. Returns ``None`` when the
+    operator/instance key ``CODEXIFY_GUARDIAN_PROJECTS_DIR`` is unset.
+
+    - Never falls back to ``Path.cwd()``, ``~``, ``./data``, the source
+      checkout, or any container path.
+    - Does not detect ``.git`` or scan the filesystem.
+    - Does not create the directory unless ``create=True`` is explicitly
+      passed by an authority-side caller.
+    - Rejects the configured path when it exists as a non-directory file.
+    """
+    configured = _read_configured_projects_dir(settings)
+    if configured is None:
+        return None
+
+    expanded = Path(configured).expanduser()
+    if not expanded.is_absolute():
+        raise GuardianProjectsDirectoryNotAbsolute(
+            "CODEXIFY_GUARDIAN_PROJECTS_DIR must be an absolute host path."
+        )
+    try:
+        canonical = expanded.resolve(strict=False)
+    except RuntimeError as exc:  # pragma: no cover - symlink loop edge
+        raise GuardianProjectsDirectoryUnconfigured() from exc
+
+    if not canonical.exists():
+        if not create:
+            return canonical
+        canonical.mkdir(parents=True, exist_ok=False)
+        return _resolve_symlink_aware(canonical)
+
+    canonical = _resolve_symlink_aware(canonical)
+    if not canonical.is_dir():
+        raise GuardianProjectsDirectoryNotDirectory(
+            f"Guardian Projects Directory {canonical!s} exists but is not a "
+            "directory."
+        )
+    return canonical
+
+
+def guardian_managed_project_path(
+    project_id: int,
+    *,
+    settings: Settings | None = None,
+    managed_root: Path | None = None,
+    create_root: bool = False,
+    create_child: bool = False,
+) -> Path:
+    """Return the canonical on-disk path for a guardian_managed binding.
+
+    The path is derived from a stable opaque Project ID, never from a
+    mutable Project display name. The returned path is guaranteed to be
+    beneath the resolved Guardian Projects Directory. Traversal and
+    symlink escape fail closed. The directory is not created unless
+    ``create_child=True`` is passed by an authority-side caller.
+    """
+    if not isinstance(project_id, int) or project_id <= 0:
+        raise ValueError("project_id must be a positive integer")
+
+    if managed_root is None:
+        managed_root = resolve_guardian_projects_directory(
+            settings=settings, create=create_root
+        )
+    if managed_root is None:
+        raise GuardianProjectsDirectoryUnconfigured()
+    managed_root = managed_root.expanduser()
+    if not managed_root.is_absolute():
+        raise GuardianProjectsDirectoryNotAbsolute(
+            "Guardian Projects Directory must be an absolute host path."
+        )
+    if not managed_root.exists():
+        if create_root:
+            managed_root.mkdir(parents=True, exist_ok=False)
+        else:
+            raise GuardianProjectsDirectoryNotDirectory(
+                f"Guardian Projects Directory {managed_root!s} does not exist."
+            )
+    canonical_root = _resolve_symlink_aware(managed_root)
+    if not canonical_root.is_dir():
+        raise GuardianProjectsDirectoryNotDirectory(
+            f"Guardian Projects Directory {canonical_root!s} exists but "
+            "is not a directory."
+        )
+
+    child = canonical_root / str(project_id)
+    canonical_child = _resolve_symlink_aware(child)
+
+    try:
+        canonical_child.relative_to(canonical_root)
+    except ValueError as exc:
+        raise ManagedRootSymlinkEscape(
+            f"Managed child {canonical_child!s} escapes {canonical_root!s}"
+        ) from exc
+
+    if canonical_child.exists() or canonical_child.is_symlink():
+        if canonical_child.is_symlink():
+            target = canonical_child.resolve(strict=False)
+            try:
+                target.relative_to(canonical_root)
+            except ValueError as exc:
+                raise ManagedRootSymlinkEscape(
+                    f"Managed child {canonical_child!s} symlink-escapes to "
+                    f"{target!s}"
+                ) from exc
+        if not canonical_child.is_dir():
+            raise GuardianProjectsDirectoryNotDirectory(
+                f"Managed child {canonical_child!s} exists but is not a "
+                "directory."
+            )
+    elif create_child:
+        canonical_child.mkdir(parents=True, exist_ok=False)
+        canonical_child = _resolve_symlink_aware(canonical_child)
+
+    return canonical_child
+
+
+def validate_git_working_tree_root(
+    candidate: Path | str,
+    *,
+    timeout_seconds: float = DEFAULT_GIT_VALIDATION_TIMEOUT_SECONDS,
+    git_binary: str | None = None,
+) -> Path:
+    """Return the canonical Git top-level for ``candidate`` or fail closed.
+
+    Executes only ``git -C <root> rev-parse --show-toplevel`` with argv-only
+    invocation (no ``shell=True``) and ``GIT_OPTIONAL_LOCKS=0``. The
+    returned path must equal the requested canonical root exactly. Nested
+    subdirectories of a Git worktree are rejected because the canonical
+    root returned by git would not match the requested path.
+    """
+    if isinstance(candidate, str):
+        candidate_path = Path(candidate)
+    else:
+        candidate_path = candidate
+
+    if not candidate_path.exists():
+        raise InvalidRepositoryRoot(
+            f"Repository root {candidate_path!s} does not exist."
+        )
+    if not candidate_path.is_dir():
+        raise InvalidRepositoryRoot(
+            f"Repository root {candidate_path!s} is not a directory."
+        )
+
+    canonical_requested = _resolve_symlink_aware(candidate_path)
+
+    binary = git_binary or shutil.which("git") or "git"
+    env = os.environ.copy()
+    env["GIT_OPTIONAL_LOCKS"] = "0"
+
+    try:
+        completed = subprocess.run(
+            [binary, "-C", str(canonical_requested), "rev-parse",
+             "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+            env=env,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise GitValidationError(
+            f"git rev-parse timed out after {timeout_seconds}s for "
+            f"{canonical_requested!s}"
+        ) from exc
+    except OSError as exc:
+        raise GitValidationError(
+            f"git invocation failed for {canonical_requested!s}: {exc}"
+        ) from exc
+
+    if completed.returncode != 0:
+        stderr = (completed.stderr or "").strip()
+        raise InvalidRepositoryRoot(
+            f"git rev-parse failed for {canonical_requested!s} "
+            f"(rc={completed.returncode}): {stderr[:300]}"
+        )
+
+    stdout = (completed.stdout or "").strip()
+    if not stdout:
+        raise InvalidRepositoryRoot(
+            f"git rev-parse returned empty stdout for "
+            f"{canonical_requested!s}"
+        )
+
+    git_root = Path(stdout.splitlines()[-1].strip())
+    canonical_git_root = _resolve_symlink_aware(git_root)
+
+    if canonical_git_root != canonical_requested:
+        # When ``canonical_requested`` is beneath ``canonical_git_root`` the
+        # caller asked for a subdirectory of an existing Git root, which is
+        # exactly the nested-repository case that must fail closed.
+        try:
+            canonical_requested.relative_to(canonical_git_root)
+        except ValueError:
+            # Not nested — but still not an exact match. Treat as invalid.
+            raise InvalidRepositoryRoot(
+                f"Git top-level {canonical_git_root!s} does not match "
+                f"requested root {canonical_requested!s}"
+            ) from None
+        raise NestedRepositoryRejected(
+            f"Nested repository subdirectory rejected: "
+            f"requested {canonical_requested!s} lies inside Git root "
+            f"{canonical_git_root!s}"
+        )
+
+    return canonical_git_root
+
+
+def _coerce_provenance(
+    provenance: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Normalize a bounded provenance mapping to a JSONB-safe dict.
+
+    Caller-supplied provenance is never trusted to grant authority. Only
+    bounded registration metadata is permitted. The structure is
+    deliberately shallow and serializable.
+    """
+    if provenance is None:
+        return {}
+    if not isinstance(provenance, Mapping):
+        raise InvalidRepositoryBindingProvenance(
+            "provenance must be a mapping or None"
+        )
+
+    normalized = {str(key): value for key, value in provenance.items()}
+    unexpected = set(normalized) - PROVENANCE_ALLOWED_KEYS
+    if unexpected:
+        raise InvalidRepositoryBindingProvenance(
+            "provenance contains unsupported keys: "
+            f"{sorted(unexpected)!r}"
+        )
+
+    for key in ("registration_source", "operation_class"):
+        value = normalized.get(key)
+        if value is not None and (
+            not isinstance(value, str)
+            or not value.strip()
+            or len(value) > PROVENANCE_MAX_VALUE_LENGTH
+        ):
+            raise InvalidRepositoryBindingProvenance(
+                f"provenance {key} must be a nonempty bounded string"
+            )
+
+    context = normalized.get("authority_context")
+    if context is not None:
+        if not isinstance(context, Mapping):
+            raise InvalidRepositoryBindingProvenance(
+                "authority_context must be a mapping"
+            )
+        if len(context) > PROVENANCE_MAX_CONTEXT_ITEMS:
+            raise InvalidRepositoryBindingProvenance(
+                "authority_context exceeds the bounded item limit"
+            )
+        normalized_context: dict[str, str | int | float | bool | None] = {}
+        for raw_key, value in context.items():
+            key = str(raw_key)
+            if not key or len(key) > PROVENANCE_MAX_KEY_LENGTH:
+                raise InvalidRepositoryBindingProvenance(
+                    "authority_context keys must be bounded nonempty strings"
+                )
+            if isinstance(value, str):
+                if len(value) > PROVENANCE_MAX_VALUE_LENGTH:
+                    raise InvalidRepositoryBindingProvenance(
+                        "authority_context string value exceeds the limit"
+                    )
+            elif not isinstance(value, (int, float, bool)) and value is not None:
+                raise InvalidRepositoryBindingProvenance(
+                    "authority_context values must be JSON scalar values"
+                )
+            normalized_context[key] = value
+        normalized["authority_context"] = normalized_context
+
+    serialized = repr(normalized).encode("utf-8")
+    if len(serialized) > PROVENANCE_MAX_SERIALIZED_BYTES:
+        raise InvalidRepositoryBindingProvenance(
+            "provenance exceeds the bounded storage limit"
+        )
+    return normalized
+
+
+def _load_project(session: Session, project_id: int) -> Project:
+    project = session.get(Project, project_id)
+    if project is None:
+        raise ProjectNotFound(
+            f"Project id={project_id} does not exist."
+        )
+    return project
+
+
+def _verify_account_ownership(
+    project: Project,
+    authenticated_account_id: str | None,
+) -> None:
+    if not authenticated_account_id:
+        raise AccountProjectMismatch(
+            "Authenticated account identity is required."
+        )
+    if str(project.user_id) != str(authenticated_account_id):
+        raise AccountProjectMismatch(
+            "Authenticated account does not own Project "
+            f"id={project.id}."
+        )
+
+
+def _ensure_supported_source_class(source_class: str) -> None:
+    if source_class == DISCOVERY_CANDIDATE_CLASS:
+        raise UnsupportedSourceClass(
+            "discovery_candidate is not a binding source class."
+        )
+    if source_class not in BINDING_SOURCE_CLASSES:
+        raise UnsupportedSourceClass(
+            f"Unsupported source class: {source_class!r}. Expected one of "
+            f"{BINDING_SOURCE_CLASSES!r}."
+        )
+
+
+def _ensure_managed_containment(
+    *,
+    source_class: str,
+    canonical_root: Path,
+    settings: Settings | None,
+) -> None:
+    if source_class != SOURCE_CLASS_GUARDIAN_MANAGED:
+        return
+    managed_root = resolve_guardian_projects_directory(settings=settings)
+    if managed_root is None:
+        raise GuardianProjectsDirectoryUnconfigured()
+    canonical_managed_root = _resolve_symlink_aware(managed_root)
+    try:
+        canonical_root.relative_to(canonical_managed_root)
+    except ValueError as exc:
+        raise GuardianProjectsDirectoryOutsideAllowedRoot(
+            f"guardian_managed root {canonical_root!s} escapes Guardian "
+            f"Projects Directory {canonical_managed_root!s}"
+        ) from exc
+    if canonical_root == canonical_managed_root:
+        raise GuardianProjectsDirectoryOutsideAllowedRoot(
+            "guardian_managed root must be a child of Guardian Projects "
+            f"Directory {canonical_managed_root!s}"
+        )
+
+
+def _count_active_bindings(session: Session, project_id: int) -> int:
+    stmt = select(RepositoryBinding).where(
+        RepositoryBinding.project_id == project_id,
+        RepositoryBinding.is_active.is_(True),
+    )
+    return len(list(session.execute(stmt).scalars().all()))
+
+
+def create_repository_binding(
+    session: Session,
+    *,
+    authenticated_account_id: str | None,
+    project_id: int,
+    source_class: str,
+    working_tree_root: Path | str,
+    provenance: Mapping[str, Any] | None = None,
+    settings: Settings | None = None,
+    timeout_seconds: float = DEFAULT_GIT_VALIDATION_TIMEOUT_SECONDS,
+) -> RepositoryBinding:
+    """Create a new RepositoryBinding record (authority-side metadata).
+
+    Caller owns the surrounding transaction. ``session.flush()`` is
+    performed to assign surrogate state, but no commit is issued. Fails
+    closed on every invariant violation.
+    """
+    project = _load_project(session, project_id)
+    _verify_account_ownership(project, authenticated_account_id)
+    _ensure_supported_source_class(source_class)
+
+    canonical_root = validate_git_working_tree_root(
+        working_tree_root, timeout_seconds=timeout_seconds
+    )
+
+    _ensure_managed_containment(
+        source_class=source_class,
+        canonical_root=canonical_root,
+        settings=settings,
+    )
+
+    if _count_active_bindings(session, project_id) > 0:
+        raise ActiveBindingAlreadyExists(
+            f"Project id={project_id} already has an active "
+            "RepositoryBinding."
+        )
+
+    now = datetime.now(timezone.utc)
+    binding = RepositoryBinding(
+        id=str(uuid.uuid4()),
+        project_id=project_id,
+        source_class=source_class,
+        canonical_root=str(canonical_root),
+        is_active=True,
+        provenance=_coerce_provenance(provenance),
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(binding)
+    session.flush()
+    return binding
+
+
+def resolve_project_repository_binding(
+    session: Session,
+    *,
+    authenticated_account_id: str | None,
+    project_id: int,
+    settings: Settings | None = None,
+    timeout_seconds: float = DEFAULT_GIT_VALIDATION_TIMEOUT_SECONDS,
+) -> ResolvedRepositoryBinding:
+    """Resolve exactly one active RepositoryBinding for a Project.
+
+    Fail closed on every invariant violation: missing Project, account
+    mismatch, zero active bindings, multiple active bindings, inactive
+    binding only, missing root, non-directory root, invalid Git root,
+    stored/canonical root mismatch, managed-root escape.
+    """
+    project = _load_project(session, project_id)
+    _verify_account_ownership(project, authenticated_account_id)
+
+    stmt = (
+        select(RepositoryBinding)
+        .where(
+            RepositoryBinding.project_id == project_id,
+            RepositoryBinding.is_active.is_(True),
+        )
+        .order_by(RepositoryBinding.created_at.asc())
+    )
+    bindings = list(session.execute(stmt).scalars().all())
+    if not bindings:
+        raise BindingResolutionFailed(
+            f"Project id={project_id} has no active RepositoryBinding."
+        )
+    if len(bindings) > 1:
+        raise BindingResolutionFailed(
+            f"Project id={project_id} has {len(bindings)} active "
+            "RepositoryBindings; ambiguous resolution fails closed."
+        )
+
+    binding = bindings[0]
+    _ensure_supported_source_class(binding.source_class)
+    canonical_root = validate_git_working_tree_root(
+        binding.canonical_root, timeout_seconds=timeout_seconds
+    )
+
+    _ensure_managed_containment(
+        source_class=binding.source_class,
+        canonical_root=canonical_root,
+        settings=settings,
+    )
+
+    if str(canonical_root) != str(binding.canonical_root):
+        raise BindingResolutionFailed(
+            "Stored canonical root does not match observed Git top-level "
+            f"({binding.canonical_root!s} vs {canonical_root!s})."
+        )
+
+    return ResolvedRepositoryBinding(
+        binding_id=binding.id,
+        project_id=project_id,
+        source_class=binding.source_class,
+        canonical_root=canonical_root,
+    )

--- a/guardian/db/migrations/versions/6e2b9c4a7d1f_add_repository_bindings.py
+++ b/guardian/db/migrations/versions/6e2b9c4a7d1f_add_repository_bindings.py
@@ -1,0 +1,120 @@
+"""Add repository_bindings table for Project-to-Git-working-tree authority.
+
+Revision ID: 6e2b9c4a7d1f
+Revises: c1a2b3c4d5e6
+Create Date: 2026-08-12 00:00:00.000000
+
+Stage 2K.1 (ADR-065): introduce durable Project-to-RepositoryBinding authority.
+Cardinality is one active binding per Project. The binding resolves one
+authorized working-tree root and is Guardian-owned durable authority state,
+never model input or conversational context.
+
+This migration introduces ONLY the new table, its columns, the Project FK,
+the source-class check, the partial unique active-binding index, and one
+narrowly justified lookup index. There is no backfill, no Project mutation,
+no ``General`` binding creation, and no filesystem work.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "6e2b9c4a7d1f"
+down_revision: Union[str, Sequence[str], None] = "c1a2b3c4d5e6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLE_NAME = "repository_bindings"
+_TABLE_SCHEMA = "public"
+_FK_NAME = "fk_repository_bindings_project_id"
+_CHECK_NAME = "ck_repository_bindings_source_class"
+_LOOKUP_INDEX_NAME = "ix_repository_bindings_project_id"
+_ACTIVE_UNIQUE_INDEX_NAME = "uq_repository_bindings_one_active_per_project"
+_ACTIVE_UNIQUE_POSTGRES_WHERE = "is_active IS TRUE"
+_SOURCE_CLASS_VALUES = ("'guardian_managed'", "'external_linked'")
+
+
+def upgrade() -> None:
+    """Add the repository_bindings table and its access invariants."""
+    op.create_table(
+        _TABLE_NAME,
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("project_id", sa.Integer(), nullable=False),
+        sa.Column("source_class", sa.String(length=32), nullable=False),
+        sa.Column("canonical_root", sa.String(length=4096), nullable=False),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.Column(
+            "provenance",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "source_class IN ("
+            + ", ".join(_SOURCE_CLASS_VALUES)
+            + ")",
+            name=_CHECK_NAME,
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["projects.id"],
+            name=_FK_NAME,
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        schema=_TABLE_SCHEMA,
+    )
+    op.create_index(
+        _LOOKUP_INDEX_NAME,
+        _TABLE_NAME,
+        ["project_id"],
+        unique=False,
+        schema=_TABLE_SCHEMA,
+    )
+    op.create_index(
+        _ACTIVE_UNIQUE_INDEX_NAME,
+        _TABLE_NAME,
+        ["project_id"],
+        unique=True,
+        postgresql_where=sa.text(_ACTIVE_UNIQUE_POSTGRES_WHERE),
+        schema=_TABLE_SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    """Remove only the objects introduced by this migration."""
+    op.drop_index(
+        _ACTIVE_UNIQUE_INDEX_NAME,
+        table_name=_TABLE_NAME,
+        postgresql_where=sa.text(_ACTIVE_UNIQUE_POSTGRES_WHERE),
+        schema=_TABLE_SCHEMA,
+    )
+    op.drop_index(
+        _LOOKUP_INDEX_NAME,
+        table_name=_TABLE_NAME,
+        schema=_TABLE_SCHEMA,
+    )
+    op.drop_table(_TABLE_NAME, schema=_TABLE_SCHEMA)

--- a/guardian/db/models.py
+++ b/guardian/db/models.py
@@ -431,6 +431,89 @@ class Project(Base):
 
 
 # =========================
+# Repository Bindings (Stage 2K.1 / ADR-065)
+# =========================
+
+
+REPOSITORY_BINDING_SOURCE_CLASS_GUARDIAN_MANAGED = "guardian_managed"
+REPOSITORY_BINDING_SOURCE_CLASS_EXTERNAL_LINKED = "external_linked"
+REPOSITORY_BINDING_SOURCE_CLASSES_SQL = (
+    f"'{REPOSITORY_BINDING_SOURCE_CLASS_GUARDIAN_MANAGED}',"
+    f"'{REPOSITORY_BINDING_SOURCE_CLASS_EXTERNAL_LINKED}'"
+)
+REPOSITORY_BINDING_SOURCE_CLASS_CHECK = (
+    f"source_class IN ({REPOSITORY_BINDING_SOURCE_CLASSES_SQL})"
+)
+
+
+class RepositoryBinding(Base):
+    """Stage 2K.1 (ADR-065) durable Project-to-Git-working-tree authority.
+
+    A repository is available to Guardian only through an explicit,
+    account/project-owned ``RepositoryBinding``. Cardinality is one active
+    binding per Project; inactive historical bindings may coexist. The
+    binding resolves one authorized working-tree root and is Guardian-owned
+    durable authority state, never model input or conversational context.
+
+    Discovery candidates (``discovery_candidate``) are NOT stored here —
+    they are not bindings and never gain tool eligibility. Existing
+    Projects receive no automatic binding; ``General`` receives no implicit
+    binding.
+    """
+
+    __tablename__ = "repository_bindings"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    project_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    source_class: Mapped[str] = mapped_column(
+        String(32), nullable=False
+    )
+    canonical_root: Mapped[str] = mapped_column(
+        String(4096), nullable=False
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    provenance: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    project: Mapped[Project] = relationship("Project")
+
+    __table_args__ = (
+        CheckConstraint(
+            REPOSITORY_BINDING_SOURCE_CLASS_CHECK,
+            name="ck_repository_bindings_source_class",
+        ),
+        Index(
+            "ix_repository_bindings_project_id",
+            "project_id",
+        ),
+        Index(
+            "uq_repository_bindings_one_active_per_project",
+            "project_id",
+            unique=True,
+            postgresql_where=text("is_active IS TRUE"),
+        ),
+    )
+
+    __mapper_args__ = {"eager_defaults": True}
+
+
+# =========================
 # Capability Grants
 # =========================
 

--- a/tests/core/test_repository_authority.py
+++ b/tests/core/test_repository_authority.py
@@ -1,0 +1,850 @@
+"""Unit tests for Stage 2K.1 (ADR-065) repository authority module.
+
+The authority module must:
+
+- Resolve Guardian Projects Directory deterministically per ADR-065.
+- Use opaque stable Project IDs, not display names, for child paths.
+- Reject symlink / traversal escape.
+- Validate an exact Git working-tree root via read-only ``git
+  rev-parse --show-toplevel`` (argv-only, ``GIT_OPTIONAL_LOCKS=0``).
+- Fail closed on every ambiguity, mismatch, or missing invariant.
+- Never fall back to ``Path.cwd()``, nearest ``.git``,
+  ``CODEXIFY_WORKTREE_REPO_PATH``, worktree query paths, application
+  checkout, or development defaults.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import uuid
+from pathlib import Path
+
+import pytest
+
+from guardian.core import repository_authority as authority
+from guardian.core.config import Settings
+from guardian.db.models import (
+    Project,
+    RepositoryBinding,
+    User,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _init_git_repo(path: Path) -> None:
+    """Initialize a real Git repository at ``path`` (argv-only, safe defaults)."""
+    path.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env["GIT_OPTIONAL_LOCKS"] = "0"
+    env["GIT_AUTHOR_NAME"] = "Stage 2K.1 Tests"
+    env["GIT_AUTHOR_EMAIL"] = "stage2k1@example.invalid"
+    env["GIT_COMMITTER_NAME"] = "Stage 2K.1 Tests"
+    env["GIT_COMMITTER_EMAIL"] = "stage2k1@example.invalid"
+    subprocess.run(["git", "init", "--initial-branch=main"], cwd=str(path), env=env, check=True)
+    subprocess.run(["git", "config", "user.email", "stage2k1@example.invalid"], cwd=str(path), env=env, check=True)
+    subprocess.run(["git", "config", "user.name", "Stage 2K.1 Tests"], cwd=str(path), env=env, check=True)
+    (path / "README.md").write_text("stage 2k.1 fixture\n")
+    subprocess.run(["git", "add", "README.md"], cwd=str(path), env=env, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=str(path), env=env, check=True)
+
+
+def _init_linked_worktree(repo: Path, worktree: Path) -> None:
+    """Create a linked Git worktree inside ``worktree`` rooted at ``repo``."""
+    worktree.parent.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env["GIT_OPTIONAL_LOCKS"] = "0"
+    subprocess.run(
+        ["git", "-C", str(repo), "worktree", "add", str(worktree), "-b",
+         "stage2k1-test"],
+        env=env, check=True,
+    )
+
+
+@pytest.fixture
+def temp_git_repo(tmp_path: Path) -> Path:
+    """Fresh disposable Git checkout for one test."""
+    repo = tmp_path / "repo.git"
+    _init_git_repo(repo)
+    return repo
+
+
+@pytest.fixture
+def temp_linked_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """A pair (repo, linked_worktree)."""
+    repo = tmp_path / "main.git"
+    _init_git_repo(repo)
+    worktree = tmp_path / "wt"
+    _init_linked_worktree(repo, worktree)
+    return repo, worktree
+
+
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip authority-affecting env vars for the duration of a test."""
+    monkeypatch.delenv("CODEXIFY_GUARDIAN_PROJECTS_DIR", raising=False)
+    monkeypatch.delenv("CODEXIFY_WORKTREE_REPO_PATH", raising=False)
+    monkeypatch.delenv("CODEXIFY_LOCAL_ONLY_MODE", raising=False)
+
+
+@pytest.fixture
+def guardian_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A real, persisted-on-disk Guardian Projects Directory."""
+    root = tmp_path / "guardian-projects"
+    root.mkdir()
+    monkeypatch.setenv("CODEXIFY_GUARDIAN_PROJECTS_DIR", str(root))
+    return root
+
+
+def _settings_with_dir(value: str | None) -> Settings:
+    """Construct a Settings instance with the Guardian Projects Directory override.
+
+    The Settings class is a Pydantic BaseSettings; passing the field as a
+    construction kwarg is the canonical way to override an environment
+    value for the duration of a single test.
+    """
+    return Settings(CODEXIFY_GUARDIAN_PROJECTS_DIR=value)
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (1) configured managed root resolves deterministically
+# ---------------------------------------------------------------------------
+
+
+def test_configured_managed_root_resolves_deterministically(
+    guardian_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = guardian_dir
+    resolved = authority.resolve_guardian_projects_directory(
+        settings=_settings_with_dir(str(target))
+    )
+    assert resolved == target.resolve()
+
+
+def test_configured_managed_root_expands_user(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Use the configured path verbatim — never infer ~ or $HOME.
+    target = tmp_path / "abs-root"
+    target.mkdir()
+    resolved = authority.resolve_guardian_projects_directory(
+        settings=_settings_with_dir(str(target))
+    )
+    assert resolved == target.resolve()
+
+
+def test_relative_managed_root_is_rejected(
+    clean_env: None,
+) -> None:
+    with pytest.raises(authority.GuardianProjectsDirectoryNotAbsolute):
+        authority.resolve_guardian_projects_directory(
+            settings=_settings_with_dir("relative-guardian-projects")
+        )
+
+
+def test_unconfigured_returns_none(clean_env: None) -> None:
+    assert authority.resolve_guardian_projects_directory(
+        settings=_settings_with_dir(None)
+    ) is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (3) no cwd fallback
+# ---------------------------------------------------------------------------
+
+
+def test_no_cwd_fallback(
+    clean_env: None, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Changing cwd must not change the resolver outcome."""
+    monkeypatch.chdir(tmp_path)
+    assert authority.resolve_guardian_projects_directory(
+        settings=_settings_with_dir(None)
+    ) is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (4) managed child path uses immutable Project ID
+# ---------------------------------------------------------------------------
+
+
+def test_managed_project_path_uses_project_id(
+    guardian_dir: Path,
+) -> None:
+    child = authority.guardian_managed_project_path(
+        4242, managed_root=guardian_dir
+    )
+    assert child == (guardian_dir / "4242").resolve()
+    # The path is derived from the integer ID, never from a name.
+    assert child.name == "4242"
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (5) display name does not affect authority path
+# ---------------------------------------------------------------------------
+
+
+def test_display_name_does_not_affect_authority_path(
+    guardian_dir: Path,
+) -> None:
+    """Same Project ID yields the same on-disk path regardless of name."""
+    a = authority.guardian_managed_project_path(
+        7, managed_root=guardian_dir
+    )
+    b = authority.guardian_managed_project_path(
+        7, managed_root=guardian_dir
+    )
+    assert a == b
+    # The path must not depend on a display name string.
+    assert a.name == "7"
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (6) traversal escape rejected
+# ---------------------------------------------------------------------------
+
+
+def test_traversal_escape_rejected_via_relative_to_check(
+    guardian_dir: Path,
+) -> None:
+    # Even with a non-existent child, an explicit traversal segment that
+    # resolves outside the managed root must raise. We craft a relative
+    # candidate and ask the relative_to check directly.
+    canonical_root = (guardian_dir).resolve()
+    escapee = (canonical_root / ".." / "evil").resolve()
+    with pytest.raises(Exception):
+        escapee.relative_to(canonical_root)
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (7) symlink escape rejected
+# ---------------------------------------------------------------------------
+
+
+def test_symlink_escape_rejected(
+    guardian_dir: Path, tmp_path: Path,
+) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    # The child path is derived from the Project ID; create a symlink at
+    # exactly that on-disk location pointing outside the managed root.
+    link = guardian_dir / "99"
+    link.symlink_to(outside)
+    with pytest.raises(authority.ManagedRootSymlinkEscape):
+        authority.guardian_managed_project_path(
+            99, managed_root=guardian_dir
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (8) managed root that is a file rejected
+# ---------------------------------------------------------------------------
+
+
+def test_managed_root_path_is_a_file_rejected(
+    tmp_path: Path,
+) -> None:
+    file_path = tmp_path / "not-a-dir"
+    file_path.write_text("not a directory")
+    with pytest.raises(authority.GuardianProjectsDirectoryNotDirectory):
+        authority.guardian_managed_project_path(
+            1, managed_root=file_path
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (9) valid normal Git repo accepted
+# ---------------------------------------------------------------------------
+
+
+def test_valid_normal_git_repo_accepted(temp_git_repo: Path) -> None:
+    canonical = authority.validate_git_working_tree_root(temp_git_repo)
+    assert canonical == temp_git_repo.resolve()
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (10) valid linked Git worktree accepted
+# ---------------------------------------------------------------------------
+
+
+def test_valid_linked_git_worktree_accepted(
+    temp_linked_worktree: tuple[Path, Path],
+) -> None:
+    _repo, worktree = temp_linked_worktree
+    canonical = authority.validate_git_working_tree_root(worktree)
+    assert canonical == worktree.resolve()
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (11) non-Git directory rejected
+# ---------------------------------------------------------------------------
+
+
+def test_non_git_directory_rejected(tmp_path: Path) -> None:
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    with pytest.raises(authority.InvalidRepositoryRoot):
+        authority.validate_git_working_tree_root(plain)
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (12) nested repo subdirectory rejected
+# ---------------------------------------------------------------------------
+
+
+def test_nested_repo_subdirectory_rejected(temp_git_repo: Path) -> None:
+    nested = temp_git_repo / "src" / "pkg"
+    nested.mkdir(parents=True)
+    with pytest.raises(authority.NestedRepositoryRejected):
+        authority.validate_git_working_tree_root(nested)
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (13) guardian_managed root outside managed directory rejected
+# ---------------------------------------------------------------------------
+
+
+def test_managed_root_outside_guardian_dir_rejected(
+    clean_env: None,
+    temp_git_repo: Path,
+    tmp_path: Path,
+) -> None:
+    """A guardian-managed binding cannot point outside the configured root."""
+    managed_dir = tmp_path / "configured-root"
+    managed_dir.mkdir()
+
+    session = _FakeSession.empty()
+    project = _seed_project(session, "user-1", name="outsider")
+    with pytest.raises(authority.GuardianProjectsDirectoryOutsideAllowedRoot):
+        authority.create_repository_binding(
+            session,
+            authenticated_account_id="user-1",
+            project_id=project["id"],
+            source_class=authority.SOURCE_CLASS_GUARDIAN_MANAGED,
+            working_tree_root=temp_git_repo,
+            provenance={"registration_source": "unit_test"},
+            settings=_settings_with_dir(str(managed_dir)),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (14) external_linked valid root outside managed directory allowed
+# ---------------------------------------------------------------------------
+
+
+def test_external_linked_outside_managed_dir_allowed(
+    clean_env: None,
+    temp_git_repo: Path,
+    tmp_path: Path,
+) -> None:
+    managed_dir = tmp_path / "configured-root"
+    managed_dir.mkdir()
+
+    session = _FakeSession.empty()
+    project = _seed_project(session, "user-1", name="external-repo")
+    binding = authority.create_repository_binding(
+        session,
+        authenticated_account_id="user-1",
+        project_id=project["id"],
+        source_class=authority.SOURCE_CLASS_EXTERNAL_LINKED,
+        working_tree_root=temp_git_repo,
+        provenance={"registration_source": "explicit_import"},
+        settings=_settings_with_dir(str(managed_dir)),
+    )
+    assert binding.is_active is True
+    assert binding.source_class == authority.SOURCE_CLASS_EXTERNAL_LINKED
+
+
+def test_guardian_managed_root_cannot_equal_managed_directory(
+    clean_env: None,
+    guardian_dir: Path,
+) -> None:
+    _init_git_repo(guardian_dir)
+    session = _FakeSession.empty()
+    project = _seed_project(session, "user-1", name="managed-child-required")
+    with pytest.raises(authority.GuardianProjectsDirectoryOutsideAllowedRoot):
+        authority.create_repository_binding(
+            session,
+            authenticated_account_id="user-1",
+            project_id=project["id"],
+            source_class=authority.SOURCE_CLASS_GUARDIAN_MANAGED,
+            working_tree_root=guardian_dir,
+            provenance={"registration_source": "guardian_creation"},
+            settings=_settings_with_dir(str(guardian_dir)),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (15) discovery_candidate rejected
+# ---------------------------------------------------------------------------
+
+
+def test_discovery_candidate_rejected(
+    temp_git_repo: Path, clean_env: None,
+) -> None:
+    session = _FakeSession.empty()
+    project = _seed_project(session, "user-1", name="candidate-rejection")
+    with pytest.raises(authority.UnsupportedSourceClass):
+        authority.create_repository_binding(
+            session,
+            authenticated_account_id="user-1",
+            project_id=project["id"],
+            source_class=authority.DISCOVERY_CANDIDATE_CLASS,
+            working_tree_root=temp_git_repo,
+            provenance={},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (16) missing Project rejected
+# ---------------------------------------------------------------------------
+
+
+def test_missing_project_rejected(temp_git_repo: Path, clean_env: None) -> None:
+    session = _FakeSession.empty()
+    with pytest.raises(authority.ProjectNotFound):
+        authority.create_repository_binding(
+            session,
+            authenticated_account_id="user-1",
+            project_id=999_999,
+            source_class=authority.SOURCE_CLASS_EXTERNAL_LINKED,
+            working_tree_root=temp_git_repo,
+            provenance={},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (17) account/Project mismatch rejected
+# ---------------------------------------------------------------------------
+
+
+def test_account_project_mismatch_rejected(
+    temp_git_repo: Path, clean_env: None,
+) -> None:
+    session = _FakeSession.empty()
+    project = _seed_project(session, "user-1", name="owner-project")
+    with pytest.raises(authority.AccountProjectMismatch):
+        authority.create_repository_binding(
+            session,
+            authenticated_account_id="user-2",
+            project_id=project["id"],
+            source_class=authority.SOURCE_CLASS_EXTERNAL_LINKED,
+            working_tree_root=temp_git_repo,
+            provenance={},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (18) no active binding rejected at resolver
+# ---------------------------------------------------------------------------
+
+
+def test_no_active_binding_rejected(clean_env: None) -> None:
+    session = _FakeSession.empty()
+    project = _seed_project(session, "user-1", name="empty-project")
+    with pytest.raises(authority.BindingResolutionFailed):
+        authority.resolve_project_repository_binding(
+            session,
+            authenticated_account_id="user-1",
+            project_id=project["id"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (19) multiple active bindings rejected at resolver layer
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_active_bindings_rejected(
+    clean_env: None, temp_git_repo: Path, tmp_path: Path,
+) -> None:
+    session = _FakeSession.empty()
+    project = _seed_project(session, "user-1", name="multi-active")
+    # Bypass the API to manufacture two active bindings (only possible via
+    # direct DB tampering; the API itself rejects the second).
+    _insert_active_binding(
+        session, project_id=project["id"], canonical_root=temp_git_repo
+    )
+    _insert_active_binding(
+        session, project_id=project["id"],
+        canonical_root=temp_git_repo,
+    )
+    with pytest.raises(authority.BindingResolutionFailed):
+        authority.resolve_project_repository_binding(
+            session,
+            authenticated_account_id="user-1",
+            project_id=project["id"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (20) inactive-only binding rejected
+# ---------------------------------------------------------------------------
+
+
+def test_inactive_only_binding_rejected(
+    clean_env: None, temp_git_repo: Path,
+) -> None:
+    session = _FakeSession.empty()
+    project = _seed_project(session, "user-1", name="inactive-only")
+    _insert_active_binding(
+        session, project_id=project["id"], canonical_root=temp_git_repo,
+        is_active=False,
+    )
+    with pytest.raises(authority.BindingResolutionFailed):
+        authority.resolve_project_repository_binding(
+            session,
+            authenticated_account_id="user-1",
+            project_id=project["id"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (21) missing bound root rejected
+# ---------------------------------------------------------------------------
+
+
+def test_missing_bound_root_rejected(
+    clean_env: None, tmp_path: Path,
+) -> None:
+    session = _FakeSession.empty()
+    project = _seed_project(session, "user-1", name="missing-root")
+    ghost = tmp_path / "ghost"
+    _insert_active_binding(
+        session, project_id=project["id"], canonical_root=ghost,
+    )
+    with pytest.raises(authority.InvalidRepositoryRoot):
+        authority.resolve_project_repository_binding(
+            session,
+            authenticated_account_id="user-1",
+            project_id=project["id"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (22) stored-root / actual-Git-root mismatch rejected
+# ---------------------------------------------------------------------------
+
+
+def test_stored_root_mismatch_rejected(
+    clean_env: None, temp_git_repo: Path,
+) -> None:
+    """A noncanonical stored path must not be accepted after Git resolution."""
+    session = _FakeSession.empty()
+    project = _seed_project(session, "user-1", name="mismatch")
+
+    _insert_active_binding(
+        session, project_id=project["id"],
+        canonical_root=temp_git_repo,
+    )
+    stored = next(reversed(session.bindings.values()))
+    stored["canonical_root"] = str(temp_git_repo / ".." / temp_git_repo.name)
+    with pytest.raises(authority.BindingResolutionFailed):
+        authority.resolve_project_repository_binding(
+            session,
+            authenticated_account_id="user-1",
+            project_id=project["id"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (23) successful resolution returns exact canonical root
+# ---------------------------------------------------------------------------
+
+
+def test_successful_resolution_returns_canonical_root(
+    clean_env: None, temp_git_repo: Path,
+) -> None:
+    session = _FakeSession.empty()
+    project = _seed_project(session, "user-1", name="resolved")
+    _insert_active_binding(
+        session, project_id=project["id"], canonical_root=temp_git_repo,
+    )
+    resolved = authority.resolve_project_repository_binding(
+        session,
+        authenticated_account_id="user-1",
+        project_id=project["id"],
+    )
+    assert resolved.binding_id
+    assert resolved.project_id == project["id"]
+    assert resolved.source_class == authority.SOURCE_CLASS_EXTERNAL_LINKED
+    assert resolved.canonical_root == temp_git_repo.resolve()
+
+
+def test_provenance_rejects_prompt_or_credential_like_payload(
+    clean_env: None, temp_git_repo: Path,
+) -> None:
+    session = _FakeSession.empty()
+    project = _seed_project(session, "user-1", name="bounded-provenance")
+    with pytest.raises(authority.InvalidRepositoryBindingProvenance):
+        authority.create_repository_binding(
+            session,
+            authenticated_account_id="user-1",
+            project_id=project["id"],
+            source_class=authority.SOURCE_CLASS_EXTERNAL_LINKED,
+            working_tree_root=temp_git_repo,
+            provenance={"prompt": "never persist conversation text"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (24) no call to detect_project_root anywhere in the module
+# ---------------------------------------------------------------------------
+
+
+def test_module_does_not_call_detect_project_root() -> None:
+    src = Path(authority.__file__).read_text()
+    assert "detect_project_root" not in src
+    assert "WorkspaceRootManager" not in src
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (25) no use of CODEXIFY_WORKTREE_REPO_PATH
+# ---------------------------------------------------------------------------
+
+
+def test_module_does_not_use_worktree_repo_path_env() -> None:
+    """Search the module source for references to the forbidden env var.
+
+    A simple substring search is sufficient — the variable name is
+    distinctive enough that any code-path reference will surface. The
+    module docstring mentions the rejected shortcut explicitly so an
+    honest grep would catch a real misuse anyway.
+    """
+    src = Path(authority.__file__).read_text()
+    # Anything that *uses* the env must read it via ``os.getenv`` or
+    # ``os.environ``. Anything else is commentary in a docstring.
+    forbidden_patterns = (
+        "os.getenv(\"CODEXIFY_WORKTREE_REPO_PATH\"",
+        "os.environ[\"CODEXIFY_WORKTREE_REPO_PATH\"]",
+        "environ.get(\"CODEXIFY_WORKTREE_REPO_PATH\"",
+    )
+    for pattern in forbidden_patterns:
+        assert pattern not in src, f"forbidden usage: {pattern!r}"
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (26) creation does not commit Session implicitly
+# ---------------------------------------------------------------------------
+
+
+def test_create_repository_binding_does_not_commit(
+    clean_env: None, temp_git_repo: Path,
+) -> None:
+    session = _FakeSession.empty()
+    project = _seed_project(session, "user-1", name="no-commit")
+    authority.create_repository_binding(
+        session,
+        authenticated_account_id="user-1",
+        project_id=project["id"],
+        source_class=authority.SOURCE_CLASS_EXTERNAL_LINKED,
+        working_tree_root=temp_git_repo,
+        provenance={"registration_source": "unit_test"},
+    )
+    assert session.committed is False
+    assert session.added == 1
+    assert session.flushed == 1
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 (27) General receives no implicit authority
+# ---------------------------------------------------------------------------
+
+
+def test_general_receives_no_implicit_authority(
+    clean_env: None, tmp_path: Path,
+) -> None:
+    """Even if a 'General' project exists, ``resolve`` fails closed when
+    no binding has been explicitly created."""
+    session = _FakeSession.empty()
+    project = _seed_project(
+        session, "user-1", name="General",
+    )
+    with pytest.raises(authority.BindingResolutionFailed):
+        authority.resolve_project_repository_binding(
+            session,
+            authenticated_account_id="user-1",
+            project_id=project["id"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 15 second active binding creation fails closed
+# ---------------------------------------------------------------------------
+
+
+def test_second_active_binding_creation_rejected(
+    clean_env: None, temp_git_repo: Path,
+) -> None:
+    session = _FakeSession.empty()
+    project = _seed_project(session, "user-1", name="dup-active")
+    authority.create_repository_binding(
+        session,
+        authenticated_account_id="user-1",
+        project_id=project["id"],
+        source_class=authority.SOURCE_CLASS_EXTERNAL_LINKED,
+        working_tree_root=temp_git_repo,
+        provenance={},
+    )
+    with pytest.raises(authority.ActiveBindingAlreadyExists):
+        authority.create_repository_binding(
+            session,
+            authenticated_account_id="user-1",
+            project_id=project["id"],
+            source_class=authority.SOURCE_CLASS_EXTERNAL_LINKED,
+            working_tree_root=temp_git_repo,
+            provenance={},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test-double Session + helpers (no Postgres required for unit tests)
+# ---------------------------------------------------------------------------
+
+
+class _DictModel:
+    """Attribute-access wrapper over a plain dict.
+
+    The real SQLAlchemy ORM rows expose attributes; the authority module
+    accesses ``project.user_id`` directly. Tests that use the in-memory
+    fake session rely on this wrapper to provide the same surface.
+    """
+
+    def __init__(self, data: dict[str, object]) -> None:
+        self._data = data
+
+    def __getattr__(self, item: str) -> object:
+        try:
+            return self._data[item]
+        except KeyError as exc:
+            raise AttributeError(item) from exc
+
+
+class _FakeSession:
+    """Minimal in-memory Session double for unit testing.
+
+    Implements only the surface area the authority module actually uses:
+    ``session.get(Model, id)`` and ``session.execute(stmt).scalars().all()``
+    plus ``session.add``, ``session.flush``, and a flag tracking whether
+    ``commit`` was ever called (it must never be).
+    """
+
+    def __init__(self) -> None:
+        self.projects: dict[int, dict[str, object]] = {}
+        self.bindings: dict[str, dict[str, object]] = {}
+        self.next_project_id = 1
+        self.committed = False
+        self.added = 0
+        self.flushed = 0
+
+    @classmethod
+    def empty(cls) -> "_FakeSession":
+        return cls()
+
+    def get(self, model: type[object], ident: int) -> object | None:
+        if model is Project:
+            data = self.projects.get(ident)
+            return _DictModel(data) if data is not None else None
+        if model is User:
+            return None
+        return None
+
+    def add(self, instance: RepositoryBinding) -> None:
+        self.added += 1
+        self.bindings[instance.id] = {
+            "id": instance.id,
+            "project_id": instance.project_id,
+            "source_class": instance.source_class,
+            "canonical_root": instance.canonical_root,
+            "is_active": instance.is_active,
+            "provenance": dict(instance.provenance or {}),
+            "created_at": instance.created_at,
+            "updated_at": instance.updated_at,
+        }
+
+    def flush(self) -> None:
+        self.flushed += 1
+
+    def commit(self) -> None:
+        self.committed = True
+
+    def execute(self, stmt):  # type: ignore[no-untyped-def]
+        # ``stmt`` is a SQLAlchemy Select object. We can't introspect it
+        # cheaply, so we use thread-local state via ``_FakeResult`` to
+        # expose the right slice. The caller always calls
+        # ``.scalars().all()`` on the result, so we just return a wrapper.
+        return _FakeResult(self._matching_bindings(stmt))
+
+    def _matching_bindings(self, stmt) -> list[_DictModel]:
+        # ``stmt.where`` builds a Select; we can't introspect it. Instead
+        # we rely on the test always inserting through ``_insert_active_binding``
+        # or via the API. We return all active bindings for the *last*
+        # project id that had any binding operation. This is sufficient
+        # for the unit-test matrix because we never mix multiple projects
+        # in a single test.
+        return [
+            _DictModel(binding) for binding in self.bindings.values()
+            if binding.get("is_active")
+        ]
+
+
+class _FakeResult:
+    def __init__(self, rows: list[object]) -> None:
+        self._rows = rows
+
+    def scalars(self) -> "_FakeScalars":
+        return _FakeScalars(self._rows)
+
+
+class _FakeScalars:
+    def __init__(self, rows: list[object]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[object]:
+        return list(self._rows)
+
+
+def _seed_project(
+    session: _FakeSession,
+    user_id: str,
+    *,
+    name: str,
+) -> dict[str, object]:
+    project_id = session.next_project_id
+    session.next_project_id += 1
+    project = {
+        "id": project_id,
+        "user_id": user_id,
+        "name": name,
+        "description": None,
+        "icon": None,
+        "identity_depth": "light",
+        "created_at": None,
+        "updated_at": None,
+    }
+    session.projects[project_id] = project
+    return project
+
+
+def _insert_active_binding(
+    session: _FakeSession,
+    *,
+    project_id: int,
+    canonical_root: Path,
+    is_active: bool = True,
+) -> None:
+    binding_id = str(uuid.uuid4())
+    session.bindings[binding_id] = {
+        "id": binding_id,
+        "project_id": project_id,
+        "source_class": authority.SOURCE_CLASS_EXTERNAL_LINKED,
+        "canonical_root": str(canonical_root.resolve()),
+        "is_active": is_active,
+        "provenance": {},
+        "created_at": None,
+        "updated_at": None,
+    }

--- a/tests/migration/test_alembic_revision_uniqueness.py
+++ b/tests/migration/test_alembic_revision_uniqueness.py
@@ -64,6 +64,7 @@ def test_alembic_revision_ids_are_unique_and_hosted_room_lineage_is_preserved():
     browser_audit = script.get_revision("c3d4e5f6a7b8")
     delegation = script.get_revision("d4e5f6a7b8c9")
     email_login_alias = script.get_revision("c1a2b3c4d5e6")
+    repository_bindings = script.get_revision("6e2b9c4a7d1f")
 
     hosted_foundation = script.get_revision("b2c3d4e5f6a8")
 
@@ -87,8 +88,12 @@ def test_alembic_revision_ids_are_unique_and_hosted_room_lineage_is_preserved():
     ]["down_revision"] == ("4c9d1e2f3a5b", "d4e5f6a7b8c9")
     assert email_login_alias.down_revision == "d0e1f2a3b4c6"
 
+    assert repository_bindings is not None
+    assert repository_bindings.down_revision == "c1a2b3c4d5e6"
+    assert isinstance(repository_bindings.down_revision, str)
+
     heads = script.get_heads()
-    assert heads == ["c1a2b3c4d5e6"]
+    assert heads == ["6e2b9c4a7d1f"]
     assert script.get_revision("d0e1f2a3b4c6").down_revision == (
         "8c4d2e7f1a9b",
         "c8d9e0f1a2b3",

--- a/tests/migration/test_repository_bindings_migration.py
+++ b/tests/migration/test_repository_bindings_migration.py
@@ -1,0 +1,285 @@
+"""Postgres round-trip proof for the Stage 2K.1 RepositoryBinding migration."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+try:
+    import psycopg  # type: ignore
+except ImportError:  # pragma: no cover - environment specific
+    psycopg = None
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.engine import Engine, make_url
+from sqlalchemy.exc import IntegrityError
+
+
+BASELINE_REVISION = "c1a2b3c4d5e6"
+REPOSITORY_BINDING_REVISION = "6e2b9c4a7d1f"
+
+
+def _database_url(base_url: str, database_name: str) -> str:
+    return make_url(base_url).set(
+        drivername="postgresql+psycopg", database=database_name
+    ).render_as_string(hide_password=False)
+
+
+def _admin_database_url(base_url: str) -> str:
+    return make_url(base_url).set(
+        drivername="postgresql", database="postgres"
+    ).render_as_string(hide_password=False)
+
+
+@pytest.fixture
+def migration_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[tuple[Config, Engine], None, None]:
+    """Create and destroy one uniquely named Postgres database for this test."""
+    if psycopg is None:
+        pytest.skip("psycopg not installed")
+
+    base_url = os.getenv("TEST_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if not base_url:
+        pytest.skip("TEST_DATABASE_URL or DATABASE_URL is required")
+
+    database_name = f"codexify_repository_bindings_{uuid.uuid4().hex[:12]}"
+    admin_url = _admin_database_url(base_url)
+    database_url = _database_url(base_url, database_name)
+
+    try:
+        with psycopg.connect(admin_url, autocommit=True) as admin_connection:
+            with admin_connection.cursor() as cursor:
+                cursor.execute(f'CREATE DATABASE "{database_name}"')
+    except Exception as exc:  # pragma: no cover - environment specific
+        pytest.skip(f"Unable to create temporary Postgres database: {exc}")
+
+    repo_root = Path(__file__).resolve().parents[2]
+    config = Config(str(repo_root / "backend" / "alembic.ini"))
+    config.set_main_option("sqlalchemy.url", database_url)
+    config.set_main_option(
+        "script_location", str(repo_root / "guardian" / "db" / "migrations")
+    )
+    monkeypatch.setenv("DATABASE_URL", database_url)
+
+    engine: Engine | None = None
+    try:
+        command.upgrade(config, BASELINE_REVISION)
+        engine = create_engine(database_url, future=True)
+        yield config, engine
+    finally:
+        if engine is not None:
+            engine.dispose()
+        try:
+            with psycopg.connect(admin_url, autocommit=True) as admin_connection:
+                with admin_connection.cursor() as cursor:
+                    cursor.execute(
+                        "SELECT pg_terminate_backend(pid) "
+                        "FROM pg_stat_activity "
+                        "WHERE datname = %s AND pid <> pg_backend_pid()",
+                        (database_name,),
+                    )
+                    cursor.execute(f'DROP DATABASE IF EXISTS "{database_name}"')
+        except Exception:
+            # Do not hide a migration assertion behind cleanup failure; the
+            # generated database name remains uniquely scoped to this test.
+            pass
+
+
+def _seed_preexisting_project(engine: Engine) -> tuple[int, dict[str, object]]:
+    """Create a User/Project that existed before the new migration."""
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "INSERT INTO users "
+                "(id, username, password_hash, role) "
+                "VALUES (:id, :username, :password_hash, :role)"
+            ),
+            {
+                "id": "repository-binding-test-user",
+                "username": "repository-binding-test-user",
+                "password_hash": "not-a-real-password-hash",
+                "role": "guest",
+            },
+        )
+        project_id = connection.execute(
+            text(
+                "INSERT INTO projects "
+                "(user_id, name, description, icon, identity_depth) "
+                "VALUES (:user_id, :name, :description, :icon, :identity_depth) "
+                "RETURNING id"
+            ),
+            {
+                "user_id": "repository-binding-test-user",
+                "name": "Repository binding migration fixture",
+                "description": "must survive migration unchanged",
+                "icon": "folder",
+                "identity_depth": "light",
+            },
+        ).scalar_one()
+        snapshot = connection.execute(
+            text(
+                "SELECT id, user_id, name, description, icon, identity_depth "
+                "FROM projects WHERE id = :project_id"
+            ),
+            {"project_id": project_id},
+        ).mappings().one()
+    return int(project_id), dict(snapshot)
+
+
+def _project_snapshot(engine: Engine, project_id: int) -> dict[str, object]:
+    with engine.connect() as connection:
+        snapshot = connection.execute(
+            text(
+                "SELECT id, user_id, name, description, icon, identity_depth "
+                "FROM projects WHERE id = :project_id"
+            ),
+            {"project_id": project_id},
+        ).mappings().one()
+    return dict(snapshot)
+
+
+@pytest.mark.integration
+def test_repository_bindings_migration_round_trip(
+    migration_database: tuple[Config, Engine],
+) -> None:
+    config, engine = migration_database
+    inspector = inspect(engine)
+
+    assert "repository_bindings" not in inspector.get_table_names(schema="public")
+    with engine.connect() as connection:
+        assert connection.execute(
+            text("SELECT version_num FROM alembic_version")
+        ).scalar_one() == BASELINE_REVISION
+
+    project_id, project_before = _seed_preexisting_project(engine)
+
+    command.upgrade(config, "head")
+    inspector.clear_cache()
+    assert "repository_bindings" in inspector.get_table_names(schema="public")
+    with engine.connect() as connection:
+        assert connection.execute(
+            text("SELECT version_num FROM alembic_version")
+        ).scalar_one() == REPOSITORY_BINDING_REVISION
+
+    columns = {
+        column["name"]
+        for column in inspector.get_columns("repository_bindings", schema="public")
+    }
+    assert {
+        "id",
+        "project_id",
+        "source_class",
+        "canonical_root",
+        "is_active",
+        "provenance",
+        "created_at",
+        "updated_at",
+    } <= columns
+
+    foreign_keys = inspector.get_foreign_keys(
+        "repository_bindings", schema="public"
+    )
+    project_fk = next(
+        fk for fk in foreign_keys if fk["name"] == "fk_repository_bindings_project_id"
+    )
+    assert project_fk["constrained_columns"] == ["project_id"]
+    assert project_fk["referred_table"] == "projects"
+    assert project_fk["referred_columns"] == ["id"]
+    assert str(project_fk.get("options", {}).get("ondelete", "")).upper() == "CASCADE"
+
+    checks = {
+        check["name"]: check.get("sqltext", "")
+        for check in inspector.get_check_constraints(
+            "repository_bindings", schema="public"
+        )
+    }
+    assert "ck_repository_bindings_source_class" in checks
+    assert "guardian_managed" in checks["ck_repository_bindings_source_class"]
+    assert "external_linked" in checks["ck_repository_bindings_source_class"]
+
+    indexes = {
+        index["name"]: index
+        for index in inspector.get_indexes("repository_bindings", schema="public")
+    }
+    active_index = indexes["uq_repository_bindings_one_active_per_project"]
+    assert active_index["unique"] is True
+    predicate = active_index.get("dialect_options", {}).get("postgresql_where")
+    assert predicate is not None
+    assert "is_active" in str(predicate)
+    assert "true" in str(predicate).lower()
+    assert indexes["ix_repository_bindings_project_id"]["column_names"] == ["project_id"]
+
+    with engine.connect() as connection:
+        assert connection.execute(
+            text("SELECT count(*) FROM repository_bindings WHERE project_id = :project_id"),
+            {"project_id": project_id},
+        ).scalar_one() == 0
+    assert _project_snapshot(engine, project_id) == project_before
+
+    active_values = {
+        "id": "binding-active",
+        "project_id": project_id,
+        "source_class": "external_linked",
+        "canonical_root": "/authority-side/example",
+        "is_active": True,
+        "provenance": "{}",
+    }
+    insert_binding = text(
+        "INSERT INTO repository_bindings "
+        "(id, project_id, source_class, canonical_root, is_active, provenance) "
+        "VALUES "
+        "(:id, :project_id, :source_class, :canonical_root, :is_active, "
+        "CAST(:provenance AS jsonb))"
+    )
+    with engine.begin() as connection:
+        connection.execute(insert_binding, active_values)
+
+    with engine.connect() as connection:
+        transaction = connection.begin()
+        try:
+            with pytest.raises(IntegrityError):
+                connection.execute(
+                    insert_binding,
+                    {**active_values, "id": "binding-second-active"},
+                )
+        finally:
+            transaction.rollback()
+
+    with engine.begin() as connection:
+        connection.execute(
+            insert_binding,
+            {
+                **active_values,
+                "id": "binding-inactive-history",
+                "is_active": False,
+            },
+        )
+
+    with engine.connect() as connection:
+        assert connection.execute(
+            text(
+                "SELECT count(*) FROM repository_bindings "
+                "WHERE project_id = :project_id"
+            ),
+            {"project_id": project_id},
+        ).scalar_one() == 2
+
+    command.downgrade(config, BASELINE_REVISION)
+    inspector.clear_cache()
+    assert "repository_bindings" not in inspector.get_table_names(schema="public")
+    assert _project_snapshot(engine, project_id) == project_before
+
+    command.upgrade(config, "head")
+    inspector.clear_cache()
+    assert "repository_bindings" in inspector.get_table_names(schema="public")
+    with engine.connect() as connection:
+        assert connection.execute(
+            text("SELECT version_num FROM alembic_version")
+        ).scalar_one() == REPOSITORY_BINDING_REVISION


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
