### PR TITLE
Add explicit repository import

### DIFF
--- a/docs/architecture/proofs/2026-08-12-stage2k3-repository-import-binding-proof.md
+++ b/docs/architecture/proofs/2026-08-12-stage2k3-repository-import-binding-proof.md
@@ -1,0 +1,275 @@
+# Stage 2K.3 Explicit Repository Import and Project Binding Proof
+
+## Date
+
+2026-08-12
+
+## Verdict
+
+PASS — the explicit, authenticated import path is established as a bounded
+Guardian/API mutation. It grants no model, tool, provider, Workspace, or
+runtime authority beyond the durable external_linked Project binding.
+
+## Diagnostic Outcome
+
+EXPLICIT_REPOSITORY_IMPORT_ESTABLISHED
+
+## Base Commit
+
+aeb286e5b8b5ea582fa10e1c3aeb8576211ee813 (origin/main at task start).
+
+## Branch/Worktree
+
+- Branch: codex/stage2k3-repository-import-binding
+- Worktree: /private/tmp/codexify-stage2k3-repository-import-binding
+
+## Governing ADRs
+
+- ADR-065, Guardian-Managed Repository Onboarding Boundary — primary.
+- ADR-061, Capability-Oriented Mesh Architecture.
+- ADR-005, account scoping and user isolation.
+- ADR-020 and ADR-024, Guardian-issued filesystem scope and evidence versus
+  authority boundaries.
+
+## ADR Impact
+
+Aligned with existing ADR(s). No ADR changed. The implementation executes the
+explicit import/link transition selected by ADR-065 without changing discovery
+doctrine, binding doctrine, capability advertisement, or execution.
+
+## Stage 2K.1 Prerequisite
+
+The unchanged Stage 2K.1 authority seam still owns exact Git-root validation,
+account/Project checks, one-active-binding enforcement, bounded provenance,
+and external_linked binding creation without commit.
+
+## Stage 2K.2 Prerequisite
+
+The unchanged Stage 2K.2 seam still requires an AuthorizedDiscoveryRoot, uses
+bounded read-only discovery, and returns only ephemeral discovery_candidate
+observations.
+
+## Current Truth Before
+
+RepositoryBinding storage and typed candidate discovery existed, but no
+authenticated API could promote a candidate to Project authority. Workspace
+had no accepted durable Project-membership seam.
+
+## Explicit Authentication Boundary
+
+POST /api/projects/repository-import resolves ownership only through
+RequestUserScope and the existing canonical account helper. Client-provided
+account or user identity is neither accepted nor used.
+
+## Import API Surface
+
+The API-only route accepts discovery_root, candidate_relative_path, optional
+project_id, optional project_name, and optional project_description. Its
+response contains only ok, opaque binding and Project IDs, created/reused
+flags, and the fixed external_linked class.
+
+## Discovery Root Authority
+
+The service authorizes only the explicitly selected authenticated-user root
+through authorize_explicit_discovery_root(...). It has no default root, cwd,
+home, worktree, or nearest-Git fallback.
+
+## Candidate Relative Selection
+
+The selector is a normalized POSIX relative token. A root-dot selector and
+safe nested paths are supported; absolute, empty, backslash, and traversal
+selectors fail closed. It is compared only with fresh candidate
+root_relative_path values.
+
+## Fresh Discovery Proof
+
+Every import reruns discover_repository_candidates(...) after root
+authorization and selects exactly one candidate. Missing or ambiguous
+candidate selection fails closed.
+
+## Import-Time Revalidation
+
+The selected candidate must retain discovery_candidate source class and the
+authenticated actor. The service reruns Stage 2K.1
+validate_git_working_tree_root(...) and requires exact equality with the
+candidate's observed canonical root.
+
+## Project Target Modes
+
+Exactly one mode is valid: an owned existing project_id, or a trimmed,
+non-empty new project_name. Ambiguous, absent, and blank targets are rejected.
+
+## New Project Ownership
+
+New Projects are inserted directly in the caller-owned SQLAlchemy Session with
+Project.user_id set to the authenticated account. Names are bounded, and
+descriptions are bounded and reject the canonical repository path.
+
+## Existing Project Ownership
+
+Existing targets are loaded in the same Session and must belong to the
+authenticated account; cross-account Project targets fail with the bounded
+403 route outcome.
+
+## RepositoryBinding Creation
+
+The service creates the binding only through unchanged
+create_repository_binding(...), after fresh discovery/revalidation and
+duplicate-root checks. The core service does not commit.
+
+## External Linked Source Class
+
+Every new binding uses only the Stage 2K.1 canonical external_linked source
+class. No request field can select or override it.
+
+## Duplicate Canonical Root Behavior
+
+Active bindings are checked by exact canonical working-tree root before any
+Project or binding creation. A different owned Project, another account, or
+multiple existing active bindings fails closed.
+
+## Idempotency Behavior
+
+The same canonical root for the same owned Project returns the existing
+binding. A new-Project request for a root already linked by that account also
+reuses the existing Project/binding without creating a second Project.
+
+## Cross-Account Conflict Behavior
+
+A root bound under another account produces generic 409 conflict output with
+no foreign account, Project, or binding information.
+
+## Ambiguous Authority Behavior
+
+Multiple active bindings already resolving to one canonical root raise the
+explicit ambiguity error and create no additional authority.
+
+## Transaction Ownership
+
+repository_import.py performs Session flushes only. The Projects API route
+opens one chatlog_db.get_session() context and commits exactly once only after
+successful import; all known and unexpected failures roll back.
+
+## Commit/Rollback Proof
+
+The disposable Postgres test observed new Project and binding rows before
+commit, then observed them from a fresh Session after commit. A separate
+import followed by caller rollback left neither generated Project nor binding
+in a fresh Session.
+
+## Postgres Integration Proof
+
+TEST_DATABASE_URL=... pytest -v
+tests/integration/test_repository_import_postgres.py ran against a dedicated
+loopback-only disposable Postgres 15 container and a uniquely named temporary
+database. The test passed, then dropped that database; the temporary container
+was stopped and removed. No supported, preview, or production database was
+used.
+
+## Provenance Boundary
+
+Binding provenance contains only repository_candidate_import, external_link,
+discovery provenance class, Git evidence kind, and observed timestamp. It
+stores no discovery root, canonical root duplication, selector, remote,
+prompt, credential, or source content.
+
+## Filesystem Immutability
+
+Core coverage uses temporary Git fixtures outside the Codexify checkout,
+records representative bytes, mtime, HEAD, and branch before import, and
+proves all remain unchanged afterward.
+
+## Git Mutation Denial
+
+The import seam delegates only exact Stage 2K.1 Git validation. It contains no
+remote, fetch, pull, checkout, clone, init, status, move, copy, or delete
+operation.
+
+## Workspace Projection Deferral
+
+WORKSPACE_PROJECT_PROJECTION_DEFERRED — Workspace Project projection is
+deferred because no canonical durable Workspace-to-Project membership seam
+exists in the current accepted runtime.
+
+## No Automatic Import Proof
+
+Only the new authenticated API route calls the explicit-import entry point.
+No startup, Project creation, thread creation, scanner, provider, chat,
+Command Bus, or worker path calls it.
+
+## No Tool/Model Exposure Proof
+
+Repository import is absent from capability catalogs, model schemas, provider
+adapters, command definitions, ordinary-chat preparation, and completion
+services. No model parameter exposes discovery or canonical repository paths.
+
+## Alembic Head Result
+
+Before and after this no-schema slice, alembic -c backend/alembic.ini heads
+reported exactly 6e2b9c4a7d1f (head).
+
+## Core Test Results
+
+pytest -v tests/core/test_repository_import.py — 25 passed.
+
+## Route Test Results
+
+pytest -v tests/routes/test_project_repository_import.py — 10 passed.
+
+## Existing Project Regression Results
+
+pytest -v tests/routes/test_projects_account_scope.py — 6 passed.
+
+## Stage 2K.1 Regression Results
+
+pytest -v tests/core/test_repository_authority.py — 32 passed.
+
+## Stage 2K.2 Regression Results
+
+pytest -v tests/core/test_repository_discovery.py — 39 passed.
+
+## Architecture Test Results
+
+pytest -v tests/architecture — 394 passed.
+
+## Docs Validation
+
+python3 scripts/validate_docs.py passed. make docs PYTHON=python3 passed,
+including the repository diagram-freshness check.
+
+## What Was Proven
+
+An authenticated Codexify user can now explicitly promote one freshly
+rediscovered and revalidated external Git working-tree candidate into durable
+Project-to-RepositoryBinding authority, atomically creating or reusing the
+owned Project while leaving repository files in place and granting no
+repository capability to the model.
+
+## What Was Not Proven
+
+- No automatic coding-agent repository import exists.
+- No background repository onboarding exists.
+- No repository is moved into Guardian Projects Directory.
+- No Guardian-managed repository creation exists.
+- No detach, rebind, or replacement flow exists.
+- No durable Workspace-to-Project projection was added.
+- No repository.search Command Bus capability exists.
+- No ordinary-chat repository capability exists.
+- No model receives repository/discovery host paths.
+- No provider inference occurred.
+- No supported runtime was restarted.
+
+## Documentation Follow-Through
+
+This proof receipt is the authorized documentation follow-through. ADR-065,
+the repository-onboarding authority contract, current state, and schema/docs
+contracts remain intentionally unchanged.
+
+## Final File Scope
+
+Only the six task-authorized paths are changed: the core import service, the
+Projects API route, core/route/Postgres tests, and this receipt.
+
+## Commit
+
+The scoped commit is recorded in the final Git closeout for this receipt.

