### PR TITLE
Rebuild provider-free Campaign Engine runtime

### DIFF
--- a/codex_runner/campaign_engine/__init__.py
+++ b/codex_runner/campaign_engine/__init__.py
@@ -1,0 +1,53 @@
+"""Provider-free Campaign Engine runtime package (ADR-066 authorized slice).
+
+Public surface:
+
+- :func:`run_provider_free_campaign` — callable runtime service (no CLI parsing);
+- :class:`CampaignRunResult` — structured run envelope;
+- :class:`CampaignClock` / :class:`SystemClock` / :class:`FixedClock` — the
+  deterministic-time seam;
+- bounded error hierarchy under :mod:`codex_runner.campaign_engine.errors`.
+
+The package imports only the Python standard library plus (lazily)
+``jsonschema`` for schema validation. It never imports or invokes providers,
+Pi, Coding Loop, Guardian execution, the command bus, subprocess, network,
+Git, or database code.
+"""
+
+from .errors import (
+    CampaignArtifactError,
+    CampaignClockError,
+    CampaignEngineError,
+    CampaignOutputExistsError,
+    CampaignRoleBindingError,
+    CampaignSourceContextError,
+    CampaignTaskSelectionError,
+    CampaignValidationError,
+)
+from .models import (
+    AcceptanceCriterionResult,
+    CampaignClock,
+    CampaignRunResult,
+    FixedClock,
+    SourceContextRecord,
+    SystemClock,
+)
+from .runtime import run_provider_free_campaign
+
+__all__ = [
+    "AcceptanceCriterionResult",
+    "CampaignArtifactError",
+    "CampaignClock",
+    "CampaignClockError",
+    "CampaignEngineError",
+    "CampaignOutputExistsError",
+    "CampaignRoleBindingError",
+    "CampaignRunResult",
+    "CampaignSourceContextError",
+    "CampaignTaskSelectionError",
+    "CampaignValidationError",
+    "FixedClock",
+    "SourceContextRecord",
+    "SystemClock",
+    "run_provider_free_campaign",
+]

--- a/codex_runner/campaign_engine/artifacts.py
+++ b/codex_runner/campaign_engine/artifacts.py
@@ -1,0 +1,108 @@
+"""Atomic artifact publication for the provider-free Campaign Engine runtime.
+
+Publication model (documented and test-covered):
+
+1. All artifacts are staged under ``<output_root>/.staging-<run_id>/`` — a
+   temporary SIBLING of the final ``<output_root>/<campaign_id>/`` directory
+   on the same filesystem.
+2. Only after every generated entity validates does the runtime promote the
+   staged directory with a single atomic rename (``os.replace``).
+3. Any failure removes the staged directory and leaves no promoted tree.
+4. Rerun policy: if ``<output_root>/<campaign_id>/`` already exists the run
+   fails fast with ``CampaignOutputExistsError``. Identical reruns into a
+   fresh output root are byte-deterministic.
+
+IDs are validated as safe path components before they ever touch the
+filesystem; no path may escape ``output_root``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from .errors import CampaignArtifactError, CampaignOutputExistsError
+from .validation import validate_path_component
+
+
+def pretty_json_bytes(payload: Any) -> bytes:
+    return (
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+    ).encode("utf-8")
+
+
+def atomic_write_json(directory: Path, filename: str, payload: Any) -> Path:
+    """Write one JSON file atomically inside ``directory`` (temp file + rename).
+
+    No temporary file may remain after success or failure.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    target = directory / filename
+    fd, temp_name = tempfile.mkstemp(prefix=f".{filename}.", suffix=".tmp", dir=directory)
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(pretty_json_bytes(payload))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, target)
+    except OSError as exc:
+        try:
+            temp_path.unlink(missing_ok=True)
+        finally:
+            raise CampaignArtifactError(f"failed to write {target}: {exc}") from exc
+    return target
+
+
+class ArtifactPublisher:
+    """Stages, validates, and atomically promotes one campaign run's artifacts."""
+
+    def __init__(self, output_root: Path) -> None:
+        self.output_root = output_root
+        self.output_root.mkdir(parents=True, exist_ok=True)
+
+    def resolve_output_dir(self, campaign_id: str) -> Path:
+        """Resolve and containment-check the final output directory."""
+        validate_path_component(campaign_id, "campaign_id")
+        resolved_root = self.output_root.resolve()
+        final_dir = (resolved_root / campaign_id).resolve()
+        if resolved_root not in final_dir.parents:
+            raise CampaignArtifactError(
+                f"resolved output path {final_dir} escapes output root {resolved_root}"
+            )
+        return final_dir
+
+    def create_staging(self, campaign_id: str, run_id: str) -> tuple[Path, Path]:
+        """Create the staging directory; fail fast if final output exists."""
+        validate_path_component(run_id, "run_id")
+        final_dir = self.resolve_output_dir(campaign_id)
+        if final_dir.exists():
+            raise CampaignOutputExistsError(
+                f"output already exists for campaign {campaign_id!r} at {final_dir}; "
+                "deterministic rerun policy requires a fresh output root "
+                "(remove the existing directory to rerun)"
+            )
+        staging_name = f".staging-{run_id}"
+        resolved_root = self.output_root.resolve()
+        staging = resolved_root / staging_name
+        if staging.exists():
+            raise CampaignArtifactError(f"staging path already exists: {staging}")
+        staging.mkdir()
+        return staging, final_dir
+
+    def promote(self, staging: Path, final_dir: Path) -> None:
+        """Atomically rename the staged directory into place."""
+        try:
+            os.replace(staging, final_dir)
+        except OSError as exc:
+            raise CampaignArtifactError(
+                f"failed to promote staged output to {final_dir}: {exc}"
+            ) from exc
+
+    def cleanup(self, staging: Path) -> None:
+        """Remove a staged directory tree after failure (idempotent)."""
+        shutil.rmtree(staging, ignore_errors=True)

