### PR TITLE
R1P1C: Land canonical Alembic psycopg3 driver normalization

### DIFF
--- a/docs/architecture/00-current-state.md
+++ b/docs/architecture/00-current-state.md
@@ -4,7 +4,7 @@ This file is Codexify's canonical short-form source of truth for current operati
 
 ## Last updated
 
-2026-08-12
+2026-08-13
 
 ## Interpretation rule
 
@@ -28,7 +28,8 @@ This file is authoritative for:
 - Added Whoosh'd capability projection, structured transport, qualification/attestation seams, and exact-target identity reconciliation; the receipt covers one target/schema identity only.
 - Canonicalized ADR-060 through ADR-063 and reverified DLG/knowledge-graph freshness after history corrections; these are control-plane/documentation changes.
 - Added a Doctrine of Legible Responsibility and related tool-loop contract updates; they clarify boundaries without proving runtime readiness.
-- Repaired the historical `d6f7a8b9c0d1` ThreadSpace migration lineage and the `b2c3d4e5f6a7` account-observability migration-content drift: `b2c3d4e5f6a7` was restored to its original applied body and a forward normalization migration (`9d4c2a7e1b6f`) converges clean, already-canonical, and backup-derived tester schemas onto one canonical ADR-049 shape at a single Alembic head. The preserved tester source remains unmodified and still requires a separate live upgrade/startup task; the canonical migrator psycopg driver compatibility remains a separate blocker until independently landed/proven; Hosted Room runtime proof remains pending; no release promise was widened.
+- Repaired the historical `d6f7a8b9c0d1` ThreadSpace migration lineage and the `b2c3d4e5f6a7` account-observability migration-content drift: `b2c3d4e5f6a7` was restored to its original applied body and a forward normalization migration (`9d4c2a7e1b6f`) converges clean, already-canonical, and backup-derived tester schemas onto one canonical ADR-049 shape at a single Alembic head. The preserved tester source remains unmodified and still requires a separate live upgrade/startup task; the canonical migrator psycopg driver compatibility is now landed and proven (see the 2026-08-13 driver-normalization proof); Hosted Room runtime proof remains pending; no release promise was widened.
+- Landed canonical Alembic psycopg v3 driver normalization (`guardian/db/migrations/env.py`): driver-neutral `postgresql://` Alembic URLs now resolve to the installed psycopg v3 dialect before SQLAlchemy engine construction, for both the `DATABASE_URL` environment and the `alembic.ini` `sqlalchemy.url` source, while the process-wide `DATABASE_URL` contract is preserved for `seed_defaults.py` and runtime consumers; proven on a disposable Compose project with the canonical migrator and no ephemeral URL override (`docs/architecture/proofs/2026-08-13-alembic-psycopg3-driver-normalization-proof.md`). Migration graph unchanged at a single head `9d4c2a7e1b6f`; no release promise was widened.
 
 ## Current supported reality
 

