### PR TITLE
Add bounded repository search

### DIFF
--- a/docs/architecture/proofs/2026-08-12-stage2k4-repository-search-command-bus-proof.md
+++ b/docs/architecture/proofs/2026-08-12-stage2k4-repository-search-command-bus-proof.md
@@ -1,0 +1,294 @@
+# Stage 2K.4 Repository Search Command Bus Proof
+
+## Date
+
+2026-08-12
+
+## Verdict
+
+PASS — one bounded read-only repository search Command Bus command is
+implemented. It remains a raw API/Command Bus capability and is not exposed to
+ordinary-chat models.
+
+## Diagnostic Outcome
+
+REPOSITORY_SEARCH_COMMAND_ESTABLISHED
+
+## Base Commit
+
+a146de133ae2e5e11a2fdc38479ca26b5cab3952, the verified origin/main
+baseline at task start.
+
+## Branch/Worktree
+
+- Branch: codex/stage2k4-repository-search
+- Worktree: /private/tmp/codexify-stage2k4-repository-search
+
+## Governing ADRs
+
+- ADR-065, Guardian-Managed Repository Onboarding Boundary — primary.
+- ADR-005, account/user isolation.
+- ADR-020 and ADR-024, Guardian-issued filesystem scope and authorized
+  crossing doctrine.
+- ADR-061, capability authorization boundaries.
+- Current Command Bus and bounded tool-turn contracts.
+
+## ADR Impact
+
+Aligned with existing ADR(s). No ADR, onboarding contract, current-state
+document, schema, or migration changed.
+
+## Stage 2K.1 Prerequisite
+
+The unchanged authority seam resolves a Project only through one active binding
+and revalidates exact Git working-tree identity, ownership, cardinality,
+managed-root containment, and stale/missing failure cases.
+
+## Stage 2K.2 Prerequisite
+
+The unchanged bounded discovery seam remains non-authorizing; a discovery
+candidate cannot reach this search path without durable binding authority.
+
+## Stage 2K.3 Prerequisite
+
+The unchanged explicit import seam remains the only candidate-to-binding
+transition. Search neither discovers nor imports repositories.
+
+## Current Truth Before
+
+Stage 2K.1 through 2K.3 were canonical, but no repository search engine,
+route, or Command Bus command existed. Ordinary chat exposed health only.
+
+## Command Identity
+
+The Projects API declares operation ID repository.search. The current
+OpenAPI-backed manifest derives command ID op::repository.search.
+
+## Command Manifest Derivation
+
+The command is not manually registered. Its derived raw alias is
+route::GET::/api/projects/{project_id}/repository/search. The manifest proves
+GET, read, read_only, safe, and no approval mode.
+
+## Authentication Boundary
+
+The API route derives the account only from RequestUserScope and the existing
+account helper. The request contains no account, user, binding, or repository
+root parameter.
+
+## Project-to-Binding Resolution
+
+The public search service first calls resolve_project_repository_binding with
+the authenticated account and requested Project. No Path-only public authority
+entry point exists.
+
+## Root Authority Proof
+
+The internal engine requires a real ResolvedRepositoryBinding and accepts its
+canonical root only after Stage 2K.1 revalidation. There is no cwd,
+nearest-Git, worktree environment, checkout, or discovery-candidate fallback.
+
+## Query Semantics
+
+Search is literal, case-insensitive Unicode casefold substring matching. It
+trims outer whitespace and rejects blank, NUL, CR, LF, and over-256-character
+queries. Regex and shell syntax have no special meaning.
+
+## Search Bounds
+
+- Query: 256 Unicode characters.
+- Returned matches: 20.
+- Candidate file entries: 5,000.
+- Git listing output: 2 MiB.
+- Individual file: 1 MiB.
+- Aggregate bytes read: 32 MiB.
+- Snippet: 400 Unicode characters.
+- Relative path: 512 Unicode characters.
+- Entire authority/search operation: 5.0 seconds.
+
+Only route result limit 1 through 20 is caller-selectable. No public caller can
+widen the remaining limits.
+
+## Git Enumeration Strategy
+
+The engine streams argv-only Git ls-files with cached, untracked, standard
+ignore, and NUL-output flags. It sets GIT_OPTIONAL_LOCKS=0, uses no shell, and
+never uses unbounded captured output.
+
+## Ignored File Behavior
+
+Git standard-ignore enumeration excludes ignored files. Core coverage proves an
+ignored matching file produces no result while an untracked non-ignored file
+does.
+
+## Secret-Risk Path Behavior
+
+The engine denies .env and .env.* names, standard credential/private-key
+basenames, and PEM/key/certificate-style suffixes before opening content.
+
+## Symlink/Containment Behavior
+
+Symlink files are skipped. Strict resolution and relative-to-root verification
+reject missing, escaping, non-regular, or outside-root paths before reading.
+
+## Binary/Text Behavior
+
+Files above the individual-size bound, NUL-containing content, and invalid
+UTF-8 produce no snippets and increment bounded skip counters.
+
+## Match/Snippet Bounds
+
+Matches carry only relative POSIX path, one-based line number, and at most 400
+characters from the matched source line. Long-line windows deterministically
+contain the first literal match and no neighboring lines.
+
+## Result Privacy
+
+Result serialization contains no binding ID, account ID, canonical root,
+repository root, discovery root, mount, cwd, or remote. Tests recursively
+check the response and Command Bus inline result shape for path leakage.
+
+## Repository Isolation
+
+The disposable Postgres proof binds Project A only to repository A while a
+second repository has distinct marker text. A Project A search finds only the
+bound repository-relative fixture result.
+
+## Cross-Account Denial
+
+The same integration proof rejects account B searching account A's Project;
+the route maps ownership mismatch to bounded 403 output.
+
+## Missing/Stale Binding Denial
+
+Repository-less Projects and a binding whose fixture root was moved both fail
+closed as repository search unavailable.
+
+## Filesystem Immutability
+
+Core and Postgres fixtures record representative bytes before search and prove
+them unchanged afterward.
+
+## Git Mutation Denial
+
+Fixture HEAD and active branch/ref remain unchanged. The implementation invokes
+only Stage 2K.1 rev-parse validation and Stage 2K.4 ls-files enumeration; it
+does not run status, grep, fetch, pull, checkout, branch, remote, or any
+mutating Git command.
+
+## Database Read-Only Proof
+
+The Postgres proof checks no new, dirty, or deleted ORM objects; Project and
+binding snapshots and row counts are unchanged after search. The route never
+commits or rolls back.
+
+## Command Bus Invocation Proof
+
+The Command Bus test invokes op::repository.search with Project path parameter
+42 and query needle/limit 5. Exactly one loopback GET is emitted with those
+path/query values, forwarded inbound authentication headers, and no body.
+
+## CommandRun Lifecycle
+
+The read-only invocation records run.created, run.started, and run.completed;
+it is completed rather than confirmation-gated.
+
+## Ordinary-Chat Non-Exposure Proof
+
+When a manifest contains both health and repository search commands, the
+unchanged ordinary-chat resolver returns health only and never returns
+op::repository.search.
+
+## No Legacy fs.search Proof
+
+The final implementation contains no legacy fs.search, ToolIntent,
+detect_project_root, cwd, or worktree-environment authority path.
+
+## Alembic Head Result
+
+Before and after this no-schema slice, the sole Alembic head is
+6e2b9c4a7d1f.
+
+## Core Test Results
+
+pytest -v tests/core/test_repository_search.py — 22 passed.
+
+## Route Test Results
+
+pytest -v tests/routes/test_project_repository_search.py — 9 passed.
+
+## Command Bus Test Results
+
+pytest -v tests/routes/test_repository_search_command_bus.py — 3 passed.
+
+## Postgres Integration Result
+
+TEST_DATABASE_URL=... pytest -v
+tests/integration/test_repository_search_postgres.py — 1 passed against a
+dedicated loopback-only disposable Postgres 15 container and unique temporary
+database. The test removed its database and the container was stopped/removed.
+
+## Stage 2K.1 Regression Results
+
+pytest -v tests/core/test_repository_authority.py — passed.
+
+## Stage 2K.2 Regression Results
+
+pytest -v tests/core/test_repository_discovery.py — passed.
+
+## Stage 2K.3 Regression Results
+
+pytest -v tests/core/test_repository_import.py and
+pytest -v tests/routes/test_project_repository_import.py — passed.
+
+## Command Bus Regression Results
+
+tests/routes/test_command_bus_phase1_manifest.py and
+tests/routes/test_command_bus_phase1_invoke.py — 10 passed.
+
+## Architecture Test Results
+
+pytest -v tests/architecture — 394 passed.
+
+## Docs Validation
+
+python3 scripts/validate_docs.py passed. make docs PYTHON=python3 passed,
+including the diagram freshness check.
+
+## What Was Proven
+
+Codexify now has one bounded read-only repository.search Command Bus command
+that derives its filesystem authority exclusively from the authenticated
+Project's active RepositoryBinding and returns only bounded
+repository-relative matches/snippets; the command remains unavailable to
+ordinary-chat models until a separate Stage 2K.5 exposure decision.
+
+## What Was Not Proven
+
+- repository.search is not automatically advertised to ordinary chat;
+- no current-thread-to-Project model argument hydration exists yet;
+- no provider receives repository.search in this task;
+- no model executed repository.search;
+- no multi-command repository agent loop exists;
+- no repository write capability exists;
+- no repository file read-by-path capability exists;
+- no repository mutation capability exists;
+- no automatic import exists;
+- no Workspace projection change exists;
+- no supported runtime repository-search replay was performed;
+- no provider inference occurred;
+- no supported runtime was restarted.
+
+## Documentation Follow-Through
+
+This proof receipt is the authorized implementation evidence. ADR-065, the
+repository-onboarding authority contract, and current-state remain unchanged.
+
+## Final File Scope
+
+Only the seven task-authorized paths are changed: the bounded core engine, the
+Projects route, core/route/Command Bus/Postgres tests, and this receipt.
+
+## Commit
+
+The scoped commit hash is recorded in the final task closeout.