--- a/guardian/core/repository_import.py
+++ b/guardian/core/repository_import.py
@@ -1,0 +1,411 @@
+"""Explicit repository candidate import (Stage 2K.3 / ADR-065).
+
+This module promotes one freshly rediscovered, authenticated-user-selected
+repository candidate into durable Project-to-RepositoryBinding authority.  It
+does not move repository files, expose a model/tool payload, or own a database
+transaction.  The HTTP route is responsible for authentication transport and
+commit or rollback.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from guardian.core.repository_authority import (
+    ActiveBindingAlreadyExists,
+    AccountProjectMismatch,
+    DISCOVERY_CANDIDATE_CLASS,
+    ProjectNotFound,
+    RepositoryAuthorityError,
+    RepositoryBinding,
+    SOURCE_CLASS_EXTERNAL_LINKED,
+    create_repository_binding,
+    validate_git_working_tree_root,
+)
+from guardian.core.repository_discovery import (
+    RepositoryDiscoveryCandidate,
+    authorize_explicit_discovery_root,
+    discover_repository_candidates,
+)
+from guardian.db.models import Project
+
+
+PROJECT_NAME_MAX_LENGTH = 255
+PROJECT_DESCRIPTION_MAX_LENGTH = 4096
+IMPORT_REGISTRATION_SOURCE = "repository_candidate_import"
+IMPORT_OPERATION_CLASS = "external_link"
+
+
+class RepositoryImportError(Exception):
+    """Base class for bounded repository-import failures."""
+
+
+class InvalidImportTarget(RepositoryImportError):
+    """The caller did not select exactly one valid Project target."""
+
+
+class CandidateActorMismatch(RepositoryImportError):
+    """A discovery candidate belongs to a different authenticated actor."""
+
+
+class CandidateNotFound(RepositoryImportError):
+    """The requested relative candidate was absent from a fresh scan."""
+
+
+class CandidateRevalidationFailed(RepositoryImportError):
+    """The observed candidate no longer resolves to the same Git root."""
+
+
+class RepositoryAlreadyLinked(RepositoryImportError):
+    """A root is already linked to a different Project for this account."""
+
+
+class RepositoryBindingAmbiguous(RepositoryImportError):
+    """Multiple active bindings resolve to one canonical working-tree root."""
+
+
+class RepositoryBindingOwnedByAnotherAccount(RepositoryImportError):
+    """A root is already linked under another account."""
+
+
+@dataclass(frozen=True)
+class RepositoryImportResult:
+    """Bounded result for the authenticated API layer, never a tool payload."""
+
+    project_id: int
+    binding_id: str
+    created_project: bool
+    reused_existing: bool
+    source_class: str = SOURCE_CLASS_EXTERNAL_LINKED
+
+    def __post_init__(self) -> None:
+        if self.source_class != SOURCE_CLASS_EXTERNAL_LINKED:
+            raise ValueError("repository imports must be external_linked")
+
+
+@dataclass(frozen=True)
+class _ImportTarget:
+    project_id: int | None
+    project_name: str | None
+    project_description: str | None
+
+    @property
+    def creates_project(self) -> bool:
+        return self.project_id is None
+
+
+def _require_authenticated_account_id(
+    authenticated_account_id: str | None,
+) -> str:
+    account_id = str(authenticated_account_id or "").strip()
+    if not account_id:
+        raise InvalidImportTarget("authenticated account identity is required")
+    return account_id
+
+
+def _normalize_candidate_selector(candidate_relative_path: str) -> str:
+    """Return one safe POSIX relative candidate token without traversal."""
+    raw = str(candidate_relative_path or "").strip()
+    if not raw or "\\" in raw:
+        raise InvalidImportTarget("candidate selector must be a POSIX path")
+
+    selector = PurePosixPath(raw)
+    if selector.is_absolute() or ".." in selector.parts:
+        raise InvalidImportTarget("candidate selector must stay below root")
+
+    normalized = selector.as_posix()
+    if not normalized or normalized == "..":
+        raise InvalidImportTarget("candidate selector is invalid")
+    return normalized
+
+
+def _validate_import_target(
+    *,
+    project_id: int | None,
+    project_name: str | None,
+    project_description: str | None,
+) -> _ImportTarget:
+    if project_id is not None and (
+        not isinstance(project_id, int) or isinstance(project_id, bool) or project_id <= 0
+    ):
+        raise InvalidImportTarget("project_id must be a positive integer")
+    if project_id is not None and project_name is not None:
+        raise InvalidImportTarget("select an existing Project or a new Project")
+    if project_id is not None:
+        if project_description is not None:
+            raise InvalidImportTarget(
+                "project_description is valid only for a new Project"
+            )
+        return _ImportTarget(
+            project_id=project_id,
+            project_name=None,
+            project_description=None,
+        )
+
+    name = str(project_name or "").strip()
+    if not name:
+        raise InvalidImportTarget("new Project name is required")
+    if len(name) > PROJECT_NAME_MAX_LENGTH:
+        raise InvalidImportTarget("new Project name exceeds the allowed length")
+
+    description = None
+    if project_description is not None:
+        description = str(project_description).strip()
+        if len(description) > PROJECT_DESCRIPTION_MAX_LENGTH:
+            raise InvalidImportTarget(
+                "new Project description exceeds the allowed length"
+            )
+    return _ImportTarget(
+        project_id=None,
+        project_name=name,
+        project_description=description,
+    )
+
+
+def _candidate_selector(candidate: RepositoryDiscoveryCandidate) -> str:
+    relative_path = candidate.root_relative_path
+    if relative_path.is_absolute():
+        raise CandidateRevalidationFailed("candidate relative identity is invalid")
+    if ".." in relative_path.parts:
+        raise CandidateRevalidationFailed("candidate relative identity is invalid")
+    return PurePosixPath(relative_path.as_posix()).as_posix()
+
+
+def _find_candidate(
+    candidates: tuple[RepositoryDiscoveryCandidate, ...],
+    selector: str,
+) -> RepositoryDiscoveryCandidate:
+    matches = [
+        candidate
+        for candidate in candidates
+        if _candidate_selector(candidate) == selector
+    ]
+    if not matches:
+        raise CandidateNotFound("selected repository candidate was not found")
+    if len(matches) != 1:
+        raise CandidateRevalidationFailed(
+            "selected repository candidate is ambiguous"
+        )
+    return matches[0]
+
+
+def _load_owned_project(
+    session: Session,
+    *,
+    project_id: int,
+    authenticated_account_id: str,
+) -> Project:
+    project = session.get(Project, project_id)
+    if project is None:
+        raise ProjectNotFound("Project does not exist")
+    if str(project.user_id) != authenticated_account_id:
+        raise AccountProjectMismatch(
+            "Project does not belong to the authenticated account"
+        )
+    return project
+
+
+def _active_bindings_for_canonical_root(
+    session: Session,
+    canonical_root: Path,
+) -> list[tuple[RepositoryBinding, Project]]:
+    statement = (
+        select(RepositoryBinding, Project)
+        .join(Project, RepositoryBinding.project_id == Project.id)
+        .where(
+            RepositoryBinding.is_active.is_(True),
+            RepositoryBinding.canonical_root == str(canonical_root),
+        )
+    )
+    return list(session.execute(statement).all())
+
+
+def _candidate_provenance(
+    candidate: RepositoryDiscoveryCandidate,
+) -> dict[str, Any]:
+    """Build the Stage 2K.1 bounded provenance payload without paths."""
+    return {
+        "registration_source": IMPORT_REGISTRATION_SOURCE,
+        "operation_class": IMPORT_OPERATION_CLASS,
+        "authority_context": {
+            "discovery_provenance_class": (
+                candidate.discovery_root_provenance_class
+            ),
+            "git_evidence_kind": candidate.git_evidence_kind,
+            "candidate_observed_at": candidate.discovered_at.isoformat(),
+        },
+    }
+
+
+def _result_for_existing(
+    binding: RepositoryBinding,
+    project: Project,
+) -> RepositoryImportResult:
+    return RepositoryImportResult(
+        project_id=int(project.id),
+        binding_id=str(binding.id),
+        created_project=False,
+        reused_existing=True,
+    )
+
+
+def _revalidate_candidate(
+    candidate: RepositoryDiscoveryCandidate,
+    *,
+    authenticated_account_id: str,
+) -> Path:
+    if candidate.source_class != DISCOVERY_CANDIDATE_CLASS:
+        raise CandidateRevalidationFailed("candidate source class is invalid")
+    if candidate.authorized_actor_id != authenticated_account_id:
+        raise CandidateActorMismatch(
+            "candidate does not belong to the authenticated account"
+        )
+    try:
+        canonical_root = validate_git_working_tree_root(
+            candidate.canonical_working_tree_root
+        )
+    except RepositoryAuthorityError as exc:
+        raise CandidateRevalidationFailed(
+            "candidate Git working tree could not be revalidated"
+        ) from exc
+    if canonical_root != candidate.canonical_working_tree_root:
+        raise CandidateRevalidationFailed(
+            "candidate Git working tree identity changed"
+        )
+    return canonical_root
+
+
+def _new_project_description(
+    value: str | None,
+    *,
+    canonical_root: Path,
+) -> str | None:
+    if value is None:
+        return None
+    if str(canonical_root) in value:
+        raise InvalidImportTarget(
+            "new Project description must not contain repository paths"
+        )
+    return value
+
+
+def import_repository_candidate(
+    session: Session,
+    *,
+    authenticated_account_id: str | None,
+    candidate: RepositoryDiscoveryCandidate,
+    project_id: int | None = None,
+    project_name: str | None = None,
+    project_description: str | None = None,
+) -> RepositoryImportResult:
+    """Import one actual discovery candidate in the caller-owned transaction."""
+    account_id = _require_authenticated_account_id(authenticated_account_id)
+    target = _validate_import_target(
+        project_id=project_id,
+        project_name=project_name,
+        project_description=project_description,
+    )
+    canonical_root = _revalidate_candidate(
+        candidate, authenticated_account_id=account_id
+    )
+
+    requested_project: Project | None = None
+    if target.project_id is not None:
+        requested_project = _load_owned_project(
+            session,
+            project_id=target.project_id,
+            authenticated_account_id=account_id,
+        )
+
+    existing_bindings = _active_bindings_for_canonical_root(
+        session, canonical_root
+    )
+    if len(existing_bindings) > 1:
+        raise RepositoryBindingAmbiguous(
+            "multiple active bindings resolve to the selected repository"
+        )
+    if existing_bindings:
+        binding, project = existing_bindings[0]
+        if str(project.user_id) != account_id:
+            raise RepositoryBindingOwnedByAnotherAccount(
+                "selected repository is already linked"
+            )
+        if target.creates_project:
+            return _result_for_existing(binding, project)
+        if requested_project is not None and project.id == requested_project.id:
+            return _result_for_existing(binding, project)
+        raise RepositoryAlreadyLinked(
+            "selected repository is linked to a different Project"
+        )
+
+    created_project = False
+    if requested_project is None:
+        description = _new_project_description(
+            target.project_description, canonical_root=canonical_root
+        )
+        requested_project = Project(
+            user_id=account_id,
+            name=target.project_name or "",
+            description=description,
+        )
+        session.add(requested_project)
+        session.flush()
+        created_project = True
+
+    binding = create_repository_binding(
+        session,
+        authenticated_account_id=account_id,
+        project_id=int(requested_project.id),
+        source_class=SOURCE_CLASS_EXTERNAL_LINKED,
+        working_tree_root=canonical_root,
+        provenance=_candidate_provenance(candidate),
+    )
+    return RepositoryImportResult(
+        project_id=int(requested_project.id),
+        binding_id=str(binding.id),
+        created_project=created_project,
+        reused_existing=False,
+    )
+
+
+def import_explicit_repository_candidate(
+    session: Session,
+    *,
+    authenticated_account_id: str | None,
+    discovery_root: Path | str,
+    candidate_relative_path: str,
+    project_id: int | None = None,
+    project_name: str | None = None,
+    project_description: str | None = None,
+) -> RepositoryImportResult:
+    """Rediscover and import one authenticated explicit-root candidate."""
+    account_id = _require_authenticated_account_id(authenticated_account_id)
+    _validate_import_target(
+        project_id=project_id,
+        project_name=project_name,
+        project_description=project_description,
+    )
+    selector = _normalize_candidate_selector(candidate_relative_path)
+    authorized_root = authorize_explicit_discovery_root(
+        authorized_actor_id=account_id,
+        root=discovery_root,
+    )
+    discovery_result = discover_repository_candidates(authorized_root)
+    candidate = _find_candidate(discovery_result.candidates, selector)
+    if candidate.authorized_actor_id != account_id:
+        raise CandidateActorMismatch(
+            "candidate does not belong to the authenticated account"
+        )
+    return import_repository_candidate(
+        session,
+        authenticated_account_id=account_id,
+        candidate=candidate,
+        project_id=project_id,
+        project_name=project_name,
+        project_description=project_description,
+    )

--- a/guardian/routes/projects.py
+++ b/guardian/routes/projects.py
@@ -20,6 +20,23 @@ from guardian.core.default_project import (
     is_default_project_name,
     normalize_projects_for_listing,
 )
+from guardian.core.repository_authority import (
+    ActiveBindingAlreadyExists,
+    AccountProjectMismatch,
+    ProjectNotFound,
+)
+from guardian.core.repository_discovery import RepositoryDiscoveryError
+from guardian.core.repository_import import (
+    CandidateActorMismatch,
+    CandidateNotFound,
+    CandidateRevalidationFailed,
+    InvalidImportTarget,
+    RepositoryAlreadyLinked,
+    RepositoryBindingAmbiguous,
+    RepositoryBindingOwnedByAnotherAccount,
+    RepositoryImportError,
+    import_explicit_repository_candidate,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +101,18 @@ class ProjectCreate(BaseModel):
     user_id: Optional[str] = None
 
     model_config = ConfigDict(extra="ignore")
+
+
+class RepositoryCandidateImportRequest(BaseModel):
+    """Authenticated human/API import request; never a model tool schema."""
+
+    discovery_root: str
+    candidate_relative_path: str
+    project_id: Optional[int] = None
+    project_name: Optional[str] = None
+    project_description: Optional[str] = None
+
+    model_config = ConfigDict(extra="forbid")
 
 
 _PROJECT_OWNER_SENTINEL = "__codexify_project_owner__"
@@ -314,6 +343,128 @@ def create_project(
         return JSONResponse(
             status_code=400, content={"ok": False, "error": str(e)}
         )
+
+
+def _repository_import_error_response(exc: Exception) -> HTTPException:
+    if isinstance(exc, (InvalidImportTarget, RepositoryDiscoveryError)):
+        return HTTPException(
+            status_code=400,
+            detail={
+                "code": "repository_import_invalid_request",
+                "message": "Repository import request is invalid.",
+            },
+        )
+    if isinstance(exc, (AccountProjectMismatch, CandidateActorMismatch)):
+        return HTTPException(
+            status_code=403,
+            detail={
+                "code": "repository_import_forbidden",
+                "message": "Repository import is not authorized for this account.",
+            },
+        )
+    if isinstance(exc, (CandidateNotFound, ProjectNotFound)):
+        return HTTPException(
+            status_code=404,
+            detail={
+                "code": "repository_import_candidate_not_found",
+                "message": "Selected repository candidate was not found.",
+            },
+        )
+    if isinstance(
+        exc,
+        (
+            CandidateRevalidationFailed,
+            RepositoryAlreadyLinked,
+            RepositoryBindingAmbiguous,
+            RepositoryBindingOwnedByAnotherAccount,
+            ActiveBindingAlreadyExists,
+        ),
+    ):
+        return HTTPException(
+            status_code=409,
+            detail={
+                "code": "repository_import_conflict",
+                "message": "Repository import conflicts with current authority.",
+            },
+        )
+    if isinstance(exc, RepositoryImportError):
+        return HTTPException(
+            status_code=400,
+            detail={
+                "code": "repository_import_invalid_request",
+                "message": "Repository import request is invalid.",
+            },
+        )
+    return HTTPException(
+        status_code=500,
+        detail={
+            "code": "repository_import_internal_error",
+            "message": "Repository import could not be completed.",
+        },
+    )
+
+
+@api_router.post("/repository-import")
+def import_repository_candidate_route(
+    body: RepositoryCandidateImportRequest,
+    request_user_scope: RequestUserScope = Depends(get_request_user_scope),
+):
+    """Explicit authenticated candidate import; route owns commit or rollback."""
+    account_id = _request_account_id(request_user_scope)
+    if chatlog_db is None or not hasattr(chatlog_db, "get_session"):
+        raise _repository_import_error_response(RuntimeError("database unavailable"))
+
+    try:
+        with chatlog_db.get_session() as session:
+            try:
+                result = import_explicit_repository_candidate(
+                    session,
+                    authenticated_account_id=account_id,
+                    discovery_root=body.discovery_root,
+                    candidate_relative_path=body.candidate_relative_path,
+                    project_id=body.project_id,
+                    project_name=body.project_name,
+                    project_description=body.project_description,
+                )
+                session.commit()
+            except (
+                InvalidImportTarget,
+                RepositoryDiscoveryError,
+                AccountProjectMismatch,
+                ProjectNotFound,
+                CandidateActorMismatch,
+                CandidateNotFound,
+                CandidateRevalidationFailed,
+                RepositoryAlreadyLinked,
+                RepositoryBindingAmbiguous,
+                RepositoryBindingOwnedByAnotherAccount,
+                ActiveBindingAlreadyExists,
+                RepositoryImportError,
+            ) as exc:
+                session.rollback()
+                raise _repository_import_error_response(exc) from None
+            except Exception:
+                session.rollback()
+                logger.error("[projects] repository import failed")
+                raise _repository_import_error_response(
+                    RuntimeError("repository import failed")
+                ) from None
+    except HTTPException:
+        raise
+    except Exception:
+        logger.error("[projects] repository import session failed")
+        raise _repository_import_error_response(
+            RuntimeError("repository import session failed")
+        ) from None
+
+    return {
+        "ok": True,
+        "project_id": result.project_id,
+        "binding_id": result.binding_id,
+        "created_project": result.created_project,
+        "reused_existing": result.reused_existing,
+        "source_class": result.source_class,
+    }
 
 
 @router.patch("/{project_id}")

--- a/tests/core/test_repository_import.py
+++ b/tests/core/test_repository_import.py
@@ -1,0 +1,497 @@
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from guardian.core import repository_import
+from guardian.core.repository_authority import (
+    ActiveBindingAlreadyExists,
+    AccountProjectMismatch,
+    SOURCE_CLASS_EXTERNAL_LINKED,
+)
+from guardian.core.repository_discovery import (
+    DISCOVERY_ROOT_PROVENANCE_EXPLICIT_AUTHENTICATED_SELECTION,
+    GIT_EVIDENCE_DIRECTORY,
+    AuthorizedDiscoveryRoot,
+    RepositoryDiscoveryCandidate,
+)
+from guardian.db.models import Project
+
+
+def _run_git(*args: str, cwd: Path) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _init_repository(path: Path) -> Path:
+    path.mkdir(parents=True)
+    _run_git("init", "--quiet", cwd=path)
+    _run_git("config", "user.email", "fixture@example.invalid", cwd=path)
+    _run_git("config", "user.name", "Fixture", cwd=path)
+    fixture = path / "fixture.txt"
+    fixture.write_text("repository import fixture\n")
+    _run_git("add", "fixture.txt", cwd=path)
+    _run_git("commit", "--quiet", "-m", "fixture", cwd=path)
+    return path.resolve()
+
+
+def _candidate(
+    root: Path,
+    *,
+    relative: str = ".",
+    actor: str = "account-a",
+) -> RepositoryDiscoveryCandidate:
+    return RepositoryDiscoveryCandidate(
+        canonical_working_tree_root=root.resolve(),
+        root_relative_path=Path(relative),
+        discovery_root_provenance_class=(
+            DISCOVERY_ROOT_PROVENANCE_EXPLICIT_AUTHENTICATED_SELECTION
+        ),
+        authorized_actor_id=actor,
+        git_evidence_kind=GIT_EVIDENCE_DIRECTORY,
+        discovered_at=datetime.now(timezone.utc),
+    )
+
+
+class _FakeSession:
+    def __init__(self, projects: dict[int, Project] | None = None) -> None:
+        self.projects = projects or {}
+        self.added: list[object] = []
+        self.flush_count = 0
+        self.commit_count = 0
+
+    def get(self, model, project_id: int):
+        assert model is Project
+        return self.projects.get(project_id)
+
+    def add(self, item: object) -> None:
+        self.added.append(item)
+        if isinstance(item, Project):
+            item.id = max(self.projects, default=0) + 1
+            self.projects[item.id] = item
+
+    def flush(self) -> None:
+        self.flush_count += 1
+
+    def commit(self) -> None:
+        self.commit_count += 1
+
+
+def _patch_successful_binding(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    binding_id: str = "binding-1",
+) -> dict[str, object]:
+    calls: dict[str, object] = {}
+
+    def create(session, **kwargs):
+        calls.update(kwargs)
+        return SimpleNamespace(id=binding_id)
+
+    monkeypatch.setattr(repository_import, "create_repository_binding", create)
+    monkeypatch.setattr(
+        repository_import, "_active_bindings_for_canonical_root", lambda *_: []
+    )
+    return calls
+
+
+@pytest.mark.parametrize("account_id", [None, "", " "])
+def test_import_requires_authenticated_account_id(
+    tmp_path: Path, account_id: str | None
+) -> None:
+    repository = _init_repository(tmp_path / "repository")
+    with pytest.raises(repository_import.InvalidImportTarget):
+        repository_import.import_repository_candidate(
+            _FakeSession(),
+            authenticated_account_id=account_id,
+            candidate=_candidate(repository),
+            project_name="Imported",
+        )
+
+
+@pytest.mark.parametrize(
+    ("project_id", "project_name", "project_description"),
+    [
+        (1, "ambiguous", None),
+        (None, None, None),
+        (None, "   ", None),
+        (1, None, "not valid for an existing target"),
+        (0, None, None),
+    ],
+)
+def test_target_mode_requires_exactly_one_valid_target(
+    project_id: int | None,
+    project_name: str | None,
+    project_description: str | None,
+) -> None:
+    with pytest.raises(repository_import.InvalidImportTarget):
+        repository_import._validate_import_target(
+            project_id=project_id,
+            project_name=project_name,
+            project_description=project_description,
+        )
+
+
+@pytest.mark.parametrize(
+    ("selector", "expected"),
+    [(".", "."), ("nested/repository", "nested/repository")],
+)
+def test_safe_candidate_relative_selectors_are_accepted(
+    selector: str, expected: str
+) -> None:
+    assert repository_import._normalize_candidate_selector(selector) == expected
+
+
+@pytest.mark.parametrize("selector", ["", " ", "/absolute/repository", "../repo", "a/../repo", "a\\repo"])
+def test_unsafe_candidate_relative_selectors_are_rejected(selector: str) -> None:
+    with pytest.raises(repository_import.InvalidImportTarget):
+        repository_import._normalize_candidate_selector(selector)
+
+
+def test_explicit_import_authorizes_freshly_discovers_and_revalidates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "selected-root"
+    repository = _init_repository(root / "nested-repository")
+    candidate = _candidate(repository, relative="nested-repository")
+    session = _FakeSession()
+    binding_calls = _patch_successful_binding(monkeypatch)
+    authorized_calls: list[tuple[str, Path]] = []
+    discovery_calls: list[object] = []
+
+    authorized_root = AuthorizedDiscoveryRoot(
+        authorized_actor_id="account-a",
+        canonical_root=root,
+        provenance_class=DISCOVERY_ROOT_PROVENANCE_EXPLICIT_AUTHENTICATED_SELECTION,
+        authorized_at=datetime.now(timezone.utc),
+    )
+
+    def authorize(*, authorized_actor_id: str, root: Path | str):
+        authorized_calls.append((authorized_actor_id, Path(root)))
+        return authorized_root
+
+    def discover(value):
+        discovery_calls.append(value)
+        return SimpleNamespace(candidates=(candidate,))
+
+    monkeypatch.setattr(
+        repository_import, "authorize_explicit_discovery_root", authorize
+    )
+    monkeypatch.setattr(
+        repository_import, "discover_repository_candidates", discover
+    )
+
+    result = repository_import.import_explicit_repository_candidate(
+        session,
+        authenticated_account_id="account-a",
+        discovery_root=root,
+        candidate_relative_path="nested-repository",
+        project_name="  Imported Project  ",
+        project_description="A project description.",
+    )
+
+    assert authorized_calls == [("account-a", root)]
+    assert discovery_calls == [authorized_root]
+    assert result.project_id == 1
+    assert result.binding_id == "binding-1"
+    assert result.created_project is True
+    assert result.reused_existing is False
+    assert binding_calls["working_tree_root"] == repository
+    assert binding_calls["source_class"] == SOURCE_CLASS_EXTERNAL_LINKED
+    assert session.projects[1].user_id == "account-a"
+    assert session.projects[1].name == "Imported Project"
+    assert session.commit_count == 0
+
+
+def test_missing_candidate_is_rejected_after_fresh_discovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "selected-root"
+    root.mkdir()
+    authorized_root = AuthorizedDiscoveryRoot(
+        authorized_actor_id="account-a",
+        canonical_root=root,
+        provenance_class=DISCOVERY_ROOT_PROVENANCE_EXPLICIT_AUTHENTICATED_SELECTION,
+        authorized_at=datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(
+        repository_import,
+        "authorize_explicit_discovery_root",
+        lambda **_: authorized_root,
+    )
+    monkeypatch.setattr(
+        repository_import,
+        "discover_repository_candidates",
+        lambda _: SimpleNamespace(candidates=()),
+    )
+
+    with pytest.raises(repository_import.CandidateNotFound):
+        repository_import.import_explicit_repository_candidate(
+            _FakeSession(),
+            authenticated_account_id="account-a",
+            discovery_root=root,
+            candidate_relative_path="not-found",
+            project_name="Imported",
+        )
+
+
+def test_candidate_actor_and_source_class_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository = _init_repository(tmp_path / "repository")
+    _patch_successful_binding(monkeypatch)
+    with pytest.raises(repository_import.CandidateActorMismatch):
+        repository_import.import_repository_candidate(
+            _FakeSession(),
+            authenticated_account_id="account-a",
+            candidate=_candidate(repository, actor="account-b"),
+            project_name="Imported",
+        )
+
+    invalid_source = _candidate(repository)
+    object.__setattr__(invalid_source, "source_class", "external_linked")
+    with pytest.raises(repository_import.CandidateRevalidationFailed):
+        repository_import.import_repository_candidate(
+            _FakeSession(),
+            authenticated_account_id="account-a",
+            candidate=invalid_source,
+            project_name="Imported",
+        )
+
+
+def test_stale_or_changed_candidate_root_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    missing_root = (tmp_path / "missing").resolve()
+    stale = _candidate(missing_root)
+    _patch_successful_binding(monkeypatch)
+    with pytest.raises(repository_import.CandidateRevalidationFailed):
+        repository_import.import_repository_candidate(
+            _FakeSession(),
+            authenticated_account_id="account-a",
+            candidate=stale,
+            project_name="Imported",
+        )
+
+    repository = _init_repository(tmp_path / "repository")
+    monkeypatch.setattr(
+        repository_import,
+        "validate_git_working_tree_root",
+        lambda _: (tmp_path / "other-root").resolve(),
+    )
+    with pytest.raises(repository_import.CandidateRevalidationFailed):
+        repository_import.import_repository_candidate(
+            _FakeSession(),
+            authenticated_account_id="account-a",
+            candidate=_candidate(repository),
+            project_name="Imported",
+        )
+
+
+def test_new_project_is_owned_path_safe_and_uses_bounded_provenance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository = _init_repository(tmp_path / "repository")
+    session = _FakeSession()
+    binding_calls = _patch_successful_binding(monkeypatch)
+    result = repository_import.import_repository_candidate(
+        session,
+        authenticated_account_id="account-a",
+        candidate=_candidate(repository),
+        project_name="Imported",
+        project_description="Safe description",
+    )
+
+    assert result.source_class == SOURCE_CLASS_EXTERNAL_LINKED
+    assert session.projects[result.project_id].user_id == "account-a"
+    assert session.projects[result.project_id].description == "Safe description"
+    assert binding_calls["source_class"] == SOURCE_CLASS_EXTERNAL_LINKED
+    provenance = binding_calls["provenance"]
+    assert set(provenance) == {
+        "registration_source",
+        "operation_class",
+        "authority_context",
+    }
+    assert provenance["registration_source"] == "repository_candidate_import"
+    assert provenance["operation_class"] == "external_link"
+    assert provenance["authority_context"][
+        "discovery_provenance_class"
+    ] == DISCOVERY_ROOT_PROVENANCE_EXPLICIT_AUTHENTICATED_SELECTION
+    assert provenance["authority_context"]["git_evidence_kind"] == GIT_EVIDENCE_DIRECTORY
+    assert provenance["authority_context"]["candidate_observed_at"].endswith("+00:00")
+    assert str(repository) not in repr(provenance)
+    assert "root_relative_path" not in repr(provenance)
+
+    with pytest.raises(repository_import.InvalidImportTarget):
+        repository_import.import_repository_candidate(
+            _FakeSession(),
+            authenticated_account_id="account-a",
+            candidate=_candidate(repository),
+            project_name="Reject path",
+            project_description=f"Do not persist {repository}",
+        )
+
+
+def test_existing_project_requires_ownership_and_can_link(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository = _init_repository(tmp_path / "repository")
+    owned_project = Project(id=7, user_id="account-a", name="Owned")
+    session = _FakeSession({7: owned_project})
+    _patch_successful_binding(monkeypatch, binding_id="binding-owned")
+    result = repository_import.import_repository_candidate(
+        session,
+        authenticated_account_id="account-a",
+        candidate=_candidate(repository),
+        project_id=7,
+    )
+    assert result == repository_import.RepositoryImportResult(
+        project_id=7,
+        binding_id="binding-owned",
+        created_project=False,
+        reused_existing=False,
+    )
+    assert session.added == []
+
+    foreign_session = _FakeSession(
+        {8: Project(id=8, user_id="account-b", name="Foreign")}
+    )
+    with pytest.raises(AccountProjectMismatch):
+        repository_import.import_repository_candidate(
+            foreign_session,
+            authenticated_account_id="account-a",
+            candidate=_candidate(repository),
+            project_id=8,
+        )
+
+
+def test_duplicate_root_cases_are_idempotent_or_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository = _init_repository(tmp_path / "repository")
+    own_project = Project(id=4, user_id="account-a", name="Owned")
+    other_project = Project(id=5, user_id="account-a", name="Other")
+    binding = SimpleNamespace(id="existing-binding")
+    session = _FakeSession({4: own_project, 5: other_project})
+    monkeypatch.setattr(
+        repository_import,
+        "_active_bindings_for_canonical_root",
+        lambda *_: [(binding, own_project)],
+    )
+
+    same = repository_import.import_repository_candidate(
+        session,
+        authenticated_account_id="account-a",
+        candidate=_candidate(repository),
+        project_id=4,
+    )
+    new_target = repository_import.import_repository_candidate(
+        session,
+        authenticated_account_id="account-a",
+        candidate=_candidate(repository),
+        project_name="Would not be created",
+    )
+    assert same.reused_existing is True
+    assert new_target.project_id == 4
+    assert len(session.projects) == 2
+    with pytest.raises(repository_import.RepositoryAlreadyLinked):
+        repository_import.import_repository_candidate(
+            session,
+            authenticated_account_id="account-a",
+            candidate=_candidate(repository),
+            project_id=5,
+        )
+
+    foreign_project = Project(id=9, user_id="account-b", name="Foreign")
+    monkeypatch.setattr(
+        repository_import,
+        "_active_bindings_for_canonical_root",
+        lambda *_: [(binding, foreign_project)],
+    )
+    with pytest.raises(repository_import.RepositoryBindingOwnedByAnotherAccount):
+        repository_import.import_repository_candidate(
+            session,
+            authenticated_account_id="account-a",
+            candidate=_candidate(repository),
+            project_name="Must not exist",
+        )
+
+    monkeypatch.setattr(
+        repository_import,
+        "_active_bindings_for_canonical_root",
+        lambda *_: [(binding, own_project), (binding, own_project)],
+    )
+    with pytest.raises(repository_import.RepositoryBindingAmbiguous):
+        repository_import.import_repository_candidate(
+            session,
+            authenticated_account_id="account-a",
+            candidate=_candidate(repository),
+            project_name="Must not exist",
+        )
+
+
+def test_existing_project_with_active_binding_is_left_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository = _init_repository(tmp_path / "repository")
+    project = Project(id=4, user_id="account-a", name="Already bound")
+    session = _FakeSession({4: project})
+    monkeypatch.setattr(
+        repository_import, "_active_bindings_for_canonical_root", lambda *_: []
+    )
+
+    def reject_binding(*args, **kwargs):
+        raise ActiveBindingAlreadyExists("already bound")
+
+    monkeypatch.setattr(
+        repository_import, "create_repository_binding", reject_binding
+    )
+    with pytest.raises(ActiveBindingAlreadyExists):
+        repository_import.import_repository_candidate(
+            session,
+            authenticated_account_id="account-a",
+            candidate=_candidate(repository),
+            project_id=4,
+        )
+    assert session.added == []
+    assert session.commit_count == 0
+
+
+def test_import_is_filesystem_and_git_immutable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository = _init_repository(tmp_path / "repository")
+    fixture = repository / "fixture.txt"
+    before_bytes = fixture.read_bytes()
+    before_stat = fixture.stat()
+    before_head = _run_git("rev-parse", "HEAD", cwd=repository)
+    before_branch = _run_git("rev-parse", "--abbrev-ref", "HEAD", cwd=repository)
+    binding_calls = _patch_successful_binding(monkeypatch)
+
+    repository_import.import_repository_candidate(
+        _FakeSession(),
+        authenticated_account_id="account-a",
+        candidate=_candidate(repository),
+        project_name="No mutation",
+    )
+
+    assert fixture.read_bytes() == before_bytes
+    assert fixture.stat().st_mtime_ns == before_stat.st_mtime_ns
+    assert _run_git("rev-parse", "HEAD", cwd=repository) == before_head
+    assert _run_git("rev-parse", "--abbrev-ref", "HEAD", cwd=repository) == before_branch
+    assert binding_calls["working_tree_root"] == repository
+    source = Path(repository_import.__file__).read_text()
+    assert "Workspace" not in source
+    assert "remote" not in source.lower()
+    assert "source_class" not in str(
+        repository_import.import_explicit_repository_candidate.__annotations__
+    )

--- a/tests/integration/test_repository_import_postgres.py
+++ b/tests/integration/test_repository_import_postgres.py
@@ -1,0 +1,296 @@
+"""Disposable Postgres transaction proof for explicit repository import."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import uuid
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+try:
+    import psycopg  # type: ignore
+except ImportError:  # pragma: no cover - environment specific
+    psycopg = None
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, select, text
+from sqlalchemy.engine import Engine, make_url
+from sqlalchemy.orm import Session, sessionmaker
+
+from guardian.core.repository_authority import ActiveBindingAlreadyExists
+from guardian.core.repository_import import (
+    RepositoryBindingOwnedByAnotherAccount,
+    import_explicit_repository_candidate,
+)
+from guardian.db.models import Project, RepositoryBinding
+
+
+ALEMBIC_HEAD = "6e2b9c4a7d1f"
+
+
+def _database_url(base_url: str, database_name: str) -> str:
+    return make_url(base_url).set(
+        drivername="postgresql+psycopg", database=database_name
+    ).render_as_string(hide_password=False)
+
+
+def _admin_database_url(base_url: str) -> str:
+    return make_url(base_url).set(
+        drivername="postgresql", database="postgres"
+    ).render_as_string(hide_password=False)
+
+
+@pytest.fixture
+def disposable_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[Engine, None, None]:
+    """Create and destroy one uniquely named database under TEST_DATABASE_URL."""
+    if psycopg is None:
+        pytest.skip("psycopg is required for the disposable Postgres proof")
+    base_url = os.getenv("TEST_DATABASE_URL")
+    if not base_url:
+        pytest.skip(
+            "TEST_DATABASE_URL is required for the disposable Postgres proof"
+        )
+
+    database_name = f"codexify_stage2k3_import_{uuid.uuid4().hex[:12]}"
+    admin_url = _admin_database_url(base_url)
+    database_url = _database_url(base_url, database_name)
+    try:
+        with psycopg.connect(admin_url, autocommit=True) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(f'CREATE DATABASE "{database_name}"')
+    except Exception as exc:  # pragma: no cover - environment specific
+        pytest.skip(f"unable to create disposable Postgres database: {exc}")
+
+    repository_root = Path(__file__).resolve().parents[2]
+    config = Config(str(repository_root / "backend" / "alembic.ini"))
+    config.set_main_option("sqlalchemy.url", database_url)
+    config.set_main_option(
+        "script_location", str(repository_root / "guardian" / "db" / "migrations")
+    )
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    engine: Engine | None = None
+    try:
+        command.upgrade(config, ALEMBIC_HEAD)
+        engine = create_engine(database_url, future=True)
+        yield engine
+    finally:
+        if engine is not None:
+            engine.dispose()
+        try:
+            with psycopg.connect(admin_url, autocommit=True) as connection:
+                with connection.cursor() as cursor:
+                    cursor.execute(
+                        "SELECT pg_terminate_backend(pid) "
+                        "FROM pg_stat_activity "
+                        "WHERE datname = %s AND pid <> pg_backend_pid()",
+                        (database_name,),
+                    )
+                    cursor.execute(f'DROP DATABASE IF EXISTS "{database_name}"')
+        except Exception:
+            pass
+
+
+def _run_git(*args: str, cwd: Path) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _init_repository(path: Path) -> Path:
+    path.mkdir()
+    _run_git("init", "--quiet", cwd=path)
+    _run_git("config", "user.email", "fixture@example.invalid", cwd=path)
+    _run_git("config", "user.name", "Fixture", cwd=path)
+    (path / "fixture.txt").write_text("Postgres import fixture\n")
+    _run_git("add", "fixture.txt", cwd=path)
+    _run_git("commit", "--quiet", "-m", "fixture", cwd=path)
+    return path.resolve()
+
+
+def _seed_account(engine: Engine, account_id: str) -> None:
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "INSERT INTO users (id, username, password_hash, role) "
+                "VALUES (:id, :username, :password_hash, :role)"
+            ),
+            {
+                "id": account_id,
+                "username": account_id,
+                "password_hash": "not-a-real-password-hash",
+                "role": "guest",
+            },
+        )
+
+
+def _import(
+    session: Session,
+    *,
+    account_id: str,
+    discovery_root: Path,
+    selector: str,
+    project_id: int | None = None,
+    project_name: str | None = None,
+) -> object:
+    return import_explicit_repository_candidate(
+        session,
+        authenticated_account_id=account_id,
+        discovery_root=discovery_root,
+        candidate_relative_path=selector,
+        project_id=project_id,
+        project_name=project_name,
+        project_description=(
+            "transaction proof" if project_id is None else None
+        ),
+    )
+
+
+@pytest.mark.integration
+def test_repository_import_postgres_commit_rollback_and_conflicts(
+    disposable_database: Engine,
+    tmp_path: Path,
+) -> None:
+    engine = disposable_database
+    sessions = sessionmaker(engine, expire_on_commit=False, future=True)
+    _seed_account(engine, "account-a")
+    _seed_account(engine, "account-b")
+
+    discovery_root = tmp_path / "discovery"
+    discovery_root.mkdir()
+    repository_a = _init_repository(discovery_root / "repository-a")
+    repository_b = _init_repository(discovery_root / "repository-b")
+    repository_c = _init_repository(discovery_root / "repository-c")
+    repository_rollback = _init_repository(discovery_root / "repository-rollback")
+
+    with sessions() as session:
+        committed = _import(
+            session,
+            account_id="account-a",
+            discovery_root=discovery_root,
+            selector="repository-a",
+            project_name="Stage 2K.3 committed project",
+        )
+        assert session.get(Project, committed.project_id) is not None
+        binding_before_commit = session.get(RepositoryBinding, committed.binding_id)
+        assert binding_before_commit is not None
+        assert binding_before_commit.project_id == committed.project_id
+        assert binding_before_commit.source_class == "external_linked"
+        assert binding_before_commit.canonical_root == str(repository_a)
+        session.commit()
+
+    with sessions() as session:
+        persisted_project = session.get(Project, committed.project_id)
+        persisted_binding = session.get(RepositoryBinding, committed.binding_id)
+        assert persisted_project is not None
+        assert persisted_project.user_id == "account-a"
+        assert persisted_binding is not None
+        assert persisted_binding.is_active is True
+        assert persisted_binding.project_id == committed.project_id
+
+    with sessions() as session:
+        rolled_back = _import(
+            session,
+            account_id="account-a",
+            discovery_root=discovery_root,
+            selector="repository-rollback",
+            project_name="Stage 2K.3 rolled back project",
+        )
+        rolled_back_project_id = rolled_back.project_id
+        rolled_back_binding_id = rolled_back.binding_id
+        session.rollback()
+
+    with sessions() as session:
+        assert session.get(Project, rolled_back_project_id) is None
+        assert session.get(RepositoryBinding, rolled_back_binding_id) is None
+
+    with sessions() as session:
+        existing_project = Project(
+            user_id="account-a",
+            name="Stage 2K.3 existing project",
+            description="repository-less before explicit import",
+        )
+        session.add(existing_project)
+        session.commit()
+        existing_project_id = existing_project.id
+
+    with sessions() as session:
+        linked = _import(
+            session,
+            account_id="account-a",
+            discovery_root=discovery_root,
+            selector="repository-b",
+            project_id=existing_project_id,
+        )
+        session.commit()
+        assert linked.project_id == existing_project_id
+        assert linked.created_project is False
+
+    with sessions() as session:
+        binding = session.scalar(
+            select(RepositoryBinding).where(
+                RepositoryBinding.project_id == existing_project_id,
+                RepositoryBinding.is_active.is_(True),
+            )
+        )
+        assert binding is not None
+        assert binding.canonical_root == str(repository_b)
+
+    with sessions() as session:
+        reused = _import(
+            session,
+            account_id="account-a",
+            discovery_root=discovery_root,
+            selector="repository-a",
+            project_name="This project must not be created",
+        )
+        assert reused.reused_existing is True
+        assert reused.project_id == committed.project_id
+        session.commit()
+
+    with sessions() as session:
+        with pytest.raises(RepositoryBindingOwnedByAnotherAccount):
+            _import(
+                session,
+                account_id="account-b",
+                discovery_root=discovery_root,
+                selector="repository-a",
+                project_name="Account B must not receive a project",
+            )
+        session.rollback()
+
+    with sessions() as session:
+        account_b_projects = session.scalars(
+            select(Project).where(Project.user_id == "account-b")
+        ).all()
+        assert account_b_projects == []
+
+    with sessions() as session:
+        with pytest.raises(ActiveBindingAlreadyExists):
+            _import(
+                session,
+                account_id="account-a",
+                discovery_root=discovery_root,
+                selector="repository-c",
+                project_id=existing_project_id,
+            )
+        session.rollback()
+
+    with sessions() as session:
+        original_binding = session.scalar(
+            select(RepositoryBinding).where(
+                RepositoryBinding.project_id == existing_project_id,
+                RepositoryBinding.is_active.is_(True),
+            )
+        )
+        assert original_binding is not None
+        assert original_binding.canonical_root == str(repository_b)

