### PR TITLE
Expose read-only Connections control plane

### DIFF
--- a/config/supported_profiles/v1-local-core-web-mcp.yaml
+++ b/config/supported_profiles/v1-local-core-web-mcp.yaml
@@ -38,6 +38,7 @@ route_posture:
     - obsidian
     - agent_orchestration
     - agent_orchestration_chat
+    - connections
   internal_only:
     - coding_work_orders
     - command_bus

--- a/docs/architecture/00-current-state.md
+++ b/docs/architecture/00-current-state.md
@@ -81,6 +81,10 @@ The canonical human-facing release classification uses five classes. The corresp
 - Obsidian / local workspace ingestion and retrieval.
 - Bounded verified personal-facts / personalization behavior already used by ordinary chat.
 - Core settings that configure currently supported runtime behavior.
+- The read-only Connections catalog/control-plane is available through the
+  existing core Settings Connectors bay on the supported local profile. This
+  exposes catalog and safe state projection only; it does not expose generic
+  connector execution or mutation.
 
 **Identity and ownership**
 
@@ -132,6 +136,9 @@ The canonical human-facing release classification uses five classes. The corresp
 - Public Command Bus exposure.
 - Generic cron / unattended automation.
 - Generic connectors without separate qualification.
+- Provider-specific OAuth, messaging setup, web-provider execution, and
+  generic sync connector support remain Out of Beta/quarantined. Read-only
+  Connections catalog exposure does not promote any of those capabilities.
 - Graph-write / Neo4j-derived-write behavior where the supported path remains flagged off or quarantined.
 - Remote / multi-user repository execution not covered by a separately accepted authority contract and live proof.
 

--- a/docs/architecture/connections-control-plane.md
+++ b/docs/architecture/connections-control-plane.md
@@ -233,11 +233,15 @@ authoritative mutation surfaces: `/api/channels/*` for channels,
 plus provider-registry policy for inference. The Connections API creates
 no duplicate mutation routes.
 
-The router is registered in `guardian_api.py` under the existing
-`connectors` supported-profile label and the existing
-`CODEXIFY_ENABLE_CONNECTOR_ROUTES` flag, so the bay and its data source
-stay gated together. Without a configured database, the API degrades to
-the static catalog (no user state) rather than failing.
+`guardian_api.py` registers the read-only Connections router under the
+distinct `connections` supported-profile route identity and the
+`CODEXIFY_ENABLE_CONNECTIONS_ROUTES` flag. The legacy sync connector router
+remains under the separate `connectors` identity and
+`CODEXIFY_ENABLE_CONNECTOR_ROUTES` flag. The supported local Web profile
+enables the former while quarantining the latter, so exposing
+`/api/connections` does not expose `/api/connectors` or its mutation/sync
+authority. Without a configured database, the API degrades to the static
+catalog (no user state) rather than failing.
 
 ## Setup/configuration versus authorization versus health
 

