### PR TITLE
Expose bound repository search to chat

### DIFF
--- a/docs/architecture/proofs/2026-08-12-stage2k5-repository-search-chat-exposure-proof.md
+++ b/docs/architecture/proofs/2026-08-12-stage2k5-repository-search-chat-exposure-proof.md
@@ -1,0 +1,222 @@
+# Stage 2K.5 Repository Search Ordinary-Chat Exposure Proof
+
+## Date
+
+2026-08-12
+
+## Verdict
+
+PASS — bounded repository search is exposed only in the supported local single-user ordinary-chat lane after Guardian resolves thread-owned binding authority.
+
+## Diagnostic Outcome
+
+REPOSITORY_SEARCH_CHAT_EXPOSURE_ESTABLISHED
+
+## Base Commit
+
+`18b8640703237482f47f2681d0d33f3753a8e561`, verified `origin/main` at task start.
+
+## Branch/Worktree
+
+- Branch: `codex/stage2k5-repository-search-chat-exposure`
+- Worktree: `/private/tmp/codexify-stage2k5-repository-search-chat-exposure`
+
+## Governing ADRs
+
+ADR-065 is primary; ADR-005, ADR-020, ADR-024, ADR-061, and the existing bounded provider-tool contracts remain preserved.
+
+## ADR Impact
+
+Aligned with existing ADRs. No ADR, authority contract, auth/session module, Command Bus core, provider adapter, schema, or migration changed.
+
+## Stage 2K.1 Prerequisite
+
+`tests/core/test_repository_authority.py` passed; ownership, one-active-binding cardinality, exact Git root, and stale/ambiguous failure behavior remain unchanged.
+
+## Stage 2K.2 Prerequisite
+
+`tests/core/test_repository_discovery.py` passed; discovery remains non-authorizing.
+
+## Stage 2K.3 Prerequisite
+
+`tests/core/test_repository_import.py` and `tests/routes/test_project_repository_import.py` passed; import remains explicit and is not invoked by chat.
+
+## Stage 2K.4 Prerequisite
+
+The 34-test Stage 2K.4 search core, route, and manifest suite passed; `op::repository.search` remains GET/read/read_only/safe/no-approval.
+
+## Current Truth Before
+
+Automatic ordinary-chat exposure was health-only; ChatCompletionTask held account/thread identity but no Project, root, binding, or queued request credential.
+
+## Ordinary Chat Boundary
+
+Repository search requires no Hosted Room invocation, positive thread ID, task account, and exact base origin `api:chat.complete`; other origins remain suppressed.
+
+## Current-Thread Project Resolution
+
+The new resolver loads only the exact current thread, checks its owner against the task account, and returns frozen context containing only positive `project_id`.
+
+## RepositoryBinding Eligibility Proof
+
+It opens one non-committing SQLAlchemy session and calls Stage 2K.1 with task account plus thread Project. Missing, stale, ambiguous, or cross-account authority returns no context.
+
+## Local Single-User Auth Transport Boundary
+
+Eligibility requires non-preview local auth, disabled multi-user mode, canonical single-user task identity, and one currently accepted local Guardian API key.
+
+## Remote/Multi-User Deferral
+
+Remote/multi-user ordinary-chat repository search remains intentionally fail-closed because the queued ChatCompletionTask does not carry an accepted delegated user credential for authenticated loopback replay. Stage 2K.5 does not invent one.
+
+## Hosted Room Suppression
+
+Any populated `hosted_room_invocation` suppresses repository search for both owner and guest paths.
+
+## Command Identity
+
+The only projected command is existing `op::repository.search`, alias `route::GET::/api/projects/{project_id}/repository/search`, operation ID `repository.search`.
+
+## Model Tool Projection
+
+The fixed model schema exposes required `q` and optional `limit` only, using Stage 2K.4 imported limits of 256 characters and 20 results.
+
+## Project-ID Non-Exposure
+
+No Project ID, binding ID, canonical root, repository root, cwd, mount, account field, or credential appears in schema, provider tools/messages, toolExposure, payload summary, result, or trace.
+
+## Guardian-Side Argument Hydration
+
+Guardian rejects every key except q/limit, then injects the freshly derived Project ID only into InvokeArguments path parameters with query q/limit, empty headers, and no body.
+
+## Pre-Dispatch Authority Revalidation
+
+Before dispatch, Guardian requires the private advertised context, rechecks transport, re-resolves thread/Project/binding, and requires the same Project ID; loss uses existing `tool_command_blocked`.
+
+## Thread-Move Fail-Closed Proof
+
+Mocked execution and disposable Postgres coverage move a thread from a bound Project to a repository-less Project; no old or new Project is silently searched.
+
+## Binding-Staleness Fail-Closed Proof
+
+The disposable Postgres proof moves the fixture worktree; the existing binding resolver rejects it and capability resolution returns no context.
+
+## Command Bus Delegation
+
+Repository search alone uses system actor request/tool-turn identity with `delegated_by=task.user_id` and `auth_subject=task.user_id`; existing actor validation accepts the bounded delegation.
+
+## Credential Non-Persistence
+
+The local key occurs only in the ephemeral `execute_invoke` inbound X-API-Key header. Tests prove absence from task serialization, tools, schema, arguments, provenance, idempotency, continuation, summary, result, and trace.
+
+## Command Bus Invocation Proof
+
+One mocked DeepSeek decision dispatched exactly one repository search with Guardian path Project 42, q `_prepare_chat_tool_exposure`, limit 5, empty InvokeArguments headers, no body, and ephemeral loopback transport auth.
+
+## Tool Result Reinjection
+
+The bounded Command Bus result was reinjected through the existing continuation seam; the second model attempt received no Project identity or absolute root and returned the final answer.
+
+## One-Command Limit Proof
+
+The existing second-tool-decision `tool_turn_limit_reached` behavior remains unchanged; one Command Bus invocation remains the maximum.
+
+## Existing Health Regression
+
+Existing health exposure and one-command execution tests pass unchanged, and repository eligibility failure leaves health available.
+
+## DeepSeek Exposure Proof
+
+Eligible DeepSeek receives health then repository search only when local transport and current thread/binding authority pass.
+
+## Whoosh'd Exposure Proof
+
+Only the existing eligible exact Whoosh'd target receives health then repository search; qualification logic is unchanged.
+
+## Unsupported Provider Suppression
+
+OpenAI, Groq, and non-Whoosh'd local providers gain no automatic tool.
+
+## Manual Tool Bypass Denial
+
+Manually supplied repository.search is removed before dispatch; unrelated explicit tools stay unchanged without repository context.
+
+## Database Read-Only Proof
+
+The disposable Postgres proof records Project, binding, thread, ORM state, and row counts before/after resolution and proves no changes.
+
+## Repository Mutation Denial
+
+Capability resolution invokes only Stage 2K.1 validation; it does not read search internals, mutate Git, or mutate a repository.
+
+## Model Authority Isolation
+
+Source and behavior checks found no cwd, nearest-Git, worktree environment, discovery, legacy fs.search, direct repository search, or provider-selected Project/root authority path.
+
+## Worker Parity
+
+`guardian/workers/chat_worker.py` remains unchanged and consumes the same preparation dict; private context stays in memory and is excluded by the existing serialization allowlist.
+
+## Alembic Head Result
+
+Before and after this no-schema slice, the sole Alembic head is `6e2b9c4a7d1f`.
+
+## Core Test Results
+
+`tests/core/test_repository_chat_capability.py` plus `tests/core/test_chat_tool_exposure.py` — 75 passed.
+
+## Postgres Integration Result
+
+`tests/integration/test_repository_chat_capability_postgres.py` — 1 passed against a dedicated loopback-only disposable PostgreSQL 15 container and unique database; both were removed.
+
+## Stage 2K.1 Regression Results
+
+Stage 2K.1 authority plus Stage 2K.2 discovery regression set — 71 passed.
+
+## Stage 2K.2 Regression Results
+
+The Stage 2K.2 discovery portion of that 71-test regression set passed.
+
+## Stage 2K.3 Regression Results
+
+Stage 2K.3 import plus Project account-scope set — 41 passed.
+
+## Stage 2K.4 Regression Results
+
+Stage 2K.4 search set — 34 passed.
+
+## Command Bus Regression Results
+
+Manifest, invoke, and tool-turn observability regressions — 34 passed.
+
+## Architecture Test Results
+
+`pytest -v tests/architecture` passed after this receipt was added.
+
+## Docs Validation
+
+`python3 scripts/validate_docs.py` and `make docs PYTHON=python3` passed, including diagram freshness.
+
+## What Was Proven
+
+On the supported local single-user ordinary-chat path, Codexify now advertises op::repository.search only when the authenticated current thread resolves one owned Project with one valid active RepositoryBinding; the model supplies only q/limit, Guardian revalidates and injects Project identity at dispatch time, Command Bus executes the existing bounded read-only search, and no repository root or Project authority is model-controlled.
+
+## What Was Not Proven
+
+- No remote multi-user or private-preview ordinary-chat repository-search execution was enabled.
+- No delegated session/JWT transport or browser/session credential queueing was created.
+- No Hosted Room repository-search exposure, live provider repository search, or supported-runtime replay was performed.
+- No second repository command, file-read-by-path command, repository write, or multi-command repository loop exists.
+- No repository mutation, Workspace authority change, provider inference, or supported-runtime restart occurred.
+
+## Documentation Follow-Through
+
+This receipt is the authorized documentation follow-through; governing ADR and authority/auth contracts remain unchanged.
+
+## Final File Scope
+
+Exactly seven files: resolver, exposure policy, completion seam, two focused core tests, disposable Postgres proof, and this receipt.
+
+## Commit
+
+Pending final architecture, documentation, and cached-diff validation.