--- a/docs/architecture/proofs/2026-08-13-alembic-psycopg3-driver-normalization-proof.md
+++ b/docs/architecture/proofs/2026-08-13-alembic-psycopg3-driver-normalization-proof.md
@@ -1,0 +1,265 @@
+# Alembic psycopg3 driver normalization proof
+
+## Result
+
+**GO**
+
+The canonical Codexify migrator now correctly uses the installed psycopg v3
+SQLAlchemy dialect for driver-neutral `postgresql://` URLs. The Alembic
+environment (`guardian/db/migrations/env.py`) normalizes a bare PostgreSQL URL
+to `postgresql+psycopg://` before SQLAlchemy engine construction, for both the
+`DATABASE_URL` environment path and the configured `sqlalchemy.url` path,
+without changing the process-wide `DATABASE_URL` contract, without breaking
+`seed_defaults.py`, without mutating the preserved tester database, and
+without changing the migration graph (still exactly one head:
+`9d4c2a7e1b6f`).
+
+The canonical disposable Compose proof ran with **no ephemeral URL override**:
+the migrator service received the unmodified driver-neutral
+`DATABASE_URL=postgresql://...` from `docker-compose.yml`, exited 0, applied
+all 101 migrations to the single head, and `seed_defaults.py` took its
+Postgres path (default project `General` present). A second run was a no-op.
+
+## Baseline
+
+- Branch: `proof/chroma-startup-isolation`
+- Pre-task HEAD: `653e58f61e54d09c96e78e3b3f7fd4e19f457899`
+- Pre-task tracked worktree: clean
+- Pre-task Alembic head: exactly one — `9d4c2a7e1b6f`
+- Pre-task migration suite `tests/migration`: `111 passed, 29 skipped`
+
+## Regression guard (per task brief)
+
+Inspected at current HEAD:
+
+- `guardian/db/migrations/env.py` — `_get_database_url()` passed the bare
+  `postgresql://` URL straight into `sqlalchemy.url`; **no normalization**.
+- `backend/scripts/docker/run_migrator.py` — pure wrapper around
+  `alembic upgrade heads` + `seed_defaults.py`; no URL handling.
+- `backend/scripts/seed_defaults.py` — connects via raw psycopg v3 (psycopg2
+  fallback), `_is_pg()` accepts only `postgres://`/`postgresql://`; untouched.
+- `docker-compose.yml` — `DATABASE_URL` is driver-neutral
+  `postgresql://${POSTGRES_USER:-codexify}:${POSTGRES_PASSWORD:-codexify}@db:5432/${POSTGRES_DB:-Codexify}`;
+  `GUARDIAN_DATABASE_URL` is the repo's own `postgresql+psycopg://` scheme.
+- Backend runtime dependency declarations —
+  `backend/requirements.txt` (canonical manifest copied into the runtime
+  image) declares `psycopg[binary]>=3.2.10`; the runtime image ships
+  psycopg 3.3.4.
+- Migration tests — no driver-normalization test exists at HEAD.
+  `tests/test_alembic_config_contract.py` (34 lines) covers only
+  `alembic.ini` script_location pathing.
+- Proof artifacts — `2026-08-13-account-observability-migration-compatibility-proof.md`
+  records the migrator driver incompatibility as a separate, pre-existing
+  defect and documents the ephemeral `postgresql+psycopg://` override used
+  for its disposable proofs. `2026-08-13-d6f7a8b9c0d1-compatibility-bridge-proof.md`
+  names the unmerged fix (`cb35d4e80`, branch
+  `codex/alembic-psycopg3-runtime-driver-20260812`, proof
+  `2026-08-12-alembic-psycopg3-driver-normalization-proof.md`).
+
+Historical/unmerged fixes inspected (not blindly cherry-picked):
+
+| Commit | Branch(es) | Shape |
+| --- | --- | --- |
+| `2113b5101` | `codex/2026-08-12-retire-obsolete-chroma-index` | new module `guardian/db/migration_url.py` + env.py wiring + `tests/ops/test_alembic_psycopg_driver_contract.py` |
+| `cb35d4e80` / `4d5649473` / `13d2a28ce` | `codex/alembic-psycopg3-runtime-driver-20260812`, `codex/alembic-psycopg3-abaf-main-20260812`, `codex/alembic-psycopg3-current-main-20260812`, `codex/backend-schema-psycopg3-current-20260812` | new module `guardian/db/migration_driver.py` + env.py wiring + `tests/test_alembic_config_contract.py` (driver-contract variant) |
+
+All are unmerged (`git merge-base --is-ancestor <commit> main` = false; HEAD's
+env.py is unnormalized). None of the helper modules exists at HEAD
+(`guardian/db/migration_url.py`, `guardian/db/migration_driver.py`, and the
+symbol `normalize_alembic_database_url` have zero matches in the tree).
+
+Verdict: **NOT ALREADY SATISFIED** — no criterion of the four holds at HEAD.
+Per the task's authorized-file list, the implementation file is
+`guardian/db/migrations/env.py` only; the historical fix shape (a new shared
+helper module) was therefore NOT recreated here. The normalization lives as
+an env.py-local function; a future extraction into a shared module (for the
+separate backend startup seam) is a distinct, separately authorized task.
+
+## ADR impact
+
+- Classification: `Aligned with existing ADR(s)`
+- Governing ADR(s): none pin a PostgreSQL Python driver. The ADR index
+  (1–65) was inspected; the only "driver" reference is unrelated
+  ("Decision drivers" in ADR-064). ADR-031 (Continuity Phase A Storage
+  Migration Gate) governs storage-migration proof, not SQLAlchemy driver
+  selection.
+- Reason: this task repairs the implementation of the already-accepted
+  Postgres/Alembic runtime contract (`DATABASE_URL` is a Postgres DSN for
+  migrations per `docs/architecture/config-and-ops.md`). It changes no
+  persistence meaning, schema meaning, migration lineage, supported database
+  technology, or upgrade semantics.
+
+## The repaired seam
+
+```text
+external runtime contract
+DATABASE_URL=postgresql://...        (unchanged, driver-neutral)
+
+              |
+              v
+
+guardian/db/migrations/env.py
+normalize_alembic_database_url()     (env.py-local; both URL sources)
+
+              |
+              v
+
+SQLAlchemy URL
+postgresql+psycopg://...             (psycopg v3 dialect)
+
+              |
+              v
+
+installed psycopg v3 (3.3.4 in runtime image)
+```
+
+Implementation (single file, `guardian/db/migrations/env.py`):
+
+- New module-level `normalize_alembic_database_url(url)`:
+  - `postgresql://...` → `postgresql+psycopg://...` (scheme prefix only;
+    every byte after it preserved).
+  - Explicit `postgresql+psycopg://` and `postgresql+psycopg2://` → unchanged.
+  - Any other scheme or non-string input → unchanged.
+- `_get_database_url()` now normalizes both sources — the `DATABASE_URL`
+  environment variable and the `alembic.ini` `sqlalchemy.url` setting — then
+  sets the normalized value via `config.set_main_option("sqlalchemy.url", ...)`
+  and returns it, so offline mode (`context.configure(url=...)`) and online
+  mode (`engine_from_config`) both see the psycopg v3 dialect.
+- `os.environ["DATABASE_URL"]` is never modified: seed/runtime consumers
+  keep the original driver-neutral contract. `seed_defaults.py` (separate
+  process) therefore takes its Postgres path (`_is_pg()` accepts the bare
+  scheme), with no SQLite fallback.
+
+`backend/scripts/docker/run_migrator.py`, `backend/scripts/seed_defaults.py`,
+`docker-compose.yml`, `docker-compose.tester.yml`, `.env.tester`, existing
+migrations, revision identifiers, Hosted Room runtime code, frontend code,
+and ADRs were not modified.
+
+## Focused test
+
+New file: `tests/migration/test_alembic_psycopg3_driver_normalization.py`
+(14 tests, DB-free, no network I/O, no psycopg2 import attempt):
+
+- Pure-function contract: bare URL → `+psycopg` scheme; user/password/host/
+  port/database suffix preserved; query string preserved; percent-encoded
+  credential bytes preserved; explicit `+psycopg` and `+psycopg2` unchanged;
+  non-Postgres scheme unchanged; non-string input unchanged.
+- SQLAlchemy resolution: `make_url` reports drivername `postgresql+psycopg`;
+  `create_engine(..., poolclass=NullPool)` resolves dialect driver `psycopg`
+  without connecting.
+- Environment wiring (env.py executed via `runpy` against a faked offline
+  alembic context): `DATABASE_URL` path normalized into `sqlalchemy.url` and
+  the offline `configure(url=...)`; `alembic.ini` path normalized the same
+  way; explicit `+psycopg` URL passes through; and the process-wide
+  `DATABASE_URL` environment variable remains byte-identical after env.py
+  runs.
+
+Result: `14 passed`.
+
+## Validation
+
+- Focused test: `14 passed`.
+- Full migration suite `tests/migration` + runtime dependency contract
+  (`tests/ops/test_backend_runtime_dependency_contract.py`):
+  `129 passed, 29 skipped` (baseline 111 + 14 new + 4 dep contract;
+  no regressions, no failures).
+- Alembic graph: exactly one head, `9d4c2a7e1b6f` (unchanged).
+- `make docs` (validate_docs.py + check_diagram_freshness.py): pass.
+- `git diff --check`: clean.
+- In-image probe (runtime image built for this proof):
+  - Image: `codexify-backend-runtime:r1p1c-psycopg3-proof` (built from this
+    worktree; the shared `latest` tag was not touched).
+  - Probe result: input `postgresql://probe_user:***@db:5432/Codexify` →
+    normalized `postgresql+psycopg://...`; `env_unchanged: True`;
+    `drivername: postgresql+psycopg`; `dialect.driver: psycopg`;
+    `psycopg_version: 3.3.4`; no connection made.
+- Pre-existing limitation (out of scope, proven pre-existing at HEAD
+  `653e58f61` on a detached worktree): `alembic upgrade --sql` (offline mode)
+  fails on the inspector-based `9d4c2a7e1b6f` migration with
+  `NoInspectionAvailable ... MockConnection`. Offline SQL generation is not
+  part of the canonical migrator path (`run_migrator.py` runs online
+  `upgrade heads`) and the failure reproduces identically without this
+  change.
+
+## Disposable Compose proof (canonical path, no ephemeral override)
+
+- Isolated project: `codexify_r1p1c_psycopg3_proof` (fresh volumes, host
+  ports removed via a `/tmp`-only override; image pointed at the proof tag).
+- The migrator service environment was validated with
+  `docker compose config --format json` BEFORE the run:
+  `DATABASE_URL=postgresql://codexify:***@db:5432/Codexify` — driver-neutral,
+  unchanged from `docker-compose.yml`. No `postgresql+psycopg` override was
+  present anywhere.
+- Run 1 (canonical `run_migrator.py`, exit 0):
+  - `[Migrator] Using Alembic config: /app/backend/alembic.ini`
+  - `alembic --raiseerr -c ... upgrade heads` completed; 101 `Running upgrade`
+    lines (full clean-start chain base → `9d4c2a7e1b6f`).
+  - `[Migrator] Running seed defaults` → `seed_defaults.py` connected via its
+    Postgres path (driver-neutral URL recognized) and completed.
+  - `[Migrator] Done`
+- Post-run verification (psql against the disposable db):
+  - `alembic_version = 9d4c2a7e1b6f` (the single canonical head)
+  - `projects` row present: `1:General` — seeding succeeded on Postgres
+    (the previous ephemeral-override proofs observed the SQLite fallback
+    side effect; with the canonical fix, `_is_pg()` sees the original
+    driver-neutral URL and the seed runs normally).
+- Run 2 (idempotence, exit 0): zero `Running upgrade` lines; seed re-ran
+  idempotently.
+- Teardown: `down -v` on the disposable project only.
+
+## Migration graph and schema
+
+- No migration file was created, rewritten, reordered, squashed, or
+  replaced. Revision identifiers unchanged. Lineage unchanged.
+- Single head `9d4c2a7e1b6f` before and after.
+
+## Preserved tester safety
+
+- The preserved tester database was not started, mounted, written, stamped,
+  upgraded, or deleted. No read-only copy was even needed: the proof is a
+  clean-start disposable database.
+- No container or volume of the preserved `codexify_tester` project was
+  touched; the shared `codexify-backend-runtime:latest` image tag was not
+  rebuilt or modified.
+
+## Release impact
+
+No release-support expansion. This repairs the canonical migrator boot
+prerequisite; it does not widen the supported install path, provider
+posture, or beta surface. The preserved friends/family tester upgrade may
+proceed as its own separately authorized task now that the migrator boot
+prerequisite is closed.
+
+## DLG freshness consequence (expected, separate follow-on)
+
+This task's authorized docs edits (`00-current-state.md` content update and a
+new proof file under `docs/architecture/proofs/`) change the canonical source
+bytes of DLG nodes. `tests/architecture` was verified BEFORE the docs edit at
+pristine HEAD `653e58f61` (both `test_current_nine_node_corpus_validates` and
+`test_validator_cli_runs_without_runtime_services` pass), and fails AFTER the
+edit with `corpus.code = "content_hash_mismatch"` on the `00-current-state.md`
+node. This is the repo's known pattern: DLG freshness reverification is a
+separate task (`architecture-control-plane-freshness-reverification`, variant
+B: recompute `content_hash` + freshness metadata) that lands as its own
+commit — the precedent is commit `4f3b977cf` after the account-observability
+repair. DLG/knowledge-graph files were NOT modified here (not authorized).
+
+The `check_diagram_freshness.py` review-marker warning fires only while the
+docs change is uncommitted (the check diffs HEAD vs the working tree); a
+committed clean tree passes, and CI does not run the freshness script in
+base-ref mode. Per repo precedent, the `Diagram Review Marker:` lines were
+not touched (still dated 2026-08-11).
+
+## Limits and non-goals honored
+
+- No modification to `run_migrator.py`, `seed_defaults.py`,
+  `docker-compose.yml`, `docker-compose.tester.yml`, `.env.tester`, existing
+  migrations, revision identifiers, Hosted Room runtime code, frontend code,
+  or ADRs.
+- No second normalization seam: no new shared helper module was created
+  (the task authorizes `env.py` only); the backend startup schema-verification
+  seam (`run_backend.py`) remains a separate, separately authorized task.
+- No DLG/knowledge-graph edit (freshness reverification after this proof
+  lands is the repo's separate follow-on task).
+- No preserved tester mutation, no manual stamp, no provider inference, no
+  secret material emitted.

--- a/guardian/db/migrations/env.py
+++ b/guardian/db/migrations/env.py
@@ -78,6 +78,36 @@ def _server_default_compare(
     return None  # Use Alembic's default comparison
 
 
+def normalize_alembic_database_url(url: str) -> str:
+    """
+    Normalize a driver-neutral PostgreSQL URL to the canonical psycopg v3
+    SQLAlchemy dialect.
+
+    SQLAlchemy resolves a bare ``postgresql://`` URL through its default
+    PostgreSQL driver selection (psycopg2). Codexify's canonical Postgres
+    driver is psycopg v3 (``psycopg[binary]`` in the backend runtime
+    manifest), so the Alembic environment rewrites the bare scheme to
+    ``postgresql+psycopg://`` before SQLAlchemy engine construction.
+
+    Only the scheme prefix is rewritten; every byte after it is preserved.
+    Explicit driver selections (``postgresql+psycopg://``,
+    ``postgresql+psycopg2://``, ...) are preserved unchanged. The
+    process-wide ``DATABASE_URL`` environment contract is never modified.
+    """
+    if not isinstance(url, str):
+        # Defensive guard: keep downstream errors descriptive rather than
+        # masked by an unexpected coercion.
+        return url
+
+    bare_scheme = "postgresql://"
+    if url.startswith(bare_scheme):
+        return "postgresql+psycopg://" + url[len(bare_scheme):]
+
+    # Explicit driver selections (psycopg, psycopg2, asyncpg, ...) are
+    # preserved exactly. No silent override of an explicitly selected driver.
+    return url
+
+
 def _get_database_url() -> str:
     """
     Get database URL with environment override support.
@@ -85,6 +115,13 @@ def _get_database_url() -> str:
     Priority:
     1. DATABASE_URL environment variable (Docker/prod)
     2. alembic.ini sqlalchemy.url setting (local dev)
+
+    A driver-neutral ``postgresql://`` URL is normalized to the canonical
+    ``postgresql+psycopg://`` SQLAlchemy dialect before engine construction
+    so the resolved DBAPI driver matches the psycopg v3 runtime dependency.
+    Explicit driver selections are preserved unchanged. The ``DATABASE_URL``
+    environment variable itself is never modified, so seed/runtime consumers
+    keep the original external contract.
     """
     env_url = os.getenv("DATABASE_URL")
     if env_url:
@@ -94,9 +131,10 @@ def _get_database_url() -> str:
                 f"Codexify requires Postgres. Got: {env_url[:30]}...\n"
                 f"Set DATABASE_URL to a postgresql:// URL"
             )
+        normalized = normalize_alembic_database_url(env_url)
         logger.info("Using DATABASE_URL from environment")
-        config.set_main_option("sqlalchemy.url", env_url)
-        return env_url
+        config.set_main_option("sqlalchemy.url", normalized)
+        return normalized
 
     url = config.get_main_option("sqlalchemy.url")
     if not url:
@@ -110,7 +148,9 @@ def _get_database_url() -> str:
             f"Codexify requires Postgres. Check alembic.ini: {url[:30]}..."
         )
 