--- a/guardian/core/repository_search.py
+++ b/guardian/core/repository_search.py
@@ -1,0 +1,629 @@
+"""Bounded, read-only repository search (Stage 2K.4 / ADR-065).
+
+Filesystem authority is derived only from a previously resolved active
+RepositoryBinding. The public Project entry point resolves that binding before
+search; the lower-level engine accepts the typed authority result, never a
+caller-supplied repository path. This module has no HTTP, model-tool, provider,
+database-mutation, or shell-execution responsibility.
+"""
+
+from __future__ import annotations
+
+import os
+import select
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Callable
+
+from sqlalchemy.orm import Session
+
+from guardian.core.repository_authority import (
+    AccountProjectMismatch,
+    ProjectNotFound,
+    RepositoryAuthorityError,
+    ResolvedRepositoryBinding,
+    resolve_project_repository_binding,
+)
+
+
+MAX_QUERY_CHARACTERS = 256
+MAX_RETURNED_MATCHES = 20
+MAX_CANDIDATE_FILE_ENTRIES = 5_000
+MAX_GIT_FILE_LIST_BYTES = 2 * 1024 * 1024
+MAX_INDIVIDUAL_FILE_BYTES = 1 * 1024 * 1024
+MAX_AGGREGATE_FILE_BYTES = 32 * 1024 * 1024
+MAX_SNIPPET_CHARACTERS = 400
+MAX_REPOSITORY_RELATIVE_PATH_CHARACTERS = 512
+MAX_SEARCH_SECONDS = 5.0
+_LISTING_READ_CHUNK_BYTES = 64 * 1024
+_PROCESS_WAIT_SECONDS = 0.25
+
+STOP_REASON_COMPLETED = "completed"
+STOP_REASON_RESULT_LIMIT_REACHED = "result_limit_reached"
+STOP_REASON_FILE_LIMIT_REACHED = "file_limit_reached"
+STOP_REASON_LISTING_LIMIT_REACHED = "listing_limit_reached"
+STOP_REASON_BYTE_LIMIT_REACHED = "byte_limit_reached"
+STOP_REASON_TIMEOUT_REACHED = "timeout_reached"
+STOP_REASONS = frozenset(
+    {
+        STOP_REASON_COMPLETED,
+        STOP_REASON_RESULT_LIMIT_REACHED,
+        STOP_REASON_FILE_LIMIT_REACHED,
+        STOP_REASON_LISTING_LIMIT_REACHED,
+        STOP_REASON_BYTE_LIMIT_REACHED,
+        STOP_REASON_TIMEOUT_REACHED,
+    }
+)
+
+_SENSITIVE_BASENAMES = frozenset(
+    {
+        ".env",
+        ".netrc",
+        ".npmrc",
+        ".pypirc",
+        ".git-credentials",
+        "id_rsa",
+        "id_dsa",
+        "id_ecdsa",
+        "id_ed25519",
+    }
+)
+_SENSITIVE_SUFFIXES = (
+    ".pem",
+    ".key",
+    ".p12",
+    ".pfx",
+    ".jks",
+    ".keystore",
+)
+
+
+class RepositorySearchError(Exception):
+    """Base class for bounded repository-search failures."""
+
+
+class InvalidRepositorySearchQuery(RepositorySearchError):
+    """Query or requested result limit is outside the fixed search envelope."""
+
+
+class RepositorySearchUnavailable(RepositorySearchError):
+    """The Project binding cannot safely provide search authority."""
+
+
+class RepositorySearchEnumerationFailed(RepositorySearchError):
+    """Read-only Git file-list enumeration could not complete safely."""
+
+
+@dataclass(frozen=True)
+class RepositorySearchLimits:
+    """Fixed Stage 2K.4 safety envelope; callers cannot widen it."""
+
+    max_query_characters: int = MAX_QUERY_CHARACTERS
+    max_returned_matches: int = MAX_RETURNED_MATCHES
+    max_candidate_file_entries: int = MAX_CANDIDATE_FILE_ENTRIES
+    max_git_file_list_bytes: int = MAX_GIT_FILE_LIST_BYTES
+    max_individual_file_bytes: int = MAX_INDIVIDUAL_FILE_BYTES
+    max_aggregate_file_bytes: int = MAX_AGGREGATE_FILE_BYTES
+    max_snippet_characters: int = MAX_SNIPPET_CHARACTERS
+    max_path_characters: int = MAX_REPOSITORY_RELATIVE_PATH_CHARACTERS
+    max_wall_clock_seconds: float = MAX_SEARCH_SECONDS
+
+    def __post_init__(self) -> None:
+        positive_ints = (
+            self.max_query_characters,
+            self.max_returned_matches,
+            self.max_candidate_file_entries,
+            self.max_git_file_list_bytes,
+            self.max_individual_file_bytes,
+            self.max_aggregate_file_bytes,
+            self.max_snippet_characters,
+            self.max_path_characters,
+        )
+        if any(
+            not isinstance(value, int) or isinstance(value, bool) or value <= 0
+            for value in positive_ints
+        ):
+            raise ValueError("repository search integer limits must be positive")
+        if (
+            not isinstance(self.max_wall_clock_seconds, (int, float))
+            or isinstance(self.max_wall_clock_seconds, bool)
+            or self.max_wall_clock_seconds <= 0
+        ):
+            raise ValueError("repository search wall-clock limit must be positive")
+
+
+@dataclass(frozen=True)
+class RepositorySearchMatch:
+    """One bounded repository-relative text match."""
+
+    path: str
+    line: int
+    snippet: str
+
+    def __post_init__(self) -> None:
+        candidate = PurePosixPath(self.path)
+        if (
+            not self.path
+            or candidate.is_absolute()
+            or ".." in candidate.parts
+            or len(self.path) > MAX_REPOSITORY_RELATIVE_PATH_CHARACTERS
+        ):
+            raise ValueError("repository search match path must be relative")
+        if not isinstance(self.line, int) or self.line <= 0:
+            raise ValueError("repository search match line must be positive")
+        if len(self.snippet) > MAX_SNIPPET_CHARACTERS:
+            raise ValueError("repository search snippet exceeds fixed bound")
+
+
+@dataclass(frozen=True)
+class RepositorySearchResult:
+    """Bounded, path-private result for the route and Command Bus."""
+
+    matches: tuple[RepositorySearchMatch, ...]
+    count: int
+    truncated: bool
+    stop_reason: str
+    scanned_files: int
+    scanned_bytes: int
+    skipped_binary_files: int
+    skipped_oversized_files: int
+    skipped_sensitive_files: int
+    skipped_symlink_files: int
+
+    def __post_init__(self) -> None:
+        if self.stop_reason not in STOP_REASONS:
+            raise ValueError("unsupported repository search stop reason")
+        if self.count != len(self.matches):
+            raise ValueError("repository search count must match returned matches")
+        counters = (
+            self.scanned_files,
+            self.scanned_bytes,
+            self.skipped_binary_files,
+            self.skipped_oversized_files,
+            self.skipped_sensitive_files,
+            self.skipped_symlink_files,
+        )
+        if any(not isinstance(value, int) or value < 0 for value in counters):
+            raise ValueError("repository search counters must be non-negative")
+
+    def to_payload(self) -> dict[str, object]:
+        """Return only the approved route and Command Bus result surface."""
+        return {
+            "matches": [
+                {
+                    "path": match.path,
+                    "line": match.line,
+                    "snippet": match.snippet,
+                }
+                for match in self.matches
+            ],
+            "count": self.count,
+            "truncated": self.truncated,
+            "stop_reason": self.stop_reason,
+            "scanned_files": self.scanned_files,
+            "scanned_bytes": self.scanned_bytes,
+            "skipped_binary_files": self.skipped_binary_files,
+            "skipped_oversized_files": self.skipped_oversized_files,
+            "skipped_sensitive_files": self.skipped_sensitive_files,
+            "skipped_symlink_files": self.skipped_symlink_files,
+        }
+
+
+@dataclass(frozen=True)
+class _EnumerationResult:
+    paths: tuple[str, ...]
+    stop_reason: str
+
+
+def _normalize_query(query: str, *, limits: RepositorySearchLimits) -> str:
+    raw_value = str(query or "")
+    if "\x00" in raw_value or "\r" in raw_value or "\n" in raw_value:
+        raise InvalidRepositorySearchQuery("repository search query is invalid")
+    value = raw_value.strip()
+    if not value:
+        raise InvalidRepositorySearchQuery("repository search query is required")
+    if len(value) > limits.max_query_characters:
+        raise InvalidRepositorySearchQuery("repository search query is invalid")
+    return value
+
+
+def _validate_result_limit(
+    result_limit: int, *, limits: RepositorySearchLimits
+) -> int:
+    if (
+        not isinstance(result_limit, int)
+        or isinstance(result_limit, bool)
+        or result_limit < 1
+        or result_limit > limits.max_returned_matches
+    ):
+        raise InvalidRepositorySearchQuery(
+            "repository search result limit is invalid"
+        )
+    return result_limit
+
+
+def _remaining_seconds(deadline: float, monotonic: Callable[[], float]) -> float:
+    return max(0.0, deadline - monotonic())
+
+
+def _terminate_process(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        process.terminate()
+        process.wait(timeout=_PROCESS_WAIT_SECONDS)
+    except (subprocess.TimeoutExpired, OSError):
+        try:
+            process.kill()
+            process.wait(timeout=_PROCESS_WAIT_SECONDS)
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+
+
+def _valid_repository_relative_path(
+    raw_path: bytes,
+    *,
+    limits: RepositorySearchLimits,
+) -> str | None:
+    try:
+        path = raw_path.decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        return None
+    if not path or len(path) > limits.max_path_characters:
+        return None
+    candidate = PurePosixPath(path)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        return None
+    normalized = candidate.as_posix()
+    if (
+        not normalized
+        or normalized == "."
+        or len(normalized) > limits.max_path_characters
+    ):
+        return None
+    return normalized
+
+
+def _enumerate_repository_paths(
+    root: Path,
+    *,
+    deadline: float,
+    limits: RepositorySearchLimits,
+    monotonic: Callable[[], float] = time.monotonic,
+    popen_factory: Callable[..., subprocess.Popen[bytes]] = subprocess.Popen,
+) -> _EnumerationResult:
+    """Stream bounded Git file-list output without unbounded capture."""
+    git_binary = shutil.which("git") or "git"
+    environment = os.environ.copy()
+    environment["GIT_OPTIONAL_LOCKS"] = "0"
+    try:
+        process = popen_factory(
+            [
+                git_binary,
+                "-C",
+                str(root),
+                "ls-files",
+                "--cached",
+                "--others",
+                "--exclude-standard",
+                "-z",
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            shell=False,
+            env=environment,
+        )
+    except OSError as exc:
+        raise RepositorySearchEnumerationFailed(
+            "repository file enumeration could not start"
+        ) from exc
+
+    if process.stdout is None:
+        _terminate_process(process)
+        raise RepositorySearchEnumerationFailed(
+            "repository file enumeration did not provide stdout"
+        )
+
+    output_bytes = 0
+    pending = b""
+    accepted_paths: set[str] = set()
+    stop_reason = STOP_REASON_COMPLETED
+    try:
+        while True:
+            remaining = _remaining_seconds(deadline, monotonic)
+            if remaining <= 0:
+                stop_reason = STOP_REASON_TIMEOUT_REACHED
+                break
+            ready, _, _ = select.select([process.stdout], [], [], remaining)
+            if not ready:
+                if process.poll() is None:
+                    stop_reason = STOP_REASON_TIMEOUT_REACHED
+                    break
+                chunk = process.stdout.read1(_LISTING_READ_CHUNK_BYTES)
+            else:
+                chunk = process.stdout.read1(
+                    min(
+                        _LISTING_READ_CHUNK_BYTES,
+                        limits.max_git_file_list_bytes - output_bytes + 1,
+                    )
+                )
+
+            if not chunk:
+                if process.poll() is None:
+                    continue
+                break
+            output_bytes += len(chunk)
+            if output_bytes > limits.max_git_file_list_bytes:
+                stop_reason = STOP_REASON_LISTING_LIMIT_REACHED
+                break
+
+            pending += chunk
+            entries = pending.split(b"\0")
+            pending = entries.pop()
+            for raw_path in entries:
+                normalized = _valid_repository_relative_path(
+                    raw_path, limits=limits
+                )
+                if normalized is None:
+                    continue
+                accepted_paths.add(normalized)
+                if len(accepted_paths) >= limits.max_candidate_file_entries:
+                    stop_reason = STOP_REASON_FILE_LIMIT_REACHED
+                    break
+            if stop_reason != STOP_REASON_COMPLETED:
+                break
+
+        if stop_reason != STOP_REASON_COMPLETED:
+            _terminate_process(process)
+        else:
+            try:
+                returncode = process.wait(
+                    timeout=_remaining_seconds(deadline, monotonic)
+                )
+            except subprocess.TimeoutExpired:
+                _terminate_process(process)
+                return _EnumerationResult(
+                    paths=tuple(sorted(accepted_paths)),
+                    stop_reason=STOP_REASON_TIMEOUT_REACHED,
+                )
+            if returncode != 0:
+                raise RepositorySearchEnumerationFailed(
+                    "repository file enumeration failed"
+                )
+    finally:
+        if process.stdout is not None:
+            process.stdout.close()
+
+    return _EnumerationResult(
+        paths=tuple(sorted(accepted_paths)),
+        stop_reason=stop_reason,
+    )
+
+
+def _is_sensitive_path(relative_path: str) -> bool:
+    basename = PurePosixPath(relative_path).name.casefold()
+    return (
+        basename in _SENSITIVE_BASENAMES
+        or basename.startswith(".env.")
+        or basename.endswith(_SENSITIVE_SUFFIXES)
+    )
+
+
+def _resolved_regular_file(
+    root: Path, relative_path: str
+) -> tuple[Path | None, bool]:
+    """Return a contained regular file and whether a symlink was rejected."""
+    candidate = root.joinpath(*PurePosixPath(relative_path).parts)
+    try:
+        if candidate.is_symlink():
+            return None, True
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(root)
+    except (FileNotFoundError, OSError, RuntimeError, ValueError):
+        return None, False
+    if not resolved.is_file():
+        return None, False
+    return resolved, False
+
+
+def _casefold_match_span(
+    line: str, query_casefold: str
+) -> tuple[int, int] | None:
+    folded_parts: list[str] = []
+    source_positions: list[int] = []
+    for index, character in enumerate(line):
+        folded = character.casefold()
+        folded_parts.append(folded)
+        source_positions.extend([index] * len(folded))
+    folded_line = "".join(folded_parts)
+    start = folded_line.find(query_casefold)
+    if start < 0:
+        return None
+    end_folded = start + len(query_casefold) - 1
+    if not source_positions or end_folded >= len(source_positions):
+        return None
+    return source_positions[start], source_positions[end_folded] + 1
+
+
+def _bounded_snippet(
+    line: str,
+    *,
+    match_start: int,
+    match_end: int,
+    max_characters: int,
+) -> str:
+    if len(line) <= max_characters:
+        return line
+    match_width = max(1, match_end - match_start)
+    available = max(0, max_characters - min(match_width, max_characters))
+    window_start = max(0, match_start - (available // 2))
+    window_start = min(window_start, len(line) - max_characters)
+    return line[window_start : window_start + max_characters]
+
+
+def _search_bound_repository(
+    binding: ResolvedRepositoryBinding,
+    *,
+    normalized_query: str,
+    result_limit: int,
+    limits: RepositorySearchLimits,
+    monotonic: Callable[[], float] = time.monotonic,
+    deadline: float | None = None,
+) -> RepositorySearchResult:
+    """Search only one typed, validated binding root under fixed bounds."""
+    if not isinstance(binding, ResolvedRepositoryBinding):
+        raise TypeError("repository search requires ResolvedRepositoryBinding")
+    resolved_deadline = deadline or (
+        monotonic() + limits.max_wall_clock_seconds
+    )
+    if _remaining_seconds(resolved_deadline, monotonic) <= 0:
+        return RepositorySearchResult(
+            matches=(),
+            count=0,
+            truncated=True,
+            stop_reason=STOP_REASON_TIMEOUT_REACHED,
+            scanned_files=0,
+            scanned_bytes=0,
+            skipped_binary_files=0,
+            skipped_oversized_files=0,
+            skipped_sensitive_files=0,
+            skipped_symlink_files=0,
+        )
+    enumeration = _enumerate_repository_paths(
+        binding.canonical_root,
+        deadline=resolved_deadline,
+        limits=limits,
+        monotonic=monotonic,
+    )
+
+    matches: list[RepositorySearchMatch] = []
+    scanned_files = 0
+    scanned_bytes = 0
+    skipped_binary_files = 0
+    skipped_oversized_files = 0
+    skipped_sensitive_files = 0
+    skipped_symlink_files = 0
+    stop_reason = enumeration.stop_reason
+    query_casefold = normalized_query.casefold()
+
+    for relative_path in enumeration.paths:
+        if stop_reason != STOP_REASON_COMPLETED:
+            break
+        if _remaining_seconds(resolved_deadline, monotonic) <= 0:
+            stop_reason = STOP_REASON_TIMEOUT_REACHED
+            break
+        if _is_sensitive_path(relative_path):
+            skipped_sensitive_files += 1
+            continue
+
+        candidate, rejected_symlink = _resolved_regular_file(
+            binding.canonical_root, relative_path
+        )
+        if rejected_symlink:
+            skipped_symlink_files += 1
+            continue
+        if candidate is None:
+            continue
+        try:
+            size = candidate.stat().st_size
+        except OSError:
+            continue
+        if size > limits.max_individual_file_bytes:
+            skipped_oversized_files += 1
+            continue
+        if scanned_bytes + size > limits.max_aggregate_file_bytes:
+            stop_reason = STOP_REASON_BYTE_LIMIT_REACHED
+            break
+        if _remaining_seconds(resolved_deadline, monotonic) <= 0:
+            stop_reason = STOP_REASON_TIMEOUT_REACHED
+            break
+        try:
+            content = candidate.read_bytes()
+        except OSError:
+            continue
+        scanned_files += 1
+        scanned_bytes += len(content)
+        if b"\0" in content:
+            skipped_binary_files += 1
+            continue
+        try:
+            text = content.decode("utf-8", errors="strict")
+        except UnicodeDecodeError:
+            skipped_binary_files += 1
+            continue
+
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            span = _casefold_match_span(line, query_casefold)
+            if span is None:
+                continue
+            matches.append(
+                RepositorySearchMatch(
+                    path=relative_path,
+                    line=line_number,
+                    snippet=_bounded_snippet(
+                        line,
+                        match_start=span[0],
+                        match_end=span[1],
+                        max_characters=limits.max_snippet_characters,
+                    ),
+                )
+            )
+            if len(matches) >= result_limit:
+                stop_reason = STOP_REASON_RESULT_LIMIT_REACHED
+                break
+        if stop_reason != STOP_REASON_COMPLETED:
+            break
+
+    return RepositorySearchResult(
+        matches=tuple(matches),
+        count=len(matches),
+        truncated=stop_reason != STOP_REASON_COMPLETED,
+        stop_reason=stop_reason,
+        scanned_files=scanned_files,
+        scanned_bytes=scanned_bytes,
+        skipped_binary_files=skipped_binary_files,
+        skipped_oversized_files=skipped_oversized_files,
+        skipped_sensitive_files=skipped_sensitive_files,
+        skipped_symlink_files=skipped_symlink_files,
+    )
+
+
+def search_project_repository(
+    session: Session,
+    *,
+    authenticated_account_id: str | None,
+    project_id: int,
+    query: str,
+    result_limit: int = MAX_RETURNED_MATCHES,
+) -> RepositorySearchResult:
+    """Resolve Project authority, then run one bounded read-only search."""
+    active_limits = RepositorySearchLimits()
+    started_at = time.monotonic()
+    deadline = started_at + active_limits.max_wall_clock_seconds
+    try:
+        binding = resolve_project_repository_binding(
+            session,
+            authenticated_account_id=authenticated_account_id,
+            project_id=project_id,
+            timeout_seconds=active_limits.max_wall_clock_seconds,
+        )
+    except (AccountProjectMismatch, ProjectNotFound):
+        raise
+    except RepositoryAuthorityError as exc:
+        raise RepositorySearchUnavailable(
+            "repository search authority is unavailable"
+        ) from exc
+
+    normalized_query = _normalize_query(query, limits=active_limits)
+    requested_limit = _validate_result_limit(result_limit, limits=active_limits)
+    return _search_bound_repository(
+        binding,
+        normalized_query=normalized_query,
+        result_limit=requested_limit,
+        limits=active_limits,
+        deadline=deadline,
+    )

--- a/guardian/routes/projects.py
+++ b/guardian/routes/projects.py
@@ -10,7 +10,7 @@ import json
 import logging
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Request
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict
 
@@ -36,6 +36,13 @@ from guardian.core.repository_import import (
     RepositoryBindingOwnedByAnotherAccount,
     RepositoryImportError,
     import_explicit_repository_candidate,
+)
+from guardian.core.repository_search import (
+    InvalidRepositorySearchQuery,
+    RepositorySearchEnumerationFailed,
+    RepositorySearchError,
+    RepositorySearchUnavailable,
+    search_project_repository,
 )
 
 logger = logging.getLogger(__name__)
@@ -465,6 +472,114 @@ def import_repository_candidate_route(
         "reused_existing": result.reused_existing,
         "source_class": result.source_class,
     }
+
+
+def _repository_search_error_response(exc: Exception) -> HTTPException:
+    if isinstance(exc, InvalidRepositorySearchQuery):
+        return HTTPException(
+            status_code=400,
+            detail={
+                "code": "repository_search_invalid_query",
+                "message": "Repository search query is invalid.",
+            },
+        )
+    if isinstance(exc, AccountProjectMismatch):
+        return HTTPException(
+            status_code=403,
+            detail={
+                "code": "repository_search_forbidden",
+                "message": "Repository search is not authorized for this account.",
+            },
+        )
+    if isinstance(exc, ProjectNotFound):
+        return HTTPException(
+            status_code=404,
+            detail={
+                "code": "repository_search_project_not_found",
+                "message": "Project was not found.",
+            },
+        )
+    if isinstance(
+        exc,
+        (
+            RepositorySearchUnavailable,
+            RepositorySearchEnumerationFailed,
+        ),
+    ):
+        return HTTPException(
+            status_code=409,
+            detail={
+                "code": "repository_search_unavailable",
+                "message": "Repository search is unavailable.",
+            },
+        )
+    if isinstance(exc, RepositorySearchError):
+        return HTTPException(
+            status_code=409,
+            detail={
+                "code": "repository_search_unavailable",
+                "message": "Repository search is unavailable.",
+            },
+        )
+    return HTTPException(
+        status_code=500,
+        detail={
+            "code": "repository_search_internal_error",
+            "message": "Repository search could not be completed.",
+        },
+    )
+
+
+@api_router.get(
+    "/{project_id}/repository/search",
+    operation_id="repository.search",
+)
+def search_project_repository_route(
+    project_id: int,
+    q: str = Query(..., min_length=1, max_length=256),
+    limit: int = Query(20, ge=1, le=20),
+    request_user_scope: RequestUserScope = Depends(get_request_user_scope),
+):
+    """Search only the authenticated Project's resolved repository binding."""
+    account_id = _request_account_id(request_user_scope)
+    if chatlog_db is None or not hasattr(chatlog_db, "get_session"):
+        raise _repository_search_error_response(
+            RuntimeError("database unavailable")
+        )
+
+    try:
+        with chatlog_db.get_session() as session:
+            try:
+                result = search_project_repository(
+                    session,
+                    authenticated_account_id=account_id,
+                    project_id=project_id,
+                    query=q,
+                    result_limit=limit,
+                )
+            except (
+                InvalidRepositorySearchQuery,
+                AccountProjectMismatch,
+                ProjectNotFound,
+                RepositorySearchUnavailable,
+                RepositorySearchEnumerationFailed,
+                RepositorySearchError,
+            ) as exc:
+                raise _repository_search_error_response(exc) from None
+            except Exception:
+                logger.error("[projects] repository search failed")
+                raise _repository_search_error_response(
+                    RuntimeError("repository search failed")
+                ) from None
+    except HTTPException:
+        raise
+    except Exception:
+        logger.error("[projects] repository search session failed")
+        raise _repository_search_error_response(
+            RuntimeError("repository search session failed")
+        ) from None
+
+    return {"ok": True, **result.to_payload()}
 
 
 @router.patch("/{project_id}")

--- a/tests/core/test_repository_search.py
+++ b/tests/core/test_repository_search.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from guardian.core import repository_search
+from guardian.core.repository_authority import ResolvedRepositoryBinding
+
+
+def _run_git(*args: str, cwd: Path) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _init_repository(path: Path) -> Path:
+    path.mkdir()
+    _run_git("init", "--quiet", cwd=path)
+    _run_git("config", "user.email", "fixture@example.invalid", cwd=path)
+    _run_git("config", "user.name", "Fixture", cwd=path)
+    return path.resolve()
+
+
+def _commit_all(repository: Path, message: str = "fixture") -> None:
+    _run_git("add", ".", cwd=repository)
+    _run_git("commit", "--quiet", "-m", message, cwd=repository)
+
+
+def _binding(repository: Path, project_id: int = 7) -> ResolvedRepositoryBinding:
+    return ResolvedRepositoryBinding(
+        binding_id="binding-fixture",
+        project_id=project_id,
+        source_class="external_linked",
+        canonical_root=repository.resolve(),
+    )
+
+
+def _search(
+    repository: Path,
+    query: str,
+    *,
+    limit: int = 20,
+    limits: repository_search.RepositorySearchLimits | None = None,
+) -> repository_search.RepositorySearchResult:
+    return repository_search._search_bound_repository(
+        _binding(repository),
+        normalized_query=repository_search._normalize_query(
+            query,
+            limits=limits or repository_search.RepositorySearchLimits(),
+        ),
+        result_limit=limit,
+        limits=limits or repository_search.RepositorySearchLimits(),
+    )
+
+
+@pytest.mark.parametrize("query", ["", "   ", "x" * 257, "needle\x00", "needle\r", "needle\n"])
+def test_invalid_queries_are_rejected(query: str) -> None:
+    with pytest.raises(repository_search.InvalidRepositorySearchQuery):
+        repository_search._normalize_query(
+            query, limits=repository_search.RepositorySearchLimits()
+        )
+
+
+@pytest.mark.parametrize("limit", [0, -1, 21, True])
+def test_invalid_result_limits_are_rejected(limit: int) -> None:
+    with pytest.raises(repository_search.InvalidRepositorySearchQuery):
+        repository_search._validate_result_limit(
+            limit, limits=repository_search.RepositorySearchLimits()
+        )
+
+
+def test_search_project_repository_resolves_binding_before_search(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository = _init_repository(tmp_path / "repository")
+    (repository / "tracked.txt").write_text("Needle\n")
+    _commit_all(repository)
+    resolved_calls: list[dict[str, object]] = []
+
+    def resolve(session, **kwargs):
+        resolved_calls.append({"session": session, **kwargs})
+        return _binding(repository, project_id=23)
+
+    monkeypatch.setattr(
+        repository_search, "resolve_project_repository_binding", resolve
+    )
+    result = repository_search.search_project_repository(
+        object(),
+        authenticated_account_id="account-a",
+        project_id=23,
+        query="needle",
+        result_limit=5,
+    )
+
+    assert resolved_calls == [
+        {
+            "session": resolved_calls[0]["session"],
+            "authenticated_account_id": "account-a",
+            "project_id": 23,
+            "timeout_seconds": 5.0,
+        }
+    ]
+    assert result.matches[0].path == "tracked.txt"
+    assert "canonical_root" not in result.to_payload()
+    assert "repository_root" not in result.to_payload()
+
+
+def test_search_requires_authenticated_account_at_binding_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def reject(*args, **kwargs):
+        raise repository_search.AccountProjectMismatch("account required")
+
+    monkeypatch.setattr(
+        repository_search, "resolve_project_repository_binding", reject
+    )
+    with pytest.raises(repository_search.AccountProjectMismatch):
+        repository_search.search_project_repository(
+            object(),
+            authenticated_account_id="",
+            project_id=1,
+            query="needle",
+        )
+
+
+def test_tracked_untracked_ignored_and_casefold_literal_search(
+    tmp_path: Path,
+) -> None:
+    repository = _init_repository(tmp_path / "repository")
+    (repository / "tracked.txt").write_text("First\nNEEDLE\n")
+    (repository / ".gitignore").write_text("ignored.txt\n")
+    _commit_all(repository)
+    (repository / "untracked.txt").write_text("Needle in an untracked file\n")
+    (repository / "ignored.txt").write_text("needle must remain hidden\n")
+    (repository / "regex.txt").write_text("a[bc] literal\n")
+
+    result = _search(repository, "needle")
+    assert [(match.path, match.line) for match in result.matches] == [
+        ("tracked.txt", 2),
+        ("untracked.txt", 1),
+    ]
+    assert _search(repository, "[bc]").matches[0].path == "regex.txt"
+    assert _search(repository, "needle").matches[0].path != str(repository)
+
+
+def test_matches_are_deterministic_relative_and_line_bounded(
+    tmp_path: Path,
+) -> None:
+    repository = _init_repository(tmp_path / "repository")
+    (repository / "zeta.txt").write_text("needle zeta\n")
+    (repository / "alpha.txt").write_text("first\nneedle alpha\n")
+    _commit_all(repository)
+    result = _search(repository, "needle")
+
+    assert [(match.path, match.line) for match in result.matches] == [
+        ("alpha.txt", 2),
+        ("zeta.txt", 1),
+    ]
+    assert all(not Path(match.path).is_absolute() for match in result.matches)
+    assert all(len(match.snippet) <= 400 for match in result.matches)
+    assert str(repository) not in repr(result.to_payload())
+
+
+def test_long_line_snippet_is_match_centered_and_bounded(tmp_path: Path) -> None:
+    repository = _init_repository(tmp_path / "repository")
+    long_line = "a" * 500 + "needle" + "z" * 500
+    (repository / "long.txt").write_text(long_line + "\n")
+    _commit_all(repository)
+    snippet = _search(repository, "needle").matches[0].snippet
+    assert len(snippet) == 400
+    assert "needle" in snippet
+    assert snippet == _search(repository, "needle").matches[0].snippet
+
+
+def test_result_cap_file_entry_and_listing_byte_bounds(
+    tmp_path: Path,
+) -> None:
+    repository = _init_repository(tmp_path / "repository")
+    for index in range(4):
+        (repository / f"{index}.txt").write_text("needle\n")
+    _commit_all(repository)
+
+    capped = _search(repository, "needle", limit=2)
+    assert capped.count == 2
+    assert capped.truncated is True
+    assert capped.stop_reason == "result_limit_reached"
+
+    file_limited = _search(
+        repository,
+        "needle",
+        limits=repository_search.RepositorySearchLimits(
+            max_candidate_file_entries=2
+        ),
+    )
+    assert file_limited.truncated is True
+    assert file_limited.stop_reason == "file_limit_reached"
+
+    listing_limited = _search(
+        repository,
+        "needle",
+        limits=repository_search.RepositorySearchLimits(
+            max_git_file_list_bytes=3
+        ),
+    )
+    assert listing_limited.truncated is True
+    assert listing_limited.stop_reason == "listing_limit_reached"
+
+
+def test_aggregate_byte_limit_and_individual_oversize_skip(tmp_path: Path) -> None:
+    repository = _init_repository(tmp_path / "repository")
+    (repository / "one.txt").write_text("needle small\n")
+    (repository / "two.txt").write_text("needle another\n")
+    (repository / "large.txt").write_text("needle " + ("x" * 80))
+    _commit_all(repository)
+    byte_limited = _search(
+        repository,
+        "needle",
+        limits=repository_search.RepositorySearchLimits(
+            max_aggregate_file_bytes=15
+        ),
+    )
+    assert byte_limited.truncated is True
+    assert byte_limited.stop_reason == "byte_limit_reached"
+
+    oversized = _search(
+        repository,
+        "needle",
+        limits=repository_search.RepositorySearchLimits(
+            max_individual_file_bytes=10
+        ),
+    )
+    assert oversized.skipped_oversized_files >= 1
+
+
+def test_binary_invalid_utf8_and_sensitive_paths_are_not_read(tmp_path: Path) -> None:
+    repository = _init_repository(tmp_path / "repository")
+    (repository / "binary.bin").write_bytes(b"needle\x00bytes")
+    (repository / "invalid.txt").write_bytes(b"needle\xff")
+    (repository / ".env").write_text("needle=secret\n")
+    (repository / ".env.local").write_text("needle=secret\n")
+    (repository / "id_rsa").write_text("needle secret\n")
+    (repository / "certificate.pem").write_text("needle secret\n")
+    (repository / "safe.txt").write_text("needle safe\n")
+    _commit_all(repository)
+
+    result = _search(repository, "needle")
+    assert [match.path for match in result.matches] == ["safe.txt"]
+    assert result.skipped_binary_files == 2
+    assert result.skipped_sensitive_files == 4
+
+
+def test_symlinks_and_escape_paths_are_never_followed(tmp_path: Path) -> None:
+    repository = _init_repository(tmp_path / "repository")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("needle outside\n")
+    os.symlink(outside, repository / "link.txt")
+    (repository / "safe.txt").write_text("needle safe\n")
+    _commit_all(repository)
+
+    result = _search(repository, "needle")
+    assert [match.path for match in result.matches] == ["safe.txt"]
+    assert result.skipped_symlink_files == 1
+
+
+def test_enumeration_uses_only_read_only_git_argv_and_optional_locks(
+    tmp_path: Path,
+) -> None:
+    repository = _init_repository(tmp_path / "repository")
+    (repository / "tracked.txt").write_text("needle\n")
+    _commit_all(repository)
+    captured: dict[str, object] = {}
+    original_popen = subprocess.Popen
+
+    def recording_popen(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return original_popen(*args, **kwargs)
+
+    result = repository_search._enumerate_repository_paths(
+        repository,
+        deadline=repository_search.time.monotonic() + 5,
+        limits=repository_search.RepositorySearchLimits(),
+        popen_factory=recording_popen,
+    )
+    command = captured["args"][0]
+    assert command[1:] == [
+        "-C",
+        str(repository),
+        "ls-files",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+        "-z",
+    ]
+    assert captured["kwargs"]["shell"] is False
+    assert captured["kwargs"]["env"]["GIT_OPTIONAL_LOCKS"] == "0"
+    assert result.paths == ("tracked.txt",)
+
+
+def test_deadline_is_enforced_without_filesystem_or_git_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository = _init_repository(tmp_path / "repository")
+    fixture = repository / "fixture.txt"
+    fixture.write_text("needle fixture\n")
+    _commit_all(repository)
+    before_bytes = fixture.read_bytes()
+    before_head = _run_git("rev-parse", "HEAD", cwd=repository)
+    before_branch = _run_git("rev-parse", "--abbrev-ref", "HEAD", cwd=repository)
+
+    monkeypatch.setattr(
+        repository_search,
+        "_enumerate_repository_paths",
+        lambda *_args, **_kwargs: repository_search._EnumerationResult(
+            paths=("fixture.txt",),
+            stop_reason=repository_search.STOP_REASON_COMPLETED,
+        ),
+    )
+    clock_values = iter((0.0, 0.0, 6.0))
+    result = repository_search._search_bound_repository(
+        _binding(repository),
+        normalized_query="needle",
+        result_limit=20,
+        limits=repository_search.RepositorySearchLimits(),
+        monotonic=lambda: next(clock_values),
+    )
+
+    assert result.stop_reason == "timeout_reached"
+    assert result.matches == ()
+    assert fixture.read_bytes() == before_bytes
+    assert _run_git("rev-parse", "HEAD", cwd=repository) == before_head
+    assert _run_git("rev-parse", "--abbrev-ref", "HEAD", cwd=repository) == before_branch
+
+
+def test_search_has_no_path_only_public_authority_entry_point() -> None:
+    source = Path(repository_search.__file__).read_text()
+    assert "Path.cwd()" not in source
+    assert "CODEXIFY_WORKTREE_REPO_PATH" not in source
+    assert "detect_project_root" not in source
+    assert "fs.search" not in source
+    assert "subprocess.run" not in source
+    with pytest.raises(TypeError):
+        repository_search._search_bound_repository(  # type: ignore[arg-type]
+            SimpleNamespace(canonical_root=Path("/")),
+            normalized_query="needle",
+            result_limit=1,
+            limits=repository_search.RepositorySearchLimits(),
+        )

--- a/tests/integration/test_repository_search_postgres.py
+++ b/tests/integration/test_repository_search_postgres.py
@@ -1,0 +1,304 @@
+"""Disposable Postgres proof for binding-authorized repository search."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import uuid
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+try:
+    import psycopg  # type: ignore
+except ImportError:  # pragma: no cover - environment specific
+    psycopg = None
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, func, select, text
+from sqlalchemy.engine import Engine, make_url
+from sqlalchemy.orm import Session, sessionmaker
+
+from guardian.core.repository_authority import (
+    AccountProjectMismatch,
+    SOURCE_CLASS_EXTERNAL_LINKED,
+    create_repository_binding,
+)
+from guardian.core.repository_search import (
+    RepositorySearchUnavailable,
+    search_project_repository,
+)
+from guardian.db.models import Project, RepositoryBinding
+
+
+ALEMBIC_HEAD = "6e2b9c4a7d1f"
+
+
+def _database_url(base_url: str, database_name: str) -> str:
+    return make_url(base_url).set(
+        drivername="postgresql+psycopg", database=database_name
+    ).render_as_string(hide_password=False)
+
+
+def _admin_database_url(base_url: str) -> str:
+    return make_url(base_url).set(
+        drivername="postgresql", database="postgres"
+    ).render_as_string(hide_password=False)
+
+
+@pytest.fixture
+def disposable_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[Engine, None, None]:
+    """Create and destroy a unique database under the explicit test server."""
+    if psycopg is None:
+        pytest.skip("psycopg is required for the disposable Postgres proof")
+    base_url = os.getenv("TEST_DATABASE_URL")
+    if not base_url:
+        pytest.skip(
+            "TEST_DATABASE_URL is required for the disposable Postgres proof"
+        )
+
+    database_name = f"codexify_stage2k4_search_{uuid.uuid4().hex[:12]}"
+    admin_url = _admin_database_url(base_url)
+    database_url = _database_url(base_url, database_name)
+    try:
+        with psycopg.connect(admin_url, autocommit=True) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(f'CREATE DATABASE "{database_name}"')
+    except Exception as exc:  # pragma: no cover - environment specific
+        pytest.skip(f"unable to create disposable Postgres database: {exc}")
+
+    repository_root = Path(__file__).resolve().parents[2]
+    config = Config(str(repository_root / "backend" / "alembic.ini"))
+    config.set_main_option("sqlalchemy.url", database_url)
+    config.set_main_option(
+        "script_location", str(repository_root / "guardian" / "db" / "migrations")
+    )
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    engine: Engine | None = None
+    try:
+        command.upgrade(config, ALEMBIC_HEAD)
+        engine = create_engine(database_url, future=True)
+        yield engine
+    finally:
+        if engine is not None:
+            engine.dispose()
+        try:
+            with psycopg.connect(admin_url, autocommit=True) as connection:
+                with connection.cursor() as cursor:
+                    cursor.execute(
+                        "SELECT pg_terminate_backend(pid) "
+                        "FROM pg_stat_activity "
+                        "WHERE datname = %s AND pid <> pg_backend_pid()",
+                        (database_name,),
+                    )
+                    cursor.execute(f'DROP DATABASE IF EXISTS "{database_name}"')
+        except Exception:
+            pass
+
+
+def _run_git(*args: str, cwd: Path) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _init_repository(path: Path, marker: str) -> Path:
+    path.mkdir()
+    _run_git("init", "--quiet", cwd=path)
+    _run_git("config", "user.email", "fixture@example.invalid", cwd=path)
+    _run_git("config", "user.name", "Fixture", cwd=path)
+    (path / "fixture.txt").write_text(marker + "\n")
+    _run_git("add", "fixture.txt", cwd=path)
+    _run_git("commit", "--quiet", "-m", "fixture", cwd=path)
+    return path.resolve()
+
+
+def _seed_account(engine: Engine, account_id: str) -> None:
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "INSERT INTO users (id, username, password_hash, role) "
+                "VALUES (:id, :username, :password_hash, :role)"
+            ),
+            {
+                "id": account_id,
+                "username": account_id,
+                "password_hash": "not-a-real-password-hash",
+                "role": "guest",
+            },
+        )
+
+
+def _create_bound_project(
+    session: Session,
+    *,
+    account_id: str,
+    name: str,
+    repository: Path,
+) -> tuple[Project, RepositoryBinding]:
+    project = Project(
+        user_id=account_id,
+        name=name,
+        description="repository search proof",
+    )
+    session.add(project)
+    session.flush()
+    binding = create_repository_binding(
+        session,
+        authenticated_account_id=account_id,
+        project_id=project.id,
+        source_class=SOURCE_CLASS_EXTERNAL_LINKED,
+        working_tree_root=repository,
+        provenance={
+            "registration_source": "repository_search_integration_proof",
+            "operation_class": "external_link",
+        },
+    )
+    return project, binding
+
+
+@pytest.mark.integration
+def test_repository_search_postgres_authority_and_read_only_proof(
+    disposable_database: Engine,
+    tmp_path: Path,
+) -> None:
+    engine = disposable_database
+    sessions = sessionmaker(engine, expire_on_commit=False, future=True)
+    _seed_account(engine, "account-a")
+    _seed_account(engine, "account-b")
+
+    repository_a = _init_repository(tmp_path / "repository-a", "needle-a")
+    repository_b = _init_repository(tmp_path / "repository-b", "needle-b")
+    repository_stale = _init_repository(
+        tmp_path / "repository-stale", "needle-stale"
+    )
+    fixture = repository_a / "fixture.txt"
+    before_bytes = fixture.read_bytes()
+    before_head = _run_git("rev-parse", "HEAD", cwd=repository_a)
+    before_branch = _run_git(
+        "rev-parse", "--abbrev-ref", "HEAD", cwd=repository_a
+    )
+
+    with sessions() as session:
+        project_a, binding_a = _create_bound_project(
+            session,
+            account_id="account-a",
+            name="Stage 2K.4 Project A",
+            repository=repository_a,
+        )
+        project_stale, _ = _create_bound_project(
+            session,
+            account_id="account-a",
+            name="Stage 2K.4 Project Stale",
+            repository=repository_stale,
+        )
+        repository_less = Project(
+            user_id="account-a",
+            name="Stage 2K.4 Repository-less",
+            description="remains valid without a binding",
+        )
+        session.add(repository_less)
+        session.commit()
+        project_a_id = project_a.id
+        binding_a_id = binding_a.id
+        project_stale_id = project_stale.id
+        repository_less_id = repository_less.id
+
+    with sessions() as session:
+        before_project_rows = session.scalar(select(func.count()).select_from(Project))
+        before_binding_rows = session.scalar(
+            select(func.count()).select_from(RepositoryBinding)
+        )
+        project_before = session.get(Project, project_a_id)
+        binding_before = session.get(RepositoryBinding, binding_a_id)
+        assert project_before is not None
+        assert binding_before is not None
+        project_snapshot = (
+            project_before.user_id,
+            project_before.name,
+            project_before.description,
+        )
+        binding_snapshot = (
+            binding_before.canonical_root,
+            binding_before.source_class,
+            binding_before.is_active,
+            dict(binding_before.provenance),
+        )
+
+        result = search_project_repository(
+            session,
+            authenticated_account_id="account-a",
+            project_id=project_a_id,
+            query="needle-a",
+        )
+        assert [(match.path, match.line) for match in result.matches] == [
+            ("fixture.txt", 1)
+        ]
+        assert "needle-b" not in repr(result.to_payload())
+        assert str(repository_a) not in repr(result.to_payload())
+        assert not session.new
+        assert not session.dirty
+        assert not session.deleted
+        assert session.scalar(select(func.count()).select_from(Project)) == before_project_rows
+        assert (
+            session.scalar(select(func.count()).select_from(RepositoryBinding))
+            == before_binding_rows
+        )
+        project_after = session.get(Project, project_a_id)
+        binding_after = session.get(RepositoryBinding, binding_a_id)
+        assert project_after is not None
+        assert binding_after is not None
+        assert (
+            project_after.user_id,
+            project_after.name,
+            project_after.description,
+        ) == project_snapshot
+        assert (
+            binding_after.canonical_root,
+            binding_after.source_class,
+            binding_after.is_active,
+            dict(binding_after.provenance),
+        ) == binding_snapshot
+
+    with sessions() as session:
+        with pytest.raises(AccountProjectMismatch):
+            search_project_repository(
+                session,
+                authenticated_account_id="account-b",
+                project_id=project_a_id,
+                query="needle-a",
+            )
+
+        with pytest.raises(RepositorySearchUnavailable):
+            search_project_repository(
+                session,
+                authenticated_account_id="account-a",
+                project_id=repository_less_id,
+                query="needle",
+            )
+
+    moved_stale_repository = tmp_path / "repository-stale-moved"
+    repository_stale.rename(moved_stale_repository)
+    with sessions() as session:
+        with pytest.raises(RepositorySearchUnavailable):
+            search_project_repository(
+                session,
+                authenticated_account_id="account-a",
+                project_id=project_stale_id,
+                query="needle-stale",
+            )
+
+    assert fixture.read_bytes() == before_bytes
+    assert _run_git("rev-parse", "HEAD", cwd=repository_a) == before_head
+    assert (
+        _run_git("rev-parse", "--abbrev-ref", "HEAD", cwd=repository_a)
+        == before_branch
+    )

--- a/tests/routes/test_project_repository_search.py
+++ b/tests/routes/test_project_repository_search.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from guardian.core.dependencies import RequestUserScope
+from guardian.core.repository_authority import AccountProjectMismatch, ProjectNotFound
+from guardian.core.repository_search import (
+    InvalidRepositorySearchQuery,
+    RepositorySearchEnumerationFailed,
+    RepositorySearchMatch,
+    RepositorySearchResult,
+    RepositorySearchUnavailable,
+)
+from guardian.routes import projects as projects_routes
+
+
+class _Session:
+    def __init__(self) -> None:
+        self.commits = 0
+        self.rollbacks = 0
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+class _Database:
+    def __init__(self, session: _Session) -> None:
+        self.session = session
+
+    @contextmanager
+    def get_session(self):
+        yield self.session
+
+
+def _scope(account_id: str = "account-a") -> RequestUserScope:
+    return RequestUserScope(
+        user_id=account_id,
+        account_id=account_id,
+        multi_user_enabled=True,
+    )
+
+
+def _result() -> RepositorySearchResult:
+    return RepositorySearchResult(
+        matches=(
+            RepositorySearchMatch(
+                path="src/example.py",
+                line=42,
+                snippet="needle is safely repository relative",
+            ),
+        ),
+        count=1,
+        truncated=False,
+        stop_reason="completed",
+        scanned_files=3,
+        scanned_bytes=123,
+        skipped_binary_files=0,
+        skipped_oversized_files=0,
+        skipped_sensitive_files=0,
+        skipped_symlink_files=0,
+    )
+
+
+def test_search_route_is_api_only_with_exact_operation_and_input_surface() -> None:
+    app = FastAPI()
+    app.include_router(projects_routes.api_router)
+    schema = app.openapi()
+    operation = schema["paths"]["/api/projects/{project_id}/repository/search"][
+        "get"
+    ]
+
+    assert operation["operationId"] == "repository.search"
+    assert "/projects/{project_id}/repository/search" not in schema["paths"]
+    parameters = {
+        parameter["name"]: parameter
+        for parameter in operation["parameters"]
+    }
+    assert {"project_id", "q", "limit"} <= set(parameters)
+    assert parameters["project_id"]["in"] == "path"
+    assert parameters["q"]["in"] == "query"
+    assert parameters["q"]["required"] is True
+    assert parameters["limit"]["in"] == "query"
+    assert not {
+        "account_id",
+        "user_id",
+        "binding_id",
+        "repository_root",
+        "discovery_root",
+        "repoPath",
+        "cwd",
+        "mount",
+    } & set(parameters)
+
+
+def test_search_route_uses_scope_calls_service_and_never_commits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _Session()
+    monkeypatch.setattr(projects_routes, "chatlog_db", _Database(session))
+    captured: dict[str, object] = {}
+
+    def search(received_session, **kwargs):
+        captured["session"] = received_session
+        captured.update(kwargs)
+        return _result()
+
+    monkeypatch.setattr(projects_routes, "search_project_repository", search)
+    response = projects_routes.search_project_repository_route(
+        42,
+        q="needle",
+        limit=5,
+        request_user_scope=_scope(),
+    )
+
+    assert captured == {
+        "session": session,
+        "authenticated_account_id": "account-a",
+        "project_id": 42,
+        "query": "needle",
+        "result_limit": 5,
+    }
+    assert response == {
+        "ok": True,
+        "matches": [
+            {
+                "path": "src/example.py",
+                "line": 42,
+                "snippet": "needle is safely repository relative",
+            }
+        ],
+        "count": 1,
+        "truncated": False,
+        "stop_reason": "completed",
+        "scanned_files": 3,
+        "scanned_bytes": 123,
+        "skipped_binary_files": 0,
+        "skipped_oversized_files": 0,
+        "skipped_sensitive_files": 0,
+        "skipped_symlink_files": 0,
+    }
+    assert session.commits == 0
+    assert session.rollbacks == 0
+    assert "canonical_root" not in response
+    assert "repository_root" not in response
+    assert "account-a" not in repr(response)
+
+
+@pytest.mark.parametrize(
+    ("error", "status", "code"),
+    [
+        (
+            InvalidRepositorySearchQuery("bad /private/path"),
+            400,
+            "repository_search_invalid_query",
+        ),
+        (
+            AccountProjectMismatch("other account"),
+            403,
+            "repository_search_forbidden",
+        ),
+        (
+            ProjectNotFound("missing project"),
+            404,
+            "repository_search_project_not_found",
+        ),
+        (
+            RepositorySearchUnavailable("stale /private/repository"),
+            409,
+            "repository_search_unavailable",
+        ),
+        (
+            RepositorySearchEnumerationFailed("stderr /private/repository"),
+            409,
+            "repository_search_unavailable",
+        ),
+    ],
+)
+def test_search_errors_are_bounded_and_path_safe(
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+    status: int,
+    code: str,
+) -> None:
+    session = _Session()
+    monkeypatch.setattr(projects_routes, "chatlog_db", _Database(session))
+
+    def fail(*_args, **_kwargs):
+        raise error
+
+    monkeypatch.setattr(projects_routes, "search_project_repository", fail)
+    with pytest.raises(HTTPException) as exc_info:
+        projects_routes.search_project_repository_route(
+            8, q="needle", request_user_scope=_scope()
+        )
+
+    assert exc_info.value.status_code == status
+    assert exc_info.value.detail["code"] == code
+    assert "/private/repository" not in repr(exc_info.value.detail)
+    assert session.commits == 0
+    assert session.rollbacks == 0
+
+
+def test_unexpected_search_error_is_generic_and_path_safe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _Session()
+    monkeypatch.setattr(projects_routes, "chatlog_db", _Database(session))
+
+    def fail(*_args, **_kwargs):
+        raise RuntimeError("do not leak /private/repository")
+
+    monkeypatch.setattr(projects_routes, "search_project_repository", fail)
+    with pytest.raises(HTTPException) as exc_info:
+        projects_routes.search_project_repository_route(
+            8, q="needle", request_user_scope=_scope()
+        )
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == {
+        "code": "repository_search_internal_error",
+        "message": "Repository search could not be completed.",
+    }
+    assert session.commits == 0
+    assert session.rollbacks == 0
+
+
+def test_fastapi_rejects_out_of_range_route_inputs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GUARDIAN_API_KEY", "test-key")
+    app = FastAPI()
+    app.include_router(projects_routes.api_router)
+    client = TestClient(app)
+
+    empty = client.get(
+        "/api/projects/1/repository/search?q=",
+        headers={"X-API-Key": "test-key"},
+    )
+    too_many = client.get(
+        "/api/projects/1/repository/search?q=needle&limit=21",
+        headers={"X-API-Key": "test-key"},
+    )
+    assert empty.status_code == 422
+    assert too_many.status_code == 422

--- a/tests/routes/test_repository_search_command_bus.py
+++ b/tests/routes/test_repository_search_command_bus.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from guardian.command_bus.contracts import CommandSpec
+from guardian.command_bus import loopback_http_adapter
+from guardian.routes import command_bus, projects
+from guardian.tools.chat_exposure import resolve_ordinary_chat_tools
+
+
+def _build_client(monkeypatch) -> TestClient:
+    monkeypatch.setenv("GUARDIAN_API_KEY", "test-key")
+    monkeypatch.setenv("DEBUG", "1")
+    command_bus.configure_db(None)
+    app = FastAPI()
+
+    @app.get("/health", operation_id="health_health_get")
+    def health() -> dict[str, bool]:
+        return {"ok": True}
+
+    def current_user(request: Request) -> str:
+        return request.headers.get("X-User-Id", "operator")
+
+    app.dependency_overrides[command_bus.get_current_user] = current_user
+    app.include_router(projects.api_router)
+    app.include_router(command_bus.router)
+    return TestClient(app)
+
+
+def _manifest(client: TestClient) -> dict[str, Any]:
+    response = client.get(
+        "/api/guardian/commands/manifest",
+        headers={"X-API-Key": "test-key", "X-User-Id": "operator"},
+    )
+    assert response.status_code == 200
+    return response.json()
+
+
+def _repository_command(manifest: dict[str, Any]) -> dict[str, Any]:
+    matches = [
+        command
+        for command in manifest["commands"]
+        if command.get("operation_id") == "repository.search"
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def test_repository_search_manifest_is_derived_from_projects_openapi(
+    monkeypatch,
+) -> None:
+    command = _repository_command(_manifest(_build_client(monkeypatch)))
+
+    assert command["command_id"] == "op::repository.search"
+    assert command["aliases"] == [
+        "route::GET::/api/projects/{project_id}/repository/search"
+    ]
+    assert command["method"] == "GET"
+    assert command["path_template"] == "/api/projects/{project_id}/repository/search"
+    assert command["operation_id"] == "repository.search"
+    assert command["layer"] == "raw"
+    assert command["risk"] == "read_only"
+    assert command["effect"] == "read"
+    assert command["idempotency"] == "safe"
+    assert command["approval_mode"] == "none"
+
+    input_schema = command["input_schema"]
+    assert input_schema["path_params"]["required"] == ["project_id"]
+    assert "project_id" in input_schema["path_params"]["properties"]
+    assert input_schema["query"]["required"] == ["q"]
+    assert set(input_schema["query"]["properties"]) == {"q", "limit"}
+    serialized = repr(input_schema)
+    for forbidden in (
+        "repository_root",
+        "canonical_root",
+        "discovery_root",
+        "account_id",
+        "user_id",
+        "binding_id",
+        "repoPath",
+        "cwd",
+    ):
+        assert forbidden not in serialized
+
+
+def test_repository_search_command_invokes_once_over_loopback(
+    monkeypatch,
+) -> None:
+    captured: list[dict[str, Any]] = []
+
+    class _FakeResponse:
+        status_code = 200
+        headers = {"content-type": "application/json"}
+
+        @property
+        def text(self) -> str:
+            return '{"ok": true}'
+
+        def json(self) -> dict[str, Any]:
+            return {
+                "ok": True,
+                "matches": [
+                    {
+                        "path": "src/example.py",
+                        "line": 2,
+                        "snippet": "needle",
+                    }
+                ],
+            }
+
+    class _FakeAsyncClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            _ = args, kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            _ = exc_type, exc, tb
+
+        async def request(self, **kwargs: Any) -> _FakeResponse:
+            captured.append(dict(kwargs))
+            return _FakeResponse()
+
+    monkeypatch.setenv(
+        "GUARDIAN_COMMAND_BUS_LOOPBACK_BASE", "http://127.0.0.1:9999"
+    )
+    monkeypatch.setattr(
+        loopback_http_adapter.httpx, "AsyncClient", _FakeAsyncClient
+    )
+    client = _build_client(monkeypatch)
+    command = _repository_command(_manifest(client))
+
+    response = client.post(
+        "/api/guardian/commands/invoke",
+        headers={"X-API-Key": "test-key", "X-User-Id": "operator"},
+        json={
+            "invoke_version": "1.0",
+            "command_id": command["command_id"],
+            "actor": {"kind": "human", "id": "operator"},
+            "arguments": {
+                "path_params": {"project_id": 42},
+                "query": {"q": "needle", "limit": 5},
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "completed"
+    assert payload["inline_result"]["status_code"] == 200
+    assert len(captured) == 1
+    assert captured[0]["method"] == "GET"
+    assert (
+        captured[0]["url"]
+        == "http://127.0.0.1:9999/api/projects/42/repository/search"
+    )
+    assert captured[0]["params"] == {"q": "needle", "limit": 5}
+    assert "json" not in captured[0]
+    forwarded = {key.lower(): value for key, value in captured[0]["headers"].items()}
+    assert forwarded["x-api-key"] == "test-key"
+    assert forwarded["x-user-id"] == "operator"
+
+    events = command_bus.get_store().list_events_after(
+        run_id=payload["run_id"], after_seq=0
+    )
+    assert [event["event_type"] for event in events] == [
+        "run.created",
+        "run.started",
+        "run.completed",
+    ]
+
+
+def test_repository_search_is_never_in_ordinary_chat_exposure() -> None:
+    health = CommandSpec(
+        command_id="op::health_health_get",
+        aliases=["route::GET::/health"],
+        layer="raw",
+        method="GET",
+        path_template="/health",
+        operation_id="health_health_get",
+        risk="read_only",
+        effect="read",
+        idempotency="safe",
+        approval_mode="none",
+        input_schema={
+            "path_params": {"properties": {}, "required": []},
+            "query": {"properties": {}, "required": []},
+            "headers": {"properties": {}, "required": []},
+            "body": {},
+        },
+    )
+    repository_search = CommandSpec(
+        command_id="op::repository.search",
+        aliases=[
+            "route::GET::/api/projects/{project_id}/repository/search"
+        ],
+        layer="raw",
+        method="GET",
+        path_template="/api/projects/{project_id}/repository/search",
+        operation_id="repository.search",
+        risk="read_only",
+        effect="read",
+        idempotency="safe",
+        approval_mode="none",
+        input_schema={
+            "path_params": {"properties": {"project_id": {}}, "required": ["project_id"]},
+            "query": {"properties": {"q": {}}, "required": ["q"]},
+            "headers": {"properties": {}, "required": []},
+            "body": {},
+        },
+    )
+
+    tools = resolve_ordinary_chat_tools(
+        provider="deepseek",
+        model="model",
+        provider_vendor=None,
+        manifest_commands=[health, repository_search],
+    )
+    assert tools == [
+        {
+            "command_id": "op::health_health_get",
+            "description": "Read the current Guardian health status (GET /health).",
+            "input_schema": {
+                "type": "object",
+                "additionalProperties": False,
+                "maxProperties": 0,
+            },
+        }
+    ]
+    assert all(tool["command_id"] != "op::repository.search" for tool in tools)


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
