### PR TITLE
R1P1C: Land canonical Alembic psycopg3 driver normalization

### DIFF
--- a/docs/architecture/00-current-state.md
+++ b/docs/architecture/00-current-state.md
@@ -4,7 +4,7 @@ This file is Codexify's canonical short-form source of truth for current operati
 
 ## Last updated
 
-2026-08-12
+2026-08-13
 
 ## Interpretation rule
 
@@ -28,7 +28,8 @@ This file is authoritative for:
 - Added Whoosh'd capability projection, structured transport, qualification/attestation seams, and exact-target identity reconciliation; the receipt covers one target/schema identity only.
 - Canonicalized ADR-060 through ADR-063 and reverified DLG/knowledge-graph freshness after history corrections; these are control-plane/documentation changes.
 - Added a Doctrine of Legible Responsibility and related tool-loop contract updates; they clarify boundaries without proving runtime readiness.
-- Repaired the historical `d6f7a8b9c0d1` ThreadSpace migration lineage and the `b2c3d4e5f6a7` account-observability migration-content drift: `b2c3d4e5f6a7` was restored to its original applied body and a forward normalization migration (`9d4c2a7e1b6f`) converges clean, already-canonical, and backup-derived tester schemas onto one canonical ADR-049 shape at a single Alembic head. The preserved tester source remains unmodified and still requires a separate live upgrade/startup task; the canonical migrator psycopg driver compatibility remains a separate blocker until independently landed/proven; Hosted Room runtime proof remains pending; no release promise was widened.
+- Repaired the historical `d6f7a8b9c0d1` ThreadSpace migration lineage and the `b2c3d4e5f6a7` account-observability migration-content drift: `b2c3d4e5f6a7` was restored to its original applied body and a forward normalization migration (`9d4c2a7e1b6f`) converges clean, already-canonical, and backup-derived tester schemas onto one canonical ADR-049 shape at a single Alembic head. The preserved tester source remains unmodified and still requires a separate live upgrade/startup task; the canonical migrator psycopg driver compatibility is now landed and proven (see the 2026-08-13 driver-normalization proof); Hosted Room runtime proof remains pending; no release promise was widened.
+- Landed canonical Alembic psycopg v3 driver normalization (`guardian/db/migrations/env.py`): driver-neutral `postgresql://` Alembic URLs now resolve to the installed psycopg v3 dialect before SQLAlchemy engine construction, for both the `DATABASE_URL` environment and the `alembic.ini` `sqlalchemy.url` source, while the process-wide `DATABASE_URL` contract is preserved for `seed_defaults.py` and runtime consumers; proven on a disposable Compose project with the canonical migrator and no ephemeral URL override (`docs/architecture/proofs/2026-08-13-alembic-psycopg3-driver-normalization-proof.md`). Migration graph unchanged at a single head `9d4c2a7e1b6f`; no release promise was widened.
 
 ## Current supported reality
 