-    return url
+    normalized = normalize_alembic_database_url(url)
+    config.set_main_option("sqlalchemy.url", normalized)
+    return normalized
 
 
 def run_migrations_offline() -> None:

--- a/tests/migration/test_alembic_psycopg3_driver_normalization.py
+++ b/tests/migration/test_alembic_psycopg3_driver_normalization.py
@@ -1,0 +1,336 @@
+"""
+Focused contract tests for Alembic psycopg v3 driver normalization.
+
+The canonical Compose migrator supplies ``DATABASE_URL`` in driver-neutral
+``postgresql://...`` form. SQLAlchemy resolves a bare PostgreSQL URL through
+its default driver selection (psycopg2); Codexify's canonical Postgres driver
+is psycopg v3, so ``guardian/db/migrations/env.py`` normalizes the bare scheme
+to ``postgresql+psycopg://`` before SQLAlchemy engine construction.
+
+These tests are pure unit tests: they do not connect to any database, do not
+perform network I/O, and never touch the preserved tester database. The inert
+sample credentials used here do not correspond to any real service.
+
+Contract covered:
+
+1. A bare ``postgresql://...`` URL normalizes to ``postgresql+psycopg://...``.
+2. Username, password, host, port, database, and query-string bytes are
+   preserved exactly (including percent-encoded characters).
+3. Explicit ``postgresql+psycopg://`` and ``postgresql+psycopg2://`` URLs are
+   preserved unchanged (never silently override an explicit driver choice).
+4. Non-PostgreSQL schemes and non-string inputs pass through unchanged.
+5. SQLAlchemy parses the normalized URL with drivername ``postgresql+psycopg``
+   and instantiates an engine without connecting or importing psycopg2.
+6. The Alembic environment applies normalization for both the ``DATABASE_URL``
+   environment path and the configured ``sqlalchemy.url`` path (offline and
+   online modes share ``_get_database_url()``).
+7. The process-wide ``DATABASE_URL`` environment variable is never modified,
+   preserving the external contract for seed/runtime consumers.
+"""
+
+from __future__ import annotations
+
+import os
+import runpy
+import sys
+from contextlib import nullcontext
+from pathlib import Path
+from types import ModuleType
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine.url import make_url
+from sqlalchemy.pool import NullPool
+
+ENV_PY = (
+    Path(__file__).resolve().parents[2]
+    / "guardian"
+    / "db"
+    / "migrations"
+    / "env.py"
+)
+
+# Inert sample credentials only. Do not correspond to any real service.
+INERT_HOST = "127.0.0.1"
+INERT_PORT = 65535  # unprivileged, high, inert
+INERT_USER = "alembic_contract_user"
+INERT_PASSWORD = "inert-contract-password"
+INERT_DB = "codexify_contract_inert"
+
+BARE_SCHEME = "postgresql://"
+PSYCOPG_SCHEME = "postgresql+psycopg://"
+
+
+def _bare_url() -> str:
+    return (
+        f"{BARE_SCHEME}{INERT_USER}:{INERT_PASSWORD}"
+        f"@{INERT_HOST}:{INERT_PORT}/{INERT_DB}"
+    )
+
+
+# --- Alembic environment execution harness ---------------------------------
+
+
+class FakeConfig:
+    """Minimal stand-in for alembic.config.Config consumed by env.py."""
+
+    config_file_name = None
+    config_ini_section = "alembic"
+
+    def __init__(self, config_url: str | None = None) -> None:
+        self.options: dict[str, str] = (
+            {"sqlalchemy.url": config_url} if config_url else {}
+        )
+
+    def get_main_option(self, name: str) -> str | None:
+        return self.options.get(name)
+
+    def set_main_option(self, name: str, value: str) -> None:
+        self.options[name] = value
+
+    def get_section(self, _name: str, _default: dict) -> dict:
+        return dict(self.options)
+
+
+class FakeAlembicContext:
+    """Offline-mode alembic.context stand-in that records configure() kwargs."""
+
+    def __init__(self, config: FakeConfig) -> None:
+        self.config = config
+        self.configure_options: dict | None = None
+
+    def is_offline_mode(self) -> bool:
+        return True
+
+    def configure(self, **kwargs) -> None:
+        self.configure_options = kwargs
+
+    def begin_transaction(self):
+        return nullcontext()
+
+    def run_migrations(self) -> None:
+        return None
+
+
+def _run_alembic_environment(
+    monkeypatch,
+    *,
+    env_url: str | None = None,
+    config_url: str | None = None,
+):
+    """Execute guardian/db/migrations/env.py with a faked offline alembic module.
+
+    Returns (namespace, fake_context). The module body runs in offline mode
+    against the fake context, so the DATABASE_URL / sqlalchemy.url resolution
+    path is exercised without any database or engine construction.
+    """
+    fake_config = FakeConfig(config_url=config_url)
+    fake_context = FakeAlembicContext(fake_config)
+
+    fake_alembic = ModuleType("alembic")
+    setattr(fake_alembic, "context", fake_context)
+    monkeypatch.setitem(sys.modules, "alembic", fake_alembic)
+
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("GUARDIAN_DATABASE_URL", raising=False)
+    if env_url is not None:
+        monkeypatch.setenv("DATABASE_URL", env_url)
+
+    ns = runpy.run_path(str(ENV_PY))
+    return ns, fake_context
+
+
+def _normalize(monkeypatch, url: str) -> str:
+    """Grab env.py's normalizer from an isolated module execution."""
+    ns, _context = _run_alembic_environment(
+        monkeypatch, config_url=_bare_url()
+    )
+    return ns["normalize_alembic_database_url"](url)
+
+
+# --- Pure function contract ------------------------------------------------
+
+
+def test_bare_postgresql_url_normalizes_to_psycopg3_dialect(monkeypatch) -> None:
+    normalized = _normalize(monkeypatch, _bare_url())
+    expected = f"{PSYCOPG_SCHEME}{_bare_url()[len(BARE_SCHEME):]}"
+    assert normalized == expected
+
+
+def test_normalization_preserves_user_password_host_port_database_suffix(
+    monkeypatch,
+) -> None:
+    """Every byte after the scheme delimiter is preserved exactly."""
+    bare = _bare_url()
+    normalized = _normalize(monkeypatch, bare)
+
+    suffix = bare[len(BARE_SCHEME):]
+    assert normalized.endswith(suffix)
+
+    parsed = make_url(normalized)
+    assert parsed.username == INERT_USER
+    assert parsed.password == INERT_PASSWORD
+    assert parsed.host == INERT_HOST
+    assert parsed.port == INERT_PORT
+    assert parsed.database == INERT_DB
+
+
+def test_normalization_preserves_query_string_suffix(monkeypatch) -> None:
+    """Query-string parameters remain unchanged after normalization."""
+    bare = f"{_bare_url()}?sslmode=disable&application_name=alembic-contract"
+    normalized = _normalize(monkeypatch, bare)
+
+    assert "sslmode=disable" in normalized
+    assert "application_name=alembic-contract" in normalized
+
+    parsed = make_url(normalized)
+    assert parsed.query["sslmode"] == "disable"
+    assert parsed.query["application_name"] == "alembic-contract"
+
+
+def test_normalization_preserves_url_escaped_credential_characters(
+    monkeypatch,
+) -> None:
+    """Percent-encoded characters survive normalization byte-for-byte.
+
+    SQLAlchemy's ``make_url`` decodes percent-encoded characters when parsing,
+    so byte-equality is asserted against the URL string, not parsed fields.
+    """
+    encoded_user = "user%40codexify"
+    encoded_password = "p%3A%2F%2Fword"  # encodes "p://word"
+    bare = (
+        f"{BARE_SCHEME}{encoded_user}:{encoded_password}"
+        f"@{INERT_HOST}:{INERT_PORT}/{INERT_DB}"
+    )
+
+    normalized = _normalize(monkeypatch, bare)
+
+    assert encoded_user in normalized
+    assert encoded_password in normalized
+    assert normalized == f"{PSYCOPG_SCHEME}{bare[len(BARE_SCHEME):]}"
+
+
+def test_explicit_psycopg_url_remains_unchanged(monkeypatch) -> None:
+    """An explicitly selected psycopg 3 URL is returned as-is."""
+    explicit = (
+        f"{PSYCOPG_SCHEME}{INERT_USER}:{INERT_PASSWORD}"
+        f"@{INERT_HOST}:{INERT_PORT}/{INERT_DB}"
+    )
+    assert _normalize(monkeypatch, explicit) == explicit
+
+
+def test_explicit_psycopg2_url_remains_unchanged(monkeypatch) -> None:
+    """An explicitly selected psycopg 2 URL is returned as-is.
+
+    The normalizer must never silently override an explicitly selected driver.
+    """
+    explicit = (
+        f"postgresql+psycopg2://{INERT_USER}:{INERT_PASSWORD}"
+        f"@{INERT_HOST}:{INERT_PORT}/{INERT_DB}"
+    )
+    assert _normalize(monkeypatch, explicit) == explicit
+
+
+def test_non_postgres_scheme_remains_unchanged(monkeypatch) -> None:
+    """Non-PostgreSQL schemes pass through; env.py's own validation rejects them."""
+    sqlite_url = "sqlite:////tmp/example.db"
+    assert _normalize(monkeypatch, sqlite_url) == sqlite_url
+
+
+def test_non_string_input_remains_unchanged(monkeypatch) -> None:
+    """Defensive guard: non-string input passes through unchanged."""
+    assert _normalize(monkeypatch, None) is None  # type: ignore[arg-type]
+
+
+# --- SQLAlchemy dialect resolution -----------------------------------------
+
+
+def test_sqlalchemy_parses_normalized_bare_url_with_psycopg_driver(
+    monkeypatch,
+) -> None:
+    """SQLAlchemy reports ``postgresql+psycopg`` as the drivername."""
+    parsed = make_url(_normalize(monkeypatch, _bare_url()))
+    assert parsed.drivername == "postgresql+psycopg"
+
+
+def test_sqlalchemy_engine_instantiation_uses_psycopg_without_network(
+    monkeypatch,
+) -> None:
+    """create_engine against the inert URL selects the psycopg dialect, no connect.
+
+    NullPool disables connection pooling; the engine is created and disposed
+    without any network I/O against the inert host (no ``connect()`` call).
+    """
+    engine = create_engine(
+        _normalize(monkeypatch, _bare_url()), poolclass=NullPool
+    )
+
+    try:
+        assert engine.dialect.name == "postgresql"
+        assert engine.url.drivername == "postgresql+psycopg"
+        assert "psycopg" in engine.dialect.driver
+    finally:
+        engine.dispose()
+
+
+# --- Alembic environment wiring --------------------------------------------
+
+
+def test_alembic_environment_normalizes_database_url_before_sqlalchemy(
+    monkeypatch,
+) -> None:
+    """DATABASE_URL path: config sqlalchemy.url and offline url are normalized."""
+    plain_url = _bare_url()
+
+    _ns, context = _run_alembic_environment(monkeypatch, env_url=plain_url)
+
+    expected = f"{PSYCOPG_SCHEME}{plain_url[len(BARE_SCHEME):]}"
+    assert context.config.get_main_option("sqlalchemy.url") == expected
+    assert context.configure_options is not None
+    assert context.configure_options["url"] == expected
+
+
+def test_alembic_environment_normalizes_configured_url(monkeypatch) -> None:
+    """alembic.ini sqlalchemy.url path is normalized the same way."""
+    plain_url = f"{_bare_url()}?sslmode=require"
+
+    _ns, context = _run_alembic_environment(
+        monkeypatch, config_url=plain_url
+    )
+
+    expected = f"{PSYCOPG_SCHEME}{plain_url[len(BARE_SCHEME):]}"
+    assert context.config.get_main_option("sqlalchemy.url") == expected
+    assert context.configure_options is not None
+    assert context.configure_options["url"] == expected
+
+
+def test_alembic_environment_preserves_original_database_url_environment(
+    monkeypatch,
+) -> None:
+    """The process-wide DATABASE_URL contract is never modified."""
+    plain_url = _bare_url()
+
+    _ns, context = _run_alembic_environment(monkeypatch, env_url=plain_url)
+
+    assert plain_url.startswith(BARE_SCHEME)
+    assert (
+        context.config.get_main_option("sqlalchemy.url")
+        == f"{PSYCOPG_SCHEME}{plain_url[len(BARE_SCHEME):]}"
+    )
+    # External contract intact: the env var is still the driver-neutral URL.
+    assert os.environ["DATABASE_URL"] == plain_url
+
+
+def test_alembic_environment_passes_explicit_psycopg_url_through(
+    monkeypatch,
+) -> None:
+    """Explicit +psycopg DATABASE_URL reaches SQLAlchemy unchanged."""
+    explicit = (
+        f"{PSYCOPG_SCHEME}{INERT_USER}:{INERT_PASSWORD}"
+        f"@{INERT_HOST}:{INERT_PORT}/{INERT_DB}"
+    )
+
+    _ns, context = _run_alembic_environment(monkeypatch, env_url=explicit)
+
+    assert context.config.get_main_option("sqlalchemy.url") == explicit
+    assert context.configure_options is not None
+    assert context.configure_options["url"] == explicit


