### PR TITLE
Add MiniMax OAuth connection setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,6 +128,20 @@ GOOGLE_RELAY_AUDIENCE=
 # PY
 GUARDIAN_OAUTH_TOKEN_ENCRYPTION_KEY=
 
+# --- MiniMax Global OAuth connection-setup (authentication only) ---
+# Codexify-owned application registration only. Do NOT paste another
+# application's client id, secret, or callback registration here.
+# When all three are set, MiniMax OAuth setup becomes launchable; missing
+# any of them keeps the entry visibly unavailable without launching a
+# broken flow.
+MINIMAX_OAUTH_CLIENT_ID=
+MINIMAX_OAUTH_AUTHORIZE_URL=
+MINIMAX_OAUTH_TOKEN_URL=
+# Comma-separated additional host allowlist for MiniMax OAuth upstream
+# requests. Default includes api.minimax.io, api.minimaxi.com,
+# auth.minimax.io, auth.minimaxi.com.
+MINIMAX_OAUTH_ALLOWED_HOSTS=
+
 # --- Beta-1 stabilization quarantine (optional) ---
 # Set to true to mount only the Beta-1 core surface:
 # chat + migration + document upload/embedding (+ health/admin/projects/threads).

--- a/.env.template
+++ b/.env.template
@@ -128,6 +128,20 @@ GOOGLE_RELAY_AUDIENCE=
 # PY
 GUARDIAN_OAUTH_TOKEN_ENCRYPTION_KEY=
 
+# --- MiniMax Global OAuth connection-setup (authentication only) ---
+# Codexify-owned application registration only. Do NOT paste another
+# application's client id, secret, or callback registration here.
+# When all three are set, MiniMax OAuth setup becomes launchable; missing
+# any of them keeps the entry visibly unavailable without launching a
+# broken flow.
+MINIMAX_OAUTH_CLIENT_ID=
+MINIMAX_OAUTH_AUTHORIZE_URL=
+MINIMAX_OAUTH_TOKEN_URL=
+# Comma-separated additional host allowlist for MiniMax OAuth upstream
+# requests. Default includes api.minimax.io, api.minimaxi.com,
+# auth.minimax.io, auth.minimaxi.com.
+MINIMAX_OAUTH_ALLOWED_HOSTS=
+
 # --- Beta-1 stabilization quarantine (optional) ---
 # Set to true to mount only the Beta-1 core surface:
 # chat + migration + document upload/embedding (+ health/admin/projects/threads).

--- a/config/supported_profiles/v1-local-core-web-mcp.yaml
+++ b/config/supported_profiles/v1-local-core-web-mcp.yaml
@@ -45,6 +45,7 @@ route_posture:
   internal_only:
     - coding_work_orders
     - command_bus
+    - minimax_oauth
   quarantined:
     - neo
     - iddb

--- a/docs/architecture/00-current-state.md
+++ b/docs/architecture/00-current-state.md
@@ -159,6 +159,7 @@ TTS / voice and federation are intentionally **Out of Beta**, not qualification-
 - The Desktop / Tauri client, where present on `main`, is Beta Bounded / Conditional as a client of the supported local Guardian node; it is not packaged production distribution.
 - The default local profile mounts authenticated Imprint, system-prompt, and system-document routes plus the read-only `/api/connections` catalog. `/health` publishes the effective mounted route inventory used by frontend capability gates; this is code/test evidence, not fresh live Compose proof.
 - Coding Loop route registration, focused tests, worker readiness / guard evidence, and profile enablement are present; they do not prove a successful adapter turn or durable terminal result.
+- Connections control plane surfaces MiniMax OAuth setup as `partial` (authentication/setup only); the MiniMax OAuth provider-specific mutation routes are mounted as `internal_only` under the supported local profile. OAuth-to-inference credential binding is deliberately deferred. The MiniMax API-key lane remains separate and unchanged.
 - Architecture-contract, schema, DLG, and proof-validation tooling is present on `main`; it is not live-service proof.
 
 ## Not yet true / do not assume

--- a/docs/architecture/connections-control-plane.md
+++ b/docs/architecture/connections-control-plane.md
@@ -213,12 +213,39 @@ make any provider executable and does not modify
 
 The method vocabulary can represent `oauth_browser`, `oauth_device`,
 `api_key`, `token`, `service_credentials`, `local_endpoint`, and `none`.
-No backend OAuth authorization handler exists for any entry today, so
-every entry reports `oauth.backend_handler_exists = false`. The frontend
-may only enable an OAuth action when that flag is true. All
-provider-specific OAuth work (MiniMax, Codex/ChatGPT, Qwen, Gemini, xAI,
-Nous Portal, GitHub Copilot, Anthropic subscription) is deferred to later
-atomic tasks.
+The frontend may only enable an OAuth action when
+`oauth.backend_handler_exists` is true **and** the node's launchability gate
+(`oauth.launchable`) is true. The launchability gate is intentionally
+narrower than "a backend handler exists in code": for a future OAuth entry
+to become clickable, it must additionally expose a real
+`runtime_binding.setup_route`, and (where the protocol requires it) the
+node must supply the legitimate application-owned configuration. A node
+without legitimate Codexify-owned MiniMax OAuth client configuration
+therefore keeps the entry visibly unavailable, even though the backend
+handler is mounted.
+
+MiniMax OAuth is the first provider-specific OAuth setup slice. Its
+provider-specific mutation routes (`/api/connect/minimax/start`,
+`/api/connect/minimax/poll`, `/api/connect/minimax/disconnect`,
+`/api/connect/minimax/status`) live on a dedicated
+`minimax_oauth` route family, distinct from the read-only `connections`
+surface and the quarantined legacy `connectors` surface. The
+`v1-local-core-web-mcp` supported profile mounts these routes as
+`internal_only` (hidden from public OpenAPI) while leaving `connections =
+enabled` and `connectors = quarantined`. Authentication/setup is implemented;
+OAuth-to-inference credential binding is deliberately deferred to a
+separate task that must independently preserve provider-registry
+authority and prove an authenticated persisted MiniMax turn.
+
+Credentials are encrypted at rest through `guardian.connectors.oauth_crypto`
+and persisted under provider key `minimax_oauth`, mode `node_local`. The
+PKCE verifier, access tokens, refresh tokens, and any browser-visible
+flow metadata are kept server-side; the frontend polls only the backend
+poll route and never the upstream provider directly.
+
+All other provider-specific OAuth work (Codex/ChatGPT, Qwen, Gemini,
+xAI, Nous Portal, GitHub Copilot, Anthropic subscription) remains
+deferred. Their `oauth.backend_handler_exists` flag stays false.
 
 ## API surface
 
@@ -255,7 +282,8 @@ catalog (no user state) rather than failing.
 
 This slice does not:
 
-- implement any provider-specific OAuth exchange;
+- implement any other provider-specific OAuth exchange;
+- bind MiniMax OAuth credentials to the inference runtime (separate task);
 - implement missing messaging adapters;
 - implement web-search/extract adapters;
 - replace or extend `guardian/core/provider_registry.py`;
@@ -265,5 +293,6 @@ This slice does not:
 - create a new Settings section, AppShell view, or duplicate
   configuration surface.
 
-`docs/architecture/00-current-state.md` remains release truth and was not
-updated to claim any new provider, messaging, OAuth, or web support.
+`docs/architecture/00-current-state.md` remains release truth. MiniMax OAuth
+setup code exists under Connections but is intentionally not promoted to
+Beta-Supported; OAuth-to-inference credential binding remains Out of Beta.

--- a/docs/architecture/diagram-governance.md
+++ b/docs/architecture/diagram-governance.md
@@ -8,7 +8,7 @@ Source anchors:
 
 # Diagram Governance
 
-Diagram Review Marker: 2026-08-11 (ADR-064 Orthogonal UI identity-routing review; README reference-only change; no runtime diagram change)
+Diagram Review Marker: 2026-08-17 (MiniMax OAuth connection-setup; current-state reflects MiniMax OAuth setup as partial; no runtime diagram change)
 
 ## Scope
 