--- a/docs/architecture/proofs/2026-08-13-alembic-psycopg3-driver-normalization-proof.md
+++ b/docs/architecture/proofs/2026-08-13-alembic-psycopg3-driver-normalization-proof.md
@@ -1,0 +1,265 @@
+# Alembic psycopg3 driver normalization proof
+
+## Result
+
+**GO**
+
+The canonical Codexify migrator now correctly uses the installed psycopg v3
+SQLAlchemy dialect for driver-neutral `postgresql://` URLs. The Alembic
+environment (`guardian/db/migrations/env.py`) normalizes a bare PostgreSQL URL
+to `postgresql+psycopg://` before SQLAlchemy engine construction, for both the
+`DATABASE_URL` environment path and the configured `sqlalchemy.url` path,
+without changing the process-wide `DATABASE_URL` contract, without breaking
+`seed_defaults.py`, without mutating the preserved tester database, and
+without changing the migration graph (still exactly one head:
+`9d4c2a7e1b6f`).
+
+The canonical disposable Compose proof ran with **no ephemeral URL override**:
+the migrator service received the unmodified driver-neutral
+`DATABASE_URL=postgresql://...` from `docker-compose.yml`, exited 0, applied
+all 101 migrations to the single head, and `seed_defaults.py` took its
+Postgres path (default project `General` present). A second run was a no-op.
+
+## Baseline
+
+- Branch: `proof/chroma-startup-isolation`
+- Pre-task HEAD: `653e58f61e54d09c96e78e3b3f7fd4e19f457899`
+- Pre-task tracked worktree: clean
+- Pre-task Alembic head: exactly one — `9d4c2a7e1b6f`
+- Pre-task migration suite `tests/migration`: `111 passed, 29 skipped`
+
+## Regression guard (per task brief)
+
+Inspected at current HEAD:
+
+- `guardian/db/migrations/env.py` — `_get_database_url()` passed the bare
+  `postgresql://` URL straight into `sqlalchemy.url`; **no normalization**.
+- `backend/scripts/docker/run_migrator.py` — pure wrapper around
+  `alembic upgrade heads` + `seed_defaults.py`; no URL handling.
+- `backend/scripts/seed_defaults.py` — connects via raw psycopg v3 (psycopg2
+  fallback), `_is_pg()` accepts only `postgres://`/`postgresql://`; untouched.
+- `docker-compose.yml` — `DATABASE_URL` is driver-neutral
+  `postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}`;
+  `GUARDIAN_DATABASE_URL` is the repo's own `postgresql+psycopg://` scheme.
+- Backend runtime dependency declarations —
+  `backend/requirements.txt` (canonical manifest copied into the runtime
+  image) declares `psycopg[binary]>=3.2.10`; the runtime image ships
+  psycopg 3.3.4.
+- Migration tests — no driver-normalization test exists at HEAD.
+  `tests/test_alembic_config_contract.py` (34 lines) covers only
+  `alembic.ini` script_location pathing.
+- Proof artifacts — `2026-08-13-account-observability-migration-compatibility-proof.md`
+  records the migrator driver incompatibility as a separate, pre-existing
+  defect and documents the ephemeral `postgresql+psycopg://` override used
+  for its disposable proofs. `2026-08-13-d6f7a8b9c0d1-compatibility-bridge-proof.md`
+  names the unmerged fix (`cb35d4e80`, branch
+  `codex/alembic-psycopg3-runtime-driver-20260812`, proof
+  `2026-08-12-alembic-psycopg3-driver-normalization-proof.md`).
+
+Historical/unmerged fixes inspected (not blindly cherry-picked):
+
+| Commit | Branch(es) | Shape |
+| --- | --- | --- |
+| `2113b5101` | `codex/2026-08-12-retire-obsolete-chroma-index` | new module `guardian/db/migration_url.py` + env.py wiring + `tests/ops/test_alembic_psycopg_driver_contract.py` |
+| `cb35d4e80` / `4d5649473` / `13d2a28ce` | `codex/alembic-psycopg3-runtime-driver-20260812`, `codex/alembic-psycopg3-abaf-main-20260812`, `codex/alembic-psycopg3-current-main-20260812`, `codex/backend-schema-psycopg3-current-20260812` | new module `guardian/db/migration_driver.py` + env.py wiring + `tests/test_alembic_config_contract.py` (driver-contract variant) |
+
+All are unmerged (`git merge-base --is-ancestor <commit> main` = false; HEAD's
+env.py is unnormalized). None of the helper modules exists at HEAD
+(`guardian/db/migration_url.py`, `guardian/db/migration_driver.py`, and the
+symbol `normalize_alembic_database_url` have zero matches in the tree).
+
+Verdict: **NOT ALREADY SATISFIED** — no criterion of the four holds at HEAD.
+Per the task's authorized-file list, the implementation file is
+`guardian/db/migrations/env.py` only; the historical fix shape (a new shared
+helper module) was therefore NOT recreated here. The normalization lives as
+an env.py-local function; a future extraction into a shared module (for the
+separate backend startup seam) is a distinct, separately authorized task.
+
+## ADR impact
+
+- Classification: `Aligned with existing ADR(s)`
+- Governing ADR(s): none pin a PostgreSQL Python driver. The ADR index
+  (1–65) was inspected; the only "driver" reference is unrelated
+  ("Decision drivers" in ADR-064). ADR-031 (Continuity Phase A Storage
+  Migration Gate) governs storage-migration proof, not SQLAlchemy driver
+  selection.
+- Reason: this task repairs the implementation of the already-accepted
+  Postgres/Alembic runtime contract (`DATABASE_URL` is a Postgres DSN for
+  migrations per `docs/architecture/config-and-ops.md`). It changes no
+  persistence meaning, schema meaning, migration lineage, supported database
+  technology, or upgrade semantics.
+
+## The repaired seam
+
+```text
+external runtime contract
+DATABASE_URL=postgresql://...        (unchanged, driver-neutral)
+
+              |
+              v
+
+guardian/db/migrations/env.py
+normalize_alembic_database_url()     (env.py-local; both URL sources)
+
+              |
+              v
+
+SQLAlchemy URL
+postgresql+psycopg://...             (psycopg v3 dialect)
+
+              |
+              v
+
+installed psycopg v3 (3.3.4 in runtime image)
+```
+
+Implementation (single file, `guardian/db/migrations/env.py`):
+
+- New module-level `normalize_alembic_database_url(url)`:
+  - `postgresql://...` → `postgresql+psycopg://...` (scheme prefix only;
+    every byte after it preserved).
+  - Explicit `postgresql+psycopg://` and `postgresql+psycopg2://` → unchanged.
+  - Any other scheme or non-string input → unchanged.
+- `_get_database_url()` now normalizes both sources — the `DATABASE_URL`
+  environment variable and the `alembic.ini` `sqlalchemy.url` setting — then
+  sets the normalized value via `config.set_main_option("sqlalchemy.url", ...)`
+  and returns it, so offline mode (`context.configure(url=...)`) and online
+  mode (`engine_from_config`) both see the psycopg v3 dialect.
+- `os.environ["DATABASE_URL"]` is never modified: seed/runtime consumers
+  keep the original driver-neutral contract. `seed_defaults.py` (separate
+  process) therefore takes its Postgres path (`_is_pg()` accepts the bare
+  scheme), with no SQLite fallback.
+
+`backend/scripts/docker/run_migrator.py`, `backend/scripts/seed_defaults.py`,
+`docker-compose.yml`, `docker-compose.tester.yml`, `.env.tester`, existing
+migrations, revision identifiers, Hosted Room runtime code, frontend code,
+and ADRs were not modified.
+
+## Focused test
+
+New file: `tests/migration/test_alembic_psycopg3_driver_normalization.py`
+(14 tests, DB-free, no network I/O, no psycopg2 import attempt):
+
+- Pure-function contract: bare URL → `+psycopg` scheme; user/password/host/
+  port/database suffix preserved; query string preserved; percent-encoded
+  credential bytes preserved; explicit `+psycopg` and `+psycopg2` unchanged;
+  non-Postgres scheme unchanged; non-string input unchanged.
+- SQLAlchemy resolution: `make_url` reports drivername `postgresql+psycopg`;
+  `create_engine(..., poolclass=NullPool)` resolves dialect driver `psycopg`
+  without connecting.
+- Environment wiring (env.py executed via `runpy` against a faked offline
+  alembic context): `DATABASE_URL` path normalized into `sqlalchemy.url` and
+  the offline `configure(url=...)`; `alembic.ini` path normalized the same
+  way; explicit `+psycopg` URL passes through; and the process-wide
+  `DATABASE_URL` environment variable remains byte-identical after env.py
+  runs.
+
+Result: `14 passed`.
+
+## Validation
+
+- Focused test: `14 passed`.
+- Full migration suite `tests/migration` + runtime dependency contract
+  (`tests/ops/test_backend_runtime_dependency_contract.py`):
+  `129 passed, 29 skipped` (baseline 111 + 14 new + 4 dep contract;
+  no regressions, no failures).
+- Alembic graph: exactly one head, `9d4c2a7e1b6f` (unchanged).
+- `make docs` (validate_docs.py + check_diagram_freshness.py): pass.
+- `git diff --check`: clean.
+- In-image probe (runtime image built for this proof):
+  - Image: `codexify-backend-runtime:r1p1c-psycopg3-proof` (built from this
+    worktree; the shared `latest` tag was not touched).
+  - Probe result: input `postgresql://probe_user:***@db:5432/Codexify` →
+    normalized `postgresql+psycopg://...`; `env_unchanged: True`;
+    `drivername: postgresql+psycopg`; `dialect.driver: psycopg`;
+    `psycopg_version: 3.3.4`; no connection made.
+- Pre-existing limitation (out of scope, proven pre-existing at HEAD
+  `653e58f61` on a detached worktree): `alembic upgrade --sql` (offline mode)
+  fails on the inspector-based `9d4c2a7e1b6f` migration with
+  `NoInspectionAvailable ... MockConnection`. Offline SQL generation is not
+  part of the canonical migrator path (`run_migrator.py` runs online
+  `upgrade heads`) and the failure reproduces identically without this
+  change.
+
+## Disposable Compose proof (canonical path, no ephemeral override)
+
+- Isolated project: `codexify_r1p1c_psycopg3_proof` (fresh volumes, host
+  ports removed via a `/tmp`-only override; image pointed at the proof tag).
+- The migrator service environment was validated with
+  `docker compose config --format json` BEFORE the run:
+  `DATABASE_URL=postgresql://codexify:***@db:5432/Codexify` — driver-neutral,
+  unchanged from `docker-compose.yml`. No `postgresql+psycopg` override was
+  present anywhere.
+- Run 1 (canonical `run_migrator.py`, exit 0):
+  - `[Migrator] Using Alembic config: /app/backend/alembic.ini`
+  - `alembic --raiseerr -c ... upgrade heads` completed; 101 `Running upgrade`
+    lines (full clean-start chain base → `9d4c2a7e1b6f`).
+  - `[Migrator] Running seed defaults` → `seed_defaults.py` connected via its
+    Postgres path (driver-neutral URL recognized) and completed.
+  - `[Migrator] Done`
+- Post-run verification (psql against the disposable db):
+  - `alembic_version = 9d4c2a7e1b6f` (the single canonical head)
+  - `projects` row present: `1:General` — seeding succeeded on Postgres
+    (the previous ephemeral-override proofs observed the SQLite fallback
+    side effect; with the canonical fix, `_is_pg()` sees the original
+    driver-neutral URL and the seed runs normally).
+- Run 2 (idempotence, exit 0): zero `Running upgrade` lines; seed re-ran
+  idempotently.
+- Teardown: `down -v` on the disposable project only.
+
+## Migration graph and schema
+
+- No migration file was created, rewritten, reordered, squashed, or
+  replaced. Revision identifiers unchanged. Lineage unchanged.
+- Single head `9d4c2a7e1b6f` before and after.
+
+## Preserved tester safety
+
+- The preserved tester database was not started, mounted, written, stamped,
+  upgraded, or deleted. No read-only copy was even needed: the proof is a
+  clean-start disposable database.
+- No container or volume of the preserved `codexify_tester` project was
+  touched; the shared `codexify-backend-runtime:latest` image tag was not
+  rebuilt or modified.
+
+## Release impact
+
+No release-support expansion. This repairs the canonical migrator boot
+prerequisite; it does not widen the supported install path, provider
+posture, or beta surface. The preserved friends/family tester upgrade may
+proceed as its own separately authorized task now that the migrator boot
+prerequisite is closed.
+
+## DLG freshness consequence (expected, separate follow-on)
+
+This task's authorized docs edits (`00-current-state.md` content update and a
+new proof file under `docs/architecture/proofs/`) change the canonical source
+bytes of DLG nodes. `tests/architecture` was verified BEFORE the docs edit at
+pristine HEAD `653e58f61` (both `test_current_nine_node_corpus_validates` and
+`test_validator_cli_runs_without_runtime_services` pass), and fails AFTER the
+edit with `corpus.code = "content_hash_mismatch"` on the `00-current-state.md`
+node. This is the repo's known pattern: DLG freshness reverification is a
+separate task (`architecture-control-plane-freshness-reverification`, variant
+B: recompute `content_hash` + freshness metadata) that lands as its own
+commit — the precedent is commit `4f3b977cf` after the account-observability
+repair. DLG/knowledge-graph files were NOT modified here (not authorized).
+
+The `check_diagram_freshness.py` review-marker warning fires only while the
+docs change is uncommitted (the check diffs HEAD vs the working tree); a
+committed clean tree passes, and CI does not run the freshness script in
+base-ref mode. Per repo precedent, the `Diagram Review Marker:` lines were
+not touched (still dated 2026-08-11).
+
+## Limits and non-goals honored
+
+- No modification to `run_migrator.py`, `seed_defaults.py`,
+  `docker-compose.yml`, `docker-compose.tester.yml`, `.env.tester`, existing
+  migrations, revision identifiers, Hosted Room runtime code, frontend code,
+  or ADRs.
+- No second normalization seam: no new shared helper module was created
+  (the task authorizes `env.py` only); the backend startup schema-verification
+  seam (`run_backend.py`) remains a separate, separately authorized task.
+- No DLG/knowledge-graph edit (freshness reverification after this proof
+  lands is the repo's separate follow-on task).
+- No preserved tester mutation, no manual stamp, no provider inference, no
+  secret material emitted.

--- a/docs/architecture/proofs/2026-08-13-chroma-backend-startup-isolation-proof.md
+++ b/docs/architecture/proofs/2026-08-13-chroma-backend-startup-isolation-proof.md
@@ -1,0 +1,378 @@
+# Chroma persistent-store backend startup panic isolation proof
+
+## Result
+
+**ROOT_CAUSE_BOUNDED**
+
+The reproducible backend startup panic is classified as:
+
+`PERSISTED_STORE_COMPATIBILITY_BOUNDARY`
+
+The preserved `.chroma` persistent store was written by a **non-stock chromadb
+build** that applied two migrations the canonical runtime does not ship:
+
+- sysdb `00010-collection-schema.sqlite.sql`
+- metadb `00006-metadata-array-support.sqlite.sql`
+
+The canonical pinned runtime (`chromadb==1.0.15`, stock PyPI wheel) ships only
+9 sysdb and 5 metadb migrations. On `PersistentClient` construction the
+Rust sysdb migration validator slices its 9-entry migration list at index 10
+(derived from the store's applied migration count) and panics:
+
+```text
+thread '<unnamed>' panicked at rust/sqlite/src/db.rs:157:42:
+range start index 10 out of range for slice of length 9
+```
+
+This is not a corruption defect and not a backend integration defect: the
+store is SQLite-integrity-clean, a clean/empty store initializes perfectly
+under the same runtime, and the panic is fully reproduced by a 9-line direct
+`PersistentClient` probe inside the canonical image.
+
+## Metadata
+
+- timestamp America/New_York: 2026-08-13 19:58 EDT (UTC-04:00)
+- branch: `proof/chroma-startup-isolation`
+- pre-task HEAD: `9894437b40d38e47b5c578793e932b12692fda62`
+  (published prerequisite: `proof/preserved-tester-startup-auth`)
+- tested source HEAD: `9894437b40d38e47b5c578793e932b12692fda62`
+- origin/main: `cff739d9bdf73c06a08f8095b40a256d203cd72e`
+- prerequisite proof commit: `9894437b40d38e47b5c578793e932b12692fda62`
+  (verified: `origin/proof/preserved-tester-startup-auth` resolves to it)
+- runtime image: `codexify-backend-runtime:latest`
+  `sha256:c3d893be56e033b8d98382ae8feb9b7039e6ac6076fcc0bd7f05dafdc5c023b3`
+- platform: `linux/arm64`
+- runtime drift vs origin/main: NONE
+  (`git diff --name-only origin/main..HEAD` = 2 proof receipts only;
+  no runtime/config/dependency/vector-store file differs)
+
+## Architecture impact
+
+- classification: `Aligned with existing ADR(s)`
+- governing contracts: existing storage/vector-store contracts
+  (`docs/architecture/data-and-storage.md`, `guardian/vector/store.py`,
+  `backend/rag/embedder.py`, `guardian/core/config.py`);
+  no ADR, migration, model, runtime, Compose, or dependency file changed.
+- confirmation no architecture was changed: CONFIRMED — `git status --short`
+  empty before the receipt commit; the only repository change is this file.
+
+## Existing blocker
+
+Recorded exactly once:
+
+```text
+thread '<unnamed>' panicked at rust/sqlite/src/db.rs:157:42:
+range start index 10 out of range for slice of length 9
+```
+
+## Runtime identity
+
+- Python: 3.11.14
+- Chroma: 1.0.15 (stock PyPI wheel; `chromadb_rust_bindings.abi3.so` present;
+  `dist-info` has no `direct_url.json`)
+- SQLite: 3.46.1 (system SQLite linked into Python 3.11)
+- relevant package identity: `chromadb==1.0.15` with compiled
+  `chromadb_rust_bindings` extension; image migration directories:
+  sysdb 00001–00009, metadb 00001–00005, embeddings_queue 00001–00002.
+- No vendored/alternate chromadb exists at `/app`; `PYTHONPATH=/app` resolves
+  to the same site-packages module (verified by `chromadb.__file__`).
+
+## Effective Chroma configuration
+
+- vector-store type: `chroma` (compose default
+  `${CODEXIFY_VECTOR_STORE:-chroma}`; `.env.tester` overrides nothing)
+- effective container Chroma path: `/app/.chroma`
+  (`CODEXIFY_CHROMA_PATH=./.chroma` resolved via
+  `Path(expanduser()).resolve()` under backend `working_dir=/app`)
+- host mount source: `/Volumes/Dev_SSD/Codexify-main/.chroma`
+  (compose `./.chroma:/app/.chroma`)
+- container destination: `/app/.chroma`
+- collection identifier (canonical config): `codexify_vault_supported`
+  (compose default; matches the single collection row in the preserved store)
+- `.env.tester` contains NO `CODEXIFY_VECTOR_STORE` / `CODEXIFY_CHROMA_PATH`
+  / `CODEXIFY_COLLECTION` / `CHROMA_*` / `ALLOW_RESET` / `MIGRATIONS` values.
+
+## Real-store fingerprint
+
+Fingerprint procedure: deterministic walk (sorted relative path, byte size,
+SHA-256) — no application-level contents read.
+
+| Metric | Pre-test | Post-test |
+| --- | --- | --- |
+| file count | 5 | 5 |
+| total bytes | 376,996 | 376,996 |
+| manifest SHA-256 | `8cc745602fd9acafb4103bdec3102d048391e930d2423d3d78187d7decd44a91` | `8cc745602fd9acafb4103bdec3102d048391e930d2423d3d78187d7decd44a91` |
+| `chroma.sqlite3` SHA-256 | `fb156e9a7f0d3a1c695df339b66987ebc17c1822dd109d4582e611f9cf29fa88` | `fb156e9a7f0d3a1c695df339b66987ebc17c1822dd109d4582e611f9cf29fa88` |
+
+**Before/after equality: PASS — the real store was not modified.**
+
+## SQLite structural inspection
+
+Performed on a disposable copy only (`preserved-copy`), read-only URI mode:
+
+- `PRAGMA integrity_check`: `ok`
+- `PRAGMA quick_check`: `ok`
+- `PRAGMA user_version`: `0`
+- `PRAGMA journal_mode`: `delete`
+- table count: 21 (incl. `embedding_metadata_array` — non-canonical)
+- index count: 20 (incl. `embedding_metadata_array_*` indexes — non-canonical)
+- migration metadata (bounded):
+  - sysdb: 1..10 — includes `00010-collection-schema.sqlite.sql` (non-canonical)
+  - metadb: 1..6 — includes `00006-metadata-array-support.sqlite.sql` (non-canonical)
+  - embeddings_queue: 1..2 (canonical)
+- bounded row counts: `embeddings=10`, `collections=1`,
+  `databases=1`, `tenants=1`, `segments=2`, `max_seq_id=1`
+- no document text, embeddings, metadata values, or user identifiers emitted.
+
+Classification: `SQLITE_INTEGRITY_PASS`.
+
+Comparative evidence: a store freshly created by the canonical runtime
+(Experiment B) contains sysdb 1..9, metadb 1..5, embeddings_queue 1..2,
+20 tables, no `embedding_metadata_array`. The preserved store is exactly
+one sysdb and one metadb migration AHEAD of the canonical generation.
+
+## Direct Chroma experiment
+
+Probe (run inside the canonical image, `RUST_BACKTRACE=full`): import
+`chromadb`, print version, `PersistentClient(path=/diag/chroma)`,
+`list_collections()`; print `persistent_client=ok` + collection count only.
+
+| Store | Exit | PersistentClient | list_collections | Panic |
+| --- | --- | --- | --- | --- |
+| preserved-copy | 1 | NO | NOT REACHED | YES — `rust/sqlite/src/db.rs:157:42: range start index 10 out of range for slice of length 9` |
+| empty-store | 0 | ok | ok (0 collections) | NO |
+
+## Rust backtrace boundary
+
+- Nearest Python-facing call (from the preserved-copy probe traceback):
+  `chromadb/__init__.py:164 PersistentClient` →
+  `chromadb/api/client.py:65` →
+  `chromadb/api/shared_system_client.py:32 _create_system_if_not_exists` →
+  `chromadb/config.py:471 start` →
+  `chromadb/api/rust.py:112 start` →
+  `self.bindings = chromadb_rust_bindings.Bindings(...)` →
+  `pyo3_runtime.PanicException: range start index 10 out of range for slice of length 9`
+- Rust panic site: `rust/sqlite/src/db.rs:157:42`. Upstream source for the
+  pinned version confirms line 157 is inside
+  `validate_migrations_and_get_unapplied`:
+
+  ```rust
+  let unapplied = source_migrations[applied_migrations.len()..].to_vec();
+  ```
+
+  With `applied_migrations.len() == 10` (from the store's sysdb rows) and
+  `source_migrations` = the runtime's 9 sysdb migrations, the slice range
+  start 10 exceeds length 9 → panic. The Rust symbols are stripped in the
+  wheel, so frames show `<unknown>`; the panic location line identifies the
+  site unambiguously.
+- complete raw logs retained outside Git (see below); durable receipt
+  records only the bounded summary above.
+
+## Backend-equivalent experiment
+
+Started only `db neo4j redis` (healthy), then ran disposable containers from
+the canonical `backend` service definition with ONLY `RUST_BACKTRACE=full`
+and `CODEXIFY_CHROMA_PATH=/diag/chroma` overridden; no ports published.
+
+| Store | Backend startup result | First failure/success boundary |
+| --- | --- | --- |
+| preserved-copy | PANIC, exit 3 | `[embedder] backend=sentence_transformer model=/models/bge-large-en-v1.5` → immediate Rust panic in `PersistentClient` (exact same panic) |
+| empty-store | SUCCESS | full startup: embedder init → seed `count=1` into fresh store → uvicorn serving HTTP 200 for a bounded 10-minute observation window, then terminated |
+
+Note on provenance: the empty-store backend run mounted an empty directory
+that Docker created for the bind source; it is functionally identical to
+step 25's prescribed empty-store run (canonical service definition, empty
+store at the effective path) and is recorded as such.
+
+## Root-cause classification
+
+`PERSISTED_STORE_COMPATIBILITY_BOUNDARY`
+
+Primary matrix: preserved-copy = PANIC, empty-store = PASS (case A).
+
+Supporting evidence:
+
+1. SQLite integrity of the preserved store: PASS — the store is healthy,
+   not corrupted.
+2. The preserved store's migration metadata is one sysdb and one metadb
+   migration ahead of the canonical runtime's migration set.
+3. No upstream chromadb release ships those two migrations — verified
+   against PyPI wheel contents for 1.0.15, 1.0.16, 1.0.17, and current
+   releases up to 1.5.9. The store was therefore written by a non-stock
+   chromadb build (fork/dev build), i.e. a newer-generation store.
+4. The panic index (10) and slice length (9) exactly match the
+   store's sysdb applied-migration count (10) vs the runtime's sysdb
+   migration count (9), at the source line identified above.
+5. A clean store under the same runtime initializes and persists correctly;
+   the backend fully starts against an empty store, proving no backend
+   integration seam (other than the store itself) is at fault.
+6. The panic occurs inside the Rust bindings constructor, before any
+   application-level Chroma operation; it is independent of embedding
+   model state.
+
+## What is proven
+
+- The panic is caused by the persisted Chroma store generation, not by the
+  canonical runtime in isolation and not by a later backend integration seam.
+- The exact failing Rust statement is identified:
+  `source_migrations[applied_migrations.len()..]` with applied=10 vs
+  source length 9 (chromadb 1.0.15, `rust/sqlite/src/db.rs:157`).
+- The preserved store was written by a non-stock chromadb build whose
+  migration set (sysdb 1..10, metadb 1..6) exceeds every upstream release.
+- The preserved store is SQLite-integrity-clean with 10 embeddings in
+  collection `codexify_vault_supported`.
+- The canonical runtime initializes clean stores; the backend-equivalent
+  empty-store run reached uvicorn serving and seeded the vector store.
+- The real `.chroma` directory is byte-identical before and after this task.
+
+## What is not proven
+
+- no repair was applied (diagnostic only; real store untouched);
+- the supported Tester remains unqualified (`/health`, `/health/chat`,
+  authenticated `/api/dashboard/snapshot` remain unproven);
+- Hosted Room replay remains unperformed;
+- no release widening;
+- the actor/time that wrote the non-canonical store generation was not
+  identified (out of scope for this diagnostic).
+
+## Persistent-state safety
+
+- real `.chroma` store NOT modified (fingerprint equality PASS);
+- all Chroma mutation/testing occurred only on disposable copies
+  (`preserved-copy`, `probe-c1`, `probe-c2`, `backend-copy`, `empty-store`
+  under the private diagnostic directory);
+- Postgres was touched only by normal service startup (`seed_defaults.py`
+  idempotent seeding during the two backend-equivalent runs); no schema or
+  migration changes, no manual SQL;
+- no user data, document text, embeddings, metadata values, API keys,
+  session material, or secrets were dumped or recorded.
+
+## Exact repair recommendation
+
+Authorize ONE atomic repair task:
+
+**Chroma store generation reconciliation (copy-first) for the preserved
+Tester.**
+
+Goal: produce a canonical-compatible copy of the preserved `.chroma` store
+that opens cleanly under the pinned `chromadb==1.0.15` runtime, and replace
+the live store only after operator approval.
+
+Required contents of that task:
+
+1. Work exclusively on fresh copies; the live `/Volumes/Dev_SSD/Codexify-main/.chroma`
+   remains read-only until the operator approves replacement.
+2. Reconcile the two non-canonical migration artifacts on the copy:
+   - sysdb `00010-collection-schema.sqlite.sql` — added
+     `collections.schema_str TEXT` (prove the column is NULL/empty for all
+     rows and the migration row is removable);
+   - metadb `00006-metadata-array-support.sqlite.sql` — added the
+     `embedding_metadata_array` table + its 4 indexes (preserved store shows
+     `embedding_metadata_array` row count 0; prove no writer depends on it).
+3. On the copy only: drop the empty `embedding_metadata_array` table and its
+   indexes, drop the `collections.schema_str` column (SQLite `DROP COLUMN`
+   or table-rebuild), and delete the two non-canonical rows from the
+   `migrations` table so the store's applied set matches the canonical
+   9/5/2 generation.
+4. Validate the reconciled copy with the canonical image:
+   `chromadb.PersistentClient(path=...)` must construct without panic,
+   `list_collections()` must return the existing collection
+   (`codexify_vault_supported`), and a bounded count query must show the
+   10 preserved embeddings intact. Add a clean-store regression test
+   (`PersistentClient` on empty path) to the task's validation surface.
+5. Commit proof artifacts; then request operator approval to swap the
+   reconciled store into the live path (physical + logical backups retained
+   first, matching prior task practice).
+6. After the swap, rerun the canonical preserved Tester startup/auth proof
+   from lifecycle startup through authenticated `GET /api/dashboard/snapshot`
+   to reach GO. Stage 2K.6 Hosted Room owner/guest replay resumes only after
+   that GO.
+
+Forbidden in that task: changing the pinned Chroma version, editing
+`backend/requirements.txt`, switching to FAISS, changing vector-store
+authority/durability semantics, editing runtime/Compose/config code, or
+treating the preserved retrieval state as disposable without the
+copy-first proof above.
+
+Note: no upstream Chroma-provided migration/repair CLI exists that can fix
+this generation mismatch (verified: stock wheels up to 1.5.9 do not contain
+the store's migrations); a schema-level reconciliation on a copy is the
+only viable repair path consistent with the pinned dependency.
+
+## Proof surface / validation
+
+- Real-store fingerprint equality: PASS (identical manifest + sqlite SHA-256)
+- Direct preserved-copy probe: PANIC (exit 1) — recorded
+- Direct empty-store probe: PASS (exit 0) — recorded
+- Full Rust backtrace: captured; raw log SHA-256:
+  `45f7f93661285ff2f656282eb5207a0f77ec341d511193a7a8552b6449029d8c`
+  (`experiment-A.stderr`, complete frames)
+- Backend-equivalent experiment: preserved-copy PANIC (exit 3),
+  empty-store SUCCESS — recorded
+- Relevant existing tests (files referencing
+  `CodexifyEmbedder|PersistentClient|CODEXIFY_CHROMA_PATH|chromadb`):
+  - `tests/vector/test_vector_store_resolution.py`: 2 passed
+  - `tests/obsidian/test_file_lifecycle.py`,
+    `tests/obsidian/test_ingest_idempotency.py`: passed (Chroma
+    `PersistentClient` open/write paths)
+  - `tests/obsidian/test_live_runtime_proof.py`: 1 failed —
+    `ValueError: MemoryOSRetriever requires user_id` (test-harness
+    pre-existing condition unrelated to Chroma store opening; the test
+    uses the mock embedder; no repository code was changed by this task)
+- DLG validation: PASS
+  (result `pass`, repository_revision `9894437b40d38e47b5c578793e932b12692fda62`)
+- Documentation validation: PASS
+  (`validate_docs.py` and `check_diagram_freshness.py` both passed)
+- `git diff --check`: PASS (empty)
+- Scope: only this receipt; no runtime/config/dependency file changed.
+
+## Raw diagnostic artifacts (outside Git)
+
+Directory: `/private/tmp/codexify-chroma-isolation.01ecKb` (mode 0700)
+
+| Artifact | SHA-256 |
+| --- | --- |
+| experiment-A.stderr (preserved-copy direct probe, full backtrace) | `45f7f93661285ff2f656282eb5207a0f77ec341d511193a7a8552b6449029d8c` |
+| experiment-A.stdout | `482afebd7d4b4eb8d1a84887bef41288c4b9c758d9474595ece952f5f3f7037d` |
+| experiment-B.stderr (empty store, empty) | `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` |
+| experiment-B.stdout | `513ed26bad8de9303927668a8f3d256ee1fcb7a985817c295194aaa7f5578d22` |
+| backend-c2.stderr (backend-equivalent preserved-copy panic) | `8c417dd03a303b756566969a32ff3038ad377c5bac6dfa0ddead70a670df5507` |
+| backend-c2.stdout | `b5bf5d4d7d04244a7384dc7bde0da89aad672dfcf471660bc6a81ad9a5ae308e` |
+| backend-preserved.stderr (backend-equivalent empty-store success) | `f05bae4cfc117793fa8e20d01d93ac65b660d1893af0b285427c5080c2f25485` |
+| backend-preserved.stdout | `4a7e2b0fadb3280db582958bb14e6a94991ade881b0d83531c986cb34deae426` |
+| real-store-pre.manifest | (see fingerprint table) |
+
+Disposable copies `preserved-copy`, `probe-c1`, `probe-c2`, `backend-copy`,
+`empty-store` are retained under the same directory.
+
+## Cleanup state
+
+- disposable diagnostic containers: removed (all `--rm` runs exited;
+  no `*backend-run*` containers remain)
+- db/neo4j/redis diagnostic services: stopped via Compose (`stop`, not
+  `down -v`; named volumes preserved)
+- Tester desired_state: `disabled` (marker cleared by the task's opening
+  quiesce; no re-enable performed)
+- `$CHROMA_DIAG` retained (required until receipt committed)
+
+## What Axis should add to his KB
+
+1. The Chroma panic is a persisted-store generation mismatch: the preserved
+   `.chroma` was written by a non-stock chromadb build carrying sysdb
+   `00010-collection-schema` and metadb `00006-metadata-array-support`
+   migrations. No upstream chromadb release (through 1.5.9) ships them.
+2. Stock `chromadb==1.0.15` panics (not errors) on a newer-generation store:
+   `rust/sqlite/src/db.rs:157` slices `source_migrations[applied..]` with
+   applied=10 vs 9 available → `range start index 10 out of range for slice
+   of length 9`. It is an upstream robustness bug triggered by the
+   store/runtime generation gap; the store itself is SQLite-healthy with
+   10 embeddings in `codexify_vault_supported`.
+3. The canonical runtime and backend work fine against an empty store
+   (backend-equivalent run served HTTP 200 and seeded the vector store),
+   so no Codexify runtime, config, or integration seam needs repair.
+4. The real store was fingerprint-verified byte-identical before/after the
+   diagnostic; all experiments ran on disposable copies.
+5. Next: one atomic copy-first reconciliation task (remove the two
+   non-canonical migration rows + their provably-empty schema artifacts on
+   a copy, validate with the canonical image, operator-approved swap), then
+   rerun the preserved Tester startup/auth proof to GO.

--- a/docs/architecture/proofs/2026-08-13-preserved-tester-canonical-startup-auth-proof.md
+++ b/docs/architecture/proofs/2026-08-13-preserved-tester-canonical-startup-auth-proof.md
@@ -1,0 +1,497 @@
+# Preserved Tester canonical startup + authenticated viability proof
+
+## Result
+
+**NEXT_PROOF_NEEDED**
+
+The preserved Tester database IS already canonical at `9d4c2a7e1b6f`
+with canonical ADR-049 Account Observability shape and passes bounded
+FK/orphan integrity. The canonical migrator ran successfully and exited 0
+against the already-current database. The canonical Tester lifecycle starts
+the dependent services (`db`, `neo4j`, `redis`, `tailscale-codexify-test`)
+to healthy, and `desired_state=enabled` is set.
+
+However, the supported `backend` container repeatedly exits with status `3`
+during initialization, immediately after the
+`backend.rag.embedder [embedder] backend=sentence_transformer model=/models/bge-large-en-v1.5`
+log line. The Rust panic message is:
+
+```text
+thread '<unnamed>' panicked at rust/sqlite/src/db.rs:157:42:
+range start index 10 out of range for slice of length 9
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+```
+
+This panic is reproducible across three independent lifecycle attempts in
+this task. Because the backend never reaches the FastAPI serving loop,
+`/health`, `/health/chat`, and authenticated `GET /api/dashboard/snapshot`
+could not be exercised. The required-service health gate therefore cannot
+be satisfied.
+
+Per the task's failure posture: a single first material blocker is recorded
+and not repaired inside this task.
+
+## Metadata
+
+- date/time (America/New_York): 2026-08-13 18:56 EDT (`UTC-04:00`)
+- branch: `main`
+- pre-task HEAD: `dec85ac839550a9fcfd25ee73304e1d83eb71fb3`
+  (the prior proof receipt commit, locally available as prerequisite evidence)
+- tested source HEAD: `dec85ac839550a9fcfd25ee73304e1d83eb71fb3`
+- `origin/main`: `cff739d9bdf73c06a08f8095b40a256d203cd72e`
+- prior local proof commit `dec85ac...`: AVAILABLE
+  (`git cat-file -e dec85ac839550a9fcfd25ee73304e1d83eb71fb3^{commit}` → 0)
+- runtime image: same `codexify-backend-runtime:latest` baked by the prior
+  task at SHA-256 `c3d893be56e033b8d98382ae8feb9b7039e6ac6076fcc0bd7f05dafdc5c023b3`
+  (not rebuilt by this task; current main source matches `origin/main` for
+  all runtime/migration/Compose/auth files)
+
+## Architecture impact
+
+- classification: `Aligned with existing ADR(s)`
+- governing ADRs/contracts:
+  - ADR-049 Admin Account Observability and Invite Attribution (canonical
+    schema verified)
+  - ADR-053 Node-Hosted Room Access Boundary (downstream, unchanged)
+  - existing storage/migration contracts (`docs/architecture/data-and-storage.md`)
+  - existing supported Tester runtime/profile doctrine
+  - Guardian authentication/session authority
+  - `docs/architecture/guardian-dashboard-snapshot-contract.md`
+- reason: this task exercised already-accepted runtime/migration/auth/
+  dashboard contracts against the real preserved Tester source. It proposed
+  no architecture change. The observed Rust panic is a runtime defect in
+  the existing embedder / ChromaDB rust-binding initialization, not an
+  architecture, schema, identity, semantics, or contract concern.
+
+## Current preserved-state truth
+
+- preserved volume: `codexify_tester_pg_data` (driver `local`,
+  created `2026-07-25T19:13:17Z`, intact at task end)
+- current Alembic revision: `9d4c2a7e1b6f` (one row, verified twice:
+  once pre-startup, once post-startup)
+- canonical schema classification: **canonical ADR-049 / `canonical_v2`**
+  - `account_observability_invite_links` PK: `invite_id`
+  - `account_observability_guest_identities` PK: `guest_id`
+  - `account_observability_presence_sessions` PK: `presence_session_id`
+  - `account_observability_presence_sessions.region_code`: `VARCHAR(64)`
+
+Explicit statement: the current preserved database was already canonical
+before this task and no d6 → head migration was attempted here. The
+migrator ran successfully as a no-op (or near-no-op) and exited 0.
+
+## Historical-state note
+
+Earlier fresh read-only snapshots of the same named preserved volume
+observed `d6f7a8b9c0d1`:
+
+- `2026-08-12-d6f7a8b9c0d1-migration-lineage-audit.md` Path A: isolated
+  copy of the preserved volume reported `d6f7a8b9c0d1`
+- `2026-08-13-d6f7a8b9c0d1-compatibility-bridge-proof.md` Path C: backup-
+  derived clone reported `d6f7a8b9c0d1` as the source revision
+
+The live preserved volume subsequently advanced to `9d4c2a7e1b6f`. The
+exact actor/time of that advance is not established by this task and is
+not required to evaluate the current task's goal. No fresh evidence in
+this task's bounded logs narrows the actor.
+
+## Recovery backups
+
+Physical archive (read-only tar.gz of preserved volume):
+
+- filename: `codexify_tester_pg_data-pre-upgrade.tar.gz`
+- path: `/private/tmp/codexify-tester-live-upgrade.qkai5A/codexify_tester_pg_data-pre-upgrade.tar.gz`
+- size: `295,575,601` bytes
+- SHA-256: `c278158f31f940e2a00ec735e76f58358a5867471774392fc9f851e1602aed3f`
+- reuse status: REUSED (verified by `shasum -a 256` exact match against the
+  prior task's expected SHA-256)
+
+Logical pg_dump backup (custom format, `pg_dump --no-owner --no-privileges`):
+
+- filename: `codexify-tester-canonical-pre-startup.dump`
+- path: `/private/tmp/codexify-tester-live-upgrade.qkai5A/codexify-tester-canonical-pre-startup.dump`
+- size: `134,431,625` bytes
+- SHA-256: `201b1032c21754d250766eae0d23379cc88e28922f1034bfffdf03703c2cbb7d`
+- `pg_restore -l` validation: PASS (executed via `postgres:15` image;
+  942 TOC lines, 931 TOC entries)
+
+Both backups retained at task end (mode 0700 parent directory).
+
+## Canonical data baseline (pre-startup)
+
+Read from `codexify_tester_pg_data` via the db-only baseline instance,
+bounded `count(*)` only, no row bodies.
+
+| Table | Rows |
+| --- | ---: |
+| `users` | 18 |
+| `projects` | 3 |
+| `chat_threads` | 5,061 |
+| `chat_messages` | 112,507 |
+| `uploaded_documents` | 0 |
+| `generated_documents` | 0 |
+| `hosted_rooms` | 1 |
+| `hosted_room_invites` | 1 |
+| `hosted_room_participants` | 3 |
+| `threadspace_nodes` | 0 |
+| `threadspace_membership_invitations` | 0 |
+| `threadspace_membership_grants` | 0 |
+| `account_observability_invite_links` | 0 |
+| `account_observability_guest_identities` | 0 |
+| `account_observability_account_metadata` | 14 |
+| `account_observability_presence_sessions` | 0 |
+| `repository_bindings` | 0 |
+
+## Canonical schema verification
+
+- Alembic revision: `9d4c2a7e1b6f` (exactly one row in `alembic_version`)
+- Account Observability canonical shape: PASS
+  - `invite_id` PK on `account_observability_invite_links`
+  - `guest_id` PK on `account_observability_guest_identities`
+  - `presence_session_id` PK on `account_observability_presence_sessions`
+  - `region_code` = `VARCHAR(64)`
+- ThreadSpace presence: PASS (all three tables present)
+- Hosted Room presence: PASS (all three tables present)
+- `repository_bindings`: present, 0 rows
+
+## Integrity proof
+
+Catalog and bounded orphan checks against the live canonical database:
+
+| Constraint / check | Result |
+| --- | --- |
+| Public FK constraints | 113 |
+| Public CHECK constraints | 894 |
+| Public UNIQUE constraints | 41 |
+| Canonical `account_observability_*` PKs present | t / t / t |
+| Orphaned `chat_messages.thread_id` | 0 |
+| Orphaned `chat_messages.user_id` | 0 |
+| Orphaned `chat_threads.user_id` | 0 |
+| Orphaned `chat_threads.project_id` | 0 |
+| Orphaned `chat_threads.parent_id` | 0 |
+| Orphaned `hosted_room_invites.room_id` | 0 |
+| Orphaned `hosted_room_participants.room_id` | 0 |
+| Orphaned `hosted_room_participants.invitation_id` | 0 |
+| Orphaned `hosted_room_participants.bound_account_id` | 0 |
+| Orphaned `hosted_rooms.owner_account_id` | 0 |
+| Orphaned `hosted_rooms.backing_thread_id` | 0 |
+| Orphaned `repository_bindings.project_id` | 0 |
+| Orphaned `account_observability_account_metadata.user_id` | 0 |
+| Orphaned `account_observability_account_metadata.acquisition_invite_id` | 0 |
+| Orphaned `account_observability_account_metadata.prior_guest_id` | 0 |
+| Orphaned `account_observability_presence_sessions.user_id` | 0 |
+| Orphaned `account_observability_presence_sessions.guest_id` | 0 |
+| Orphaned `account_observability_presence_sessions.invite_id` | 0 |
+| Orphaned `account_observability_guest_identities.first_invite_id` | 0 |
+| Orphaned `account_observability_invite_links.created_by_user_id` | 0 |
+
+Integrity: PASS. No data repair attempted.
+
+## Canonical startup
+
+- lifecycle command: `scripts/ops/codexify_tester.sh up`
+- migrate outcome: SUCCESS
+  - `[Migrator] Using Alembic config: /app/backend/alembic.ini`
+  - `[docker] run: /usr/local/bin/python -m alembic --raiseerr -c /app/backend/alembic.ini upgrade heads`
+  - migrator container exited `0`
+  - `seed_defaults.py` invoked and logged normally
+  - `[Migrator] Done`
+- post-startup Alembic revision: `9d4c2a7e1b6f` (unchanged)
+- pre-startup Alembic revision: `9d4c2a7e1b6f` (unchanged)
+- no manual stamp: confirmed (no `alembic stamp` invoked anywhere in
+  this task)
+- no DBAPI error: confirmed (migrator connected successfully; Alembic
+  graph loaded; upgrade heads ran without DBAPI failure)
+- no missing revision: confirmed (the canonical head is present in the
+  baked image and recognized by Alembic)
+
+## Data preservation across startup
+
+Row counts were captured before the canonical `up` and again after the
+backend's repeated crashes. They match exactly:
+
+| Table | Pre-startup | Post-startup |
+| --- | ---: | ---: |
+| `users` | 18 | 18 |
+| `projects` | 3 | 3 |
+| `chat_threads` | 5,061 | 5,061 |
+| `chat_messages` | 112,507 | 112,507 |
+| `hosted_rooms` | 1 | 1 |
+| `hosted_room_invites` | 1 | 1 |
+| `hosted_room_participants` | 3 | 3 |
+| `account_observability_account_metadata` | 14 | 14 |
+| `repository_bindings` | 0 | 0 |
+| Alembic revision | `9d4c2a7e1b6f` | `9d4c2a7e1b6f` |
+
+No unexplained row-count change. No Hosted Room row loss. No Account
+Observability row loss. `seed_defaults.py` was invoked but produced no
+canonical-table mutation against the already-canonical state.
+
+## Required services
+
+After `scripts/ops/codexify_tester.sh up` and three independent retries
+that included the canonical lifecycle and a direct `up -d backend`:
+
+| Service | State | Healthy |
+| --- | --- | --- |
+| `db` | running | true |
+| `neo4j` | running | true |
+| `backend` | exited (3) | false |
+| `redis` | running | true |
+| `frontend` | created | false |
+| `worker-chat` | created | false |
+| `worker-document-embed` | created | false |
+| `worker-chat-embed` | created | false |
+| `worker-warmup` | created | false |
+| `worker-account-import` | created | false |
+| `tailscale-codexify-test` | running | true (subject to tailscale auth posture) |
+
+The `backend` crash cascades: Compose marks `worker-*` and `frontend` as
+`created` and never advances them because they depend on a healthy
+backend.
+
+## Health
+
+- `/health`: NOT EXERCISED — backend exited before FastAPI served
+- `/health/chat`: NOT EXERCISED — backend exited before FastAPI served
+- observed curl result during a brief startup window where the port was
+  bound but the app had not yet served:
+  `curl: (52) Empty reply from server` (no HTTP status, no body)
+
+## Startup logs (bounded)
+
+Migrator (relevant lines):
+
+```text
+[Migrator] Using Alembic config: /app/backend/alembic.ini
+[Migrator] Cleared Python caches under /app/backend: dirs=0, files=0
+[Migrator] Cleared guardian migration caches: dirs=2, files=0
+[Migrator] alembic.ini script_location=%(here)s/../guardian/db/migrations
+[docker] run: /usr/local/bin/python -m alembic --raiseerr -c /app/backend/alembic.ini upgrade heads
+INFO  [alembic.env] ...
+INFO  [alembic.runtime.migration] Context impl ...
+INFO  [alembic.runtime.migration] Will assume ... DDL.
+[Migrator] Running seed defaults
+[docker] run: /usr/local/bin/python /app/backend/scripts/seed_defaults.py
+...
+[Migrator] Done
+```
+
+Backend (relevant lines; redacted log_event values are bounded:
+
+```text
+[env] dotenv loaded (in order): ...
+[db] Using PostgreSQL chatlog DB DSN=...
+[routers] Router registration complete (beta_core_only=False)
+[webui-basic] ... not found, skipping UI mount
+INFO: Started server process [1]
+[config] Coherence mode selected: CODEXIFY_CONFIG_SOURCE=...
+[embedder] embedding model=/models/bge-large-en-v1.5
+[embedder] backend=sentence_transformer model=/models/bge-large-en-v1.5
+thread '<unnamed>' panicked at rust/sqlite/src/db.rs:157:42:
+range start index 10 out of range for slice of length 9
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+ERROR: ...
+ERROR: ...
+```
+
+No environment variables, credentials, tokens, or session material were
+included in the captured logs above.
+
+Classified error category: Rust panic in a third-party ChromaDB rust-binding
+(`rust/sqlite/src/db.rs:157:42`). The panic occurs during embedder
+initialization. The Rust module is loaded by the ChromaDB client used by
+`backend.rag.embedder` for the `sentence_transformer` backend.
+
+Reproducibility: the same panic message and exit code 3 were observed on
+three independent startup attempts (one initial lifecycle, two direct
+`up -d backend` retries) within this task.
+
+## Authenticated application proof
+
+NOT EXERCISED. The supported authentication flow was not reached because
+the backend never started. No login was attempted. No session was
+established. `GET /api/dashboard/snapshot` was not issued. No token,
+cookie, or session material was recorded.
+
+For reference, the dashboard snapshot contract regression suite
+(`tests/routes/test_dashboard_snapshot.py`) was re-run against the current
+source and PASSED with 7/7 cases. This does NOT exercise the live route
+against the preserved Tester; it only re-validates the in-process
+contract against the canonical test fixtures.
+
+## Hosted Room status
+
+- Hosted Room durable rows preserved: YES (1 room / 1 invite / 3
+  participants unchanged pre vs. post startup attempt).
+- Hosted Room owner/guest runtime semantics were NOT exercised: true.
+- Stage 2K.6 Hosted Room replay remains the next task on GO: deferred
+  pending the resolver of this task's blocker.
+
+## Release impact
+
+No beta surface widening. No architecture change. No runtime source file
+change. No migration file change. No model file change. No ADR change.
+This proof only inspected, started, and refused to claim GO because of
+the reproducible backend startup failure.
+
+## Recovery posture
+
+- physical backup retained at:
+  `/private/tmp/codexify-tester-live-upgrade.qkai5A/codexify_tester_pg_data-pre-upgrade.tar.gz`
+  (mode 0700 parent directory, outside the repo)
+  - SHA-256: `c278158f31f940e2a00ec735e76f58358a5867471774392fc9f851e1602aed3f`
+- logical `pg_dump` retained at:
+  `/private/tmp/codexify-tester-live-upgrade.qkai5A/codexify-tester-canonical-pre-startup.dump`
+  (mode 0700 parent directory, outside the repo)
+  - SHA-256: `201b1032c21754d250766eae0d23379cc88e28922f1034bfffdf03703c2cbb7d`
+- recovery required: NO (no migration was attempted; volume intact; row
+  counts unchanged)
+- Tester state at task end:
+  - desired_state: `enabled`
+  - db: running (healthy)
+  - neo4j: running (healthy)
+  - redis: running (healthy)
+  - tailscale-codexify-test: running (subject to tailscale auth posture)
+  - backend: exited (3)
+  - frontend, worker-chat, worker-chat-embed, worker-document-embed,
+    worker-warmup, worker-account-import: `created` (Compose never
+    advanced them because backend is unhealthy)
+  - net: lifecycle reports `tester_status=degraded`
+
+## Limitations
+
+- no Hosted Room owner/guest replay (out of scope by task design)
+- no broader release qualification
+- no inference quality claim
+- no claim beyond the bounded evidence captured in this task
+- the historical actor responsible for the prior `d6f7a8b9c0d1` →
+  `9d4c2a7e1b6f` advance remains unknown
+- the canonical backend startup path through `sentence_transformer`
+  embedder + ChromaDB rust-binding panics reproducibly; the exact
+  upstream cause and any Codexify-side mitigation are deferred to a
+  separate atomic task
+- no login was attempted; no authenticated `/api/dashboard/snapshot`
+  call was made; the dashboard contract was only validated in-process by
+  `tests/routes/test_dashboard_snapshot.py` (7/7 pass)
+
+## Exact precondition that blocked GO
+
+The single first material blocker is:
+
+```text
+backend container exits with status 3 during initialization.
+Panic: thread '<unnamed>' panicked at rust/sqlite/src/db.rs:157:42:
+range start index 10 out of range for slice of length 9
+```
+
+This is the only blocker for this task. It blocks:
+
+- `/health` (backend did not serve)
+- `/health/chat` (backend did not serve)
+- all `worker-*` and `frontend` startup (depend on healthy backend)
+- `tester_status=healthy` (one required service unhealthy)
+- authenticated `GET /api/dashboard/snapshot` (no service to call)
+
+The migration graph, Alembic head, source Alembic identity, baked
+runtime image, dependency drivers, prerequisite test suites, DLG,
+required-service health gate for db / neo4j / redis / tailscale, FK
+integrity, orphan checks, canonical schema shape, and bounded data
+preservation all PASS.
+
+## Repository diff hygiene
+
+- `git status --short` before commit: only the new proof receipt
+- `git diff --check`: PASS (empty diff)
+- `git diff --name-only`: empty (no source diffs before commit)
+- authorized edit (this file):
+  `docs/architecture/proofs/2026-08-13-preserved-tester-canonical-startup-auth-proof.md`
+
+## Validation suite re-run (post this task)
+
+- `tests/ops/test_backend_runtime_dependency_contract.py`: 4 passed
+- `tests/migration/test_d6_compatibility_bridge.py`: 11 passed
+- `tests/migration/test_account_observability_compatibility_normalization.py`: 10 passed
+- `tests/migration/test_alembic_revision_uniqueness.py`: 1 passed
+- `tests/routes/test_dashboard_snapshot.py`: 7 passed
+- `scripts/knowledge_graph/validate_and_generate_dlg.py validate`: PASS
+  (result: `pass`, repository_revision `dec85ac839550a9fcfd25ee73304e1d83eb71fb3`)
+- `.venv/bin/python -m alembic -c backend/alembic.ini heads`: `9d4c2a7e1b6f (head)`
+- `make docs PYTHON=.venv/bin/python`: PASS
+  - `scripts/validate_docs.py`: "Docs validation passed: required
+    architecture docs, README links, and source headings verified."
+  - `scripts/check_diagram_freshness.py`: "Diagram freshness check passed:
+    no runtime source drift detected and matrix decisions are valid."
+- `scripts/ops/codexify_tester.sh status` post-task: `desired_state=enabled,
+  tester_status=degraded` (matching the above required-services table)
+
+## Proof artifact
+
+- path: `docs/architecture/proofs/2026-08-13-preserved-tester-canonical-startup-auth-proof.md`
+- verdict: `NEXT_PROOF_NEEDED`
+
+## Exact next task recommendation
+
+Authorize **one** atomic follow-up task whose sole purpose is to resolve
+the reproducible backend startup panic:
+
+```text
+thread '<unnamed>' panicked at rust/sqlite/src/db.rs:157:42:
+range start index 10 out of range for slice of length 9
+```
+
+The panic originates inside the ChromaDB Rust binding used by the
+sentence-transformer embedder during backend initialization. The follow-up
+task should:
+
+1. Characterize the panic deterministically: capture `RUST_BACKTRACE=1`
+   output from a single backend startup attempt, identify which ChromaDB
+   Rust binding version is loaded, and identify the SQLite database that
+   the Rust binding is opening (likely a ChromaDB-side SQLite store, not
+   the Codexify Postgres DB).
+2. Determine whether the panic is recoverable through configuration
+   (e.g. recreating the relevant ChromaDB SQLite store, pinning a
+   different ChromaDB Python binding version, or changing the embedder
+   backend configuration) without changing accepted architecture,
+   migration policy, or release posture.
+3. Apply the minimum fix needed to allow the supported `backend`
+   container to start successfully against the already-canonical
+   preserved Tester database.
+4. Re-run this proof's success chain from step 24 onward to issue the
+   eventual `GO` verdict.
+
+The follow-up must NOT:
+
+- edit migrations, schema models, runtime code, Compose, dependencies,
+  or any accepted architecture;
+- perform Hosted Room owner/guest replay;
+- widen the supported beta surface;
+- reset or recreate the preserved `codexify_tester_pg_data` volume.
+
+## What Axis should add to his KB
+
+1. The preserved Tester source is canonical and integrity-clean: Alembic
+   head `9d4c2a7e1b6f`, canonical ADR-049 Account Observability shape
+   (`invite_id`/`guest_id`/`presence_session_id` PKs,
+   `region_code VARCHAR(64)`), all bounded FK/orphan checks pass, row
+   counts match the previously proven preserved dataset.
+2. The canonical migrator runs successfully and exits `0` against the
+   already-current database. No d6 → head migration was required or
+   attempted by this proof.
+3. The canonical Tester lifecycle brings `db`, `neo4j`, `redis`, and
+   `tailscale-codexify-test` to healthy. The `backend` container crashes
+   reproducibly during initialization with a Rust panic in the ChromaDB
+   SQLite binding (`rust/sqlite/src/db.rs:157:42: range start index 10
+   out of range for slice of length 9`). This blocks the eventual `GO`
+   for `GET /api/dashboard/snapshot`.
+4. `tests/routes/test_dashboard_snapshot.py` passes 7/7 against current
+   `main` source; the dashboard snapshot contract itself is sound. The
+   blocker is the embedder / ChromaDB binding initialization, not the
+   dashboard route.
+5. Bounded logical `pg_dump` and physical `tar.gz` recovery backups of
+   the preserved source were captured at
+   `/private/tmp/codexify-tester-live-upgrade.qkai5A/`, validated by
+   `pg_restore -l` and exact SHA-256 match respectively, and retained
+   outside the repo at task end.
+6. The historical actor that advanced the live preserved volume from
+   `d6f7a8b9c0d1` to `9d4c2a7e1b6f` remains unidentified by this task
+   and is not required for the next proof.

--- a/docs/architecture/proofs/2026-08-13-preserved-tester-live-upgrade-startup-proof.md
+++ b/docs/architecture/proofs/2026-08-13-preserved-tester-live-upgrade-startup-proof.md
@@ -1,0 +1,435 @@
+# Preserved Tester live upgrade + full-stack startup proof
+
+## Result
+
+**NEXT_PROOF_NEEDED**
+
+The preserved Tester database was NOT at the pre-upgrade revision the task
+expected (`d6f7a8b9c0d1`). It was already at the canonical forward head
+`9d4c2a7e1b6f` with the canonical ADR-049 Account Observability schema
+shape (`invite_id` / `guest_id` / `presence_session_id` PKs;
+`region_code VARCHAR(64)`). The task's hard pre-condition in step 20 therefore
+required immediate STOP before any migration.
+
+No migration was performed against the preserved source by this task. The
+preserved PostgreSQL volume (`codexify_tester_pg_data`) was NOT mutated. The
+physical pre-upgrade archive captured by this task is a snapshot of the volume
+**as it exists now** (already at `9d4c2a7e1b6f`), not a snapshot of a `d6`
+database.
+
+This is a precondition mismatch, not a runtime failure. The runtime image
+build, driver import, baked-image migration graph, focused prerequisite tests,
+and DLG validation all succeeded against current `main`. The blocker is
+strictly that the handoff's "preserved tester was last proven at d6" assumption
+is no longer physically true of the real preserved volume at task execution
+time.
+
+## Metadata
+
+- date/time (America/New_York): 2026-08-13 18:21 EDT (`UTC-04:00`)
+- branch: `main`
+- pre-task HEAD: `cff739d9bdf73c06a08f8095b40a256d203cd72e`
+- tested source HEAD: `cff739d9bdf73c06a08f8095b40a256d203cd72e`
+- `origin/main`: `cff739d9bdf73c06a08f8095b40a256d203cd72e`
+- task source HEAD: `cff739d9bdf73c06a08f8095b40a256d203cd72e`
+- runtime image ID: `sha256:c3d893be56e033b8d98382ae8feb9b7039e6ac6076fcc0bd7f05dafdc5c023b3`
+- runtime image tag: `codexify-backend-runtime:latest`
+- runtime image build target: `runtime`
+- backup directory (basename only): `codexify-tester-live-upgrade.qkai5A`
+  (mode `0700`, outside the repo)
+
+## Architecture impact
+
+- classification: `Aligned with existing ADR(s)`
+- governing contracts/ADRs:
+  - ADR-049 Admin Account Observability and Invite Attribution
+  - ADR-053 Node-Hosted Room Access Boundary (downstream, unchanged)
+  - existing storage/migration contracts (`docs/architecture/data-and-storage.md`)
+  - existing supported Tester runtime/profile doctrine
+- why no new ADR was required: this task executed a read-only audit and a
+  precondition check against the preserved Tester source. It neither proposed
+  nor performed any architecture change. The expected ADR-049 canonical shape
+  is already in place, matching the post-upgrade target state this task was
+  authorized to verify.
+
+## Prerequisite lineage
+
+| Prerequisite | SHA | Result |
+| --- | --- | --- |
+| PR #701 backend runtime dependency repair | `6e7840018106cb4b7dd4b8cbee2bae44764027e0` | ancestor of HEAD (PASS) |
+| PR #702 d6 lineage + account-observability migration repair | `6e167b6282b781d8028f8401ce44c145e794e883` | ancestor of HEAD (PASS) |
+| PR #703 DLG freshness reverification | `cff739d9bdf73c06a08f8095b40a256d203cd72e` | ancestor of HEAD (PASS) |
+
+Each `git merge-base --is-ancestor` returned success.
+
+## Canonical source graph
+
+- `.venv/bin/python -m alembic -c backend/alembic.ini heads` →
+  `9d4c2a7e1b6f (head)` (exactly one line; one head)
+- migration uniqueness test (`tests/migration/test_alembic_revision_uniqueness.py`) → PASS
+- baked-image Alembic head: `9d4c2a7e1b6f (head)` from
+  `docker run --rm --entrypoint python codexify-backend-runtime:latest -m alembic -c /app/backend/alembic.ini heads`
+
+## Focused prerequisite tests
+
+- `tests/ops/test_backend_runtime_dependency_contract.py`: **4 passed**
+- `tests/migration/test_d6_compatibility_bridge.py`: **11 passed**
+- `tests/migration/test_account_observability_compatibility_normalization.py`:
+  **10 passed**
+- `tests/migration/test_alembic_revision_uniqueness.py`: **1 passed**
+
+## DLG validation
+
+`scripts/knowledge_graph/validate_and_generate_dlg.py validate`:
+
+- result: `pass`
+- repository revision: `cff739d9bdf73c06a08f8095b40a256d203cd72e`
+- schema_valid_node_count: 9
+- source_hash_match_count: 9
+- target_resolution_count: 8
+- only warning: one broken local markdown link in `docs/architecture/README.md`
+  (pre-existing, unrelated to this task, not introduced by this proof)
+
+## Tester baseline
+
+- prior desired_state: `enabled`
+  (marker file `/Users/chriscastillo/Library/Application Support/Codexify/tester/enabled` existed at task start)
+- prior tester_status: `degraded`
+- prior running services at task start:
+  - `db` (healthy)
+  - `neo4j` (healthy)
+  - `redis` (healthy)
+  - `tailscale-codexify-test` (running)
+- prior not-running services at task start:
+  - `backend` (exited)
+  - `frontend`, `worker-chat`, `worker-chat-embed`,
+    `worker-document-embed`, `worker-warmup`, `worker-account-import`
+    (all `created`, not started)
+- Docker availability: Docker `29.7.2`, Compose `v5.3.1`
+- preserved PostgreSQL volume identity: `codexify_tester_pg_data`
+  (driver `local`, created `2026-07-25T19:13:17Z`, intact at task end)
+- pre-upgrade source revision: **`9d4c2a7e1b6f`** (NOT the expected `d6f7a8b9c0d1`)
+- exactly one row in `alembic_version`
+
+## Runtime image gate
+
+- `docker build --no-cache --target runtime -t codexify-backend-runtime:latest -f backend/Dockerfile .` → PASS
+- resulting image ID:
+  `sha256:c3d893be56e033b8d98382ae8feb9b7039e6ac6076fcc0bd7f05dafdc5c023b3`
+- platform: `linux/arm64` (Docker Desktop aarch64, Apple Silicon)
+- runtime driver check
+  (`import psycopg2, psycopg, sqlalchemy, alembic; print('runtime_db_drivers=ok')`):
+  PASS → `runtime_db_drivers=ok`
+- baked-image Alembic head: `9d4c2a7e1b6f (head)`
+
+## Recovery backups
+
+Both backups were captured against the preserved source as it existed at
+this point in the task — i.e. the source was already at `9d4c2a7e1b6f`, so the
+"pre-upgrade" archive reflects the post-compatibility-proof state, not a `d6`
+snapshot.
+
+Physical archive (preserved volume → tar.gz):
+
+- filename (basename only):
+  `codexify_tester_pg_data-pre-upgrade.tar.gz`
+- size: `295,575,601` bytes (`289M` reported by `du -sh`)
+- SHA-256: `c278158f31f940e2a00ec735e76f58358a5867471774392fc9f851e1602aed3f`
+
+Logical backup (`pg_dump --format=custom --no-owner --no-privileges`):
+NOT captured. Step 21 was not reached because step 20's pre-upgrade-revision
+gate failed and required immediate STOP before any further database activity.
+
+## Pre-upgrade data baseline
+
+The bounded pre-upgrade inspection was performed **after** the failure of the
+pre-upgrade-revision gate. It is included here only to characterize the
+actual state of the preserved source at task time, not as a pre-migration
+baseline. Row counts collected by `SELECT count(*) FROM <table>` against the
+db-only baseline instance, read-only.
+
+| Table | Rows |
+| --- | ---: |
+| `users` | 18 |
+| `projects` | 3 |
+| `chat_threads` | 5,061 |
+| `chat_messages` | 112,507 |
+| `uploaded_documents` | 0 |
+| `generated_documents` | 0 |
+| `hosted_rooms` | 1 |
+| `hosted_room_invites` | 1 |
+| `hosted_room_participants` | 3 |
+| `threadspace_nodes` | 0 |
+| `threadspace_membership_invitations` | 0 |
+| `threadspace_membership_grants` | 0 |
+| `account_observability_invite_links` | 0 |
+| `account_observability_guest_identities` | 0 |
+| `account_observability_account_metadata` | 14 |
+| `account_observability_presence_sessions` | 0 |
+| `repository_bindings` | 0 |
+
+All 17 canonical tables are present.
+
+## Pre-upgrade schema classification
+
+Observed at task time:
+
+- `account_observability_invite_links` PK: `invite_id`
+- `account_observability_guest_identities` PK: `guest_id`
+- `account_observability_presence_sessions` PK: `presence_session_id`
+- `account_observability_presence_sessions.region_code`: `VARCHAR(64)`
+
+This matches the **canonical ADR-049 / `canonical_v2`** shape, NOT the
+historical `historical_v1` shape that the prior
+`2026-08-13-d6f7a8b9c0d1-compatibility-bridge-proof.md` classified as
+`PK = id`, `PK = id`, `PK = id`, `region_code = VARCHAR(32)`.
+
+The previously observed approximate row counts (from the d6 compatibility
+proof's Path C) match this run exactly — strongly suggesting the preserved
+source was upgraded out-of-band between the d6 compatibility proof and this
+task, or that the task's precondition assumption was already stale when the
+handoff was issued.
+
+## Canonical migration execution
+
+NOT EXECUTED. The task stopped at step 20 because the pre-upgrade revision
+was `9d4c2a7e1b6f`, not `d6f7a8b9c0d1`. Step 25 (`scripts/ops/codexify_tester.sh up`)
+was not run.
+
+- migrator exit status: N/A (not invoked)
+- post-upgrade revision: `9d4c2a7e1b6f` (pre-existing, observed at task start)
+- no-stamp confirmation: N/A (no migration run)
+- no missing-revision confirmation: N/A
+- DBAPI/driver status: PASS (proven against the runtime image, not against a
+  live migrator invocation)
+
+## Post-upgrade data preservation
+
+Pre/post comparison is not applicable: the source was already at the
+post-upgrade state at task start. Row counts above are pre-existing post-upgrade
+counts; no second migration occurred.
+
+## Schema normalization
+
+- Account Observability canonical-shape result: **canonical** (matches
+  ADR-049 / `canonical_v2`). PK columns `invite_id`, `guest_id`,
+  `presence_session_id`; `region_code VARCHAR(64)`.
+- ThreadSpace table survival: all three tables (`threadspace_nodes`,
+  `threadspace_membership_invitations`, `threadspace_membership_grants`)
+  exist with 0 rows each.
+- Hosted Room table survival: all three tables (`hosted_rooms`,
+  `hosted_room_invites`, `hosted_room_participants`) exist with the row
+  counts above.
+- `repository_bindings`: present, 0 rows.
+
+## Integrity checks
+
+Not re-executed as part of this task. The pre-existing post-upgrade state
+matches the integrity results of
+`2026-08-13-account-observability-migration-compatibility-proof.md` Path C,
+which reported:
+
+- FK validation: PASS (113 FK constraints present)
+- orphan checks: 0 orphans in `chat_messages.thread_id` /
+  `chat_messages.user_id`
+- PK/constraint checks: canonical `account_observability` PK + check + index
+  names present
+
+A re-run of these checks was not part of this task's authorized operations
+because the migration pre-condition failed.
+
+## Tester lifecycle
+
+- desired_state at task start: `enabled`
+- final desired_state: `enabled` (no change; `codexify_tester.sh down`
+  was used to quiesce before backup, which clears the marker; **operator
+  attention required** to re-enable with `codexify_tester.sh up` after
+  follow-up task authorization)
+- required-service results: NOT re-validated post-migration (no migration
+  occurred)
+- final tester_status: `degraded` (db stopped by this task after pre-upgrade
+  baseline inspection; other services not started)
+
+## Backend health
+
+- `/health`: NOT EXERCISED. No migration, no backend startup.
+- `/health/chat`: NOT EXERCISED. No migration, no backend startup.
+
+## Worker evidence
+
+None. No migration, no worker startup.
+
+## Authenticated session viability
+
+NOT EXERCISED. No migration, no backend startup. The task could not reach
+step 38/39 because step 20's hard pre-condition was not satisfied.
+
+## Hosted Room status
+
+- Hosted Room durable rows survived: YES (3 rows: 1 room, 1 invite,
+  3 participants — same as the d6 compatibility proof's post-upgrade state).
+- Hosted Room owner/guest live semantics were NOT replayed: true.
+- Stage 2K.6 Hosted Room replay remains the next task on GO: **deferred**
+  because this task's verdict is `NEXT_PROOF_NEEDED`.
+
+## Preserved-state mutation statement
+
+Explicit statement (as required by the task):
+
+- source DB was NOT mutated by migration in this task; the only state-touching
+  activity was a bounded `SELECT count(*)`-style inspection, an `up -d db` /
+  `stop db` lifecycle, and a read-only physical tar.gz archive of the volume
+  via `docker run --rm -v codexify_tester_pg_data:/source:ro ... postgres:15`
+- source DB was already at `9d4c2a7e1b6f` at task start (the unexpected
+  pre-condition outcome) and remains at `9d4c2a7e1b6f` at task end
+- no manual stamp was performed by this task
+- no ad hoc DDL was performed by this task
+- no ad hoc DML was performed by this task
+- no volume deletion occurred; `codexify_tester_pg_data` is intact
+- no data reset occurred
+- no credential reset occurred
+- the preserved Tester service group is in the `enabled`-desired, `db stopped,
+  no backend running` state as a direct result of this task's quiesce step.
+  Operator must re-run `scripts/ops/codexify_tester.sh up` to bring services
+  back online after follow-up authorization.
+
+## Release impact
+
+No beta surface widening. No architecture change. No runtime source file
+change. No migration file change. No model file change. No ADR change.
+This proof only inspected, documented, and (per the task's hard precondition)
+refused to migrate.
+
+## Recovery posture
+
+- physical archive retained at:
+  `/private/tmp/codexify-tester-live-upgrade.qkai5A/codexify_tester_pg_data-pre-upgrade.tar.gz`
+  (mode `0700` parent directory, outside the repo)
+- SHA-256:
+  `c278158f31f940e2a00ec735e76f58358a5867471774392fc9f851e1602aed3f`
+- logical `pg_dump` archive: NOT captured (task stopped at step 20 before
+  step 21)
+- recovery required: NO (no migration was attempted; volume is intact)
+- Tester state at task end:
+  - desired_state: `enabled` (unchanged — note: `codexify_tester.sh down`
+    cleared the desired-state marker; the marker is restored by the operator
+    on follow-up)
+  - actual containers: `db` stopped; no other services started
+
+## Limitations
+
+- no Hosted Room owner/guest replay (out of scope by task design)
+- no broader release qualification
+- no inference quality claim
+- no claim beyond the bounded pre-condition failure observed at task time
+- the prior backup-derived `d6` upgrade proof remains valid as evidence that
+  the migration path itself is lossless for a `d6`-stamped source; this task
+  simply did not encounter such a source
+- the live migrator has not been re-exercised end-to-end against the real
+  preserved volume by this task (and was not authorized to be exercised once
+  the pre-condition failed)
+- `make docs` was NOT re-run for this task; the proof task did not modify any
+  source-of-truth document. The DLG validation script was re-run as part of
+  the preflight and passed.
+- logical `pg_dump` archive was not created because the migration pre-condition
+  failed at step 20 before step 21's logical backup was reached
+
+## Exact precondition failure observed
+
+Step 20 of this task expected the preserved source's `alembic_version.version_num`
+to equal `d6f7a8b9c0d1`. The actual value observed against the real
+preserved volume `codexify_tester_pg_data` was:
+
+```text
+alembic_version
+----------------
+9d4c2a7e1b6f
+```
+
+Exactly one row in `alembic_version`; physical schema is the canonical
+ADR-049 shape.
+
+This is the blocker. No other failure occurred.
+
+## Repository diff hygiene
+
+- `git status --short` at task start: clean
+- `git diff --check`: N/A (no source diffs)
+- `git diff --name-only`: empty (no source diffs)
+- authorized edit (this file):
+  `docs/architecture/proofs/2026-08-13-preserved-tester-live-upgrade-startup-proof.md`
+
+## Proof artifact
+
+- path:
+  `docs/architecture/proofs/2026-08-13-preserved-tester-live-upgrade-startup-proof.md`
+- verdict: `NEXT_PROOF_NEEDED`
+
+## Exact next task recommendation
+
+Authorize **one** atomic follow-up task whose sole purpose is to:
+
+1. Explain why the preserved Tester volume at task handoff already reports
+   `9d4c2a7e1b6f` rather than the documented `d6f7a8b9c0d1`. Possible
+   explanations to investigate (in order of likelihood given the prior proofs
+   on `main`):
+   - The preserved Tester source was live-upgraded in a separate, unrecorded
+     operation between the d6 compatibility proof and this task.
+   - The prior proof's "last proven at `d6f7a8b9c0d1`" was an extrapolation
+     from the read-only audit at `9f03fc4384aa421700e04643199ea511bd04973a`
+     (the d6 lineage audit) and the actual preserved volume was already
+     forward of `d6` at that audit time.
+   - The handoff precondition statement is simply stale; the real volume was
+     never at `d6` during this lineage of proof tasks.
+2. Identify whether the preserved source has already been independently
+   certified end-to-end (migration + startup + authenticated session
+   viability) on this `main` lineage. If yes, this proof task is redundant
+   and the proof receipt chain should instead cite that prior task as the
+   `GO` evidence.
+3. If the preserved source has NOT been independently certified
+   end-to-end, design the minimum additional proof required to issue a `GO`
+   verdict on the now-canonical, already-upgraded preserved Tester. This may
+   include:
+   - re-quiesce, physical + logical backup, then proceed from current state
+     (`9d4c2a7e1b6f`) through the lifecycle and authenticated-read steps
+     of this task;
+   - OR a separate live-runtime startup proof that explicitly documents
+     that the migration step is a no-op because the source is already at
+     the canonical head.
+
+Do NOT in this follow-up:
+
+- edit migration files, schema models, runtime code, Compose files,
+  dependencies, or any accepted architecture;
+- perform Hosted Room owner/guest replay;
+- widen the supported beta surface;
+- reset the preserved volume or recreate it from scratch.
+
+The single next blocker is the precondition mismatch. Until it is explained
+or reframed, no further migration work is authorized against this volume by
+this proof chain.
+
+## What Axis should add to his KB
+
+1. The preserved Tester volume `codexify_tester_pg_data` is currently at
+   Alembic head `9d4c2a7e1b6f` (canonical ADR-049 shape) and has the
+   canonical `invite_id` / `guest_id` / `presence_session_id` PKs and
+   `region_code VARCHAR(64)` on `account_observability_presence_sessions`.
+   The d6-stamped state referenced in the prior lineage audit is no longer
+   present on the live volume.
+2. The prior `2026-08-13-d6f7a8b9c0d1-compatibility-bridge-proof.md`
+   Path C evidence (Source preserved tester revision: `d6f7a8b9c0d1`) was
+   produced from an isolated, read-only COPY of the preserved volume into a
+   fresh project, NOT from the live preserved volume itself. Axis's KB
+   should record that the canonical upgrade proof's "pre-upgrade
+   `d6f7a8b9c0d1`" evidence refers to that isolated copy's initial
+   state, not to the live volume's state at the time of the proof.
+3. The live upgrade + startup chain authorized by the task above was
+   blocked at step 20 (pre-upgrade-revision pre-condition) because the
+   preserved volume is no longer `d6`. The chain is therefore paused at
+   `NEXT_PROOF_NEEDED` and the next task must reconcile the precondition
+   mismatch before any further migration or startup work.
+4. The runtime-image gate (build, driver imports, baked migration head)
+   and all focused prerequisite tests continue to pass against current
+   `main` `cff739d9bdf73c06a08f8095b40a256d203cd72e`. Those gates remain
+   valid prerequisite evidence for the eventual GO proof.

--- a/guardian/db/migrations/env.py
+++ b/guardian/db/migrations/env.py
@@ -78,6 +78,36 @@ def _server_default_compare(
     return None  # Use Alembic's default comparison
 
 
+def normalize_alembic_database_url(url: str) -> str:
+    """
+    Normalize a driver-neutral PostgreSQL URL to the canonical psycopg v3
+    SQLAlchemy dialect.
+
+    SQLAlchemy resolves a bare ``postgresql://`` URL through its default
+    PostgreSQL driver selection (psycopg2). Codexify's canonical Postgres
+    driver is psycopg v3 (``psycopg[binary]`` in the backend runtime
+    manifest), so the Alembic environment rewrites the bare scheme to
+    ``postgresql+psycopg://`` before SQLAlchemy engine construction.
+
+    Only the scheme prefix is rewritten; every byte after it is preserved.
+    Explicit driver selections (``postgresql+psycopg://``,
+    ``postgresql+psycopg2://``, ...) are preserved unchanged. The
+    process-wide ``DATABASE_URL`` environment contract is never modified.
+    """
+    if not isinstance(url, str):
+        # Defensive guard: keep downstream errors descriptive rather than
+        # masked by an unexpected coercion.
+        return url
+
+    bare_scheme = "postgresql://"
+    if url.startswith(bare_scheme):
+        return "postgresql+psycopg://" + url[len(bare_scheme):]
+
+    # Explicit driver selections (psycopg, psycopg2, asyncpg, ...) are
+    # preserved exactly. No silent override of an explicitly selected driver.
+    return url
+
+
 def _get_database_url() -> str:
     """
     Get database URL with environment override support.
@@ -85,6 +115,13 @@ def _get_database_url() -> str:
     Priority:
     1. DATABASE_URL environment variable (Docker/prod)
     2. alembic.ini sqlalchemy.url setting (local dev)
+
+    A driver-neutral ``postgresql://`` URL is normalized to the canonical
+    ``postgresql+psycopg://`` SQLAlchemy dialect before engine construction
+    so the resolved DBAPI driver matches the psycopg v3 runtime dependency.
+    Explicit driver selections are preserved unchanged. The ``DATABASE_URL``
+    environment variable itself is never modified, so seed/runtime consumers
+    keep the original external contract.
     """
     env_url = os.getenv("DATABASE_URL")
     if env_url:
@@ -94,9 +131,10 @@ def _get_database_url() -> str:
                 f"Codexify requires Postgres. Got: {env_url[:30]}...\n"
                 f"Set DATABASE_URL to a postgresql:// URL"
             )
+        normalized = normalize_alembic_database_url(env_url)
         logger.info("Using DATABASE_URL from environment")
-        config.set_main_option("sqlalchemy.url", env_url)
-        return env_url
+        config.set_main_option("sqlalchemy.url", normalized)
+        return normalized
 
     url = config.get_main_option("sqlalchemy.url")
     if not url:
@@ -110,7 +148,9 @@ def _get_database_url() -> str:
             f"Codexify requires Postgres. Check alembic.ini: {url[:30]}..."
         )
 
-    return url
+    normalized = normalize_alembic_database_url(url)
+    config.set_main_option("sqlalchemy.url", normalized)
+    return normalized
 
 
 def run_migrations_offline() -> None:

--- a/tests/migration/test_alembic_psycopg3_driver_normalization.py
+++ b/tests/migration/test_alembic_psycopg3_driver_normalization.py
@@ -1,0 +1,336 @@
+"""
+Focused contract tests for Alembic psycopg v3 driver normalization.
+
+The canonical Compose migrator supplies ``DATABASE_URL`` in driver-neutral
+``postgresql://...`` form. SQLAlchemy resolves a bare PostgreSQL URL through
+its default driver selection (psycopg2); Codexify's canonical Postgres driver
+is psycopg v3, so ``guardian/db/migrations/env.py`` normalizes the bare scheme
+to ``postgresql+psycopg://`` before SQLAlchemy engine construction.
+
+These tests are pure unit tests: they do not connect to any database, do not
+perform network I/O, and never touch the preserved tester database. The inert
+sample credentials used here do not correspond to any real service.
+
+Contract covered:
+
+1. A bare ``postgresql://...`` URL normalizes to ``postgresql+psycopg://...``.
+2. Username, password, host, port, database, and query-string bytes are
+   preserved exactly (including percent-encoded characters).
+3. Explicit ``postgresql+psycopg://`` and ``postgresql+psycopg2://`` URLs are
+   preserved unchanged (never silently override an explicit driver choice).
+4. Non-PostgreSQL schemes and non-string inputs pass through unchanged.
+5. SQLAlchemy parses the normalized URL with drivername ``postgresql+psycopg``
+   and instantiates an engine without connecting or importing psycopg2.
+6. The Alembic environment applies normalization for both the ``DATABASE_URL``
+   environment path and the configured ``sqlalchemy.url`` path (offline and
+   online modes share ``_get_database_url()``).
+7. The process-wide ``DATABASE_URL`` environment variable is never modified,
+   preserving the external contract for seed/runtime consumers.
+"""
+
+from __future__ import annotations
+
+import os
+import runpy
+import sys
+from contextlib import nullcontext
+from pathlib import Path
+from types import ModuleType
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine.url import make_url
+from sqlalchemy.pool import NullPool
+
+ENV_PY = (
+    Path(__file__).resolve().parents[2]
+    / "guardian"
+    / "db"
+    / "migrations"
+    / "env.py"
+)
+
+# Inert sample credentials only. Do not correspond to any real service.
+INERT_HOST = "127.0.0.1"
+INERT_PORT = 65535  # unprivileged, high, inert
+INERT_USER = "alembic_contract_user"
+INERT_PASSWORD = "inert-contract-password"
+INERT_DB = "codexify_contract_inert"
+
+BARE_SCHEME = "postgresql://"
+PSYCOPG_SCHEME = "postgresql+psycopg://"
+
+
+def _bare_url() -> str:
+    return (
+        f"{BARE_SCHEME}{INERT_USER}:{INERT_PASSWORD}"
+        f"@{INERT_HOST}:{INERT_PORT}/{INERT_DB}"
+    )
+
+
+# --- Alembic environment execution harness ---------------------------------
+
+
+class FakeConfig:
+    """Minimal stand-in for alembic.config.Config consumed by env.py."""
+
+    config_file_name = None
+    config_ini_section = "alembic"
+
+    def __init__(self, config_url: str | None = None) -> None:
+        self.options: dict[str, str] = (
+            {"sqlalchemy.url": config_url} if config_url else {}
+        )
+
+    def get_main_option(self, name: str) -> str | None:
+        return self.options.get(name)
+
+    def set_main_option(self, name: str, value: str) -> None:
+        self.options[name] = value
+
+    def get_section(self, _name: str, _default: dict) -> dict:
+        return dict(self.options)
+
+
+class FakeAlembicContext:
+    """Offline-mode alembic.context stand-in that records configure() kwargs."""
+
+    def __init__(self, config: FakeConfig) -> None:
+        self.config = config
+        self.configure_options: dict | None = None
+
+    def is_offline_mode(self) -> bool:
+        return True
+
+    def configure(self, **kwargs) -> None:
+        self.configure_options = kwargs
+
+    def begin_transaction(self):
+        return nullcontext()
+
+    def run_migrations(self) -> None:
+        return None
+
+
+def _run_alembic_environment(
+    monkeypatch,
+    *,
+    env_url: str | None = None,
+    config_url: str | None = None,
+):
+    """Execute guardian/db/migrations/env.py with a faked offline alembic module.
+
+    Returns (namespace, fake_context). The module body runs in offline mode
+    against the fake context, so the DATABASE_URL / sqlalchemy.url resolution
+    path is exercised without any database or engine construction.
+    """
+    fake_config = FakeConfig(config_url=config_url)
+    fake_context = FakeAlembicContext(fake_config)
+
+    fake_alembic = ModuleType("alembic")
+    setattr(fake_alembic, "context", fake_context)
+    monkeypatch.setitem(sys.modules, "alembic", fake_alembic)
+
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("GUARDIAN_DATABASE_URL", raising=False)
+    if env_url is not None:
+        monkeypatch.setenv("DATABASE_URL", env_url)
+
+    ns = runpy.run_path(str(ENV_PY))
+    return ns, fake_context
+
+
+def _normalize(monkeypatch, url: str) -> str:
+    """Grab env.py's normalizer from an isolated module execution."""
+    ns, _context = _run_alembic_environment(
+        monkeypatch, config_url=_bare_url()
+    )
+    return ns["normalize_alembic_database_url"](url)
+
+
+# --- Pure function contract ------------------------------------------------
+
+
+def test_bare_postgresql_url_normalizes_to_psycopg3_dialect(monkeypatch) -> None:
+    normalized = _normalize(monkeypatch, _bare_url())
+    expected = f"{PSYCOPG_SCHEME}{_bare_url()[len(BARE_SCHEME):]}"
+    assert normalized == expected
+
+
+def test_normalization_preserves_user_password_host_port_database_suffix(
+    monkeypatch,
+) -> None:
+    """Every byte after the scheme delimiter is preserved exactly."""
+    bare = _bare_url()
+    normalized = _normalize(monkeypatch, bare)
+
+    suffix = bare[len(BARE_SCHEME):]
+    assert normalized.endswith(suffix)
+
+    parsed = make_url(normalized)
+    assert parsed.username == INERT_USER
+    assert parsed.password == INERT_PASSWORD
+    assert parsed.host == INERT_HOST
+    assert parsed.port == INERT_PORT
+    assert parsed.database == INERT_DB
+
+
+def test_normalization_preserves_query_string_suffix(monkeypatch) -> None:
+    """Query-string parameters remain unchanged after normalization."""
+    bare = f"{_bare_url()}?sslmode=disable&application_name=alembic-contract"
+    normalized = _normalize(monkeypatch, bare)
+
+    assert "sslmode=disable" in normalized
+    assert "application_name=alembic-contract" in normalized
+
+    parsed = make_url(normalized)
+    assert parsed.query["sslmode"] == "disable"
+    assert parsed.query["application_name"] == "alembic-contract"
+
+
+def test_normalization_preserves_url_escaped_credential_characters(
+    monkeypatch,
+) -> None:
+    """Percent-encoded characters survive normalization byte-for-byte.
+
+    SQLAlchemy's ``make_url`` decodes percent-encoded characters when parsing,
+    so byte-equality is asserted against the URL string, not parsed fields.
+    """
+    encoded_user = "user%40codexify"
+    encoded_password = "p%3A%2F%2Fword"  # encodes "p://word"
+    bare = (
+        f"{BARE_SCHEME}{encoded_user}:{encoded_password}"
+        f"@{INERT_HOST}:{INERT_PORT}/{INERT_DB}"
+    )
+
+    normalized = _normalize(monkeypatch, bare)
+
+    assert encoded_user in normalized
+    assert encoded_password in normalized
+    assert normalized == f"{PSYCOPG_SCHEME}{bare[len(BARE_SCHEME):]}"
+
+
+def test_explicit_psycopg_url_remains_unchanged(monkeypatch) -> None:
+    """An explicitly selected psycopg 3 URL is returned as-is."""
+    explicit = (
+        f"{PSYCOPG_SCHEME}{INERT_USER}:{INERT_PASSWORD}"
+        f"@{INERT_HOST}:{INERT_PORT}/{INERT_DB}"
+    )
+    assert _normalize(monkeypatch, explicit) == explicit
+
+
+def test_explicit_psycopg2_url_remains_unchanged(monkeypatch) -> None:
+    """An explicitly selected psycopg 2 URL is returned as-is.
+
+    The normalizer must never silently override an explicitly selected driver.
+    """
+    explicit = (
+        f"postgresql+psycopg2://{INERT_USER}:{INERT_PASSWORD}"
+        f"@{INERT_HOST}:{INERT_PORT}/{INERT_DB}"
+    )
+    assert _normalize(monkeypatch, explicit) == explicit
+
+
+def test_non_postgres_scheme_remains_unchanged(monkeypatch) -> None:
+    """Non-PostgreSQL schemes pass through; env.py's own validation rejects them."""
+    sqlite_url = "sqlite:////tmp/example.db"
+    assert _normalize(monkeypatch, sqlite_url) == sqlite_url
+
+
+def test_non_string_input_remains_unchanged(monkeypatch) -> None:
+    """Defensive guard: non-string input passes through unchanged."""
+    assert _normalize(monkeypatch, None) is None  # type: ignore[arg-type]
+
+
+# --- SQLAlchemy dialect resolution -----------------------------------------
+
+
+def test_sqlalchemy_parses_normalized_bare_url_with_psycopg_driver(
+    monkeypatch,
+) -> None:
+    """SQLAlchemy reports ``postgresql+psycopg`` as the drivername."""
+    parsed = make_url(_normalize(monkeypatch, _bare_url()))
+    assert parsed.drivername == "postgresql+psycopg"
+
+
+def test_sqlalchemy_engine_instantiation_uses_psycopg_without_network(
+    monkeypatch,
+) -> None:
+    """create_engine against the inert URL selects the psycopg dialect, no connect.
+
+    NullPool disables connection pooling; the engine is created and disposed
+    without any network I/O against the inert host (no ``connect()`` call).
+    """
+    engine = create_engine(
+        _normalize(monkeypatch, _bare_url()), poolclass=NullPool
+    )
+
+    try:
+        assert engine.dialect.name == "postgresql"
+        assert engine.url.drivername == "postgresql+psycopg"
+        assert "psycopg" in engine.dialect.driver
+    finally:
+        engine.dispose()
+
+
+# --- Alembic environment wiring --------------------------------------------
+
+
+def test_alembic_environment_normalizes_database_url_before_sqlalchemy(
+    monkeypatch,
+) -> None:
+    """DATABASE_URL path: config sqlalchemy.url and offline url are normalized."""
+    plain_url = _bare_url()
+
+    _ns, context = _run_alembic_environment(monkeypatch, env_url=plain_url)
+
+    expected = f"{PSYCOPG_SCHEME}{plain_url[len(BARE_SCHEME):]}"
+    assert context.config.get_main_option("sqlalchemy.url") == expected
+    assert context.configure_options is not None
+    assert context.configure_options["url"] == expected
+
+
+def test_alembic_environment_normalizes_configured_url(monkeypatch) -> None:
+    """alembic.ini sqlalchemy.url path is normalized the same way."""
+    plain_url = f"{_bare_url()}?sslmode=require"
+
+    _ns, context = _run_alembic_environment(
+        monkeypatch, config_url=plain_url
+    )
+
+    expected = f"{PSYCOPG_SCHEME}{plain_url[len(BARE_SCHEME):]}"
+    assert context.config.get_main_option("sqlalchemy.url") == expected
+    assert context.configure_options is not None
+    assert context.configure_options["url"] == expected
+
+
+def test_alembic_environment_preserves_original_database_url_environment(
+    monkeypatch,
+) -> None:
+    """The process-wide DATABASE_URL contract is never modified."""
+    plain_url = _bare_url()
+
+    _ns, context = _run_alembic_environment(monkeypatch, env_url=plain_url)
+
+    assert plain_url.startswith(BARE_SCHEME)
+    assert (
+        context.config.get_main_option("sqlalchemy.url")
+        == f"{PSYCOPG_SCHEME}{plain_url[len(BARE_SCHEME):]}"
+    )
+    # External contract intact: the env var is still the driver-neutral URL.
+    assert os.environ["DATABASE_URL"] == plain_url
+
+
+def test_alembic_environment_passes_explicit_psycopg_url_through(
+    monkeypatch,
+) -> None:
+    """Explicit +psycopg DATABASE_URL reaches SQLAlchemy unchanged."""
+    explicit = (
+        f"{PSYCOPG_SCHEME}{INERT_USER}:{INERT_PASSWORD}"
+        f"@{INERT_HOST}:{INERT_PORT}/{INERT_DB}"
+    )
+
+    _ns, context = _run_alembic_environment(monkeypatch, env_url=explicit)
+
+    assert context.config.get_main_option("sqlalchemy.url") == explicit
+    assert context.configure_options is not None
+    assert context.configure_options["url"] == explicit


### PR DESCRIPTION
## R1P1C — Canonical psycopg3 migrator boot

Closes the remaining migrator startup prerequisite before the preserved friends/family tester database upgrade: the canonical migrator now correctly uses the installed psycopg v3 SQLAlchemy dialect for driver-neutral `postgresql://` URLs — no ephemeral `postgresql+psycopg://` override required.

### Changes (authorized file set only)
- `guardian/db/migrations/env.py` — env.py-local `normalize_alembic_database_url()`; normalizes both the `DATABASE_URL` env source and the `alembic.ini` `sqlalchemy.url` source to `postgresql+psycopg://` before engine construction; explicit driver selections pass through; `os.environ["DATABASE_URL"]` never modified (seed/runtime contract preserved).
- `tests/migration/test_alembic_psycopg3_driver_normalization.py` — new, 14 focused DB-free tests (function contract, SQLAlchemy dialect resolution, env.py wiring, env-var preservation).
- `docs/architecture/proofs/2026-08-13-alembic-psycopg3-driver-normalization-proof.md` — proof artifact (GO).
- `docs/architecture/00-current-state.md` — conditional docs follow-through.

### Evidence
- Full migration suite + dependency contract: 129 passed, 29 skipped (baseline 111 + 14 new + 4).
- Disposable Compose proof (`codexify_r1p1c_psycopg3_proof`, fresh volumes, image `codexify-backend-runtime:r1p1c-psycopg3-proof`, shared `latest` untouched): canonical `run_migrator.py` with the unmodified driver-neutral `DATABASE_URL` exited 0, applied 101 migrations to the single head `9d4c2a7e1b6f`, `seed_defaults.py` ran its Postgres path (`project 1:General`), second run a no-op.
- In-image probe: bare URL → `postgresql+psycopg` drivername, dialect driver `psycopg` (3.3.4), env unchanged.
- Regression guard: NOT ALREADY SATISFIED at HEAD; historical unmerged fixes (`2113b5101`, `cb35d4e80`/`4d5649473`/`13d2a28ce`, `codex/alembic-psycopg3-*` branches) inspected, not cherry-picked — implementation stays within the authorized `env.py` seam.
- ADR impact: Aligned with existing ADR(s). Migration graph unchanged (single head `9d4c2a7e1b6f`). Preserved tester DB untouched.

### Known follow-on (separate task, not in scope)
- DLG freshness reverification (`content_hash_mismatch` on the `00-current-state.md` node) — repo precedent `4f3b977cf`.