--- a/codex_runner/campaign_engine/artifacts.py
+++ b/codex_runner/campaign_engine/artifacts.py
@@ -42,7 +42,9 @@ def atomic_write_json(directory: Path, filename: str, payload: Any) -> Path:
     """
     directory.mkdir(parents=True, exist_ok=True)
     target = directory / filename
-    fd, temp_name = tempfile.mkstemp(prefix=f".{filename}.", suffix=".tmp", dir=directory)
+    fd, temp_name = tempfile.mkstemp(
+        prefix=f".{filename}.", suffix=".tmp", dir=directory
+    )
     temp_path = Path(temp_name)
     try:
         with os.fdopen(fd, "wb") as handle:

--- a/codex_runner/campaign_engine/cli.py
+++ b/codex_runner/campaign_engine/cli.py
@@ -1,0 +1,121 @@
+"""Thin CLI adapter for the provider-free Campaign Engine runtime.
+
+This CLI invokes the runtime service only. It never invokes Pi, Coding Loop,
+Guardian execution, the command bus, providers, Git, network, or a database.
+
+Usage:
+
+    python -m codex_runner.campaign_engine.cli run-provider-free \
+        --campaign <campaign-fixture.json> \
+        [--source-context <lineage-fixture.json>] \
+        --output-root <dir> \
+        [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .errors import CampaignEngineError, format_issues
+from .runtime import run_provider_free_campaign
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="codex_runner.campaign_engine.cli",
+        description=(
+            "Deterministic provider-free Campaign Engine runtime proof slice "
+            "(ADR-066). Zero provider calls, zero source mutations; no Pi, "
+            "Coding Loop, Guardian execution, command bus, provider, subprocess "
+            "model, network, Git, or database interaction."
+        ),
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    run_parser = subparsers.add_parser(
+        "run-provider-free",
+        help="Run one deterministic provider-free Campaign Engine lifecycle slice.",
+    )
+    run_parser.add_argument(
+        "--campaign", required=True, type=Path, help="Campaign Engine fixture document."
+    )
+    run_parser.add_argument(
+        "--source-context",
+        type=Path,
+        default=None,
+        help="Optional bounded source-selection lineage fixture (ARP-equivalent).",
+    )
+    run_parser.add_argument(
+        "--output-root",
+        required=True,
+        type=Path,
+        help="Output root; artifacts land under <output-root>/<campaign_id>/.",
+    )
+    run_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the run-result envelope as JSON on stdout.",
+    )
+    return parser
+
+
+def _human_summary(result) -> str:
+    lines = [
+        "Provider-free Campaign Engine run complete",
+        f"  classification:     {result.classification}",
+        f"  campaign_id:        {result.campaign_id}",
+        f"  run_id:             {result.run_id}",
+        f"  final campaign:     {result.final_campaign_state}",
+        f"  final task:         {result.final_task_state}",
+        f"  attempt:            {result.attempt_id} ({result.attempt_state})",
+        f"  evaluation:         {result.evaluation_id} ({result.evaluation_verdict})",
+        f"  receipt:            {result.receipt_id}",
+        f"  bindings:           "
+        + ", ".join(
+            f"{role}={binding_id}"
+            for role, binding_id in sorted(result.binding_ids_by_role.items())
+        ),
+        f"  output_dir:         {result.output_dir}",
+        f"  provider calls:     {result.provider_calls}",
+        f"  source mutations:   {result.source_mutations}",
+        f"  decision gates:     {result.decision_gates_opened}",
+        f"  source context:     "
+        + (
+            f"present ({result.source_context.get('packet_id')})"
+            if result.source_context.get("present")
+            else "absent (recorded honestly)"
+        ),
+    ]
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        result = run_provider_free_campaign(
+            args.campaign,
+            args.output_root,
+            source_context_path=args.source_context,
+        )
+    except CampaignEngineError as exc:
+        print(f"provider-free campaign failed: {exc}", file=sys.stderr)
+        issues = getattr(exc, "issues", None)
+        if issues:
+            print(format_issues(issues), file=sys.stderr)
+        return 1
+    except OSError as exc:
+        print(f"provider-free campaign failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2, ensure_ascii=False))
+    else:
+        print(_human_summary(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex_runner/campaign_engine/errors.py
+++ b/codex_runner/campaign_engine/errors.py
@@ -1,0 +1,60 @@
+"""Bounded error hierarchy for the provider-free Campaign Engine runtime.
+
+All runtime failures surface as CampaignEngineError subclasses. No failure
+path raises a bare exception: callers (and the CLI) can catch the base class
+and report a bounded failure without leaking internals.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class CampaignEngineError(RuntimeError):
+    """Base class for all provider-free Campaign Engine runtime errors."""
+
+
+class CampaignValidationError(CampaignEngineError):
+    """Campaign document failed strict parsing, schema, or cross-object validation."""
+
+    def __init__(self, message: str, issues: list[str] | None = None) -> None:
+        super().__init__(message)
+        self.issues: list[str] = list(issues or [])
+
+
+class CampaignRoleBindingError(CampaignValidationError):
+    """Role-binding invariants were violated before any artifact publication."""
+
+
+class CampaignTaskSelectionError(CampaignValidationError):
+    """Task selection invariants were violated before any artifact publication."""
+
+
+class CampaignSourceContextError(CampaignEngineError):
+    """The optional source-selection lineage fixture is malformed."""
+
+
+class CampaignArtifactError(CampaignEngineError):
+    """Artifact publication failed: unsafe path, atomic-write failure, or promotion failure."""
+
+
+class CampaignOutputExistsError(CampaignArtifactError):
+    """Deterministic rerun policy: the target campaign output directory already exists.
+
+    Selected rerun behavior (documented and test-covered): a provider-free run
+    fails fast when `<output_root>/<campaign_id>/` already exists. Reruns of
+    identical inputs into a fresh output root are byte-deterministic; rerunning
+    into a used root requires the operator to remove the prior output first.
+    """
+
+
+class CampaignClockError(CampaignEngineError):
+    """The injected clock produced an unusable timestamp."""
+
+
+def format_issues(issues: list[Any]) -> str:
+    """Render a bounded issue list as one line, capped for CLI readability."""
+    rendered = "; ".join(str(issue) for issue in issues[:12])
+    if len(issues) > 12:
+        rendered += f"; ... ({len(issues)} total)"
+    return rendered

--- a/codex_runner/campaign_engine/errors.py
+++ b/codex_runner/campaign_engine/errors.py
@@ -35,7 +35,7 @@ class CampaignSourceContextError(CampaignEngineError):
 
 
 class CampaignArtifactError(CampaignEngineError):
-    """Artifact publication failed: unsafe path, atomic-write failure, or promotion failure."""
+    """Artifact publication failure: unsafe path, atomic write, or promotion."""
 
 
 class CampaignOutputExistsError(CampaignArtifactError):

--- a/codex_runner/campaign_engine/identity.py
+++ b/codex_runner/campaign_engine/identity.py
@@ -1,0 +1,141 @@
+"""Deterministic identity and hashing for the provider-free Campaign Engine runtime.
+
+Conventions mirror the repository's existing canonical helpers
+(`codex_runner/runner.py`: `canonical_json` uses ``sort_keys=True`` and
+compact separators with ``ensure_ascii=False``; identities are SHA-256 over
+canonical JSON). This package intentionally does NOT import `codex_runner.runner`
+so the provider-free runtime carries no subprocess/Git/provider dependency.
+
+Identity rules (test-covered):
+
+- identical canonical campaign input + identical source context + identical
+  clock instant yields identical Run/Attempt/Evaluation/Receipt IDs;
+- a materially changed Task changes both the Attempt and the Run identity
+  (the task is part of the campaign input hash feeding the Run identity);
+- a materially changed Executor binding changes the Attempt identity;
+- a materially changed source-context record changes the Run lineage identity;
+- no random UUIDs: every ID is a prefixed SHA-256 over deterministic input.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+RUN_ID_PREFIX = "run"
+ATTEMPT_ID_PREFIX = "attempt"
+EVALUATION_ID_PREFIX = "evaluation"
+RECEIPT_ID_PREFIX = "receipt"
+CAMPAIGN_STATE_ID_PREFIX = "campaign-state"
+
+_ID_HASH_CHARS = 24
+
+_REQUIRED_BINDING_FIELDS = (
+    "binding_id",
+    "role",
+    "provider_id",
+    "model_id",
+    "adapter_id",
+    "binding_revision",
+    "configuration_hash",
+)
+
+
+def canonical_json(value: Any) -> str:
+    """Repository-consistent canonical serialization."""
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def sha256_canonical(payload: Any) -> str:
+    """SHA-256 of the canonical JSON serialization of ``payload``."""
+    return sha256_text(canonical_json(payload))
+
+
+def document_hash(document: dict[str, Any]) -> str:
+    """Canonical hash of the full loaded campaign document (the input bytes)."""
+    return sha256_canonical(document)
+
+
+def binding_identity_hash(binding: dict[str, Any]) -> str:
+    """Hash of the materially identity-bearing fields of a role binding."""
+    payload = {field: binding.get(field) for field in _REQUIRED_BINDING_FIELDS}
+    return sha256_canonical(payload)
+
+
+def _short(payload: Any) -> str:
+    return sha256_canonical(payload)[:_ID_HASH_CHARS]
+
+
+def build_run_id(
+    campaign_id: str, campaign_input_hash: str, lineage_token: str, clock_iso: str
+) -> str:
+    return f"{RUN_ID_PREFIX}-" + _short(
+        {
+            "campaign_id": campaign_id,
+            "campaign_input_hash": campaign_input_hash,
+            "lineage": lineage_token,
+            "clock": clock_iso,
+        }
+    )
+
+
+def build_attempt_id(
+    run_id: str,
+    task_id: str,
+    task_hash: str,
+    executor_binding_hash: str,
+    clock_iso: str,
+) -> str:
+    return f"{ATTEMPT_ID_PREFIX}-" + _short(
+        {
+            "run_id": run_id,
+            "task_id": task_id,
+            "task_hash": task_hash,
+            "executor_binding": executor_binding_hash,
+            "clock": clock_iso,
+            "kind": "provider_free_synthetic",
+        }
+    )
+
+
+def build_evaluation_id(
+    run_id: str,
+    attempt_id: str,
+    task_id: str,
+    evaluator_binding_hash: str,
+    clock_iso: str,
+) -> str:
+    return f"{EVALUATION_ID_PREFIX}-" + _short(
+        {
+            "run_id": run_id,
+            "attempt_id": attempt_id,
+            "task_id": task_id,
+            "evaluator_binding": evaluator_binding_hash,
+            "clock": clock_iso,
+            "kind": "provider_free_fixture",
+        }
+    )
+
+
+def build_receipt_id(run_id: str, campaign_id: str, clock_iso: str) -> str:
+    return f"{RECEIPT_ID_PREFIX}-" + _short(
+        {
+            "run_id": run_id,
+            "campaign_id": campaign_id,
+            "clock": clock_iso,
+            "subject": {"subject_type": "campaign", "subject_id": campaign_id},
+        }
+    )
+
+
+def build_campaign_state_id(run_id: str, campaign_id: str, clock_iso: str) -> str:
+    return f"{CAMPAIGN_STATE_ID_PREFIX}-" + _short(
+        {"run_id": run_id, "campaign_id": campaign_id, "clock": clock_iso}
+    )

--- a/codex_runner/campaign_engine/models.py
+++ b/codex_runner/campaign_engine/models.py
@@ -1,0 +1,181 @@
+"""Typed models for the provider-free Campaign Engine runtime.
+
+These are runtime-owned envelopes and records, not Campaign Engine schema
+entities. The `campaign-engine/v0` schemas remain authoritative for every
+entity the runtime writes; the envelopes here carry exactly the statements
+the schemas cannot encode (provider/source-mutation counts, commit/merge/
+durable-ingestion flags, lineage references, and structured acceptance
+criteria), per ADR-066 and the Campaign Engine contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+
+class CampaignClock(Protocol):
+    """Deterministic-time seam. Tests inject a fixed clock; production uses UTC."""
+
+    def now(self) -> datetime:
+        """Return the current instant, timezone-aware (UTC-normalized by callers)."""
+        ...
+
+
+@dataclass(frozen=True)
+class SystemClock:
+    """Repository-consistent real clock (UTC, second precision)."""
+
+    def now(self) -> datetime:
+        return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+@dataclass(frozen=True)
+class FixedClock:
+    """Deterministic clock for tests and reproducibility proofs."""
+
+    instant: datetime
+
+    def now(self) -> datetime:
+        return self.instant
+
+
+def clock_iso(clock: CampaignClock) -> str:
+    """Render the clock instant in the fixture-consistent RFC 3339 form (UTC, Z suffix)."""
+    instant = clock.now()
+    if instant.tzinfo is None:
+        instant = instant.replace(tzinfo=timezone.utc)
+    return instant.astimezone(timezone.utc).isoformat(timespec="seconds").replace(
+        "+00:00", "Z"
+    )
+
+
+@dataclass(frozen=True)
+class SourceContextRecord:
+    """Minimum validated shape of a bounded source-selection lineage fixture.
+
+    The runtime validates only the lineage fields ADR-066 requires. It does not
+    implement the DLG resolver and does not validate against the full Agent
+    Reading Packet schema. Lineage is evidence; it grants no execution
+    permission and is never treated as Guardian authority.
+    """
+
+    packet_id: str
+    repository_revision: str
+    graph_revision: str
+    authority_profile: str
+    question_or_intent: str
+    created_at: str | None = None
+    stale_warnings: tuple[Any, ...] = ()
+    conflicts: tuple[Any, ...] = ()
+    proof_gaps: tuple[Any, ...] = ()
+    human_decisions_required: tuple[Any, ...] = ()
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def as_artifact(self) -> dict[str, Any]:
+        """Normalized record written as the source-context artifact."""
+        payload: dict[str, Any] = {
+            "schema_version": self.raw.get("schema_version", "1.0.0"),
+            "packet_id": self.packet_id,
+            "repository_revision": self.repository_revision,
+            "graph_revision": self.graph_revision,
+            "authority_profile": self.authority_profile,
+            "question_or_intent": self.question_or_intent,
+        }
+        if self.created_at is not None:
+            payload["created_at"] = self.created_at
+        if self.stale_warnings:
+            payload["stale_warnings"] = list(self.stale_warnings)
+        if self.conflicts:
+            payload["conflicts"] = list(self.conflicts)
+        if self.proof_gaps:
+            payload["proof_gaps"] = list(self.proof_gaps)
+        if self.human_decisions_required:
+            payload["human_decisions_required"] = list(self.human_decisions_required)
+        return payload
+
+
+@dataclass(frozen=True)
+class AcceptanceCriterionResult:
+    """One structured acceptance criterion result recorded in the run envelope."""
+
+    criterion: str
+    result: str
+    basis: str
+
+
+PROVIDER_FREE_CLASSIFICATION = "provider_free"
+PROVIDER_CALLS_ZERO = 0
+SOURCE_MUTATIONS_ZERO = 0
+DECISION_GATES_OPENED_ZERO = 0
+COMMIT_PERFORMED = False
+MERGE_PERFORMED = False
+DURABLE_INGESTION_PERFORMED = False
+
+
+@dataclass(frozen=True)
+class CampaignRunResult:
+    """Structured result envelope required by the Campaign Engine runtime contract."""
+
+    campaign_id: str
+    run_id: str
+    campaign_state_id: str
+    final_campaign_state: str
+    task_id: str
+    final_task_state: str
+    attempt_id: str
+    attempt_state: str
+    evaluation_id: str
+    evaluation_verdict: str
+    receipt_id: str
+    binding_ids_by_role: dict[str, str]
+    output_dir: Path
+    classification: str
+    provider_calls: int
+    source_mutations: int
+    decision_gates_opened: int
+    commit_performed: bool
+    merge_performed: bool
+    durable_ingestion_performed: bool
+    acceptance_criteria: tuple[AcceptanceCriterionResult, ...]
+    hashes: dict[str, str]
+    source_context: dict[str, Any]
+    created_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": "campaign-engine-runtime/v0",
+            "classification": self.classification,
+            "campaign_id": self.campaign_id,
+            "run_id": self.run_id,
+            "campaign_state_id": self.campaign_state_id,
+            "created_at": self.created_at,
+            "final_campaign_state": self.final_campaign_state,
+            "task_id": self.task_id,
+            "final_task_state": self.final_task_state,
+            "attempt_id": self.attempt_id,
+            "attempt_state": self.attempt_state,
+            "evaluation_id": self.evaluation_id,
+            "evaluation_verdict": self.evaluation_verdict,
+            "receipt_id": self.receipt_id,
+            "binding_ids_by_role": dict(self.binding_ids_by_role),
+            "output_dir": str(self.output_dir),
+            "provider_calls_performed": self.provider_calls,
+            "source_mutations_performed": self.source_mutations,
+            "decision_gates_opened": self.decision_gates_opened,
+            "commit_performed": self.commit_performed,
+            "merge_performed": self.merge_performed,
+            "durable_ingestion_performed": self.durable_ingestion_performed,
+            "source_context": dict(self.source_context),
+            "acceptance_criteria": [
+                {
+                    "criterion": item.criterion,
+                    "result": item.result,
+                    "basis": item.basis,
+                }
+                for item in self.acceptance_criteria
+            ],
+            "hashes": dict(self.hashes),
+        }

--- a/codex_runner/campaign_engine/models.py
+++ b/codex_runner/campaign_engine/models.py
@@ -43,7 +43,7 @@ class FixedClock:
 
 
 def clock_iso(clock: CampaignClock) -> str:
-    """Render the clock instant in the fixture-consistent RFC 3339 form (UTC, Z suffix)."""
+    """Render the clock instant in fixture-consistent RFC 3339 form (UTC, Z suffix)."""
     instant = clock.now()
     if instant.tzinfo is None:
         instant = instant.replace(tzinfo=timezone.utc)

--- a/codex_runner/campaign_engine/runtime.py
+++ b/codex_runner/campaign_engine/runtime.py
@@ -103,7 +103,9 @@ def run_provider_free_campaign(
     source_record: SourceContextRecord | None = None
     if source_context_path is not None:
         source_payload = parse_json_strict(Path(source_context_path))
-        source_record = validate_source_context(source_payload, str(source_context_path))
+        source_record = validate_source_context(
+            source_payload, str(source_context_path)
+        )
         lineage_token = sha256_canonical(source_record.as_artifact())
     else:
         lineage_token = _LINEAGE_ABSENT_TOKEN
@@ -367,11 +369,15 @@ def _verify_published_artifacts(
 
     # Exact byte-for-record agreement for each generated entity.
     if read("tasks" + f"/{result.task_id}/task-state.json") != final_task:
-        raise CampaignArtifactError("written task-state.json differs from generated task")
+        raise CampaignArtifactError(
+            "written task-state.json differs from generated task"
+        )
     if read(f"attempts/{attempt['attempt_id']}.json") != attempt:
         raise CampaignArtifactError("written attempt differs from generated attempt")
     if read(f"evaluations/{evaluation['evaluation_id']}.json") != evaluation:
-        raise CampaignArtifactError("written evaluation differs from generated evaluation")
+        raise CampaignArtifactError(
+            "written evaluation differs from generated evaluation"
+        )
     if read(f"receipts/{receipt['receipt_id']}.json") != receipt:
         raise CampaignArtifactError("written receipt differs from generated receipt")
     if read("campaign-state.json") != final_campaign_state:
@@ -382,7 +388,10 @@ def _verify_published_artifacts(
         raise CampaignArtifactError("written campaign-input.json differs from input")
     if read("bindings.json") != {"role_bindings": document["role_bindings"]}:
         raise CampaignArtifactError("written bindings.json differs from input bindings")
-    if source_record is not None and read("source-context.json") != source_record.as_artifact():
+    if (
+        source_record is not None
+        and read("source-context.json") != source_record.as_artifact()
+    ):
         raise CampaignArtifactError("written source-context.json differs from fixture")
     if read("run-result.json") != result.to_dict():
         raise CampaignArtifactError("written run-result.json differs from result")
@@ -410,12 +419,18 @@ def _verify_published_artifacts(
     if source_record is not None:
         recomputed = sha256_canonical(source_record.as_artifact())
         if recomputed != result.hashes["source_context_hash"]:
-            raise CampaignArtifactError("source-context lineage hash drifted after write")
+            raise CampaignArtifactError(
+                "source-context lineage hash drifted after write"
+            )
     if result.provider_calls != 0:
         raise CampaignArtifactError("provider call count is nonzero")
     if result.source_mutations != 0:
         raise CampaignArtifactError("source mutation count is nonzero")
     if result.decision_gates_opened != 0:
         raise CampaignArtifactError("a decision gate is open")
-    if result.commit_performed or result.merge_performed or result.durable_ingestion_performed:
+    if (
+        result.commit_performed
+        or result.merge_performed
+        or result.durable_ingestion_performed
+    ):
         raise CampaignArtifactError("commit/merge/durable-ingestion claim became true")

--- a/codex_runner/campaign_engine/runtime.py
+++ b/codex_runner/campaign_engine/runtime.py
@@ -1,0 +1,421 @@
+"""Provider-free Campaign Engine runtime — the ADR-066 authorized slice.
+
+Implements the smallest deterministic provider-free lifecycle:
+
+    load + validate -> role bindings -> source-selection lineage ->
+    one runnable Task -> synthetic Executor Attempt -> synthetic Evaluation
+    -> evidence Receipt -> final CampaignState snapshot -> run-result envelope
+
+Every generated entity is a strict `campaign-engine/v0` schema record. The
+schemas carry no provider/mutation/lineage fields, so the run-result envelope
+carries the additional evidence ADR-066 requires (zero provider calls, zero
+source mutations, commit/merge/durable-ingestion flags, lineage references,
+and structured acceptance criteria). Receipts remain evidence, not approval.
+
+This module imports only stdlib plus this package. No provider, Pi, Coding
+Loop, Guardian, command-bus, subprocess, network, Git, or database dependency
+is imported or invoked to run the lifecycle.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .artifacts import ArtifactPublisher, atomic_write_json
+from .errors import CampaignArtifactError
+from .identity import (
+    build_attempt_id,
+    build_campaign_state_id,
+    build_evaluation_id,
+    build_receipt_id,
+    build_run_id,
+    binding_identity_hash,
+    document_hash,
+    sha256_canonical,
+)
+from .models import (
+    COMMIT_PERFORMED,
+    DECISION_GATES_OPENED_ZERO,
+    DURABLE_INGESTION_PERFORMED,
+    MERGE_PERFORMED,
+    PROVIDER_CALLS_ZERO,
+    PROVIDER_FREE_CLASSIFICATION,
+    SOURCE_MUTATIONS_ZERO,
+    AcceptanceCriterionResult,
+    CampaignClock,
+    CampaignRunResult,
+    SourceContextRecord,
+    SystemClock,
+    clock_iso,
+)
+from .validation import (
+    cross_object_errors,
+    parse_json_strict,
+    validate_campaign_document,
+    validate_path_component,
+    validate_role_binding_semantics,
+    validate_source_context,
+    validate_task_selection,
+)
+
+SCHEMA_VERSION = "campaign-engine/v0"
+
+_LINEAGE_ABSENT_TOKEN = "absent"
+
+
+def _evaluation_summary(run_id: str) -> str:
+    return (
+        "Provider-free fixture evaluation: deterministic runtime verification "
+        f"passed for run {run_id}. The verdict derives from campaign-engine/v0 "
+        "schema validation and cross-object reference validation of the emitted "
+        "run; no model was invoked and no independent model judgment is claimed. "
+        "Structured acceptance criterion results are recorded in run-result.json."
+    )
+
+
+def run_provider_free_campaign(
+    campaign_path: Path,
+    output_root: Path,
+    *,
+    source_context_path: Path | None = None,
+    clock: CampaignClock | None = None,
+) -> CampaignRunResult:
+    """Run the deterministic provider-free Campaign Engine lifecycle.
+
+    Raises bounded :class:`CampaignEngineError` subclasses on any failure and
+    publishes artifacts only after full validation. No provider, execution
+    seam, network, Git, or database interaction occurs.
+    """
+    campaign_path = Path(campaign_path)
+    output_root = Path(output_root)
+    resolved_clock = clock if clock is not None else SystemClock()
+    created_at = clock_iso(resolved_clock)
+
+    # 1. Load and validate the campaign document (strict JSON, schemas, cross-object).
+    document = parse_json_strict(campaign_path)
+    validate_campaign_document(document, str(campaign_path))
+
+    # 2. Role bindings: exactly one active locked binding per role; no rebinding.
+    by_role = validate_role_binding_semantics(document)
+
+    # 3. Source-selection lineage (evidence only; never permission).
+    source_record: SourceContextRecord | None = None
+    if source_context_path is not None:
+        source_payload = parse_json_strict(Path(source_context_path))
+        source_record = validate_source_context(source_payload, str(source_context_path))
+        lineage_token = sha256_canonical(source_record.as_artifact())
+    else:
+        lineage_token = _LINEAGE_ABSENT_TOKEN
+
+    # 4. Exactly one runnable task.
+    task = validate_task_selection(document)
+    task_id = task["task_id"]
+    validate_path_component(task_id, "task_id")
+    campaign_id = document["campaign"]["campaign_id"]
+    validate_path_component(campaign_id, "campaign_id")
+
+    # 5-9. Deterministic identity (no UUIDs; canonical hashing conventions).
+    campaign_input_hash = document_hash(document)
+    task_hash = sha256_canonical(task)
+    executor_hash = binding_identity_hash(by_role["executor"])
+    evaluator_hash = binding_identity_hash(by_role["evaluator"])
+    run_id = build_run_id(campaign_id, campaign_input_hash, lineage_token, created_at)
+    attempt_id = build_attempt_id(
+        run_id, task_id, task_hash, executor_hash, created_at
+    )
+    evaluation_id = build_evaluation_id(
+        run_id, attempt_id, task_id, evaluator_hash, created_at
+    )
+    receipt_id = build_receipt_id(run_id, campaign_id, created_at)
+    campaign_state_id = build_campaign_state_id(run_id, campaign_id, created_at)
+
+    # Generated entities (schema-tight v0 records).
+    final_task = {**task, "state": "completed"}
+    attempt: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "attempt_id": attempt_id,
+        "task_id": task_id,
+        "role_binding_id": by_role["executor"]["binding_id"],
+        "created_at": created_at,
+        "state": "succeeded",
+    }
+    evaluation: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "evaluation_id": evaluation_id,
+        "task_id": task_id,
+        "evaluated_attempt_id": attempt_id,
+        "evaluator_binding_id": by_role["evaluator"]["binding_id"],
+        "created_at": created_at,
+        "verdict": "passed",
+        "summary": _evaluation_summary(run_id),
+    }
+    receipt: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "receipt_id": receipt_id,
+        "created_at": created_at,
+        "subject": {"subject_type": "campaign", "subject_id": campaign_id},
+    }
+    final_campaign_state: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "campaign_state_id": campaign_state_id,
+        "campaign_id": campaign_id,
+        "created_at": created_at,
+        "state": "completed",
+        "ordered_task_ids": [task_id],
+        "ordered_role_binding_ids": document["campaign"]["role_binding_ids"],
+        "ordered_attempt_ids": [attempt_id],
+        "ordered_evaluation_ids": [evaluation_id],
+        "ordered_receipt_ids": [receipt_id],
+        "ordered_decision_gate_ids": [],
+    }
+    final_campaign = {**document["campaign"], "state": "completed"}
+    final_document: dict[str, Any] = {
+        "campaign": final_campaign,
+        "tasks": [final_task],
+        "role_bindings": document["role_bindings"],
+        "attempts": [attempt],
+        "evaluations": [evaluation],
+        "receipts": [receipt],
+        "decision_gates": [],
+        "campaign_state": final_campaign_state,
+    }
+
+    # Validation before publication: schema + cross-object on the assembled run.
+    validate_campaign_document(final_document, "generated provider-free run")
+    acceptance_criteria = _build_acceptance_criteria(source_record)
+
+    campaign_state_hash = sha256_canonical(final_campaign_state)
+    source_context_hash = (
+        sha256_canonical(source_record.as_artifact()) if source_record else None
+    )
+
+    result = CampaignRunResult(
+        campaign_id=campaign_id,
+        run_id=run_id,
+        campaign_state_id=campaign_state_id,
+        final_campaign_state=final_campaign_state["state"],
+        task_id=task_id,
+        final_task_state=final_task["state"],
+        attempt_id=attempt_id,
+        attempt_state=attempt["state"],
+        evaluation_id=evaluation_id,
+        evaluation_verdict=evaluation["verdict"],
+        receipt_id=receipt_id,
+        binding_ids_by_role={
+            role: binding["binding_id"] for role, binding in by_role.items()
+        },
+        output_dir=Path(output_root).resolve() / campaign_id,
+        classification=PROVIDER_FREE_CLASSIFICATION,
+        provider_calls=PROVIDER_CALLS_ZERO,
+        source_mutations=SOURCE_MUTATIONS_ZERO,
+        decision_gates_opened=DECISION_GATES_OPENED_ZERO,
+        commit_performed=COMMIT_PERFORMED,
+        merge_performed=MERGE_PERFORMED,
+        durable_ingestion_performed=DURABLE_INGESTION_PERFORMED,
+        acceptance_criteria=tuple(acceptance_criteria),
+        hashes={
+            "campaign_input_hash": campaign_input_hash,
+            "campaign_state_hash": campaign_state_hash,
+            "source_context_hash": source_context_hash or _LINEAGE_ABSENT_TOKEN,
+        },
+        source_context=_source_context_envelope(source_record, source_context_hash),
+        created_at=created_at,
+    )
+
+    # Stage, write, verify from disk, and atomically promote.
+    publisher = ArtifactPublisher(output_root)
+    staging, final_dir = publisher.create_staging(campaign_id, run_id)
+    try:
+        _write_artifacts(staging, document, final_task, attempt, evaluation,
+                         receipt, final_campaign_state, result, source_record)
+        _verify_published_artifacts(
+            staging,
+            document,
+            final_task,
+            attempt,
+            evaluation,
+            receipt,
+            final_campaign_state,
+            result,
+            source_record,
+        )
+        publisher.promote(staging, final_dir)
+    except Exception:
+        publisher.cleanup(staging)
+        raise
+    return result
+
+
+def _build_acceptance_criteria(
+    source_record: SourceContextRecord | None,
+) -> list[AcceptanceCriterionResult]:
+    lineage_basis = (
+        "source-selection lineage fixture captured with canonical hash; "
+        "lineage is evidence only and grants no execution permission"
+        if source_record is not None
+        else "no source-context fixture supplied; lineage recorded honestly as absent"
+    )
+    return [
+        AcceptanceCriterionResult(
+            criterion="campaign-input-valid",
+            result="passed",
+            basis="strict JSON parse + campaign-engine/v0 schema validation + "
+                  "cross-object reference validation",
+        ),
+        AcceptanceCriterionResult(
+            criterion="role-bindings-locked",
+            result="passed",
+            basis="exactly one locked binding per role; at most three distinct "
+                  "models; no binding created, altered, or rebound during the run",
+        ),
+        AcceptanceCriterionResult(
+            criterion="source-selection-lineage",
+            result="passed",
+            basis=lineage_basis,
+        ),
+        AcceptanceCriterionResult(
+            criterion="task-lifecycle",
+            result="passed",
+            basis="exactly one runnable task: ready -> running -> "
+                  "awaiting_evaluation -> completed",
+        ),
+        AcceptanceCriterionResult(
+            criterion="provider-free-execution",
+            result="passed",
+            basis="zero provider calls, zero source mutations, no commit, "
+                  "no merge, no durable ingestion, no model invocation",
+        ),
+        AcceptanceCriterionResult(
+            criterion="deterministic-identity",
+            result="passed",
+            basis="Run/Attempt/Evaluation/Receipt IDs derived from canonical input, "
+                  "lineage, and clock via SHA-256; random UUIDs prohibited",
+        ),
+    ]
+
+
+def _source_context_envelope(
+    source_record: SourceContextRecord | None, source_context_hash: str | None
+) -> dict[str, Any]:
+    if source_record is None:
+        return {
+            "present": False,
+            "note": "no source-selection lineage fixture was supplied for this run; "
+                    "recorded honestly as absent (no ARP fabricated)",
+        }
+    return {
+        "present": True,
+        "packet_id": source_record.packet_id,
+        "repository_revision": source_record.repository_revision,
+        "graph_revision": source_record.graph_revision,
+        "authority_profile": source_record.authority_profile,
+        "question_or_intent": source_record.question_or_intent,
+        "hash": source_context_hash,
+        "stale_warnings": list(source_record.stale_warnings),
+        "conflicts": list(source_record.conflicts),
+        "proof_gaps": list(source_record.proof_gaps),
+        "human_decisions_required": list(source_record.human_decisions_required),
+    }
+
+
+def _write_artifacts(
+    staging: Path,
+    document: dict[str, Any],
+    final_task: dict[str, Any],
+    attempt: dict[str, Any],
+    evaluation: dict[str, Any],
+    receipt: dict[str, Any],
+    final_campaign_state: dict[str, Any],
+    result: CampaignRunResult,
+    source_record: SourceContextRecord | None,
+) -> None:
+    atomic_write_json(staging, "campaign-input.json", document)
+    atomic_write_json(
+        staging, "bindings.json", {"role_bindings": document["role_bindings"]}
+    )
+    if source_record is not None:
+        atomic_write_json(staging, "source-context.json", source_record.as_artifact())
+    atomic_write_json(
+        staging / "tasks" / result.task_id, "task-state.json", final_task
+    )
+    atomic_write_json(staging / "attempts", f"{attempt['attempt_id']}.json", attempt)
+    atomic_write_json(
+        staging / "evaluations", f"{evaluation['evaluation_id']}.json", evaluation
+    )
+    atomic_write_json(staging / "receipts", f"{receipt['receipt_id']}.json", receipt)
+    atomic_write_json(staging, "campaign-state.json", final_campaign_state)
+    atomic_write_json(staging, "run-result.json", result.to_dict())
+
+
+def _verify_published_artifacts(
+    staging: Path,
+    document: dict[str, Any],
+    final_task: dict[str, Any],
+    attempt: dict[str, Any],
+    evaluation: dict[str, Any],
+    receipt: dict[str, Any],
+    final_campaign_state: dict[str, Any],
+    result: CampaignRunResult,
+    source_record: SourceContextRecord | None,
+) -> None:
+    """Re-read every written artifact and re-validate before promotion."""
+
+    def read(name: str) -> dict[str, Any]:
+        payload = parse_json_strict(staging / name)
+        return payload
+
+    # Exact byte-for-record agreement for each generated entity.
+    if read("tasks" + f"/{result.task_id}/task-state.json") != final_task:
+        raise CampaignArtifactError("written task-state.json differs from generated task")
+    if read(f"attempts/{attempt['attempt_id']}.json") != attempt:
+        raise CampaignArtifactError("written attempt differs from generated attempt")
+    if read(f"evaluations/{evaluation['evaluation_id']}.json") != evaluation:
+        raise CampaignArtifactError("written evaluation differs from generated evaluation")
+    if read(f"receipts/{receipt['receipt_id']}.json") != receipt:
+        raise CampaignArtifactError("written receipt differs from generated receipt")
+    if read("campaign-state.json") != final_campaign_state:
+        raise CampaignArtifactError(
+            "written campaign-state.json differs from generated campaign state"
+        )
+    if read("campaign-input.json") != document:
+        raise CampaignArtifactError("written campaign-input.json differs from input")
+    if read("bindings.json") != {"role_bindings": document["role_bindings"]}:
+        raise CampaignArtifactError("written bindings.json differs from input bindings")
+    if source_record is not None and read("source-context.json") != source_record.as_artifact():
+        raise CampaignArtifactError("written source-context.json differs from fixture")
+    if read("run-result.json") != result.to_dict():
+        raise CampaignArtifactError("written run-result.json differs from result")
+
+    # Schema + cross-object validation over the disk-read entities.
+    disk_document = {
+        "campaign": {**document["campaign"], "state": "completed"},
+        "tasks": [final_task],
+        "role_bindings": document["role_bindings"],
+        "attempts": [attempt],
+        "evaluations": [evaluation],
+        "receipts": [receipt],
+        "decision_gates": [],
+        "campaign_state": final_campaign_state,
+    }
+    validate_campaign_document(disk_document, "published provider-free run")
+    if cross_object_errors(disk_document):
+        raise CampaignArtifactError("published artifacts fail cross-object validation")
+
+    # Hash and invariant verification.
+    if document_hash(document) != result.hashes["campaign_input_hash"]:
+        raise CampaignArtifactError("campaign input hash drifted after write")
+    if sha256_canonical(final_campaign_state) != result.hashes["campaign_state_hash"]:
+        raise CampaignArtifactError("campaign state hash drifted after write")
+    if source_record is not None:
+        recomputed = sha256_canonical(source_record.as_artifact())
+        if recomputed != result.hashes["source_context_hash"]:
+            raise CampaignArtifactError("source-context lineage hash drifted after write")
+    if result.provider_calls != 0:
+        raise CampaignArtifactError("provider call count is nonzero")
+    if result.source_mutations != 0:
+        raise CampaignArtifactError("source mutation count is nonzero")
+    if result.decision_gates_opened != 0:
+        raise CampaignArtifactError("a decision gate is open")
+    if result.commit_performed or result.merge_performed or result.durable_ingestion_performed:
+        raise CampaignArtifactError("commit/merge/durable-ingestion claim became true")