--- a/docs/architecture/proofs/2026-08-18-connections-browser-qa-round-2.md
+++ b/docs/architecture/proofs/2026-08-18-connections-browser-qa-round-2.md
@@ -1,0 +1,158 @@
+# Connections Browser QA Round 2
+
+## Result
+
+`BLOCKED`
+
+The fresh merged-mainline checkout reached the existing Settings → Connectors
+bay, but the live Connections read API was not mounted on the tested supported
+profile. The catalog shell rendered with no entries, while authenticated
+`GET /api/connections` and detail requests returned `404 Not Found`. Provider,
+category, detail, setup, and semantic-comparison passes therefore could not be
+run without changing runtime/product configuration or using another checkout.
+
+## Environment
+
+- Repository: `/Volumes/Dev_SSD/Codexify-main`
+- Branch: `codex/validate-connections-live-ui-round-2-fresh`
+- Tested HEAD: `f0ed9b938c4094aa29b8fac911ec4b16975d899d`
+- `origin/main` at test start: `f0ed9b938c4094aa29b8fac911ec4b16975d899d`
+- Canonical lineage: `PASS`; `git merge-base --is-ancestor 7c270b943fa3d1e9d0e28e1c029723fcd7e7ff46 HEAD` exited `0`
+- Required source identity: `PASS`; `guardian/connections/catalog.py`, `guardian/routes/connections.py`, `docs/architecture/connections-control-plane.md`, and `docs/architecture/adr/071-connections-control-plane-boundary.md` were present at the tested HEAD
+- Browser URL: `http://127.0.0.1:5173/`
+- Backend URL: `http://127.0.0.1:8888`
+- Browser: Codex in-app Browser (`iab`)
+- Viewports: default `1055×994`; narrower responsive pass `800×900`
+- Themes: dark baseline/restored; light inspected and restored to dark
+- Runtime: backend and frontend were started from this checkout with transient process-level QA overrides for the local supported profile and local authentication. No product configuration file was edited.
+
+The application shell loaded before Connections-specific testing. The browser
+showed the existing Settings tab list and the `Connectors` tab; no separate
+Connections page was created or expected.
+
+## Lineage reconciliation
+
+Round 1 used stale HEAD `5df15d6...` and stopped before browser testing. The
+obsolete pre-rebase implementation SHA `634ddeb...` is historical provenance
+only and is not the current mainline proof anchor. PR #713 merged Connections at
+`7c270b943fa3d1e9d0e28e1c029723fcd7e7ff46` with subject
+`feat(connections): establish Connections control plane`. The current governing
+decision is ADR-071, `Connections Control Plane Boundary`, not ADR-068.
+
+Round 2 was created from the current `origin/main` and tested a descendant of
+the canonical merged commit. The requested branch name already existed
+locally, so the non-conflicting proof-only suffix `-fresh` was used; the
+existing branch was not deleted, reset, or force-moved. The Round 1 artifact was
+not present in this fresh checkout and was not modified.
+
+## Coverage
+
+Observed and exercised:
+
+- `PASS` — fresh checkout, canonical lineage gate, required source-file gate,
+  runtime startup, application load, Settings → Connectors navigation, and
+  existing Connectors bay identity.
+- `PASS` — Connections search control accepted exact (`slack`), partial,
+  mixed-case (`SLaCk`), no-result, and clear interactions. Every query had no
+  rows because the catalog response was unavailable; this does not prove
+  filtering correctness against a populated catalog.
+- `PASS` — navigation from Appearance to Connectors, reload, repeated tab
+  return, and retained non-crashing empty bay state.
+- `PASS` — light and dark theme controls were exercised; selected theme state
+  was visible and dark was restored.
+- `PASS` — default and narrower `800×900` viewport checks showed no document
+  horizontal overflow or clipping in the rendered empty state.
+- `BUG` — the live Connections catalog route was unavailable, so category
+  controls, provider rows, selected-item detail, setup flows, adapter/setup/
+  registry distinctions, and provider-specific truth could not be exercised.
+
+Not reached because the catalog did not provide rows or categories:
+
+- Messaging category and Slack, Discord, Telegram, Signal, WhatsApp, Matrix.
+- Web category and Firecrawl, Tavily, Exa, Parallel, SearXNG, Brave Search,
+  DDGS / DuckDuckGo, xAI / Grok.
+- Inference category and DeepSeek, MiniMax OAuth, MiniMax API, OpenAI Codex,
+  OpenAI API, Gemini OAuth, Groq, and Qwen OAuth.
+- Detail selection, API-key setup, OAuth-oriented setup, unavailable-provider
+  setup, local-endpoint setup, secret-input treatment, and stale-form reset.
+- Category switching, scrolling through populated lists, and rapid switching
+  between Messaging, Web, and Inference; only the `All` control was present.
+- Legacy GitHub controls: the existing `Sync connectors` section remained
+  visible and reported `No sync connectors configured`, but no GitHub control
+  was reachable and no destructive sync/config action was attempted.
+
+## Findings
+
+| ID | Classification | Severity | Surface | Finding | Reproduction | Evidence | Likely owner |
+|---|---|---|---|---|---|---|---|
+| R2-001 | BUG | P1 | Supported-profile route posture / Settings → Connectors | The merged Connections control plane is not reachable on fresh current `origin/main`; the UI presents an empty catalog shell instead of a usable catalog or an explicit route-unavailable state. | Start the backend and frontend from the fresh branch using the local supported profile, open Settings → Connectors, then request the catalog and representative detail routes. | Browser showed `Connections`, `All`, `Search connections`, and `No connections match`, with no Messaging/Web/Inference controls or rows. Authenticated `GET /api/connections`, `/api/connections/slack`, `/api/connections/telegram`, `/api/connections/firecrawl`, `/api/connections/searxng`, `/api/connections/deepseek`, `/api/connections/minimax-oauth`, and `/api/connections/openai-codex` each returned `404`; OpenAPI exposed no `connections` or `connectors` paths. `GET /health` was `200` with supported profile `v1-local-core-web-mcp`, `valid: true`, and no mismatches. | Connections API |
+
+The finding is a live route/readiness failure, not a reinterpretation of the
+Round 1 stale-checkout block. The checked-out source and canonical merge are
+present; the tested runtime simply does not expose the read route under the
+active supported profile.
+
+## Expected-unavailable sample
+
+No provider-level `EXPECTED-UNAVAILABLE` sample was reached. The catalog was
+unavailable before unsupported integrations could be selected, so no fake
+OAuth flow or unavailable-provider setup action was launched. The legacy
+`/api/connectors` route also returned `404` under this profile, but that is part
+of the route/readiness finding rather than a successful provider-unavailable
+behavior sample.
+
+## Console / Network summary
+
+Console inspection found no React error, uncaught exception, rejected promise,
+Connections-specific error, missing Connections asset, or repeated Connections
+request error. The browser emitted one unrelated warning that `/codex/entries`
+was not found and returned an empty list, plus normal Vite/React development
+messages. The existing `Provider degraded / failure: chat_unhealthy` banner was
+not treated as a Connections defect.
+
+The available browser diagnostics exposed console logs but not a network-panel
+API. Network evidence was therefore captured from the same local frontend and
+backend URLs with authenticated request inspection; the API key and all
+headers were omitted from this artifact.
+
+- `GET /health`: `200`; supported profile `v1-local-core-web-mcp`, valid, with
+  no reported mismatches.
+- `GET /api/connections`: `404`, body shape only `{"detail":"Not Found"}`.
+- `GET /api/connections/{id}` for representative requested IDs: `404`.
+- `GET /api/connectors`: `404`.
+- OpenAPI contained no `connections` or `connectors` paths.
+- No token, API key, secret, or credential material appeared in the observed
+  ordinary response bodies.
+- No request loop or retry storm was observed.
+
+## API/UI consistency
+
+Live semantic comparison was blocked for all requested samples. The following
+entries could not be compared because neither the list route nor detail route
+returned a catalog object:
+
+| Integration | Category / state / auth / capability comparison |
+|---|---|
+| Slack | Not sampleable; `/api/connections/slack` returned `404`; no UI row |
+| Telegram | Not sampleable; `/api/connections/telegram` returned `404`; no UI row |
+| Firecrawl | Not sampleable; `/api/connections/firecrawl` returned `404`; no UI row |
+| SearXNG | Not sampleable; `/api/connections/searxng` returned `404`; no UI row |
+| DeepSeek | Not sampleable; `/api/connections/deepseek` returned `404`; API-key labeling not live-verifiable |
+| MiniMax OAuth | Not sampleable; `/api/connections/minimax-oauth` returned `404`; OAuth dead-flow prevention not live-verifiable |
+| OpenAI Codex | Not sampleable; `/api/connections/openai-codex` returned `404`; auth/registry semantics not live-verifiable |
+
+The empty UI is consistent with receiving no catalog rows, but it is not a
+semantically sufficient projection of the route-unavailable condition. No
+claim is made here about the provider metadata that the source catalog would
+return once the route is exposed.
+
+## Recommendation
+
+`repair-connections-first`
+
+Restore an explicitly supported, live `GET /api/connections` projection path
+for the existing Settings Connectors bay, while preserving the separate legacy
+connector authority and the adapter/setup/registry distinctions. Then rerun
+the full provider, setup, API/UI, console/network, responsive, and theme matrix
+from a fresh descendant of the repaired mainline. No product or runtime fix was
+made in this proof task.