### PR DESCRIPTION
## R1P1C — Canonical psycopg3 migrator boot

This replacement PR is intentionally atomic. It contains only the four authorized R1P1C files, recreated from commit `791252aae54b991e2546eadd4fb72e8fd2571528` on a clean branch from current `main` (`cff739d9bdf73c06a08f8095b40a256d203cd72e`).

### Changes
- `guardian/db/migrations/env.py` — normalize driver-neutral `postgresql://` Alembic URLs to `postgresql+psycopg://` without mutating process-wide `DATABASE_URL`.
- `tests/migration/test_alembic_psycopg3_driver_normalization.py` — focused contract coverage.
- `docs/architecture/proofs/2026-08-13-alembic-psycopg3-driver-normalization-proof.md` — GO proof artifact.
- `docs/architecture/00-current-state.md` — narrow current-truth follow-through.

### Proven evidence carried from R1P1C
- Focused normalization tests: 14 passed.
- Full migration suite + runtime dependency contract: 129 passed, 29 skipped.
- Alembic graph remains one head: `9d4c2a7e1b6f`.
- Disposable canonical Compose migrator run succeeded with the ordinary driver-neutral `DATABASE_URL`, no ephemeral psycopg override.
- `seed_defaults.py` stayed on the Postgres path and remained idempotent.
- Preserved tester database was untouched by R1P1C.

### Cleanup note
PR #705 carried three unrelated pre-existing proof files because its source branch was not based directly on current `main`. This PR removes that branch-history contamination; no R1P1C implementation semantics were changed.

No auto-merge.