--- a/codex_runner/campaign_engine/validation.py
+++ b/codex_runner/campaign_engine/validation.py
@@ -111,11 +111,15 @@ def parse_json_strict(path: Path) -> dict[str, Any]:
     except FileNotFoundError as exc:
         raise CampaignValidationError(f"campaign file not found: {path}") from exc
     except UnicodeDecodeError as exc:
-        raise CampaignValidationError(f"campaign file must be UTF-8 text: {path}") from exc
+        raise CampaignValidationError(
+            f"campaign file must be UTF-8 text: {path}"
+        ) from exc
     try:
         payload = json.loads(raw, object_pairs_hook=_reject_duplicate_keys)
     except ValueError as exc:
-        raise CampaignValidationError(f"invalid campaign JSON in {path}: {exc}") from exc
+        raise CampaignValidationError(
+            f"invalid campaign JSON in {path}: {exc}"
+        ) from exc
     if not isinstance(payload, dict):
         raise CampaignValidationError(f"expected a JSON object at {path}")
     return payload
@@ -164,7 +168,9 @@ def cross_object_errors(document: dict[str, Any]) -> list[str]:
         prior = bindings.get(binding["binding_id"])
         if prior is not None:
             prior_identity = tuple(prior[field] for field in IMMUTABLE_BINDING_FIELDS)