--- a/docs/architecture/proofs/2026-08-18-connections-browser-qa-round-3.md
+++ b/docs/architecture/proofs/2026-08-18-connections-browser-qa-round-3.md
@@ -1,0 +1,264 @@
+# Connections Browser QA Round 3
+
+## Result
+
+`PASS WITH FINDINGS`
+
+The merged read-only Connections control plane rendered in the existing
+Settings → Connectors bay under the supported local Web profile. Category
+navigation, populated search, detail state, unsupported-provider truth,
+adapter/setup/registry separation, legacy connector quarantine, responsive
+behavior, theme behavior, and API/UI semantics were exercised. One localized
+P3 visual defect was found: disabled Configure controls lose their label
+contrast in light theme. No P0, P1, or P2 finding was observed.
+
+## Environment
+
+- Repository: `/Volumes/Dev_SSD/Codexify-main`
+- Branch: `codex/validate-connections-live-ui-round-2-fresh`
+- Tested HEAD: `6386231aa5b09566b7b7800391d4e1a2ed445f94`
+- `origin/main` at test start: `f0ed9b938c4094aa29b8fac911ec4b16975d899d`
+- Supported profile: `v1-local-core-web-mcp`
+- Browser URL: `http://localhost:5173/`
+- Backend URL: `http://localhost:8888`
+- Browser: Codex In-app Browser (`iab`)
+- Viewports: default desktop `1280×720`; narrower `768×900`
+- Themes: system baseline/resolved light, explicit light, dark, then system
+  restored
+- Runtime: temporary local backend and frontend containers from this checkout;
+  process-level QA environment overrides only; no product/runtime source or
+  configuration files were edited
+
+The application shell loaded before Connections-specific testing. The tested
+surface was the existing Settings `Connectors` tab. No separate Connections
+page was created or expected. The local `.env` emitted shell-source warnings
+during one runtime setup attempt; the final containers used explicit
+process-level values and the repository files remained unchanged.
+
+## Prerequisite proof
+
+- `git merge-base --is-ancestor 6386231aa5b09566b7b7800391d4e1a2ed445f94 HEAD`:
+  exit `0`.
+- `git merge-base --is-ancestor 7c270b943fa3d1e9d0e28e1c029723fcd7e7ff46 HEAD`:
+  exit `0`.
+- Required source identity was present at the tested HEAD:
+  `guardian/connections/catalog.py`, `guardian/routes/connections.py`,
+  `docs/architecture/connections-control-plane.md`, and
+  `docs/architecture/adr/071-connections-control-plane-boundary.md`.
+- Supported-profile health reported `v1-local-core-web-mcp` valid with no
+  mismatches, `connections: enabled`, and `connectors: quarantined`.
+- Authenticated live route probes returned:
+  `GET /api/connections` = `200`,
+  `GET /api/connections/deepseek` = `200`,
+  `GET /api/connections/slack` = `200`,
+  unknown connection = `404`, and
+  `GET /api/connectors` = `404`.
+- The catalog response contained `categories` and `items` with 57 items.
+- OpenAPI exposed `/api/connections` and
+  `/api/connections/{connection_id}`; it did not expose `/api/connectors`.
+
+## Lineage reconciliation
+
+Round 1 used stale HEAD `5df15d6...` and stopped before browser testing. The
+obsolete pre-rebase implementation SHA `634ddeb...` is historical provenance
+only and is not the current mainline proof anchor. PR #713 merged Connections
+at `7c270b943fa3d1e9d0e28e1c029723fcd7e7ff46` with subject
+`feat(connections): establish Connections control plane`. The current
+governing decision is ADR-071, `Connections Control Plane Boundary`, not
+ADR-068.
+
+Round 3 tested a descendant of the canonical merged commit. The tested branch
+was the existing non-conflicting proof branch created from current
+`origin/main`; no stale Round 1 branch was reset, force-moved, or rewritten.
+The Round 1 artifact was not modified.
+
+## Executive summary
+
+- PASS: the supported profile exposed the read-only Connections catalog while
+  keeping the legacy sync connector route quarantined.
+- PASS: 57 catalog items rendered in one existing Settings Connectors bay,
+  split into 23 Messaging, 8 Web, and 26 Inference items.
+- PASS: search, category filtering, detail state, scrolling, reload, and
+  navigation behaved coherently without stale detail or duplicated bay state.
+- PASS: catalog metadata kept adapter implementation, setup availability,
+  registry authorization, and connection health distinguishable.
+- PASS: unsupported messaging, web, and OAuth-oriented entries were visible
+  as unavailable/discovery-only and did not launch fake setup flows.
+- BUG P3: disabled Configure labels are visually unreadable in light theme
+  because the disabled text and background resolve to the same gray.
+
+Counts for the classified observations below: `PASS 15`, `BUG 1` (`P3 1`),
+`CONFUSING 0`, and `EXPECTED-UNAVAILABLE 4`.
+
+## Coverage
+
+Exercised surfaces:
+
+- Existing Settings → Connectors bay and the Connections catalog projection.
+- Categories: All, Messaging, Web, and Inference; selected category styling;
+  populated list counts; list scrolling; and detail selection.
+- Search: exact `Slack`, partial `fire`, mixed-case `TaViLy`, no-result query,
+  keyboard clearing, search while switching categories, and rapid sequential
+  typing for `deepseek`.
+- Messaging: Slack, Discord, Telegram, Signal, WhatsApp, and Matrix.
+- Web: Firecrawl, Tavily, Exa, Parallel, SearXNG, Brave Search,
+  DDGS / DuckDuckGo, and xAI / Grok.
+- Inference: DeepSeek, MiniMax OAuth, MiniMax API, OpenAI Codex / ChatGPT,
+  OpenAI API, Google Gemini OAuth, Groq, Qwen OAuth, and GitHub Copilot.
+- Adapter / Setup / Registry separation on implemented, partial,
+  unimplemented, registry-authorized, registry-unauthorized, and registry-not-
+  listed samples.
+- Setup/detail behavior for API-key, OAuth-oriented, unavailable, and local
+  endpoint entries; no credentials were entered and no secret values were
+  recorded.
+- Reload, leave-and-return navigation, rapid category switching, repeated
+  detail opening, and state reset after navigation.
+- Console inspection, authenticated API/OpenAPI probes, and frontend proxy
+  request inspection.
+- Responsive desktop and `768×900` layout checks; light and dark theme checks;
+  keyboard focus/input smoke.
+
+## Findings
+
+| ID | Classification | Severity | Surface | Finding | Reproduction | Evidence | Likely owner |
+|---|---|---|---|---|---|---|---|
+| R3-001 | PASS | — | Supported profile / route posture | The read-only Connections route is enabled independently of the legacy connector route. | Start the supported local profile and inspect health, OpenAPI, and authenticated endpoint responses. | Profile reported `connections: enabled`, `connectors: quarantined`; `/api/connections` and its detail routes returned `200`; `/api/connectors` returned `404`; OpenAPI contained only the Connections paths. | Connections API |
+| R3-002 | PASS | — | Settings surface | The application loads into the existing Settings Connectors bay and renders the catalog without creating a separate page. | Open `http://localhost:5173/`, select Settings → Connectors, and wait for the catalog. | `connections-bay` rendered with the catalog explanation, category controls, search, rows, and the truthful sync-connector unavailable message. | frontend projection |
+| R3-003 | PASS | — | Category navigation | All, Messaging, Web, and Inference switch the visible list and selected styling; changing category clears selected detail. | Select each category, select Slack, then switch to Web and Inference. | Counts were All `57`, Messaging `23`, Web `8`, Inference `26`; active category used the selected accent style; Slack detail disappeared on category switch. | frontend projection |
+| R3-004 | PASS | — | Search and filtering | Exact, partial, mixed-case, no-result, clear, category-filtered, and rapid-typing searches produced the expected rows without category leakage. | Search `Slack`, `fire`, `TaViLy`, and `zzzz-no-connection`; clear with keyboard; search `slack` while switching Web/Messaging; type `deepseek` sequentially. | Results were respectively Slack, Firecrawl, Tavily, no rows, restored list, no Web rows, Slack in Messaging, and no Messaging rows for DeepSeek. | frontend projection |
+| R3-005 | PASS | — | List scrolling / detail state | The populated list scrolls, representative detail panels are correct, and repeated selection does not duplicate or retain the prior provider. | Scroll the catalog by 800px, select representative rows repeatedly, and switch providers. | Scroll container reported `scrollHeight 2731` against `clientHeight 485`; visible rows changed; each sampled detail panel matched its selected provider; one `connection-detail` panel remained. | frontend projection |
+| R3-006 | PASS | — | Messaging truth | Slack, Discord, and Telegram show partial adapter existence while keeping setup unavailable; Signal, WhatsApp, and Matrix clearly show no adapter and discovery-only behavior. | Open each requested Messaging detail panel and inspect Adapter, Setup, Authentication, and explanatory text. | Slack/Discord/Telegram showed `Adapter Partial`, `Setup Not available`, token auth, and no production runtime path; Signal/WhatsApp/Matrix showed `Adapter Not implemented`, `Setup Not available`, and no fake setup path. | channels subsystem |
+| R3-007 | PASS | — | Web truth | Web catalog capabilities and authentication labels match the intended Search + Extract or Search-only split without implying live Codexify search execution. | Open Firecrawl, Tavily, Exa, Parallel, SearXNG, Brave Search, DDGS / DuckDuckGo, and xAI / Grok. | Firecrawl/Tavily/Exa/Parallel showed `Capabilities: extract, search`; SearXNG/Brave/DDGS/xAI-Grok showed `Capabilities: search`; each said catalog discovery only and had Configure disabled. | Connections API |
+| R3-008 | PASS | — | Inference truth | DeepSeek is labeled API key, not OAuth; OAuth-oriented entries identify browser OAuth and unavailable handlers; implemented API lanes remain setup/registry-state distinct. | Inspect DeepSeek, MiniMax OAuth/API, OpenAI Codex/API, Gemini OAuth, Groq, Qwen OAuth, and GitHub Copilot. | DeepSeek showed `Authentication: API key`; MiniMax OAuth/OpenAI Codex/Gemini OAuth/Qwen OAuth/GitHub Copilot showed `OAuth (browser)` and no backend authorization handler; API lanes showed API-key metadata. | provider registry |
+| R3-009 | PASS | — | Adapter / Setup / Registry | The catalog does not collapse adapter existence, setup, registry authorization, and health into one connected state. | Compare Slack, DeepSeek, MiniMax OAuth, OpenAI Codex, and API providers. | Slack was `Partial`/`Not available`; DeepSeek was `Implemented`/`Needs setup`/`Registry not authorized`; MiniMax OAuth was `Not implemented`/`Not available`/`Registry not authorized`; OpenAI Codex was `Not implemented`/`Not available`/`Registry not listed`. No row claimed connected or healthy. | frontend projection |
+| R3-010 | PASS | — | Setup UX / unavailable actions | Representative setup states expose only relevant metadata; unavailable or server-owned setup actions do not open a stale form or accept credentials. | Inspect DeepSeek (API key), MiniMax OAuth (OAuth), Signal (unavailable), SearXNG (local endpoint), and Slack; inspect Configure controls. | All sampled Configure controls were disabled with `aria-disabled=true`; no dialog or input opened; API response metadata marked DeepSeek's required field as secret/password without returning a value. | frontend projection |
+| R3-011 | PASS | — | Legacy sync connectors | Legacy GitHub/sync connector execution remains quarantined while the Connections catalog is available. | Open Settings → Connectors and inspect the sync subsection; issue the explicit authenticated legacy route probe. | UI said `Sync connectors are unavailable in this runtime profile`; `/api/connectors` returned `404`; no legacy GitHub mutation or sync control was exposed. | legacy connector surface |
+| R3-012 | PASS | — | Reload / navigation resilience | Reload, leaving Settings, returning, rapid category switching, and repeated detail opening do not crash, blank the bay, duplicate it, or retain stale detail. | Select Web/Firecrawl, leave to Appearance, return to Connectors, rapidly switch categories, and reload. | Return and reload each produced one bay, 57 rows, no detail duplication, and the All category active; no blank panel or crash appeared. | frontend projection |
+| R3-013 | PASS | — | API/UI semantics | API and visible UI agree on category, implementation, setup, auth, capabilities, and registry semantics for the requested sample set. | Compare live catalog/detail metadata with Slack, Telegram, Firecrawl, SearXNG, DeepSeek, MiniMax OAuth, and OpenAI Codex. | The API/UI comparison table below records matching values; display wording differences were presentation-only. | Connections API |
+| R3-014 | PASS | — | Console / network / response hygiene | The corrected final browser run has no Connections console errors, missing assets, uncaught exceptions, or retry storm; ordinary catalog responses contain no credential values. | Load a clean browser tab, navigate the bay, select details, and inspect console plus backend/frontend request evidence. | Clean post-runtime tab reported no console logs; frontend proxy logs had no errors after correction; response scan found no secret-like credential values and no nonempty credential-value fields. | unknown |
+| R3-015 | PASS | — | Responsive / theme / keyboard smoke | Desktop and narrower layout states remain usable, theme states render, and keyboard input/focus smoke does not crash the surface. | Exercise `1280×720`, `768×900`, light, dark, restore system, search keyboard clearing, focus, and Escape. | Narrow layout had no measured horizontal overflow; category/search/detail stayed within bounds; light/dark states rendered; search accepted keyboard input and native controls remained focusable. | frontend projection |
+| R3-016 | BUG | P3 | Light theme / disabled setup controls | Disabled Configure controls lose visual label contrast in light theme. | Set Appearance → Light, return to Connectors, and inspect any unavailable Configure button. | For the DeepSeek disabled button, computed foreground and background were both `rgb(107, 114, 128)` with `opacity: 0.5`; the screenshot showed a gray pill without a legible Configure label. Dark theme rendered the label legibly. | frontend projection |
+| R3-017 | EXPECTED-UNAVAILABLE | — | Unsupported messaging | Signal, WhatsApp, and Matrix correctly remain discovery-only and cannot launch setup. | Open each detail panel and inspect Configure state. | Each showed `Adapter Not implemented`, `Setup Not available`, explanatory no-adapter text, and disabled Configure. | channels subsystem |
+| R3-018 | EXPECTED-UNAVAILABLE | — | Catalog-only web providers | Firecrawl, Tavily, Exa, Parallel, SearXNG, Brave Search, DDGS / DuckDuckGo, and xAI / Grok correctly remain catalog-only. | Open each web detail panel and inspect capabilities, setup, and Configure state. | Search capability labels matched the expected split; each said no Codexify web adapter exists and selecting it does not change current search behavior; Configure was disabled. | Connections API |
+| R3-019 | EXPECTED-UNAVAILABLE | — | OAuth-oriented inference | MiniMax OAuth, OpenAI Codex, Google Gemini OAuth, Qwen OAuth, and GitHub Copilot safely avoid dead OAuth flows. | Open each OAuth-oriented detail panel and inspect auth text and Configure state. | Each showed `OAuth (browser)`, no backend authorization handler, catalog/discovery-only wording, and disabled Configure; no OAuth request was sent. | provider registry |
+| R3-020 | EXPECTED-UNAVAILABLE | — | API-key / local setup | Server-owned API-key setup and the local SearXNG endpoint remain unavailable in this read-only control plane. | Inspect DeepSeek, OpenAI API, MiniMax API, Groq, and SearXNG. | API-key entries showed `Needs setup` plus registry state, but no credential form or mutation route; SearXNG showed `Local endpoint` and `Setup Not available`. | provider registry |
+
+## Sampled expected-unavailable integrations
+
+The following unavailable behavior worked correctly and is not a product defect:
+
+| Integration(s) | Expected behavior observed |
+|---|---|
+| Signal, WhatsApp, Matrix | Visible for discovery, `Not implemented`, `Not available`, no fake setup path. |
+| Firecrawl, Tavily, Exa, Parallel, SearXNG, Brave Search, DDGS / DuckDuckGo, xAI / Grok | Capabilities are descriptive catalog metadata; no live search/extract adapter or setup action is implied. |
+| MiniMax OAuth, OpenAI Codex, Google Gemini OAuth, Qwen OAuth, GitHub Copilot | Browser-OAuth intent is labeled, but missing backend handler is explicit and Configure is disabled. |
+| DeepSeek, OpenAI API, MiniMax API, Groq, SearXNG | Server-owned API-key/local setup remains unavailable; registry or endpoint metadata does not imply a live connection. |
+
+## API/UI consistency summary
+
+The live API response and the UI projection were semantically consistent for
+the requested samples. The API response used canonical fields while the UI
+used human-readable labels.
+
+| Integration | API meaning | UI meaning | Result |
+|---|---|---|---|
+| Slack | `messaging`; `partial`; setup `unavailable`; token auth; channel adapter binding | Messaging; Adapter Partial; Setup Not available; Authentication: Token; runtime adapter text | PASS |
+| Telegram | `messaging`; `partial`; setup `unavailable`; token auth; channel adapter binding | Messaging; Adapter Partial; Setup Not available; Authentication: Token; runtime adapter text | PASS |
+| Firecrawl | `web`; `unimplemented`; setup `unavailable`; API key; `extract, search`; no adapter binding | Web; Adapter Not implemented; Setup Not available; API key; extract/search; catalog-only text | PASS |
+| SearXNG | `web`; `unimplemented`; setup `unavailable`; local endpoint; `search`; no adapter binding | Web; Adapter Not implemented; Setup Not available; Local endpoint; search; catalog-only text | PASS |
+| DeepSeek | `inference`; `implemented`; setup `needs_setup`; API key; registry registered but unauthorized because credentials are missing | Inference; Adapter Implemented; Setup Needs setup; Authentication: API key; Registry not authorized | PASS |
+| MiniMax OAuth | `inference`; `unimplemented`; setup `unavailable`; `oauth_browser`; handler absent; registry entry unauthorized | Inference; Adapter Not implemented; Setup Not available; OAuth (browser); Registry not authorized; no handler text | PASS |
+| OpenAI Codex | `inference`; `unimplemented`; setup `unavailable`; `oauth_browser`; handler absent; not registered | Inference; Adapter Not implemented; Setup Not available; OAuth (browser); Registry not listed; no handler text | PASS |
+
+The ordinary catalog payload contained no secret-bearing credential values.
+Required-field metadata identified secret/password treatment for DeepSeek, but
+no API key or token value was returned.
+
+## Console summary
+
+The clean post-runtime browser tab reported no console `error` or `warn` entries
+while loading and exercising Settings → Connectors. No React error, uncaught
+exception, rejected promise, missing Connections asset, or Connections API
+error was observed in the corrected run. The application shell still showed
+the pre-existing `Provider degraded / failure: chat_unhealthy` status banner;
+it was unrelated to the Connections catalog and was not classified as a
+Connections defect.
+
+The first temporary frontend container was discarded before the final pass
+because its proxy still targeted the unavailable Compose hostname `backend`.
+Its 500 transport errors, including failed optional requests, are harness
+preflight evidence only and are not counted as Round 3 product findings.
+
+## Network summary
+
+- `GET /api/connections`: authenticated `200`; the browser rendered all 57
+  catalog items through the same-origin frontend proxy.
+- `GET /api/connections/{id}`: authenticated direct probes for Slack and
+  DeepSeek returned `200`; an unknown ID returned `404`. Detail selection in
+  the UI uses the already-loaded catalog object and did not require a separate
+  detail request for each click.
+- `GET /api/connectors` requested?: **No in the corrected final browser run**;
+  the legacy subsection rendered the unavailable-profile message. The explicit
+  authenticated backend quarantine probe did request it and returned `404`.
+- OpenAPI exposed only `/api/connections` and
+  `/api/connections/{connection_id}` for these two route families; the legacy
+  connector path was absent.
+- Unavailable OAuth Configure controls were disabled, so no nonexistent OAuth
+  handler was requested.
+- No request loop or retry storm was observed after the frontend proxy was
+  corrected; the final frontend proxy log contained no API error.
+- No secret-bearing request headers or credential values were recorded.
+
+## Responsive/theme summary
+
+At the default `1280×720` viewport, the Connections bay, category controls,
+search, list, detail panel, and sync-connector message rendered in the
+existing Settings layout. At `768×900`, the category controls and search
+remained in bounds; the bay reported no horizontal overflow, and the list and
+detail panel remained vertically scrollable. Long labels remained within the
+measured content bounds. The light and dark themes both rendered the selected
+category, status text, borders, and detail panel; disabled-action label
+contrast in light theme is the P3 finding R3-016. System theme was restored
+after the pass.
+
+Keyboard smoke covered focus, search typing, keyboard clearing, Escape, and
+native button/input presence. Search input accepted sequential keyboard input;
+the in-app browser's synthetic Tab/Enter activation could not be separated
+reliably from browser-driver event behavior, so no product keyboard defect is
+asserted from that limitation.
+
+## OAuth-readiness assessment
+
+1. **MiniMax OAuth auth type:** `OAuth (browser)` / `oauth_browser`, with
+   chat capability and no API-key field.
+2. **Safely unavailable?** Yes. The catalog reports the entry as unimplemented,
+   setup unavailable, and lacking a backend authorization handler; Configure is
+   disabled and no dead flow launches.
+3. **Obvious future OAuth place?** Yes. The existing Connections detail panel
+   already presents auth, setup, registry, and handler state, and the
+   catalog's OAuth metadata provides a natural future authorization action in
+   that same detail surface.
+4. **Redesign likely?** No for the next implementation slice. A future
+   MiniMax OAuth handler can attach to the existing detail/setup boundary; it
+   will need backend authorization, callback/state handling, and explicit
+   persistence/registry semantics, but this QA found no need for a new Settings
+   page or a catalog redesign.
+
+## Recommendation
+
+`proceed-to-minimax-oauth`
+
+The catalog/control-plane semantics are trustworthy enough to proceed to a
+bounded MiniMax OAuth implementation slice. Keep the light-theme disabled
+Configure contrast defect as deferred frontend polish and preserve the current
+no-handler, no-mutation behavior until OAuth backend proof exists.
+
+## Release-truth boundary
+
+This proof establishes live availability of the read-only Connections catalog
+and per-connection projection in the supported local Web profile. Catalog
+visibility does not promote provider execution, runtime authorization,
+connection health, credential persistence, messaging setup, web-provider
+execution, generic sync connector support, or any OAuth flow. The legacy
+`connectors` route remains quarantined, the connector worker behavior was not
+changed, and no provider-registry or cloud-provider governance was widened.

