### PR TITLE
Establish Guardian Pi live invocation seam

### DIFF
--- a/codex_runner/src/agent-wrapper.js
+++ b/codex_runner/src/agent-wrapper.js
@@ -15,12 +15,15 @@
  */
 
 import path from "node:path";
+import { readFile } from "node:fs/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 // Parse command line args
 const args = process.argv.slice(2);
 const mode = args[0] || "help";
 const prompt = args.slice(1).join(" ");
+const guardianAuthorizedMode = mode === "guardian-authorized-task";
+const ACTUAL_HARNESS_ID = "pi-coding-agent";
 
 const OPTIONS = {
 	cwd: process.cwd(),
@@ -85,6 +88,9 @@ async function loadPiSdk() {
 	const piAi = await import(
 		pathToFileURL(path.join(nodeModulesRoot, "@mariozechner/pi-ai/dist/index.js")).href
 	);
+	const packageMetadata = JSON.parse(
+		await readFile(path.join(packageRoot, "package.json"), "utf8")
+	);
 	return {
 		createAgentSession: codingAgent.createAgentSession,
 		SessionManager: codingAgent.SessionManager,
@@ -92,7 +98,22 @@ async function loadPiSdk() {
 		ModelRegistry: codingAgent.ModelRegistry,
 		createCodingTools: codingAgent.createCodingTools,
 		getModel: piAi.getModel,
+		harnessId: ACTUAL_HARNESS_ID,
+		harnessVersion: String(packageMetadata.version || ""),
 	};
+}
+
+function requireGuardianAuthorizedIdentity() {
+	const identity = {
+		providerId: String(process.env.PI_PROVIDER || "").trim(),
+		modelId: String(process.env.PI_MODEL || "").trim(),
+		harnessId: String(process.env.PI_GUARDIAN_HARNESS_ID || "").trim(),
+		harnessVersion: String(process.env.PI_GUARDIAN_HARNESS_VERSION || "").trim(),
+	};
+	if (process.env.PI_GUARDIAN_AUTHORIZED !== "1" || Object.values(identity).some(value => !value)) {
+		throw new Error("guardian_authorized_identity_missing");
+	}
+	return identity;
 }
 
 async function checkReadiness() {
@@ -143,6 +164,10 @@ async function runAgent() {
 	let createCodingTools;
 	let getModel;
 
+	const authorizedIdentity = guardianAuthorizedMode
+		? requireGuardianAuthorizedIdentity()
+		: null;
+
 	try {
 		({
 			createAgentSession,
@@ -151,6 +176,8 @@ async function runAgent() {
 			ModelRegistry,
 			createCodingTools,
 			getModel,
+			harnessId,
+			harnessVersion,
 		} = await loadPiSdk());
 	} catch (error) {
 		if (isModuleResolutionError(error)) {
@@ -163,7 +190,12 @@ async function runAgent() {
 		throw error;
 	}
 
-	const resolvedModelId = resolveModel(OPTIONS.model, getModel);
+	const resolvedModelId = guardianAuthorizedMode
+		? authorizedIdentity.modelId
+		: resolveModel(OPTIONS.model, getModel);
+	const resolvedProviderId = guardianAuthorizedMode
+		? authorizedIdentity.providerId
+		: OPTIONS.provider;
 
 	// Set up auth and model registry
 	const authStorage = AuthStorage.create();
@@ -172,7 +204,7 @@ async function runAgent() {
 	const tools = OPTIONS.disableTools ? [] : createCodingTools(OPTIONS.cwd);
 
 	// Get model
-	const model = getModel(OPTIONS.provider, resolvedModelId);
+	const model = getModel(resolvedProviderId, resolvedModelId);
 	if (!model) {
 		console.error(`Model not found: ${resolvedModelId}`);
 		console.error("Available models:");
@@ -185,6 +217,23 @@ async function runAgent() {
 		console.error("  PI_PROVIDER=google PI_MODEL=gemini-2.5-pro");
 		process.exit(1);
 	}
+	if (guardianAuthorizedMode && (
+		authorizedIdentity.harnessId !== harnessId ||
+		authorizedIdentity.harnessVersion !== harnessVersion ||
+		model.provider !== authorizedIdentity.providerId ||
+		model.id !== authorizedIdentity.modelId
+	)) {
+		console.error("Guardian-authorized identity does not match the resolved Pi runtime.");
+		process.exit(1);
+	}
+	const actualRuntimeIdentity = guardianAuthorizedMode
+		? {
+			actual_provider_id: model.provider,
+			actual_model_id: model.id,
+			actual_harness_id: harnessId,
+			actual_harness_version: harnessVersion,
+		}
+		: null;
 
 	// Check API key availability
 	try {
@@ -251,6 +300,22 @@ async function runAgent() {
 	const messages = session.agent.state.messages;
 
 	// Print final output
+	if (guardianAuthorizedMode) {
+		const response = extractJsonResponse(messages);
+		console.log(JSON.stringify({
+			status: "ok",
+			summary: "Guardian-authorized Pi task completed",
+			actual_runtime_identity: actualRuntimeIdentity,
+			execution_result: {
+				status: "completed",
+				result_kind: response && Object.prototype.hasOwnProperty.call(response, "text")
+					? "text"
+					: "structured",
+				content_omitted: true,
+			},
+		}));
+		return;
+	}
 	if (mode === "audit" || mode === "compile" || mode === "task") {
 		const response = extractJsonResponse(messages);
 		if (response) {
@@ -267,6 +332,8 @@ function buildPrompt(mode, userPrompt) {
 			return userPrompt || "Compile the audit results into a campaign set JSON.";
 		case "task":
 			return userPrompt || "Execute the task and output results as JSON.";
+		case "guardian-authorized-task":
+			return userPrompt || "Execute the authorized task and return bounded evidence.";
 		case "help":
 		default:
 			return null;
@@ -339,6 +406,7 @@ Modes:
   audit    - Run audit analysis on the repository
   compile  - Compile audit results into campaign set
   task     - Execute a single task
+  guardian-authorized-task - Execute one explicitly authorized task with identity attestation
   readiness - Check adapter and credential posture without executing a prompt
   help     - Show this help
 

--- a/docs/architecture/proofs/2026-08-16-guardian-pi-live-invocation-seam-proof.md
+++ b/docs/architecture/proofs/2026-08-16-guardian-pi-live-invocation-seam-proof.md
@@ -1,0 +1,292 @@
+# Guardian-authorized Pi live invocation seam proof
+
+## 1. Scope
+
+Implemented and deterministically proved one internal Guardian-owned, one-shot
+Pi invocation primitive. It consumes existing Pi authorization contracts,
+invokes an injected or existing Pi harness adapter once, and returns bounded
+in-memory outcome, receipt, and result objects. It adds no Campaign Engine
+orchestration, persistence, queueing, MiniMax configuration, or live provider
+call.
+
+## 2. Workflow classification
+
+- Execution lane: `architecture-impact`
+- Task kind: `implementation + proof`
+- Evidence posture: `IMPLEMENTED_AND_TEST_PROVEN`, not live-provider proof.
+
+## 3. ADR impact
+
+`Aligned with existing ADR(s)`. No ADR was created or modified. This is the
+accepted lower-level implementation of Guardian authority, identity, result
+validation, and bounded-mutation requirements.
+
+## 4. Governing ADRs/contracts
+
+- ADR-066 Campaign Engine Runtime Recovery Contract
+- ADR-068 Campaign Engine Live Role Execution Contract
+- Pi Invocation Boundary Contract
+- Agent Tool Loop Contract
+- Runtime Protocol Token Contract
+
+## 5. Task base HEAD
+
+`a71c8d1c88e9a6f861af6ffbf197c760f174a642`
+
+## 6. Integration/drift result
+
+`PASS`. The required prior base
+`bf0d46bc05037486dbf4af17592e61abe38c9a68` is an ancestor of the observed
+remote head. Intervening changes were inspected before editing and did not
+modify Guardian Pi, agent adapters, Coding Worker, Pi wrapper, ADR-066,
+ADR-068, Pi Invocation Boundary, Agent Tool Loop, provider-execution, or
+coding-execution authority. The worktree was created from that remote head;
+no merge or rebase occurred.
+
+## 7. Prior blocker
+
+`RESOLVED_AT_IMPLEMENTATION_AND_TEST_PROOF_LEVEL`.
+
+Before this change, `guardian/pi/` supplied contracts and pure validation only;
+the direct Codex adapter intentionally failed closed; the legacy Pi adapter
+used ambient/default provider/model configuration; and the Pi task wrapper had
+no actual provider/model/harness attestation. Campaign Engine remains
+provider-free and has no live invocation adapter.
+
+## 8. Existing Pi boundary before change
+
+`PiInvocationEnvelope`, `PiInvocationPolicyDecision`,
+`PiInvocationReceipt`, and `PiHarnessResult` already represented the needed
+authority lineage, permissions, configured provider lane, harness identity,
+and bounded result shapes. No contract meaning changed.
+
+## 9. New Guardian invocation owner
+
+`guardian/pi/invocation.py` provides `invoke_guardian_authorized_pi`. It has
+no Campaign Engine, FastAPI, database, Redis, AgentStore, Coding Worker, or
+queue dependency. It returns only a non-persisted bounded outcome to its
+caller.
+
+## 10. Authorization validation sequence
+
+The entrypoint validates envelope and policy decision, validates their exact
+cross-object relationship, requires `decision == allowed`, rejects
+credential-named contract material, freezes explicit identity, captures target
+and Git state, then calls the harness at most once. Preflight rejection makes
+zero runner calls.
+
+`GUARDIAN_AUTHORIZATION_BEFORE_EXECUTION: PASS`
+
+## 11. Envelope/policy cross-object validation
+
+`validate_policy_decision_against_envelope` requires exact invocation id,
+source thread/message lineage, harness id, full Guardian boundary,
+requested-permission set, and granted-permission set equality. It preserves
+existing validation failures and adds canonical relationship mismatch failure
+tokens. Deterministic tests cover each mismatch with zero runner calls.
+
+## 12. Provider identity freeze
+
+The validated envelope's non-empty provider name is frozen in a typed request
+and passed only through the adapter's invocation-local subprocess environment.
+Authorized wrapper mode does not use the legacy provider default.
+
+`IMMUTABLE_PROVIDER_IDENTITY: PASS`
+
+## 13. Model identity freeze
+
+The validated envelope's non-empty model id is frozen identically. Authorized
+wrapper mode passes it directly to Pi resolution and does not apply legacy
+alias/default normalization.
+
+`IMMUTABLE_MODEL_IDENTITY: PASS`
+
+## 14. Harness identity freeze
+
+The envelope's non-empty harness id and version are frozen with the same typed
+request. Authorized wrapper mode compares both with the installed Pi package
+identity before it creates a session.
+
+`IMMUTABLE_HARNESS_IDENTITY: PASS`
+
+## 15. Actual identity source
+
+The opt-in `guardian-authorized-task` wrapper mode obtains provider and model
+from the resolved Pi model object and harness version from installed Pi package
+metadata. It returns them as `actual_runtime_identity`; the adapter parses
+that structure separately from arbitrary model content and the wrapper returns
+only bounded result metadata in this mode.
+
+`ACTUAL_RUNTIME_IDENTITY_ATTESTATION: PASS`
+
+## 16. Requested vs authorized vs actual equality rule
+
+Requested/authorized provider, model, harness id, and harness version derive
+from the validated envelope. Actual identity originates with the harness
+response and must equal all four frozen fields. Missing attestation or any
+mismatch fails closed after one call and returns no successful receipt/result.
+
+`IDENTITY_MISMATCH_FAIL_CLOSED: PASS`
+
+## 17. Filesystem mutation enforcement
+
+Each `files.write` resource is resolved against target cwd before execution.
+Empty roots, traversal, and roots outside target fail before a call. The rail
+snapshots all target entries, including untracked content, before and after;
+only the Git-internal directory is excluded from tree hashing. Changes outside
+a granted root fail, as do changed symlinks that resolve outside the target.
+
+`FILESYSTEM_SCOPE_ENFORCEMENT: PASS`
+
+## 18. Git mutation enforcement
+
+For a Git target, the rail records `HEAD` before and after execution. Any
+advance is `git_mutation_violation`; the rail does not reset or repair the
+fixture. A temporary repository test creates a commit and proves closure.
+
+`NO_GIT_HISTORY_MUTATION: PASS`
+
+## 19. Read-only enforcement
+
+No `files.write` grant yields a read-only harness request. The existing wrapper
+mechanism receives `PI_DISABLE_TOOLS=1`, disabling coding tools rather than
+relying on prompt wording. Target state must remain equivalent; any mutation
+is `read_only_violation`.
+
+`READ_ONLY_ENFORCEMENT: PASS`
+
+## 20. Receipt construction
+
+Success constructs a completed `PiInvocationReceipt` with the original
+Guardian boundary, invocation/source lineage, permissions, configured provider
+lane, harness identity, and a bounded `pi://guardian-authorized/.../result`
+artifact reference. It is validated against the envelope before return.
+
+`RECEIPT_VALIDATION: PASS`
+
+## 21. HarnessResult construction
+
+The same success path constructs a success `PiHarnessResult` with attested
+identity only after equality validation, inherited authorization lineage and
+permissions, and a bounded artifact reference. It validates against receipt.
+
+`HARNESS_RESULT_VALIDATION: PASS`
+
+## 22. Zero-retry behavior
+
+There is one execution site and no loop. Every terminal outcome reports
+`retry_count=0`.
+
+`AUTOMATIC_RETRY: 0`
+
+## 23. Zero-fallback behavior
+
+The primitive has no fallback provider/model/harness input or secondary runner
+path. Every terminal outcome reports `fallback_count=0`.
+
+`AUTOMATIC_FALLBACK: 0`
+
+## 24. Legacy Coding Worker compatibility
+
+Legacy `PiCodexRunnerAdapter.execute` and wrapper `task` behavior remain
+separate from new `execute_authorized` and `guardian-authorized-task` paths.
+Coding Worker source was not changed; its direct runtime-contract regression
+passed.
+
+## 25. Direct Codex fail-closed status
+
+`guardian/agents/adapters/codex.py` was not changed. A focused test confirms
+`CodexAdapter()` still raises the established unsupported error.
+
+## 26. External provider-call count
+
+`0`. All invocation tests used injected deterministic fake runners or mocked
+subprocess execution. The wrapper was syntax-checked only; no provider,
+credential store, API, subscription, MiniMax configuration, or live harness
+was invoked.
+
+`EXTERNAL_PROVIDER_CALLS: 0`
+
+## 27. Credential exposure review
+
+No credentials, tokens, headers, cookies, auth-file contents, or provider
+request payloads were added to tracked files, tests, receipts, results, or this
+proof. The runtime rejects credential-named envelope/policy metadata before a
+harness call and its authorized wrapper output omits model response content.
+The focused test proves a credential-like prompt string is absent from returned
+receipt/result payloads. No repository secret scanner was available or claimed.
+
+## 28. Focused tests
+
+The requested tests passed without provider calls:
+
+```text
+PYTHONPATH="" .venv/bin/python -m pytest -v \
+  tests/pi/test_pi_invocation_contracts.py \
+  tests/pi/test_pi_live_invocation.py \
+  tests/ops/test_worker_coding_pi_runtime_contract.py
+
+47 passed in 1.07s
+```
+
+The new suite has 29 passing tests: pre-invocation zero-call failures; exact
+frozen identity; actual provider/model/harness id/version mismatches;
+read-only and scoped writes; traversal and symlink escape; commit detection;
+no retry/fallback; contract validation; credential non-persistence; legacy
+adapter compatibility; and direct Codex failure closure.
+
+## 29. Campaign Engine regression
+
+Campaign Engine was inspected but not changed. Its provider-free regression
+suite passed:
+
+```text
+PYTHONPATH="" .venv/bin/python -m pytest -v \
+  codex_runner/tests/test_campaign_engine_schemas.py \
+  codex_runner/tests/test_campaign_engine_runtime.py
+
+96 passed in 0.96s
+```
+
+`CAMPAIGN_ENGINE_MUTATION: NONE`
+
+## 30. What this proves
+
+The repository now has a deterministic Guardian-owned Pi invocation rail that
+enforces authorization-before-invocation, explicit identity freeze, runtime
+identity equality, filesystem/read-only/Git constraints, bounded receipt/result
+construction, and zero retry/fallback behavior. Provider-free Campaign Engine
+and Coding Worker contract surfaces remain regression-green.
+
+## 31. What this does not prove
+
+This does not prove a live provider execution, Codex-compatible subscription
+binding, MiniMax configuration/evaluation, Campaign Engine consumption,
+provider governance, cross-process sandbox completeness, queue/store behavior,
+autonomous remediation, or a release-support expansion.
+
+`MINIMAX_CONFIGURATION_CHANGE: NONE`
+
+`LIVE_PROVIDER_PROOF: NOT_PERFORMED`
+
+## 32. Final classification
+
+`PASS` — all deterministic authority, identity, filesystem, Git, read-only,
+receipt/result, compatibility, and provider-free regression requirements passed
+without a real provider call.
+
+## 33. Documentation follow-through
+
+Added this focused proof receipt only. `docs/architecture/00-current-state.md`
+and release/support documentation were intentionally unchanged because no
+release claim was proven false or widened.
+
+## 34. Exact next gate
+
+Return to Axis. The next atomic task is:
+
+> Qualify one Codex-compatible subscription-backed Executor binding through
+> the new Guardian-authorized Pi invocation seam.
+
+That task must prove one real Executor invocation in a disposable repository.
+MiniMax configuration and qualification remain a separate subsequent gate.

--- a/guardian/agents/adapters/__init__.py
+++ b/guardian/agents/adapters/__init__.py
@@ -2,6 +2,7 @@
 
 from .base import (
     AgentAdapter,
+    AgentExecutionIdentity,
     AgentExecutionRequest,
     AgentRunEnvelope,
     AgentRunStatus,
@@ -18,6 +19,7 @@ ADAPTERS = {
 __all__ = [
     "ADAPTERS",
     "AgentAdapter",
+    "AgentExecutionIdentity",
     "AgentExecutionRequest",
     "AgentRunEnvelope",
     "AgentRunStatus",

--- a/guardian/agents/adapters/base.py
+++ b/guardian/agents/adapters/base.py
@@ -25,6 +25,10 @@ class AgentRunEnvelope(BaseModel):
     spec_alignment_ok: bool = True
     schema_valid: bool = True
     model_self_confidence: float | None = None
+    actual_provider_id: str | None = None
+    actual_model_id: str | None = None
+    actual_harness_id: str | None = None
+    actual_harness_version: str | None = None
 
     model_config = ConfigDict(extra="forbid")
 
@@ -35,6 +39,16 @@ class AgentExecutionRequest:
     cwd: str | None = None
     timeout_seconds: int = 120
     metadata: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class AgentExecutionIdentity:
+    """Explicit identity frozen by a Guardian-authorized invocation."""
+
+    provider_id: str
+    model_id: str
+    harness_id: str
+    harness_version: str
 
 
 class AgentAdapter(Protocol):

--- a/guardian/agents/adapters/pi_codex_runner.py
+++ b/guardian/agents/adapters/pi_codex_runner.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from guardian.agents.adapters.base import (
     AgentAdapter,
+    AgentExecutionIdentity,
     AgentExecutionRequest,
     AgentRunEnvelope,
 )
@@ -84,8 +85,76 @@ class PiCodexRunnerAdapter:
                 metrics={},
             )
 
+    def execute_authorized(
+        self,
+        request: AgentExecutionRequest,
+        identity: AgentExecutionIdentity,
+        *,
+        read_only: bool,
+    ) -> AgentRunEnvelope:
+        """Execute exactly one Guardian-authorized Pi task.
+
+        This opt-in path never falls back to the legacy provider/model defaults.
+        Its local subprocess environment is the only configuration surface it
+        changes; global process environment remains untouched.
+        """
+        if not all(
+            (
+                identity.provider_id,
+                identity.model_id,
+                identity.harness_id,
+                identity.harness_version,
+            )
+        ):
+            return AgentRunEnvelope(
+                status="error",
+                summary="Guardian-authorized Pi identity is incomplete",
+                errors=["authorized_identity_missing"],
+            )
+
+        wrapper_path = _get_pi_wrapper_path()
+        env = os.environ.copy()
+        env.update(
+            {
+                "PI_PROVIDER": identity.provider_id,
+                "PI_MODEL": identity.model_id,
+                "PI_GUARDIAN_AUTHORIZED": "1",
+                "PI_GUARDIAN_HARNESS_ID": identity.harness_id,
+                "PI_GUARDIAN_HARNESS_VERSION": identity.harness_version,
+                "PI_DISABLE_TOOLS": "1" if read_only else "0",
+            }
+        )
+        cmd = ["node", str(wrapper_path), "guardian-authorized-task", request.prompt]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=request.cwd,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=request.timeout_seconds,
+            )
+            return self._parse_result(result, require_runtime_identity=True)
+        except subprocess.TimeoutExpired:
+            return AgentRunEnvelope(
+                status="error",
+                summary=f"Execution timed out after {request.timeout_seconds}s",
+                errors=["timeout_expired"],
+                metrics={"timeout_seconds": request.timeout_seconds},
+            )
+        except FileNotFoundError:
+            return AgentRunEnvelope(
+                status="error",
+                summary="Pi agent wrapper not found",
+                errors=["pi_wrapper_not_found"],
+            )
+
     def _parse_result(
-        self, result: subprocess.CompletedProcess[str]
+        self,
+        result: subprocess.CompletedProcess[str],
+        *,
+        require_runtime_identity: bool = False,
     ) -> AgentRunEnvelope:
         """Parse subprocess result into AgentRunEnvelope."""
         stdout = (result.stdout or "").strip()
@@ -104,6 +173,13 @@ class PiCodexRunnerAdapter:
         if stdout:
             try:
                 data = json.loads(stdout)
+                runtime_identity = data.get("actual_runtime_identity")
+                if require_runtime_identity and not isinstance(runtime_identity, dict):
+                    return AgentRunEnvelope(
+                        status="error",
+                        summary="Pi wrapper omitted runtime identity attestation",
+                        errors=["actual_identity_missing"],
+                    )
                 return AgentRunEnvelope(
                     status=data.get("status", "ok"),
                     summary=data.get(
@@ -113,8 +189,34 @@ class PiCodexRunnerAdapter:
                     next_actions=data.get("next_actions", []),
                     errors=data.get("errors", []),
                     metrics=data.get("metrics", {}),
+                    actual_provider_id=(
+                        runtime_identity.get("actual_provider_id")
+                        if isinstance(runtime_identity, dict)
+                        else None
+                    ),
+                    actual_model_id=(
+                        runtime_identity.get("actual_model_id")
+                        if isinstance(runtime_identity, dict)
+                        else None
+                    ),
+                    actual_harness_id=(
+                        runtime_identity.get("actual_harness_id")
+                        if isinstance(runtime_identity, dict)
+                        else None
+                    ),
+                    actual_harness_version=(
+                        runtime_identity.get("actual_harness_version")
+                        if isinstance(runtime_identity, dict)
+                        else None
+                    ),
                 )
             except json.JSONDecodeError:
+                if require_runtime_identity:
+                    return AgentRunEnvelope(
+                        status="error",
+                        summary="Pi wrapper returned a non-attested result",
+                        errors=["actual_identity_missing"],
+                    )
                 # Non-JSON output - wrap as text summary
                 return AgentRunEnvelope(
                     status="ok",
@@ -127,9 +229,13 @@ class PiCodexRunnerAdapter:
 
         return AgentRunEnvelope(
             status="ok",
-            summary="Task completed with no output",
+            summary=(
+                "Pi wrapper omitted runtime identity attestation"
+                if require_runtime_identity
+                else "Task completed with no output"
+            ),
             artifacts=[],
             next_actions=[],
-            errors=[],
+            errors=["actual_identity_missing"] if require_runtime_identity else [],
             metrics={},
         )

--- a/guardian/pi/invocation.py
+++ b/guardian/pi/invocation.py
@@ -1,0 +1,533 @@
+"""Guardian-owned, one-shot invocation rail for the existing Pi harness.
+
+This module deliberately owns no queue, persistence, Campaign Engine state,
+FastAPI route, or Coding Worker behavior.  It evaluates immutable Guardian
+authorization, invokes one injected or Pi-backed harness, and returns bounded
+Pi contract records to its caller without persisting them.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping
+
+from guardian.pi.contracts import (
+    PiHarnessResult,
+    PiInvocationArtifact,
+    PiInvocationEnvelope,
+    PiInvocationPolicyDecision,
+    PiInvocationReceipt,
+    PiPermissionGrant,
+    PiProviderLane,
+)
+from guardian.pi.tokens import (
+    PiHarnessResultClass,
+    PiInvocationReceiptStatus,
+    PiValidationFailureReason,
+)
+from guardian.pi.validation import (
+    validate_harness_result_against_receipt,
+    validate_policy_decision_against_envelope,
+    validate_receipt_against_envelope,
+)
+
+
+_SUCCESS_STATUSES = frozenset({"ok", "success", "succeeded", "completed"})
+_SENSITIVE_KEY_PARTS = frozenset(
+    {
+        "api_key",
+        "authorization",
+        "cookie",
+        "credential",
+        "password",
+        "refresh_token",
+        "secret",
+        "session",
+    }
+)
+_SENSITIVE_KEY_NAMES = frozenset(
+    {
+        "access_token",
+        "api_token",
+        "bearer_token",
+        "id_token",
+        "token",
+    }
+)
+_GIT_TIMEOUT_SECONDS = 5
+
+
+@dataclass(frozen=True, slots=True)
+class PiAuthorizedExecutionIdentity:
+    """Identity frozen from a validated envelope and allowed decision."""
+
+    provider_id: str
+    model_id: str
+    harness_id: str
+    harness_version: str
+
+
+@dataclass(frozen=True, slots=True)
+class PiAuthorizedHarnessRequest:
+    """The only execution request a Guardian-authorized runner receives."""
+
+    prompt: str
+    cwd: Path
+    timeout_seconds: int
+    identity: PiAuthorizedExecutionIdentity
+    read_only: bool
+
+
+@dataclass(frozen=True, slots=True)
+class PiHarnessRuntimeEvidence:
+    """Bounded runtime identity returned by the harness itself.
+
+    The invocation rail intentionally accepts no requested identity here.  The
+    adapter must populate these values from its resolved runtime result.
+    """
+
+    status: str
+    actual_provider_id: str | None
+    actual_model_id: str | None
+    actual_harness_id: str | None
+    actual_harness_version: str | None
+
+
+PiAuthorizedHarnessRunner = Callable[
+    [PiAuthorizedHarnessRequest], PiHarnessRuntimeEvidence
+]
+
+
+@dataclass(frozen=True, slots=True)
+class PiLiveInvocationOutcome:
+    """Terminal, non-persisted result for exactly one invocation attempt."""
+
+    ok: bool
+    failure_reason: str | None
+    runner_call_count: int
+    retry_count: int
+    fallback_count: int
+    receipt: PiInvocationReceipt | None = None
+    harness_result: PiHarnessResult | None = None
+    actual_identity: PiAuthorizedExecutionIdentity | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _TargetSnapshot:
+    entries: tuple[tuple[str, str], ...]
+    git_head: str | None
+
+
+def invoke_guardian_authorized_pi(
+    *,
+    envelope: PiInvocationEnvelope,
+    decision: PiInvocationPolicyDecision,
+    prompt: str,
+    cwd: str | Path,
+    timeout_seconds: int,
+    harness_runner: PiAuthorizedHarnessRunner | None = None,
+) -> PiLiveInvocationOutcome:
+    """Authorize and invoke one Pi harness call without durable side effects.
+
+    The function never retries, falls back, repairs a target, or writes a
+    receipt/result to a database, queue, store, or Campaign Engine artifact.
+    """
+    authorization = validate_policy_decision_against_envelope(envelope, decision)
+    if not authorization.ok:
+        return _blocked(
+            PiValidationFailureReason.POLICY_ENVELOPE_MISMATCH,
+            runner_call_count=0,
+        )
+    if decision.decision != "allowed":
+        return _blocked(
+            PiValidationFailureReason.AUTHORIZATION_DENIED,
+            runner_call_count=0,
+        )
+    if _contains_sensitive_keys(envelope.to_payload()) or _contains_sensitive_keys(
+        decision.to_payload()
+    ):
+        return _blocked(
+            PiValidationFailureReason.CREDENTIAL_MATERIAL_REJECTED,
+            runner_call_count=0,
+        )
+
+    identity, identity_failure = _authorized_identity(envelope)
+    if identity_failure is not None:
+        return _blocked(identity_failure, runner_call_count=0)
+    assert identity is not None
+
+    target = Path(cwd).expanduser().resolve(strict=False)
+    if not target.is_dir():
+        return _blocked(
+            PiValidationFailureReason.MUTATION_SCOPE_VIOLATION,
+            runner_call_count=0,
+        )
+    write_roots, scope_failure = _granted_write_roots(envelope, target)
+    if scope_failure is not None:
+        return _blocked(scope_failure, runner_call_count=0)
+
+    pre_execution = _snapshot_target(target)
+    request = PiAuthorizedHarnessRequest(
+        prompt=str(prompt),
+        cwd=target,
+        timeout_seconds=max(1, int(timeout_seconds)),
+        identity=identity,
+        read_only=not write_roots,
+    )
+    runner = harness_runner or _run_with_pi_adapter
+    evidence: PiHarnessRuntimeEvidence | None = None
+    runner_failed = False
+    try:
+        evidence = runner(request)
+    except Exception:
+        runner_failed = True
+    post_execution = _snapshot_target(target)
+    state_failure = _enforce_target_posture(
+        target=target,
+        pre_execution=pre_execution,
+        post_execution=post_execution,
+        write_roots=write_roots,
+    )
+    if state_failure is not None:
+        return _blocked(state_failure, runner_call_count=1)
+    if runner_failed or evidence is None:
+        return _blocked(
+            PiValidationFailureReason.ADAPTER_EXECUTION_FAILURE,
+            runner_call_count=1,
+        )
+    if str(evidence.status).strip().lower() not in _SUCCESS_STATUSES:
+        return _blocked(
+            PiValidationFailureReason.ADAPTER_EXECUTION_FAILURE,
+            runner_call_count=1,
+        )
+
+    actual_identity, actual_failure = _actual_identity(evidence)
+    if actual_failure is not None:
+        return _blocked(actual_failure, runner_call_count=1)
+    assert actual_identity is not None
+    identity_failure = _validate_actual_identity(identity, actual_identity)
+    if identity_failure is not None:
+        return _blocked(identity_failure, runner_call_count=1)
+
+    artifact_ref = f"pi://guardian-authorized/{envelope.invocation_id}/result"
+    receipt = PiInvocationReceipt(
+        receipt_id=f"pi-receipt-{envelope.invocation_id}",
+        guardian_boundary=envelope.guardian_boundary,
+        source_thread_id=envelope.source_thread_id,
+        source_message_id=envelope.source_message_id,
+        authored_request_id=envelope.authored_request_id,
+        attempt_id=envelope.attempt_id,
+        invocation_id=envelope.invocation_id,
+        harness_id=envelope.harness_id,
+        harness_version=envelope.harness_version,
+        provider_lane=envelope.provider_lane,
+        requested_permissions=envelope.requested_permissions,
+        granted_permissions=envelope.granted_permissions,
+        command_bus_linkage=envelope.command_bus_linkage,
+        result_artifact_ref=artifact_ref,
+        receipt_status=PiInvocationReceiptStatus.COMPLETED.value,
+        validation_metadata={
+            "guardian_authorized": True,
+            "policy_decision_id": decision.policy_decision_id,
+        },
+    )
+    receipt_validation = validate_receipt_against_envelope(envelope, receipt)
+    if not receipt_validation.ok:
+        return _blocked(
+            PiValidationFailureReason.HARNESS_RESULT_MISMATCH,
+            runner_call_count=1,
+        )
+
+    actual_lane = PiProviderLane(
+        provider_lane_class=envelope.provider_lane.provider_lane_class,
+        provider_name=actual_identity.provider_id,
+        model_id=actual_identity.model_id,
+        metadata=envelope.provider_lane.metadata,
+    )
+    harness_result = PiHarnessResult(
+        harness_result_id=f"pi-result-{envelope.invocation_id}",
+        receipt_id=receipt.receipt_id,
+        guardian_boundary=envelope.guardian_boundary,
+        source_thread_id=envelope.source_thread_id,
+        source_message_id=envelope.source_message_id,
+        authored_request_id=envelope.authored_request_id,
+        attempt_id=envelope.attempt_id,
+        invocation_id=envelope.invocation_id,
+        harness_id=actual_identity.harness_id,
+        harness_version=actual_identity.harness_version,
+        provider_lane=actual_lane,
+        requested_permissions=envelope.requested_permissions,
+        granted_permissions=envelope.granted_permissions,
+        command_bus_linkage=envelope.command_bus_linkage,
+        artifact=PiInvocationArtifact(
+            artifact_id=f"pi-artifact-{envelope.invocation_id}",
+            artifact_ref=artifact_ref,
+            artifact_class="bounded_result",
+        ),
+        result_class=PiHarnessResultClass.SUCCESS.value,
+        validation_metadata={"actual_runtime_identity_attested": True},
+    )
+    result_validation = validate_harness_result_against_receipt(receipt, harness_result)
+    if not result_validation.ok:
+        return _blocked(
+            PiValidationFailureReason.HARNESS_RESULT_MISMATCH,
+            runner_call_count=1,
+        )
+    return PiLiveInvocationOutcome(
+        ok=True,
+        failure_reason=None,
+        runner_call_count=1,
+        retry_count=0,
+        fallback_count=0,
+        receipt=receipt,
+        harness_result=harness_result,
+        actual_identity=actual_identity,
+    )
+
+
+def _run_with_pi_adapter(
+    request: PiAuthorizedHarnessRequest,
+) -> PiHarnessRuntimeEvidence:
+    """Bridge the typed Guardian request to the approved opt-in Pi adapter."""
+    from guardian.agents.adapters.base import (
+        AgentExecutionIdentity,
+        AgentExecutionRequest,
+    )
+    from guardian.agents.adapters.pi_codex_runner import PiCodexRunnerAdapter
+
+    result = PiCodexRunnerAdapter().execute_authorized(
+        AgentExecutionRequest(
+            prompt=request.prompt,
+            cwd=str(request.cwd),
+            timeout_seconds=request.timeout_seconds,
+        ),
+        AgentExecutionIdentity(
+            provider_id=request.identity.provider_id,
+            model_id=request.identity.model_id,
+            harness_id=request.identity.harness_id,
+            harness_version=request.identity.harness_version,
+        ),
+        read_only=request.read_only,
+    )
+    return PiHarnessRuntimeEvidence(
+        status=result.status,
+        actual_provider_id=result.actual_provider_id,
+        actual_model_id=result.actual_model_id,
+        actual_harness_id=result.actual_harness_id,
+        actual_harness_version=result.actual_harness_version,
+    )
+
+
+def _authorized_identity(
+    envelope: PiInvocationEnvelope,
+) -> tuple[PiAuthorizedExecutionIdentity | None, PiValidationFailureReason | None]:
+    provider_id = str(envelope.provider_lane.provider_name or "").strip()
+    if not provider_id:
+        return None, PiValidationFailureReason.MISSING_PROVIDER_ID
+    model_id = str(envelope.provider_lane.model_id or "").strip()
+    if not model_id:
+        return None, PiValidationFailureReason.MISSING_MODEL_ID
+    if not envelope.harness_id:
+        return None, PiValidationFailureReason.MISSING_HARNESS_ID
+    if not envelope.harness_version:
+        return None, PiValidationFailureReason.MISSING_HARNESS_VERSION
+    return (
+        PiAuthorizedExecutionIdentity(
+            provider_id=provider_id,
+            model_id=model_id,
+            harness_id=envelope.harness_id,
+            harness_version=envelope.harness_version,
+        ),
+        None,
+    )
+
+
+def _actual_identity(
+    evidence: PiHarnessRuntimeEvidence,
+) -> tuple[PiAuthorizedExecutionIdentity | None, PiValidationFailureReason | None]:
+    values = (
+        evidence.actual_provider_id,
+        evidence.actual_model_id,
+        evidence.actual_harness_id,
+        evidence.actual_harness_version,
+    )
+    if any(not str(value or "").strip() for value in values):
+        return None, PiValidationFailureReason.ACTUAL_IDENTITY_MISSING
+    return (
+        PiAuthorizedExecutionIdentity(
+            provider_id=str(evidence.actual_provider_id).strip(),
+            model_id=str(evidence.actual_model_id).strip(),
+            harness_id=str(evidence.actual_harness_id).strip(),
+            harness_version=str(evidence.actual_harness_version).strip(),
+        ),
+        None,
+    )
+
+
+def _validate_actual_identity(
+    authorized: PiAuthorizedExecutionIdentity,
+    actual: PiAuthorizedExecutionIdentity,
+) -> PiValidationFailureReason | None:
+    if actual.provider_id != authorized.provider_id:
+        return PiValidationFailureReason.PROVIDER_IDENTITY_MISMATCH
+    if actual.model_id != authorized.model_id:
+        return PiValidationFailureReason.MODEL_IDENTITY_MISMATCH
+    if (
+        actual.harness_id != authorized.harness_id
+        or actual.harness_version != authorized.harness_version
+    ):
+        return PiValidationFailureReason.HARNESS_IDENTITY_MISMATCH
+    return None
+
+
+def _granted_write_roots(
+    envelope: PiInvocationEnvelope,
+    target: Path,
+) -> tuple[tuple[Path, ...], PiValidationFailureReason | None]:
+    roots: list[Path] = []
+    for permission in envelope.granted_permissions:
+        if permission.permission != "files.write":
+            continue
+        if not permission.resource:
+            return (), PiValidationFailureReason.MUTATION_SCOPE_VIOLATION
+        raw_path = Path(permission.resource)
+        candidate = raw_path if raw_path.is_absolute() else target / raw_path
+        resolved = candidate.resolve(strict=False)
+        if not _inside(resolved, target):
+            return (), PiValidationFailureReason.MUTATION_SCOPE_VIOLATION
+        roots.append(resolved)
+    return tuple(roots), None
+
+
+def _snapshot_target(target: Path) -> _TargetSnapshot:
+    entries: dict[str, str] = {}
+
+    def visit(directory: Path) -> None:
+        with os.scandir(directory) as iterator:
+            for entry in iterator:
+                if directory == target and entry.name == ".git":
+                    continue
+                path = Path(entry.path)
+                relative = path.relative_to(target).as_posix()
+                if entry.is_symlink():
+                    entries[relative] = f"symlink:{os.readlink(path)}"
+                elif entry.is_dir(follow_symlinks=False):
+                    entries[relative] = "directory"
+                    visit(path)
+                elif entry.is_file(follow_symlinks=False):
+                    entries[relative] = f"file:{_sha256(path)}"
+                else:
+                    entries[relative] = "other"
+
+    visit(target)
+    return _TargetSnapshot(
+        entries=tuple(sorted(entries.items())),
+        git_head=_git_head(target),
+    )
+
+
+def _enforce_target_posture(
+    *,
+    target: Path,
+    pre_execution: _TargetSnapshot,
+    post_execution: _TargetSnapshot,
+    write_roots: tuple[Path, ...],
+) -> PiValidationFailureReason | None:
+    if pre_execution.git_head != post_execution.git_head:
+        return PiValidationFailureReason.GIT_MUTATION_VIOLATION
+
+    before = dict(pre_execution.entries)
+    after = dict(post_execution.entries)
+    changed_paths = tuple(
+        path
+        for path in sorted(set(before) | set(after))
+        if before.get(path) != after.get(path)
+    )
+    if not changed_paths:
+        return None
+    if not write_roots:
+        return PiValidationFailureReason.READ_ONLY_VIOLATION
+    for relative in changed_paths:
+        candidate = target / relative
+        if not any(
+            _inside(candidate.resolve(strict=False), root) for root in write_roots
+        ):
+            return PiValidationFailureReason.MUTATION_SCOPE_VIOLATION
+        if candidate.is_symlink() and not _inside(
+            candidate.resolve(strict=False), target
+        ):
+            return PiValidationFailureReason.MUTATION_SCOPE_VIOLATION
+    return None
+
+
+def _git_head(target: Path) -> str | None:
+    completed = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=target,
+        capture_output=True,
+        text=True,
+        timeout=_GIT_TIMEOUT_SECONDS,
+    )
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip() or None
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(64 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _inside(candidate: Path, root: Path) -> bool:
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _contains_sensitive_keys(value: object) -> bool:
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            key_text = str(key).strip().lower()
+            if (
+                key_text in _SENSITIVE_KEY_NAMES
+                or any(part in key_text for part in _SENSITIVE_KEY_PARTS)
+            ):
+                return True
+            if _contains_sensitive_keys(nested):
+                return True
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        return any(_contains_sensitive_keys(item) for item in value)
+    return False
+
+
+def _blocked(
+    reason: PiValidationFailureReason,
+    *,
+    runner_call_count: int,
+) -> PiLiveInvocationOutcome:
+    return PiLiveInvocationOutcome(
+        ok=False,
+        failure_reason=reason.value,
+        runner_call_count=runner_call_count,
+        retry_count=0,
+        fallback_count=0,
+    )
+
+
+__all__ = [
+    "PiAuthorizedExecutionIdentity",
+    "PiAuthorizedHarnessRequest",
+    "PiAuthorizedHarnessRunner",
+    "PiHarnessRuntimeEvidence",
+    "PiLiveInvocationOutcome",
+    "invoke_guardian_authorized_pi",
+]

--- a/guardian/pi/tokens.py
+++ b/guardian/pi/tokens.py
@@ -60,6 +60,19 @@ class PiValidationFailureReason(str, Enum):
     MISSING_HARNESS_RESULT_ID = "missing_harness_result_id"
     MISSING_ARTIFACT_REFERENCE = "missing_artifact_reference"
     MALFORMED_COMMAND_BUS_LINKAGE = "malformed_command_bus_linkage"
+    AUTHORIZATION_DENIED = "authorization_denied"
+    POLICY_ENVELOPE_MISMATCH = "policy_envelope_mismatch"
+    MISSING_PROVIDER_ID = "missing_provider_id"
+    MISSING_MODEL_ID = "missing_model_id"
+    ACTUAL_IDENTITY_MISSING = "actual_identity_missing"
+    PROVIDER_IDENTITY_MISMATCH = "provider_identity_mismatch"
+    MODEL_IDENTITY_MISMATCH = "model_identity_mismatch"
+    HARNESS_IDENTITY_MISMATCH = "harness_identity_mismatch"
+    MUTATION_SCOPE_VIOLATION = "mutation_scope_violation"
+    GIT_MUTATION_VIOLATION = "git_mutation_violation"
+    READ_ONLY_VIOLATION = "read_only_violation"
+    ADAPTER_EXECUTION_FAILURE = "adapter_execution_failure"
+    CREDENTIAL_MATERIAL_REJECTED = "credential_material_rejected"
 
 
 PI_INVOCATION_ENVELOPE_STATUSES: frozenset[str] = frozenset(

--- a/guardian/pi/validation.py
+++ b/guardian/pi/validation.py
@@ -912,6 +912,72 @@ def validate_pi_invocation_policy_decision(
     return _result(reasons=reasons, metadata=metadata)
 
 
+def validate_policy_decision_against_envelope(
+    envelope: PiInvocationEnvelope,
+    decision: PiInvocationPolicyDecision,
+) -> PiInvocationValidationResult:
+    """Validate that Guardian authorized exactly the prepared invocation.
+
+    The policy decision deliberately does not duplicate provider/model values.
+    It authorizes the immutable envelope by matching its invocation, lineage,
+    Guardian boundary, harness, and exact permission posture.  Callers must
+    validate this relationship before deriving the envelope's explicit provider
+    and model as the authorized execution identity.
+    """
+    envelope_result = validate_invocation_envelope(envelope)
+    decision_result = validate_pi_invocation_policy_decision(decision)
+    reasons = list(envelope_result.failure_reasons)
+    reasons.extend(decision_result.failure_reasons)
+
+    if envelope.invocation_id != decision.invocation_id:
+        reasons.append(
+            _invalid_reason(PiValidationFailureReason.POLICY_ENVELOPE_MISMATCH)
+        )
+    if envelope.source_thread_id != decision.source_thread_id:
+        reasons.append(
+            _invalid_reason(PiValidationFailureReason.POLICY_ENVELOPE_MISMATCH)
+        )
+    if envelope.source_message_id != decision.source_message_id:
+        reasons.append(
+            _invalid_reason(PiValidationFailureReason.POLICY_ENVELOPE_MISMATCH)
+        )
+    if envelope.harness_id != decision.harness_id:
+        reasons.append(
+            _invalid_reason(PiValidationFailureReason.POLICY_ENVELOPE_MISMATCH)
+        )
+    if (
+        envelope.guardian_boundary.to_payload()
+        != decision.guardian_boundary.to_payload()
+    ):
+        reasons.append(
+            _invalid_reason(PiValidationFailureReason.POLICY_ENVELOPE_MISMATCH)
+        )
+    _compare_signature_sets(
+        expected=envelope.requested_permissions,
+        observed=decision.requested_permissions,
+        reasons=reasons,
+    )
+    _compare_signature_sets(
+        expected=envelope.granted_permissions,
+        observed=decision.granted_permissions,
+        reasons=reasons,
+    )
+
+    metadata = {
+        "validator": "policy_decision_against_envelope",
+        "envelope_validation": envelope_result.to_payload(),
+        "policy_validation": decision_result.to_payload(),
+        "comparison": {
+            "invocation_id": decision.invocation_id,
+            "source_thread_id": decision.source_thread_id,
+            "source_message_id": decision.source_message_id,
+            "harness_id": decision.harness_id,
+            "decision": decision.decision,
+        },
+    }
+    return _result(reasons=reasons, metadata=metadata)
+
+
 def validate_pi_invocation_result_return(
     result_return: PiInvocationResultReturn,
 ) -> PiInvocationValidationResult:
@@ -1026,6 +1092,7 @@ __all__ = [
     "validate_receipt_against_envelope",
     "validate_harness_result_against_receipt",
     "validate_pi_invocation_policy_decision",
+    "validate_policy_decision_against_envelope",
     "validate_pi_invocation_result_return",
     "validate_pi_invocation_operator_evidence",
 ]

--- a/tests/pi/test_pi_live_invocation.py
+++ b/tests/pi/test_pi_live_invocation.py
@@ -1,0 +1,618 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import replace
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from guardian.agents.adapters.base import AgentExecutionIdentity, AgentExecutionRequest
+from guardian.agents.adapters.codex import CodexAdapter
+from guardian.agents.adapters.pi_codex_runner import PiCodexRunnerAdapter
+from guardian.pi.contracts import (
+    PiGuardianBoundary,
+    PiInvocationEnvelope,
+    PiInvocationPolicyDecision,
+    PiPermissionGrant,
+    PiProviderLane,
+)
+from guardian.pi.invocation import (
+    PiAuthorizedHarnessRequest,
+    PiHarnessRuntimeEvidence,
+    invoke_guardian_authorized_pi,
+)
+from guardian.pi.tokens import PiValidationFailureReason
+from guardian.pi.validation import (
+    validate_harness_result_against_receipt,
+    validate_policy_decision_against_envelope,
+    validate_receipt_against_envelope,
+)
+
+
+IDENTITY = {
+    "provider_id": "openai-codex",
+    "model_id": "codex-test-model",
+    "harness_id": "pi-coding-agent",
+    "harness_version": "0.72.1",
+}
+
+
+def _boundary(account_id: str = "acct-live-invocation") -> PiGuardianBoundary:
+    return PiGuardianBoundary(owner_account_id=account_id)
+
+
+def _read_permission() -> PiPermissionGrant:
+    return PiPermissionGrant(
+        permission="files.read",
+        resource=".",
+        reason="inspect the disposable fixture",
+    )
+
+
+def _write_permission(resource: str = "src") -> PiPermissionGrant:
+    return PiPermissionGrant(
+        permission="files.write",
+        resource=resource,
+        reason="bounded fixture correction",
+    )
+
+
+def _envelope(
+    *,
+    boundary: PiGuardianBoundary | None = None,
+    invocation_id: str = "invocation-live-001",
+    source_thread_id: str = "thread-live-001",
+    source_message_id: str = "message-live-001",
+    harness_id: str = IDENTITY["harness_id"],
+    harness_version: str = IDENTITY["harness_version"],
+    provider_id: str = IDENTITY["provider_id"],
+    model_id: str = IDENTITY["model_id"],
+    requested_permissions: tuple[PiPermissionGrant, ...] | None = None,
+    granted_permissions: tuple[PiPermissionGrant, ...] | None = None,
+    validation_metadata: dict[str, object] | None = None,
+) -> PiInvocationEnvelope:
+    requested = requested_permissions or (_read_permission(),)
+    granted = granted_permissions if granted_permissions is not None else requested
+    return PiInvocationEnvelope(
+        guardian_boundary=boundary or _boundary(),
+        source_thread_id=source_thread_id,
+        source_message_id=source_message_id,
+        authored_request_id="request-live-001",
+        attempt_id="attempt-live-001",
+        invocation_id=invocation_id,
+        harness_id=harness_id,
+        harness_version=harness_version,
+        provider_lane=PiProviderLane(
+            provider_lane_class="external",
+            provider_name=provider_id,
+            model_id=model_id,
+            metadata={"lane": "test-only"},
+        ),
+        requested_permissions=requested,
+        granted_permissions=granted,
+        status="prepared",
+        validation_metadata=validation_metadata or {"fixture": "live-invocation"},
+    )
+
+
+def _decision(
+    envelope: PiInvocationEnvelope,
+    *,
+    decision: str = "allowed",
+    boundary: PiGuardianBoundary | None = None,
+    invocation_id: str | None = None,
+    source_thread_id: str | None = None,
+    source_message_id: str | None = None,
+    harness_id: str | None = None,
+    requested_permissions: tuple[PiPermissionGrant, ...] | None = None,
+    granted_permissions: tuple[PiPermissionGrant, ...] | None = None,
+) -> PiInvocationPolicyDecision:
+    return PiInvocationPolicyDecision(
+        policy_decision_id="policy-live-001",
+        invocation_id=invocation_id if invocation_id is not None else envelope.invocation_id,
+        source_thread_id=(
+            source_thread_id
+            if source_thread_id is not None
+            else envelope.source_thread_id
+        ),
+        source_message_id=(
+            source_message_id
+            if source_message_id is not None
+            else envelope.source_message_id
+        ),
+        harness_id=harness_id if harness_id is not None else envelope.harness_id,
+        decision=decision,
+        guardian_boundary=boundary or envelope.guardian_boundary,
+        requested_permissions=(
+            requested_permissions
+            if requested_permissions is not None
+            else envelope.requested_permissions
+        ),
+        granted_permissions=(
+            granted_permissions
+            if granted_permissions is not None
+            else envelope.granted_permissions
+        ),
+        permission_posture="bounded",
+        policy_source="guardian",
+        decision_reason="deterministic test authorization",
+        decided_at="2026-08-16T00:00:00Z",
+        validation_status="valid",
+        redaction_state="clean",
+    )
+
+
+def _evidence(**overrides: str | None) -> PiHarnessRuntimeEvidence:
+    return PiHarnessRuntimeEvidence(
+        status=str(overrides.get("status", "ok")),
+        actual_provider_id=overrides.get("actual_provider_id", IDENTITY["provider_id"]),
+        actual_model_id=overrides.get("actual_model_id", IDENTITY["model_id"]),
+        actual_harness_id=overrides.get("actual_harness_id", IDENTITY["harness_id"]),
+        actual_harness_version=overrides.get(
+            "actual_harness_version", IDENTITY["harness_version"]
+        ),
+    )
+
+
+class _RecordingRunner:
+    def __init__(
+        self,
+        *,
+        evidence: PiHarnessRuntimeEvidence | None = None,
+        mutation: Callable[[PiAuthorizedHarnessRequest], None] | None = None,
+        raises: bool = False,
+    ) -> None:
+        self.calls: list[PiAuthorizedHarnessRequest] = []
+        self.evidence = evidence or _evidence()
+        self.mutation = mutation
+        self.raises = raises
+
+    def __call__(self, request: PiAuthorizedHarnessRequest) -> PiHarnessRuntimeEvidence:
+        self.calls.append(request)
+        if self.mutation is not None:
+            self.mutation(request)
+        if self.raises:
+            raise RuntimeError("controlled runner failure")
+        return self.evidence
+
+
+def _invoke(
+    tmp_path: Path,
+    runner: _RecordingRunner,
+    *,
+    envelope: PiInvocationEnvelope | None = None,
+    decision: PiInvocationPolicyDecision | None = None,
+) -> object:
+    envelope = envelope or _envelope()
+    decision = decision or _decision(envelope)
+    return invoke_guardian_authorized_pi(
+        envelope=envelope,
+        decision=decision,
+        prompt="Perform the bounded fixture task.",
+        cwd=tmp_path,
+        timeout_seconds=15,
+        harness_runner=runner,
+    )
+
+
+def _assert_blocked(outcome: object, reason: PiValidationFailureReason) -> None:
+    assert not outcome.ok
+    assert outcome.failure_reason == reason.value
+    assert outcome.retry_count == 0
+    assert outcome.fallback_count == 0
+
+
+def _fixture_tree(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "function.py").write_text(
+        "def deterministic_value():\n    return 'before'\n", encoding="utf-8"
+    )
+    (tmp_path / "test_function.py").write_text(
+        "from src.function import deterministic_value\n", encoding="utf-8"
+    )
+
+
+def _initialize_git_repository(target: Path) -> None:
+    for command in (
+        ["git", "init", "-q"],
+        ["git", "config", "user.email", "pi-test@example.invalid"],
+        ["git", "config", "user.name", "Pi Invocation Test"],
+        ["git", "add", "."],
+        ["git", "commit", "-qm", "fixture baseline"],
+    ):
+        subprocess.run(command, cwd=target, check=True, capture_output=True, text=True)
+
+
+def test_invalid_envelope_blocks_before_runner(tmp_path: Path) -> None:
+    runner = _RecordingRunner()
+    envelope = replace(_envelope(), source_thread_id="")
+    outcome = _invoke(tmp_path, runner, envelope=envelope, decision=_decision(envelope))
+
+    _assert_blocked(outcome, PiValidationFailureReason.POLICY_ENVELOPE_MISMATCH)
+    assert outcome.runner_call_count == len(runner.calls) == 0
+
+
+def test_denied_policy_blocks_before_runner(tmp_path: Path) -> None:
+    runner = _RecordingRunner()
+    envelope = _envelope(granted_permissions=())
+    outcome = _invoke(
+        tmp_path,
+        runner,
+        envelope=envelope,
+        decision=_decision(envelope, decision="denied", granted_permissions=()),
+    )
+
+    _assert_blocked(outcome, PiValidationFailureReason.AUTHORIZATION_DENIED)
+    assert outcome.runner_call_count == len(runner.calls) == 0
+
+
+@pytest.mark.parametrize(
+    ("decision_kwargs", "expected_reason"),
+    [
+        ({"invocation_id": "other-invocation"}, PiValidationFailureReason.POLICY_ENVELOPE_MISMATCH),
+        ({"source_thread_id": "other-thread"}, PiValidationFailureReason.POLICY_ENVELOPE_MISMATCH),
+        ({"source_message_id": "other-message"}, PiValidationFailureReason.POLICY_ENVELOPE_MISMATCH),
+        ({"boundary": _boundary("other-account")}, PiValidationFailureReason.POLICY_ENVELOPE_MISMATCH),
+        ({"harness_id": "other-harness"}, PiValidationFailureReason.POLICY_ENVELOPE_MISMATCH),
+        (
+            {"granted_permissions": (_read_permission(), _write_permission())},
+            PiValidationFailureReason.POLICY_ENVELOPE_MISMATCH,
+        ),
+    ],
+)
+def test_cross_object_mismatches_block_before_runner(
+    tmp_path: Path,
+    decision_kwargs: dict[str, object],
+    expected_reason: PiValidationFailureReason,
+) -> None:
+    runner = _RecordingRunner()
+    envelope = _envelope()
+    outcome = _invoke(
+        tmp_path,
+        runner,
+        envelope=envelope,
+        decision=_decision(envelope, **decision_kwargs),
+    )
+
+    _assert_blocked(outcome, expected_reason)
+    assert outcome.runner_call_count == len(runner.calls) == 0
+
+
+@pytest.mark.parametrize(
+    ("provider_id", "model_id", "expected_reason"),
+    [
+        ("", IDENTITY["model_id"], PiValidationFailureReason.MISSING_PROVIDER_ID),
+        (IDENTITY["provider_id"], "", PiValidationFailureReason.MISSING_MODEL_ID),
+    ],
+)
+def test_missing_explicit_identity_blocks_before_runner(
+    tmp_path: Path,
+    provider_id: str,
+    model_id: str,
+    expected_reason: PiValidationFailureReason,
+) -> None:
+    runner = _RecordingRunner()
+    envelope = _envelope(provider_id=provider_id, model_id=model_id)
+    outcome = _invoke(tmp_path, runner, envelope=envelope, decision=_decision(envelope))
+
+    _assert_blocked(outcome, expected_reason)
+    assert outcome.runner_call_count == len(runner.calls) == 0
+
+
+def test_credential_named_metadata_is_rejected_before_runner(tmp_path: Path) -> None:
+    runner = _RecordingRunner()
+    envelope = _envelope(validation_metadata={"api_key": "redacted-for-test"})
+    outcome = _invoke(tmp_path, runner, envelope=envelope, decision=_decision(envelope))
+
+    _assert_blocked(outcome, PiValidationFailureReason.CREDENTIAL_MATERIAL_REJECTED)
+    assert outcome.runner_call_count == len(runner.calls) == 0
+
+
+def test_exact_authorized_identity_reaches_single_read_only_runner(tmp_path: Path) -> None:
+    _fixture_tree(tmp_path)
+    runner = _RecordingRunner()
+    outcome = _invoke(tmp_path, runner)
+
+    assert outcome.ok
+    assert outcome.runner_call_count == len(runner.calls) == 1
+    request = runner.calls[0]
+    assert request.identity.provider_id == IDENTITY["provider_id"]
+    assert request.identity.model_id == IDENTITY["model_id"]
+    assert request.identity.harness_id == IDENTITY["harness_id"]
+    assert request.identity.harness_version == IDENTITY["harness_version"]
+    assert request.read_only is True
+    assert outcome.retry_count == 0
+    assert outcome.fallback_count == 0
+    assert outcome.receipt is not None
+    assert outcome.harness_result is not None
+    assert validate_receipt_against_envelope(_envelope(), outcome.receipt).ok
+    assert validate_harness_result_against_receipt(
+        outcome.receipt, outcome.harness_result
+    ).ok
+
+
+@pytest.mark.parametrize(
+    ("evidence_kwargs", "expected_reason"),
+    [
+        (
+            {"actual_provider_id": "different-provider"},
+            PiValidationFailureReason.PROVIDER_IDENTITY_MISMATCH,
+        ),
+        (
+            {"actual_model_id": "different-model"},
+            PiValidationFailureReason.MODEL_IDENTITY_MISMATCH,
+        ),
+        (
+            {"actual_harness_id": "different-harness"},
+            PiValidationFailureReason.HARNESS_IDENTITY_MISMATCH,
+        ),
+        (
+            {"actual_harness_version": "9.9.9"},
+            PiValidationFailureReason.HARNESS_IDENTITY_MISMATCH,
+        ),
+        (
+            {"actual_provider_id": None},
+            PiValidationFailureReason.ACTUAL_IDENTITY_MISSING,
+        ),
+    ],
+)
+def test_actual_identity_mismatch_fails_closed(
+    tmp_path: Path,
+    evidence_kwargs: dict[str, str | None],
+    expected_reason: PiValidationFailureReason,
+) -> None:
+    runner = _RecordingRunner(evidence=_evidence(**evidence_kwargs))
+    outcome = _invoke(tmp_path, runner)
+
+    _assert_blocked(outcome, expected_reason)
+    assert outcome.runner_call_count == len(runner.calls) == 1
+
+
+def test_read_only_mutation_fails_closed(tmp_path: Path) -> None:
+    _fixture_tree(tmp_path)
+    runner = _RecordingRunner(
+        mutation=lambda request: (request.cwd / "src" / "function.py").write_text(
+            "mutated", encoding="utf-8"
+        )
+    )
+    outcome = _invoke(tmp_path, runner)
+
+    _assert_blocked(outcome, PiValidationFailureReason.READ_ONLY_VIOLATION)
+    assert outcome.runner_call_count == len(runner.calls) == 1
+
+
+def test_allowed_write_inside_exact_grant_succeeds(tmp_path: Path) -> None:
+    _fixture_tree(tmp_path)
+    permissions = (_read_permission(), _write_permission("src"))
+    envelope = _envelope(
+        requested_permissions=permissions,
+        granted_permissions=permissions,
+    )
+    runner = _RecordingRunner(
+        mutation=lambda request: (request.cwd / "src" / "function.py").write_text(
+            "def deterministic_value():\n    return 'after'\n", encoding="utf-8"
+        )
+    )
+    outcome = _invoke(tmp_path, runner, envelope=envelope, decision=_decision(envelope))
+
+    assert outcome.ok
+    assert outcome.runner_call_count == len(runner.calls) == 1
+    assert (tmp_path / "src" / "function.py").read_text(encoding="utf-8").endswith(
+        "'after'\n"
+    )
+
+
+def test_write_outside_granted_root_fails_closed(tmp_path: Path) -> None:
+    _fixture_tree(tmp_path)
+    permissions = (_read_permission(), _write_permission("src"))
+    envelope = _envelope(
+        requested_permissions=permissions,
+        granted_permissions=permissions,
+    )
+    runner = _RecordingRunner(
+        mutation=lambda request: (request.cwd / "outside.txt").write_text(
+            "outside scope", encoding="utf-8"
+        )
+    )
+    outcome = _invoke(tmp_path, runner, envelope=envelope, decision=_decision(envelope))
+
+    _assert_blocked(outcome, PiValidationFailureReason.MUTATION_SCOPE_VIOLATION)
+    assert outcome.runner_call_count == len(runner.calls) == 1
+
+
+def test_path_traversal_write_grant_blocks_before_runner(tmp_path: Path) -> None:
+    _fixture_tree(tmp_path)
+    permissions = (_read_permission(), _write_permission("../outside"))
+    envelope = _envelope(
+        requested_permissions=permissions,
+        granted_permissions=permissions,
+    )
+    runner = _RecordingRunner()
+    outcome = _invoke(tmp_path, runner, envelope=envelope, decision=_decision(envelope))
+
+    _assert_blocked(outcome, PiValidationFailureReason.MUTATION_SCOPE_VIOLATION)
+    assert outcome.runner_call_count == len(runner.calls) == 0
+
+
+def test_symlink_escape_fails_closed(tmp_path: Path) -> None:
+    _fixture_tree(tmp_path)
+    permissions = (_read_permission(), _write_permission("src"))
+    envelope = _envelope(
+        requested_permissions=permissions,
+        granted_permissions=permissions,
+    )
+    outside = tmp_path.parent / "symlink-escape-target.txt"
+
+    def _create_escape(request: PiAuthorizedHarnessRequest) -> None:
+        escape = request.cwd / "src" / "escape"
+        escape.symlink_to(outside)
+        escape.write_text("outside target", encoding="utf-8")
+
+    runner = _RecordingRunner(mutation=_create_escape)
+    outcome = _invoke(tmp_path, runner, envelope=envelope, decision=_decision(envelope))
+
+    _assert_blocked(outcome, PiValidationFailureReason.MUTATION_SCOPE_VIOLATION)
+    assert outcome.runner_call_count == len(runner.calls) == 1
+
+
+def test_git_head_mutation_fails_closed(tmp_path: Path) -> None:
+    _fixture_tree(tmp_path)
+    _initialize_git_repository(tmp_path)
+    permissions = (_read_permission(), _write_permission("src"))
+    envelope = _envelope(
+        requested_permissions=permissions,
+        granted_permissions=permissions,
+    )
+
+    def _commit(request: PiAuthorizedHarnessRequest) -> None:
+        (request.cwd / "src" / "function.py").write_text("committed mutation", encoding="utf-8")
+        subprocess.run(["git", "add", "src/function.py"], cwd=request.cwd, check=True)
+        subprocess.run(
+            ["git", "commit", "-qm", "unauthorized mutation"],
+            cwd=request.cwd,
+            check=True,
+        )
+
+    runner = _RecordingRunner(mutation=_commit)
+    outcome = _invoke(tmp_path, runner, envelope=envelope, decision=_decision(envelope))
+
+    _assert_blocked(outcome, PiValidationFailureReason.GIT_MUTATION_VIOLATION)
+    assert outcome.runner_call_count == len(runner.calls) == 1
+
+
+def test_runner_exception_after_mutation_still_enforces_read_only(tmp_path: Path) -> None:
+    _fixture_tree(tmp_path)
+    runner = _RecordingRunner(
+        mutation=lambda request: (request.cwd / "src" / "function.py").write_text(
+            "mutated before error", encoding="utf-8"
+        ),
+        raises=True,
+    )
+    outcome = _invoke(tmp_path, runner)
+
+    _assert_blocked(outcome, PiValidationFailureReason.READ_ONLY_VIOLATION)
+    assert outcome.runner_call_count == len(runner.calls) == 1
+
+
+def test_returned_records_do_not_contain_prompt_credentials(tmp_path: Path) -> None:
+    runner = _RecordingRunner()
+    envelope = _envelope()
+    decision = _decision(envelope)
+    outcome = invoke_guardian_authorized_pi(
+        envelope=envelope,
+        decision=decision,
+        prompt="Do not retain credential value: test-secret-value-12345",
+        cwd=tmp_path,
+        timeout_seconds=15,
+        harness_runner=runner,
+    )
+
+    assert outcome.ok
+    payload = json.dumps(
+        {
+            "receipt": outcome.receipt.to_payload() if outcome.receipt else None,
+            "result": outcome.harness_result.to_payload() if outcome.harness_result else None,
+        },
+        sort_keys=True,
+    )
+    assert "test-secret-value-12345" not in payload
+
+
+def test_cross_object_validator_exposes_permission_expansion() -> None:
+    envelope = _envelope()
+    decision = _decision(
+        envelope,
+        granted_permissions=(_read_permission(), _write_permission("src")),
+    )
+
+    validation = validate_policy_decision_against_envelope(envelope, decision)
+
+    assert not validation.ok
+    assert PiValidationFailureReason.PERMISSION_POSTURE_INCONSISTENT.value in validation.failure_reasons
+
+
+def test_authorized_adapter_uses_invocation_local_identity(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    observed: dict[str, object] = {}
+
+    def _run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        observed["command"] = command
+        observed["environment"] = kwargs["env"]
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                {
+                    "status": "ok",
+                    "summary": "bounded",
+                    "actual_runtime_identity": {
+                        "actual_provider_id": IDENTITY["provider_id"],
+                        "actual_model_id": IDENTITY["model_id"],
+                        "actual_harness_id": IDENTITY["harness_id"],
+                        "actual_harness_version": IDENTITY["harness_version"],
+                    },
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(
+        "guardian.agents.adapters.pi_codex_runner.subprocess.run", _run
+    )
+    monkeypatch.setenv("PI_PROVIDER", "ambient-provider")
+    monkeypatch.setenv("PI_MODEL", "ambient-model")
+    result = PiCodexRunnerAdapter().execute_authorized(
+        AgentExecutionRequest(prompt="bounded", cwd=str(tmp_path), timeout_seconds=12),
+        AgentExecutionIdentity(**IDENTITY),
+        read_only=True,
+    )
+
+    environment = observed["environment"]
+    assert isinstance(environment, dict)
+    assert observed["command"][-2] == "guardian-authorized-task"
+    assert environment["PI_PROVIDER"] == IDENTITY["provider_id"]
+    assert environment["PI_MODEL"] == IDENTITY["model_id"]
+    assert environment["PI_GUARDIAN_AUTHORIZED"] == "1"
+    assert environment["PI_DISABLE_TOOLS"] == "1"
+    assert result.actual_provider_id == IDENTITY["provider_id"]
+    assert result.actual_model_id == IDENTITY["model_id"]
+    assert result.actual_harness_id == IDENTITY["harness_id"]
+    assert result.actual_harness_version == IDENTITY["harness_version"]
+    assert result.errors == []
+    assert result.status == "ok"
+    assert result.summary == "bounded"
+
+
+def test_legacy_pi_adapter_keeps_task_mode_and_output_shape(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    observed: dict[str, object] = {}
+
+    def _run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        observed["command"] = command
+        observed["environment"] = kwargs["env"]
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps({"status": "ok", "summary": "legacy task"}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(
+        "guardian.agents.adapters.pi_codex_runner.subprocess.run", _run
+    )
+    result = PiCodexRunnerAdapter().execute(
+        AgentExecutionRequest(prompt="legacy", cwd=str(tmp_path), timeout_seconds=12)
+    )
+
+    assert observed["command"][-2] == "task"
+    assert result.status == "ok"
+    assert result.summary == "legacy task"
+    assert result.actual_provider_id is None
+    assert result.actual_model_id is None
+    assert result.actual_harness_id is None
+    assert result.actual_harness_version is None
+
+
+def test_direct_codex_adapter_remains_unsupported() -> None:
+    with pytest.raises(RuntimeError, match="unsupported"):
+        CodexAdapter()


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