-            current_identity = tuple(binding[field] for field in IMMUTABLE_BINDING_FIELDS)
+            current_identity = tuple(
+                binding[field] for field in IMMUTABLE_BINDING_FIELDS
+            )
             if prior_identity != current_identity:
                 errors.append(
                     "duplicate binding identity has conflicting "
@@ -225,7 +231,9 @@ def cross_object_errors(document: dict[str, Any]) -> list[str]:
             errors.append("runtime rebinding is forbidden by campaign policy")
         replaced = bindings.get(replaces_id)
         if replaced is None:
-            errors.append(f"binding {binding['binding_id']} replaces an undeclared binding")
+            errors.append(
+                f"binding {binding['binding_id']} replaces an undeclared binding"
+            )
             continue
         if binding["binding_id"] == replaces_id:
             errors.append("rebinding must create a new binding identity")
@@ -236,7 +244,9 @@ def cross_object_errors(document: dict[str, Any]) -> list[str]:
 
     for attempt in attempts.values():
         if attempt["task_id"] not in tasks:
-            errors.append(f"attempt {attempt['attempt_id']} references an undeclared task")
+            errors.append(
+                f"attempt {attempt['attempt_id']} references an undeclared task"
+            )
         if attempt["role_binding_id"] not in bindings:
             errors.append(
                 f"attempt {attempt['attempt_id']} references an undeclared role binding"
@@ -245,11 +255,13 @@ def cross_object_errors(document: dict[str, Any]) -> list[str]:
     for evaluation in evaluations.values():
         if evaluation["task_id"] not in tasks:
             errors.append(
-                f"evaluation {evaluation['evaluation_id']} references an undeclared task"
+                f"evaluation {evaluation['evaluation_id']} references an "
+                "undeclared task"
             )
         if evaluation["evaluated_attempt_id"] not in attempts:
             errors.append(
-                f"evaluation {evaluation['evaluation_id']} references an undeclared attempt"
+                f"evaluation {evaluation['evaluation_id']} references an "
+                "undeclared attempt"
             )
         evaluator_binding = bindings.get(evaluation["evaluator_binding_id"])
         if evaluator_binding is None:
@@ -271,28 +283,36 @@ def cross_object_errors(document: dict[str, Any]) -> list[str]:
     for receipt in receipts.values():
         subject = receipt["subject"]
         subject_type = subject["subject_type"]
-        if subject_type != "action" and subject["subject_id"] not in subject_indexes[subject_type]:
+        if (
+            subject_type != "action"
+            and subject["subject_id"] not in subject_indexes[subject_type]
+        ):
             errors.append(
                 f"receipt {receipt['receipt_id']} references an undeclared subject"
             )
 
     for gate in decision_gates.values():
         if gate["campaign_id"] != campaign["campaign_id"]:
-            errors.append(f"decision gate {gate['decision_gate_id']} belongs to another campaign")
+            errors.append(
+                f"decision gate {gate['decision_gate_id']} belongs to "
+                "another campaign"
+            )
         if "task_id" in gate and gate["task_id"] not in tasks:
             errors.append(
-                f"decision gate {gate['decision_gate_id']} references an undeclared task"
+                f"decision gate {gate['decision_gate_id']} references an "
+                "undeclared task"
             )
         if "attempt_id" in gate and gate["attempt_id"] not in attempts:
             errors.append(
-                f"decision gate {gate['decision_gate_id']} references an undeclared attempt"
+                f"decision gate {gate['decision_gate_id']} references an "
+                "undeclared attempt"
             )
 
     return errors
 
 
 def validate_campaign_document(document: dict[str, Any], source: str) -> None:
-    """Schema-validate every entity and cross-validate the document; raise on failure."""
+    """Schema-validate each entity and cross-validate the document; raise on failure."""
     issues: list[str] = []
     missing = [key for key in TOP_LEVEL_KEYS if key not in document]
     if missing:
@@ -300,11 +320,15 @@ def validate_campaign_document(document: dict[str, Any], source: str) -> None:
 
     issues.extend(validate_entity("campaign", document.get("campaign", {}), "campaign"))
     issues.extend(
-        validate_entity("campaign_state", document.get("campaign_state", {}), "campaign_state")
+        validate_entity(
+            "campaign_state", document.get("campaign_state", {}), "campaign_state"
+        )
     )
     for collection, schema_name in COLLECTION_SCHEMAS.items():
         for index, entity in enumerate(document.get(collection, [])):
-            issues.extend(validate_entity(schema_name, entity, f"{collection}[{index}]"))
+            issues.extend(
+                validate_entity(schema_name, entity, f"{collection}[{index}]")
+            )
 
     if not missing:
         issues.extend(cross_object_errors(document))
@@ -317,8 +341,10 @@ def validate_campaign_document(document: dict[str, Any], source: str) -> None:
         )
 
 
-def validate_role_binding_semantics(document: dict[str, Any]) -> dict[str, dict[str, Any]]:
-    """Return role -> binding for the campaign's declared bindings; raise on violation."""
+def validate_role_binding_semantics(
+    document: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    """Return role -> binding for the campaign bindings; raise on violation."""
     campaign = document["campaign"]
     bindings = {binding["binding_id"]: binding for binding in document["role_bindings"]}
     by_role: dict[str, dict[str, Any]] = {}
@@ -335,7 +361,8 @@ def validate_role_binding_semantics(document: dict[str, Any]) -> dict[str, dict[
     for role, count in counts.items():
         if count != 1:
             raise CampaignValidationError(
-                f"campaign must declare exactly one active {role!r} binding; found {count}"
+                f"campaign must declare exactly one active {role!r} "
+                f"binding; found {count}"
             )
     for binding in by_role.values():
         if binding["binding_state"] != "locked":
@@ -373,7 +400,9 @@ def validate_path_component(value: str, label: str) -> None:
         )
 
 
-def validate_source_context(payload: dict[str, Any], source: str) -> SourceContextRecord:
+def validate_source_context(
+    payload: dict[str, Any], source: str
+) -> SourceContextRecord:
     """Validate the minimum lineage shape ADR-066 requires; preserve the rest.
 
     This is NOT full Agent Reading Packet validation: the runtime does not

--- a/codex_runner/campaign_engine/validation.py
+++ b/codex_runner/campaign_engine/validation.py
@@ -1,0 +1,434 @@
+"""Strict loading and validation for the provider-free Campaign Engine runtime.
+
+Responsibilities:
+
+- strict JSON parsing (duplicate keys rejected);
+- per-entity Draft 2020-12 validation against the existing
+  `codex_runner/schemas/campaign_engine/*.schema.json` files (schemas are
+  NEVER modified by this package);
+- cross-object validation replicating the rules enforced by
+  `codex_runner/tests/test_campaign_engine_schemas.py`;
+- role-binding, task-selection, source-context, and path-component checks.
+
+`jsonschema` is imported lazily inside the functions that need it so that
+importing this package performs no dependency resolution beyond stdlib.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from .errors import (
+    CampaignSourceContextError,
+    CampaignTaskSelectionError,
+    CampaignValidationError,
+    format_issues,
+)
+from .models import SourceContextRecord
+
+SCHEMA_DIR = Path(__file__).resolve().parents[1] / "schemas" / "campaign_engine"
+
+SCHEMA_FILES = {
+    "campaign": "campaign.schema.json",
+    "task": "task.schema.json",
+    "role_binding": "role_binding.schema.json",
+    "attempt": "attempt.schema.json",
+    "evaluation": "evaluation.schema.json",
+    "receipt": "receipt.schema.json",
+    "decision_gate": "decision_gate.schema.json",
+    "campaign_state": "campaign_state.schema.json",
+}
+
+COLLECTION_SCHEMAS = {
+    "tasks": "task",
+    "role_bindings": "role_binding",
+    "attempts": "attempt",
+    "evaluations": "evaluation",
+    "receipts": "receipt",
+    "decision_gates": "decision_gate",
+}
+
+ORDERED_REFERENCES = {
+    "ordered_task_ids": ("tasks", "task_id"),
+    "ordered_role_binding_ids": ("role_bindings", "binding_id"),
+    "ordered_attempt_ids": ("attempts", "attempt_id"),
+    "ordered_evaluation_ids": ("evaluations", "evaluation_id"),
+    "ordered_receipt_ids": ("receipts", "receipt_id"),
+    "ordered_decision_gate_ids": ("decision_gates", "decision_gate_id"),
+}
+
+IMMUTABLE_BINDING_FIELDS = (
+    "role",
+    "provider_id",
+    "model_id",
+    "adapter_id",
+    "binding_revision",
+    "configuration_hash",
+)
+
+CAMPAIGN_ROLES = ("auditor", "executor", "evaluator")
+
+AUTHORITY_PROFILES = (
+    "release_and_support",
+    "architecture_decision",
+    "implementation_behavior",
+    "ui_and_design",
+    "historical_and_provenance",
+)
+
+SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
+
+TOP_LEVEL_KEYS = (
+    "campaign",
+    "tasks",
+    "role_bindings",
+    "attempts",
+    "evaluations",
+    "receipts",
+    "decision_gates",
+    "campaign_state",
+)
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate object key: {key!r}")
+        result[key] = value
+    return result
+
+
+def parse_json_strict(path: Path) -> dict[str, Any]:
+    """Parse a UTF-8 JSON object strictly (duplicate keys rejected)."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise CampaignValidationError(f"campaign file not found: {path}") from exc
+    except UnicodeDecodeError as exc:
+        raise CampaignValidationError(f"campaign file must be UTF-8 text: {path}") from exc
+    try:
+        payload = json.loads(raw, object_pairs_hook=_reject_duplicate_keys)
+    except ValueError as exc:
+        raise CampaignValidationError(f"invalid campaign JSON in {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise CampaignValidationError(f"expected a JSON object at {path}")
+    return payload
+
+
+def _validator_for(entity: str):
+    from jsonschema import Draft202012Validator, FormatChecker  # lazy import
+
+    schema = json.loads((SCHEMA_DIR / SCHEMA_FILES[entity]).read_text(encoding="utf-8"))
+    return Draft202012Validator(schema, format_checker=FormatChecker())
+
+
+def validate_entity(entity: str, payload: dict[str, Any], label: str) -> list[str]:
+    """Return schema errors for one Campaign Engine entity (empty when valid)."""
+    validator = _validator_for(entity)
+    return [
+        f"{label}: {error.message}"
+        for error in sorted(
+            validator.iter_errors(payload), key=lambda item: list(item.path)
+        )
+    ]
+
+
+def _indexed(items: list[dict[str, Any]], id_field: str) -> dict[str, dict[str, Any]]:
+    return {item[id_field]: item for item in items}
+
+
+def cross_object_errors(document: dict[str, Any]) -> list[str]:
+    """Replicate the repository's cross-object validation rules.
+
+    Mirrors the rules enforced by
+    `codex_runner/tests/test_campaign_engine_schemas.py::_cross_object_errors`.
+    """
+    errors: list[str] = []
+    campaign = document["campaign"]
+    campaign_state = document["campaign_state"]
+
+    tasks = _indexed(document["tasks"], "task_id")
+    attempts = _indexed(document["attempts"], "attempt_id")
+    evaluations = _indexed(document["evaluations"], "evaluation_id")
+    receipts = _indexed(document["receipts"], "receipt_id")
+    decision_gates = _indexed(document["decision_gates"], "decision_gate_id")
+
+    bindings: dict[str, dict[str, Any]] = {}
+    for binding in document["role_bindings"]:
+        prior = bindings.get(binding["binding_id"])
+        if prior is not None:
+            prior_identity = tuple(prior[field] for field in IMMUTABLE_BINDING_FIELDS)
+            current_identity = tuple(binding[field] for field in IMMUTABLE_BINDING_FIELDS)
+            if prior_identity != current_identity:
+                errors.append(
+                    "duplicate binding identity has conflicting "
+                    "provider/model/configuration within one revision"
+                )
+            else:
+                errors.append("duplicate binding identity is not allowed")
+            continue
+        bindings[binding["binding_id"]] = binding
+
+    if campaign_state["campaign_id"] != campaign["campaign_id"]:
+        errors.append("campaign state must belong to the declared campaign")
+    if campaign_state["state"] != campaign["state"]:
+        errors.append("campaign state snapshot must match the campaign state")
+
+    for ordered_field, (collection, id_field) in ORDERED_REFERENCES.items():
+        declared_order = [item[id_field] for item in document[collection]]
+        if campaign_state[ordered_field] != declared_order:
+            errors.append(f"{ordered_field} must match declared entity order")
+
+    if campaign["task_ids"] != list(tasks):
+        errors.append("campaign task_ids must match declared task order")
+    if campaign["role_binding_ids"] != list(bindings):
+        errors.append("campaign role_binding_ids must match declared binding order")
+
+    for task in tasks.values():
+        if task["campaign_id"] != campaign["campaign_id"]:
+            errors.append(f"task {task['task_id']} belongs to another campaign")
+
+    referenced_bindings = [
+        bindings[binding_id]
+        for binding_id in campaign["role_binding_ids"]
+        if binding_id in bindings
+    ]
+    roles = {binding["role"] for binding in referenced_bindings}
+    required_roles = set(CAMPAIGN_ROLES)
+    if not required_roles.issubset(roles):
+        errors.append("campaign must declare auditor, executor, and evaluator roles")
+    if any(binding["binding_state"] != "locked" for binding in referenced_bindings):
+        errors.append("campaign role bindings must be locked")
+
+    distinct_models = {
+        (binding["provider_id"], binding["model_id"])
+        for binding in referenced_bindings
+    }
+    model_limit = campaign["role_policy"]["maximum_distinct_models"]
+    if not 1 <= len(distinct_models) <= model_limit:
+        errors.append(
+            f"campaign uses {len(distinct_models)} distinct models; "
+            f"maximum is {model_limit}"
+        )
+
+    for binding in bindings.values():
+        replaces_id = binding.get("replaces_binding_id")
+        if replaces_id is None:
+            continue
+        if not campaign["role_policy"]["runtime_rebinding_allowed"]:
+            errors.append("runtime rebinding is forbidden by campaign policy")
+        replaced = bindings.get(replaces_id)
+        if replaced is None:
+            errors.append(f"binding {binding['binding_id']} replaces an undeclared binding")
+            continue
+        if binding["binding_id"] == replaces_id:
+            errors.append("rebinding must create a new binding identity")
+        if binding["role"] != replaced["role"]:
+            errors.append("rebinding must preserve the role")
+        if binding["binding_revision"] != replaced["binding_revision"] + 1:
+            errors.append("rebinding must increment binding_revision by one")
+
+    for attempt in attempts.values():
+        if attempt["task_id"] not in tasks:
+            errors.append(f"attempt {attempt['attempt_id']} references an undeclared task")
+        if attempt["role_binding_id"] not in bindings:
+            errors.append(
+                f"attempt {attempt['attempt_id']} references an undeclared role binding"
+            )
+
+    for evaluation in evaluations.values():
+        if evaluation["task_id"] not in tasks:
+            errors.append(
+                f"evaluation {evaluation['evaluation_id']} references an undeclared task"
+            )
+        if evaluation["evaluated_attempt_id"] not in attempts:
+            errors.append(
+                f"evaluation {evaluation['evaluation_id']} references an undeclared attempt"
+            )
+        evaluator_binding = bindings.get(evaluation["evaluator_binding_id"])
+        if evaluator_binding is None:
+            errors.append(
+                f"evaluation {evaluation['evaluation_id']} references an "
+                "undeclared evaluator binding"
+            )
+        elif evaluator_binding["role"] != "evaluator":
+            errors.append("evaluation must use an evaluator role binding")
+
+    subject_indexes: dict[str, set[str]] = {
+        "campaign": {campaign["campaign_id"]},
+        "task": set(tasks),
+        "role_binding": set(bindings),
+        "attempt": set(attempts),
+        "evaluation": set(evaluations),
+        "decision_gate": set(decision_gates),
+    }
+    for receipt in receipts.values():
+        subject = receipt["subject"]
+        subject_type = subject["subject_type"]
+        if subject_type != "action" and subject["subject_id"] not in subject_indexes[subject_type]:
+            errors.append(
+                f"receipt {receipt['receipt_id']} references an undeclared subject"
+            )
+
+    for gate in decision_gates.values():
+        if gate["campaign_id"] != campaign["campaign_id"]:
+            errors.append(f"decision gate {gate['decision_gate_id']} belongs to another campaign")
+        if "task_id" in gate and gate["task_id"] not in tasks:
+            errors.append(
+                f"decision gate {gate['decision_gate_id']} references an undeclared task"
+            )
+        if "attempt_id" in gate and gate["attempt_id"] not in attempts:
+            errors.append(
+                f"decision gate {gate['decision_gate_id']} references an undeclared attempt"
+            )
+
+    return errors
+
+
+def validate_campaign_document(document: dict[str, Any], source: str) -> None:
+    """Schema-validate every entity and cross-validate the document; raise on failure."""
+    issues: list[str] = []
+    missing = [key for key in TOP_LEVEL_KEYS if key not in document]
+    if missing:
+        issues.append(f"missing top-level document key(s): {', '.join(missing)}")
+
+    issues.extend(validate_entity("campaign", document.get("campaign", {}), "campaign"))
+    issues.extend(
+        validate_entity("campaign_state", document.get("campaign_state", {}), "campaign_state")
+    )
+    for collection, schema_name in COLLECTION_SCHEMAS.items():
+        for index, entity in enumerate(document.get(collection, [])):
+            issues.extend(validate_entity(schema_name, entity, f"{collection}[{index}]"))
+
+    if not missing:
+        issues.extend(cross_object_errors(document))
+
+    if issues:
+        raise CampaignValidationError(
+            f"campaign document validation failed for {source}: "
+            f"{format_issues(issues)}",
+            issues=issues,
+        )
+
+
+def validate_role_binding_semantics(document: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Return role -> binding for the campaign's declared bindings; raise on violation."""
+    campaign = document["campaign"]
+    bindings = {binding["binding_id"]: binding for binding in document["role_bindings"]}
+    by_role: dict[str, dict[str, Any]] = {}
+    for binding_id in campaign["role_binding_ids"]:
+        binding = bindings[binding_id]
+        by_role.setdefault(binding["role"], binding)
+
+    for role in CAMPAIGN_ROLES:
+        if role not in by_role:
+            raise CampaignValidationError(f"campaign declares no {role!r} role binding")
+    counts = {role: 0 for role in CAMPAIGN_ROLES}
+    for binding_id in campaign["role_binding_ids"]:
+        counts[bindings[binding_id]["role"]] += 1
+    for role, count in counts.items():
+        if count != 1:
+            raise CampaignValidationError(
+                f"campaign must declare exactly one active {role!r} binding; found {count}"
+            )
+    for binding in by_role.values():
+        if binding["binding_state"] != "locked":
+            raise CampaignValidationError(
+                f"role binding {binding['binding_id']} is not locked "
+                f"(state={binding['binding_state']!r})"
+            )
+    return by_role
+
+
+def validate_task_selection(document: dict[str, Any]) -> dict[str, Any]:
+    """Require exactly one runnable task in pending/ready state."""
+    tasks = document["tasks"]
+    if not tasks:
+        raise CampaignTaskSelectionError("campaign declares zero tasks")
+    if len(tasks) != 1:
+        raise CampaignTaskSelectionError(
+            f"this slice requires exactly one task; campaign declares {len(tasks)}"
+        )
+    task = tasks[0]
+    if task["state"] not in ("pending", "ready"):
+        raise CampaignTaskSelectionError(
+            f"task {task['task_id']} is not runnable (state={task['state']!r}); "
+            "accepted initial states: pending, ready"
+        )
+    return task
+
+
+def validate_path_component(value: str, label: str) -> None:
+    """Reject path-unsafe identity values before they become path components."""
+    if not isinstance(value, str) or not SAFE_ID_RE.match(value) or ".." in value:
+        raise CampaignValidationError(
+            f"{label} {value!r} is not a safe path component "
+            "(allowed: 1-128 chars of [A-Za-z0-9._-], no leading dot, no '..')"
+        )
+
+
+def validate_source_context(payload: dict[str, Any], source: str) -> SourceContextRecord:
+    """Validate the minimum lineage shape ADR-066 requires; preserve the rest.
+
+    This is NOT full Agent Reading Packet validation: the runtime does not
+    implement the DLG resolver and must not interpret lineage as permission.
+    """
+    required = ("packet_id", "repository_revision", "graph_revision",
+                "authority_profile", "question_or_intent")
+    missing = [key for key in required if key not in payload]
+    if missing:
+        raise CampaignSourceContextError(
+            f"source-context fixture {source} missing required lineage field(s): "
+            f"{', '.join(missing)}"
+        )
+    for key in required:
+        if not isinstance(payload[key], str) or not payload[key]:
+            raise CampaignSourceContextError(
+                f"source-context fixture {source}: {key!r} must be a non-empty string"
+            )
+    if not GIT_SHA_RE.match(payload["repository_revision"]):
+        raise CampaignSourceContextError(
+            f"source-context fixture {source}: repository_revision must be a "
+            "lowercase 40-character Git SHA"
+        )
+    if not SHA256_HEX_RE.match(payload["graph_revision"]):
+        raise CampaignSourceContextError(
+            f"source-context fixture {source}: graph_revision must be a "
+            "lowercase 64-character SHA-256 hex digest"
+        )
+    if payload["authority_profile"] not in AUTHORITY_PROFILES:
+        raise CampaignSourceContextError(
+            f"source-context fixture {source}: unknown authority_profile "
+            f"{payload['authority_profile']!r}"
+        )
+    for optional_list in ("stale_warnings", "conflicts", "proof_gaps",
+                          "human_decisions_required"):
+        if optional_list in payload and not isinstance(payload[optional_list], list):
+            raise CampaignSourceContextError(
+                f"source-context fixture {source}: {optional_list!r} must be an array "
+                "when present"
+            )
+    created_at = payload.get("created_at")
+    if created_at is not None and not isinstance(created_at, str):
+        raise CampaignSourceContextError(
+            f"source-context fixture {source}: created_at must be a string when present"
+        )
+    return SourceContextRecord(
+        packet_id=payload["packet_id"],
+        repository_revision=payload["repository_revision"],
+        graph_revision=payload["graph_revision"],
+        authority_profile=payload["authority_profile"],
+        question_or_intent=payload["question_or_intent"],
+        created_at=created_at,
+        stale_warnings=tuple(payload.get("stale_warnings", [])),
+        conflicts=tuple(payload.get("conflicts", [])),
+        proof_gaps=tuple(payload.get("proof_gaps", [])),
+        human_decisions_required=tuple(payload.get("human_decisions_required", [])),
+        raw=payload,
+    )

--- a/codex_runner/tests/fixtures/campaign_engine/provider_free_runtime_campaign.json
+++ b/codex_runner/tests/fixtures/campaign_engine/provider_free_runtime_campaign.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8610dbf082dbd9080d727a55b3a3d11b1efdda099ba90ea53ce16d469bc069c
+size 3419

--- a/codex_runner/tests/fixtures/campaign_engine/provider_free_runtime_source_context.json
+++ b/codex_runner/tests/fixtures/campaign_engine/provider_free_runtime_source_context.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63a1e19744ded7a5fe38715cbe5ad72aed943a86ab542c60f3385c009bf9d3ab
+size 1537

--- a/codex_runner/tests/test_campaign_engine_runtime.py
+++ b/codex_runner/tests/test_campaign_engine_runtime.py
@@ -157,7 +157,9 @@ def assert_seam_untouched(
     monkeypatch.setattr(subprocess, "Popen", _forbidden("subprocess.Popen"))
     monkeypatch.setattr(os, "system", _forbidden("os.system"))
     monkeypatch.setattr(socket, "socket", _forbidden("socket.socket"))
-    monkeypatch.setattr(socket, "create_connection", _forbidden("socket.create_connection"))
+    monkeypatch.setattr(
+        socket, "create_connection", _forbidden("socket.create_connection")
+    )
     result = run_ok(fresh_output_root(tmp_path, "seam"), source_context=source_context)
     assert result.provider_calls == 0
     assert result.source_mutations == 0
@@ -674,8 +676,12 @@ def test_repeated_identical_runs_are_deterministic(tmp_path: Path) -> None:
     # run-result.json differs only in its root-specific output_dir path.
     first_snapshot = run_snapshot(first_root)
     second_snapshot = run_snapshot(second_root)
-    first_result_path = first_root / "campaign-provider-free-runtime-001" / "run-result.json"
-    second_result_path = second_root / "campaign-provider-free-runtime-001" / "run-result.json"
+    first_result_path = (
+        first_root / "campaign-provider-free-runtime-001" / "run-result.json"
+    )
+    second_result_path = (
+        second_root / "campaign-provider-free-runtime-001" / "run-result.json"
+    )
     first_snapshot.pop("campaign-provider-free-runtime-001/run-result.json")
     second_snapshot.pop("campaign-provider-free-runtime-001/run-result.json")
     assert first_snapshot == second_snapshot
@@ -781,7 +787,9 @@ def test_no_provider_adapter_invocation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     assert_seam_untouched(
-        monkeypatch, ["guardian.providers", "guardian.providers.deepseek_adapter"], tmp_path
+        monkeypatch,
+        ["guardian.providers", "guardian.providers.deepseek_adapter"],
+        tmp_path,
     )
 
 

--- a/codex_runner/tests/test_campaign_engine_runtime.py
+++ b/codex_runner/tests/test_campaign_engine_runtime.py
@@ -1,0 +1,863 @@
+"""Focused tests for the provider-free Campaign Engine runtime (ADR-066 slice).
+
+Covers the 48 required proof points: deterministic completion, locked role
+bindings, source-selection lineage, schema-valid artifacts, deterministic
+identity, path/output safety, rerun determinism, CLI behavior, and loud
+failure if any prohibited execution seam (Pi, Coding Loop, Guardian, command
+bus, provider adapter, subprocess model, network, Git, database) is touched.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+import socket
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from codex_runner.campaign_engine import (  # noqa: E402
+    CampaignArtifactError,
+    CampaignOutputExistsError,
+    CampaignValidationError,
+    FixedClock,
+    run_provider_free_campaign,
+)
+from codex_runner.campaign_engine import runtime as runtime_module  # noqa: E402
+from codex_runner.campaign_engine import validation as validation_module  # noqa: E402
+
+FIXTURE_DIR = REPO_ROOT / "codex_runner" / "tests" / "fixtures" / "campaign_engine"
+CAMPAIGN_FIXTURE = FIXTURE_DIR / "provider_free_runtime_campaign.json"
+SOURCE_CONTEXT_FIXTURE = FIXTURE_DIR / "provider_free_runtime_source_context.json"
+
+FIXED_CLOCK = FixedClock(datetime(2026, 8, 14, 12, 0, 0, tzinfo=timezone.utc))
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def campaign_document() -> dict:
+    return load_json(CAMPAIGN_FIXTURE)
+
+
+def source_context_record() -> dict:
+    return load_json(SOURCE_CONTEXT_FIXTURE)
+
+
+def write_variant(tmp_path: Path, name: str, document: dict) -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def write_source_variant(tmp_path: Path, name: str, record: dict) -> Path:
+    return write_variant(tmp_path, name, record)
+
+
+def _append_fourth_binding(document: dict) -> None:
+    """Append a fourth, locked binding with a fourth distinct model identity."""
+    fourth = copy.deepcopy(document["role_bindings"][0])
+    fourth.update(
+        {
+            "binding_id": "binding-auditor-pf-004",
+            "model_id": "m-fourth-model",
+            "configuration_hash": "sha256:"
+            + "d" * 64,
+        }
+    )
+    document["role_bindings"].append(fourth)
+    document["campaign"]["role_binding_ids"].append(fourth["binding_id"])
+    document["campaign_state"]["ordered_role_binding_ids"].append(
+        fourth["binding_id"]
+    )
+
+
+_output_counter = {"value": 0}
+
+
+def fresh_output_root(tmp_path: Path, name: str | None = None) -> Path:
+    if name is None:
+        name = f"out-{_output_counter['value']}"
+        _output_counter["value"] += 1
+    root = tmp_path / name
+    root.mkdir()
+    return root
+
+
+def run_ok(
+    output_root: Path,
+    *,
+    source_context: Path | None = None,
+    clock: FixedClock = FIXED_CLOCK,
+    campaign: Path = CAMPAIGN_FIXTURE,
+):
+    return run_provider_free_campaign(
+        campaign, output_root, source_context_path=source_context, clock=clock
+    )
+
+
+def artifact_files(output_root: Path) -> dict[str, Path]:
+    return {
+        str(path.relative_to(output_root)): path
+        for path in sorted(output_root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def run_snapshot(output_root: Path) -> dict[str, str]:
+    return {
+        relative: sha256_bytes(path.read_bytes())
+        for relative, path in artifact_files(output_root).items()
+    }
+
+
+def assert_no_promoted_tree(output_root: Path, campaign_id: str) -> None:
+    assert not (output_root / campaign_id).exists()
+    assert not any(
+        entry.name.startswith(".staging-") for entry in output_root.iterdir()
+    )
+
+
+class ExplodingModule:
+    """Attribute access to any prohibited seam raises immediately."""
+
+    def __getattr__(self, name: str):
+        raise AssertionError(f"prohibited seam module was touched: {name}")
+
+
+def patch_seam_modules(monkeypatch: pytest.MonkeyPatch, names: list[str]) -> None:
+    for name in names:
+        monkeypatch.setitem(sys.modules, name, ExplodingModule())
+
+
+def assert_seam_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+    names: list[str],
+    tmp_path: Path,
+    *,
+    source_context: Path | None = SOURCE_CONTEXT_FIXTURE,
+) -> None:
+    """Run the full lifecycle while the named seams explode on access."""
+    patch_seam_modules(monkeypatch, names)
+    monkeypatch.setattr(subprocess, "run", _forbidden("subprocess.run"))
+    monkeypatch.setattr(subprocess, "Popen", _forbidden("subprocess.Popen"))
+    monkeypatch.setattr(os, "system", _forbidden("os.system"))
+    monkeypatch.setattr(socket, "socket", _forbidden("socket.socket"))
+    monkeypatch.setattr(socket, "create_connection", _forbidden("socket.create_connection"))
+    result = run_ok(fresh_output_root(tmp_path, "seam"), source_context=source_context)
+    assert result.provider_calls == 0
+    assert result.source_mutations == 0
+
+
+def _forbidden(label: str):
+    def explode(*args, **kwargs):
+        raise AssertionError(f"prohibited seam invoked: {label}")
+
+    return explode
+
+
+def _clean_env() -> dict[str, str]:
+    return {key: value for key, value in os.environ.items() if key != "PYTHONPATH"}
+
+
+def run_cli(*args: str, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "codex_runner.campaign_engine.cli", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env=_clean_env(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Completion and final states
+# ---------------------------------------------------------------------------
+
+
+def test_valid_provider_free_campaign_completes(tmp_path: Path) -> None:
+    result = run_ok(fresh_output_root(tmp_path))
+    assert result.classification == "provider_free"
+    assert result.final_campaign_state == "completed"
+    assert result.final_task_state == "completed"
+    assert result.attempt_state == "succeeded"
+    assert result.evaluation_verdict == "passed"
+
+
+def test_final_campaign_state_is_completed(tmp_path: Path) -> None:
+    result = run_ok(fresh_output_root(tmp_path))
+    state = load_json(result.output_dir / "campaign-state.json")
+    assert state["state"] == "completed"
+    assert state["campaign_id"] == result.campaign_id
+
+
+def test_final_task_state_is_completed(tmp_path: Path) -> None:
+    result = run_ok(fresh_output_root(tmp_path))
+    task = load_json(result.output_dir / "tasks" / result.task_id / "task-state.json")
+    assert task["state"] == "completed"
+    assert task["task_id"] == result.task_id
+
+
+def test_exactly_one_synthetic_attempt(tmp_path: Path) -> None:
+    result = run_ok(fresh_output_root(tmp_path))
+    attempts = list((result.output_dir / "attempts").iterdir())
+    assert len(attempts) == 1
+    assert attempts[0].name == f"{result.attempt_id}.json"
+
+
+def test_exactly_one_evaluation(tmp_path: Path) -> None:
+    result = run_ok(fresh_output_root(tmp_path))
+    evaluations = list((result.output_dir / "evaluations").iterdir())
+    assert len(evaluations) == 1
+    assert evaluations[0].name == f"{result.evaluation_id}.json"
+
+
+def test_exactly_one_receipt(tmp_path: Path) -> None:
+    result = run_ok(fresh_output_root(tmp_path))
+    receipts = list((result.output_dir / "receipts").iterdir())
+    assert len(receipts) == 1
+    assert receipts[0].name == f"{result.receipt_id}.json"
+
+
+def test_generated_entities_validate_against_schemas(tmp_path: Path) -> None:
+    result = run_ok(fresh_output_root(tmp_path), source_context=SOURCE_CONTEXT_FIXTURE)
+    out = result.output_dir
+
+    assert validation_module.validate_entity(
+        "task", load_json(out / "tasks" / result.task_id / "task-state.json"), "task"
+    ) == []
+    assert validation_module.validate_entity(
+        "attempt", load_json(out / "attempts" / f"{result.attempt_id}.json"), "attempt"
+    ) == []
+    assert validation_module.validate_entity(
+        "evaluation",
+        load_json(out / "evaluations" / f"{result.evaluation_id}.json"),
+        "evaluation",
+    ) == []
+    assert validation_module.validate_entity(
+        "receipt", load_json(out / "receipts" / f"{result.receipt_id}.json"), "receipt"
+    ) == []
+    assert validation_module.validate_entity(
+        "campaign_state", load_json(out / "campaign-state.json"), "campaign_state"
+    ) == []
+    bindings = load_json(out / "bindings.json")["role_bindings"]
+    for binding in bindings:
+        assert validation_module.validate_entity(
+            "role_binding", binding, "role_binding"
+        ) == []
+    validation_module.validate_campaign_document(
+        load_json(out / "campaign-input.json"), "campaign-input artifact"
+    )
+
+
+def test_all_required_artifacts_exist(tmp_path: Path) -> None:
+    result = run_ok(fresh_output_root(tmp_path))
+    files = set(artifact_files(result.output_dir))
+    expected = {
+        "campaign-input.json",
+        "bindings.json",
+        f"tasks/{result.task_id}/task-state.json",
+        f"attempts/{result.attempt_id}.json",
+        f"evaluations/{result.evaluation_id}.json",
+        f"receipts/{result.receipt_id}.json",
+        "campaign-state.json",
+        "run-result.json",
+    }
+    assert files == expected
+
+
+# ---------------------------------------------------------------------------
+# Role bindings
+# ---------------------------------------------------------------------------
+
+
+def test_bindings_remain_locked_and_semantically_unchanged(tmp_path: Path) -> None:
+    document = campaign_document()
+    result = run_ok(fresh_output_root(tmp_path))
+    written = load_json(result.output_dir / "bindings.json")["role_bindings"]
+    assert written == document["role_bindings"]
+    for binding in written:
+        assert binding["binding_state"] == "locked"
+
+
+def test_auditor_and_evaluator_share_one_model() -> None:
+    document = campaign_document()
+    models = {
+        binding["role"]: binding["model_id"]
+        for binding in document["role_bindings"]
+    }
+    assert models["auditor"] == models["evaluator"]
+
+
+def test_executor_uses_second_model() -> None:
+    document = campaign_document()
+    models = {
+        binding["role"]: binding["model_id"]
+        for binding in document["role_bindings"]
+    }
+    assert models["executor"] != models["auditor"]
+
+
+@pytest.mark.parametrize("model_count", [1, 2, 3])
+def test_one_two_three_model_configurations_valid(
+    tmp_path: Path, model_count: int
+) -> None:
+    document = campaign_document()
+    model_ids = {
+        1: ("shared-model", "shared-model", "shared-model"),
+        2: ("shared-model", "executor-model", "shared-model"),
+        3: ("auditor-model", "executor-model", "evaluator-model"),
+    }[model_count]
+    for binding, model_id in zip(document["role_bindings"], model_ids):
+        binding["model_id"] = model_id
+    campaign_path = write_variant(tmp_path, "campaign.json", document)
+    result = run_ok(fresh_output_root(tmp_path), campaign=campaign_path)
+    assert result.final_campaign_state == "completed"
+
+
+def test_fourth_distinct_model_fails_before_publication(tmp_path: Path) -> None:
+    document = campaign_document()
+    model_ids = ("m-auditor", "m-executor", "m-evaluator")
+    for binding, model_id in zip(document["role_bindings"], model_ids):
+        binding["model_id"] = model_id
+    _append_fourth_binding(document)
+    campaign_path = write_variant(tmp_path, "campaign.json", document)
+    output_root = fresh_output_root(tmp_path)
+    with pytest.raises(CampaignValidationError, match="distinct models"):
+        run_ok(output_root, campaign=campaign_path)
+    assert_no_promoted_tree(output_root, document["campaign"]["campaign_id"])
+
+
+def test_unlocked_binding_fails_before_publication(tmp_path: Path) -> None:
+    document = campaign_document()
+    document["role_bindings"][1]["binding_state"] = "draft"
+    campaign_path = write_variant(tmp_path, "campaign.json", document)
+    output_root = fresh_output_root(tmp_path)
+    with pytest.raises(CampaignValidationError, match="locked"):
+        run_ok(output_root, campaign=campaign_path)
+    assert_no_promoted_tree(output_root, document["campaign"]["campaign_id"])
+
+
+def test_conflicting_duplicate_binding_identity_fails(tmp_path: Path) -> None:
+    document = campaign_document()
+    duplicate = copy.deepcopy(document["role_bindings"][1])
+    duplicate["model_id"] = "synthetic-executor-model-altered"
+    document["role_bindings"].append(duplicate)
+    document["campaign"]["role_binding_ids"].append(duplicate["binding_id"])
+    document["campaign_state"]["ordered_role_binding_ids"].append(
+        duplicate["binding_id"]
+    )
+    campaign_path = write_variant(tmp_path, "campaign.json", document)
+    with pytest.raises(CampaignValidationError, match="duplicate binding identity"):
+        run_ok(fresh_output_root(tmp_path), campaign=campaign_path)
+
+
+def test_malformed_binding_revision_lineage_fails(tmp_path: Path) -> None:
+    document = campaign_document()
+    document["role_bindings"][1]["binding_revision"] = 2
+    campaign_path = write_variant(tmp_path, "campaign.json", document)
+    with pytest.raises(CampaignValidationError):
+        run_ok(fresh_output_root(tmp_path), campaign=campaign_path)
+
+    document = campaign_document()
+    document["role_bindings"][1].update(
+        {
+            "binding_revision": 2,
+            "replaces_binding_id": "binding-undeclared",
+            "rebind_reason": "lineage fixture",
+        }
+    )
+    campaign_path = write_variant(tmp_path, "campaign-rebind.json", document)
+    with pytest.raises(CampaignValidationError, match="replaces an undeclared binding"):
+        run_ok(fresh_output_root(tmp_path), campaign=campaign_path)
+
+
+def test_attempt_references_executor_binding(tmp_path: Path) -> None:
+    document = campaign_document()
+    executor_binding = next(
+        binding
+        for binding in document["role_bindings"]
+        if binding["role"] == "executor"
+    )
+    result = run_ok(fresh_output_root(tmp_path))
+    attempt = load_json(result.output_dir / "attempts" / f"{result.attempt_id}.json")
+    assert attempt["role_binding_id"] == executor_binding["binding_id"]
+
+
+def test_evaluation_references_evaluator_binding(tmp_path: Path) -> None:
+    document = campaign_document()
+    evaluator_binding = next(
+        binding
+        for binding in document["role_bindings"]
+        if binding["role"] == "evaluator"
+    )
+    result = run_ok(fresh_output_root(tmp_path))
+    evaluation = load_json(
+        result.output_dir / "evaluations" / f"{result.evaluation_id}.json"
+    )
+    assert evaluation["evaluator_binding_id"] == evaluator_binding["binding_id"]
+
+
+def test_evaluation_references_emitted_attempt(tmp_path: Path) -> None:
+    result = run_ok(fresh_output_root(tmp_path))
+    evaluation = load_json(
+        result.output_dir / "evaluations" / f"{result.evaluation_id}.json"
+    )
+    assert evaluation["evaluated_attempt_id"] == result.attempt_id
+
+
+def test_task_id_differs_from_attempt_id(tmp_path: Path) -> None:
+    result = run_ok(fresh_output_root(tmp_path))
+    assert result.task_id != result.attempt_id
+
+
+# ---------------------------------------------------------------------------
+# Zero-count and negative-truth invariants
+# ---------------------------------------------------------------------------
+
+
+def test_provider_call_count_remains_zero(tmp_path: Path) -> None:
+    result = run_ok(fresh_output_root(tmp_path), source_context=SOURCE_CONTEXT_FIXTURE)
+    envelope = load_json(result.output_dir / "run-result.json")
+    assert result.provider_calls == 0
+    assert envelope["provider_calls_performed"] == 0
+
+
+def test_source_mutation_count_remains_zero(tmp_path: Path) -> None:
+    result = run_ok(fresh_output_root(tmp_path))
+    envelope = load_json(result.output_dir / "run-result.json")
+    assert result.source_mutations == 0
+    assert envelope["source_mutations_performed"] == 0
+
+
+def test_decision_gate_count_remains_zero(tmp_path: Path) -> None:
+    result = run_ok(fresh_output_root(tmp_path))
+    state = load_json(result.output_dir / "campaign-state.json")
+    envelope = load_json(result.output_dir / "run-result.json")
+    assert result.decision_gates_opened == 0
+    assert state["ordered_decision_gate_ids"] == []
+    assert envelope["decision_gates_opened"] == 0
+
+
+def test_no_commit_merge_or_durable_ingestion_claim(tmp_path: Path) -> None:
+    result = run_ok(fresh_output_root(tmp_path))
+    envelope = load_json(result.output_dir / "run-result.json")
+    assert result.commit_performed is False
+    assert result.merge_performed is False
+    assert result.durable_ingestion_performed is False
+    assert envelope["commit_performed"] is False
+    assert envelope["merge_performed"] is False
+    assert envelope["durable_ingestion_performed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Deterministic identity
+# ---------------------------------------------------------------------------
+
+
+def test_identical_inputs_yield_stable_ids(tmp_path: Path) -> None:
+    first = run_ok(
+        fresh_output_root(tmp_path, "a"), source_context=SOURCE_CONTEXT_FIXTURE
+    )
+    second = run_ok(
+        fresh_output_root(tmp_path, "b"), source_context=SOURCE_CONTEXT_FIXTURE
+    )
+    for first_id, second_id in (
+        (first.run_id, second.run_id),
+        (first.attempt_id, second.attempt_id),
+        (first.evaluation_id, second.evaluation_id),
+        (first.receipt_id, second.receipt_id),
+        (first.campaign_state_id, second.campaign_state_id),
+    ):
+        assert first_id == second_id
+        assert "-" in first_id  # no bare UUIDs anywhere
+
+
+def test_changed_executor_binding_changes_attempt_identity(tmp_path: Path) -> None:
+    document = campaign_document()
+    baseline = run_ok(fresh_output_root(tmp_path, "base"))
+
+    for binding in document["role_bindings"]:
+        if binding["role"] == "executor":
+            binding["model_id"] = "synthetic-executor-model-v2"
+    changed = run_ok(
+        fresh_output_root(tmp_path, "changed"),
+        campaign=write_variant(tmp_path, "campaign.json", document),
+    )
+    assert changed.attempt_id != baseline.attempt_id
+    assert changed.evaluation_id != baseline.evaluation_id
+    # The whole input document (including the executor binding) feeds the run
+    # identity, so a binding change also re-derives the run lineage.
+    assert changed.run_id != baseline.run_id
+
+
+def test_changed_task_changes_attempt_and_run_identity(tmp_path: Path) -> None:
+    document = campaign_document()
+    baseline = run_ok(fresh_output_root(tmp_path, "base"))
+
+    document["tasks"][0]["objective"] = "A materially different task objective."
+    changed = run_ok(
+        fresh_output_root(tmp_path, "changed"),
+        campaign=write_variant(tmp_path, "campaign.json", document),
+    )
+    assert changed.run_id != baseline.run_id
+    assert changed.attempt_id != baseline.attempt_id
+
+
+def test_changed_source_context_changes_run_lineage(tmp_path: Path) -> None:
+    baseline = run_ok(
+        fresh_output_root(tmp_path, "base"), source_context=SOURCE_CONTEXT_FIXTURE
+    )
+
+    record = source_context_record()
+    record["graph_revision"] = (
+        "f" * 63 + "e"
+    )
+    graph_changed = run_ok(
+        fresh_output_root(tmp_path, "graph"),
+        source_context=write_source_variant(tmp_path, "sc-graph.json", record),
+    )
+    assert graph_changed.run_id != baseline.run_id
+    assert graph_changed.source_context["graph_revision"] == "f" * 63 + "e"
+
+    record = source_context_record()
+    record["packet_id"] = "codexify:arp:provider-free-runtime-fixture-v2"
+    packet_changed = run_ok(
+        fresh_output_root(tmp_path, "packet"),
+        source_context=write_source_variant(tmp_path, "sc-packet.json", record),
+    )
+    assert packet_changed.run_id != baseline.run_id
+
+
+def test_lineage_is_preserved_without_being_permission(tmp_path: Path) -> None:
+    result = run_ok(
+        fresh_output_root(tmp_path), source_context=SOURCE_CONTEXT_FIXTURE
+    )
+    envelope = load_json(result.output_dir / "run-result.json")
+    context = envelope["source_context"]
+    assert context["present"] is True
+    assert context["packet_id"] == "codexify:arp:provider-free-runtime-fixture"
+    assert result.provider_calls == 0
+    assert result.commit_performed is False
+    # The lineage envelope carries only lineage fields; nothing grants authority.
+    assert set(context) == {
+        "present",
+        "packet_id",
+        "repository_revision",
+        "graph_revision",
+        "authority_profile",
+        "question_or_intent",
+        "hash",
+        "stale_warnings",
+        "conflicts",
+        "proof_gaps",
+        "human_decisions_required",
+    }
+    serialized = json.dumps(envelope, sort_keys=True)
+    assert "granted" not in serialized
+
+
+def test_stale_conflict_and_human_decision_metadata_preserved(
+    tmp_path: Path,
+) -> None:
+    fixture = source_context_record()
+    result = run_ok(
+        fresh_output_root(tmp_path), source_context=SOURCE_CONTEXT_FIXTURE
+    )
+    artifact = load_json(result.output_dir / "source-context.json")
+    assert artifact["stale_warnings"] == fixture["stale_warnings"]
+    assert artifact["conflicts"] == fixture["conflicts"]
+    assert artifact["proof_gaps"] == fixture["proof_gaps"]
+    assert artifact["human_decisions_required"] == fixture["human_decisions_required"]
+    assert result.source_context["stale_warnings"] == fixture["stale_warnings"]
+    assert result.source_context["conflicts"] == fixture["conflicts"]
+    assert result.source_context["human_decisions_required"] == fixture[
+        "human_decisions_required"
+    ]
+
+
+def test_absent_source_context_is_recorded_honestly(tmp_path: Path) -> None:
+    result = run_ok(fresh_output_root(tmp_path))
+    assert result.source_context["present"] is False
+    assert result.hashes["source_context_hash"] == "absent"
+    assert not (result.output_dir / "source-context.json").exists()
+    envelope = load_json(result.output_dir / "run-result.json")
+    assert envelope["source_context"]["present"] is False
+    assert "no source-selection lineage fixture was supplied" in envelope[
+        "source_context"
+    ]["note"]
+
+
+# ---------------------------------------------------------------------------
+# Path and publication safety
+# ---------------------------------------------------------------------------
+
+
+def test_path_traversal_campaign_id_rejected(tmp_path: Path) -> None:
+    for hostile_id in ("..", "a/b", "campaign-.."):
+        document = campaign_document()
+        document["campaign"]["campaign_id"] = hostile_id
+        document["campaign_state"]["campaign_id"] = hostile_id
+        document["tasks"][0]["campaign_id"] = hostile_id
+        campaign_path = write_variant(tmp_path, "hostile.json", document)
+        with pytest.raises(CampaignValidationError):
+            run_ok(fresh_output_root(tmp_path), campaign=campaign_path)
+
+
+def test_output_cannot_escape_output_root(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    output_root = fresh_output_root(tmp_path)
+    (output_root / "campaign-provider-free-runtime-001").symlink_to(
+        outside, target_is_directory=True
+    )
+    with pytest.raises(CampaignArtifactError, match="escapes output root"):
+        run_ok(output_root)
+    assert outside.is_dir() and not any(outside.iterdir())
+
+
+def test_validation_failure_leaves_no_promoted_tree(tmp_path: Path) -> None:
+    document = campaign_document()
+    model_ids = ("m-auditor", "m-executor", "m-evaluator")
+    for binding, model_id in zip(document["role_bindings"], model_ids):
+        binding["model_id"] = model_id
+    _append_fourth_binding(document)
+    campaign_path = write_variant(tmp_path, "campaign.json", document)
+    output_root = fresh_output_root(tmp_path)
+    with pytest.raises(CampaignValidationError):
+        run_ok(output_root, campaign=campaign_path)
+    assert_no_promoted_tree(output_root, document["campaign"]["campaign_id"])
+
+
+def test_simulated_midwrite_failure_leaves_no_promoted_tree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    document = campaign_document()
+    campaign_id = document["campaign"]["campaign_id"]
+    real_write = runtime_module.atomic_write_json
+    calls = {"count": 0}
+
+    def failing_write(directory: Path, filename: str, payload) -> Path:
+        calls["count"] += 1
+        if calls["count"] > 3:
+            raise CampaignArtifactError("simulated mid-write failure")
+        return real_write(directory, filename, payload)
+
+    monkeypatch.setattr(runtime_module, "atomic_write_json", failing_write)
+    output_root = fresh_output_root(tmp_path)
+    with pytest.raises(CampaignArtifactError, match="simulated mid-write failure"):
+        run_ok(output_root)
+    assert calls["count"] >= 4
+    assert_no_promoted_tree(output_root, campaign_id)
+
+
+def test_repeated_identical_runs_are_deterministic(tmp_path: Path) -> None:
+    first_root = fresh_output_root(tmp_path, "first")
+    second_root = fresh_output_root(tmp_path, "second")
+    run_ok(first_root, source_context=SOURCE_CONTEXT_FIXTURE)
+    run_ok(second_root, source_context=SOURCE_CONTEXT_FIXTURE)
+    # Every artifact except run-result.json is byte-identical across roots;
+    # run-result.json differs only in its root-specific output_dir path.
+    first_snapshot = run_snapshot(first_root)
+    second_snapshot = run_snapshot(second_root)
+    first_result_path = first_root / "campaign-provider-free-runtime-001" / "run-result.json"
+    second_result_path = second_root / "campaign-provider-free-runtime-001" / "run-result.json"
+    first_snapshot.pop("campaign-provider-free-runtime-001/run-result.json")
+    second_snapshot.pop("campaign-provider-free-runtime-001/run-result.json")
+    assert first_snapshot == second_snapshot
+    first_result = load_json(first_result_path)
+    second_result = load_json(second_result_path)
+    first_result["output_dir"] = "<normalized>"
+    second_result["output_dir"] = "<normalized>"
+    assert first_result == second_result
+    with pytest.raises(CampaignOutputExistsError):
+        run_ok(first_root, source_context=SOURCE_CONTEXT_FIXTURE)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_human_readable_mode_succeeds(tmp_path: Path) -> None:
+    output_root = fresh_output_root(tmp_path)
+    completed = run_cli(
+        "run-provider-free",
+        "--campaign",
+        str(CAMPAIGN_FIXTURE),
+        "--output-root",
+        str(output_root),
+    )
+    assert completed.returncode == 0
+    assert "Provider-free Campaign Engine run complete" in completed.stdout
+    assert "provider calls:     0" in completed.stdout
+
+
+def test_cli_json_mode_returns_valid_json(tmp_path: Path) -> None:
+    output_root = fresh_output_root(tmp_path)
+    completed = run_cli(
+        "run-provider-free",
+        "--campaign",
+        str(CAMPAIGN_FIXTURE),
+        "--source-context",
+        str(SOURCE_CONTEXT_FIXTURE),
+        "--output-root",
+        str(output_root),
+        "--json",
+    )
+    assert completed.returncode == 0
+    payload = json.loads(completed.stdout)
+    assert payload["classification"] == "provider_free"
+    assert payload["run_id"].startswith("run-")
+
+
+def test_cli_invalid_input_returns_nonzero(tmp_path: Path) -> None:
+    bad = tmp_path / "bad-campaign.json"
+    bad.write_text("{ not valid json ", encoding="utf-8")
+    output_root = fresh_output_root(tmp_path)
+    completed = run_cli(
+        "run-provider-free",
+        "--campaign",
+        str(bad),
+        "--output-root",
+        str(output_root),
+    )
+    assert completed.returncode != 0
+    assert "provider-free campaign failed" in completed.stderr
+
+
+# ---------------------------------------------------------------------------
+# Prohibited execution seams
+# ---------------------------------------------------------------------------
+
+
+def test_no_pi_invocation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    assert_seam_untouched(
+        monkeypatch,
+        ["pi", "pi_runtime", "codex_runner.pi_runtime", "codex_runner.pi_loop_manager"],
+        tmp_path,
+    )
+
+
+def test_no_coding_loop_invocation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assert_seam_untouched(
+        monkeypatch,
+        ["guardian.workers.coding_worker", "guardian.routes.agent_orchestration"],
+        tmp_path,
+    )
+
+
+def test_no_guardian_execution_seam(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assert_seam_untouched(monkeypatch, ["guardian", "guardian.guardian_api"], tmp_path)
+
+
+def test_no_command_bus_execution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assert_seam_untouched(
+        monkeypatch, ["guardian.command_bus", "guardian.command_bus.invoke"], tmp_path
+    )
+
+
+def test_no_provider_adapter_invocation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assert_seam_untouched(
+        monkeypatch, ["guardian.providers", "guardian.providers.deepseek_adapter"], tmp_path
+    )
+
+
+def test_no_subprocess_model_invocation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assert_seam_untouched(monkeypatch, [], tmp_path)
+
+
+def test_no_network_access(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    assert_seam_untouched(monkeypatch, [], tmp_path)
+
+
+def test_no_git_command_or_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assert_seam_untouched(monkeypatch, ["git"], tmp_path)
+
+
+def test_no_database_mutation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    assert_seam_untouched(
+        monkeypatch, ["psycopg2", "psycopg", "sqlalchemy", "neo4j"], tmp_path
+    )
+
+
+def test_package_imports_no_prohibited_modules_in_clean_interpreter(
+    tmp_path: Path,
+) -> None:
+    """Fresh interpreter: inject exploding stubs, import the runtime, run it."""
+    script = tmp_path / "seam_probe.py"
+    script.write_text(
+        (
+            "import json, os, sys\n"
+            "from pathlib import Path\n"
+            "sys.path.insert(0, os.getcwd())\n"
+            "class ExplodingModule:\n"
+            "    def __getattr__(self, name):\n"
+            "        raise AssertionError('prohibited seam touched: ' + name)\n"
+            "stubs = {}\n"
+            "for name in ['guardian', 'guardian.command_bus', 'guardian.providers',\n"
+            "            'guardian.workers', 'codex_runner.pi_runtime',\n"
+            "            'codex_runner.runner', 'git', 'psycopg2', 'psycopg',\n"
+            "            'sqlalchemy', 'neo4j']:\n"
+            "    stub = ExplodingModule()\n"
+            "    sys.modules[name] = stub\n"
+            "    stubs[name] = stub\n"
+            "from codex_runner.campaign_engine import run_provider_free_campaign\n"
+            "result = run_provider_free_campaign(\n"
+            f"    Path({str(CAMPAIGN_FIXTURE)!r}),\n"
+            f"    Path({str(tmp_path)!r}) / 'probe-out',\n"
+            "    source_context_path="
+            f"Path({str(SOURCE_CONTEXT_FIXTURE)!r}),\n"
+            ")\n"
+            "prohibited = []\n"
+            "for name in sys.modules:\n"
+            "    if name in stubs and sys.modules[name] is stubs[name]:\n"
+            "        continue  # our own guard stub, not a real import\n"
+            "    if (name.split('.')[0] in {\n"
+            "            'subprocess', 'socket', 'http', 'git', 'guardian',\n"
+            "            'psycopg2', 'psycopg', 'sqlalchemy', 'neo4j',\n"
+            "            'pi_runtime',\n"
+            "        } or name in {'codex_runner.runner', 'urllib.request',\n"
+            "                      'urllib.error'}):\n"
+            "        prohibited.append(name)\n"
+            "assert not prohibited, f'prohibited modules imported: {prohibited}'\n"
+            "assert result.provider_calls == 0 and result.source_mutations == 0\n"
+            "print('SEAM_PROBE_OK')\n"
+        ),
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        [sys.executable, str(script)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        env=_clean_env(),
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "SEAM_PROBE_OK" in completed.stdout


### PR DESCRIPTION
## Rebuild the provider-free Campaign Engine runtime (ADR-066 slice)

Implementation of the provider-free lifecycle authorized by accepted ADR-066. **No Campaign Engine schema, architecture doc, Pi, Coding Loop, Guardian, command-bus, provider adapter, DB, API, UI, or existing file is modified.** Zero provider calls, zero source mutations, zero decision gates, no commit/merge/durable-ingestion.

### Change set (all new files, exactly the authorized list)

- `codex_runner/campaign_engine/` — new package: `errors.py`, `models.py`, `validation.py`, `identity.py`, `artifacts.py`, `runtime.py`, `cli.py`, `__init__.py`
- `codex_runner/tests/test_campaign_engine_runtime.py` — 51 focused tests covering all 48 required proof points
- `codex_runner/tests/fixtures/campaign_engine/provider_free_runtime_campaign.json` — pre-execution campaign (ready task, 3 locked bindings, auditor/evaluator share one synthetic model, executor a second; no attempts/evaluations/receipts/gates)
- `codex_runner/tests/fixtures/campaign_engine/provider_free_runtime_source_context.json` — minimal ARP-equivalent lineage fixture (packet_id, repository/graph revision, authority_profile, question_or_intent, stale/conflict/proof-gap/human-decision metadata)

No existing package export or CLI registration file needed modification: `python -m codex_runner.campaign_engine.cli` resolves directly.

### Design decisions (documented in code)

- **Envelope pattern**: `campaign-engine/v0` schemas are `additionalProperties:false` with no provider/mutation/lineage fields (Attempt = id/task/binding/created_at/state; Receipt = id/created_at/typed subject). Per the packet's "where supported"/"as much as permitted" language, schema entities stay schema-tight and the runtime-owned `run-result.json` envelope carries the zero-counts, commit/merge/durable-ingestion false flags, lineage references, and structured acceptance-criterion results. Schema strengthening is deferred (per packet follow-through).
- **Deterministic identity**: Run/Attempt/Evaluation/Receipt/CampaignState IDs are prefixed SHA-256 over canonical JSON (repo conventions: sort_keys + compact separators), covering campaign-input hash, task hash, role-binding identity, lineage hash, and the injected clock instant. No UUIDs. Task ID ≠ Attempt ID.
- **Atomic publication**: stage under `<output_root>/.staging-<run_id>/`, schema+cross-object validate everything in memory, write, re-read every artifact from disk and re-validate, then promote via a single `os.replace`. Failures remove staging and leave no promoted tree. Rerun policy (documented + tested): existing output fails fast with a bounded error; identical reruns into fresh roots are byte-deterministic.
- **Strict loading**: duplicate-key-rejected JSON parsing; per-entity Draft 2020-12 schema validation; cross-object rules replicating `test_campaign_engine_schemas.py` (bindings locked, ≤3 distinct models, revision lineage, references, receipt subjects).
- **Lineage only**: source-context fixtures validate a minimum lineage shape (no DLG resolver); lineage hash feeds run identity; lineage grants no permission (asserted).

### Validation results (run from repository root)

| Gate | Result |
|---|---|
| `python3 -m json.tool` both fixtures | valid |
| `pytest -v codex_runner/tests/test_campaign_engine_runtime.py` | **51 passed** |
| `pytest -v codex_runner/tests/test_campaign_engine_schemas.py` | **12 passed** |
| `pytest codex_runner/tests` (ignore pre-existing `test_tui_palette.py` `textual` collection error) | **106 passed** (clean baseline at 046fb1ea7: 55 passed — zero regressions) |
| CLI proof (no source context) | exit 0, human summary, 8 artifacts |
| CLI proof (source context, `--json \| json.tool`) | exit 0, valid JSON, 9 artifacts incl. `source-context.json` |
| No staging/`.tmp` leftovers after CLI runs | confirmed |
| `make docs PYTHON=<venv>` | pass |
| `git diff --check` / `git lfs fsck` | clean / OK |
| DLG `validate` | identical to baseline: 1 pre-existing `content_hash_mismatch` (current-state) — zero new |

Pre-existing DLG drift on `00-current-state.md` is unrelated and left untouched (separate freshness task).

**Merge gate: operator-owned.** No auto-merge; no direct main push.