--- a/tests/routes/test_project_repository_import.py
+++ b/tests/routes/test_project_repository_import.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from guardian.core.dependencies import RequestUserScope
+from guardian.core.repository_authority import AccountProjectMismatch
+from guardian.core.repository_import import (
+    CandidateNotFound,
+    CandidateRevalidationFailed,
+    RepositoryAlreadyLinked,
+    RepositoryBindingOwnedByAnotherAccount,
+    RepositoryImportResult,
+)
+from guardian.routes import projects as projects_routes
+
+
+class _Session:
+    def __init__(self) -> None:
+        self.commits = 0
+        self.rollbacks = 0
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+class _Database:
+    def __init__(self, session: _Session) -> None:
+        self.session = session
+
+    @contextmanager
+    def get_session(self):
+        yield self.session
+
+
+def _scope(account_id: str = "account-a") -> RequestUserScope:
+    return RequestUserScope(
+        user_id=account_id,
+        account_id=account_id,
+        multi_user_enabled=True,
+    )
+
+
+def _body(**overrides: object) -> projects_routes.RepositoryCandidateImportRequest:
+    payload: dict[str, object] = {
+        "discovery_root": "/private/selected-root",
+        "candidate_relative_path": "nested/repository",
+        "project_name": "Imported Project",
+        "project_description": "Safe description",
+    }
+    payload.update(overrides)
+    return projects_routes.RepositoryCandidateImportRequest.model_validate(payload)
+
+
+def test_repository_import_route_is_api_only_and_request_surface_is_bounded() -> None:
+    api_paths = {
+        (route.path, tuple(sorted(route.methods)))
+        for route in projects_routes.api_router.routes
+    }
+    legacy_paths = {
+        (route.path, tuple(sorted(route.methods)))
+        for route in projects_routes.router.routes
+    }
+    assert ("/api/projects/repository-import", ("POST",)) in api_paths
+    assert not any(path.endswith("repository-import") for path, _ in legacy_paths)
+    assert set(
+        projects_routes.RepositoryCandidateImportRequest.model_json_schema()[
+            "properties"
+        ]
+    ) == {
+        "discovery_root",
+        "candidate_relative_path",
+        "project_id",
+        "project_name",
+        "project_description",
+    }
+    with pytest.raises(ValidationError):
+        projects_routes.RepositoryCandidateImportRequest.model_validate(
+            {
+                "discovery_root": "/private/selected-root",
+                "candidate_relative_path": ".",
+                "project_name": "Imported Project",
+                "user_id": "body-controlled-owner",
+            }
+        )
+
+
+def test_successful_new_project_import_passes_scope_identity_and_commits_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _Session()
+    monkeypatch.setattr(projects_routes, "chatlog_db", _Database(session))
+    calls: dict[str, object] = {}
+
+    def import_candidate(received_session, **kwargs):
+        calls["session"] = received_session
+        calls.update(kwargs)
+        return RepositoryImportResult(
+            project_id=17,
+            binding_id="binding-17",
+            created_project=True,
+            reused_existing=False,
+        )
+
+    monkeypatch.setattr(
+        projects_routes, "import_explicit_repository_candidate", import_candidate
+    )
+
+    response = projects_routes.import_repository_candidate_route(
+        _body(),
+        request_user_scope=_scope(),
+    )
+
+    assert response == {
+        "ok": True,
+        "project_id": 17,
+        "binding_id": "binding-17",
+        "created_project": True,
+        "reused_existing": False,
+        "source_class": "external_linked",
+    }
+    assert calls["session"] is session
+    assert calls["authenticated_account_id"] == "account-a"
+    assert calls["discovery_root"] == "/private/selected-root"
+    assert calls["candidate_relative_path"] == "nested/repository"
+    assert session.commits == 1
+    assert session.rollbacks == 0
+    assert "/private/selected-root" not in repr(response)
+    assert "canonical_root" not in response
+    assert "discovery_root" not in response
+
+
+def test_successful_existing_project_link_returns_only_bounded_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _Session()
+    monkeypatch.setattr(projects_routes, "chatlog_db", _Database(session))
+    monkeypatch.setattr(
+        projects_routes,
+        "import_explicit_repository_candidate",
+        lambda *_args, **_kwargs: RepositoryImportResult(
+            project_id=5,
+            binding_id="binding-5",
+            created_project=False,
+            reused_existing=True,
+        ),
+    )
+
+    response = projects_routes.import_repository_candidate_route(
+        _body(project_id=5, project_name=None, project_description=None),
+        request_user_scope=_scope(),
+    )
+
+    assert response["project_id"] == 5
+    assert response["created_project"] is False
+    assert response["reused_existing"] is True
+    assert set(response) == {
+        "ok",
+        "project_id",
+        "binding_id",
+        "created_project",
+        "reused_existing",
+        "source_class",
+    }
+    assert session.commits == 1
+
+
+@pytest.mark.parametrize(
+    ("error", "status", "code"),
+    [
+        (AccountProjectMismatch("foreign project"), 403, "repository_import_forbidden"),
+        (CandidateNotFound("missing candidate"), 404, "repository_import_candidate_not_found"),
+        (CandidateRevalidationFailed("stale candidate"), 409, "repository_import_conflict"),
+        (RepositoryAlreadyLinked("already linked"), 409, "repository_import_conflict"),
+        (
+            RepositoryBindingOwnedByAnotherAccount("foreign account id=88"),
+            409,
+            "repository_import_conflict",
+        ),
+    ],
+)
+def test_known_failures_rollback_with_bounded_path_safe_response(
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+    status: int,
+    code: str,
+) -> None:
+    session = _Session()
+    monkeypatch.setattr(projects_routes, "chatlog_db", _Database(session))
+
+    def fail(*_args, **_kwargs):
+        raise error
+
+    monkeypatch.setattr(
+        projects_routes, "import_explicit_repository_candidate", fail
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        projects_routes.import_repository_candidate_route(
+            _body(discovery_root="/private/selected-root"),
+            request_user_scope=_scope(),
+        )
+
+    assert exc_info.value.status_code == status
+    assert exc_info.value.detail["code"] == code
+    assert "/private/selected-root" not in repr(exc_info.value.detail)
+    assert "foreign account id=88" not in repr(exc_info.value.detail)
+    assert session.commits == 0
+    assert session.rollbacks == 1
+
+
+def test_unexpected_failure_rolls_back_and_is_generic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _Session()
+    monkeypatch.setattr(projects_routes, "chatlog_db", _Database(session))
+
+    def fail(*_args, **_kwargs):
+        raise RuntimeError("leaked /private/selected-root")
+
+    monkeypatch.setattr(
+        projects_routes, "import_explicit_repository_candidate", fail
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        projects_routes.import_repository_candidate_route(
+            _body(), request_user_scope=_scope()
+        )
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == {
+        "code": "repository_import_internal_error",
+        "message": "Repository import could not be completed.",
+    }
+    assert session.commits == 0
+    assert session.rollbacks == 1
+
+
+def test_import_route_uses_request_scope_not_body_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _Session()
+    monkeypatch.setattr(projects_routes, "chatlog_db", _Database(session))
+    captured = SimpleNamespace(account_id=None)
+
+    def import_candidate(*_args, **kwargs):
+        captured.account_id = kwargs["authenticated_account_id"]
+        return RepositoryImportResult(
+            project_id=2,
+            binding_id="binding-2",
+            created_project=True,
+            reused_existing=False,
+        )
+
+    monkeypatch.setattr(
+        projects_routes, "import_explicit_repository_candidate", import_candidate
+    )
+    projects_routes.import_repository_candidate_route(
+        _body(), request_user_scope=_scope("scope-owned-account")
+    )
+    assert captured.account_id == "scope-owned-account"


### PR DESCRIPTION
## Summary

Implements Stage 2K.3 explicit authenticated repository candidate import.

- Adds API-only `POST /api/projects/repository-import`.
- Re-discovers and revalidates one selected candidate before creating or reusing an owned Project binding.
- Enforces account ownership, canonical-root duplicate handling, idempotency, and route-owned atomic commit/rollback.
- Keeps Workspace projection, schema changes, repository mutation, and model/tool/provider exposure out of scope.

## Validation

- `pytest -v tests/core/test_repository_import.py` — 25 passed
- `pytest -v tests/routes/test_project_repository_import.py` — 10 passed
- Disposable Postgres transaction proof — 1 passed
- Existing account-scope and Stage 2K.1/2 regressions — passed
- `pytest -v tests/architecture` — 394 passed
- Alembic sole head `6e2b9c4a7d1f`; docs and diagram-freshness validation passed.