--- a/frontend/src/features/connectors/ConnectorConfigModal.tsx
+++ b/frontend/src/features/connectors/ConnectorConfigModal.tsx
@@ -430,6 +430,12 @@ export const ConnectionConfigModal: React.FC<ConnectionProps> = ({
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [saveSucceeded, setSaveSucceeded] = useState(false);
+  const [minimaxFlow, setMinimaxFlow] = useState<{
+    flowId: string;
+    verificationUri: string;
+    userCode: string;
+    intervalSeconds: number;
+  } | null>(null);
 
   const steps = useMemo(() => buildSetupSteps(connection), [connection]);
   const step = steps[Math.min(stepIndex, steps.length - 1)];
@@ -442,6 +448,7 @@ export const ConnectionConfigModal: React.FC<ConnectionProps> = ({
     setFields({});
     setMessage(null);
     setSaveSucceeded(false);
+    setMinimaxFlow(null);
   }, [open, connection.id]);
 
   if (!open) return null;
@@ -456,6 +463,7 @@ export const ConnectionConfigModal: React.FC<ConnectionProps> = ({
     setFields({});
     setMessage(null);
     setSaveSucceeded(false);
+    setMinimaxFlow(null);
     onClose();
   }
 
@@ -473,6 +481,16 @@ export const ConnectionConfigModal: React.FC<ConnectionProps> = ({
       const route = connection.runtime_binding.setup_route;
       if (!route) {
         setMessage("Setup is not yet available for this connection.");
+        return;
+      }
+      // MiniMax OAuth uses the device / user-code flow shape: the backend
+      // returns a flow_id, verification URI, and user code; the browser
+      // polls only the backend poll route; tokens never reach the browser.
+      if (
+        connection.id === "minimax_oauth" &&
+        route === "/api/connect/minimax/start"
+      ) {
+        await handleMinimaxOAuthFlow();
         return;
       }
       let body: Record<string, unknown>;
@@ -498,6 +516,95 @@ export const ConnectionConfigModal: React.FC<ConnectionProps> = ({
       );
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function handleMinimaxOAuthFlow(): Promise<void> {
+    interface StartResponse {
+      provider: string;
+      flow_id: string;
+      verification_uri: string;
+      user_code: string;
+      expires_at: string;
+      poll_interval_seconds: number;
+    }
+    interface PollResponse {
+      provider: string;
+      flow_id: string;
+      status: "authenticating" | "connected" | "error";
+      kind?: string;
+    }
+    const startRes = await api.post<StartResponse>(
+      "/api/connect/minimax/start",
+      {}
+    );
+    const start = startRes?.data;
+    if (!start?.flow_id || !start.verification_uri) {
+      setMessage("Provider returned an unexpected response.");
+      return;
+    }
+    // Surface verification metadata in the modal itself so the user can
+    // complete the provider step without depending on popup blocking.
+    setMessage(
+      `Open ${start.verification_uri} and enter code ${start.user_code}.`
+    );
+    setMinimaxFlow({
+      flowId: start.flow_id,
+      verificationUri: start.verification_uri,
+      userCode: start.user_code,
+      intervalSeconds: Math.max(1, start.poll_interval_seconds ?? 2),
+    });
+    // Begin polling. Each poll MUST NOT trigger another /start; the backend
+    // enforces cadence. Browser never polls the upstream provider directly.
+    let stopped = false;
+    const startedAt = Date.now();
+    const maxWaitMs = 10 * 60 * 1000;
+    while (!stopped) {
+      await new Promise((r) => setTimeout(r, start.poll_interval_seconds ?? 2));
+      if (Date.now() - startedAt > maxWaitMs) {
+        setMessage("Timed out waiting for the provider.");
+        return;
+      }
+      try {
+        const pollRes = await api.post<PollResponse>(
+          "/api/connect/minimax/poll",
+          { flow_id: start.flow_id }
+        );
+        const status = pollRes?.data?.status;
+        if (status === "connected") {
+          stopped = true;
+          setSaveSucceeded(true);
+          setMessage("Setup: Connected.");
+          onChanged();
+          return;
+        }
+        if (status === "error") {
+          stopped = true;
+          setMessage(
+            pollRes?.data?.kind
+              ? `Provider reported: ${pollRes.data.kind}`
+              : "Setup failed."
+          );
+          return;
+        }
+      } catch (e: any) {
+        // 429 cadence guard: backend already throttles; continue waiting.
+        const status = e?.response?.status;
+        if (status === 410) {
+          stopped = true;
+          setMessage("OAuth flow has expired. Please try again.");
+          return;
+        }
+        if (status !== 429 && status !== 404) {
+          stopped = true;
+          setMessage(
+            e?.response?.data?.detail ||
+              e?.message ||
+              "Polling failed."
+          );
+          return;
+        }
+      }
     }
   }
 
@@ -645,6 +752,34 @@ export const ConnectionConfigModal: React.FC<ConnectionProps> = ({
           ? "Sign in with the provider to continue."
           : "Continue to save your settings."}
       </div>
+      {minimaxFlow && (
+        <div
+          className="rounded border p-2 text-xs"
+          data-testid="minimax-oauth-flow"
+        >
+          <div>
+            <span className="opacity-70">Verification URL:</span>{" "}
+            <span className="font-mono">
+              {minimaxFlow.verificationUri}
+            </span>
+          </div>
+          <div>
+            <span className="opacity-70">User code:</span>{" "}
+            <span className="font-mono">{minimaxFlow.userCode}</span>
+          </div>
+          <div className="mt-1 flex gap-2">
+            <a
+              href={minimaxFlow.verificationUri}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="underline"
+              data-testid="minimax-oauth-open-link"
+            >
+              Open verification page
+            </a>
+          </div>
+        </div>
+      )}
       {message && <div className="text-xs">{message}</div>}
       {loading && (
         <div className="flex items-center gap-2 text-sm opacity-80">

--- a/frontend/src/features/connectors/__tests__/MinimaxOAuth.test.tsx
+++ b/frontend/src/features/connectors/__tests__/MinimaxOAuth.test.tsx
@@ -1,0 +1,258 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ConnectionConfigModal } from "@/features/connectors/ConnectorConfigModal";
+
+const unconfiguredMiniMaxEntry = {
+  id: "minimax_oauth",
+  display_name: "MiniMax OAuth",
+  category: "inference",
+  description: "MiniMax Global OAuth subscription-style setup.",
+  auth_methods: ["oauth_browser"],
+  capabilities: ["chat_completion"],
+  implementation_state: "partial",
+  setup_state: "unavailable",
+  runtime_binding: {
+    subsystem: "guardian.connectors.minimax",
+    adapter: null,
+    setup_route: "/api/connect/minimax/start",
+    registry_provider_id: "minimax",
+    oauth_backend_handler_exists: true,
+  },
+  required_fields: [],
+  scopes: [],
+  setup_help:
+    "MiniMax OAuth setup uses the Codexify-owned application configuration on this node.",
+  oauth: {
+    supported: true,
+    backend_handler_exists: true,
+    launchable: false,
+    node_configured: false,
+    connection: null,
+  },
+  authorization: {
+    registered: true,
+    registry_provider_id: "minimax",
+    governance_classification: "static_authorized",
+    authorized: false,
+    available: false,
+    enabled: false,
+    disabled_reason: "Missing provider credentials",
+  },
+};
+
+const configuredPendingEntry = {
+  ...unconfiguredMiniMaxEntry,
+  setup_state: "authenticating",
+  oauth: {
+    ...unconfiguredMiniMaxEntry.oauth,
+    launchable: true,
+    node_configured: true,
+    connection: {
+      provider: "minimax_oauth",
+      mode: "node_local",
+      status: "pending",
+      scopes: [],
+      expires_at: null,
+      last_refresh_at: null,
+      error_kind: null,
+    },
+  },
+};
+
+const configuredConnectedEntry = {
+  ...unconfiguredMiniMaxEntry,
+  setup_state: "connected",
+  oauth: {
+    ...unconfiguredMiniMaxEntry.oauth,
+    launchable: true,
+    node_configured: true,
+    connection: {
+      provider: "minimax_oauth",
+      mode: "node_local",
+      status: "connected",
+      scopes: ["chat"],
+      expires_at: "2027-01-01T00:00:00+00:00",
+      last_refresh_at: "2026-08-17T00:00:00+00:00",
+      error_kind: null,
+    },
+  },
+};
+
+const mockedApi = vi.hoisted(() => ({
+  get: vi.fn(async () => ({ data: [] })),
+  post: vi.fn(async () => ({ data: {} })),
+  patch: vi.fn(async () => ({ data: {} })),
+  delete: vi.fn(async () => ({ data: {} })),
+  interceptors: {
+    request: { use: vi.fn(() => 1), eject: vi.fn() },
+    response: { use: vi.fn(() => 2), eject: vi.fn() },
+  },
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: (props: Record<string, unknown>) => (
+    <button {...props}>{props.children as string}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: Record<string, unknown>) => <input {...props} />,
+}));
+
+vi.mock("@/components/ui/textarea", () => ({
+  Textarea: (props: Record<string, unknown>) => <textarea {...props} />,
+}));
+
+vi.mock("@/lib/api", () => ({
+  default: mockedApi,
+  clearRuntimeApiKey: vi.fn(),
+  getAuthToken: vi.fn(() => null),
+  getDevApiKey: vi.fn(() => ""),
+  readRuntimeApiKey: vi.fn(() => ""),
+  refreshApiBaseUrl: vi.fn(),
+  setRuntimeApiKey: vi.fn(),
+}));
+
+describe("MiniMax OAuth lifecycle modal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  it("shows node-not-configured state when backend handler exists but launchable is false", async () => {
+    render(
+      <ConnectionConfigModal
+        connection={unconfiguredMiniMaxEntry}
+        open
+        onClose={vi.fn()}
+        onChanged={vi.fn()}
+      />
+    );
+
+    // When launchable=false, the setup state reads "Not available" via
+    // the canonical SETUP_STATE_LABELS projection. The provider registry
+    // shows static_authorized classification (registry authorization is
+    // independent of OAuth setup availability).
+    expect(screen.getByText("Not available")).toBeInTheDocument();
+    // No verification metadata exposed when the entry cannot launch.
+    expect(screen.queryByTestId("minimax-oauth-flow")).not.toBeInTheDocument();
+  });
+
+  it("renders verification URI, user code, and a manual open link when launchable", async () => {
+    render(
+      <ConnectionConfigModal
+        connection={configuredPendingEntry}
+        open
+        onClose={vi.fn()}
+        onChanged={vi.fn()}
+      />
+    );
+
+    // The persisted pending connection is shown.
+    expect(
+      screen.getByText(/Persisted OAuth state: pending/)
+    ).toBeInTheDocument();
+  });
+
+  it("never writes the verification URL or user code to local/session storage", async () => {
+    render(
+      <ConnectionConfigModal
+        connection={configuredPendingEntry}
+        open
+        onClose={vi.fn()}
+        onChanged={vi.fn()}
+      />
+    );
+
+    const allLocal = JSON.stringify(window.localStorage);
+    const allSession = JSON.stringify(window.sessionStorage);
+    expect(allLocal).not.toMatch(/minimax/i);
+    expect(allSession).not.toMatch(/minimax/i);
+    expect(allLocal).not.toMatch(/user[_-]?code/i);
+    expect(allSession).not.toMatch(/user[_-]?code/i);
+    expect(allLocal).not.toMatch(/flow[_-]?id/i);
+    expect(allSession).not.toMatch(/flow[_-]?id/i);
+  });
+
+  it("shows Connected status without exposing any token in the detail surface", async () => {
+    render(
+      <ConnectionConfigModal
+        connection={configuredConnectedEntry}
+        open
+        onClose={vi.fn()}
+        onChanged={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText(/Persisted OAuth state: connected/)
+    ).toBeInTheDocument();
+    const body = document.body.textContent || "";
+    // No token prefixes, suffixes, or lengths leak into the DOM.
+    expect(body).not.toMatch(/access_token/);
+    expect(body).not.toMatch(/refresh_token/);
+    expect(body).not.toMatch(/Bearer /);
+    // Provider-registry authorization still reports static_authorized
+    // (the registry's governance classification); active authorization
+    // is governed by the supported profile, not by OAuth credential
+    // presence.
+    expect(screen.getByText("static_authorized")).toBeInTheDocument();
+  });
+});
+
+describe("MiniMax OAuth start/poll lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  it("calls /api/connect/minimax/start on save and surfaces the verification URI + user code", async () => {
+    mockedApi.post.mockImplementation(async (url: string) => {
+      if (url === "/api/connect/minimax/start") {
+        return {
+          data: {
+            provider: "minimax_oauth",
+            flow_id: "flow-test-abc",
+            verification_uri: "https://api.minimax.io/activate",
+            user_code: "USER-CODE-XYZ",
+            expires_at: "2026-08-17T01:00:00+00:00",
+            poll_interval_seconds: 2,
+          },
+        };
+      }
+      return { data: {} };
+    });
+
+    render(
+      <ConnectionConfigModal
+        connection={{ ...configuredPendingEntry, oauth: { ...configuredPendingEntry.oauth, connection: null } }}
+        open
+        onClose={vi.fn()}
+        onChanged={vi.fn()}
+      />
+    );
+
+    // Click Continue on the save step.
+    const continueBtn = screen.getByRole("button", { name: /continue/i });
+    await act(async () => {
+      fireEvent.click(continueBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockedApi.post).toHaveBeenCalledWith(
+        "/api/connect/minimax/start",
+        expect.any(Object)
+      );
+    });
+    expect(screen.getByTestId("minimax-oauth-flow")).toBeInTheDocument();
+    expect(screen.getByTestId("minimax-oauth-open-link")).toBeInTheDocument();
+    // PKCE verifier is never serialized to the DOM.
+    const body = document.body.textContent || "";
+    expect(body).not.toMatch(/verifier/);
+    expect(body).not.toMatch(/code_verifier/);
+    expect(body).not.toMatch(/code_challenge/);
+  });
+});

--- a/frontend/src/features/connectors/connectionCatalog.ts
+++ b/frontend/src/features/connectors/connectionCatalog.ts
@@ -65,6 +65,8 @@ export interface ConnectionOAuthProjection {
   supported: boolean;
   backend_handler_exists: boolean;
   connection: ConnectionOAuthRow | null;
+  launchable?: boolean;
+  node_configured?: boolean;
 }
 
 export interface ConnectionAuthorization {
@@ -151,9 +153,14 @@ export function canLaunchSetup(entry: ConnectionEntry): boolean {
   return Boolean(entry.runtime_binding.setup_route);
 }
 
-/** OAuth may launch only when a real backend authorization handler exists. */
+/** OAuth may launch only when a real backend authorization handler exists AND
+ *  the entry's setup can actually be launched on the current node (e.g.
+ *  the operator has provided the necessary application configuration).
+ */
 export function canLaunchOAuth(entry: ConnectionEntry): boolean {
-  return Boolean(entry.oauth?.backend_handler_exists);
+  if (!entry.oauth?.backend_handler_exists) return false;
+  if (entry.oauth.launchable === false) return false;
+  return true;
 }
 
 export function matchesSearch(entry: ConnectionEntry, query: string): boolean {

--- a/guardian/connections/catalog.py
+++ b/guardian/connections/catalog.py
@@ -225,6 +225,11 @@ def _inference_oauth_entry(
     description: str,
     *,
     registry_provider_id: str | None = None,
+    setup_route: str | None = None,
+    implementation_state: str = _UNIMPLEMENTED,
+    default_setup_state: str = _UNAVAILABLE,
+    oauth_backend_handler_exists: bool = False,
+    setup_help: str | None = None,
 ) -> ConnectionCatalogEntry:
     return ConnectionCatalogEntry(
         id=entry_id,
@@ -233,12 +238,18 @@ def _inference_oauth_entry(
         description=description,
         auth_methods=(_OAUTH_BROWSER,),
         capabilities=frozenset({_CHAT}),
+        implementation_state=implementation_state,
+        default_setup_state=default_setup_state,
         runtime_binding=ConnectionRuntimeBinding(
-            subsystem="guardian.core.provider_registry",
+            subsystem="guardian.connectors.minimax"
+            if entry_id == "minimax_oauth"
+            else "guardian.core.provider_registry",
             registry_provider_id=registry_provider_id,
+            setup_route=setup_route,
+            oauth_backend_handler_exists=oauth_backend_handler_exists,
         ),
         scopes=("chat",),
-        setup_help=_OAUTH_UNAVAILABLE_HELP,
+        setup_help=setup_help or _OAUTH_UNAVAILABLE_HELP,
         oauth_provider_key=entry_id,
     )
 
@@ -509,10 +520,20 @@ def _build_catalog() -> tuple[ConnectionCatalogEntry, ...]:
             _inference_oauth_entry(
                 "minimax_oauth",
                 "MiniMax OAuth",
-                "MiniMax OAuth-style access. No backend OAuth handler "
-                "exists yet; the MiniMax API-key lane is registry-governed "
-                "separately.",
+                "MiniMax Global OAuth subscription-style setup. A backend "
+                "OAuth setup handler now exists; OAuth-to-inference "
+                "credential binding remains deliberately deferred. The "
+                "MiniMax API-key lane is registry-governed separately.",
                 registry_provider_id="minimax",
+                setup_route="/api/connect/minimax/start",
+                implementation_state=_PARTIAL,
+                default_setup_state=_NEEDS_SETUP,
+                oauth_backend_handler_exists=True,
+                setup_help=(
+                    "MiniMax OAuth setup uses the Codexify-owned application "
+                    "configuration on this node. Authentication/setup is "
+                    "implemented; OAuth-to-inference binding is not."
+                ),
             ),
             _inference_oauth_entry(
                 "qwen_oauth",

--- a/guardian/connectors/minimax.py
+++ b/guardian/connectors/minimax.py
@@ -1,0 +1,765 @@
+"""MiniMax Global OAuth connection-setup lifecycle.
+
+This module implements one bounded MiniMax Global OAuth setup slice for the
+Connections control plane:
+
+  POST /api/connect/minimax/start
+  POST /api/connect/minimax/poll
+  POST /api/connect/minimax/disconnect
+
+It is strictly an authentication/setup lifecycle. It does NOT bind MiniMax
+OAuth credentials into the inference runtime, does NOT alter the canonical
+provider-registry authority, and does NOT widen the active provider
+posture. Credentials are encrypted at rest using
+``guardian.connectors.oauth_crypto`` and persisted in the existing
+``oauth_connections`` table under provider ``minimax_oauth`` / mode
+``node_local``.
+
+Design notes (verified MiniMax Global OAuth UX is the device / user-code
+shape, but exact endpoints / client-registration values are operator-supplied
+through configuration to avoid borrowing any other application's identity):
+
+* Authorization endpoint, token endpoint, and client identity are read from
+  the documented node configuration. Defaults are intentionally absent so
+  that a node without legitimate MiniMax OAuth application configuration
+  continues to report setup unavailable, never launching a broken flow.
+* PKCE (S256) and a random ``state`` value are generated server-side. The
+  PKCE verifier is never returned to the browser.
+* The user code + verification URI returned by the upstream authorization
+  endpoint are projected to the browser only as opaque flow metadata.
+* The browser only polls this module's poll route; it never polls the
+  upstream provider directly. Tokens are decrypted server-side, never
+  serialized to the browser.
+* Host allowlists bound upstream requests to known MiniMax Global hosts.
+  Arbitrary caller-supplied upstream URLs are rejected.
+* All upstream requests use explicit timeouts and bounded body reads. No
+  raw upstream body is ever returned to the browser.
+* The process-local flow registry is coordination-only, TTL-bounded, and
+  user-bound. It is never durable authority.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import os
+import secrets
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from urllib.parse import urlencode
+
+import requests
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from guardian.connectors.oauth_crypto import (
+    decrypt_token,
+    encrypt_token,
+)
+from guardian.core.dependencies import get_current_user
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/connect/minimax", tags=["Connections"])
+
+# ---------- canonical constants ---------------------------------
+
+_PROVIDER = "minimax_oauth"
+_MODE = "node_local"
+
+# TTL for in-process OAuth flow state.
+_FLOW_TTL_SECONDS = 600
+# Minimum polling cadence enforced between consecutive upstream polls.
+_POLL_INTERVAL_SECONDS = 2
+# Bounded body read for upstream HTTP requests.
+_UPSTREAM_TIMEOUT_SECONDS = 15
+_UPSTREAM_MAX_RESPONSE_BYTES = 16 * 1024
+
+# Host allowlist. Only requests to these MiniMax Global hosts are accepted.
+# The list is conservative on purpose; arbitrary caller-supplied URLs are
+# rejected. Operators who legitimately register Codexify with MiniMax may
+# need to extend this list through documented configuration.
+_DEFAULT_ALLOWED_HOSTS: tuple[str, ...] = (
+    "api.minimax.io",
+    "api.minimaxi.com",
+    "auth.minimax.io",
+    "auth.minimaxi.com",
+)
+
+
+# ---------- configuration -------------------------------------
+
+
+def _is_host_allowed(host: str) -> bool:
+    """Return True iff host is a member of the configured allowlist."""
+
+    candidate = (host or "").strip().lower()
+    if not candidate:
+        return False
+    allowed = {h.strip().lower() for h in _allowed_hosts()}
+    return candidate in allowed
+
+
+def _allowed_hosts() -> tuple[str, ...]:
+    """Resolve the host allowlist from configuration.
+
+    The default is ``_DEFAULT_ALLOWED_HOSTS``. Operators may extend the
+    allowlist through ``MINIMAX_OAUTH_ALLOWED_HOSTS`` (comma-separated).
+    """
+
+    raw = (os.getenv("MINIMAX_OAUTH_ALLOWED_HOSTS") or "").strip()
+    if not raw:
+        return _DEFAULT_ALLOWED_HOSTS
+    extras = tuple(
+        h.strip().lower()
+        for h in raw.split(",")
+        if h.strip()
+    )
+    return _DEFAULT_ALLOWED_HOSTS + extras
+
+
+def _node_oauth_config() -> tuple[str, str, str]:
+    """Resolve the MiniMax OAuth node configuration.
+
+    Returns ``(authorize_url, token_url, client_id)`` iff every required
+    value is configured. Raises ``HTTPException(503)`` otherwise. We never
+    fall back to borrowed values from other applications.
+    """
+
+    authorize_url = (os.getenv("MINIMAX_OAUTH_AUTHORIZE_URL") or "").strip()
+    token_url = (os.getenv("MINIMAX_OAUTH_TOKEN_URL") or "").strip()
+    client_id = (os.getenv("MINIMAX_OAUTH_CLIENT_ID") or "").strip()
+    if not authorize_url or not token_url or not client_id:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "MiniMax OAuth is not configured on this node. Set "
+                "MINIMAX_OAUTH_AUTHORIZE_URL, MINIMAX_OAUTH_TOKEN_URL, and "
+                "MINIMAX_OAUTH_CLIENT_ID with the Codexify-owned application "
+                "registration before initiating setup."
+            ),
+        )
+    # Reject arbitrary caller-supplied URLs by validating hosts.
+    for url_value in (authorize_url, token_url):
+        try:
+            host = url_value.split("://", 1)[1].split("/", 1)[0].split(
+                ":", 1
+            )[0]
+        except IndexError:
+            raise HTTPException(
+                status_code=503,
+                detail="MiniMax OAuth endpoint URL is malformed.",
+            )
+        if not _is_host_allowed(host):
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    f"MiniMax OAuth endpoint host {host!r} is not in the "
+                    "configured allowlist. Refusing to send a request."
+                ),
+            )
+    return authorize_url, token_url, client_id
+
+
+# ---------- ephemeral flow registry ---------------------------
+
+_flows_lock = threading.Lock()
+_flows: dict[str, dict[str, Any]] = {}
+
+
+def _new_flow_id() -> str:
+    return secrets.token_urlsafe(24)
+
+
+def _store_flow(flow_id: str, record: dict[str, Any]) -> None:
+    with _flows_lock:
+        _flows[flow_id] = record
+
+
+def _get_flow(flow_id: str) -> dict[str, Any] | None:
+    now = time.time()
+    with _flows_lock:
+        record = _flows.get(flow_id)
+        if record is None:
+            return None
+        if now - float(record["created_at"]) > _FLOW_TTL_SECONDS:
+            del _flows[flow_id]
+            return None
+        return record
+
+
+def _drop_flow(flow_id: str) -> None:
+    with _flows_lock:
+        _flows.pop(flow_id, None)
+
+
+# ---------- PKCE helpers --------------------------------------
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def _pkce_pair() -> tuple[str, str]:
+    """Return a fresh PKCE (verifier, challenge) pair using S256."""
+
+    verifier = _b64url(secrets.token_bytes(48))
+    challenge = _b64url(
+        hashlib.sha256(verifier.encode("ascii")).digest()
+    )
+    return verifier, challenge
+
+
+# ---------- upstream HTTP helpers -----------------------------
+
+
+def _bounded_post(
+    url: str,
+    *,
+    data: dict[str, str],
+    timeout: int = _UPSTREAM_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """POST to an allowlisted upstream with bounded read and timeouts."""
+
+    try:
+        response = requests.post(url, data=data, timeout=timeout)
+    except requests.RequestException as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"MiniMax OAuth upstream request failed: {exc.__class__.__name__}",
+        ) from exc
+    raw = response.content[:_UPSTREAM_MAX_RESPONSE_BYTES]
+    try:
+        body = json.loads(raw.decode("utf-8", errors="replace"))
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail="MiniMax OAuth upstream returned non-JSON body.",
+        ) from exc
+    if response.status_code >= 400:
+        raise HTTPException(
+            status_code=502,
+            detail="MiniMax OAuth upstream returned an error.",
+        )
+    if not isinstance(body, dict):
+        raise HTTPException(
+            status_code=502,
+            detail="MiniMax OAuth upstream returned an unexpected payload shape.",
+        )
+    return body
+
+
+# ---------- authorization request -----------------------------
+
+
+def _request_user_code(
+    *,
+    authorize_url: str,
+    client_id: str,
+    state: str,
+    challenge: str,
+) -> dict[str, Any]:
+    """Issue the MiniMax OAuth authorization request and parse it.
+
+    The MiniMax Global OAuth contract is the device / user-code shape:
+    the upstream returns ``user_code`` + ``verification_uri`` + ``expires_in``
+    + ``interval``. Required fields are validated defensively; missing or
+    malformed responses fail closed.
+    """
+
+    params = {
+        "client_id": client_id,
+        "response_type": "code",
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+    }
+    data = urlencode(params)
+    full_url = f"{authorize_url}?{data}"
+    body = _bounded_post(full_url, data={})
+    user_code = str(body.get("user_code") or "").strip()
+    verification_uri = str(body.get("verification_uri") or "").strip()
+    interval_raw = body.get("interval")
+    expires_in = body.get("expires_in")
+    if not user_code or not verification_uri:
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                "MiniMax OAuth authorization response is missing "
+                "user_code or verification_uri."
+            ),
+        )
+    try:
+        interval = int(str(interval_raw)) if interval_raw is not None else _POLL_INTERVAL_SECONDS
+    except (TypeError, ValueError):
+        interval = _POLL_INTERVAL_SECONDS
+    if interval < _POLL_INTERVAL_SECONDS:
+        interval = _POLL_INTERVAL_SECONDS
+    try:
+        ttl = int(str(expires_in)) if expires_in is not None else _FLOW_TTL_SECONDS
+    except (TypeError, ValueError):
+        ttl = _FLOW_TTL_SECONDS
+    if ttl <= 0 or ttl > _FLOW_TTL_SECONDS:
+        ttl = _FLOW_TTL_SECONDS
+    return {
+        "user_code": user_code,
+        "verification_uri": verification_uri,
+        "interval": interval,
+        "expires_in": ttl,
+    }
+
+
+# ---------- token exchange / refresh --------------------------
+
+
+def _exchange_or_pending(
+    *,
+    token_url: str,
+    client_id: str,
+    state: str,
+    verifier: str,
+) -> dict[str, Any]:
+    """Call the MiniMax token endpoint. Returns success dict or pending dict."""
+
+    data = {
+        "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+        "client_id": client_id,
+        "device_code": verifier,
+        "state": state,
+    }
+    try:
+        response = requests.post(
+            token_url, data=data, timeout=_UPSTREAM_TIMEOUT_SECONDS
+        )
+    except requests.RequestException as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"MiniMax OAuth token endpoint failed: {exc.__class__.__name__}",
+        ) from exc
+    raw = response.content[:_UPSTREAM_MAX_RESPONSE_BYTES]
+    try:
+        body = json.loads(raw.decode("utf-8", errors="replace"))
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail="MiniMax OAuth token endpoint returned non-JSON body.",
+        ) from exc
+    if response.status_code == 400:
+        # Pending responses for device/user-code flows. We surface only the
+        # canonical "pending" classification; raw provider error text is not
+        # serialized.
+        error_kind = str(body.get("error") or "").strip().lower()
+        if error_kind in {"authorization_pending", "slow_down", "pending"}:
+            return {"status": "pending"}
+        if error_kind in {"expired_token", "access_denied"}:
+            return {"status": "error", "kind": error_kind}
+    if response.status_code >= 400:
+        return {"status": "error", "kind": "provider_error"}
+    access = body.get("access_token")
+    refresh = body.get("refresh_token")
+    if not isinstance(access, str) or not access:
+        return {"status": "error", "kind": "missing_access_token"}
+    return {
+        "status": "connected",
+        "access_token": access,
+        "refresh_token": refresh if isinstance(refresh, str) and refresh else None,
+        "expires_in": body.get("expires_in"),
+        "scopes": body.get("scope"),
+    }
+
+
+def _refresh_token(
+    *,
+    refresh_token: str,
+    client_id: str,
+    token_url: str,
+) -> dict[str, Any]:
+    """Call the MiniMax refresh endpoint; never serialize tokens."""
+
+    data = {
+        "grant_type": "refresh_token",
+        "client_id": client_id,
+        "refresh_token": refresh_token,
+    }
+    try:
+        response = requests.post(
+            token_url, data=data, timeout=_UPSTREAM_TIMEOUT_SECONDS
+        )
+    except requests.RequestException as exc:
+        raise RuntimeError(
+            f"MiniMax OAuth refresh failed: {exc.__class__.__name__}"
+        ) from exc
+    raw = response.content[:_UPSTREAM_MAX_RESPONSE_BYTES]
+    try:
+        body = json.loads(raw.decode("utf-8", errors="replace"))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("MiniMax OAuth refresh returned non-JSON body.") from exc
+    if response.status_code >= 400:
+        raise RuntimeError("MiniMax OAuth refresh was rejected by the provider.")
+    access = body.get("access_token")
+    if not isinstance(access, str) or not access:
+        raise RuntimeError("MiniMax OAuth refresh did not return access_token.")
+    return {
+        "access_token": access,
+        "refresh_token": body.get("refresh_token"),
+        "expires_in": body.get("expires_in"),
+    }
+
+
+# ---------- persistence (existing oauth_connections table) ----
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _expires_at_from(expires_in: Any) -> datetime | None:
+    if expires_in is None:
+        return None
+    try:
+        seconds = int(str(expires_in))
+    except (TypeError, ValueError):
+        return None
+    if seconds <= 0:
+        return None
+    return _now_utc() + timedelta(seconds=seconds)
+
+
+def _persist(
+    *,
+    user_id: str,
+    status: str,
+    scopes: list[str],
+    encrypted_access_token: str | None = None,
+    encrypted_refresh_token: str | None = None,
+    expires_at: datetime | None = None,
+    last_error: str | None = None,
+    set_last_refresh: bool = False,
+) -> None:
+    """Persist the connection under (user_id, provider, mode)."""
+
+    from guardian.core.db import load_guardian_db_from_env
+
+    db = load_guardian_db_from_env()
+    if db is None:
+        raise RuntimeError("Guardian database is not configured.")
+    db.upsert_oauth_connection(
+        user_id=user_id,
+        provider=_PROVIDER,
+        mode=_MODE,
+        scopes=scopes,
+        status=status,
+        encrypted_access_token=encrypted_access_token,
+        encrypted_refresh_token=encrypted_refresh_token,
+        expires_at=expires_at,
+        last_refresh_at=_now_utc() if set_last_refresh else None,
+        last_error=last_error,
+    )
+
+
+# ---------- routes --------------------------------------------
+
+
+class PollRequest(BaseModel):
+    flow_id: str
+
+
+class DisconnectRequest(BaseModel):
+    pass
+
+
+@router.post("/start")
+def start_connect(current_user: str = Depends(get_current_user)) -> dict:
+    """Begin a MiniMax OAuth setup flow.
+
+    Returns safe browser-facing flow metadata: opaque ``flow_id``,
+    verification URI, user code, and TTL. The PKCE verifier is never
+    returned.
+    """
+
+    authorize_url, _token_url, client_id = _node_oauth_config()
+    state = secrets.token_urlsafe(24)
+    verifier, challenge = _pkce_pair()
+    upstream = _request_user_code(
+        authorize_url=authorize_url,
+        client_id=client_id,
+        state=state,
+        challenge=challenge,
+    )
+    flow_id = _new_flow_id()
+    _store_flow(
+        flow_id,
+        {
+            "user_id": current_user,
+            "state": state,
+            "verifier": verifier,
+            "client_id": client_id,
+            "interval": upstream["interval"],
+            "expires_at": _now_utc()
+            + timedelta(seconds=upstream["expires_in"]),
+            "created_at": time.time(),
+            "started_at": time.time(),
+            "last_poll": 0.0,
+            "verification_uri": upstream["verification_uri"],
+        },
+    )
+    # Best-effort pending projection so the catalog immediately reflects
+    # authenticating state for this user, without revealing tokens.
+    try:
+        _persist(
+            user_id=current_user,
+            status="pending",
+            scopes=[],
+        )
+    except Exception as exc:  # pragma: no cover - DB degraded
+        logger.warning(
+            "[minimax-oauth] pending projection failed kind=%s",
+            exc.__class__.__name__,
+        )
+    return {
+        "provider": _PROVIDER,
+        "flow_id": flow_id,
+        "verification_uri": upstream["verification_uri"],
+        "user_code": upstream["user_code"],
+        "expires_at": (
+            _now_utc() + timedelta(seconds=upstream["expires_in"])
+        ).isoformat(),
+        "poll_interval_seconds": upstream["interval"],
+    }
+
+
+@router.post("/poll")
+def poll_connect(
+    payload: PollRequest,
+    current_user: str = Depends(get_current_user),
+) -> dict:
+    """Poll the upstream token endpoint for an in-flight MiniMax OAuth flow.
+
+    Browser polls only this route; tokens never leave the server.
+    """
+
+    flow_id = (payload.flow_id or "").strip()
+    if not flow_id:
+        raise HTTPException(status_code=400, detail="Missing flow_id.")
+    record = _get_flow(flow_id)
+    if record is None:
+        raise HTTPException(status_code=410, detail="OAuth flow has expired.")
+    if record["user_id"] != current_user:
+        # Cross-user polling must fail closed without leaking existence.
+        raise HTTPException(status_code=404, detail="OAuth flow not found.")
+    if _now_utc() >= record["expires_at"]:
+        _drop_flow(flow_id)
+        try:
+            _persist(
+                user_id=current_user,
+                status="error",
+                scopes=[],
+                last_error="flow_expired",
+            )
+        except Exception:  # pragma: no cover
+            pass
+        raise HTTPException(status_code=410, detail="OAuth flow has expired.")
+    now = time.time()
+    last_marker = float(record.get("last_poll") or record.get("started_at") or 0.0)
+    if now - last_marker < float(record["interval"]):
+        raise HTTPException(
+            status_code=429,
+            detail="Polling cadence not yet satisfied.",
+        )
+    record["last_poll"] = now
+    if record.get("started_at") is None:
+        record["started_at"] = now
+    _token_url = (os.getenv("MINIMAX_OAUTH_TOKEN_URL") or "").strip()
+    if not _token_url:
+        # Should be guarded by _node_oauth_config at start, but fail closed.
+        _drop_flow(flow_id)
+        raise HTTPException(status_code=503, detail="MiniMax OAuth is not configured.")
+    try:
+        result = _exchange_or_pending(
+            token_url=_token_url,
+            client_id=record["client_id"],
+            state=record["state"],
+            verifier=record["verifier"],
+        )
+    except HTTPException:
+        # Malformed/non-JSON upstream bodies fail closed at the exchange
+        # layer. Drop the flow so the user can retry cleanly.
+        _drop_flow(flow_id)
+        raise
+    status = str(result.get("status") or "")
+    if status == "pending":
+        return {"provider": _PROVIDER, "flow_id": flow_id, "status": "authenticating"}
+    if status == "error":
+        _drop_flow(flow_id)
+        kind = str(result.get("kind") or "provider_error")
+        try:
+            _persist(
+                user_id=current_user,
+                status="error",
+                scopes=[],
+                last_error=kind,
+            )
+        except Exception:  # pragma: no cover
+            pass
+        return {"provider": _PROVIDER, "flow_id": flow_id, "status": "error", "kind": kind}
+    # Connected: encrypt and persist.
+    encrypted_access = encrypt_token(result.get("access_token"))
+    encrypted_refresh = encrypt_token(result.get("refresh_token"))
+    expires_at = _expires_at_from(result.get("expires_in"))
+    scopes_raw = result.get("scopes")
+    if isinstance(scopes_raw, str):
+        scopes = sorted({s for s in scopes_raw.split() if s})
+    elif isinstance(scopes_raw, list):
+        scopes = sorted({str(s) for s in scopes_raw if s})
+    else:
+        scopes = []
+    try:
+        _persist(
+            user_id=current_user,
+            status="connected",
+            scopes=scopes,
+            encrypted_access_token=encrypted_access,
+            encrypted_refresh_token=encrypted_refresh,
+            expires_at=expires_at,
+            set_last_refresh=True,
+        )
+    except RuntimeError as exc:
+        _drop_flow(flow_id)
+        raise HTTPException(
+            status_code=503,
+            detail=f"OAuth persistence unavailable: {exc}",
+        ) from exc
+    _drop_flow(flow_id)
+    return {
+        "provider": _PROVIDER,
+        "flow_id": flow_id,
+        "status": "connected",
+        "scopes": scopes,
+    }
+
+
+@router.post("/disconnect")
+def disconnect(
+    current_user: str = Depends(get_current_user),
+) -> dict:
+    """Disconnect the current user's MiniMax OAuth connection."""
+
+    from guardian.core.db import load_guardian_db_from_env
+
+    db = load_guardian_db_from_env()
+    if db is None:
+        raise HTTPException(status_code=503, detail="Database unavailable.")
+    count = db.disconnect_oauth_connection(
+        user_id=current_user, provider=_PROVIDER, mode=_MODE
+    )
+    return {"provider": _PROVIDER, "mode": _MODE, "disconnected": int(count or 0)}
+
+
+@router.get("/status")
+def connection_status(current_user: str = Depends(get_current_user)) -> dict:
+    """Read-only status of the current user's MiniMax OAuth connection.
+
+    No tokens are ever serialized.
+    """
+
+    from guardian.core.db import load_guardian_db_from_env
+
+    db = load_guardian_db_from_env()
+    if db is None:
+        raise HTTPException(status_code=503, detail="Database unavailable.")
+    row = db.get_oauth_connection(
+        user_id=current_user, provider=_PROVIDER, mode=_MODE
+    )
+    if not row:
+        return {
+            "provider": _PROVIDER,
+            "mode": _MODE,
+            "status": "disconnected",
+            "connected": False,
+        }
+    return {
+        "provider": _PROVIDER,
+        "mode": row.get("mode") or _MODE,
+        "status": row.get("status") or "disconnected",
+        "connected": row.get("status") == "connected",
+        "scopes": list(row.get("scopes") or []),
+        "expires_at": (
+            row["expires_at"].isoformat() if row.get("expires_at") else None
+        ),
+        "last_refresh_at": (
+            row["last_refresh_at"].isoformat()
+            if row.get("last_refresh_at")
+            else None
+        ),
+    }
+
+
+# ---------- provider-owned refresh helper ---------------------
+
+
+def refresh_minimax_oauth(
+    *,
+    user_id: str,
+    encrypted_refresh_token: str,
+) -> dict[str, Any]:
+    """Refresh the current user's MiniMax OAuth access token.
+
+    This helper exists for a future OAuth-to-runtime binding task. It is
+    not invoked by any inference path today. It must NEVER serialize
+    credentials.
+    """
+
+    client_id = (os.getenv("MINIMAX_OAUTH_CLIENT_ID") or "").strip()
+    token_url = (os.getenv("MINIMAX_OAUTH_TOKEN_URL") or "").strip()
+    if not client_id or not token_url:
+        raise RuntimeError("MiniMax OAuth is not configured on this node.")
+    refresh_token = decrypt_token(encrypted_refresh_token)
+    if not refresh_token:
+        raise RuntimeError("Stored MiniMax OAuth refresh token is missing.")
+    result = _refresh_token(
+        refresh_token=refresh_token,
+        client_id=client_id,
+        token_url=token_url,
+    )
+    new_refresh = result.get("refresh_token")
+    # Preserve the existing refresh token when the provider omits one.
+    encrypted_access = encrypt_token(result.get("access_token"))
+    encrypted_refresh = (
+        encrypt_token(new_refresh)
+        if isinstance(new_refresh, str) and new_refresh
+        else encrypted_refresh_token
+    )
+    _persist(
+        user_id=user_id,
+        status="connected",
+        scopes=[],
+        encrypted_access_token=encrypted_access,
+        encrypted_refresh_token=encrypted_refresh,
+        expires_at=_expires_at_from(result.get("expires_in")),
+        set_last_refresh=True,
+    )
+    return {
+        "provider": _PROVIDER,
+        "mode": _MODE,
+        "status": "connected",
+    }
+
+
+# ---------- node configuration helper -------------------------
+
+
+def node_oauth_configured() -> bool:
+    """Return True iff this node has a complete MiniMax OAuth configuration.
+
+    Used by catalog projection and frontend gating. Never raises.
+    """
+
+    try:
+        _node_oauth_config()
+        return True
+    except HTTPException:
+        return False

--- a/guardian/guardian_api.py
+++ b/guardian/guardian_api.py
@@ -56,6 +56,7 @@ logger = logging.getLogger(__name__)
 
 from guardian.config.system_config import ensure_system_dirs
 from guardian.connectors.google import router as google_connect_router
+from guardian.connectors.minimax import router as minimax_oauth_router
 
 # Import core dependencies module (contains shared helpers)
 from guardian.core import dependencies, event_bus, metrics
@@ -1293,6 +1294,14 @@ _include_router(
     label="google_connect",
     flag_name="CODEXIFY_ENABLE_GOOGLE_CONNECT_ROUTES",
     include_fn=lambda: app.include_router(google_connect_router),
+)
+_include_router(
+    label="minimax_oauth",
+    flag_name="CODEXIFY_ENABLE_MINIMAX_OAUTH_ROUTES",
+    include_fn=lambda: app.include_router(
+        minimax_oauth_router,
+        include_in_schema=_include_internal_only_schema("minimax_oauth"),
+    ),
 )
 _include_router(
     label="media",

--- a/guardian/routes/connections.py
+++ b/guardian/routes/connections.py
@@ -253,16 +253,46 @@ def _project_entry(
     oauth_key = entry.oauth_provider_key
     if oauth_key:
         item["oauth"] = {
-            "supported": False,
+            "supported": bool(
+                entry.runtime_binding.oauth_backend_handler_exists
+            ),
             "backend_handler_exists": (
                 entry.runtime_binding.oauth_backend_handler_exists
             ),
             "connection": oauth_rows.get(oauth_key),
+            "launchable": False,
+            "node_configured": False,
         }
+        if entry.runtime_binding.oauth_backend_handler_exists:
+            item["oauth"]["launchable"] = _oauth_launchable(entry)
+            item["oauth"]["node_configured"] = item["oauth"]["launchable"]
+            if not item["oauth"]["launchable"]:
+                # A node without legitimate OAuth application configuration
+                # must surface unavailable, even though the backend handler
+                # exists in code.
+                item["setup_state"] = ConnectionSetupState.UNAVAILABLE.value
     else:
         item["oauth"] = None
     item["authorization"] = inference_authorization
     return item
+
+
+def _oauth_launchable(entry: ConnectionCatalogEntry) -> bool:
+    """Return True iff this entry's OAuth setup can actually launch on this node."""
+
+    if not entry.runtime_binding.oauth_backend_handler_exists:
+        return False
+    if entry.id == "minimax_oauth":
+        try:
+            from guardian.connectors.minimax import node_oauth_configured
+
+            return bool(node_oauth_configured())
+        except Exception:  # pragma: no cover - defensive
+            return False
+    # Generic rule for future entries: a setup route must exist. The rule
+    # is intentionally conservative so future entries do not become
+    # accidentally clickable merely because a backend handler exists.
+    return bool(entry.runtime_binding.setup_route)
 
 
 def _project_all(user_id: str) -> list[dict[str, Any]]:

--- a/tests/connections/test_connection_catalog.py
+++ b/tests/connections/test_connection_catalog.py
@@ -145,13 +145,58 @@ def test_deepseek_is_api_key_only() -> None:
     assert entry.runtime_binding.oauth_backend_handler_exists is False
 
 
-def test_no_entry_claims_an_oauth_backend_handler_exists() -> None:
-    # No provider-specific OAuth exchange is implemented in this slice, so
-    # no entry may advertise one; OAuth UI must stay disabled.
-    for entry in get_catalog():
-        assert (
-            entry.runtime_binding.oauth_backend_handler_exists is False
-        ), entry.id
+def test_minimax_oauth_is_partial_with_real_backend_handler() -> None:
+    """MiniMax OAuth is the first provider-specific OAuth setup entry.
+
+    Authentication/setup code path exists; OAuth-to-inference credential
+    binding remains deliberately deferred. The MiniMax API-key lane is
+    registry-governed separately.
+    """
+
+    entry = get_connection("minimax_oauth")
+    assert entry is not None
+    assert entry.id == "minimax_oauth"
+    # MiniMax OAuth is distinct from MiniMax API-key.
+    assert entry.auth_methods == ("oauth_browser",)
+    assert entry.implementation_state == "partial"
+    assert entry.runtime_binding.setup_route == "/api/connect/minimax/start"
+    assert entry.runtime_binding.oauth_backend_handler_exists is True
+    assert entry.runtime_binding.registry_provider_id == "minimax"
+    # MiniMax API-key entry remains unchanged.
+    api_entry = get_connection("minimax_api")
+    assert api_entry is not None
+    assert api_entry.implementation_state == "implemented"
+    assert api_entry.auth_methods == ("api_key",)
+    assert api_entry.runtime_binding.oauth_backend_handler_exists is False
+    assert api_entry.runtime_binding.registry_provider_id == "minimax"
+    # Unrelated OAuth entries remain unimplemented.
+    for entry_id in (
+        "codex_chatgpt",
+        "qwen_oauth",
+        "gemini_oauth",
+        "xai_oauth",
+        "nous_portal",
+        "github_copilot",
+        "anthropic_subscription",
+    ):
+        other = get_connection(entry_id)
+        assert other is not None
+        assert other.runtime_binding.oauth_backend_handler_exists is False, entry_id
+
+
+def test_oauth_setup_route_uses_dedicated_provider_label() -> None:
+    """The MiniMax OAuth setup route is independent from the read-only
+    Connections surface and from the quarantined legacy connectors surface.
+    """
+
+    entry = get_connection("minimax_oauth")
+    assert entry is not None
+    setup_route = entry.runtime_binding.setup_route
+    assert setup_route is not None
+    # Not on the read-only Connections surface.
+    assert not setup_route.startswith("/api/connections")
+    # Not on the quarantined legacy connector surface.
+    assert not setup_route.startswith("/api/connectors")
 
 
 def test_inference_registry_mapping_matches_provider_registry() -> None:

--- a/tests/connectors/test_minimax_oauth.py
+++ b/tests/connectors/test_minimax_oauth.py
@@ -1,0 +1,852 @@
+"""Bounded MiniMax OAuth setup lifecycle tests.
+
+These tests mock all upstream MiniMax network calls and exercise only the
+provider-owned start / poll / disconnect / refresh surface. They prove:
+
+* missing node OAuth configuration fails safely;
+* start generates PKCE + state + opaque flow metadata;
+* poll enforces user-binding, TTL, and cadence;
+* successful poll persists the encrypted credential under minimax_oauth;
+* plaintext access/refresh tokens never enter persistence;
+* encrypted credentials decrypt in the test seam;
+* malformed upstream responses fail closed;
+* terminal flow state is discarded;
+* the refresh helper rotates access tokens and preserves refresh on omission;
+* no API-key environment mutation occurs.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+import types
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+# ---------- helpers ----------------------------------------------
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class _FakeDB:
+    def __init__(self) -> None:
+        self.rows: dict[tuple[str, str, str], dict[str, Any]] = {}
+
+    def upsert_oauth_connection(
+        self,
+        *,
+        user_id: str,
+        provider: str,
+        mode: str,
+        scopes: list[str],
+        status: str,
+        encrypted_access_token: str | None = None,
+        encrypted_refresh_token: str | None = None,
+        expires_at: datetime | None = None,
+        last_refresh_at: datetime | None = None,
+        last_error: str | None = None,
+    ) -> dict[str, Any]:
+        key = (user_id, provider, mode)
+        existing = self.rows.get(key, {})
+        existing.update(
+            {
+                "user_id": user_id,
+                "provider": provider,
+                "mode": mode,
+                "scopes": scopes,
+                "status": status,
+                "encrypted_access_token": encrypted_access_token,
+                "encrypted_refresh_token": encrypted_refresh_token,
+                "expires_at": expires_at,
+                "last_refresh_at": (
+                    last_refresh_at if last_refresh_at is not None else existing.get("last_refresh_at")
+                ),
+                "last_error": last_error,
+            }
+        )
+        self.rows[key] = existing
+        return existing
+
+    def get_oauth_connection(
+        self, *, user_id: str, provider: str, mode: str
+    ) -> dict[str, Any] | None:
+        return self.rows.get((user_id, provider, mode))
+
+    def disconnect_oauth_connection(
+        self, *, user_id: str, provider: str, mode: str
+    ) -> int:
+        key = (user_id, provider, mode)
+        if key in self.rows:
+            self.rows[key]["status"] = "disconnected"
+            return 1
+        return 0
+
+
+@contextmanager
+def _env(values: dict[str, str]):
+    original = {k: os.environ.get(k) for k in values}
+    for k, v in values.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+    try:
+        yield
+    finally:
+        for k, v in original.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def _load_minimax_module(env: dict[str, str] | None = None):
+    """(Re)load the minimax module with the supplied env applied."""
+
+    env = env or {}
+    for k in (
+        "MINIMAX_OAUTH_CLIENT_ID",
+        "MINIMAX_OAUTH_AUTHORIZE_URL",
+        "MINIMAX_OAUTH_TOKEN_URL",
+        "MINIMAX_OAUTH_ALLOWED_HOSTS",
+    ):
+        os.environ.pop(k, None)
+    for k, v in env.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+    # Force a fresh module so _node_oauth_config / _flows are clean.
+    sys.modules.pop("guardian.connectors.minimax", None)
+    return importlib.import_module("guardian.connectors.minimax")
+
+
+def _install_db_override(mod: types.ModuleType, db: _FakeDB) -> None:
+    """Install a fake DB override for minimax module persistence calls."""
+
+    from cryptography.fernet import Fernet
+
+    os.environ.setdefault(
+        "GUARDIAN_OAUTH_TOKEN_ENCRYPTION_KEY",
+        Fernet.generate_key().decode("ascii"),
+    )
+    monkey_guardian_db = MagicMock()
+    monkey_guardian_db.upsert_oauth_connection = (
+        lambda **kwargs: db.upsert_oauth_connection(**kwargs)
+    )
+    monkey_guardian_db.get_oauth_connection = (
+        lambda **kwargs: db.get_oauth_connection(**kwargs)
+    )
+    monkey_guardian_db.disconnect_oauth_connection = (
+        lambda **kwargs: db.disconnect_oauth_connection(**kwargs)
+    )
+    import guardian.core.db as _real_db  # type: ignore
+
+    _real_db.load_guardian_db_from_env = lambda: monkey_guardian_db
+
+
+# ---------- configuration tests ---------------------------------
+
+
+def test_node_oauth_not_configured_when_env_missing() -> None:
+    mod = _load_minimax_module({})
+    assert mod.node_oauth_configured() is False
+
+
+def test_node_oauth_configured_when_all_required_env_present() -> None:
+    mod = _load_minimax_module(
+        {
+            "MINIMAX_OAUTH_CLIENT_ID": "codexify-minimax-oauth-client",
+            "MINIMAX_OAUTH_AUTHORIZE_URL": "https://api.minimax.io/oauth/authorize",
+            "MINIMAX_OAUTH_TOKEN_URL": "https://api.minimax.io/oauth/token",
+        }
+    )
+    assert mod.node_oauth_configured() is True
+
+
+def test_node_oauth_rejects_unallowed_upstream_url() -> None:
+    mod = _load_minimax_module(
+        {
+            "MINIMAX_OAUTH_CLIENT_ID": "codexify-minimax-oauth-client",
+            "MINIMAX_OAUTH_AUTHORIZE_URL": "https://attacker.example.com/authorize",
+            "MINIMAX_OAUTH_TOKEN_URL": "https://api.minimax.io/oauth/token",
+        }
+    )
+    assert mod.node_oauth_configured() is False
+
+
+def test_allowed_hosts_extension_is_accepted() -> None:
+    mod = _load_minimax_module(
+        {
+            "MINIMAX_OAUTH_CLIENT_ID": "codexify-minimax-oauth-client",
+            "MINIMAX_OAUTH_AUTHORIZE_URL": "https://minimax.example.test/oauth/authorize",
+            "MINIMAX_OAUTH_TOKEN_URL": "https://minimax.example.test/oauth/token",
+            "MINIMAX_OAUTH_ALLOWED_HOSTS": "minimax.example.test",
+        }
+    )
+    assert mod.node_oauth_configured() is True
+
+
+# ---------- start / poll lifecycle -------------------------------
+
+
+def _build_client(mod: types.ModuleType, db: _FakeDB) -> tuple[TestClient, FastAPI]:
+    """Construct a TestClient with the minimax router and a fake DB."""
+
+    # Provide a static Fernet key so encrypt_token/decrypt_token work.
+    from cryptography.fernet import Fernet
+
+    test_key = Fernet.generate_key().decode("ascii")
+    os.environ["GUARDIAN_OAUTH_TOKEN_ENCRYPTION_KEY"] = test_key
+
+    # Replace the loader that minimax.py captures per call.
+    monkey_guardian_db = MagicMock()
+    monkey_guardian_db.upsert_oauth_connection = (
+        lambda **kwargs: db.upsert_oauth_connection(**kwargs)
+    )
+    monkey_guardian_db.get_oauth_connection = (
+        lambda **kwargs: db.get_oauth_connection(**kwargs)
+    )
+    monkey_guardian_db.disconnect_oauth_connection = (
+        lambda **kwargs: db.disconnect_oauth_connection(**kwargs)
+    )
+    import guardian.core.db as _real_db  # type: ignore
+
+    _real_db.load_guardian_db_from_env = lambda: monkey_guardian_db
+
+    # Provide a simple current_user dependency for tests.
+    def _stub_user() -> str:
+        return "test-user"
+
+    app = FastAPI()
+    app.include_router(mod.router)
+    app.dependency_overrides[mod.get_current_user] = _stub_user
+    return TestClient(app), app
+
+
+def test_start_returns_only_safe_metadata() -> None:
+    env = {
+        "MINIMAX_OAUTH_CLIENT_ID": "codexify-minimax-oauth-client",
+        "MINIMAX_OAUTH_AUTHORIZE_URL": "https://api.minimax.io/oauth/authorize",
+        "MINIMAX_OAUTH_TOKEN_URL": "https://api.minimax.io/oauth/token",
+    }
+    mod = _load_minimax_module(env)
+    db = _FakeDB()
+    client, app = _build_client(mod, db)
+
+    fake_authorize = {
+        "user_code": "ABCD-EFGH",
+        "verification_uri": "https://api.minimax.io/activate",
+        "interval": 5,
+        "expires_in": 600,
+    }
+    with patch.object(mod.requests, "post", return_value=_fake_response(fake_authorize)):
+        response = client.post("/api/connect/minimax/start")
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["provider"] == "minimax_oauth"
+    assert payload["flow_id"]
+    assert payload["verification_uri"] == "https://api.minimax.io/activate"
+    assert payload["user_code"] == "ABCD-EFGH"
+    assert payload["poll_interval_seconds"] >= 2
+    # PKCE verifier must never be serialized.
+    for forbidden in (
+        "verifier",
+        "code_verifier",
+        "code_challenge",
+        "pkce",
+        "access_token",
+        "refresh_token",
+    ):
+        assert forbidden not in payload
+    # flow registry records the verifier server-side, not in payload.
+    flow_id = payload["flow_id"]
+    assert mod._get_flow(flow_id) is not None
+    assert "verifier" in mod._get_flow(flow_id)
+    # A pending row was projected so the catalog reads "authenticating".
+    row = db.rows.get(("test-user", "minimax_oauth", "node_local"))
+    assert row is not None
+    assert row["status"] == "pending"
+
+
+def test_start_generates_pkce_and_state_per_call() -> None:
+    env = {
+        "MINIMAX_OAUTH_CLIENT_ID": "codexify-minimax-oauth-client",
+        "MINIMAX_OAUTH_AUTHORIZE_URL": "https://api.minimax.io/oauth/authorize",
+        "MINIMAX_OAUTH_TOKEN_URL": "https://api.minimax.io/oauth/token",
+    }
+    mod = _load_minimax_module(env)
+    db = _FakeDB()
+    client, app = _build_client(mod, db)
+
+    captured_query: list[dict[str, str]] = []
+
+    def _fake_post(url, data, **kwargs):
+        # The authorize call passes params via query string.
+        from urllib.parse import parse_qs, urlparse
+
+        parsed = urlparse(url)
+        captured_query.append({k: v[0] for k, v in parse_qs(parsed.query).items()})
+        return _fake_response(
+            {
+                "user_code": "ABCD",
+                "verification_uri": "https://api.minimax.io/activate",
+                "interval": 5,
+                "expires_in": 600,
+            }
+        )
+
+    with patch.object(mod.requests, "post", side_effect=_fake_post):
+        client.post("/api/connect/minimax/start")
+        client.post("/api/connect/minimax/start")
+
+    assert len(captured_query) == 2
+    first, second = captured_query
+    assert first["code_challenge_method"] == "S256"
+    assert first["response_type"] == "code"
+    assert first["client_id"] == "codexify-minimax-oauth-client"
+    assert "code_challenge" in first
+    assert first["state"] != second["state"]
+    # Different flow_ids and different PKCE challenges are issued.
+    assert first["code_challenge"] != second["code_challenge"]
+
+
+def test_start_fails_closed_on_incomplete_upstream_response() -> None:
+    env = {
+        "MINIMAX_OAUTH_CLIENT_ID": "codexify-minimax-oauth-client",
+        "MINIMAX_OAUTH_AUTHORIZE_URL": "https://api.minimax.io/oauth/authorize",
+        "MINIMAX_OAUTH_TOKEN_URL": "https://api.minimax.io/oauth/token",
+    }
+    mod = _load_minimax_module(env)
+    db = _FakeDB()
+    client, app = _build_client(mod, db)
+
+    # Missing user_code and verification_uri: must fail closed.
+    bad = {
+        "interval": 5,
+        "expires_in": 600,
+    }
+    with patch.object(mod.requests, "post", return_value=_fake_response(bad)):
+        response = client.post("/api/connect/minimax/start")
+    assert response.status_code == 502
+
+
+def test_poll_rejects_cross_user_flow_lookup() -> None:
+    env = {
+        "MINIMAX_OAUTH_CLIENT_ID": "codexify-minimax-oauth-client",
+        "MINIMAX_OAUTH_AUTHORIZE_URL": "https://api.minimax.io/oauth/authorize",
+        "MINIMAX_OAUTH_TOKEN_URL": "https://api.minimax.io/oauth/token",
+    }
+    mod = _load_minimax_module(env)
+    db = _FakeDB()
+    client, app = _build_client(mod, db)
+
+    # Start a flow as test-user; we will then poll under a different user.
+    with patch.object(
+        mod.requests,
+        "post",
+        return_value=_fake_response(
+            {
+                "user_code": "ABCD",
+                "verification_uri": "https://api.minimax.io/activate",
+                "interval": 1,
+                "expires_in": 600,
+            }
+        ),
+    ):
+        start_response = client.post("/api/connect/minimax/start")
+    flow_id = start_response.json()["flow_id"]
+
+    def _as_other_user() -> str:
+        return "other-user"
+
+    app.dependency_overrides[mod.get_current_user] = _as_other_user
+    response = client.post("/api/connect/minimax/poll", json={"flow_id": flow_id})
+    assert response.status_code == 404
+    # flow still belongs to test-user
+    assert mod._get_flow(flow_id)["user_id"] == "test-user"
+
+
+def test_poll_enforces_cadence() -> None:
+    env = {
+        "MINIMAX_OAUTH_CLIENT_ID": "codexify-minimax-oauth-client",
+        "MINIMAX_OAUTH_AUTHORIZE_URL": "https://api.minimax.io/oauth/authorize",
+        "MINIMAX_OAUTH_TOKEN_URL": "https://api.minimax.io/oauth/token",
+    }
+    mod = _load_minimax_module(env)
+    db = _FakeDB()
+    client, app = _build_client(mod, db)
+
+    with patch.object(
+        mod.requests,
+        "post",
+        return_value=_fake_response(
+            {
+                "user_code": "ABCD",
+                "verification_uri": "https://api.minimax.io/activate",
+                "interval": 60,
+                "expires_in": 600,
+            }
+        ),
+    ):
+        start_response = client.post("/api/connect/minimax/start")
+    flow_id = start_response.json()["flow_id"]
+
+    # Started_at was just set; an immediate poll MUST fail cadence.
+    response = client.post("/api/connect/minimax/poll", json={"flow_id": flow_id})
+    assert response.status_code == 429
+
+
+def test_poll_pending_response_remains_pending() -> None:
+    env = {
+        "MINIMAX_OAUTH_CLIENT_ID": "codexify-minimax-oauth-client",
+        "MINIMAX_OAUTH_AUTHORIZE_URL": "https://api.minimax.io/oauth/authorize",
+        "MINIMAX_OAUTH_TOKEN_URL": "https://api.minimax.io/oauth/token",
+    }
+    mod = _load_minimax_module(env)
+    db = _FakeDB()
+    client, app = _build_client(mod, db)
+
+    with patch.object(
+        mod.requests,
+        "post",
+        side_effect=[
+            _fake_response(
+                {
+                    "user_code": "ABCD",
+                    "verification_uri": "https://api.minimax.io/activate",
+                    "interval": 1,
+                    "expires_in": 600,
+                }
+            ),
+            _fake_response({"error": "authorization_pending"}, status_code=400),
+        ],
+    ):
+        start_response = client.post("/api/connect/minimax/start")
+        flow_id = start_response.json()["flow_id"]
+        # Patch last_poll so cadence allows the poll.
+        flow = mod._get_flow(flow_id)
+        flow["last_poll"] = 0.0
+        flow["started_at"] = 0.0
+        flow["started_at"] = 0.0
+        poll_response = client.post(
+            "/api/connect/minimax/poll", json={"flow_id": flow_id}
+        )
+    assert poll_response.status_code == 200
+    assert poll_response.json()["status"] == "authenticating"
+    assert db.rows[("test-user", "minimax_oauth", "node_local")]["status"] == "pending"
+
+
+def test_poll_successful_response_persists_encrypted_credentials() -> None:
+    env = {
+        "MINIMAX_OAUTH_CLIENT_ID": "codexify-minimax-oauth-client",
+        "MINIMAX_OAUTH_AUTHORIZE_URL": "https://api.minimax.io/oauth/authorize",
+        "MINIMAX_OAUTH_TOKEN_URL": "https://api.minimax.io/oauth/token",
+    }
+    mod = _load_minimax_module(env)
+    db = _FakeDB()
+    client, app = _build_client(mod, db)
+
+    token_body = {
+        "access_token": "plaintext-access-secret-XYZ",
+        "refresh_token": "plaintext-refresh-secret-UVW",
+        "expires_in": 3600,
+        "scope": "chat",
+    }
+    with patch.object(
+        mod.requests,
+        "post",
+        side_effect=[
+            _fake_response(
+                {
+                    "user_code": "ABCD",
+                    "verification_uri": "https://api.minimax.io/activate",
+                    "interval": 1,
+                    "expires_in": 600,
+                }
+            ),
+            _fake_response(token_body),
+        ],
+    ):
+        start_response = client.post("/api/connect/minimax/start")
+        flow_id = start_response.json()["flow_id"]
+        mod._get_flow(flow_id)["last_poll"] = 0.0
+        mod._get_flow(flow_id)["started_at"] = 0.0
+        mod._get_flow(flow_id)["started_at"] = 0.0
+        mod._get_flow(flow_id)["started_at"] = 0.0
+        poll_response = client.post(
+            "/api/connect/minimax/poll", json={"flow_id": flow_id}
+        )
+    assert poll_response.status_code == 200
+    assert poll_response.json()["status"] == "connected"
+    # No plaintext values returned in any poll response payload.
+    body_text = poll_response.text
+    assert "plaintext-access-secret-XYZ" not in body_text
+    assert "plaintext-refresh-secret-UVW" not in body_text
+
+    row = db.rows[("test-user", "minimax_oauth", "node_local")]
+    assert row["status"] == "connected"
+    encrypted_access = row["encrypted_access_token"]
+    encrypted_refresh = row["encrypted_refresh_token"]
+    assert encrypted_access and encrypted_refresh
+    # Plaintext secrets MUST NOT appear in the persisted row.
+    assert "plaintext-access-secret-XYZ" not in encrypted_access
+    assert "plaintext-refresh-secret-UVW" not in encrypted_refresh
+    # Round-trip decryption recovers plaintext in the backend test seam.
+    from guardian.connectors.oauth_crypto import decrypt_token
+
+    assert decrypt_token(encrypted_access) == "plaintext-access-secret-XYZ"
+    assert decrypt_token(encrypted_refresh) == "plaintext-refresh-secret-UVW"
+    # Expires recorded.
+    assert isinstance(row["expires_at"], datetime)
+    # Flow state is discarded after terminal success.
+    assert mod._get_flow(flow_id) is None
+
+
+def test_poll_malformed_token_response_fails_closed() -> None:
+    env = {
+        "MINIMAX_OAUTH_CLIENT_ID": "codexify-minimax-oauth-client",
+        "MINIMAX_OAUTH_AUTHORIZE_URL": "https://api.minimax.io/oauth/authorize",
+        "MINIMAX_OAUTH_TOKEN_URL": "https://api.minimax.io/oauth/token",
+    }
+    mod = _load_minimax_module(env)
+    db = _FakeDB()
+    client, app = _build_client(mod, db)
+
+    with patch.object(
+        mod.requests,
+        "post",
+        side_effect=[
+            _fake_response(
+                {
+                    "user_code": "ABCD",
+                    "verification_uri": "https://api.minimax.io/activate",
+                    "interval": 1,
+                    "expires_in": 600,
+                }
+            ),
+            # Upstream returned non-JSON garbage.
+            _fake_response("not-json", status_code=200),
+        ],
+    ):
+        start_response = client.post("/api/connect/minimax/start")
+        flow_id = start_response.json()["flow_id"]
+        mod._get_flow(flow_id)["last_poll"] = 0.0
+        mod._get_flow(flow_id)["started_at"] = 0.0
+        mod._get_flow(flow_id)["started_at"] = 0.0
+        mod._get_flow(flow_id)["started_at"] = 0.0
+        poll_response = client.post(
+            "/api/connect/minimax/poll", json={"flow_id": flow_id}
+        )
+    assert poll_response.status_code == 502
+    assert mod._get_flow(flow_id) is None
+
+
+def test_poll_provider_error_persists_error_status() -> None:
+    env = {
+        "MINIMAX_OAUTH_CLIENT_ID": "codexify-minimax-oauth-client",
+        "MINIMAX_OAUTH_AUTHORIZE_URL": "https://api.minimax.io/oauth/authorize",
+        "MINIMAX_OAUTH_TOKEN_URL": "https://api.minimax.io/oauth/token",
+    }
+    mod = _load_minimax_module(env)
+    db = _FakeDB()
+    client, app = _build_client(mod, db)
+
+    with patch.object(
+        mod.requests,
+        "post",
+        side_effect=[
+            _fake_response(
+                {
+                    "user_code": "ABCD",
+                    "verification_uri": "https://api.minimax.io/activate",
+                    "interval": 1,
+                    "expires_in": 600,
+                }
+            ),
+            _fake_response({"error": "access_denied"}, status_code=400),
+        ],
+    ):
+        start_response = client.post("/api/connect/minimax/start")
+        flow_id = start_response.json()["flow_id"]
+        mod._get_flow(flow_id)["last_poll"] = 0.0
+        mod._get_flow(flow_id)["started_at"] = 0.0
+        mod._get_flow(flow_id)["started_at"] = 0.0
+        mod._get_flow(flow_id)["started_at"] = 0.0
+        poll_response = client.post(
+            "/api/connect/minimax/poll", json={"flow_id": flow_id}
+        )
+    assert poll_response.status_code == 200
+    assert poll_response.json()["status"] == "error"
+    row = db.rows[("test-user", "minimax_oauth", "node_local")]
+    assert row["status"] == "error"
+    # Raw upstream error text MUST NOT be persisted verbatim; only the
+    # bounded classification survives.
+    assert row["last_error"] == "access_denied"
+    assert mod._get_flow(flow_id) is None
+
+
+def test_poll_rejects_expired_flow() -> None:
+    env = {
+        "MINIMAX_OAUTH_CLIENT_ID": "codexify-minimax-oauth-client",
+        "MINIMAX_OAUTH_AUTHORIZE_URL": "https://api.minimax.io/oauth/authorize",
+        "MINIMAX_OAUTH_TOKEN_URL": "https://api.minimax.io/oauth/token",
+    }
+    mod = _load_minimax_module(env)
+    db = _FakeDB()
+    client, app = _build_client(mod, db)
+
+    with patch.object(
+        mod.requests,
+        "post",
+        return_value=_fake_response(
+            {
+                "user_code": "ABCD",
+                "verification_uri": "https://api.minimax.io/activate",
+                "interval": 1,
+                "expires_in": 600,
+            }
+        ),
+    ):
+        start_response = client.post("/api/connect/minimax/start")
+        flow_id = start_response.json()["flow_id"]
+        # Force the flow past its TTL.
+        flow = mod._get_flow(flow_id)
+        flow["expires_at"] = _now_utc() - timedelta(seconds=1)
+        poll_response = client.post(
+            "/api/connect/minimax/poll", json={"flow_id": flow_id}
+        )
+    assert poll_response.status_code == 410
+
+
+# ---------- disconnect ------------------------------------------
+
+
+def test_disconnect_clears_state() -> None:
+    env = {
+        "MINIMAX_OAUTH_CLIENT_ID": "codexify-minimax-oauth-client",
+        "MINIMAX_OAUTH_AUTHORIZE_URL": "https://api.minimax.io/oauth/authorize",
+        "MINIMAX_OAUTH_TOKEN_URL": "https://api.minimax.io/oauth/token",
+    }
+    mod = _load_minimax_module(env)
+    db = _FakeDB()
+    client, app = _build_client(mod, db)
+
+    db.upsert_oauth_connection(
+        user_id="test-user",
+        provider="minimax_oauth",
+        mode="node_local",
+        scopes=[],
+        status="connected",
+        encrypted_access_token="dummy",
+        encrypted_refresh_token="dummy",
+    )
+    response = client.post("/api/connect/minimax/disconnect")
+    assert response.status_code == 200
+    assert response.json()["disconnected"] == 1
+    assert db.rows[("test-user", "minimax_oauth", "node_local")]["status"] == (
+        "disconnected"
+    )
+
+
+# ---------- refresh helper --------------------------------------
+
+
+def test_refresh_helper_rotates_access_and_preserves_refresh_when_omitted() -> None:
+    env = {
+        "MINIMAX_OAUTH_CLIENT_ID": "codexify-minimax-oauth-client",
+        "MINIMAX_OAUTH_AUTHORIZE_URL": "https://api.minimax.io/oauth/authorize",
+        "MINIMAX_OAUTH_TOKEN_URL": "https://api.minimax.io/oauth/token",
+    }
+    mod = _load_minimax_module(env)
+    db = _FakeDB()
+    _install_db_override(mod, db)
+
+    # Seed an existing connection with an encrypted refresh token.
+    from guardian.connectors.oauth_crypto import encrypt_token
+
+    existing_refresh = encrypt_token("original-refresh-token-AAA")
+    db.upsert_oauth_connection(
+        user_id="test-user",
+        provider="minimax_oauth",
+        mode="node_local",
+        scopes=[],
+        status="connected",
+        encrypted_access_token=encrypt_token("old-access"),
+        encrypted_refresh_token=existing_refresh,
+    )
+
+    # Upstream returns ONLY a new access_token (refresh omitted).
+    refresh_body = {
+        "access_token": "new-access-secret-NEW",
+        "expires_in": 1800,
+    }
+    with patch.object(
+        mod.requests, "post", return_value=_fake_response(refresh_body)
+    ) as post_mock:
+        result = mod.refresh_minimax_oauth(
+            user_id="test-user",
+            encrypted_refresh_token=existing_refresh,
+        )
+        # Confirm we hit the token endpoint with refresh grant.
+        assert post_mock.called
+        kwargs = post_mock.call_args.kwargs
+        body = kwargs.get("data") or {}
+        assert body.get("grant_type") == "refresh_token"
+        assert body.get("client_id") == "codexify-minimax-oauth-client"
+
+    assert result["status"] == "connected"
+    row = db.rows[("test-user", "minimax_oauth", "node_local")]
+    from guardian.connectors.oauth_crypto import decrypt_token
+
+    assert decrypt_token(row["encrypted_access_token"]) == "new-access-secret-NEW"
+    # Refresh token preserved verbatim.
+    assert decrypt_token(row["encrypted_refresh_token"]) == "original-refresh-token-AAA"
+
+
+def test_refresh_helper_accepts_new_refresh_when_supplied() -> None:
+    env = {
+        "MINIMAX_OAUTH_CLIENT_ID": "codexify-minimax-oauth-client",
+        "MINIMAX_OAUTH_AUTHORIZE_URL": "https://api.minimax.io/oauth/authorize",
+        "MINIMAX_OAUTH_TOKEN_URL": "https://api.minimax.io/oauth/token",
+    }
+    mod = _load_minimax_module(env)
+    db = _FakeDB()
+    _install_db_override(mod, db)
+
+    from guardian.connectors.oauth_crypto import encrypt_token
+
+    existing_refresh = encrypt_token("old-refresh-AAA")
+    db.upsert_oauth_connection(
+        user_id="test-user",
+        provider="minimax_oauth",
+        mode="node_local",
+        scopes=[],
+        status="connected",
+        encrypted_access_token=encrypt_token("old-access"),
+        encrypted_refresh_token=existing_refresh,
+    )
+
+    refresh_body = {
+        "access_token": "new-access-NEW",
+        "refresh_token": "rotated-refresh-BBB",
+        "expires_in": 1800,
+    }
+    with patch.object(mod.requests, "post", return_value=_fake_response(refresh_body)):
+        mod.refresh_minimax_oauth(
+            user_id="test-user",
+            encrypted_refresh_token=existing_refresh,
+        )
+    row = db.rows[("test-user", "minimax_oauth", "node_local")]
+    from guardian.connectors.oauth_crypto import decrypt_token
+
+    assert decrypt_token(row["encrypted_refresh_token"]) == "rotated-refresh-BBB"
+
+
+def test_refresh_helper_fails_closed_on_malformed_response() -> None:
+    env = {
+        "MINIMAX_OAUTH_CLIENT_ID": "codexify-minimax-oauth-client",
+        "MINIMAX_OAUTH_AUTHORIZE_URL": "https://api.minimax.io/oauth/authorize",
+        "MINIMAX_OAUTH_TOKEN_URL": "https://api.minimax.io/oauth/token",
+    }
+    mod = _load_minimax_module(env)
+    db = _FakeDB()
+    _install_db_override(mod, db)
+
+    from guardian.connectors.oauth_crypto import encrypt_token
+
+    existing_refresh = encrypt_token("seed-refresh-AAA")
+    db.upsert_oauth_connection(
+        user_id="test-user",
+        provider="minimax_oauth",
+        mode="node_local",
+        scopes=[],
+        status="connected",
+        encrypted_access_token=encrypt_token("old-access"),
+        encrypted_refresh_token=existing_refresh,
+    )
+
+    # Missing access_token -> helper must raise, row must NOT be mutated.
+    with patch.object(
+        mod.requests,
+        "post",
+        return_value=_fake_response({"expires_in": 600}),
+    ):
+        with pytest.raises(RuntimeError):
+            mod.refresh_minimax_oauth(
+                user_id="test-user",
+                encrypted_refresh_token=existing_refresh,
+            )
+    row = db.rows[("test-user", "minimax_oauth", "node_local")]
+    from guardian.connectors.oauth_crypto import decrypt_token
+
+    assert decrypt_token(row["encrypted_access_token"]) == "old-access"
+
+
+# ---------- environment invariants ------------------------------
+
+
+def test_oauth_lifecycle_does_not_mutate_minimax_api_key() -> None:
+    env = {
+        "MINIMAX_OAUTH_CLIENT_ID": "codexify-minimax-oauth-client",
+        "MINIMAX_OAUTH_AUTHORIZE_URL": "https://api.minimax.io/oauth/authorize",
+        "MINIMAX_OAUTH_TOKEN_URL": "https://api.minimax.io/oauth/token",
+    }
+    mod = _load_minimax_module(env)
+    db = _FakeDB()
+    client, app = _build_client(mod, db)
+
+    with patch.object(
+        mod.requests,
+        "post",
+        return_value=_fake_response(
+            {
+                "user_code": "ABCD",
+                "verification_uri": "https://api.minimax.io/activate",
+                "interval": 1,
+                "expires_in": 600,
+            }
+        ),
+    ):
+        before = dict(os.environ)
+        response = client.post("/api/connect/minimax/start")
+        after = dict(os.environ)
+    assert response.status_code == 200
+    # No MINIMAX_API_KEY write occurred during setup.
+    assert before.get("MINIMAX_API_KEY") == after.get("MINIMAX_API_KEY")
+
+
+# ---------- helpers ----------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, body: Any, status_code: int = 200) -> None:
+        self._body = body
+        self.status_code = status_code
+        if isinstance(body, (dict, list)):
+            text = json.dumps(body)
+        else:
+            text = str(body)
+        self.content = text.encode("utf-8")
+        self.text = text
+
+    def json(self) -> Any:
+        if isinstance(self._body, (dict, list)):
+            return self._body
+        return json.loads(self._body)
+
+
+def _fake_response(body: Any, status_code: int = 200) -> _FakeResponse:
+    return _FakeResponse(body, status_code)

--- a/tests/core/test_supported_profile.py
+++ b/tests/core/test_supported_profile.py
@@ -38,6 +38,9 @@ def test_v1_supported_profile_manifest_loads() -> None:
     assert manifest.route_status("system_prompt") == "enabled"
     assert manifest.route_status("system_docs") == "enabled"
     assert manifest.route_status("connections") == "enabled"
+    # MiniMax OAuth provider-specific auth route is internal-only,
+    # not Beta-Supported and not quarantined.
+    assert manifest.route_status("minimax_oauth") == "internal_only"
     # The read-only catalog promotion must not expose legacy connector
     # mutation or sync routes.
     assert manifest.route_status("connectors") == "quarantined"

--- a/tests/core/test_supported_profile_quarantine.py
+++ b/tests/core/test_supported_profile_quarantine.py
@@ -263,6 +263,34 @@ def test_supported_profile_exposes_read_only_connections_without_legacy_connecto
         assert set(paths["/api/connections/{connection_id}"]) == {"get"}
 
 
+def test_supported_profile_mounts_minimax_oauth_routes_as_internal_only(
+    monkeypatch,
+) -> None:
+    """MiniMax OAuth provider-specific auth routes must be mounted under
+    the supported local profile but hidden from public OpenAPI according
+    to current internal-only behavior. Connector-quarantine assertions
+    are not weakened.
+    """
+
+    with _build_supported_profile_client(monkeypatch) as client:
+        headers = {"X-API-Key": "test-api-key"}
+
+        # Connector quarantine is unchanged.
+        assert client.get("/api/connectors", headers=headers).status_code == 404
+
+        paths = client.get("/openapi.json").json().get("paths", {})
+        # MiniMax OAuth routes are intentionally hidden from public
+        # OpenAPI per the internal-only posture. Their handlers do
+        # exist; the supported profile simply suppresses schema
+        # visibility.
+        assert "/api/connect/minimax/start" not in paths
+        assert "/api/connect/minimax/poll" not in paths
+        assert "/api/connect/minimax/disconnect" not in paths
+        assert "/api/connect/minimax/status" not in paths
+        # Other OAuth/connector surfaces remain absent.
+        assert "/api/connect/google/start" not in paths
+
+
 def test_agent_orchestration_chat_readback_enforced(
     monkeypatch,
 ) -> None:

--- a/tests/routes/test_connections.py
+++ b/tests/routes/test_connections.py
@@ -172,8 +172,18 @@ def test_unimplemented_entries_report_unavailable(
 
 def test_oauth_rows_project_only_safe_fields(
     client: tuple[TestClient, _TestDB],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     test_client, db = client
+    # Force a clean, unconfigured state regardless of env leaked from
+    # earlier tests in the run.
+    for env_var in (
+        "MINIMAX_OAUTH_CLIENT_ID",
+        "MINIMAX_OAUTH_AUTHORIZE_URL",
+        "MINIMAX_OAUTH_TOKEN_URL",
+        "MINIMAX_OAUTH_ALLOWED_HOSTS",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
     expires = datetime.datetime(
         2026, 9, 1, 12, 0, 0, tzinfo=datetime.timezone.utc
     )
@@ -191,12 +201,15 @@ def test_oauth_rows_project_only_safe_fields(
     )
     assert response.status_code == 200
     item = response.json()
-    # No Codexify OAuth flow exists for this entry, so setup stays
-    # unavailable even though a safe oauth_connections row is projected.
+    # The MiniMax OAuth backend handler is now implemented, so setup is
+    # launchable only when the node has legitimate configuration.
+    # Without node config the entry remains visibly unavailable even
+    # though a safe oauth_connections row is projected.
     assert item["setup_state"] == "unavailable"
     oauth = item["oauth"]
-    assert oauth["backend_handler_exists"] is False
-    assert oauth["supported"] is False
+    assert oauth["backend_handler_exists"] is True
+    assert oauth["launchable"] is False
+    assert oauth["node_configured"] is False
     connection_row = oauth["connection"]
     assert connection_row["provider"] == "minimax_oauth"
     assert connection_row["status"] == "connected"
@@ -214,8 +227,27 @@ def test_oauth_rows_project_only_safe_fields(
 
 def test_oauth_error_is_sanitized_classification_only(
     client: tuple[TestClient, _TestDB],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     test_client, db = client
+    # Make sure no prior test leaked node OAuth config into the env.
+    for env_var in (
+        "MINIMAX_OAUTH_CLIENT_ID",
+        "MINIMAX_OAUTH_AUTHORIZE_URL",
+        "MINIMAX_OAUTH_TOKEN_URL",
+        "MINIMAX_OAUTH_ALLOWED_HOSTS",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+    monkeypatch.setenv(
+        "MINIMAX_OAUTH_CLIENT_ID", "codexify-minimax-oauth-client"
+    )
+    monkeypatch.setenv(
+        "MINIMAX_OAUTH_AUTHORIZE_URL",
+        "https://api.minimax.io/oauth/authorize",
+    )
+    monkeypatch.setenv(
+        "MINIMAX_OAUTH_TOKEN_URL", "https://api.minimax.io/oauth/token"
+    )
     db.add_oauth_connection(
         oauth_id=1,
         user_id=_SERVER_USER_ID,
@@ -227,7 +259,7 @@ def test_oauth_error_is_sanitized_classification_only(
         "/api/connections/minimax_oauth", headers=_headers()
     )
     item = response.json()
-    assert item["setup_state"] == "unavailable"
+    assert item["setup_state"] == "error"
     connection_row = item["oauth"]["connection"]
     assert connection_row["error_kind"] == "provider_error"
     # Raw error text must never be serialized.
@@ -353,3 +385,243 @@ def test_connections_router_is_read_only(
         "/api/connections": {"GET"},
         "/api/connections/{connection_id}": {"GET"},
     }
+
+
+def test_minimax_oauth_node_unconfigured_reports_unavailable(
+    client: tuple[TestClient, _TestDB],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without legitimate MiniMax OAuth node configuration, the entry
+    must surface unavailable even though a backend handler exists, with
+    no secrets serialized."""
+
+    test_client, _ = client
+    for env_var in (
+        "MINIMAX_OAUTH_CLIENT_ID",
+        "MINIMAX_OAUTH_AUTHORIZE_URL",
+        "MINIMAX_OAUTH_TOKEN_URL",
+        "MINIMAX_OAUTH_ALLOWED_HOSTS",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+    response = test_client.get(
+        "/api/connections/minimax_oauth", headers=_headers()
+    )
+    assert response.status_code == 200
+    item = response.json()
+    assert item["oauth"]["backend_handler_exists"] is True
+    assert item["oauth"]["launchable"] is False
+    assert item["oauth"]["node_configured"] is False
+    # Node unconfigured => unavailable, even with a handler in code.
+    assert item["setup_state"] == "unavailable"
+    # Provider registry still reports blocked-by-default posture.
+    assert item["authorization"]["registered"] is True
+    assert item["authorization"]["authorized"] is False
+    # No secrets appear in any projection field.
+    body = response.text
+    for forbidden in (
+        "encrypted_access_token",
+        "encrypted_refresh_token",
+        "access_token",
+        "refresh_token",
+        "client_id",
+        "client_secret",
+        "pkce",
+        "verifier",
+    ):
+        assert forbidden not in body, forbidden
+
+
+def test_minimax_oauth_node_configured_reports_needs_setup(
+    client: tuple[TestClient, _TestDB],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With legitimate node configuration, the entry surfaces needs_setup
+    until the user has authenticated."""
+
+    test_client, _ = client
+    monkeypatch.setenv(
+        "MINIMAX_OAUTH_CLIENT_ID", "codexify-minimax-oauth-client"
+    )
+    monkeypatch.setenv(
+        "MINIMAX_OAUTH_AUTHORIZE_URL",
+        "https://api.minimax.io/oauth/authorize",
+    )
+    monkeypatch.setenv(
+        "MINIMAX_OAUTH_TOKEN_URL", "https://api.minimax.io/oauth/token"
+    )
+
+    response = test_client.get(
+        "/api/connections/minimax_oauth", headers=_headers()
+    )
+    assert response.status_code == 200
+    item = response.json()
+    assert item["oauth"]["backend_handler_exists"] is True
+    assert item["oauth"]["launchable"] is True
+    assert item["oauth"]["node_configured"] is True
+    # No persisted row => needs_setup, NOT connected.
+    assert item["setup_state"] == "needs_setup"
+    assert item["oauth"]["connection"] is None
+
+
+def test_minimax_oauth_pending_row_projects_authenticating(
+    client: tuple[TestClient, _TestDB],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pending oauth_connections row projects authenticating, NOT
+    connected."""
+
+    test_client, db = client
+    monkeypatch.setenv(
+        "MINIMAX_OAUTH_CLIENT_ID", "codexify-minimax-oauth-client"
+    )
+    monkeypatch.setenv(
+        "MINIMAX_OAUTH_AUTHORIZE_URL",
+        "https://api.minimax.io/oauth/authorize",
+    )
+    monkeypatch.setenv(
+        "MINIMAX_OAUTH_TOKEN_URL", "https://api.minimax.io/oauth/token"
+    )
+    db.add_oauth_connection(
+        oauth_id=11,
+        user_id=_SERVER_USER_ID,
+        provider="minimax_oauth",
+        status="pending",
+    )
+
+    response = test_client.get(
+        "/api/connections/minimax_oauth", headers=_headers()
+    )
+    assert response.status_code == 200
+    item = response.json()
+    assert item["setup_state"] == "authenticating"
+
+
+def test_minimax_oauth_error_row_projects_error(
+    client: tuple[TestClient, _TestDB],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An error oauth_connections row projects error."""
+
+    test_client, db = client
+    monkeypatch.setenv(
+        "MINIMAX_OAUTH_CLIENT_ID", "codexify-minimax-oauth-client"
+    )
+    monkeypatch.setenv(
+        "MINIMAX_OAUTH_AUTHORIZE_URL",
+        "https://api.minimax.io/oauth/authorize",
+    )
+    monkeypatch.setenv(
+        "MINIMAX_OAUTH_TOKEN_URL", "https://api.minimax.io/oauth/token"
+    )
+    db.add_oauth_connection(
+        oauth_id=12,
+        user_id=_SERVER_USER_ID,
+        provider="minimax_oauth",
+        status="error",
+        last_error="access_denied",
+    )
+
+    response = test_client.get(
+        "/api/connections/minimax_oauth", headers=_headers()
+    )
+    assert response.status_code == 200
+    item = response.json()
+    assert item["setup_state"] == "error"
+    # Provider error text never appears in the projection.
+    assert "access_denied" not in response.text
+    # But the bounded error_kind classification IS serialized.
+    assert item["oauth"]["connection"]["error_kind"] == "provider_error"
+
+
+def test_minimax_oauth_connected_row_projects_connected(
+    client: tuple[TestClient, _TestDB],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connected oauth_connections row projects connected. The registry
+    authorization remains NOT authorized under the supported profile.
+    """
+
+    test_client, db = client
+    monkeypatch.setenv(
+        "MINIMAX_OAUTH_CLIENT_ID", "codexify-minimax-oauth-client"
+    )
+    monkeypatch.setenv(
+        "MINIMAX_OAUTH_AUTHORIZE_URL",
+        "https://api.minimax.io/oauth/authorize",
+    )
+    monkeypatch.setenv(
+        "MINIMAX_OAUTH_TOKEN_URL", "https://api.minimax.io/oauth/token"
+    )
+    db.add_oauth_connection(
+        oauth_id=13,
+        user_id=_SERVER_USER_ID,
+        provider="minimax_oauth",
+        status="connected",
+    )
+
+    response = test_client.get(
+        "/api/connections/minimax_oauth", headers=_headers()
+    )
+    assert response.status_code == 200
+    item = response.json()
+    assert item["setup_state"] == "connected"
+    # Provider-registry authorization remains unchanged: not authorized
+    # under the supported profile. OAuth credentials are NOT executable.
+    assert item["authorization"]["registered"] is True
+    assert item["authorization"]["authorized"] is False
+
+
+def test_minimax_api_relationship_to_oauth_is_unchanged(
+    client: tuple[TestClient, _TestDB],
+) -> None:
+    """The MiniMax API-key entry remains separate from MiniMax OAuth."""
+
+    test_client, _ = client
+    response = test_client.get(
+        "/api/connections/minimax_api", headers=_headers()
+    )
+    assert response.status_code == 200
+    item = response.json()
+    assert item["id"] == "minimax_api"
+    assert item["auth_methods"] == ["api_key"]
+    assert item["oauth"] is None
+    assert item["implementation_state"] == "implemented"
+
+
+def test_setup_launchability_gate_does_not_enable_other_oauth_entries(
+    client: tuple[TestClient, _TestDB],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The launchability gate is minimax-specific. Other OAuth entries
+    must remain disabled even if the node happens to have OAuth
+    configuration."""
+
+    test_client, _ = client
+    monkeypatch.setenv(
+        "MINIMAX_OAUTH_CLIENT_ID", "codexify-minimax-oauth-client"
+    )
+    monkeypatch.setenv(
+        "MINIMAX_OAUTH_AUTHORIZE_URL",
+        "https://api.minimax.io/oauth/authorize",
+    )
+    monkeypatch.setenv(
+        "MINIMAX_OAUTH_TOKEN_URL", "https://api.minimax.io/oauth/token"
+    )
+
+    response = test_client.get("/api/connections", headers=_headers())
+    assert response.status_code == 200
+    items = _items_by_id(response.json())
+    for entry_id in (
+        "codex_chatgpt",
+        "qwen_oauth",
+        "gemini_oauth",
+        "xai_oauth",
+        "nous_portal",
+        "github_copilot",
+        "anthropic_subscription",
+    ):
+        oauth = items[entry_id]["oauth"]
+        assert oauth["backend_handler_exists"] is False, entry_id
+        assert oauth["launchable"] is False, entry_id
+        assert items[entry_id]["setup_state"] == "unavailable", entry_id


### PR DESCRIPTION
## Summary

This PR lands the **MiniMax OAuth connection setup** slice — authentication/setup only — as the first provider-specific OAuth setup seam under the existing Connections control plane.

## What this slice does

- Establishes provider-specific MiniMax OAuth setup routes:
  - `POST /api/connect/minimax/start`
  - `POST /api/connect/minimax/poll`
  - `POST /api/connect/minimax/disconnect`
  - `GET  /api/connect/minimax/status`
- Generates PKCE (S256) + state server-side; PKCE verifier never reaches the browser.
- Coordinates the in-flight flow via a TTL-bounded process-local registry that is user-bound, provider-bound, cadence-bound, and discarded on terminal success/error.
- Persists encrypted access + refresh credentials under the existing `oauth_connections` table at `(provider=minimax_oauth, mode=node_local, user_id)` using `guardian.connectors.oauth_crypto`. No plaintext tokens on disk.
- Projects safe browser metadata only: `flow_id`, `verification_uri`, `user_code`, `expires_at`, `poll_interval_seconds`. PKCE verifier, access token, refresh token, client secret, and raw upstream error text are never serialized.
- Upstream requests use explicit timeouts, bounded body reads, and a host allowlist that refuses arbitrary caller-supplied URLs.
- Frontend reuses the existing metadata-driven `ConnectionConfigModal` with a narrow extension for the device/user-code flow: displays the verification URL + user code, exposes a manual `Open verification page` link (no popup-blocker dependence), polls only the backend poll route, never persists flow metadata to localStorage/sessionStorage.

## What this slice does NOT do

- **Authentication/setup only.** OAuth-to-inference credential binding is intentionally deferred.
- **No third-party OAuth client identity borrowed.** All OAuth endpoints and the client identity are read from documented node configuration (`MINIMAX_OAUTH_CLIENT_ID`, `MINIMAX_OAUTH_AUTHORIZE_URL`, `MINIMAX_OAUTH_TOKEN_URL`, optional `MINIMAX_OAUTH_ALLOWED_HOSTS`). A node without legitimate Codexify-owned MiniMax OAuth application configuration keeps the entry visibly unavailable without launching a broken flow.
- **No provider-registry widening.** `guardian/core/provider_registry.py` is byte-identical to `origin/main`. `authorization.authorized` remains `false` for `minimax_oauth` under the supported profile even after a successful OAuth connection.
- **No MiniMax runtime adapter modification.** `guardian/providers/minimax_adapter.py` is byte-identical to `origin/main`. The OAuth access token is not used as `MINIMAX_API_KEY` and is not an inference credential.
- **No Beta / cloud-provider promotion.** `00-current-state.md` records the slice as `partial` (authentication/setup only) and explicitly notes OAuth credential-to-inference binding remains absent and default provider posture remains local-only.
- **No new migration, no new database table, no Redis choreography.**
- **No real-account MiniMax OAuth qualification.** No legitimate Codexify `MINIMAX_OAUTH_CLIENT_ID` was available in the implementation environment; the protocol smoke test was therefore skipped. Actual account authorization is manual qualification and remains deferred.

## Supported-profile posture (after this slice)

```
route_posture:
  enabled:
    - connections
  internal_only:
    - minimax_oauth        # new
  quarantined:
    - connectors            # unchanged

provider_contract:
  LLM_PROVIDER: local
  ALLOW_CLOUD_PROVIDERS: false
  CODEXIFY_LOCAL_ONLY_MODE: true
  CODEXIFY_EGRESS_ALLOWLIST: ""
```

The MiniMax OAuth auth routes are mounted as `internal_only` and therefore hidden from public OpenAPI per the existing internal-only schema-gating behavior. `/api/connections` remains `enabled` (read-only); `/api/connectors` remains `quarantined` (404).

## Validation

| Suite | Result |
| --- | --- |
| `tests/connectors/test_minimax_oauth.py` | **19 passed** |
| `tests/connections/test_connection_catalog.py` + `tests/routes/test_connections.py` | **35 passed** |
| `tests/core/test_supported_profile.py` + `tests/core/test_supported_profile_quarantine.py` | **34 passed** |
| Frontend: `features/connectors/__tests__/ConnectionsCatalog.test.tsx` + `MinimaxOAuth.test.tsx` | **12 passed** |
| `pnpm build` | **PASS** |
| `git diff --check` | **clean** |
| `git diff origin/main -- guardian/core/provider_registry.py` | **no diff** |
| `git diff origin/main -- guardian/providers/minimax_adapter.py` | **no diff** |

## Next gate (separate task)

Only after this slice merges to `main` may the next architecture-impact task begin:

`Bind MiniMax OAuth credentials to the inference runtime`

That task must independently preserve provider-registry authority and prove an authenticated persisted MiniMax turn before any release/support promotion.