### PR TITLE
Fix Guardian DLG ancestry validation in CI

### DIFF
--- a/.github/workflows/guardian-ci.yml
+++ b/.github/workflows/guardian-ci.yml
@@ -130,6 +130,7 @@ jobs:
         if: ${{ needs.changes.outputs.run_backend == 'true' }}
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           lfs: true
 
       - name: Verify tracked paths are valid


### PR DESCRIPTION
## What changed

- Configure the backend Guardian CI checkout with `fetch-depth: 0`.
- Preserve LFS checkout behavior.

## Why

The Document Lifecycle Graph Phase 3 validator verifies that each node's reviewed commit is an ancestor of the checked-out commit. The backend job used GitHub Actions' default shallow checkout, so valid ancestry appeared missing and the nightly Guardian CI job failed.

## Validation

- `python3 -m pytest tests/architecture/test_document_lifecycle_graph_phase3.py::test_current_nine_node_corpus_validates -v` — passed
- `python3 -m pytest tests/architecture/test_document_lifecycle_graph_phase3.py -v` — 38 passed
- Workflow YAML parse — passed

This is intentionally isolated from the superseded Connections implementation in PR #719.