--- a/frontend/src/contracts/supportedProfileRoutes.ts
+++ b/frontend/src/contracts/supportedProfileRoutes.ts
@@ -2,6 +2,7 @@ export const SUPPORTED_PROFILE_ROUTE_LABELS = {
   IMPRINT: "imprint",
   SYSTEM_PROMPT: "system_prompt",
   SYSTEM_DOCS: "system_docs",
+  CONNECTIONS: "connections",
   CONNECTORS: "connectors",
   CODEX: "codex",
   UI_SESSION: "ui_session",

--- a/frontend/src/features/settings/SettingsView.test.tsx
+++ b/frontend/src/features/settings/SettingsView.test.tsx
@@ -16,6 +16,18 @@ const mockedApi = vi.hoisted(() => ({
 }));
 
 const mockedUpdatePersonaSettings = vi.hoisted(() => vi.fn());
+const mockedUseConnectors = vi.hoisted(() =>
+  vi.fn(() => ({
+    connectors: [],
+    updateConnector: vi.fn(),
+    loading: false,
+    error: null,
+    authorizeOAuth: vi.fn(),
+    testConnector: vi.fn(),
+    syncConnector: vi.fn(),
+  }))
+);
+const mockedUseConnections = vi.hoisted(() => vi.fn());
 
 vi.mock("@/components/ui/button", () => ({
   Button: (props: Record<string, unknown>) => (
@@ -36,15 +48,28 @@ vi.mock("@/components/controls/SegmentedThemeControl", () => ({
 }));
 
 vi.mock("@/features/connectors/useConnectors", () => ({
-  useConnectors: () => ({
-    connectors: [],
-    updateConnector: vi.fn(),
-    loading: false,
-    error: null,
-    authorizeOAuth: vi.fn(),
-    testConnector: vi.fn(),
-    syncConnector: vi.fn(),
-  }),
+  useConnectors: mockedUseConnectors,
+}));
+
+vi.mock("@/features/connectors/connectionCatalog", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/features/connectors/connectionCatalog")
+  >("@/features/connectors/connectionCatalog");
+  return { ...actual, useConnections: mockedUseConnections };
+});
+
+vi.mock("@/lib/runtimeRouteCapabilities", () => ({
+  ensureRuntimeRouteCapabilitiesLoaded: vi.fn(async () => undefined),
+  getRuntimeRouteCapabilityState: vi.fn(() => "available"),
+  markRuntimeRouteUnavailableIfNotFound: vi.fn(),
+  useRuntimeRouteCapabilities: vi.fn(() => ({
+    ready: true,
+    states: {
+      imprint: "available",
+      connections: "available",
+      connectors: "unavailable",
+    },
+  })),
 }));
 
 vi.mock("@/features/connectors/ConnectorCard", () => ({
@@ -134,6 +159,15 @@ function renderSettingsView(
 describe("SettingsView save flow", () => {
   beforeEach(() => {
     mockedUpdatePersonaSettings.mockReset();
+    mockedUseConnectors.mockClear();
+    mockedUseConnections.mockReset();
+    mockedUseConnections.mockReturnValue({
+      connections: [],
+      categories: [],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
     mockedApi.get.mockClear();
     mockedApi.post.mockClear();
     mockedApi.delete.mockClear();
@@ -181,6 +215,58 @@ describe("SettingsView save flow", () => {
     ).not.toBeInTheDocument();
 
     expect(setSystemPrompt).toHaveBeenCalledWith("Updated system prompt");
+  });
+
+  it("renders Connections while legacy sync connectors remain unavailable", async () => {
+    mockedUseConnections.mockReturnValue({
+      connections: [
+        {
+          id: "deepseek",
+          display_name: "DeepSeek",
+          category: "inference",
+          description: "DeepSeek inference provider.",
+          auth_methods: ["api_key"],
+          capabilities: ["chat_completion"],
+          implementation_state: "implemented",
+          setup_state: "needs_setup",
+          runtime_binding: {
+            subsystem: "provider_registry",
+            adapter: null,
+            setup_route: null,
+            registry_provider_id: "deepseek",
+            oauth_backend_handler_exists: false,
+          },
+          required_fields: [],
+          scopes: [],
+          setup_help: "Use an API key.",
+          oauth: null,
+          authorization: null,
+        },
+      ],
+      categories: ["inference"],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
+
+    renderSettingsView();
+    mockedUseConnectors.mockClear();
+    fireEvent.click(screen.getByRole("tab", { name: /^connectors$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("connections-bay")).toBeInTheDocument();
+      expect(screen.getByText("DeepSeek")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Sync connectors are unavailable in this runtime profile."
+        )
+      ).toBeInTheDocument();
+    });
+    expect(mockedUseConnectors).toHaveBeenLastCalledWith({ enabled: false });
+    expect(mockedApi.get).not.toHaveBeenCalledWith(
+      "/api/connectors",
+      expect.anything()
+    );
   });
 
   it("moves the settings rail with arrow keys", () => {

--- a/frontend/src/features/settings/SettingsView.tsx
+++ b/frontend/src/features/settings/SettingsView.tsx
@@ -472,10 +472,13 @@ export function SettingsView({
     states: runtimeRouteStates,
   } = useRuntimeRouteCapabilities([
     SUPPORTED_PROFILE_ROUTE_LABELS.IMPRINT,
+    SUPPORTED_PROFILE_ROUTE_LABELS.CONNECTIONS,
     SUPPORTED_PROFILE_ROUTE_LABELS.CONNECTORS,
   ]);
   const imprintCapability =
     runtimeRouteStates[SUPPORTED_PROFILE_ROUTE_LABELS.IMPRINT] ?? "unknown";
+  const connectionsCapability =
+    runtimeRouteStates[SUPPORTED_PROFILE_ROUTE_LABELS.CONNECTIONS] ?? "unknown";
   const connectorsCapability =
     runtimeRouteStates[SUPPORTED_PROFILE_ROUTE_LABELS.CONNECTORS] ?? "unknown";
 
@@ -1565,21 +1568,21 @@ export function SettingsView({
             className="space-y-[var(--shell-gap)]"
           >
             {runtimeCapabilitiesReady &&
-              connectorsCapability === "unavailable" && (
+              connectionsCapability === "unavailable" && (
                 <div className="text-sm" style={{ color: "var(--muted)" }}>
-                  Connectors are unavailable in this runtime profile.
+                  Connections are unavailable in this runtime profile.
                 </div>
               )}
             {!runtimeCapabilitiesReady && (
               <div className="text-sm" style={{ color: "var(--muted)" }}>
-                Checking connector availability…
+                Checking Connections availability…
               </div>
             )}
             {runtimeCapabilitiesReady &&
-              connectorsCapability !== "unavailable" && (
+              connectionsCapability !== "unavailable" && (
                 <ConnectionsBay
                   ready={runtimeCapabilitiesReady}
-                  unavailable={connectorsCapability === "unavailable"}
+                  unavailable={connectionsCapability === "unavailable"}
                 />
               )}
             <div>
@@ -1597,16 +1600,34 @@ export function SettingsView({
                 their existing configuration surface.
               </p>
             </div>
-            {loading && (
+            {runtimeCapabilitiesReady &&
+              connectorsCapability === "unavailable" && (
+                <div className="text-sm" style={{ color: "var(--muted)" }}>
+                  Sync connectors are unavailable in this runtime profile.
+                </div>
+              )}
+            {!runtimeCapabilitiesReady && (
               <div className="text-sm" style={{ color: "var(--muted)" }}>
-                Loading connectors…
+                Checking sync connector availability…
               </div>
             )}
-            {error && (
-              <div className="text-sm" style={{ color: "var(--danger-text)" }}>
-                {error}
-              </div>
-            )}
+            {runtimeCapabilitiesReady &&
+              connectorsCapability !== "unavailable" &&
+              loading && (
+                <div className="text-sm" style={{ color: "var(--muted)" }}>
+                  Loading connectors…
+                </div>
+              )}
+            {runtimeCapabilitiesReady &&
+              connectorsCapability !== "unavailable" &&
+              error && (
+                <div
+                  className="text-sm"
+                  style={{ color: "var(--danger-text)" }}
+                >
+                  {error}
+                </div>
+              )}
             {runtimeCapabilitiesReady &&
             connectorsCapability !== "unavailable" &&
             Array.isArray(connectors) &&

--- a/guardian/guardian_api.py
+++ b/guardian/guardian_api.py
@@ -601,6 +601,7 @@ async def app_lifespan(app: FastAPI):
     ensure_system_dirs()
 
     settings = get_settings()
+    _refresh_supported_profile_state(app, settings)
     if getattr(app.state, "browser_host_attachment_adapter_enabled", False):
         logger.info(
             "[browser-host] development attachment adapter enabled prefix=/dev/browser-host/v1"
@@ -1279,8 +1280,8 @@ _include_router(
     include_fn=lambda: app.include_router(connectors_router),
 )
 _include_router(
-    label="connectors",
-    flag_name="CODEXIFY_ENABLE_CONNECTOR_ROUTES",
+    label="connections",
+    flag_name="CODEXIFY_ENABLE_CONNECTIONS_ROUTES",
     include_fn=lambda: app.include_router(connections_router),
 )
 _include_router(

--- a/tests/core/test_supported_profile.py
+++ b/tests/core/test_supported_profile.py
@@ -34,6 +34,8 @@ def test_v1_supported_profile_manifest_loads() -> None:
     assert manifest.route_status("obsidian") == "enabled"
     assert manifest.route_status("agent_orchestration") == "enabled"
     assert manifest.route_status("agent_orchestration_chat") == "enabled"
+    assert manifest.route_status("connections") == "enabled"
+    assert manifest.route_status("connectors") == "quarantined"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_supported_profile_quarantine.py
+++ b/tests/core/test_supported_profile_quarantine.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock
 
 from fastapi.testclient import TestClient
 
+from guardian.connections.catalog import get_catalog
+
 
 @contextmanager
 def _build_supported_profile_client(monkeypatch):
@@ -195,6 +197,39 @@ def test_unrelated_quarantined_routes_remain_unavailable(
         assert client.get("/api/tools/manifest", headers=headers).status_code == 404
         assert client.get("/api/connectors", headers=headers).status_code == 404
         assert client.get("/api/federation/ping", headers=headers).status_code == 404
+
+
+def test_supported_profile_exposes_read_only_connections_without_legacy_connectors(
+    monkeypatch,
+) -> None:
+    with _build_supported_profile_client(monkeypatch) as client:
+        headers = {"X-API-Key": "test-api-key"}
+
+        listing = client.get("/api/connections", headers=headers)
+        assert listing.status_code == 200
+        payload = listing.json()
+        assert payload["categories"] == ["inference", "messaging", "web"]
+        assert len(payload["items"]) == len(get_catalog())
+        assert len(payload["items"]) > 0
+
+        detail = client.get("/api/connections/deepseek", headers=headers)
+        assert detail.status_code == 200
+        assert detail.json()["id"] == "deepseek"
+        assert (
+            client.get(
+                "/api/connections/does_not_exist", headers=headers
+            ).status_code
+            == 404
+        )
+
+        assert client.get("/api/connectors", headers=headers).status_code == 404
+
+        paths = client.get("/openapi.json").json().get("paths", {})
+        assert "/api/connections" in paths
+        assert "/api/connections/{connection_id}" in paths
+        assert "/api/connectors" not in paths
+        assert set(paths["/api/connections"]) == {"get"}
+        assert set(paths["/api/connections/{connection_id}"]) == {"get"}
 
 
 def test_agent_orchestration_chat_readback_enforced(

--- a/tests/routes/test_connections.py
+++ b/tests/routes/test_connections.py
@@ -260,6 +260,9 @@ def test_inference_entries_project_registry_authorization(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     test_client, _ = client
+    # This assertion exercises cloud-provider registry projection in
+    # isolation; the supported local profile contract is covered separately.
+    monkeypatch.setenv("CODEXIFY_SUPPORTED_PROFILE", "")
     monkeypatch.setenv("ALLOW_CLOUD_PROVIDERS", "true")
     monkeypatch.setenv("CODEXIFY_LOCAL_ONLY_MODE", "false")
     monkeypatch.setenv("CODEXIFY_EGRESS_ALLOWLIST", "deepseek")
@@ -336,3 +339,17 @@ def test_runtime_binding_reports_real_adapters_only(
     assert items["deepseek"]["runtime_binding"]["registry_provider_id"] == (
         "deepseek"
     )
+
+
+def test_connections_router_is_read_only(
+    client: tuple[TestClient, _TestDB],
+) -> None:
+    paths = {
+        route.path: set(route.methods or ())
+        for route in connections.router.routes
+    }
+
+    assert paths == {
+        "/api/connections": {"GET"},
+        "/api/connections/{connection_id}": {"GET"},
+    }


### PR DESCRIPTION
## What changed

- Added a distinct `connections` supported-profile route identity.
- Exposed read-only `GET /api/connections` and detail routes in `v1-local-core-web-mcp`.
- Kept legacy `connectors` and `/api/connectors` quarantined.
- Split Settings capability gating so the Connections catalog renders independently from legacy sync connectors.
- Updated focused backend/frontend tests and current-state architecture documentation.

## Root cause

The Connections router and legacy sync connector router shared the `connectors` route label and feature flag. Because the supported local profile quarantines `connectors`, both API families returned 404 and the Settings surface could not project the catalog.

## Validation

- Supported-profile and Connections route tests: 45 passed.
- Focused Settings/connectors Vitest suites: 15 passed.
- Frontend production build: passed.
- Live supported-profile proof: `/api/connections` 200, representative detail 200, unknown detail 404, `/api/connectors` 404.
- OpenAPI confirms only the read-only Connections GET paths are mounted.
- `git diff --check`: passed.

No provider-registry, connector-worker, OAuth, migration, or generic connector support changes are included. Browser QA Round 3 remains the next proof step.