### PR TITLE
Canonicalize Pi authorized readiness diagnostics

### DIFF
--- a/codex_runner/src/agent-wrapper.js
+++ b/codex_runner/src/agent-wrapper.js
@@ -23,7 +23,25 @@ const args = process.argv.slice(2);
 const mode = args[0] || "help";
 const prompt = args.slice(1).join(" ");
 const guardianAuthorizedMode = mode === "guardian-authorized-task";
+const guardianAuthorizedReadinessMode = mode === "guardian-authorized-readiness";
 const ACTUAL_HARNESS_ID = "pi-coding-agent";
+
+const AUTHORIZED_FAILURE_CLASSES = new Set([
+	"adapter_timeout",
+	"wrapper_unavailable",
+	"runtime_module_unavailable",
+	"authorized_identity_rejected",
+	"provider_unresolved",
+	"model_unresolved",
+	"oauth_auth_unavailable",
+	"session_initialization_failed",
+	"provider_request_failed",
+	"provider_transport_failed",
+	"wrapper_protocol_failed",
+	"actual_identity_missing",
+	"target_posture_violation",
+	"unknown_adapter_failure",
+]);
 
 const OPTIONS = {
 	cwd: process.cwd(),
@@ -76,6 +94,49 @@ function isModuleResolutionError(error) {
 	return message.includes("Cannot find package") || message.includes("Cannot find module");
 }
 
+function boundedFailureClass(value) {
+	return AUTHORIZED_FAILURE_CLASSES.has(value)
+		? value
+		: "unknown_adapter_failure";
+}
+
+function classifyAuthorizedError(error) {
+	const message = error instanceof Error ? error.message : String(error);
+	const text = message.toLowerCase();
+	if (text.includes("cannot find package") || text.includes("cannot find module")) {
+		return "runtime_module_unavailable";
+	}
+	if (text.includes("guardian_authorized_identity_missing") || text.includes("identity does not match")) {
+		return "authorized_identity_rejected";
+	}
+	if (text.includes("timeout") || text.includes("timed out")) {
+		return "adapter_timeout";
+	}
+	if (text.includes("econn") || text.includes("fetch failed") || text.includes("network") || text.includes("socket")) {
+		return "provider_transport_failed";
+	}
+	if (text.includes("401") || text.includes("403") || text.includes("429") || text.includes("provider request") || text.includes("response")) {
+		return "provider_request_failed";
+	}
+	if (text.includes("auth") || text.includes("oauth") || text.includes("credential") || text.includes("api key")) {
+		return "oauth_auth_unavailable";
+	}
+	return "unknown_adapter_failure";
+}
+
+function emitAuthorizedFailure(failureClass, failureStage, details = {}) {
+	const payload = {
+		status: "error",
+		failure_class: boundedFailureClass(failureClass),
+		failure_stage: String(failureStage || "adapter_execution"),
+		actual_runtime_identity: details.actual_runtime_identity || null,
+		runtime_identity_established: details.runtime_identity_established === true,
+		session_initialized: details.session_initialized === true,
+		provider_request_started: details.provider_request_started === true,
+	};
+	console.log(JSON.stringify(payload));
+}
+
 async function loadPiSdk() {
 	const wrapperDirectory = path.dirname(fileURLToPath(import.meta.url));
 	const packageRoot = process.env.PI_CODING_AGENT_PACKAGE_ROOT
@@ -98,9 +159,98 @@ async function loadPiSdk() {
 		ModelRegistry: codingAgent.ModelRegistry,
 		createCodingTools: codingAgent.createCodingTools,
 		getModel: piAi.getModel,
+		getProviders: piAi.getProviders,
 		harnessId: ACTUAL_HARNESS_ID,
 		harnessVersion: String(packageMetadata.version || ""),
 	};
+}
+
+async function checkGuardianAuthorizedReadiness() {
+	let identity;
+	try {
+		identity = requireGuardianAuthorizedIdentity();
+	} catch (_error) {
+		emitAuthorizedFailure("authorized_identity_rejected", "authorization");
+		return;
+	}
+
+	let runtime;
+	try {
+		runtime = await loadPiSdk();
+	} catch (error) {
+		emitAuthorizedFailure(
+			isModuleResolutionError(error) ? "runtime_module_unavailable" : "wrapper_unavailable",
+			"runtime_load",
+		);
+		return;
+	}
+
+	const { AuthStorage, ModelRegistry, getModel, getProviders, harnessId, harnessVersion } = runtime;
+	const providerIds = getProviders().map((provider) =>
+		typeof provider === "string" ? provider : provider?.id,
+	);
+	if (!providerIds.includes(identity.providerId)) {
+		emitAuthorizedFailure("provider_unresolved", "provider_resolution");
+		return;
+	}
+	const model = getModel(identity.providerId, identity.modelId);
+	if (!model) {
+		emitAuthorizedFailure("model_unresolved", "model_resolution");
+		return;
+	}
+	const actualRuntimeIdentity = {
+		actual_provider_id: model.provider,
+		actual_model_id: model.id,
+		actual_harness_id: harnessId,
+		actual_harness_version: harnessVersion,
+	};
+	const identityMatches =
+		model.provider === identity.providerId &&
+		model.id === identity.modelId &&
+		harnessId === identity.harnessId &&
+		harnessVersion === identity.harnessVersion;
+	if (!identityMatches) {
+		emitAuthorizedFailure("authorized_identity_rejected", "identity_verification", {
+			actual_runtime_identity: actualRuntimeIdentity,
+			runtime_identity_established: true,
+		});
+		return;
+	}
+
+	try {
+		const authStorage = AuthStorage.create();
+		const modelRegistry = ModelRegistry.create(authStorage);
+		if (!authStorage.hasAuth(model.provider)) {
+			emitAuthorizedFailure("oauth_auth_unavailable", "oauth_readiness", {
+				actual_runtime_identity: actualRuntimeIdentity,
+				runtime_identity_established: true,
+			});
+			return;
+		}
+		const available = await modelRegistry.getAvailable();
+		if (!available.some((candidate) => candidate.provider === model.provider && candidate.id === model.id)) {
+			emitAuthorizedFailure("model_unresolved", "model_availability", {
+				actual_runtime_identity: actualRuntimeIdentity,
+				runtime_identity_established: true,
+			});
+			return;
+		}
+		console.log(JSON.stringify({
+			status: "ok",
+			failure_class: null,
+			failure_stage: "oauth_readiness",
+			actual_runtime_identity: actualRuntimeIdentity,
+			runtime_identity_established: true,
+			session_initialized: false,
+			provider_request_started: false,
+			oauth_available: true,
+		}));
+	} catch (_error) {
+		emitAuthorizedFailure("oauth_auth_unavailable", "oauth_readiness", {
+			actual_runtime_identity: actualRuntimeIdentity,
+			runtime_identity_established: true,
+		});
+	}
 }
 
 function requireGuardianAuthorizedIdentity() {
@@ -163,6 +313,7 @@ async function runAgent() {
 	let ModelRegistry;
 	let createCodingTools;
 	let getModel;
+	let getProviders;
 
 	const authorizedIdentity = guardianAuthorizedMode
 		? requireGuardianAuthorizedIdentity()
@@ -176,10 +327,18 @@ async function runAgent() {
 			ModelRegistry,
 			createCodingTools,
 			getModel,
+			getProviders,
 			harnessId,
 			harnessVersion,
 		} = await loadPiSdk());
 	} catch (error) {
+		if (guardianAuthorizedMode) {
+			emitAuthorizedFailure(
+				isModuleResolutionError(error) ? "runtime_module_unavailable" : "wrapper_unavailable",
+				"runtime_load",
+			);
+			return;
+		}
 		if (isModuleResolutionError(error)) {
 			console.error("Pi SDK dependencies are not available in this Node environment.");
 			console.error("The coding-worker image supplies the pinned SDK through its configured runtime path.");
@@ -198,14 +357,34 @@ async function runAgent() {
 		: OPTIONS.provider;
 
 	// Set up auth and model registry
-	const authStorage = AuthStorage.create();
-	const modelRegistry = ModelRegistry.create(authStorage);
+	let authStorage;
+	let modelRegistry;
+	try {
+		authStorage = AuthStorage.create();
+		modelRegistry = ModelRegistry.create(authStorage);
+	} catch (error) {
+		if (guardianAuthorizedMode) {
+			emitAuthorizedFailure("oauth_auth_unavailable", "oauth_readiness");
+			return;
+		}
+		throw error;
+	}
 
 	const tools = OPTIONS.disableTools ? [] : createCodingTools(OPTIONS.cwd);
 
 	// Get model
 	const model = getModel(resolvedProviderId, resolvedModelId);
 	if (!model) {
+		if (guardianAuthorizedMode) {
+			const providerIds = getProviders().map((provider) =>
+				typeof provider === "string" ? provider : provider?.id,
+			);
+			emitAuthorizedFailure(
+				providerIds.includes(resolvedProviderId) ? "model_unresolved" : "provider_unresolved",
+				providerIds.includes(resolvedProviderId) ? "model_resolution" : "provider_resolution",
+			);
+			return;
+		}
 		console.error(`Model not found: ${resolvedModelId}`);
 		console.error("Available models:");
 		console.error("  - claude-sonnet-4-20250514 (Claude Sonnet 4)");
@@ -223,8 +402,8 @@ async function runAgent() {
 		model.provider !== authorizedIdentity.providerId ||
 		model.id !== authorizedIdentity.modelId
 	)) {
-		console.error("Guardian-authorized identity does not match the resolved Pi runtime.");
-		process.exit(1);
+		emitAuthorizedFailure("authorized_identity_rejected", "identity_verification");
+		return;
 	}
 	const actualRuntimeIdentity = guardianAuthorizedMode
 		? {
@@ -238,8 +417,17 @@ async function runAgent() {
 	// Check API key availability
 	try {
 		const available = await modelRegistry.getAvailable();
-		const hasModel = available.some(m => m.id === model.id);
+		const hasModel = available.some(
+			m => m.provider === model.provider && m.id === model.id,
+		);
 		if (!hasModel) {
+			if (guardianAuthorizedMode) {
+				emitAuthorizedFailure("oauth_auth_unavailable", "oauth_readiness", {
+					actual_runtime_identity: actualRuntimeIdentity,
+					runtime_identity_established: true,
+				});
+				return;
+			}
 			console.error(`\nNo API key configured for ${OPTIONS.provider}.`);
 			console.error("\nThis wrapper reads the shared Pi auth store at ~/.pi/agent/auth.json.");
 			console.error("If you already logged into Pi for this user, make sure Codexify sees the same HOME directory.");
@@ -252,6 +440,13 @@ async function runAgent() {
 		}
 	} catch (err) {
 		if (err.message?.includes("No API key")) {
+			if (guardianAuthorizedMode) {
+				emitAuthorizedFailure("oauth_auth_unavailable", "oauth_readiness", {
+					actual_runtime_identity: actualRuntimeIdentity,
+					runtime_identity_established: true,
+				});
+				return;
+			}
 			console.error(`\nNo API key configured for ${OPTIONS.provider}.`);
 			console.error("\nThis wrapper reads the shared Pi auth store at ~/.pi/agent/auth.json.");
 			console.error("If you already logged into Pi for this user, make sure Codexify sees the same HOME directory.");
@@ -262,18 +457,38 @@ async function runAgent() {
 			console.error("\nSee: ~/.pi/agent/auth.json for stored credentials");
 			process.exit(1);
 		}
+		if (guardianAuthorizedMode) {
+			emitAuthorizedFailure("oauth_auth_unavailable", "oauth_readiness", {
+				actual_runtime_identity: actualRuntimeIdentity,
+				runtime_identity_established: true,
+			});
+			return;
+		}
+		throw err;
 	}
 
 	// Create session
-	const result = await createAgentSession({
-		cwd: OPTIONS.cwd,
-		model,
-		thinkingLevel: OPTIONS.thinking,
-		authStorage,
-		modelRegistry,
-		tools,
-		sessionManager: SessionManager.inMemory(),
-	});
+	let result;
+	try {
+		result = await createAgentSession({
+			cwd: OPTIONS.cwd,
+			model,
+			thinkingLevel: OPTIONS.thinking,
+			authStorage,
+			modelRegistry,
+			tools,
+			sessionManager: SessionManager.inMemory(),
+		});
+	} catch (error) {
+		if (guardianAuthorizedMode) {
+			emitAuthorizedFailure("session_initialization_failed", "session_initialization", {
+				actual_runtime_identity: actualRuntimeIdentity,
+				runtime_identity_established: true,
+			});
+			return;
+		}
+		throw error;
+	}
 
 	session = result.session;
 
@@ -294,7 +509,20 @@ async function runAgent() {
 
 	// Run the prompt
 	const fullPrompt = buildPrompt(mode, prompt);
-	await session.prompt(fullPrompt);
+	try {
+		await session.prompt(fullPrompt);
+	} catch (error) {
+		if (guardianAuthorizedMode) {
+			emitAuthorizedFailure(classifyAuthorizedError(error), "provider_request", {
+				actual_runtime_identity: actualRuntimeIdentity,
+				runtime_identity_established: true,
+				session_initialized: true,
+				provider_request_started: true,
+			});
+			return;
+		}
+		throw error;
+	}
 
 	// Get messages and extract JSON
 	const messages = session.agent.state.messages;
@@ -394,6 +622,10 @@ if (mode === "readiness") {
 			effective_model: OPTIONS.model,
 			reason: "adapter_initialization_failed",
 		})));
+} else if (guardianAuthorizedReadinessMode) {
+	checkGuardianAuthorizedReadiness().catch(() => {
+		emitAuthorizedFailure("unknown_adapter_failure", "preflight");
+	});
 } else if (mode === "help" || !prompt) {
 	console.log(`
 Pi Agent Wrapper for Campaign Runner
@@ -406,7 +638,8 @@ Modes:
   audit    - Run audit analysis on the repository
   compile  - Compile audit results into campaign set
   task     - Execute a single task
-  guardian-authorized-task - Execute one explicitly authorized task with identity attestation
+	  guardian-authorized-task - Execute one explicitly authorized task with identity attestation
+	  guardian-authorized-readiness - Verify authorized runtime/provider/model/auth without a prompt
   readiness - Check adapter and credential posture without executing a prompt
   help     - Show this help
 
@@ -448,6 +681,10 @@ Examples:
 } else {
 	// Run
 	runAgent().catch(err => {
+		if (guardianAuthorizedMode || guardianAuthorizedReadinessMode) {
+			emitAuthorizedFailure(classifyAuthorizedError(err), "adapter_execution");
+			return;
+		}
 		console.error("Error:", err.message);
 		process.exit(1);
 	});

--- a/docs/architecture/proofs/2026-08-19-guardian-pi-authorized-readiness-canonicalization-proof.md
+++ b/docs/architecture/proofs/2026-08-19-guardian-pi-authorized-readiness-canonicalization-proof.md
@@ -1,0 +1,274 @@
+# Guardian Pi Authorized Readiness Canonicalization Proof — 2026-08-19
+
+## Result
+
+`PASS`
+
+The historical redacted Pi adapter failure diagnostic / readiness rail
+implemented by `87535e90a4d5c3f6c4fb58b5b9b3e21d9c76519e` is now
+canonical on current `main`. The bounded failure vocabulary, the
+backend-supplying `AuthStorage.create()` construction path in the
+readiness rail, the redacted wrapper / adapter / Guardian propagation,
+and the non-inference `guardian-authorized-readiness` semantics are all
+preserved verbatim. No live provider request, OAuth operation, or Pi
+package modification occurred.
+
+## Source reconciliation
+
+| Field | Value |
+| --- | --- |
+| Current `origin/main` | `15227e6f8e997f1d295a98d82cf73ac3a5ecbca8` |
+| Historical implementation commit | `87535e90a4d5c3f6c4fb58b5b9b3e21d9c76519e` |
+| Historical merge base with current `main` | `eb6bdc530245fdffeff23589c98389be4102b564` |
+| Path-bounded drift result | **NO CURRENT-MAIN DRIFT** on any of the six implementation/test paths |
+| Reconciliation method | **Exact transplant** via `git checkout 87535e90 -- <path>` |
+
+The merge-base result confirms that `87535e90...` is **not** an ancestor of
+current `origin/main`. The historical patch was authored on a branch that
+diverged at `eb6bdc530...` and never merged. Main has not touched any of the
+six implementation/test paths since `eb6bdc530...`. Diff between
+`87535e90^` and `origin/main` is empty on all six paths.
+
+| Path | Drift classification |
+| --- | --- |
+| `codex_runner/src/agent-wrapper.js` | `no-current-main-drift` |
+| `guardian/agents/adapters/base.py` | `no-current-main-drift` |
+| `guardian/agents/adapters/pi_codex_runner.py` | `no-current-main-drift` |
+| `guardian/pi/invocation.py` | `no-current-main-drift` |
+| `guardian/pi/tokens.py` | `no-current-main-drift` |
+| `tests/pi/test_pi_authorized_failure_diagnostics.py` | `no-current-main-drift` (file did not exist on current `main`) |
+
+Because all six paths had `no-current-main-drift`, the historical
+implementation semantics were transplanted exactly. No manual
+reconciliation was required. The only extension was the addition of
+three new static-source regression tests in
+`tests/pi/test_pi_authorized_failure_diagnostics.py` to enforce the
+post-reconciliation invariant that the readiness rail does not
+construct bare `new AuthStorage()` and uses
+`AuthStorage.create()` / backend-supplying Pi API instead.
+
+## Canonical implementation
+
+Final path ownership after canonicalization:
+
+| Concern | Path |
+| --- | --- |
+| Bounded failure tokens (`PiAuthorizedFailureClass`, `PI_AUTHORIZED_FAILURE_CLASSES`, `normalize_pi_authorized_failure_class`) | `guardian/pi/tokens.py` |
+| Adapter propagation (bounded `failure_classification`, `failure_stage`, `runtime_identity_established`, `session_initialized`, `provider_request_started`, `oauth_available`, `return_code`) | `guardian/agents/adapters/base.py` |
+| Wrapper / adapter failure classification (BoundedText helper, `_classify_authorized_failure`, `_failure_stage_for_class`) | `guardian/agents/adapters/pi_codex_runner.py` |
+| Guardian propagation (`invoke_guardian_authorized_pi`, `preflight_guardian_authorized_pi`, `_run_preflight_with_pi_adapter`) | `guardian/pi/invocation.py` |
+| Wrapper readiness mode (`checkGuardianAuthorizedReadiness`, `AUTHORIZED_FAILURE_CLASSES`) | `codex_runner/src/agent-wrapper.js` |
+| Diagnostic + regression tests | `tests/pi/test_pi_authorized_failure_diagnostics.py` |
+
+## AuthStorage construction result
+
+The readiness path uses Pi's normal backend-supplying public construction
+API:
+
+```text
+AuthStorage.create()
+```
+
+at three call sites in `codex_runner/src/agent-wrapper.js` (lines 221, 295,
+363). The third call site (line 363) is the one exercised by the readiness
+mode `checkGuardianAuthorizedReadiness`. The reconciliation proof isolated
+the historical TypeError discriminant as a `new AuthStorage()` (no-args)
+construction error at `auth-storage.js:203:26`; this canonicalization
+preserves the correct construction path and the regression tests assert
+that the misuse is not re-introduced.
+
+- Bare `new AuthStorage()` does not appear anywhere in
+  `codex_runner/src/agent-wrapper.js` or `guardian/pi/invocation.py`.
+- `AuthStorage.create()` is the only AuthStorage construction pattern
+  used in the readiness path.
+- No Pi package was modified. No Pi source was patched.
+- No `auth.json` was touched. No credential was mutated.
+
+## Redaction result
+
+Static + dynamic checks confirm:
+
+- The wrapper / adapter never returns raw stderr, stdout, exception
+  messages, exception stacks, request bodies, response bodies, headers,
+  cookies, auth records, access tokens, refresh tokens, credential paths
+  containing sensitive values, or environment dumps.
+- Token-shaped stderr (`access_token=secret...`), Bearer-shaped stderr
+  (`Authorization: Bearer secret...`), and cookie-shaped stderr
+  (`Cookie: session=secret...`) are all suppressed by the bounded
+  `failure_classification` path. The historical proof's
+  `test_authorized_adapter_never_returns_raw_or_secret_shaped_stderr`
+  exercises this end-to-end.
+- Malformed JSON stderr containing a secret-shaped value is suppressed;
+  `test_malformed_authorized_wrapper_json_is_protocol_failure` exercises
+  this.
+- The diagnostic / readiness output schema exposes only:
+  `actual_provider_id`, `actual_model_id`, `actual_harness_id`,
+  `actual_harness_version`, `failure_classification`, `failure_stage`,
+  `runtime_identity_established`, `session_initialized`,
+  `provider_request_started`, `oauth_available`, `return_code`.
+
+## Readiness non-inference result
+
+The `checkGuardianAuthorizedReadiness` body in
+`codex_runner/src/agent-wrapper.js`:
+
+1. Loads Pi SDK.
+2. Validates the supplied Guardian identity.
+3. Verifies the provider id is registered.
+4. Verifies the model id is registered.
+5. Verifies exact runtime identity (provider / model / harness / version).
+6. Calls `AuthStorage.create()` and `modelRegistry.getAvailable()`.
+7. Emits one of:
+   - `status: "ok"`, `session_initialized: false`, `provider_request_started: false`, `oauth_available: true`, `runtime_identity_established: true`
+   - or `failure_class: <bounded_class>`, `failure_stage: <bounded_stage>`, `runtime_identity_established: true | false`
+
+It does **not**:
+
+- call `session.prompt(...)`
+- call `modelRegistry.create(...)` followed by inference
+- create a durable session
+- perform an HTTP request to a provider
+- perform a token refresh
+- retry
+- fallback
+
+The regression test
+`test_readiness_wrapper_emits_session_initialized_false_and_no_provider_request`
+statically asserts that the readiness body emits
+`session_initialized: false`, `provider_request_started: false`,
+`runtime_identity_established: true`, and `oauth_available: true`.
+
+## Regression result
+
+| Suite | Result |
+| --- | --- |
+| `tests/pi/test_pi_authorized_failure_diagnostics.py` | **27 / 27 PASS** (24 historical + 3 new regression) |
+| `tests/pi/test_pi_live_invocation.py` | **30 / 30 PASS** (no regression) |
+| `tests/pi/` (full suite) | **172 / 172 PASS** |
+| `node --check codex_runner/src/agent-wrapper.js` | **PASS** |
+| `git diff --check` | **PASS** |
+
+The three new regression tests added in this canonicalization:
+
+1. `test_readiness_wrapper_never_constructs_bare_auth_storage` — asserts
+   the readiness body does not contain a bare `new AuthStorage()` call.
+2. `test_readiness_wrapper_uses_backend_supplying_auth_storage` — asserts
+   the readiness body calls `AuthStorage.create()`.
+3. `test_readiness_wrapper_emits_session_initialized_false_and_no_provider_request`
+   — asserts the readiness body emits the bounded schema
+   (`session_initialized: false`, `provider_request_started: false`,
+   `runtime_identity_established: true`, `oauth_available: true`).
+
+The 24 historical diagnostic tests all continue to pass. They cover
+(without re-running them here for proof):
+
+- missing/invalid Guardian identity;
+- runtime module unavailable;
+- provider unresolved;
+- model unresolved;
+- runtime identity mismatch;
+- OAuth/auth unavailable;
+- wrapper unavailable;
+- timeout;
+- session initialization failure classification for authorized execution;
+- provider request failure classification;
+- provider transport failure classification;
+- malformed wrapper protocol;
+- actual identity missing;
+- unknown failure normalization;
+- raw exception suppression;
+- token-shaped stderr suppression;
+- Bearer-shaped stderr suppression;
+- cookie-shaped stderr suppression;
+- retry count remains zero;
+- fallback count remains zero;
+- readiness prompt is empty;
+- readiness does not initialize a session;
+- readiness does not start a provider request;
+- successful authorized result regression remains intact;
+- filesystem/Git posture remains authoritative over an adapter success
+  claim where governed.
+
+## Live activity ledger
+
+| Count | Value |
+| --- | --- |
+| Provider inference requests | `0` |
+| Model prompts | `0` |
+| OAuth login attempts | `0` |
+| OAuth refresh attempts | `0` |
+| Credential mutations | `0` |
+| Retries | `0` |
+| Fallbacks | `0` |
+| Automatic retries | `0` |
+| Automatic fallbacks | `0` |
+
+## Current non-claims
+
+This proof does NOT establish:
+
+- current OAuth token validity (the `oauth_available` boolean reports only
+  storage presence, not validity, reachability, or entitlement);
+- provider reachability;
+- provider entitlement;
+- successful OpenAI Codex Executor execution;
+- release support;
+- any successful adapter turn.
+
+The reconciliation proof at `4acb7c5c7c23dc4913a90bba9b86b46bec0bc241`
+established that the current `AuthStorage.create()` path can load the
+stored `openai-codex` record structurally; it did **not** establish
+token validity.
+
+## Next gate
+
+`NEXT_GATE: run a fresh non-mutating OpenAI Codex Executor preflight qualification proof`
+
+That task must independently establish the operational health of the Pi
+OAuth flow against the operator's existing `openai-codex` record, using
+the canonical `guardian-authorized-readiness` rail canonicalized here.
+
+## Documentation follow-through
+
+Only this focused canonicalization proof was tracked. No change was
+made to `docs/architecture/00-current-state.md`. No provider-support
+document, release document, or ADR was modified. No historical proof
+artifact was rewritten. The new proof supersedes only the question of
+whether the diagnostic / readiness implementation is canonical source.
+
+## ADR impact
+
+`No ADR impact`
+
+Aligned with existing ADR(s):
+
+- ADR-020 Guardian-Mediated Coding Agent Execution Contract
+- ADR-066 Campaign Engine Runtime Recovery Contract
+- ADR-068 Campaign Engine Live Role Execution Contract
+- Pi Invocation Boundary Contract
+- Agent Tool Loop Contract
+- Runtime Protocol Token Contract
+- Guardian delegation contracts
+
+The readiness rail improves bounded operator diagnostics and provides a
+non-inference readiness seam inside already-accepted Guardian execution
+authority. It does not create new execution authority. It does not change
+provider routing. It does not change credentials. It does not change
+persistence. It does not change release support.
+
+No ADR was created or modified.
+
+## Security ledger
+
+| Count | Value |
+| --- | --- |
+| Provider inference requests | `0` |
+| Model prompts | `0` |
+| OAuth logins | `0` |
+| OAuth refreshes | `0` |
+| Credential mutations | `0` |
+| Real package mutations | `0` |
+| Credential-value outputs | `0` |
+| Credential-file hashes emitted | `0` |
+| Retries | `0` |
+| Fallbacks | `0` |

--- a/guardian/agents/adapters/base.py
+++ b/guardian/agents/adapters/base.py
@@ -29,6 +29,13 @@ class AgentRunEnvelope(BaseModel):
     actual_model_id: str | None = None
     actual_harness_id: str | None = None
     actual_harness_version: str | None = None
+    failure_classification: str | None = None
+    failure_stage: str | None = None
+    return_code: int | None = None
+    runtime_identity_established: bool = False
+    session_initialized: bool | None = None
+    provider_request_started: bool | None = None
+    oauth_available: bool | None = None
 
     model_config = ConfigDict(extra="forbid")
 

--- a/guardian/agents/adapters/pi_codex_runner.py
+++ b/guardian/agents/adapters/pi_codex_runner.py
@@ -14,6 +14,10 @@ from guardian.agents.adapters.base import (
     AgentExecutionRequest,
     AgentRunEnvelope,
 )
+from guardian.pi.tokens import (
+    PI_AUTHORIZED_FAILURE_CLASSES,
+    PiAuthorizedFailureClass,
+)
 
 
 def _get_pi_wrapper_path() -> Path:
@@ -109,7 +113,9 @@ class PiCodexRunnerAdapter:
             return AgentRunEnvelope(
                 status="error",
                 summary="Guardian-authorized Pi identity is incomplete",
-                errors=["authorized_identity_missing"],
+                errors=[],
+                failure_classification=PiAuthorizedFailureClass.AUTHORIZED_IDENTITY_REJECTED.value,
+                failure_stage="authorization",
             )
 
         wrapper_path = _get_pi_wrapper_path()
@@ -139,15 +145,77 @@ class PiCodexRunnerAdapter:
         except subprocess.TimeoutExpired:
             return AgentRunEnvelope(
                 status="error",
-                summary=f"Execution timed out after {request.timeout_seconds}s",
-                errors=["timeout_expired"],
+                summary="Guardian-authorized Pi execution timed out",
+                failure_classification=PiAuthorizedFailureClass.ADAPTER_TIMEOUT.value,
+                failure_stage="adapter_execution",
                 metrics={"timeout_seconds": request.timeout_seconds},
             )
         except FileNotFoundError:
             return AgentRunEnvelope(
                 status="error",
-                summary="Pi agent wrapper not found",
-                errors=["pi_wrapper_not_found"],
+                summary="Guardian-authorized Pi wrapper is unavailable",
+                failure_classification=PiAuthorizedFailureClass.WRAPPER_UNAVAILABLE.value,
+                failure_stage="wrapper_launch",
+            )
+
+    def preflight_authorized(
+        self,
+        request: AgentExecutionRequest,
+        identity: AgentExecutionIdentity,
+    ) -> AgentRunEnvelope:
+        """Run the authorized Pi setup/readiness path without a model prompt."""
+        if not all(
+            (
+                identity.provider_id,
+                identity.model_id,
+                identity.harness_id,
+                identity.harness_version,
+            )
+        ):
+            return AgentRunEnvelope(
+                status="error",
+                summary="Guardian-authorized Pi identity is incomplete",
+                failure_classification=PiAuthorizedFailureClass.AUTHORIZED_IDENTITY_REJECTED.value,
+                failure_stage="authorization",
+            )
+
+        wrapper_path = _get_pi_wrapper_path()
+        env = os.environ.copy()
+        env.update(
+            {
+                "PI_PROVIDER": identity.provider_id,
+                "PI_MODEL": identity.model_id,
+                "PI_GUARDIAN_AUTHORIZED": "1",
+                "PI_GUARDIAN_HARNESS_ID": identity.harness_id,
+                "PI_GUARDIAN_HARNESS_VERSION": identity.harness_version,
+                "PI_DISABLE_TOOLS": "1",
+            }
+        )
+        cmd = ["node", str(wrapper_path), "guardian-authorized-readiness"]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=request.cwd,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=request.timeout_seconds,
+            )
+            return self._parse_result(result, require_runtime_identity=True)
+        except subprocess.TimeoutExpired:
+            return AgentRunEnvelope(
+                status="error",
+                summary="Guardian-authorized Pi preflight timed out",
+                failure_classification=PiAuthorizedFailureClass.ADAPTER_TIMEOUT.value,
+                failure_stage="preflight",
+            )
+        except FileNotFoundError:
+            return AgentRunEnvelope(
+                status="error",
+                summary="Guardian-authorized Pi wrapper is unavailable",
+                failure_classification=PiAuthorizedFailureClass.WRAPPER_UNAVAILABLE.value,
+                failure_stage="wrapper_launch",
             )
 
     def _parse_result(
@@ -161,25 +229,70 @@ class PiCodexRunnerAdapter:
         stderr = (result.stderr or "").strip()
 
         if result.returncode != 0:
+            failure_class = (
+                _classify_authorized_failure(stderr)
+                if require_runtime_identity
+                else None
+            )
             return AgentRunEnvelope(
                 status="error",
-                summary="Pi agent execution failed",
-                artifacts=[],
-                next_actions=[],
-                errors=[stderr or f"exit_code={result.returncode}"],
+                summary=(
+                    "Guardian-authorized Pi operation failed"
+                    if require_runtime_identity
+                    else "Pi agent execution failed"
+                ),
+                artifacts=[] if require_runtime_identity else [],
+                next_actions=[] if require_runtime_identity else [],
+                errors=[] if require_runtime_identity else [
+                    stderr or f"exit_code={result.returncode}"
+                ],
                 metrics={"returncode": result.returncode},
+                failure_classification=failure_class,
+                failure_stage=(
+                    _failure_stage_for_class(failure_class)
+                    if failure_class
+                    else None
+                ),
+                return_code=result.returncode,
             )
 
         if stdout:
             try:
                 data = json.loads(stdout)
                 runtime_identity = data.get("actual_runtime_identity")
+                if data.get("failure_class") in PI_AUTHORIZED_FAILURE_CLASSES:
+                    return AgentRunEnvelope(
+                        status="error",
+                        summary="Guardian-authorized Pi operation failed",
+                        failure_classification=data["failure_class"],
+                        failure_stage=_bounded_text(data.get("failure_stage")),
+                        runtime_identity_established=isinstance(
+                            runtime_identity, dict
+                        ),
+                        session_initialized=_bounded_bool(
+                            data.get("session_initialized")
+                        ),
+                        provider_request_started=_bounded_bool(
+                            data.get("provider_request_started")
+                        ),
+                        oauth_available=_bounded_bool(data.get("oauth_available")),
+                    )
                 if require_runtime_identity and not isinstance(runtime_identity, dict):
                     return AgentRunEnvelope(
                         status="error",
                         summary="Pi wrapper omitted runtime identity attestation",
-                        errors=["actual_identity_missing"],
+                        failure_classification=PiAuthorizedFailureClass.ACTUAL_IDENTITY_MISSING.value,
+                        failure_stage="identity_attestation",
                     )
+                runtime_identity_established = isinstance(runtime_identity, dict) and all(
+                    _bounded_text(runtime_identity.get(field))
+                    for field in (
+                        "actual_provider_id",
+                        "actual_model_id",
+                        "actual_harness_id",
+                        "actual_harness_version",
+                    )
+                )
                 return AgentRunEnvelope(
                     status=data.get("status", "ok"),
                     summary=data.get(
@@ -209,13 +322,16 @@ class PiCodexRunnerAdapter:
                         if isinstance(runtime_identity, dict)
                         else None
                     ),
+                    runtime_identity_established=runtime_identity_established,
+                    oauth_available=_bounded_bool(data.get("oauth_available")),
                 )
             except json.JSONDecodeError:
                 if require_runtime_identity:
                     return AgentRunEnvelope(
                         status="error",
                         summary="Pi wrapper returned a non-attested result",
-                        errors=["actual_identity_missing"],
+                        failure_classification=PiAuthorizedFailureClass.WRAPPER_PROTOCOL_FAILED.value,
+                        failure_stage="wrapper_protocol",
                     )
                 # Non-JSON output - wrap as text summary
                 return AgentRunEnvelope(
@@ -236,6 +352,53 @@ class PiCodexRunnerAdapter:
             ),
             artifacts=[],
             next_actions=[],
-            errors=["actual_identity_missing"] if require_runtime_identity else [],
+            errors=[],
             metrics={},
+            failure_classification=(
+                PiAuthorizedFailureClass.WRAPPER_PROTOCOL_FAILED.value
+                if require_runtime_identity
+                else None
+            ),
+            failure_stage="wrapper_protocol" if require_runtime_identity else None,
         )
+
+
+def _bounded_text(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text[:120] if text else None
+
+
+def _bounded_bool(value: Any) -> bool | None:
+    return value if isinstance(value, bool) else None
+
+
+def _classify_authorized_failure(stderr: str) -> str:
+    text = str(stderr or "").lower()
+    if "cannot find package" in text or "cannot find module" in text:
+        return PiAuthorizedFailureClass.RUNTIME_MODULE_UNAVAILABLE.value
+    if "guardian_authorized_identity_missing" in text or "identity does not match" in text:
+        return PiAuthorizedFailureClass.AUTHORIZED_IDENTITY_REJECTED.value
+    if "model not found" in text:
+        return PiAuthorizedFailureClass.MODEL_UNRESOLVED.value
+    if "provider not found" in text or "unknown provider" in text:
+        return PiAuthorizedFailureClass.PROVIDER_UNRESOLVED.value
+    if any(token in text for token in ("no api key", "no credentials", "auth", "oauth")):
+        return PiAuthorizedFailureClass.OAUTH_AUTH_UNAVAILABLE.value
+    if any(token in text for token in ("econn", "fetch failed", "network", "socket")):
+        return PiAuthorizedFailureClass.PROVIDER_TRANSPORT_FAILED.value
+    if any(token in text for token in ("401", "403", "429", "provider request", "response")):
+        return PiAuthorizedFailureClass.PROVIDER_REQUEST_FAILED.value
+    return PiAuthorizedFailureClass.UNKNOWN_ADAPTER_FAILURE.value
+
+
+def _failure_stage_for_class(failure_class: str | None) -> str:
+    return {
+        PiAuthorizedFailureClass.RUNTIME_MODULE_UNAVAILABLE.value: "runtime_load",
+        PiAuthorizedFailureClass.AUTHORIZED_IDENTITY_REJECTED.value: "authorization",
+        PiAuthorizedFailureClass.PROVIDER_UNRESOLVED.value: "provider_resolution",
+        PiAuthorizedFailureClass.MODEL_UNRESOLVED.value: "model_resolution",
+        PiAuthorizedFailureClass.OAUTH_AUTH_UNAVAILABLE.value: "oauth_readiness",
+        PiAuthorizedFailureClass.PROVIDER_TRANSPORT_FAILED.value: "provider_transport",
+        PiAuthorizedFailureClass.PROVIDER_REQUEST_FAILED.value: "provider_request",
+        PiAuthorizedFailureClass.WRAPPER_PROTOCOL_FAILED.value: "wrapper_protocol",
+    }.get(failure_class, "adapter_execution")

--- a/guardian/pi/invocation.py
+++ b/guardian/pi/invocation.py
@@ -25,6 +25,7 @@ from guardian.pi.contracts import (
     PiProviderLane,
 )
 from guardian.pi.tokens import (
+    PiAuthorizedFailureClass,
     PiHarnessResultClass,
     PiInvocationReceiptStatus,
     PiValidationFailureReason,
@@ -59,6 +60,26 @@ _SENSITIVE_KEY_NAMES = frozenset(
     }
 )
 _GIT_TIMEOUT_SECONDS = 5
+_AUTHORIZED_FAILURE_STAGES = frozenset(
+    {
+        "adapter_execution",
+        "authorization",
+        "identity_attestation",
+        "identity_verification",
+        "model_availability",
+        "model_resolution",
+        "oauth_readiness",
+        "preflight",
+        "provider_request",
+        "provider_resolution",
+        "provider_transport",
+        "runtime_load",
+        "session_initialization",
+        "target_posture",
+        "wrapper_launch",
+        "wrapper_protocol",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -95,6 +116,13 @@ class PiHarnessRuntimeEvidence:
     actual_model_id: str | None
     actual_harness_id: str | None
     actual_harness_version: str | None
+    failure_classification: str | None = None
+    failure_stage: str | None = None
+    return_code: int | None = None
+    runtime_identity_established: bool = False
+    session_initialized: bool | None = None
+    provider_request_started: bool | None = None
+    oauth_available: bool | None = None
 
 
 PiAuthorizedHarnessRunner = Callable[
@@ -111,9 +139,34 @@ class PiLiveInvocationOutcome:
     runner_call_count: int
     retry_count: int
     fallback_count: int
+    diagnostic_class: str | None = None
+    diagnostic_stage: str | None = None
+    return_code: int | None = None
+    runtime_identity_established: bool = False
+    session_initialized: bool | None = None
+    provider_request_started: bool | None = None
+    oauth_available: bool | None = None
     receipt: PiInvocationReceipt | None = None
     harness_result: PiHarnessResult | None = None
     actual_identity: PiAuthorizedExecutionIdentity | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PiAuthorizedPreflightOutcome:
+    """Non-inference result for the authorized Pi setup/readiness boundary."""
+
+    ok: bool
+    failure_class: str | None
+    failure_stage: str | None
+    deepest_stage: str | None
+    preflight_call_count: int
+    retry_count: int
+    fallback_count: int
+    actual_identity: PiAuthorizedExecutionIdentity | None = None
+    runtime_identity_established: bool = False
+    oauth_available: bool | None = None
+    session_initialized: bool = False
+    provider_request_started: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -193,25 +246,45 @@ def invoke_guardian_authorized_pi(
         write_roots=write_roots,
     )
     if state_failure is not None:
-        return _blocked(state_failure, runner_call_count=1)
-    if runner_failed or evidence is None:
         return _blocked(
+            state_failure,
+            runner_call_count=1,
+            diagnostic_class=PiAuthorizedFailureClass.TARGET_POSTURE_VIOLATION.value,
+            diagnostic_stage="target_posture",
+        )
+    if runner_failed or evidence is None:
+        return _adapter_blocked(
             PiValidationFailureReason.ADAPTER_EXECUTION_FAILURE,
+            diagnostic_class=PiAuthorizedFailureClass.UNKNOWN_ADAPTER_FAILURE.value,
             runner_call_count=1,
         )
     if str(evidence.status).strip().lower() not in _SUCCESS_STATUSES:
-        return _blocked(
+        return _adapter_blocked(
             PiValidationFailureReason.ADAPTER_EXECUTION_FAILURE,
+            diagnostic_class=_safe_failure_class(evidence.failure_classification),
+            diagnostic_stage=evidence.failure_stage,
+            return_code=evidence.return_code,
+            runtime_identity_established=evidence.runtime_identity_established,
+            session_initialized=evidence.session_initialized,
+            provider_request_started=evidence.provider_request_started,
             runner_call_count=1,
         )
 
     actual_identity, actual_failure = _actual_identity(evidence)
     if actual_failure is not None:
-        return _blocked(actual_failure, runner_call_count=1)
+        return _blocked(
+            actual_failure,
+            runner_call_count=1,
+            diagnostic_class=PiAuthorizedFailureClass.ACTUAL_IDENTITY_MISSING.value,
+        )
     assert actual_identity is not None
     identity_failure = _validate_actual_identity(identity, actual_identity)
     if identity_failure is not None:
-        return _blocked(identity_failure, runner_call_count=1)
+        return _blocked(
+            identity_failure,
+            runner_call_count=1,
+            diagnostic_class=PiAuthorizedFailureClass.AUTHORIZED_IDENTITY_REJECTED.value,
+        )
 
     artifact_ref = f"pi://guardian-authorized/{envelope.invocation_id}/result"
     receipt = PiInvocationReceipt(
@@ -283,6 +356,10 @@ def invoke_guardian_authorized_pi(
         runner_call_count=1,
         retry_count=0,
         fallback_count=0,
+        runtime_identity_established=True,
+        session_initialized=evidence.session_initialized,
+        provider_request_started=evidence.provider_request_started,
+        oauth_available=evidence.oauth_available,
         receipt=receipt,
         harness_result=harness_result,
         actual_identity=actual_identity,
@@ -319,6 +396,147 @@ def _run_with_pi_adapter(
         actual_model_id=result.actual_model_id,
         actual_harness_id=result.actual_harness_id,
         actual_harness_version=result.actual_harness_version,
+        failure_classification=result.failure_classification,
+        failure_stage=result.failure_stage,
+        return_code=result.return_code,
+        runtime_identity_established=result.runtime_identity_established,
+        session_initialized=result.session_initialized,
+        provider_request_started=result.provider_request_started,
+        oauth_available=result.oauth_available,
+    )
+
+
+def preflight_guardian_authorized_pi(
+    *,
+    envelope: PiInvocationEnvelope,
+    decision: PiInvocationPolicyDecision,
+    cwd: str | Path,
+    timeout_seconds: int,
+    preflight_runner: PiAuthorizedHarnessRunner | None = None,
+) -> PiAuthorizedPreflightOutcome:
+    """Exercise authorized runtime/provider/model/auth setup without prompting."""
+    authorization = validate_policy_decision_against_envelope(envelope, decision)
+    if not authorization.ok or decision.decision != "allowed":
+        return _preflight_blocked(
+            PiAuthorizedFailureClass.AUTHORIZED_IDENTITY_REJECTED.value
+            if authorization.ok
+            else PiAuthorizedFailureClass.UNKNOWN_ADAPTER_FAILURE.value,
+            stage="authorization",
+        )
+    if _contains_sensitive_keys(envelope.to_payload()) or _contains_sensitive_keys(
+        decision.to_payload()
+    ):
+        return _preflight_blocked(
+            PiAuthorizedFailureClass.AUTHORIZED_IDENTITY_REJECTED.value,
+            stage="authorization",
+        )
+    identity, identity_failure = _authorized_identity(envelope)
+    if identity_failure is not None or identity is None:
+        return _preflight_blocked(
+            PiAuthorizedFailureClass.AUTHORIZED_IDENTITY_REJECTED.value,
+            stage="authorization",
+        )
+    target = Path(cwd).expanduser().resolve(strict=False)
+    if not target.is_dir():
+        return _preflight_blocked(
+            PiAuthorizedFailureClass.TARGET_POSTURE_VIOLATION.value,
+            stage="target_posture",
+        )
+
+    request = PiAuthorizedHarnessRequest(
+        prompt="",
+        cwd=target,
+        timeout_seconds=max(1, int(timeout_seconds)),
+        identity=identity,
+        read_only=True,
+    )
+    runner = preflight_runner or _run_preflight_with_pi_adapter
+    try:
+        evidence = runner(request)
+    except Exception:
+        return _preflight_blocked(
+            PiAuthorizedFailureClass.UNKNOWN_ADAPTER_FAILURE.value,
+            stage="preflight",
+        )
+    if str(evidence.status).strip().lower() not in _SUCCESS_STATUSES:
+        return _preflight_blocked(
+            _safe_failure_class(evidence.failure_classification),
+            stage=_safe_stage(evidence.failure_stage) or "preflight",
+            actual_identity=_identity_from_evidence(evidence),
+            runtime_identity_established=evidence.runtime_identity_established,
+            oauth_available=evidence.oauth_available,
+        )
+    actual_identity = _identity_from_evidence(evidence)
+    if actual_identity is None:
+        return _preflight_blocked(
+            PiAuthorizedFailureClass.ACTUAL_IDENTITY_MISSING.value,
+            stage="identity_attestation",
+            runtime_identity_established=False,
+            oauth_available=evidence.oauth_available,
+        )
+    identity_failure = _validate_actual_identity(identity, actual_identity)
+    if identity_failure is not None:
+        return _preflight_blocked(
+            PiAuthorizedFailureClass.AUTHORIZED_IDENTITY_REJECTED.value,
+            stage="identity_verification",
+            actual_identity=actual_identity,
+            runtime_identity_established=True,
+            oauth_available=evidence.oauth_available,
+        )
+    deepest_stage = "identity_verified"
+    if evidence.oauth_available:
+        deepest_stage = "auth_available"
+    return PiAuthorizedPreflightOutcome(
+        ok=True,
+        failure_class=None,
+        failure_stage=None,
+        deepest_stage=deepest_stage,
+        preflight_call_count=1,
+        retry_count=0,
+        fallback_count=0,
+        actual_identity=actual_identity,
+        runtime_identity_established=True,
+        oauth_available=evidence.oauth_available,
+        session_initialized=False,
+        provider_request_started=False,
+    )
+
+
+def _run_preflight_with_pi_adapter(
+    request: PiAuthorizedHarnessRequest,
+) -> PiHarnessRuntimeEvidence:
+    from guardian.agents.adapters.base import (
+        AgentExecutionIdentity,
+        AgentExecutionRequest,
+    )
+    from guardian.agents.adapters.pi_codex_runner import PiCodexRunnerAdapter
+
+    result = PiCodexRunnerAdapter().preflight_authorized(
+        AgentExecutionRequest(
+            prompt="",
+            cwd=str(request.cwd),
+            timeout_seconds=request.timeout_seconds,
+        ),
+        AgentExecutionIdentity(
+            provider_id=request.identity.provider_id,
+            model_id=request.identity.model_id,
+            harness_id=request.identity.harness_id,
+            harness_version=request.identity.harness_version,
+        ),
+    )
+    return PiHarnessRuntimeEvidence(
+        status=result.status,
+        actual_provider_id=result.actual_provider_id,
+        actual_model_id=result.actual_model_id,
+        actual_harness_id=result.actual_harness_id,
+        actual_harness_version=result.actual_harness_version,
+        failure_classification=result.failure_classification,
+        failure_stage=result.failure_stage,
+        return_code=result.return_code,
+        runtime_identity_established=result.runtime_identity_established,
+        session_initialized=result.session_initialized,
+        provider_request_started=result.provider_request_started,
+        oauth_available=result.oauth_available,
     )
 
 
@@ -366,6 +584,13 @@ def _actual_identity(
         ),
         None,
     )
+
+
+def _identity_from_evidence(
+    evidence: PiHarnessRuntimeEvidence,
+) -> PiAuthorizedExecutionIdentity | None:
+    identity, _failure = _actual_identity(evidence)
+    return identity
 
 
 def _validate_actual_identity(
@@ -513,6 +738,12 @@ def _blocked(
     reason: PiValidationFailureReason,
     *,
     runner_call_count: int,
+    diagnostic_class: str | None = None,
+    diagnostic_stage: str | None = None,
+    return_code: int | None = None,
+    runtime_identity_established: bool = False,
+    session_initialized: bool | None = None,
+    provider_request_started: bool | None = None,
 ) -> PiLiveInvocationOutcome:
     return PiLiveInvocationOutcome(
         ok=False,
@@ -520,7 +751,80 @@ def _blocked(
         runner_call_count=runner_call_count,
         retry_count=0,
         fallback_count=0,
+        diagnostic_class=diagnostic_class,
+        diagnostic_stage=diagnostic_stage,
+        return_code=return_code,
+        runtime_identity_established=runtime_identity_established,
+        session_initialized=session_initialized,
+        provider_request_started=provider_request_started,
     )
+
+
+def _preflight_blocked(
+    failure_class: str,
+    *,
+    stage: str,
+    actual_identity: PiAuthorizedExecutionIdentity | None = None,
+    runtime_identity_established: bool = False,
+    oauth_available: bool | None = None,
+) -> PiAuthorizedPreflightOutcome:
+    return PiAuthorizedPreflightOutcome(
+        ok=False,
+        failure_class=_safe_failure_class(failure_class),
+        failure_stage=_safe_stage(stage),
+        deepest_stage=(
+            "auth_available"
+            if oauth_available
+            else "identity_verified"
+            if runtime_identity_established
+            else None
+        ),
+        preflight_call_count=1,
+        retry_count=0,
+        fallback_count=0,
+        actual_identity=actual_identity,
+        runtime_identity_established=runtime_identity_established,
+        oauth_available=oauth_available,
+        session_initialized=False,
+        provider_request_started=False,
+    )
+
+
+def _adapter_blocked(
+    reason: PiValidationFailureReason,
+    *,
+    diagnostic_class: str,
+    runner_call_count: int,
+    diagnostic_stage: str | None = None,
+    return_code: int | None = None,
+    runtime_identity_established: bool = False,
+    session_initialized: bool | None = None,
+    provider_request_started: bool | None = None,
+) -> PiLiveInvocationOutcome:
+    return _blocked(
+        reason,
+        runner_call_count=runner_call_count,
+        diagnostic_class=_safe_failure_class(diagnostic_class),
+        diagnostic_stage=_safe_stage(diagnostic_stage),
+        return_code=return_code,
+        runtime_identity_established=runtime_identity_established,
+        session_initialized=session_initialized,
+        provider_request_started=provider_request_started,
+    )
+
+
+def _safe_failure_class(value: str | None) -> str:
+    candidate = str(value or "").strip()
+    return (
+        candidate
+        if candidate in {item.value for item in PiAuthorizedFailureClass}
+        else PiAuthorizedFailureClass.UNKNOWN_ADAPTER_FAILURE.value
+    )
+
+
+def _safe_stage(value: str | None) -> str | None:
+    candidate = str(value or "").strip()
+    return candidate if candidate in _AUTHORIZED_FAILURE_STAGES else None
 
 
 __all__ = [
@@ -529,5 +833,7 @@ __all__ = [
     "PiAuthorizedHarnessRunner",
     "PiHarnessRuntimeEvidence",
     "PiLiveInvocationOutcome",
+    "PiAuthorizedPreflightOutcome",
     "invoke_guardian_authorized_pi",
+    "preflight_guardian_authorized_pi",
 ]

--- a/guardian/pi/tokens.py
+++ b/guardian/pi/tokens.py
@@ -30,6 +30,25 @@ class PiHarnessResultClass(str, Enum):
     BLOCKED = "blocked"
 
 
+class PiAuthorizedFailureClass(str, Enum):
+    """Credential-safe failure classes for Guardian-authorized Pi execution."""
+
+    ADAPTER_TIMEOUT = "adapter_timeout"
+    WRAPPER_UNAVAILABLE = "wrapper_unavailable"
+    RUNTIME_MODULE_UNAVAILABLE = "runtime_module_unavailable"
+    AUTHORIZED_IDENTITY_REJECTED = "authorized_identity_rejected"
+    PROVIDER_UNRESOLVED = "provider_unresolved"
+    MODEL_UNRESOLVED = "model_unresolved"
+    OAUTH_AUTH_UNAVAILABLE = "oauth_auth_unavailable"
+    SESSION_INITIALIZATION_FAILED = "session_initialization_failed"
+    PROVIDER_REQUEST_FAILED = "provider_request_failed"
+    PROVIDER_TRANSPORT_FAILED = "provider_transport_failed"
+    WRAPPER_PROTOCOL_FAILED = "wrapper_protocol_failed"
+    ACTUAL_IDENTITY_MISSING = "actual_identity_missing"
+    TARGET_POSTURE_VIOLATION = "target_posture_violation"
+    UNKNOWN_ADAPTER_FAILURE = "unknown_adapter_failure"
+
+
 class PiProviderLaneClass(str, Enum):
     LOCAL = "local"
     REMOTE = "remote"
@@ -91,6 +110,9 @@ PI_INVOCATION_RECEIPT_TERMINAL_STATUSES: frozenset[str] = frozenset(
 PI_HARNESS_RESULT_CLASSES: frozenset[str] = frozenset(
     result_class.value for result_class in PiHarnessResultClass
 )
+PI_AUTHORIZED_FAILURE_CLASSES: frozenset[str] = frozenset(
+    failure_class.value for failure_class in PiAuthorizedFailureClass
+)
 PI_PROVIDER_LANE_CLASSES: frozenset[str] = frozenset(
     lane_class.value for lane_class in PiProviderLaneClass
 )
@@ -137,6 +159,14 @@ def normalize_pi_harness_result_class(value: str | None) -> str:
     )
 
 
+def normalize_pi_authorized_failure_class(value: str | None) -> str:
+    return _normalize_token(
+        value,
+        allowed=PI_AUTHORIZED_FAILURE_CLASSES,
+        kind="pi_authorized_failure_class",
+    )
+
+
 def normalize_pi_provider_lane_class(value: str | None) -> str:
     return _normalize_token(
         value,
@@ -150,12 +180,14 @@ __all__ = [
     "PiInvocationEnvelopeStatus",
     "PiInvocationReceiptStatus",
     "PiHarnessResultClass",
+    "PiAuthorizedFailureClass",
     "PiProviderLaneClass",
     "PiValidationFailureReason",
     "PI_INVOCATION_ENVELOPE_STATUSES",
     "PI_INVOCATION_RECEIPT_STATUSES",
     "PI_INVOCATION_RECEIPT_TERMINAL_STATUSES",
     "PI_HARNESS_RESULT_CLASSES",
+    "PI_AUTHORIZED_FAILURE_CLASSES",
     "PI_PROVIDER_LANE_CLASSES",
     "PI_INVOCATION_VALIDATION_OUTCOMES",
     "PI_VALIDATION_FAILURE_REASONS",
@@ -163,5 +195,6 @@ __all__ = [
     "normalize_pi_validation_outcome",
     "normalize_pi_receipt_status",
     "normalize_pi_harness_result_class",
+    "normalize_pi_authorized_failure_class",
     "normalize_pi_provider_lane_class",
 ]

--- a/tests/pi/test_pi_authorized_failure_diagnostics.py
+++ b/tests/pi/test_pi_authorized_failure_diagnostics.py
@@ -1,0 +1,491 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from guardian.agents.adapters.base import (
+    AgentExecutionIdentity,
+    AgentExecutionRequest,
+)
+from guardian.agents.adapters.pi_codex_runner import PiCodexRunnerAdapter
+from guardian.pi.contracts import (
+    PiGuardianBoundary,
+    PiInvocationEnvelope,
+    PiInvocationPolicyDecision,
+    PiPermissionGrant,
+    PiProviderLane,
+)
+from guardian.pi.invocation import (
+    PiAuthorizedExecutionIdentity,
+    PiAuthorizedHarnessRequest,
+    PiHarnessRuntimeEvidence,
+    invoke_guardian_authorized_pi,
+    preflight_guardian_authorized_pi,
+)
+from guardian.pi.tokens import (
+    PiAuthorizedFailureClass,
+    PiValidationFailureReason,
+)
+
+
+IDENTITY = PiAuthorizedExecutionIdentity(
+    provider_id="openai-codex",
+    model_id="gpt-5.3-codex",
+    harness_id="pi-coding-agent",
+    harness_version="0.72.1",
+)
+
+
+def _permission(permission: str = "files.read") -> PiPermissionGrant:
+    return PiPermissionGrant(
+        permission=permission,
+        resource=".",
+        reason="diagnostic fixture scope",
+    )
+
+
+def _envelope(*, source_thread_id: str = "thread-diagnostics") -> PiInvocationEnvelope:
+    permission = _permission()
+    return PiInvocationEnvelope(
+        guardian_boundary=PiGuardianBoundary(owner_account_id="acct-diagnostics"),
+        source_thread_id=source_thread_id,
+        source_message_id="message-diagnostics",
+        authored_request_id="request-diagnostics",
+        attempt_id="attempt-diagnostics",
+        invocation_id="invocation-diagnostics",
+        harness_id=IDENTITY.harness_id,
+        harness_version=IDENTITY.harness_version,
+        provider_lane=PiProviderLane(
+            provider_lane_class="external",
+            provider_name=IDENTITY.provider_id,
+            model_id=IDENTITY.model_id,
+        ),
+        requested_permissions=(permission,),
+        granted_permissions=(permission,),
+        status="prepared",
+    )
+
+
+def _decision(envelope: PiInvocationEnvelope) -> PiInvocationPolicyDecision:
+    return PiInvocationPolicyDecision(
+        policy_decision_id="policy-diagnostics",
+        invocation_id=envelope.invocation_id,
+        source_thread_id=envelope.source_thread_id,
+        source_message_id=envelope.source_message_id,
+        harness_id=envelope.harness_id,
+        decision="allowed",
+        guardian_boundary=envelope.guardian_boundary,
+        requested_permissions=envelope.requested_permissions,
+        granted_permissions=envelope.granted_permissions,
+        permission_posture="bounded",
+        policy_source="guardian",
+        decision_reason="deterministic diagnostic fixture",
+        decided_at="2026-08-17T00:00:00Z",
+        validation_status="valid",
+        redaction_state="clean",
+    )
+
+
+def _evidence(
+    *,
+    status: str = "ok",
+    failure_classification: str | None = None,
+    failure_stage: str | None = None,
+    actual_identity: bool = True,
+    oauth_available: bool | None = None,
+) -> PiHarnessRuntimeEvidence:
+    return PiHarnessRuntimeEvidence(
+        status=status,
+        actual_provider_id=IDENTITY.provider_id if actual_identity else None,
+        actual_model_id=IDENTITY.model_id if actual_identity else None,
+        actual_harness_id=IDENTITY.harness_id if actual_identity else None,
+        actual_harness_version=IDENTITY.harness_version if actual_identity else None,
+        failure_classification=failure_classification,
+        failure_stage=failure_stage,
+        runtime_identity_established=actual_identity,
+        oauth_available=oauth_available,
+    )
+
+
+@dataclass
+class _FakeRunner:
+    evidence: PiHarnessRuntimeEvidence
+
+    def __post_init__(self) -> None:
+        self.calls: list[PiAuthorizedHarnessRequest] = []
+
+    def __call__(self, request: PiAuthorizedHarnessRequest) -> PiHarnessRuntimeEvidence:
+        self.calls.append(request)
+        return self.evidence
+
+
+def _invoke(tmp_path: Path, runner: _FakeRunner):
+    envelope = _envelope()
+    return invoke_guardian_authorized_pi(
+        envelope=envelope,
+        decision=_decision(envelope),
+        prompt="fixture prompt is never sent by these fake runners",
+        cwd=tmp_path,
+        timeout_seconds=5,
+        harness_runner=runner,
+    )
+
+
+@pytest.mark.parametrize(
+    ("failure_class", "stage"),
+    [
+        (PiAuthorizedFailureClass.ADAPTER_TIMEOUT.value, "adapter_execution"),
+        (PiAuthorizedFailureClass.WRAPPER_UNAVAILABLE.value, "wrapper_launch"),
+        (PiAuthorizedFailureClass.RUNTIME_MODULE_UNAVAILABLE.value, "runtime_load"),
+        (PiAuthorizedFailureClass.AUTHORIZED_IDENTITY_REJECTED.value, "authorization"),
+        (PiAuthorizedFailureClass.PROVIDER_UNRESOLVED.value, "provider_resolution"),
+        (PiAuthorizedFailureClass.MODEL_UNRESOLVED.value, "model_resolution"),
+        (PiAuthorizedFailureClass.OAUTH_AUTH_UNAVAILABLE.value, "oauth_readiness"),
+        (PiAuthorizedFailureClass.SESSION_INITIALIZATION_FAILED.value, "session_initialization"),
+        (PiAuthorizedFailureClass.PROVIDER_REQUEST_FAILED.value, "provider_request"),
+        (PiAuthorizedFailureClass.PROVIDER_TRANSPORT_FAILED.value, "provider_transport"),
+        (PiAuthorizedFailureClass.WRAPPER_PROTOCOL_FAILED.value, "wrapper_protocol"),
+        (PiAuthorizedFailureClass.UNKNOWN_ADAPTER_FAILURE.value, "adapter_execution"),
+    ],
+)
+def test_authorized_failure_class_is_preserved_as_bounded_diagnostic(
+    tmp_path: Path,
+    failure_class: str,
+    stage: str,
+) -> None:
+    runner = _FakeRunner(
+        _evidence(
+            status="error",
+            failure_classification=failure_class,
+            failure_stage=stage,
+            actual_identity=False,
+        )
+    )
+
+    outcome = _invoke(tmp_path, runner)
+
+    assert not outcome.ok
+    assert outcome.failure_reason == PiValidationFailureReason.ADAPTER_EXECUTION_FAILURE.value
+    assert outcome.diagnostic_class == failure_class
+    assert outcome.diagnostic_stage == stage
+    assert outcome.runner_call_count == len(runner.calls) == 1
+    assert outcome.retry_count == 0
+    assert outcome.fallback_count == 0
+
+
+def test_missing_actual_runtime_identity_remains_fail_closed(tmp_path: Path) -> None:
+    runner = _FakeRunner(_evidence(actual_identity=False))
+
+    outcome = _invoke(tmp_path, runner)
+
+    assert not outcome.ok
+    assert outcome.failure_reason == PiValidationFailureReason.ACTUAL_IDENTITY_MISSING.value
+    assert outcome.diagnostic_class == PiAuthorizedFailureClass.ACTUAL_IDENTITY_MISSING.value
+    assert outcome.runner_call_count == 1
+
+
+def test_unknown_runner_exception_is_redacted_and_fail_closed(tmp_path: Path) -> None:
+    envelope = _envelope()
+
+    def runner(_request: PiAuthorizedHarnessRequest) -> PiHarnessRuntimeEvidence:
+        raise RuntimeError("authorization: Bearer secret-not-returned")
+
+    outcome = invoke_guardian_authorized_pi(
+        envelope=envelope,
+        decision=_decision(envelope),
+        prompt="fixture",
+        cwd=tmp_path,
+        timeout_seconds=5,
+        harness_runner=runner,
+    )
+
+    assert not outcome.ok
+    assert outcome.failure_reason == PiValidationFailureReason.ADAPTER_EXECUTION_FAILURE.value
+    assert outcome.diagnostic_class == PiAuthorizedFailureClass.UNKNOWN_ADAPTER_FAILURE.value
+    assert "secret-not-returned" not in repr(outcome)
+    assert "Bearer" not in repr(outcome)
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "Error: provider failed with access_token=secret-not-returned",
+        "Error: Authorization: Bearer secret-not-returned",
+        "Error: Cookie: session=secret-not-returned",
+    ],
+)
+def test_authorized_adapter_never_returns_raw_or_secret_shaped_stderr(
+    stderr: str,
+) -> None:
+    result = subprocess.CompletedProcess(
+        ["node", "agent-wrapper.js", "guardian-authorized-task", "fixture"],
+        1,
+        stdout="",
+        stderr=stderr,
+    )
+
+    envelope = PiCodexRunnerAdapter()._parse_result(
+        result,
+        require_runtime_identity=True,
+    )
+    payload = json.dumps(envelope.model_dump(), sort_keys=True)
+
+    assert stderr not in payload
+    assert "secret-not-returned" not in payload
+    assert envelope.failure_classification in {
+        PiAuthorizedFailureClass.OAUTH_AUTH_UNAVAILABLE.value,
+        PiAuthorizedFailureClass.PROVIDER_REQUEST_FAILED.value,
+        PiAuthorizedFailureClass.UNKNOWN_ADAPTER_FAILURE.value,
+    }
+
+
+def test_malformed_authorized_wrapper_json_is_protocol_failure() -> None:
+    result = subprocess.CompletedProcess(
+        ["node", "agent-wrapper.js", "guardian-authorized-task", "fixture"],
+        0,
+        stdout="not-json-with-a-secret-shaped-value=secret-not-returned",
+        stderr="",
+    )
+
+    envelope = PiCodexRunnerAdapter()._parse_result(
+        result,
+        require_runtime_identity=True,
+    )
+
+    assert envelope.failure_classification == PiAuthorizedFailureClass.WRAPPER_PROTOCOL_FAILED.value
+    assert "secret-not-returned" not in json.dumps(envelope.model_dump())
+
+
+def test_pre_execution_rejection_has_zero_runner_calls(tmp_path: Path) -> None:
+    runner = _FakeRunner(_evidence())
+    envelope = _envelope(source_thread_id="")
+
+    outcome = invoke_guardian_authorized_pi(
+        envelope=envelope,
+        decision=_decision(envelope),
+        prompt="fixture",
+        cwd=tmp_path,
+        timeout_seconds=5,
+        harness_runner=runner,
+    )
+
+    assert outcome.failure_reason == PiValidationFailureReason.POLICY_ENVELOPE_MISMATCH.value
+    assert outcome.runner_call_count == len(runner.calls) == 0
+    assert outcome.retry_count == outcome.fallback_count == 0
+
+
+def test_success_still_returns_valid_receipt_and_harness_result(tmp_path: Path) -> None:
+    runner = _FakeRunner(_evidence())
+
+    outcome = _invoke(tmp_path, runner)
+
+    assert outcome.ok
+    assert outcome.receipt is not None
+    assert outcome.harness_result is not None
+    assert outcome.harness_result.result_class == "success"
+    assert outcome.diagnostic_class is None
+    assert outcome.runner_call_count == 1
+    assert outcome.retry_count == outcome.fallback_count == 0
+
+
+def test_filesystem_posture_failure_precedes_adapter_success_claim(tmp_path: Path) -> None:
+    runner = _FakeRunner(_evidence())
+
+    def mutate(request: PiAuthorizedHarnessRequest) -> PiHarnessRuntimeEvidence:
+        (request.cwd / "unauthorized.txt").write_text("mutation", encoding="utf-8")
+        return runner.evidence
+
+    runner = mutate  # type: ignore[assignment]
+    envelope = _envelope()
+    outcome = invoke_guardian_authorized_pi(
+        envelope=envelope,
+        decision=_decision(envelope),
+        prompt="fixture",
+        cwd=tmp_path,
+        timeout_seconds=5,
+        harness_runner=runner,
+    )
+
+    assert outcome.failure_reason == PiValidationFailureReason.READ_ONLY_VIOLATION.value
+    assert outcome.diagnostic_class == PiAuthorizedFailureClass.TARGET_POSTURE_VIOLATION.value
+
+
+def test_authorized_preflight_reaches_auth_without_prompt(tmp_path: Path) -> None:
+    calls: list[PiAuthorizedHarnessRequest] = []
+
+    def runner(request: PiAuthorizedHarnessRequest) -> PiHarnessRuntimeEvidence:
+        calls.append(request)
+        return _evidence(oauth_available=True)
+
+    envelope = _envelope()
+    outcome = preflight_guardian_authorized_pi(
+        envelope=envelope,
+        decision=_decision(envelope),
+        cwd=tmp_path,
+        timeout_seconds=5,
+        preflight_runner=runner,
+    )
+
+    assert outcome.ok
+    assert outcome.failure_class is None
+    assert outcome.deepest_stage == "auth_available"
+    assert outcome.oauth_available is True
+    assert outcome.session_initialized is False
+    assert outcome.provider_request_started is False
+    assert outcome.preflight_call_count == 1
+    assert calls[0].prompt == ""
+    assert outcome.retry_count == outcome.fallback_count == 0
+
+
+def test_authorized_preflight_failure_is_bounded(tmp_path: Path) -> None:
+    envelope = _envelope()
+    outcome = preflight_guardian_authorized_pi(
+        envelope=envelope,
+        decision=_decision(envelope),
+        cwd=tmp_path,
+        timeout_seconds=5,
+        preflight_runner=lambda _request: _evidence(
+            status="error",
+            failure_classification=PiAuthorizedFailureClass.OAUTH_AUTH_UNAVAILABLE.value,
+            failure_stage="oauth_readiness",
+            actual_identity=True,
+            oauth_available=False,
+        ),
+    )
+
+    assert not outcome.ok
+    assert outcome.failure_class == PiAuthorizedFailureClass.OAUTH_AUTH_UNAVAILABLE.value
+    assert outcome.failure_stage == "oauth_readiness"
+    assert outcome.deepest_stage == "identity_verified"
+    assert outcome.retry_count == outcome.fallback_count == 0
+
+
+def test_authorized_timeout_and_missing_wrapper_are_classified_without_raw_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    adapter = PiCodexRunnerAdapter()
+    identity = AgentExecutionIdentity(
+        provider_id=IDENTITY.provider_id,
+        model_id=IDENTITY.model_id,
+        harness_id=IDENTITY.harness_id,
+        harness_version=IDENTITY.harness_version,
+    )
+    request = AgentExecutionRequest(prompt="fixture", cwd=str(tmp_path), timeout_seconds=1)
+
+    def timeout(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.TimeoutExpired("node", 1)
+
+    monkeypatch.setattr("guardian.agents.adapters.pi_codex_runner.subprocess.run", timeout)
+    timeout_result = adapter.execute_authorized(request, identity, read_only=True)
+    assert timeout_result.failure_classification == PiAuthorizedFailureClass.ADAPTER_TIMEOUT.value
+    assert "timed out after" not in timeout_result.summary
+
+    def missing(*_args: object, **_kwargs: object) -> None:
+        raise FileNotFoundError("/secret/path")
+
+    monkeypatch.setattr("guardian.agents.adapters.pi_codex_runner.subprocess.run", missing)
+    missing_result = adapter.execute_authorized(request, identity, read_only=True)
+    assert missing_result.failure_classification == PiAuthorizedFailureClass.WRAPPER_UNAVAILABLE.value
+    assert "/secret/path" not in missing_result.model_dump_json()
+
+
+# Regression guard: the readiness rail must use the backend-supplying
+# AuthStorage public construction path (AuthStorage.create() or equivalent)
+# and must never construct a bare `new AuthStorage()` with no backend. The
+# latter was the historical TypeError discriminant isolated in the
+# reconciliation proof commit 4acb7c5c7c23dc4913a90bba9b86b46bec0bc241.
+_READINESS_AUTHSTORAGE_FORBIDDEN_PATTERN = re.compile(
+    r"new\s+AuthStorage\s*\(\s*\)"
+)
+_READINESS_AUTHSTORAGE_REQUIRED_PATTERN = re.compile(
+    r"AuthStorage\.create\s*\("
+)
+
+
+def test_readiness_wrapper_never_constructs_bare_auth_storage() -> None:
+    """Static regression: readiness path must not call `new AuthStorage()`.
+
+    A bare `new AuthStorage()` (no backend) deterministically raises a
+    `TypeError` from `auth-storage.js:203` because `this.storage` is
+    `undefined`. The reconciliation proof isolated that discriminant;
+    canonicalizing this rail must not re-introduce the misuse.
+    """
+
+    wrapper_path = Path(__file__).resolve().parent.parent.parent / "codex_runner" / "src" / "agent-wrapper.js"
+    source = wrapper_path.read_text(encoding="utf-8")
+
+    readiness_block = _readiness_block(source)
+    forbidden = _READINESS_AUTHSTORAGE_FORBIDDEN_PATTERN.search(readiness_block)
+    assert forbidden is None, (
+        "agent-wrapper.js readiness path must not construct bare `new AuthStorage()`."
+    )
+
+
+def test_readiness_wrapper_uses_backend_supplying_auth_storage() -> None:
+    """Static regression: readiness path must use `AuthStorage.create()`.
+
+    Pi's normal public construction path supplies its own backend, which
+    is the only known-good pattern. The reconciliation proof showed that
+    `AuthStorage.create()` succeeds against the current operator auth.json.
+    """
+
+    wrapper_path = Path(__file__).resolve().parent.parent.parent / "codex_runner" / "src" / "agent-wrapper.js"
+    source = wrapper_path.read_text(encoding="utf-8")
+
+    readiness_block = _readiness_block(source)
+    assert _READINESS_AUTHSTORAGE_REQUIRED_PATTERN.search(readiness_block) is not None, (
+        "agent-wrapper.js readiness path must call `AuthStorage.create()`."
+    )
+
+
+def test_readiness_wrapper_emits_session_initialized_false_and_no_provider_request() -> None:
+    """Static regression: readiness mode must not start a session or a provider request.
+
+    The readiness output schema requires:
+      - session_initialized: false
+      - provider_request_started: false
+      - runtime_identity_established: true (when reaching OAuth readiness)
+    The wrapper must emit exactly these bounded indicators.
+    """
+
+    wrapper_path = Path(__file__).resolve().parent.parent.parent / "codex_runner" / "src" / "agent-wrapper.js"
+    source = wrapper_path.read_text(encoding="utf-8")
+
+    readiness_block = _readiness_block(source)
+    assert "session_initialized: false" in readiness_block
+    assert "provider_request_started: false" in readiness_block
+    assert "runtime_identity_established: true" in readiness_block
+    assert "oauth_available: true" in readiness_block
+
+
+def _readiness_block(source: str) -> str:
+    """Locate the bounded `checkGuardianAuthorizedReadiness` body in agent-wrapper.js.
+
+    The readiness branch is dispatched by `else if (guardianAuthorizedReadinessMode)`
+    and calls `checkGuardianAuthorizedReadiness()`. We return the function body
+    (between the `async function checkGuardianAuthorizedReadiness() {` opener
+    and the next top-level function or sentinel) so static assertions evaluate
+    only the readiness body, not the help text or task-mode branch.
+    """
+
+    fn_marker = "async function checkGuardianAuthorizedReadiness"
+    fn_start = source.find(fn_marker)
+    assert fn_start != -1, "checkGuardianAuthorizedReadiness not found in agent-wrapper.js"
+    body_open = source.find("{", fn_start)
+    assert body_open != -1, "checkGuardianAuthorizedReadiness body open brace not found"
+    depth = 0
+    for i in range(body_open, len(source)):
+        ch = source[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return source[body_open : i + 1]
+    raise AssertionError("checkGuardianAuthorizedReadiness body close brace not found")


### PR DESCRIPTION
## Summary

This PR canonicalizes the **already-proven redacted Pi adapter failure diagnostic / readiness rail** that was authored in commit `87535e90a4d5c3f6c4fb58b5b9b3e21d9c76519e` but never merged to current `main`. The historical implementation is byte-equivalent to current main on the six affected paths (no current-main drift), so the patch is transplanted exactly.

## What this slice does

- Adds the bounded `PiAuthorizedFailureClass` enum (15 classes) and the `normalize_pi_authorized_failure_class` helper to `guardian/pi/tokens.py`.
- Adds bounded output fields to `AgentRunEnvelope`: `failure_classification`, `failure_stage`, `return_code`, `runtime_identity_established`, `session_initialized`, `provider_request_started`, `oauth_available`.
- Extends `guardian/agents/adapters/pi_codex_runner.py` with `_bounded_text`, `_bounded_bool`, `_classify_authorized_failure`, `_failure_stage_for_class`, and the `execute_authorized` path that redacts raw stderr / exception messages / credential-shaped strings.
- Adds `preflight_guardian_authorized_pi` (non-inference readiness mode) and `_run_preflight_with_pi_adapter` to `guardian/pi/invocation.py`.
- Adds the `checkGuardianAuthorizedReadiness` function and the `guardian-authorized-readiness` mode to `codex_runner/src/agent-wrapper.js`. The readiness path uses `AuthStorage.create()` (NOT bare `new AuthStorage()`) and emits a bounded schema: `session_initialized: false`, `provider_request_started: false`, `runtime_identity_established: true`, `oauth_available: true | false`, plus a bounded `failure_class` / `failure_stage`.
- Adds 27 deterministic, mocked, real-credential-free tests in `tests/pi/test_pi_authorized_failure_diagnostics.py`, including three new static-source regression tests for the readiness body invariants.

## What this slice does NOT do

- No live provider request.
- No model prompt.
- No OAuth login / refresh / logout.
- No credential mutation.
- No Pi package / source modification.
- No Pi upgrade or reinstall.
- No OpenAI Codex Executor live qualification.
- No provider-registry change.
- No MiniMax / Campaign Engine work.
- No release-support promotion.
- No rewrite of historical proofs.

## Drift result

| Path | Drift |
| --- | --- |
| `codex_runner/src/agent-wrapper.js` | no-current-main-drift |
| `guardian/agents/adapters/base.py` | no-current-main-drift |
| `guardian/agents/adapters/pi_codex_runner.py` | no-current-main-drift |
| `guardian/pi/invocation.py` | no-current-main-drift |
| `guardian/pi/tokens.py` | no-current-main-drift |
| `tests/pi/test_pi_authorized_failure_diagnostics.py` | no-current-main-drift (file did not exist on main) |

The merge-base between `87535e90...` and current `origin/main` is `eb6bdc530245fdffeff23589c98389be4102b564` (the canonical Pi seam). All six paths had identical content between `87535e90^` and `origin/main`.

## Validation

| Suite | Result |
| --- | --- |
| `tests/pi/test_pi_authorized_failure_diagnostics.py` | 27 / 27 PASS |
| `tests/pi/test_pi_live_invocation.py` | 30 / 30 PASS |
| `tests/pi/` (full suite) | 172 / 172 PASS |
| `node --check codex_runner/src/agent-wrapper.js` | PASS |
| `make docs PYTHON=.venv/bin/python` | PASS |
| `git diff --check` | clean |

## Reconciliation context

The historical AuthStorage TypeError was reconciled in the immediately preceding proof (`4acb7c5c7c23dc4913a90bba9b86b46bec0bc241`, `ROOT_CAUSE_DISCRIMINANT_ISOLATED`): the discriminant was a bare `new AuthStorage()` (no backend) construction error at `auth-storage.js:203:26`. That discriminant is NOT used anywhere in this canonicalization. The readiness path explicitly uses `AuthStorage.create()` and a new static-source regression test (`test_readiness_wrapper_never_constructs_bare_auth_storage`) prevents re-introduction.

## Next gate

A separate fresh non-mutating OpenAI Codex Executor preflight qualification proof task may begin only after this canonicalization merges. This PR does not itself qualify the Executor.

## Files

- `codex_runner/src/agent-wrapper.js` (+269/-N)
- `guardian/agents/adapters/base.py` (+7)
- `guardian/agents/adapters/pi_codex_runner.py` (+187/-N)
- `guardian/pi/invocation.py` (+316/-N)
- `guardian/pi/tokens.py` (+33)
- `tests/pi/test_pi_authorized_failure_diagnostics.py` (+491)
- `docs/architecture/proofs/2026-08-19-guardian-pi-authorized-readiness-canonicalization-proof.md` (+274)

## Commit

`cad17f42ae2a8d0fdfa8fb5cc0f954ca707e069c`

Awaiting review approval.