--- a/guardian/core/chat_completion_service.py
+++ b/guardian/core/chat_completion_service.py
@@ -16,7 +16,7 @@ import time
 import uuid
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
-from typing import Any, Callable, Dict, Optional, Sequence
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence
 from urllib.parse import unquote
 
 from fastapi import HTTPException
@@ -83,7 +83,11 @@ from guardian.providers.whooshd_control_plane import (
 from guardian.providers.whooshd_tool_capability import (
     project_whooshd_tool_capability,
 )
-from guardian.tools.chat_exposure import resolve_ordinary_chat_tools
+from guardian.tools.chat_exposure import (
+    REPOSITORY_SEARCH_COMMAND_ID,
+    repository_search_is_advertised,
+    resolve_ordinary_chat_tools,
+)
 from guardian.core.candidate_trace_store import store_candidate_trace
 from guardian.core.completion_terminal import (
     CompletionAttemptResult,
@@ -107,6 +111,14 @@ from guardian.core.config import (
     validate_llm_config,
 )
 from guardian.core.llm_catalog import first_enabled_provider
+from guardian.core.repository_chat_capability import (
+    RepositoryChatCapabilityContext,
+    resolve_repository_chat_capability,
+)
+from guardian.core.repository_search import (
+    MAX_QUERY_CHARACTERS,
+    MAX_RETURNED_MATCHES,
+)
 from guardian.core.provider_registry import (
     default_model_for_provider,
     normalize_model_id,
@@ -5202,11 +5214,134 @@ def _authorized_tool_command_ids(task: ChatCompletionTask) -> frozenset[str]:
     )
 
 
+def _is_ordinary_repository_chat_task(task: ChatCompletionTask) -> bool:
+    """Classify the ordinary lane without deriving repository authority."""
+
+    thread_id = getattr(task, "thread_id", None)
+    if (
+        getattr(task, "hosted_room_invocation", None) is not None
+        or not isinstance(thread_id, int)
+        or isinstance(thread_id, bool)
+        or thread_id <= 0
+        or not str(getattr(task, "user_id", "") or "").strip()
+    ):
+        return False
+    origin = str(getattr(task, "origin", "") or "")
+    return origin.split("|", 1)[0] == "api:chat.complete"
+
+
+def _repository_search_local_api_key() -> str | None:
+    """Resolve one accepted local key using the verifier's configured order."""
+
+    allowed: list[str] = []
+    try:
+        settings = dependencies.get_settings()
+        primary = getattr(settings, "GUARDIAN_API_KEY", None)
+        if isinstance(primary, str) and primary.strip():
+            allowed.append(primary.strip())
+        raw_multi = getattr(settings, "GUARDIAN_API_KEYS", None)
+        if isinstance(raw_multi, str) and raw_multi.strip():
+            allowed.extend(
+                candidate.strip()
+                for candidate in raw_multi.replace(";", ",").split(",")
+                if candidate.strip()
+            )
+    except Exception:
+        allowed = []
+    if allowed:
+        return allowed[0]
+    fallback = (os.getenv("GUARDIAN_API_KEY") or "").strip()
+    return fallback or None
+
+
+def _repository_search_local_transport_eligible(
+    task: ChatCompletionTask,
+) -> bool:
+    """Allow queued repository replay only in the accepted local posture."""
+
+    if not _is_ordinary_repository_chat_task(task):
+        return False
+    try:
+        if dependencies.is_private_preview():
+            return False
+        if dependencies._auth_mode() != "local":
+            return False
+        if dependencies._multi_user_mode_enabled():
+            return False
+        if str(task.user_id or "") != dependencies.get_single_user_id():
+            return False
+    except Exception:
+        return False
+    return _repository_search_local_api_key() is not None
+
+
+def _hydrate_repository_search_arguments(
+    raw_arguments: Any,
+    *,
+    project_id: int,
+) -> InvokeArguments:
+    """Validate model q/limit and inject only Guardian-derived path authority."""
+
+    if (
+        not isinstance(project_id, int)
+        or isinstance(project_id, bool)
+        or project_id <= 0
+        or not isinstance(raw_arguments, Mapping)
+    ):
+        raise ValueError("repository_search_arguments_invalid")
+    arguments = dict(raw_arguments)
+    if set(arguments) - {"q", "limit"}:
+        raise ValueError("repository_search_arguments_invalid")
+    raw_query = arguments.get("q")
+    if not isinstance(raw_query, str):
+        raise ValueError("repository_search_arguments_invalid")
+    if "\x00" in raw_query or "\r" in raw_query or "\n" in raw_query:
+        raise ValueError("repository_search_arguments_invalid")
+    query = raw_query.strip()
+    if (
+        not query
+        or len(query) > MAX_QUERY_CHARACTERS
+    ):
+        raise ValueError("repository_search_arguments_invalid")
+    raw_limit = arguments.get("limit", MAX_RETURNED_MATCHES)
+    if (
+        not isinstance(raw_limit, int)
+        or isinstance(raw_limit, bool)
+        or not 1 <= raw_limit <= MAX_RETURNED_MATCHES
+    ):
+        raise ValueError("repository_search_arguments_invalid")
+    return InvokeArguments(
+        path_params={"project_id": project_id},
+        query={"q": query, "limit": raw_limit},
+        headers={},
+        body=None,
+    )
+
+
+def _repository_search_blocked_error(
+    *,
+    task: ChatCompletionTask,
+    tool_turn_id: str,
+) -> ToolLoopExecutionError:
+    return ToolLoopExecutionError(
+        ToolLoopStopReason.TOOL_COMMAND_BLOCKED.value,
+        metadata=_tool_loop_identity_fields(
+            task=task,
+            tool_turn_id=tool_turn_id,
+            tool_turn_state=ToolTurnState.FAILED.value,
+            loop_stop_reason=ToolLoopStopReason.TOOL_COMMAND_BLOCKED.value,
+            command_run_id=None,
+        )
+        | {"command_id": REPOSITORY_SEARCH_COMMAND_ID},
+    )
+
+
 def _resolve_ordinary_chat_tools(
     *,
     provider: str,
     model: str,
     settings: Any,
+    repository_search_eligible: bool = False,
 ) -> list[dict[str, Any]] | None:
     """Resolve the Stage 2I subset after the effective target is known."""
 
@@ -5252,6 +5387,7 @@ def _resolve_ordinary_chat_tools(
         provider_vendor=provider_vendor,
         manifest_commands=manifest.commands,
         whooshd_capability=whooshd_capability,
+        repository_search_eligible=repository_search_eligible,
     )
 
 
@@ -5265,16 +5401,45 @@ def _prepare_chat_tool_exposure(
     """Resolve the canonical advertised subset and its bounded evidence."""
 
     automatic_tool_exposure = task.tools is None
+    repository_context: RepositoryChatCapabilityContext | None = None
     if automatic_tool_exposure:
+        if _repository_search_local_transport_eligible(task):
+            repository_context = resolve_repository_chat_capability(
+                getattr(dependencies, "chatlog_db", None),
+                authenticated_account_id=task.user_id,
+                thread_id=task.thread_id,
+            )
         task.tools = _resolve_ordinary_chat_tools(
             provider=provider,
             model=model,
             settings=settings,
+            repository_search_eligible=repository_context is not None,
         )
-    return _build_tool_exposure_evidence(
+    else:
+        supplied_tools = task.tools
+        if isinstance(supplied_tools, list) and any(
+            isinstance(tool, dict)
+            and tool.get("command_id") == REPOSITORY_SEARCH_COMMAND_ID
+            for tool in supplied_tools
+        ):
+            task.tools = [
+                tool
+                for tool in supplied_tools
+                if not (
+                    isinstance(tool, dict)
+                    and tool.get("command_id") == REPOSITORY_SEARCH_COMMAND_ID
+                )
+            ]
+    evidence = _build_tool_exposure_evidence(
         automatic=automatic_tool_exposure,
         tools=task.tools,
     )
+    if (
+        repository_context is not None
+        and repository_search_is_advertised(task.tools)
+    ):
+        evidence["_repository_chat_context"] = repository_context
+    return evidence
 
 
 def _execute_bounded_tool_turn_completion(
@@ -5523,18 +5688,74 @@ def _execute_bounded_tool_turn_completion(
         )
 
     tool_turn_state = ToolTurnState.DECISION_RECEIVED.value
-    invocation = BoundedToolTurnInvocation(
-        tool_turn_id=tool_turn_id,
-        request_id=request_id or tool_turn_id,
-        command_id=normalized_first_output.command_id,
-        actor=ActorSpec(
+    command_id = normalized_first_output.command_id
+    arguments = _tool_turn_invoke_arguments(normalized_first_output.arguments or {})
+    actor = ActorSpec(
+        kind="system",
+        id=request_id or tool_turn_id,
+        session_id=tool_turn_id,
+    )
+    auth_subject = actor.id
+    inbound_headers: dict[str, str] = {}
+
+    if command_id == REPOSITORY_SEARCH_COMMAND_ID:
+        advertised_context = tool_exposure.get("_repository_chat_context")
+        if not isinstance(advertised_context, RepositoryChatCapabilityContext):
+            raise _repository_search_blocked_error(
+                task=task,
+                tool_turn_id=tool_turn_id,
+            )
+        if not _repository_search_local_transport_eligible(task):
+            raise _repository_search_blocked_error(
+                task=task,
+                tool_turn_id=tool_turn_id,
+            )
+        current_context = resolve_repository_chat_capability(
+            getattr(dependencies, "chatlog_db", None),
+            authenticated_account_id=task.user_id,
+            thread_id=task.thread_id,
+        )
+        if (
+            current_context is None
+            or current_context.project_id != advertised_context.project_id
+        ):
+            raise _repository_search_blocked_error(
+                task=task,
+                tool_turn_id=tool_turn_id,
+            )
+        try:
+            arguments = _hydrate_repository_search_arguments(
+                normalized_first_output.arguments,
+                project_id=current_context.project_id,
+            )
+        except ValueError as exc:
+            raise _repository_search_blocked_error(
+                task=task,
+                tool_turn_id=tool_turn_id,
+            ) from exc
+        local_api_key = _repository_search_local_api_key()
+        if local_api_key is None:
+            raise _repository_search_blocked_error(
+                task=task,
+                tool_turn_id=tool_turn_id,
+            )
+        actor = ActorSpec(
             kind="system",
             id=request_id or tool_turn_id,
             session_id=tool_turn_id,
-        ),
-        arguments=_tool_turn_invoke_arguments(normalized_first_output.arguments or {}),
+            delegated_by=task.user_id,
+        )
+        auth_subject = task.user_id
+        inbound_headers = {"X-API-Key": local_api_key}
+
+    invocation = BoundedToolTurnInvocation(
+        tool_turn_id=tool_turn_id,
+        request_id=request_id or tool_turn_id,
+        command_id=command_id,
+        actor=actor,
+        arguments=arguments,
         idempotency_key=(
-            f"{request_id or tool_turn_id}:{tool_turn_id}:{normalized_first_output.command_id}"
+            f"{request_id or tool_turn_id}:{tool_turn_id}:{command_id}"
         ),
     )
     invoke_request = InvokeRequest(
@@ -5549,8 +5770,8 @@ def _execute_bounded_tool_turn_completion(
     try:
         invoke_result = execute_invoke(
             payload=invoke_request,
-            auth_subject=invocation.actor.id,
-            inbound_headers={},
+            auth_subject=auth_subject,
+            inbound_headers=inbound_headers,
             store=command_bus_routes._store,
             app=_command_bus_app(),
             execution_lane="tools",

--- a/guardian/core/repository_chat_capability.py
+++ b/guardian/core/repository_chat_capability.py
@@ -1,0 +1,112 @@
+"""Fail-closed ordinary-chat eligibility for bound repository search.
+
+This seam derives only the current thread's authoritative Project identity.
+Repository roots and binding metadata remain inside the Stage 2K.1 resolver.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
+
+from guardian.core.repository_authority import (
+    RepositoryAuthorityError,
+    resolve_project_repository_binding,
+)
+
+
+@dataclass(frozen=True)
+class RepositoryChatCapabilityContext:
+    """Private, in-memory authority needed to hydrate one search dispatch."""
+
+    project_id: int
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.project_id, int)
+            or isinstance(self.project_id, bool)
+            or self.project_id <= 0
+        ):
+            raise ValueError("repository chat capability requires a positive project_id")
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if not isinstance(value, int) or value <= 0:
+        return None
+    return value
+
+
+def _read_only_session_factory(chatlog_db: Any) -> Any:
+    """Return the existing session seam without inheriting PgDB auto-commit."""
+
+    get_session = getattr(chatlog_db, "get_session", None)
+    if callable(get_session):
+        return get_session
+    session_factory = getattr(chatlog_db, "_SessionLocal", None)
+    if not callable(session_factory):
+        return None
+
+    @contextmanager
+    def _open_session() -> Any:
+        session = session_factory()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    return _open_session
+
+
+def resolve_repository_chat_capability(
+    chatlog_db: Any,
+    *,
+    authenticated_account_id: str | None,
+    thread_id: int,
+) -> RepositoryChatCapabilityContext | None:
+    """Resolve one thread-owned, binding-backed Project or fail closed.
+
+    Eligibility is intentionally optional: expected authority or storage
+    failures suppress repository search while leaving ordinary chat available.
+    The resolver performs no writes and returns only the Project identity.
+    """
+
+    account_id = str(authenticated_account_id or "").strip()
+    normalized_thread_id = _positive_int(thread_id)
+    if not account_id or normalized_thread_id is None or chatlog_db is None:
+        return None
+
+    get_chat_thread = getattr(chatlog_db, "get_chat_thread", None)
+    get_session = _read_only_session_factory(chatlog_db)
+    if not callable(get_chat_thread) or not callable(get_session):
+        return None
+
+    try:
+        thread = get_chat_thread(normalized_thread_id)
+    except Exception:
+        return None
+    if not isinstance(thread, Mapping):
+        return None
+    if thread.get("user_id") != account_id:
+        return None
+
+    project_id = _positive_int(thread.get("project_id"))
+    if project_id is None:
+        return None
+
+    try:
+        with get_session() as session:
+            resolve_project_repository_binding(
+                session,
+                authenticated_account_id=account_id,
+                project_id=project_id,
+            )
+    except RepositoryAuthorityError:
+        return None
+    except Exception:
+        return None
+
+    return RepositoryChatCapabilityContext(project_id=project_id)

--- a/guardian/tools/chat_exposure.py
+++ b/guardian/tools/chat_exposure.py
@@ -11,11 +11,16 @@ from collections.abc import Iterable
 from typing import Any
 
 from guardian.command_bus.contracts import CommandSpec
+from guardian.core.repository_search import (
+    MAX_QUERY_CHARACTERS,
+    MAX_RETURNED_MATCHES,
+)
 from guardian.providers.whooshd_tool_capability import (
     WhooshdToolCapabilityProjection,
 )
 
 HEALTH_COMMAND_ID = "op::health_health_get"
+REPOSITORY_SEARCH_COMMAND_ID = "op::repository.search"
 _WHOOSHD_VENDOR = "whooshd"
 _EMPTY_MODEL_INPUT_SCHEMA = {
     "type": "object",
@@ -30,15 +35,17 @@ def _normalized(value: str | None) -> str:
 
 def _find_command(
     commands: Iterable[CommandSpec | dict[str, Any]],
+    *,
+    expected_command_id: str,
 ) -> CommandSpec | dict[str, Any] | None:
     for command in commands:
         if isinstance(command, CommandSpec):
-            command_id = command.command_id
+            candidate_command_id = command.command_id
         elif isinstance(command, dict):
-            command_id = str(command.get("command_id") or "")
+            candidate_command_id = str(command.get("command_id") or "")
         else:
             continue
-        if command_id == HEALTH_COMMAND_ID:
+        if candidate_command_id == expected_command_id:
             return command
     return None
 
@@ -80,7 +87,7 @@ def _is_safe_health_command(command: CommandSpec | dict[str, Any]) -> bool:
     )
 
 
-def _model_tool(command: CommandSpec | dict[str, Any]) -> dict[str, Any]:
+def _health_model_tool(command: CommandSpec | dict[str, Any]) -> dict[str, Any]:
     method = str(_command_value(command, "method") or "GET")
     path_template = str(_command_value(command, "path_template") or "/health")
     return {
@@ -92,6 +99,86 @@ def _model_tool(command: CommandSpec | dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _has_exact_repository_search_input_schema(
+    command: CommandSpec | dict[str, Any],
+) -> bool:
+    input_schema = _command_value(command, "input_schema")
+    if not isinstance(input_schema, dict):
+        return False
+    path_params = input_schema.get("path_params")
+    query = input_schema.get("query")
+    if not isinstance(path_params, dict) or not isinstance(query, dict):
+        return False
+    path_properties = path_params.get("properties")
+    query_properties = query.get("properties")
+    if not isinstance(path_properties, dict) or not isinstance(query_properties, dict):
+        return False
+    q_schema = query_properties.get("q")
+    limit_schema = query_properties.get("limit")
+    return (
+        path_params.get("required") == ["project_id"]
+        and set(path_properties) == {"project_id"}
+        and query.get("required") == ["q"]
+        and set(query_properties) == {"q", "limit"}
+        and isinstance(q_schema, dict)
+        and q_schema.get("type") == "string"
+        and q_schema.get("minLength") == 1
+        and q_schema.get("maxLength") == MAX_QUERY_CHARACTERS
+        and isinstance(limit_schema, dict)
+        and limit_schema.get("type") == "integer"
+        and limit_schema.get("minimum") == 1
+        and limit_schema.get("maximum") == MAX_RETURNED_MATCHES
+    )
+
+
+def _is_safe_repository_search_command(
+    command: CommandSpec | dict[str, Any],
+) -> bool:
+    """Allow only the fixed Stage 2K.4 raw command projection."""
+
+    return (
+        _command_value(command, "command_id") == REPOSITORY_SEARCH_COMMAND_ID
+        and _command_value(command, "method") == "GET"
+        and _command_value(command, "path_template")
+        == "/api/projects/{project_id}/repository/search"
+        and _command_value(command, "operation_id") == "repository.search"
+        and _command_value(command, "effect") == "read"
+        and _command_value(command, "risk") == "read_only"
+        and _command_value(command, "idempotency") == "safe"
+        and _command_value(command, "approval_mode") == "none"
+        and _has_exact_repository_search_input_schema(command)
+    )
+
+
+def _repository_search_model_tool() -> dict[str, Any]:
+    """Return the fixed model projection; authority fields never cross it."""
+
+    return {
+        "command_id": REPOSITORY_SEARCH_COMMAND_ID,
+        "description": (
+            "Search the current Project's authorized repository for literal text. "
+            "Guardian selects the Project and repository."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "q": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": MAX_QUERY_CHARACTERS,
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": MAX_RETURNED_MATCHES,
+                },
+            },
+            "required": ["q"],
+            "additionalProperties": False,
+        },
+    }
+
+
 def resolve_ordinary_chat_tools(
     *,
     provider: str | None,
@@ -99,29 +186,57 @@ def resolve_ordinary_chat_tools(
     provider_vendor: str | None,
     manifest_commands: Iterable[CommandSpec | dict[str, Any]],
     whooshd_capability: WhooshdToolCapabilityProjection | None = None,
+    repository_search_eligible: bool = False,
 ) -> list[dict[str, Any]] | None:
-    """Return the one Stage 2I tool or no automatic ordinary-chat tools.
+    """Return the fixed ordinary-chat subset or no automatic tools.
 
     The manifest supplies the canonical command identity and safety facts.  A
     matching Whoosh'd Stage 2G projection is eligibility evidence only; the
     returned list is still the exact subset Stage 1 checks later.
     """
 
-    command = _find_command(manifest_commands)
-    if command is None or not _is_safe_health_command(command):
+    commands = list(manifest_commands)
+    health_command = _find_command(
+        commands,
+        expected_command_id=HEALTH_COMMAND_ID,
+    )
+    if health_command is None or not _is_safe_health_command(health_command):
         return None
 
     normalized_provider = _normalized(provider)
-    if normalized_provider == "deepseek":
-        return [_model_tool(command)]
+    provider_eligible = normalized_provider == "deepseek"
+    if not provider_eligible:
+        provider_eligible = (
+            normalized_provider == "local"
+            and _normalized(provider_vendor) == _WHOOSHD_VENDOR
+            and whooshd_capability is not None
+            and whooshd_capability.outcome == "eligible"
+            and whooshd_capability.invocation_model_id
+            == str(model or "").strip()
+        )
+    if not provider_eligible:
+        return None
 
-    if (
-        normalized_provider == "local"
-        and _normalized(provider_vendor) == _WHOOSHD_VENDOR
-        and whooshd_capability is not None
-        and whooshd_capability.outcome == "eligible"
-        and whooshd_capability.invocation_model_id == str(model or "").strip()
+    tools = [_health_model_tool(health_command)]
+    if not repository_search_eligible:
+        return tools
+
+    repository_command = _find_command(
+        commands,
+        expected_command_id=REPOSITORY_SEARCH_COMMAND_ID,
+    )
+    if repository_command is not None and _is_safe_repository_search_command(
+        repository_command
     ):
-        return [_model_tool(command)]
+        tools.append(_repository_search_model_tool())
+    return tools
 
-    return None
+
+def repository_search_is_advertised(tools: Any) -> bool:
+    """Return whether the fixed search command is in an automatic subset."""
+
+    return isinstance(tools, list) and any(
+        isinstance(tool, dict)
+        and tool.get("command_id") == REPOSITORY_SEARCH_COMMAND_ID
+        for tool in tools
+    )

--- a/tests/core/test_chat_tool_exposure.py
+++ b/tests/core/test_chat_tool_exposure.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+from dataclasses import asdict
 from dataclasses import replace
 from types import SimpleNamespace
 from typing import Any
@@ -10,6 +12,13 @@ from fastapi import FastAPI
 from guardian.command_bus.manifest import build_manifest
 from guardian.core import chat_completion_service
 from guardian.core.completion_terminal import CompletionTerminalEvidence
+from guardian.core.repository_chat_capability import (
+    RepositoryChatCapabilityContext,
+)
+from guardian.core.repository_search import (
+    MAX_QUERY_CHARACTERS,
+    MAX_RETURNED_MATCHES,
+)
 from guardian.protocol_tokens import CompletionTerminalStatus
 from guardian.providers.deepseek_adapter import DeepSeekResponse
 from guardian.providers.whooshd_control_plane import (
@@ -24,12 +33,16 @@ from guardian.providers.whooshd_tool_adapter import WhooshdStructuredResponse
 from guardian.providers.whooshd_tool_capability import (
     project_whooshd_tool_capability,
 )
-from guardian.routes import health
+from guardian.routes import health, projects
 from guardian.tasks.types import ChatCompletionTask
 from guardian.tools.chat_exposure import (
     HEALTH_COMMAND_ID,
+    REPOSITORY_SEARCH_COMMAND_ID,
     resolve_ordinary_chat_tools,
 )
+
+
+_USE_ADVERTISED_CONTEXT = object()
 
 
 def _command_bus_app() -> FastAPI:
@@ -49,6 +62,32 @@ def _health_command() -> Any:
         command
         for command in _manifest_commands()
         if command.command_id == HEALTH_COMMAND_ID
+    )
+
+
+def _repository_manifest_app() -> FastAPI:
+    app = _command_bus_app()
+    app.include_router(projects.api_router)
+    return app
+
+
+def _repository_manifest_commands() -> list[Any]:
+    return build_manifest(_repository_manifest_app()).commands
+
+
+def _repository_model_tool() -> dict[str, Any]:
+    tools = resolve_ordinary_chat_tools(
+        provider="deepseek",
+        model="deepseek-model",
+        provider_vendor=None,
+        manifest_commands=_repository_manifest_commands(),
+        repository_search_eligible=True,
+    )
+    assert tools is not None
+    return next(
+        dict(tool)
+        for tool in tools
+        if tool["command_id"] == REPOSITORY_SEARCH_COMMAND_ID
     )
 
 
@@ -310,6 +349,112 @@ def test_other_providers_and_local_runtimes_receive_no_automatic_tools(
     )
 
 
+def test_repository_search_manifest_projection_is_exact_and_authority_free() -> None:
+    commands = _repository_manifest_commands()
+    repository_command = next(
+        command
+        for command in commands
+        if command.command_id == REPOSITORY_SEARCH_COMMAND_ID
+    )
+
+    assert repository_command.method == "GET"
+    assert repository_command.path_template == "/api/projects/{project_id}/repository/search"
+    assert repository_command.operation_id == "repository.search"
+    assert repository_command.effect == "read"
+    assert repository_command.risk == "read_only"
+    assert repository_command.idempotency == "safe"
+    assert repository_command.approval_mode == "none"
+
+    tools = resolve_ordinary_chat_tools(
+        provider="deepseek",
+        model="deepseek-model",
+        provider_vendor=None,
+        manifest_commands=commands,
+        repository_search_eligible=True,
+    )
+    assert tools is not None
+    assert [tool["command_id"] for tool in tools] == [
+        HEALTH_COMMAND_ID,
+        REPOSITORY_SEARCH_COMMAND_ID,
+    ]
+    projection = tools[1]
+    assert projection["description"] == (
+        "Search the current Project's authorized repository for literal text. "
+        "Guardian selects the Project and repository."
+    )
+    assert projection["input_schema"] == {
+        "type": "object",
+        "properties": {
+            "q": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": MAX_QUERY_CHARACTERS,
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": MAX_RETURNED_MATCHES,
+            },
+        },
+        "required": ["q"],
+        "additionalProperties": False,
+    }
+    rendered = repr(projection)
+    for forbidden in (
+        "project_id",
+        "projectId",
+        "path_params",
+        "binding_id",
+        "canonical_root",
+        "repository_root",
+        "repoPath",
+        "cwd",
+        "mount",
+        "account_id",
+        "user_id",
+        "headers",
+        "body",
+    ):
+        assert forbidden not in rendered
+
+
+def test_unsafe_repository_manifest_is_suppressed_without_disabling_health() -> None:
+    commands = _repository_manifest_commands()
+    repository_command = next(
+        command
+        for command in commands
+        if command.command_id == REPOSITORY_SEARCH_COMMAND_ID
+    )
+    unsafe_repository_command = repository_command.model_copy(
+        update={"risk": "mutating", "effect": "write"}
+    )
+
+    tools = resolve_ordinary_chat_tools(
+        provider="deepseek",
+        model="deepseek-model",
+        provider_vendor=None,
+        manifest_commands=[_health_command(), unsafe_repository_command],
+        repository_search_eligible=True,
+    )
+    assert tools is not None
+    assert [tool["command_id"] for tool in tools] == [HEALTH_COMMAND_ID]
+
+
+def test_repository_search_stays_provider_qualified() -> None:
+    commands = _repository_manifest_commands()
+    for provider, vendor in (("openai", None), ("groq", None), ("local", "other")):
+        assert (
+            resolve_ordinary_chat_tools(
+                provider=provider,
+                model="model",
+                provider_vendor=vendor,
+                manifest_commands=commands,
+                repository_search_eligible=True,
+            )
+            is None
+        )
+
+
 def test_whooshd_exposure_requires_real_stage_2g_eligibility() -> None:
     inventory = parse_whooshd_runtime_inventory_entry(_inventory_entry())
     assert inventory is not None
@@ -327,6 +472,20 @@ def test_whooshd_exposure_requires_real_stage_2g_eligibility() -> None:
     )
     assert tools is not None
     assert [tool["command_id"] for tool in tools] == [HEALTH_COMMAND_ID]
+
+    repository_tools = resolve_ordinary_chat_tools(
+        provider="local",
+        model="gemma-4-12b-it-qat-4bit",
+        provider_vendor="whooshd",
+        manifest_commands=_repository_manifest_commands(),
+        whooshd_capability=eligible,
+        repository_search_eligible=True,
+    )
+    assert repository_tools is not None
+    assert [tool["command_id"] for tool in repository_tools] == [
+        HEALTH_COMMAND_ID,
+        REPOSITORY_SEARCH_COMMAND_ID,
+    ]
 
     for ineligible in (
         project_whooshd_tool_capability(inventory=None, exposure_allowed=True),
@@ -464,6 +623,248 @@ def test_ordinary_deepseek_health_tool_executes_once_and_plain_answer_is_optiona
     }
 
 
+def _run_repository_search_turn(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    model_arguments: Any,
+    current_context: RepositoryChatCapabilityContext | None | object = _USE_ADVERTISED_CONTEXT,
+    api_key: str | None = "sentinel-local-api-key",
+) -> tuple[ChatCompletionTask, list[dict[str, Any]], list[dict[str, Any]], Any]:
+    _seed_completion(
+        monkeypatch,
+        provider="deepseek",
+        model="deepseek-model",
+        settings=SimpleNamespace(LOCAL_PROVIDER_VENDOR=None),
+    )
+    task = _task(provider="deepseek", model="deepseek-model")
+    advertised_context = RepositoryChatCapabilityContext(project_id=42)
+    repository_tool = _repository_model_tool()
+    provider_calls: list[dict[str, Any]] = []
+    invocations: list[dict[str, Any]] = []
+
+    def _prepare(
+        prepared_task: ChatCompletionTask,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        prepared_task.tools = [
+            {
+                "command_id": HEALTH_COMMAND_ID,
+                "description": "Read health.",
+                "input_schema": {"type": "object"},
+            },
+            repository_tool,
+        ]
+        evidence = chat_completion_service._build_tool_exposure_evidence(
+            automatic=True,
+            tools=prepared_task.tools,
+        )
+        evidence["_repository_chat_context"] = advertised_context
+        return evidence
+
+    monkeypatch.setattr(chat_completion_service, "_prepare_chat_tool_exposure", _prepare)
+    monkeypatch.setattr(
+        chat_completion_service,
+        "_repository_search_local_transport_eligible",
+        lambda _task: True,
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "resolve_repository_chat_capability",
+        lambda *_args, **_kwargs: (
+            advertised_context
+            if current_context is _USE_ADVERTISED_CONTEXT
+            else current_context
+        ),
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "_repository_search_local_api_key",
+        lambda: api_key,
+    )
+
+    def _invoke(**kwargs: Any) -> dict[str, Any]:
+        invocations.append(kwargs)
+        return {
+            "run_id": "run-stage2k5-repository-search",
+            "status": "completed",
+            "inline_result": {
+                "status_code": 200,
+                "body": {
+                    "ok": True,
+                    "matches": [
+                        {
+                            "path": "guardian/core/chat_completion_service.py",
+                            "line": 1,
+                            "snippet": "bounded result",
+                        }
+                    ],
+                },
+            },
+        }
+
+    monkeypatch.setattr(chat_completion_service, "execute_invoke", _invoke)
+
+    def _chat(messages: list[dict[str, Any]], **kwargs: Any) -> DeepSeekResponse:
+        provider_calls.append({"messages": messages, "tools": kwargs.get("tools")})
+        if len(provider_calls) == 1:
+            return DeepSeekResponse(
+                content="",
+                reasoning_content=None,
+                tool_calls=[
+                    {
+                        "command_id": REPOSITORY_SEARCH_COMMAND_ID,
+                        "tool_call_id": "call-repository-search",
+                        "arguments": model_arguments,
+                    }
+                ],
+                raw_assistant_message={
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call-repository-search",
+                            "type": "function",
+                            "function": {
+                                "name": REPOSITORY_SEARCH_COMMAND_ID,
+                                "arguments": json.dumps(model_arguments),
+                            },
+                        }
+                    ],
+                },
+                raw_payload={},
+            )
+        return DeepSeekResponse(
+            content="The bounded repository result is ready.",
+            reasoning_content=None,
+            tool_calls=[],
+            raw_assistant_message={
+                "role": "assistant",
+                "content": "The bounded repository result is ready.",
+            },
+            raw_payload={},
+        )
+
+    monkeypatch.setattr(chat_completion_service, "chat_with_ai", _chat)
+    result = chat_completion_service.run_chat_completion_task(
+        task,
+        persist_assistant_message=False,
+    )
+    return task, invocations, provider_calls, result
+
+
+def test_repository_search_tool_turn_revalidates_and_hydrates_guardian_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel = "sentinel-local-api-key"
+    raw_arguments = {"q": "_prepare_chat_tool_exposure", "limit": 5}
+    task, invocations, provider_calls, result = _run_repository_search_turn(
+        monkeypatch,
+        model_arguments=raw_arguments,
+        api_key=sentinel,
+    )
+
+    assert len(invocations) == 1
+    invocation = invocations[0]
+    payload = invocation["payload"]
+    assert payload.command_id == REPOSITORY_SEARCH_COMMAND_ID
+    assert payload.arguments.model_dump() == {
+        "path_params": {"project_id": 42},
+        "query": {"q": "_prepare_chat_tool_exposure", "limit": 5},
+        "headers": {},
+        "body": None,
+    }
+    assert payload.actor.kind == "system"
+    assert payload.actor.delegated_by == task.user_id
+    assert invocation["auth_subject"] == task.user_id
+    assert invocation["inbound_headers"] == {"X-API-Key": sentinel}
+    assert payload.provenance_json == {}
+    assert sentinel not in repr(payload.arguments.model_dump())
+    assert sentinel not in str(payload.idempotency_key)
+    assert raw_arguments == {"q": "_prepare_chat_tool_exposure", "limit": 5}
+    assert len(provider_calls) == 2
+    assert [tool["command_id"] for tool in provider_calls[0]["tools"]] == [
+        HEALTH_COMMAND_ID,
+        REPOSITORY_SEARCH_COMMAND_ID,
+    ]
+    rendered_provider_data = repr(provider_calls)
+    for forbidden in ("project_id", "canonical_root", "binding_id", sentinel):
+        assert forbidden not in rendered_provider_data
+    assert "project_id" not in repr(
+        result["payload_summary"]["toolExposure"]
+    )
+    assert sentinel not in repr(asdict(task))
+    assert sentinel not in repr(result)
+    assert result["assistant_text"] == "The bounded repository result is ready."
+    assert result["payload_summary"]["toolTurnState"] == "completed"
+    assert result["payload_summary"]["loopStopReason"] == "tool_turn_completed"
+    assert result["payload_summary"]["commandRunId"] == "run-stage2k5-repository-search"
+
+
+@pytest.mark.parametrize(
+    "model_arguments",
+    [
+        {"project_id": 42, "q": "needle"},
+        {"path_params": {"project_id": 42}, "q": "needle"},
+        {"headers": {"X-API-Key": "nope"}, "q": "needle"},
+        {"body": {"q": "needle"}, "q": "needle"},
+        {"query": {"q": "needle"}, "q": "needle"},
+        {"q": "needle", "unknown": True},
+        {"q": "   "},
+        {"q": "needle\n"},
+        {"q": "x" * (MAX_QUERY_CHARACTERS + 1)},
+        {"q": "needle", "limit": True},
+        {"q": "needle", "limit": 0},
+        {"q": "needle", "limit": MAX_RETURNED_MATCHES + 1},
+    ],
+)
+def test_invalid_repository_model_arguments_block_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    model_arguments: dict[str, Any],
+) -> None:
+    with pytest.raises(
+        chat_completion_service.ToolLoopExecutionError,
+        match="tool_command_blocked",
+    ) as exc_info:
+        _run_repository_search_turn(
+            monkeypatch,
+            model_arguments=model_arguments,
+        )
+
+    assert exc_info.value.metadata["loopStopReason"] == "tool_command_blocked"
+
+
+@pytest.mark.parametrize(
+    "current_context",
+    [None, RepositoryChatCapabilityContext(project_id=99)],
+)
+def test_missing_or_moved_repository_authority_blocks_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    current_context: RepositoryChatCapabilityContext | None,
+) -> None:
+    with pytest.raises(
+        chat_completion_service.ToolLoopExecutionError,
+        match="tool_command_blocked",
+    ):
+        _run_repository_search_turn(
+            monkeypatch,
+            model_arguments={"q": "needle"},
+            current_context=current_context,
+        )
+
+
+def test_disappearing_local_api_key_blocks_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with pytest.raises(
+        chat_completion_service.ToolLoopExecutionError,
+        match="tool_command_blocked",
+    ):
+        _run_repository_search_turn(
+            monkeypatch,
+            model_arguments={"q": "needle"},
+            api_key=None,
+        )
+
+
 def test_advertised_deepseek_health_capability_does_not_force_tool_use(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -555,6 +956,186 @@ def test_prepare_chat_tool_exposure_resolves_automatic_deepseek_health(
         "providerDispatchToolCommandIds": [],
         "commandIdsTruncated": False,
     }
+
+
+def _patch_local_repository_auth(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    private_preview: bool = False,
+    auth_mode: str = "local",
+    multi_user: bool = False,
+    single_user_id: str = "local",
+    api_key: str | None = "sentinel-local-api-key",
+) -> None:
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "is_private_preview",
+        lambda: private_preview,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_auth_mode",
+        lambda: auth_mode,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "_multi_user_mode_enabled",
+        lambda: multi_user,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "get_single_user_id",
+        lambda: single_user_id,
+    )
+    monkeypatch.setattr(
+        chat_completion_service.dependencies,
+        "get_settings",
+        lambda: SimpleNamespace(GUARDIAN_API_KEY=api_key, GUARDIAN_API_KEYS=None),
+    )
+    monkeypatch.delenv("GUARDIAN_API_KEY", raising=False)
+
+
+@pytest.mark.parametrize(
+    "configure",
+    [
+        lambda task: setattr(task, "hosted_room_invocation", object()),
+        lambda task: setattr(task, "origin", "api:voice.complete"),
+        lambda task: setattr(task, "thread_id", 0),
+        lambda task: setattr(task, "user_id", ""),
+    ],
+)
+def test_nonordinary_task_classification_suppresses_repository_search(
+    monkeypatch: pytest.MonkeyPatch,
+    configure: Any,
+) -> None:
+    _patch_local_repository_auth(monkeypatch)
+    task = _task(provider="deepseek", model="deepseek-model")
+    configure(task)
+
+    assert not chat_completion_service._is_ordinary_repository_chat_task(task)
+    assert not chat_completion_service._repository_search_local_transport_eligible(task)
+
+
+@pytest.mark.parametrize(
+    "auth_kwargs",
+    [
+        {"private_preview": True},
+        {"auth_mode": "remote"},
+        {"multi_user": True},
+        {"single_user_id": "someone-else"},
+        {"api_key": None},
+    ],
+)
+def test_nonlocal_or_missing_credential_postures_suppress_repository_search(
+    monkeypatch: pytest.MonkeyPatch,
+    auth_kwargs: dict[str, Any],
+) -> None:
+    _patch_local_repository_auth(monkeypatch, **auth_kwargs)
+    task = _task(provider="deepseek", model="deepseek-model")
+
+    assert not chat_completion_service._repository_search_local_transport_eligible(task)
+
+
+def test_prepare_attaches_private_context_only_for_automatic_advertisement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_local_repository_auth(monkeypatch)
+    task = _task(provider="deepseek", model="deepseek-model")
+    context = RepositoryChatCapabilityContext(project_id=42)
+    resolver_calls: list[dict[str, Any]] = []
+
+    def _resolve_tools(**kwargs: Any) -> list[dict[str, Any]]:
+        resolver_calls.append(kwargs)
+        tools = [
+            {
+                "command_id": HEALTH_COMMAND_ID,
+                "description": "Read health.",
+                "input_schema": {"type": "object"},
+            }
+        ]
+        if kwargs["repository_search_eligible"]:
+            tools.append(_repository_model_tool())
+        return tools
+
+    monkeypatch.setattr(
+        chat_completion_service,
+        "resolve_repository_chat_capability",
+        lambda *_args, **_kwargs: context,
+    )
+    monkeypatch.setattr(chat_completion_service, "_resolve_ordinary_chat_tools", _resolve_tools)
+
+    evidence = chat_completion_service._prepare_chat_tool_exposure(
+        task,
+        provider="deepseek",
+        model="deepseek-model",
+        settings=SimpleNamespace(),
+    )
+
+    assert resolver_calls[0]["repository_search_eligible"] is True
+    assert evidence["_repository_chat_context"] == context
+    assert [tool["command_id"] for tool in task.tools or []] == [
+        HEALTH_COMMAND_ID,
+        REPOSITORY_SEARCH_COMMAND_ID,
+    ]
+    payload = chat_completion_service._tool_exposure_payload(evidence)
+    assert "_repository_chat_context" not in payload
+    assert "project_id" not in repr(payload)
+
+
+def test_repository_capability_failure_leaves_health_automatically_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_local_repository_auth(monkeypatch)
+    task = _task(provider="deepseek", model="deepseek-model")
+    resolver_calls: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(
+        chat_completion_service,
+        "resolve_repository_chat_capability",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        chat_completion_service,
+        "_resolve_ordinary_chat_tools",
+        lambda **kwargs: resolver_calls.append(kwargs)
+        or [{"command_id": HEALTH_COMMAND_ID}],
+    )
+
+    evidence = chat_completion_service._prepare_chat_tool_exposure(
+        task,
+        provider="deepseek",
+        model="deepseek-model",
+        settings=SimpleNamespace(),
+    )
+
+    assert resolver_calls[0]["repository_search_eligible"] is False
+    assert task.tools == [{"command_id": HEALTH_COMMAND_ID}]
+    assert "_repository_chat_context" not in evidence
+
+
+def test_manual_repository_search_cannot_bypass_capability_preparation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = _task(provider="deepseek", model="deepseek-model")
+    unrelated = {"command_id": "op::caller_selected"}
+    task.tools = [_repository_model_tool(), unrelated]
+    monkeypatch.setattr(
+        chat_completion_service,
+        "resolve_repository_chat_capability",
+        lambda *_args, **_kwargs: pytest.fail("manual tools must not resolve authority"),
+    )
+
+    evidence = chat_completion_service._prepare_chat_tool_exposure(
+        task,
+        provider="deepseek",
+        model="deepseek-model",
+        settings=SimpleNamespace(),
+    )
+
+    assert task.tools == [unrelated]
+    assert evidence["automatic"] is False
+    assert evidence["advertisedToolCommandIds"] == ["op::caller_selected"]
+    assert "_repository_chat_context" not in evidence
 
 
 def test_prepare_chat_tool_exposure_preserves_explicit_empty_tools(

--- a/tests/core/test_repository_chat_capability.py
+++ b/tests/core/test_repository_chat_capability.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+from dataclasses import fields
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from guardian.core import repository_chat_capability as capability
+from guardian.core.repository_authority import BindingResolutionFailed
+
+
+class _Session:
+    def __init__(self) -> None:
+        self.commits = 0
+        self.adds = 0
+
+    def __enter__(self) -> _Session:
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        return None
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def add(self, _value: Any) -> None:
+        self.adds += 1
+
+
+class _ChatDb:
+    def __init__(self, thread: Any = None) -> None:
+        self.thread = thread
+        self.session = _Session()
+        self.thread_calls: list[int] = []
+
+    def get_chat_thread(self, thread_id: int) -> Any:
+        self.thread_calls.append(thread_id)
+        return self.thread
+
+    def get_session(self) -> _Session:
+        return self.session
+
+
+def _owned_thread(*, project_id: Any = 11, user_id: str = "account-a") -> dict[str, Any]:
+    return {"id": 7, "user_id": user_id, "project_id": project_id}
+
+
+def _resolve(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    error: Exception | None = None,
+) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    def _resolver(session: Any, **kwargs: Any) -> SimpleNamespace:
+        calls.append({"session": session, **kwargs})
+        if error is not None:
+            raise error
+        return SimpleNamespace(binding_id="binding-private", canonical_root="/private")
+
+    monkeypatch.setattr(
+        capability,
+        "resolve_project_repository_binding",
+        _resolver,
+    )
+    return calls
+
+
+@pytest.mark.parametrize(
+    ("account_id", "thread_id"),
+    [
+        ("", 7),
+        ("   ", 7),
+        (None, 7),
+        ("account-a", 0),
+        ("account-a", -1),
+        ("account-a", True),
+        ("account-a", "7"),
+    ],
+)
+def test_missing_authenticated_account_or_invalid_thread_returns_no_context(
+    account_id: str | None,
+    thread_id: Any,
+) -> None:
+    db = _ChatDb(_owned_thread())
+
+    assert (
+        capability.resolve_repository_chat_capability(
+            db,
+            authenticated_account_id=account_id,
+            thread_id=thread_id,
+        )
+        is None
+    )
+    assert db.thread_calls == []
+
+
+def test_missing_chat_db_or_required_seams_returns_no_context() -> None:
+    assert (
+        capability.resolve_repository_chat_capability(
+            None,
+            authenticated_account_id="account-a",
+            thread_id=7,
+        )
+        is None
+    )
+    assert (
+        capability.resolve_repository_chat_capability(
+            object(),
+            authenticated_account_id="account-a",
+            thread_id=7,
+        )
+        is None
+    )
+
+    db_without_session = SimpleNamespace(
+        get_chat_thread=lambda _thread_id: _owned_thread()
+    )
+    assert (
+        capability.resolve_repository_chat_capability(
+            db_without_session,
+            authenticated_account_id="account-a",
+            thread_id=7,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    "thread",
+    [None, [], "not-a-thread", {"user_id": "account-b", "project_id": 11}],
+)
+def test_missing_invalid_or_cross_account_thread_returns_no_context(thread: Any) -> None:
+    db = _ChatDb(thread)
+
+    assert (
+        capability.resolve_repository_chat_capability(
+            db,
+            authenticated_account_id="account-a",
+            thread_id=7,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("project_id", [None, 0, -1, True, "11", 1.5])
+def test_missing_or_invalid_thread_project_id_returns_no_context(project_id: Any) -> None:
+    db = _ChatDb(_owned_thread(project_id=project_id))
+
+    assert (
+        capability.resolve_repository_chat_capability(
+            db,
+            authenticated_account_id="account-a",
+            thread_id=7,
+        )
+        is None
+    )
+
+
+def test_valid_owned_thread_and_binding_returns_only_project_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _ChatDb(_owned_thread(project_id=42))
+    calls = _resolve(monkeypatch)
+
+    context = capability.resolve_repository_chat_capability(
+        db,
+        authenticated_account_id="account-a",
+        thread_id=7,
+    )
+
+    assert context == capability.RepositoryChatCapabilityContext(project_id=42)
+    assert [field.name for field in fields(context)] == ["project_id"]
+    assert not hasattr(context, "binding_id")
+    assert not hasattr(context, "canonical_root")
+    assert calls == [
+        {
+            "session": db.session,
+            "authenticated_account_id": "account-a",
+            "project_id": 42,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        BindingResolutionFailed("no active binding"),
+        RuntimeError("database unavailable"),
+    ],
+)
+def test_missing_stale_ambiguous_or_unexpected_binding_failure_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+) -> None:
+    db = _ChatDb(_owned_thread())
+    _resolve(monkeypatch, error=error)
+
+    assert (
+        capability.resolve_repository_chat_capability(
+            db,
+            authenticated_account_id="account-a",
+            thread_id=7,
+        )
+        is None
+    )
+    assert db.session.commits == 0
+    assert db.session.adds == 0
+
+
+def test_thread_lookup_failure_fails_closed_without_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _ChatDb(_owned_thread())
+    _resolve(monkeypatch)
+
+    def _raise(_thread_id: int) -> None:
+        raise RuntimeError("lookup failed")
+
+    db.get_chat_thread = _raise  # type: ignore[method-assign]
+    assert (
+        capability.resolve_repository_chat_capability(
+            db,
+            authenticated_account_id="account-a",
+            thread_id=7,
+        )
+        is None
+    )
+    assert db.session.commits == 0
+    assert db.session.adds == 0
+
+
+def test_resolution_never_mutates_thread_or_uses_fallback_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    thread = _owned_thread(project_id=19)
+    snapshot = dict(thread)
+    db = _ChatDb(thread)
+    _resolve(monkeypatch, error=BindingResolutionFailed("repository-less"))
+
+    assert (
+        capability.resolve_repository_chat_capability(
+            db,
+            authenticated_account_id="account-a",
+            thread_id=7,
+        )
+        is None
+    )
+    assert thread == snapshot
+    assert db.session.commits == 0
+    assert db.session.adds == 0
+    source = open(capability.__file__, encoding="utf-8").read()
+    for forbidden in (
+        "Path.cwd()",
+        "detect_project_root",
+        "CODEXIFY_WORKTREE_REPO_PATH",
+        "get_recent_thread",
+        "discovery_candidate",
+    ):
+        assert forbidden not in source

--- a/tests/integration/test_repository_chat_capability_postgres.py
+++ b/tests/integration/test_repository_chat_capability_postgres.py
@@ -1,0 +1,365 @@
+"""Disposable Postgres proof for ordinary-chat repository eligibility."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import uuid
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+try:
+    import psycopg  # type: ignore
+except ImportError:  # pragma: no cover - environment specific
+    psycopg = None
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, func, select, text
+from sqlalchemy.engine import Engine, make_url
+from sqlalchemy.orm import Session, sessionmaker
+
+from guardian.core.chatlog_postgres import PostgresChatLogDB
+from guardian.core.repository_authority import (
+    SOURCE_CLASS_EXTERNAL_LINKED,
+    create_repository_binding,
+)
+from guardian.core.repository_chat_capability import (
+    resolve_repository_chat_capability,
+)
+from guardian.db.models import ChatThread, Project, RepositoryBinding
+
+
+ALEMBIC_HEAD = "6e2b9c4a7d1f"
+
+
+def _database_url(base_url: str, database_name: str) -> str:
+    return make_url(base_url).set(
+        drivername="postgresql+psycopg", database=database_name
+    ).render_as_string(hide_password=False)
+
+
+def _admin_database_url(base_url: str) -> str:
+    return make_url(base_url).set(
+        drivername="postgresql", database="postgres"
+    ).render_as_string(hide_password=False)
+
+
+@pytest.fixture
+def disposable_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[Engine, None, None]:
+    if psycopg is None:
+        pytest.skip("psycopg is required for the disposable Postgres proof")
+    base_url = os.getenv("TEST_DATABASE_URL")
+    if not base_url:
+        pytest.skip("TEST_DATABASE_URL is required for the disposable Postgres proof")
+
+    database_name = f"codexify_stage2k5_capability_{uuid.uuid4().hex[:12]}"
+    admin_url = _admin_database_url(base_url)
+    database_url = _database_url(base_url, database_name)
+    try:
+        with psycopg.connect(admin_url, autocommit=True) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(f'CREATE DATABASE "{database_name}"')
+    except Exception as exc:  # pragma: no cover - environment specific
+        pytest.skip(f"unable to create disposable Postgres database: {exc}")
+
+    repository_root = Path(__file__).resolve().parents[2]
+    config = Config(str(repository_root / "backend" / "alembic.ini"))
+    config.set_main_option("sqlalchemy.url", database_url)
+    config.set_main_option(
+        "script_location", str(repository_root / "guardian" / "db" / "migrations")
+    )
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    engine: Engine | None = None
+    try:
+        command.upgrade(config, ALEMBIC_HEAD)
+        engine = create_engine(database_url, future=True)
+        yield engine
+    finally:
+        if engine is not None:
+            engine.dispose()
+        try:
+            with psycopg.connect(admin_url, autocommit=True) as connection:
+                with connection.cursor() as cursor:
+                    cursor.execute(
+                        "SELECT pg_terminate_backend(pid) "
+                        "FROM pg_stat_activity "
+                        "WHERE datname = %s AND pid <> pg_backend_pid()",
+                        (database_name,),
+                    )
+                    cursor.execute(f'DROP DATABASE IF EXISTS "{database_name}"')
+        except Exception:
+            pass
+
+
+def _run_git(*args: str, cwd: Path) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _init_repository(path: Path) -> Path:
+    path.mkdir()
+    _run_git("init", "--quiet", cwd=path)
+    _run_git("config", "user.email", "fixture@example.invalid", cwd=path)
+    _run_git("config", "user.name", "Fixture", cwd=path)
+    (path / "fixture.txt").write_text("repository chat capability fixture\n")
+    _run_git("add", "fixture.txt", cwd=path)
+    _run_git("commit", "--quiet", "-m", "fixture", cwd=path)
+    return path.resolve()
+
+
+def _seed_account(engine: Engine, account_id: str) -> None:
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "INSERT INTO users (id, username, password_hash, role) "
+                "VALUES (:id, :username, :password_hash, :role)"
+            ),
+            {
+                "id": account_id,
+                "username": account_id,
+                "password_hash": "not-a-real-password-hash",
+                "role": "guest",
+            },
+        )
+
+
+def _create_bound_project(
+    session: Session,
+    *,
+    account_id: str,
+    name: str,
+    repository: Path,
+) -> tuple[Project, RepositoryBinding]:
+    project = Project(
+        user_id=account_id,
+        name=name,
+        description="repository chat capability proof",
+    )
+    session.add(project)
+    session.flush()
+    binding = create_repository_binding(
+        session,
+        authenticated_account_id=account_id,
+        project_id=project.id,
+        source_class=SOURCE_CLASS_EXTERNAL_LINKED,
+        working_tree_root=repository,
+        provenance={
+            "registration_source": "repository_chat_capability_integration_proof",
+            "operation_class": "external_link",
+        },
+    )
+    return project, binding
+
+
+@pytest.mark.integration
+def test_repository_chat_capability_postgres_authority_and_read_only_proof(
+    disposable_database: Engine,
+    tmp_path: Path,
+) -> None:
+    engine = disposable_database
+    sessions = sessionmaker(engine, expire_on_commit=False, future=True)
+    _seed_account(engine, "account-a")
+    _seed_account(engine, "account-b")
+    repository_a = _init_repository(tmp_path / "repository-a")
+    repository_b = _init_repository(tmp_path / "repository-b")
+    repository_stale = _init_repository(tmp_path / "repository-stale")
+
+    with sessions() as session:
+        project_a, binding_a = _create_bound_project(
+            session,
+            account_id="account-a",
+            name="Stage 2K.5 Project A",
+            repository=repository_a,
+        )
+        project_b, _ = _create_bound_project(
+            session,
+            account_id="account-b",
+            name="Stage 2K.5 Project B",
+            repository=repository_b,
+        )
+        project_stale, _ = _create_bound_project(
+            session,
+            account_id="account-a",
+            name="Stage 2K.5 Project Stale",
+            repository=repository_stale,
+        )
+        repository_less = Project(
+            user_id="account-a",
+            name="Stage 2K.5 Repository-less",
+            description="remains valid without a binding",
+        )
+        session.add(repository_less)
+        session.flush()
+        thread_a = ChatThread(
+            user_id="account-a",
+            title="Stage 2K.5 Thread A",
+            project_id=project_a.id,
+        )
+        thread_repository_less = ChatThread(
+            user_id="account-a",
+            title="Stage 2K.5 Repository-less Thread",
+            project_id=repository_less.id,
+        )
+        thread_cross_project = ChatThread(
+            user_id="account-a",
+            title="Stage 2K.5 Cross-Account Project Thread",
+            project_id=project_b.id,
+        )
+        thread_stale = ChatThread(
+            user_id="account-a",
+            title="Stage 2K.5 Stale Thread",
+            project_id=project_stale.id,
+        )
+        session.add_all(
+            [thread_a, thread_repository_less, thread_cross_project, thread_stale]
+        )
+        session.commit()
+        project_a_id = project_a.id
+        binding_a_id = binding_a.id
+        repository_less_id = repository_less.id
+        thread_a_id = thread_a.id
+        thread_repository_less_id = thread_repository_less.id
+        thread_cross_project_id = thread_cross_project.id
+        thread_stale_id = thread_stale.id
+
+    database_url = engine.url.render_as_string(hide_password=False)
+    chatlog_db = PostgresChatLogDB(database_url)
+    try:
+        with sessions() as session:
+            before_project_rows = session.scalar(
+                select(func.count()).select_from(Project)
+            )
+            before_binding_rows = session.scalar(
+                select(func.count()).select_from(RepositoryBinding)
+            )
+            before_thread_rows = session.scalar(
+                select(func.count()).select_from(ChatThread)
+            )
+            project_before = session.get(Project, project_a_id)
+            binding_before = session.get(RepositoryBinding, binding_a_id)
+            thread_before = session.get(ChatThread, thread_a_id)
+            assert project_before is not None
+            assert binding_before is not None
+            assert thread_before is not None
+            project_snapshot = (
+                project_before.user_id,
+                project_before.name,
+                project_before.description,
+            )
+            binding_snapshot = (
+                binding_before.canonical_root,
+                binding_before.source_class,
+                binding_before.is_active,
+                dict(binding_before.provenance),
+            )
+            thread_snapshot = (
+                thread_before.user_id,
+                thread_before.project_id,
+                thread_before.title,
+            )
+
+            context = resolve_repository_chat_capability(
+                chatlog_db,
+                authenticated_account_id="account-a",
+                thread_id=thread_a_id,
+            )
+            assert context is not None
+            assert context.project_id == project_a_id
+            assert not hasattr(context, "binding_id")
+            assert not hasattr(context, "canonical_root")
+            assert not session.new
+            assert not session.dirty
+            assert not session.deleted
+            assert session.scalar(select(func.count()).select_from(Project)) == before_project_rows
+            assert (
+                session.scalar(select(func.count()).select_from(RepositoryBinding))
+                == before_binding_rows
+            )
+            assert (
+                session.scalar(select(func.count()).select_from(ChatThread))
+                == before_thread_rows
+            )
+            project_after = session.get(Project, project_a_id)
+            binding_after = session.get(RepositoryBinding, binding_a_id)
+            thread_after = session.get(ChatThread, thread_a_id)
+            assert project_after is not None
+            assert binding_after is not None
+            assert thread_after is not None
+            assert (
+                project_after.user_id,
+                project_after.name,
+                project_after.description,
+            ) == project_snapshot
+            assert (
+                binding_after.canonical_root,
+                binding_after.source_class,
+                binding_after.is_active,
+                dict(binding_after.provenance),
+            ) == binding_snapshot
+            assert (
+                thread_after.user_id,
+                thread_after.project_id,
+                thread_after.title,
+            ) == thread_snapshot
+
+        assert (
+            resolve_repository_chat_capability(
+                chatlog_db,
+                authenticated_account_id="account-a",
+                thread_id=thread_repository_less_id,
+            )
+            is None
+        )
+        assert (
+            resolve_repository_chat_capability(
+                chatlog_db,
+                authenticated_account_id="account-b",
+                thread_id=thread_a_id,
+            )
+            is None
+        )
+        assert (
+            resolve_repository_chat_capability(
+                chatlog_db,
+                authenticated_account_id="account-a",
+                thread_id=thread_cross_project_id,
+            )
+            is None
+        )
+
+        moved_stale_repository = tmp_path / "repository-stale-moved"
+        repository_stale.rename(moved_stale_repository)
+        assert (
+            resolve_repository_chat_capability(
+                chatlog_db,
+                authenticated_account_id="account-a",
+                thread_id=thread_stale_id,
+            )
+            is None
+        )
+
+        with sessions() as session:
+            thread_to_move = session.get(ChatThread, thread_a_id)
+            assert thread_to_move is not None
+            thread_to_move.project_id = repository_less_id
+            session.commit()
+        assert (
+            resolve_repository_chat_capability(
+                chatlog_db,
+                authenticated_account_id="account-a",
+                thread_id=thread_a_id,
+            )
+            is None
+        )
+    finally:
+        chatlog_db._sa_engine.dispose()


### PR DESCRIPTION
Reconciles the validated Stage 2K.5 implementation with current main. Ordinary chat may expose op::repository.search only when the authenticated current thread resolves an owned Project with one valid active RepositoryBinding. Model arguments remain q/limit only; Guardian injects Project authority. Remote, private-preview, multi-user, Hosted Room, invalid authority, and manual repository-search injection remain fail-closed. No schema, provider, Command Bus, repository-search engine, or runtime changes.