### PR TITLE
Wire Anthropic account export imports through the supported runtime

### DIFF
--- a/backend/rag/anthropic_export_adapter.py
+++ b/backend/rag/anthropic_export_adapter.py
@@ -301,10 +301,19 @@ class AnthropicExtractedConversation:
 
 @dataclass
 class AnthropicImportResult:
-    """Bounded result returned by ``import_anthropic_export_path``."""
+    """Bounded result returned by ``import_anthropic_export_path``.
+
+    ``conversations_imported`` / ``messages_imported`` are the canonical
+    committed totals reported by the authoritative Claude writer
+    (``ingest_claude_export`` ``threads_imported`` / ``messages_imported``),
+    never source-discovery counts. Source discovery is reported separately as
+    ``conversations_discovered`` so durable job accounting can never confuse
+    discovered conversations with committed threads.
+    """
 
     conversations_discovered: int = 0
     conversations_imported: int = 0
+    messages_imported: int = 0
     conversations_failed: int = 0
     errors: list[str] = field(default_factory=list)
 
@@ -312,9 +321,19 @@ class AnthropicImportResult:
         return {
             "conversations_discovered": self.conversations_discovered,
             "conversations_imported": self.conversations_imported,
+            "messages_imported": self.messages_imported,
             "conversations_failed": self.conversations_failed,
             "errors": list(self.errors),
         }
+
+
+def _non_negative_int(value: Any) -> int:
+    """Safe non-negative integer normalization for writer-reported counts."""
+
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
 
 
 def _normalize_conversation_record(
@@ -473,5 +492,8 @@ def import_anthropic_export_path(
         result.errors.append(f"ingest_claude_export_failed: {exc}")
         return result
 
-    result.conversations_imported = int(stats.get("threads_imported", 0))
+    result.conversations_imported = _non_negative_int(
+        stats.get("threads_imported", 0)
+    )
+    result.messages_imported = _non_negative_int(stats.get("messages_imported", 0))
     return result

--- a/docs/architecture/proofs/2026-08-19-anthropic-account-import-supported-runtime-proof-r2.md
+++ b/docs/architecture/proofs/2026-08-19-anthropic-account-import-supported-runtime-proof-r2.md
@@ -1,0 +1,159 @@
+# Anthropic Account Import — Supported Runtime Proof R2 (2026-08-19)
+
+## Result
+
+**PASS**
+
+The real Anthropic account export completed the full supported runtime chain —
+rendered Web UI → `source_system="anthropic"` → durable account-import job →
+Redis → `worker-account-import` → Anthropic adapter → canonical Claude writer →
+durable committed-count accounting → terminal `completed` → PostgreSQL — and the
+durable job counters now agree exactly with the persisted canonical truth.
+
+## Lineage
+
+- Branch: `codex/wire-anthropic-import-adapter`
+- Pre-proof HEAD: `ec2814539b25bed2ff27b7436916e5aa2abbc759` (the accounting repair commit; HEAD itself)
+- Accounting repair ancestry: `git merge-base --is-ancestor ec2814539… HEAD` → success
+- First proof ancestry: `git merge-base --is-ancestor 608f483bf… HEAD` → success
+- Worktree cleanliness: clean before and after the proof; only this receipt was added.
+- Repair diff confirmed present in lineage: adapter `messages_imported` preservation, provider-neutral `record_committed_conversation_totals` seam, worker crediting before `complete_job`, and the 82-test regression additions (verified via `git show --stat ec2814539`).
+
+## Runtime identity
+
+- Compose project: `codexify_anthropic_import_proof_r2_20260819` (fresh disposable project; fresh volumes; distinct from `codexify`, `codexify_tester`, `codexify-audit`)
+- Compose files:
+  - `docker-compose.yml` (canonical base, unmodified)
+  - `/private/tmp/codexify-anthropic-proof-r2.override.yml` (ephemeral external override, never committed; `!override` port remaps to 127.0.0.1:5544/7476/7689/8890/5180 and the documented supported local Beta posture pins: `v1-local-core-web-mcp`, `GUARDIAN_AUTH_MODE=local`, `GUARDIAN_EXPOSURE_MODE=local_safe`, `LLM_PROVIDER=local`, local-only flags, blessed `whooshd-mlx` gateway contract; frontend `VITE_GUARDIAN_API_BASE=""` same-origin proxy + `VITE_GUARDIAN_AUTH_MODE=local`)
+  - `--env-file .env.tester` (operator-owned, unmodified)
+- Tester-overlay re-check: the `config --services` resolution with `docker-compose.tester.yml` succeeds, but the overlay remains non-instantiable in isolation — the `tailscale-codexify-test` sidecar's `127.0.0.1:5174` binding is still held by the live `codexify_tester` project (verified with `lsof` before startup), and the sidecar is a single-instance tailnet identity. Same documented fallback as the first proof: base compose + unique project + ephemeral external override. No live project mutated.
+- Services started: `db redis neo4j graph-init migrator model-prep backend frontend worker-account-import`
+- Final states: db/redis/neo4j healthy; graph-init/migrator/model-prep exited 0; backend healthy; frontend serving; `worker-account-import` running with `RestartCount=0` before, during, and after the job.
+- Migration head (isolated DB): `1c0a2b3c4d5e`; `chat_threads.origin_system` column present.
+- Endpoints: backend `http://127.0.0.1:8890`, frontend `http://127.0.0.1:5180`.
+- Worker boot evidence: `[account-import] worker started queue=codexify:queue:account-import recovered=0` at 23:39:33Z (before submission).
+
+## Export identity (safe structural metadata only)
+
+- Operator-selected source: directory `/Volumes/Dev_SSD/anthropic-export` (generic path reference in this receipt)
+- Form: directory; 6 files; 7,180,973 bytes
+- Structural filenames: `conversations.json`, `memories.json`, `users.json`, `projects/019a1d7f-…json`, `projects/019a5c57-…json`, `projects/019b33d4-…json`
+- Structure class (no content read): `conversations.json` = list of 65 records carrying `chat_messages`; `projects/*.json` = project-metadata dicts; `memories.json`/`users.json` = single-record lists
+- Intake SHA-256 (identical to the first proof's recorded baseline):
+  - `conversations.json` `e47d81c1b0eea38b78d36b6e38a8ff6bc21b9c4c70f211c5128033f39811ed98`
+  - `memories.json` `82688c2c5c613af35494cf17ec8eb50c1cee82c6b380a5251a3f2728235d1e6c`
+  - `users.json` `a86aa4608a1d9a01fd0643d02471e4347da15dacd8d2ccd72dc4d093179eaae8`
+  - `projects/019a1d7f-…` `5372030d65ff79f1f78561f95b7b1bc93791b865193d0477cf0fa0fd196f3dee`
+  - `projects/019a5c57-…` `b33bbc3f615638be31c364fdf05dc171189ee3a379d5cc29638f99ca920c31bf`
+  - `projects/019b33d4-…` `3826010ba920ed8ee643d9e7da705e102e05b8e9c5f880b38a409d0fd8326318`
+
+## Web evidence
+
+- Rendered UI at `http://127.0.0.1:5180`, Settings → Data → "Import ChatGPT history" → "Import account data" modal.
+- Rendered choices observed: `OpenAI (ChatGPT)` and `Anthropic (Claude)`.
+- `Anthropic (Claude)` selected (radio `anthropic` checked, verified in DOM before submission).
+- Source submitted through the normal rendered folder interaction ("Choose Folder" + OS file chooser; manual OS-picker operation permitted by the spec and required by the browser automation limitation).
+- Created job ID: `c94e8387-839f-46a0-9083-aaba1ca8d18e` (captured from the browser network response for `POST /api/imports/openai-account` and confirmed from the durable DB row — not inferred from UI selection).
+
+## Job lifecycle
+
+- job_id: `c94e8387-839f-46a0-9083-aaba1ca8d18e`
+- user_id: `local`
+- `source_system`: exactly `anthropic` (durable row)
+- Observed transitions (browser capture + durable row): `receiving` (create) → `receiving` (6/6 files staged, 7,180,973 bytes) → `queued` (commit) → `running` (worker pickup) → **`completed`** (terminal, 23:42:44Z)
+- Terminal counters: `imported_thread_count=63`, `imported_message_count=784`, `imported_media_count=0`, `duplicate_count=0`, `skipped_count=0`, `warning_count=0`, `failure_count=0`
+- `account_import_no_committed_entities`: **did not recur.**
+
+## Accounting evidence
+
+- Durable checkpoint (`openai_account_import_jobs.checkpoint`):
+  - `source_summary`: `{conversations_discovered: 65, conversations_accepted: 65, conversations_skipped: 0, conversations_failed: 0, conversation_transactions_committed: true}`
+  - `committed_conversation_totals`: `[{"key": "anthropic_conversations", "threads_imported": 63, "messages_imported": 784}]`
+- The zero-counter defect is absent: `imported_thread_count=63`, `imported_message_count=784` at terminal (first proof: both 0).
+- Consistency with PostgreSQL: `Jt = 63 = Pt`, `Jm = 784 = Pm` — exact equality, as required for this fresh isolated import.
+
+## Worker evidence
+
+- Worker was running before the job (booted 23:39:33Z, `recovered=0`).
+- Job consumed: durable status moved to `running`; worker logs show the canonical Claude writer executing for the job at 23:42:44Z (embedding handoff, 49 batches × 16 items = 784 messages, `failed_count=0 failure_class=none` per batch).
+- Durable accounting executed (checkpoint entry above); terminal classification followed (job `completed`).
+- No `[account-import] worker failed …` line; no crash; `RestartCount=0`, container `running` throughout.
+
+## Persistence evidence
+
+Baseline (before submission): anthropic threads 0; total threads 0; total messages 0; jobs 0.
+
+After terminal `completed` (readback 1):
+
+| surface | value |
+|---|---|
+| anthropic-origin threads | **63** |
+| origin distribution | `anthropic=63`, `codexify=0`, `openai=0`, `NULL=0` |
+| messages on anthropic threads | **784** |
+| distinct importing users | **1** (`local`) |
+| imported provenance metadata | `metadata->>'import_source'='claude'` on 63/63 |
+
+Second independent readback (separate psql invocation): identical — 63 threads, 784 messages, distribution `anthropic=63`, 1 distinct user.
+
+## Source-vs-commit distinction
+
+| surface | value |
+|---|---|
+| conversations discovered (source) | 65 |
+| conversations accepted (source) | 65 |
+| canonical threads committed (writer/durable) | 63 |
+| canonical messages committed (writer/durable) | 784 |
+
+Discovery (65) is not substituted for committed threads (63); the difference is the writer's legitimate skip of conversations with no importable messages, exactly as the first proof observed.
+
+## Negative checks (pre/post, isolated DB)
+
+| surface | baseline | post | verdict |
+|---|---|---|---|
+| `projects` | 1 (`General`) | 2 (`General`, `Imports`) | PASS — only the backend default and the canonical writer's import-container project exist; no Anthropic `projects/*.json` → Project entity |
+| `memory_entries` | 0 | 0 | PASS — `memories.json` created no memory state |
+| `user_profiles` | 0 | 0 | PASS — `users.json` created no persona/identity rows |
+| `personal_facts` / `personal_fact_evidence` | 0 / 0 | 3 / 74 | OBSERVED — all 74 evidence rows link via `source_message_id` to messages in anthropic-origin threads: conversation-derived fact candidates from the pre-existing canonical Claude writer, NOT `memories.json` ingestion |
+| media/document tables (`media_assets`, `uploaded_images`, `generated_images`, `uploaded_documents`, `generated_documents`, `thread_documents`, `project_document_links`) | 0 each | 0 each | PASS — no fabricated media/document rows |
+
+## Export integrity
+
+Per-file SHA-256 recomputed after the run: all six identical to the intake hashes (byte-for-byte unchanged). Staged private copy of the proof job removed from the shared staging root at teardown; unrelated staging directories untouched.
+
+## UI terminal proof
+
+Rendered modal reached terminal success: **"Import completed — Imported 63 threads, 784 messages, and 0 images. Duplicates: 0. Skipped: 0. Warnings: 0."** (operator-observed) and the coordinator persisted `{jobId: "c94e8387-…", status: "completed", sourceSystem: "anthropic"}`. No screenshot committed.
+
+## Invariants
+
+1. Rendered Web UI origin — PASS (modal interaction + network capture; not an API-only exercise)
+2. `source_system` exactly `anthropic` — PASS (durable row)
+3. Browser never assigns `origin_system` — PASS (client serializes only `source_system`; no origin field in any captured request)
+4. PostgreSQL durable authority — PASS (direct read-only psql evidence; two independent readbacks)
+5. Durable accounting agrees with persistence — PASS (`Jt=63=Pt`, `Jm=784=Pm`; checkpoint entry present)
+6. Discovery ≠ committed — PASS (65 discovered vs 63 committed, recorded separately)
+7. Job not manually repaired/edited — PASS (no row edits; terminal state produced by the runtime)
+8. Export byte-for-byte unchanged — PASS (hash equality)
+9. Isolated disposable runtime — PASS (fresh R2 project/volumes, no reuse of the first proof's volumes)
+10. No unrelated runtime mutated — PASS (`codexify`/`codexify_tester`/`codexify-audit` untouched; verified before teardown and after)
+11. No implementation fix authorized/performed — PASS (only the receipt is new; tree otherwise clean)
+12. No release widening — PASS (no release/current-state claim)
+13. Unsupported Projects/memory/users/media not inferred from conversation success — PASS (negative checks recorded as observed)
+14. Historical BLOCKED receipt unchanged — PASS (not modified)
+
+## ADR impact
+
+`Aligned with existing ADR(s); no architecture change.` Governing anchors confirmed during pre-read: ADR-001 (Queue-Based Completion Acceptance Model), ADR-005 (Runtime Mode and Account Boundary Invariants), ADR-069 (Codexify Beta Runtime Support Boundary), and the `account-export-restore-contract.md` normative contract. This task exercises already-accepted architecture; no ADR added or superseded.
+
+## Documentation follow-through
+
+- Historical BLOCKED receipt (`2026-08-19-anthropic-account-import-supported-runtime-proof.md`) remains unchanged and remains historically correct at `608f483bf`.
+- `00-current-state.md` unchanged.
+- No release/support claim widened.
+- With this PASS, the runtime evidence is now sufficient to make a separate support-posture reconciliation task eligible (deferred — see below).
+
+## Teardown
+
+- `PROOF_PROJECT=codexify_anthropic_import_proof_r2_20260819` printed and verified before teardown; torn down with the same files used to start it: `docker compose --env-file .env.tester -p codexify_anthropic_import_proof_r2_20260819 -f docker-compose.yml -f /private/tmp/codexify-anthropic-proof-r2.override.yml down -v`. Only proof-project volumes/network removed; all unrelated projects intact (20 containers unaffected).
+- Proof job's staged private bytes removed (job-scoped directory only).
+- Source export still present and unchanged afterward.

--- a/docs/architecture/proofs/2026-08-19-anthropic-account-import-supported-runtime-proof.md
+++ b/docs/architecture/proofs/2026-08-19-anthropic-account-import-supported-runtime-proof.md
@@ -1,0 +1,186 @@
+# Anthropic Account Import — Supported Runtime Proof (2026-08-19)
+
+## Status
+
+**BLOCKED**
+
+A real Anthropic account export completed the supported Web → job → Redis queue →
+worker → PostgreSQL persistence chain, but the durable account-import job reached
+terminal `failed` (not `completed`). The first blocking boundary is a worker
+bookkeeping defect in the Anthropic dispatch branch (see "First Blocking
+Boundary" below). Per task invariants, the defect is recorded, not repaired.
+
+## Orientation (workspace identity)
+
+- Worktree: `/Volumes/Dev_SSD/Codexify-main` (canonical Tester root, bind-mounted by Compose)
+- Branch: `codex/wire-anthropic-import-adapter`
+- Pre-proof HEAD: `140b9766c2681320f0f7962924c7773edc978926` (the rendered-UI proof commit)
+- Dirty state: clean before and after the proof (`git status --short` empty; only the receipt commit follows)
+- Live probes: backend `GET /health` 200 (`release_hold=true`, `supported_profile.v1-local-core-web-mcp` valid, `selected_provider=local`); all account-import routes registered in OpenAPI (`/api/imports/openai-account`, `/files`, `/commit`, `/{job_id}`, `/retry`, `/account/metadata`); frontend HTTP 200 on the proof origin.
+
+## Source identity
+
+- Branch: `codex/wire-anthropic-import-adapter`
+- HEAD: `140b9766c2681320f0f7962924c7773edc978926`
+- Ancestry: `140b9766c` is HEAD itself; `c3cc44ecbb7800e7216cd2f76bed9a39f0b2712b` is an ancestor (both `git merge-base --is-ancestor` checks returned success).
+- Worktree cleanliness: clean pre-proof and post-proof (only the receipt commit adds content).
+- Compose source correspondence: containers bind-mount the Tester root at HEAD `140b9766c`; the backend/migrator image `codexify-backend-runtime:latest` (built 2026-08-19T16:55Z) carries a migration tree byte-identical to the host tree (diff = `__pycache__` only), including `1c0a2b3c4d5e_add_chat_threads_origin_system.py`.
+
+## Runtime identity
+
+- Compose project: `codexify_anthropic_import_proof_20260819` (disposable; fresh volumes; distinct from `codexify`, `codexify_tester`, `codexify-audit`)
+- Compose files:
+  - `docker-compose.yml` (canonical base, unmodified, at HEAD)
+  - `/private/tmp/codexify-anthropic-proof.override.yml` — ephemeral EXTERNAL override, never committed, no repo file modified. Contents: port remaps (`!override`) and supported-posture pins (see below).
+  - `--env-file .env.tester` (operator-owned, unmodified)
+- Tester-overlay fallback rationale: the mandated topology resolution with `docker-compose.tester.yml` succeeds (`config --services` lists all required services), but the overlay is not usable as a second isolated Web runtime on this host: the frontend runs only inside the `tailscale-codexify-test` sidecar network namespace, and that sidecar publishes `127.0.0.1:5174`, which is already bound by the live `codexify_tester` project; a second sidecar would collide on port and tailnet identity (`TAILSCALE_TEST_HOSTNAME`/auth key are single-instance). The task forbids mutating another running Compose project. Fallback per spec: the repository's documented supported local Compose configuration (`docker-compose.yml`) under the unique proof project name.
+- Override pins (documented supported local Beta posture, matching the running audit backend's known-good boot combination): backend `CODEXIFY_SUPPORTED_PROFILE=v1-local-core-web-mcp`, `GUARDIAN_AUTH_MODE=local`, `GUARDIAN_EXPOSURE_MODE=local_safe`, `LLM_PROVIDER=local`, `ALLOW_CLOUD_PROVIDERS=false`, `CODEXIFY_LOCAL_ONLY_MODE=true`, `CODEXIFY_EGRESS_ALLOWLIST=""`, blessed local gateway contract (`LOCAL_RUNTIME_PRESET=whooshd-mlx`, `LOCAL_COMPAT_FIRST=true`, `LOCAL_PROVIDER_DISPLAY_NAME="Whoosh'd"`, `LOCAL_PROVIDER_VENDOR=whooshd`); frontend `VITE_GUARDIAN_API_BASE=""` (same-origin Vite proxy) + `VITE_GUARDIAN_AUTH_MODE=local`.
+- Services started: `db redis neo4j graph-init migrator model-prep backend frontend worker-account-import`
+- Final service states before teardown: `db` healthy, `redis` healthy, `neo4j` healthy, `graph-init` exited 0, `migrator` exited 0, `model-prep` exited 0, `backend` healthy (restarted once after env pin, healthy on pristine source), `frontend` up (Vite dev on 5173 in-container), `worker-account-import` up, `RestartCount=0`.
+- Migration head (isolated DB): `1c0a2b3c4d5e`; `chat_threads.origin_system` column present (CHECK-constrained per `guardian/conversation_origin.py`).
+- Endpoints: backend `http://127.0.0.1:8890`; frontend `http://127.0.0.1:5180`.
+- Worker identity: container `codexify_anthropic_import_proof_20260819-worker-account-import-1`, entrypoint `python -m guardian.workers.account_import_worker`, boot log `[account-import] worker started queue=codexify:queue:account-import recovered=0` at 22:10:36Z.
+- Startup diagnosis note: the first backend boot exited (3) with redacted logs; the documented log-safety bypass (`install_safe_logging` no-op) was applied temporarily to surface `LLMConfigError` (missing blessed local-gateway contract), the override was corrected, and the bypass was reverted byte-identically (blob SHA-256 `1cc41f21ea583ca3cf7866db45f7f15c312c0ffe667c7b74020886c0c81ba89f` == HEAD blob) before the final backend restart. The final runtime ran on pristine HEAD source.
+
+## Export identity (safe structural metadata only)
+
+- Operator-selected source: directory at `/Volumes/Dev_SSD/anthropic-export` (mode `drwx------`)
+- Form: directory (6 files, 7,180,973 bytes)
+- Filenames (structure identification only): `conversations.json` (6,566,116 B), `memories.json` (23,343 B), `users.json` (170 B), `projects/019a1d7f-aa06-73c4-b0db-6bbd4f9103af.json` (19,419 B), `projects/019a5c57-4700-7406-b9bb-2b9720926b65.json` (571,556 B), `projects/019b33d4-a874-75ca-a19f-c4d32fe2d2e0.json` (369 B)
+- Structural classification: `conversations.json` = top-level list of 65 records, each with keys `(account, chat_messages, created_at, name, summary, updated_at, uuid)`, 65/65 carry `chat_messages` lists (length 0–146); `projects/*.json` = single dicts (project metadata, no `chat_messages`); `memories.json`/`users.json` = single-record lists (no `chat_messages`). No message content read or recorded.
+- SHA-256 per file (recorded at intake and re-verified after the run — identical, source untouched):
+  - `conversations.json` `e47d81c1b0eea38b78d36b6e38a8ff6bc21b9c4c70f211c5128033f39811ed98`
+  - `memories.json` `82688c2c5c613af35494cf17ec8eb50c1cee82c6b380a5251a3f2728235d1e6c`
+  - `users.json` `a86aa4608a1d9a01fd0643d02471e4347da15dacd8d2ccd72dc4d093179eaae8`
+  - `projects/019a1d7f-…` `5372030d65ff79f1f78561f95b7b1bc93791b865193d0477cf0fa0fd196f3dee`
+  - `projects/019a5c57-…` `b33bbc3f615638be31c364fdf05dc171189ee3a379d5cc29638f99ca920c31bf`
+  - `projects/019b33d4-…` `3826010ba920ed8ee643d9e7da705e102e05b8e9c5f880b38a409d0fd8326318`
+- Intake gate: PASS — the export is structurally compatible with the adapter's `anthropic_legacy` detection (chat_messages-bearing records) and with the modal's folder interaction. No converter built.
+
+## UI evidence (rendered Web)
+
+- Origin: rendered frontend at `http://127.0.0.1:5180`, Settings → Data → "Import ChatGPT history" → modal "Import account data".
+- Both source options observed in the rendered modal: `OpenAI (ChatGPT)` and `Anthropic (Claude)` (radio inputs with `data-testid=account-import-source-openai|anthropic`).
+- Anthropic selected: radio `anthropic` checked (verified in DOM before submission); browser sent `source_system: "anthropic"` only.
+- Normal Web upload path: folder interaction via the rendered "Choose Folder" control and the OS folder chooser (operated manually per spec — browser automation cannot populate `webkitdirectory` inputs; explicitly permitted, does not invalidate the proof). The folder `/Volumes/Dev_SSD/anthropic-export` was selected; 6 files enumerated client-side with relative paths.
+- Job ID created: `2cc3cf45-917b-43c9-97f9-0028c4aba1be` (captured from the browser network response for `POST /api/imports/openai-account` and confirmed from the durable DB row).
+
+## Durable job evidence
+
+- job_id: `2cc3cf45-917b-43c9-97f9-0028c4aba1be`
+- user_id: `local` (single-user identity carried by the Web `X-User-Id` header)
+- `source_system`: exactly `anthropic`
+- Lifecycle states observed (browser poll + DB): `receiving` (create) → `receiving` (6/6 files staged, 7,180,973 bytes) → `queued` (commit; `source_export_fingerprint=09ceb8d7772f574f6c0c20d4be9892cfb19e6bc556c02e86077de1a646347513`) → `running` (started 22:58:15.503Z) → **`failed`** (completed_at 22:58:32.796Z)
+- Final error: `code=account_import_no_committed_entities`, message "The export finished processing, but no canonical entities were committed."
+- Durable `source_summary`: `conversations_discovered=65`, `conversations_accepted=65`, `conversations_skipped=0`, `conversations_failed=0`, `conversation_transactions_committed=true`
+- Job counters at terminal: `imported_thread_count=0`, `imported_message_count=0`, `imported_media_count=0` — see First Blocking Boundary.
+
+## Worker evidence
+
+- Running before the job: booted 22:10:34Z, `[account-import] worker started queue=codexify:queue:account-import recovered=0` (no unrelated queued work).
+- Job consumed: `running` state set at 22:58:15.503Z by the worker's `mark_running`; Redis queue `codexify:queue:account-import` (project-scoped Redis).
+- Anthropic dispatch observed: worker logs show the canonical Claude writer's embedding handoff for the job (49 batches × 16 items = 784 messages, `queued_count=16 failed_count=0 failure_class=none` per batch), then `[account-import] worker failed job_id=<redacted> exception_type=AccountImportError failure_class=runtime` (the `complete_job` failure; no conversation content in logs).
+- No crash/restart: `RestartCount=0`, container remained `running` through and after the job.
+
+## PostgreSQL evidence (isolated proof DB, user scope `local`)
+
+Baseline (before submission):
+
+| surface | count |
+|---|---|
+| alembic head | `1c0a2b3c4d5e` |
+| `chat_threads.origin_system` column | present (1) |
+| `chat_threads` total | 0 |
+| `chat_messages` total | 0 |
+| anthropic-origin threads | 0 |
+| account-import jobs | 0 |
+
+After terminal `failed` (readback 1, direct read-only psql):
+
+| surface | count |
+|---|---|
+| anthropic-origin threads | **63** |
+| origin distribution | `anthropic=63`, `codexify=0`, `openai=0`, `NULL=0` |
+| messages on anthropic threads | **784** |
+| distinct importing users | 1 (`local`) |
+| imported thread provenance metadata | `metadata->>'import_source'='claude'` on 63/63 |
+
+Second independent readback (separate psql invocation after terminal completion): identical — 63 threads, 784 messages, distribution `anthropic=63`, 1 distinct user. Postgres is the authority; no in-process or API-payload dependence.
+
+## Negative persistence checks (post-import counts, isolated DB)
+
+| surface | count | verdict |
+|---|---|---|
+| `projects` | 2 — `General` (backend default) + `Imports` (canonical writer's import container) | PASS: no `projects/*.json` record became a Project entity (3 project files → 0 project rows) |
+| `memory_entries` | 0 | PASS: `memories.json` created no memory state |
+| `personal_facts` / `personal_fact_evidence` | 3 / 74 | OBSERVED: all 74 evidence rows link via `source_message_id` to messages in anthropic-origin threads — conversation-derived fact-candidate extraction by the pre-existing canonical Claude writer (same behavior as ChatGPT imports), NOT `memories.json` ingestion |
+| `user_profiles` | 0 | PASS: `users.json` created no persona/account identity state |
+| `media_assets`, `uploaded_images`, `generated_images`, `uploaded_documents`, `generated_documents`, `thread_documents`, `project_document_links` | 0 each | PASS: no fabricated media/document assets |
+
+Limitation stated: pre-import baseline counts for non-thread tables were not captured (only threads/messages/jobs); attribution above is by row identity/lineage (canonical container project, evidence→imported-message links), which the schema supports. Nothing beyond that is claimed.
+
+## UI completion (terminal state)
+
+The rendered modal reached a terminal state and remained functional: it rendered "Account import failed — The export finished processing, but no canonical entities were committed." with a "Review failure details" disclosure, and the coordinator persisted `{jobId: 2cc3cf45-…, status: "failed", sourceSystem: "anthropic"}`. No screenshot committed.
+
+## Invariants
+
+1. One importer — PASS: no new route/queue/worker/job table/writer; single queue `codexify:queue:account-import`, single `openai_account_import_jobs` table.
+2. Explicit source authority — PASS: job created with exactly `source_system="anthropic"`.
+3. Backend provenance authority — PASS: browser never sends `origin_system` (api.ts rejects any response carrying it); persisted origin produced by backend canonicalization (`import_source="claude"` → `origin_system="anthropic"`).
+4. Canonical durable lineage — PASS: 63/63 imported threads read back `origin_system="anthropic"`.
+5. Isolated proof runtime — PASS: unique disposable Compose project, fresh volumes, `recovered=0`, zero jobs/threads at baseline; no unrelated queued work consumed.
+6. Source immutability — PASS: per-file SHA-256 identical before/after; source directory untouched; staged copy removed at teardown.
+7. Private-data minimization — PASS: no conversation text captured; receipt carries counts/IDs/hashes/statuses only.
+8. No false capability expansion — PASS: no Projects/memories/users/media claims; boundaries recorded as observed (see Negative checks).
+9. No repair smuggling — PASS: the proven defect is recorded as the blocking boundary and NOT fixed in this task.
+10. No release widening — PASS: no current-state/release change.
+
+## Acceptance criteria
+
+1. Ancestry of both Web proof commits in HEAD — PASS
+2. Focused regressions — PASS (50 passed, 1 skipped: `test_chat_thread_origin_system_migration` skips without a live admin DB; environmental)
+3. Unique disposable Compose runtime — PASS
+4. Real Postgres and Redis — PASS
+5. `worker-account-import` actually running — PASS
+6. Export initiated through rendered Web UI — PASS (folder interaction, manual OS chooser step)
+7. UI selection Anthropic — PASS
+8. Persisted job `source_system="anthropic"` — PASS
+9. Redis-backed worker execution consumes the job — PASS
+10. Job reaches durable terminal `completed` — **FAIL (terminal `failed`)**
+11. ≥1 imported anthropic-origin thread — PASS (63)
+12. ≥1 persisted message on those threads — PASS (784)
+13. Every proof-scoped imported thread `origin_system="anthropic"` — PASS (63/63)
+14. Imported rows belong to the importing user — PASS (1 user, `local`)
+15. Second independent Postgres readback reproduces counts — PASS
+16. No second importer/queue/worker/route/persistence path introduced — PASS
+17. Export not modified or committed — PASS
+18. No private content in the receipt — PASS
+19. Unsupported Projects/memory/profile/media semantics not claimed — PASS
+20. No release/current-state claim widened — PASS
+
+## First blocking boundary (required — status BLOCKED)
+
+`guardian/workers/account_import_worker.py` (Anthropic branch, lines ~198–228) invokes the canonical writer (`import_anthropic_export_path` → `ingest_claude_export`, which durably commits threads/messages and returns `threads_imported=63`) and calls `service.record_source_summary(...)` + `service.complete_job(...)` **without first recording the committed thread/message counts onto the durable job** (the OpenAI branch does this via `record_conversation_batch`; the Anthropic branch has no equivalent). `complete_job` (`guardian/services/openai_account_import.py:1210–1223`) derives `committed_entity_count` exclusively from `job.imported_thread_count + imported_message_count + imported_media_count` (plus `checkpoint.canonical_duplicate_count`); with all counters 0 it raises `account_import_no_committed_entities`, which the worker's catch-all persists as terminal `failed`.
+
+Observed consequence on the real export: 63 anthropic-origin threads and 784 messages committed to Postgres (`origin_system="anthropic"`, user `local`), while the durable job reports `failed` with zero tracked entities — a false-negative terminal verdict that violates the account-export-restore-contract's intent (a `completed` result must follow committed canonical writes whose bounded counts are known; here they were known to the adapter result and not propagated).
+
+Not repaired in this task (invariant 9).
+
+## ADR impact
+
+- Governing ADRs: **ADR-001** (Queue-Based Completion Acceptance Model), **ADR-005** (Runtime Mode and Account Boundary Invariants), **ADR-069** (Codexify Beta Runtime Support Boundary); normative contract `account-export-restore-contract.md` (canonical conversation origin + background account-import completion semantics).
+- Verdict: **Aligned with existing ADR(s); no architecture change.** The runtime exercised only already-accepted implementation; the blocker is a worker bookkeeping defect within the accepted seam, not an accepted-invariant conflict.
+
+## Documentation follow-through
+
+- Proof artifact created: this file (the only tracked change).
+- `00-current-state.md`: unchanged.
+- No release promotion made; no release/current-state claim widened.
+- Deferred next slice (BLOCKED variant, exactly one): **Repair the first proven runtime blocker in a separate atomic task before repeating the Anthropic runtime proof.**
+
+## Teardown
+
+- Project verified (`codexify_anthropic_import_proof_20260819`) and torn down with the exact same files: `docker compose --env-file .env.tester -p codexify_anthropic_import_proof_20260819 -f docker-compose.yml -f /private/tmp/codexify-anthropic-proof.override.yml down -v`. Only proof-project volumes/network removed; `codexify`, `codexify_tester`, `codexify-audit`, `codexify_private_preview` untouched.
+- Proof job's staged private bytes removed from the shared staging root (only the job-scoped directory); other projects' staging directories untouched.
+- Source export untouched.

--- a/frontend/src/components/modals/__tests__/ChatGPTImportModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/ChatGPTImportModal.test.tsx
@@ -32,12 +32,20 @@ vi.mock("@/features/imports/accountImportCoordinator", () => ({
   subscribeAccountImportCoordinator: coordinator.subscribe,
 }));
 
-vi.mock("@/lib/api", () => ({
-  default: { post: apiMocks.post },
-  normalizeChatGptImportStats: (payload: unknown) => payload,
-  normalizeImportRuntimeError: () => ({ message: "Import failed" }),
-  preflightBackendAvailability: apiMocks.preflight,
-}));
+// Use `importOriginal` so the real module exports are preserved. The modal
+// imports `isAccountImportSourceSystem` (and other helpers) from
+// `@/lib/api`; a partial mock that omits them prevents the component from
+// resolving the canonical source validator at submit time.
+vi.mock(import("@/lib/api"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    default: { post: apiMocks.post },
+    normalizeChatGptImportStats: (payload: unknown) => payload,
+    normalizeImportRuntimeError: () => ({ message: "Import failed" }),
+    preflightBackendAvailability: apiMocks.preflight,
+  };
+});
 
 import {
   ChatGPTImportModal,
@@ -149,9 +157,26 @@ describe("ChatGPTImportModal account export intake", () => {
       <ChatGPTImportModal open onOpenChange={vi.fn()} userName="account-a" />
     );
 
-    await user.click(
-      screen.getByTestId("account-import-source-anthropic")
-    );
+    const openaiRadio = screen.getByTestId(
+      "account-import-source-openai"
+    ) as HTMLInputElement;
+    const anthropicRadio = screen.getByTestId(
+      "account-import-source-anthropic"
+    ) as HTMLInputElement;
+    expect(openaiRadio.checked).toBe(true);
+    expect(anthropicRadio.checked).toBe(false);
+
+    await user.click(anthropicRadio);
+
+    // Observable rendered selection: the Anthropic radio is now checked and
+    // the OpenAI radio is no longer checked. The styled label reinforces the
+    // selection but the `checked` attribute is the canonical, library-agnostic
+    // proof of active selection.
+    expect(anthropicRadio.checked).toBe(true);
+    expect(openaiRadio.checked).toBe(false);
+    expect(
+      screen.getByText("Anthropic (Claude)").closest("label")
+    ).toHaveAttribute("style", expect.stringContaining("rgba(34, 197, 94"));
 
     fireEvent.drop(
       screen.getByText(/Drop a conversation JSON/).closest("div.rounded-xl")!,
@@ -164,11 +189,25 @@ describe("ChatGPTImportModal account export intake", () => {
     );
 
     await waitFor(() => expect(coordinator.start).toHaveBeenCalledOnce());
+    // The submission crossed the existing import-submission seam with the
+    // canonical Anthropic source. No `origin_system` field is ever sent.
     expect(coordinator.start).toHaveBeenCalledWith(
       expect.any(Array),
       "account-a",
       "anthropic"
     );
+    const [
+      startFiles,
+      startUserId,
+      startSource,
+      startOptions,
+    ] = coordinator.start.mock.calls[0];
+    expect(startFiles).toEqual(expect.any(Array));
+    expect(startUserId).toBe("account-a");
+    expect(startSource).toBe("anthropic");
+    // Only the three documented arguments flow through the seam; any
+    // surfaced origin_system would appear here as a fourth argument.
+    expect(startOptions).toBeUndefined();
   });
 
   it("sends source_system=openai when OpenAI is selected and a folder is dropped", async () => {
@@ -181,9 +220,21 @@ describe("ChatGPTImportModal account export intake", () => {
       <ChatGPTImportModal open onOpenChange={vi.fn()} userName="account-a" />
     );
 
-    await user.click(
-      screen.getByTestId("account-import-source-openai")
-    );
+    const openaiRadio = screen.getByTestId(
+      "account-import-source-openai"
+    ) as HTMLInputElement;
+    const anthropicRadio = screen.getByTestId(
+      "account-import-source-anthropic"
+    ) as HTMLInputElement;
+    expect(openaiRadio.checked).toBe(true);
+
+    // Selecting Anthropic then re-selecting OpenAI must round-trip through
+    // the rendered UI without leaking the previous selection.
+    await user.click(anthropicRadio);
+    expect(anthropicRadio.checked).toBe(true);
+    await user.click(openaiRadio);
+    expect(openaiRadio.checked).toBe(true);
+    expect(anthropicRadio.checked).toBe(false);
 
     fireEvent.drop(
       screen.getByText(/Drop a conversation JSON/).closest("div.rounded-xl")!,
@@ -201,6 +252,53 @@ describe("ChatGPTImportModal account export intake", () => {
       "account-a",
       "openai"
     );
+  });
+
+  it("routes both Anthropic and OpenAI through the same existing submission seam", async () => {
+    const user = userEvent.setup();
+    const json = new File(["[]"], "conversations.json");
+    const root = directoryEntry("/export", [
+      [fileEntry("/export/conversations.json", json)],
+    ]);
+    render(
+      <ChatGPTImportModal open onOpenChange={vi.fn()} userName="account-a" />
+    );
+
+    // Drive the Anthropic branch through the same modal, then the OpenAI
+    // branch. Both must call the same `startOpenAIAccountImport` from
+    // `@/features/imports/accountImportCoordinator` — the existing import
+    // submission seam — not a separate endpoint or component.
+    await user.click(screen.getByTestId("account-import-source-anthropic"));
+    fireEvent.drop(
+      screen.getByText(/Drop a conversation JSON/).closest("div.rounded-xl")!,
+      {
+        dataTransfer: {
+          items: [{ webkitGetAsEntry: () => root }],
+          files: [],
+        },
+      }
+    );
+    await waitFor(() => expect(coordinator.start).toHaveBeenCalledTimes(1));
+    expect(coordinator.start.mock.calls[0][2]).toBe("anthropic");
+
+    // Reset and drive the OpenAI branch through the same modal.
+    coordinator.start.mockClear();
+    await user.click(screen.getByTestId("account-import-source-openai"));
+    fireEvent.drop(
+      screen.getByText(/Drop a conversation JSON/).closest("div.rounded-xl")!,
+      {
+        dataTransfer: {
+          items: [{ webkitGetAsEntry: () => root }],
+          files: [],
+        },
+      }
+    );
+    await waitFor(() => expect(coordinator.start).toHaveBeenCalledTimes(1));
+    expect(coordinator.start.mock.calls[0][2]).toBe("openai");
+
+    // The legacy single-file ChatGPT endpoint must not be involved in
+    // either path through the rendered modal.
+    expect(apiMocks.post).not.toHaveBeenCalled();
   });
 
   it("only ever serializes canonical source values when a folder is dropped", async () => {
@@ -325,9 +423,12 @@ describe("ChatGPTImportModal account export intake", () => {
     );
 
     await waitFor(() => expect(coordinator.start).toHaveBeenCalledOnce());
+    // The default source is "openai" because the explicit selector defaults
+    // to OpenAI; the third argument must always be the canonical source.
     expect(coordinator.start).toHaveBeenCalledWith(
       [{ file: archive, relativePath: "openai-export.zip" }],
-      "account-a"
+      "account-a",
+      "openai"
     );
   });
 

--- a/guardian/services/openai_account_import.py
+++ b/guardian/services/openai_account_import.py
@@ -828,6 +828,87 @@ class OpenAIAccountImportService:
             session.refresh(job)
             return self.serialize_job(job)
 
+    def record_committed_conversation_totals(
+        self,
+        *,
+        job_id: str,
+        user_id: str,
+        threads_imported: int,
+        messages_imported: int,
+        phase_key: str = "conversations",
+    ) -> dict[str, Any]:
+        """Durably credit canonical committed conversation totals onto the job.
+
+        Provider-neutral aggregate accounting for import sources whose
+        canonical writer returns authoritative committed thread/message totals
+        (for example the Anthropic/Claude lane) instead of per-conversation
+        batch checkpoints. The worker names the phase via ``phase_key``; the
+        durable accounting semantics are source-agnostic.
+
+        Idempotency is durable, not process-local: the first application
+        records the credited totals in ``checkpoint["committed_conversation_totals"]``
+        and increments the job counters; an exact replay of the same evidence
+        leaves the totals unchanged; a replay that attempts materially
+        different totals for the same phase fails closed with an explicit
+        accounting inconsistency instead of overwriting or incrementing again.
+
+        Zero totals record no checkpoint entry and credit nothing, so a
+        legitimate zero-commit result still fails the existing
+        no-committed-entities terminal guard and can be retried later.
+        """
+
+        threads = max(0, int(threads_imported))
+        messages = max(0, int(messages_imported))
+        normalized_key = str(phase_key or "").strip() or "conversations"
+        with self.db.get_session() as session:
+            job = self._require_job(session, job_id, user_id, for_update=True)
+            checkpoint = dict(job.checkpoint or {})
+            recorded = list(checkpoint.get("committed_conversation_totals") or [])
+            existing = next(
+                (
+                    entry
+                    for entry in recorded
+                    if str(entry.get("key")) == normalized_key
+                ),
+                None,
+            )
+            if existing is not None:
+                existing_threads = max(0, int(existing.get("threads_imported", 0)))
+                existing_messages = max(0, int(existing.get("messages_imported", 0)))
+                if (existing_threads, existing_messages) != (threads, messages):
+                    raise AccountImportError(
+                        "Committed conversation totals conflict with already "
+                        f"recorded accounting for phase={normalized_key!r} "
+                        f"(recorded {existing_threads} threads / "
+                        f"{existing_messages} messages; replay attempted "
+                        f"{threads} threads / {messages} messages).",
+                        code="committed_totals_conflict",
+                        status_code=409,
+                    )
+                session.refresh(job)
+                return self.serialize_job(job)
+            if threads or messages:
+                recorded.append(
+                    {
+                        "key": normalized_key,
+                        "threads_imported": threads,
+                        "messages_imported": messages,
+                    }
+                )
+                checkpoint["committed_conversation_totals"] = recorded
+                job.checkpoint = checkpoint
+                flag_modified(job, "checkpoint")
+                job.imported_thread_count = (
+                    int(job.imported_thread_count or 0) + threads
+                )
+                job.imported_message_count = (
+                    int(job.imported_message_count or 0) + messages
+                )
+                job.updated_at = _utcnow()
+                session.commit()
+                session.refresh(job)
+            return self.serialize_job(job)
+
     def _resolve_import_project(
         self, session: Session, *, user_id: str
     ) -> Project:

--- a/guardian/workers/account_import_worker.py
+++ b/guardian/workers/account_import_worker.py
@@ -218,6 +218,19 @@ def process_account_import_task(
                     user_id=user_id,
                     summary=source_summary,
                 )
+                # Credit the canonical writer's authoritative committed totals
+                # onto the durable job BEFORE terminal classification. The
+                # adapter result carries writer-derived thread/message counts
+                # (never source-discovery totals); without this accounting,
+                # ``complete_job`` would reject the internally inconsistent
+                # zero-counter job even though persistence succeeded.
+                service.record_committed_conversation_totals(
+                    job_id=job_id,
+                    user_id=user_id,
+                    threads_imported=anthropic_result.conversations_imported,
+                    messages_imported=anthropic_result.messages_imported,
+                    phase_key="anthropic_conversations",
+                )
                 # Anthropic corpus only writes chat thread/message rows; the
                 # existing account-import contract treats media ingestion as
                 # an OpenAI-specific flow. Per source-family policy, the

--- a/tests/rag/test_anthropic_export_adapter.py
+++ b/tests/rag/test_anthropic_export_adapter.py
@@ -593,6 +593,7 @@ def test_dispatch_path_calls_ingest_claude_export_with_normalized_records(
 
     assert result.conversations_discovered == 1
     assert result.conversations_imported == 1
+    assert result.messages_imported == 2
     assert result.conversations_failed == 0
     assert captured.user_id == "account-a"
 
@@ -606,6 +607,45 @@ def test_dispatch_path_calls_ingest_claude_export_with_normalized_records(
     # Sanity: the conversation passed through keeps its original message IDs.
     message_uuids = [m["uuid"] for m in payload[0]["chat_messages"]]
     assert message_uuids == ["m-1", "m-2"]
+
+
+def test_writer_committed_counts_are_normalized_non_negative(
+    monkeypatch, tmp_path: Path
+):
+    """Writer-reported totals must survive the adapter boundary as safe
+    non-negative integers; malformed values normalize to zero."""
+
+    captured = SimpleNamespace(blob=b"")
+
+    def _capture_ingest(content: bytes, *, user_id: str):  # type: ignore[no-untyped-def]
+        captured.blob = content
+        return {
+            "threads_imported": "3",
+            "messages_imported": None,
+            "projects_created": 0,
+            "projects_reused": 0,
+            "messages_filtered": 0,
+            "embedding_candidates": 0,
+            "embeddings_persisted": 0,
+            "embeddings_failed": 0,
+            "embedding_coverage_degraded": False,
+        }
+
+    monkeypatch.setattr(
+        "backend.rag.chatgpt_migration.ingest_claude_export", _capture_ingest
+    )
+
+    conv = _anthropic_conversation(
+        conv_uuid="c-normalize",
+        name="Normalize",
+        messages=[_anthropic_message(sender="human", text="hi")],
+    )
+    _write_anthropic_export(tmp_path, conversations=[conv])
+
+    result = import_anthropic_export_path(tmp_path, user_id="account-a")
+
+    assert result.conversations_imported == 3  # "3" normalizes to 3
+    assert result.messages_imported == 0  # None normalizes to 0
 
 
 def test_projects_users_memories_presence_does_not_fail_dispatch(

--- a/tests/rag/test_openai_export_account_import.py
+++ b/tests/rag/test_openai_export_account_import.py
@@ -536,6 +536,222 @@ def test_zero_committed_entities_cannot_be_classified_as_success(
 
 
 # ---------------------------------------------------------------------------
+# Provider-neutral committed-conversation-total accounting
+# ---------------------------------------------------------------------------
+
+
+def test_committed_conversation_totals_first_application_credits_durable_job(
+    account_import_service,
+):
+    service, _sessions, _trace, _staging, _media = account_import_service
+    job = service.create_job(
+        user_id="account-a",
+        total_file_count=1,
+        total_byte_count=2,
+        source_system="anthropic",
+    )
+
+    credited = service.record_committed_conversation_totals(
+        job_id=job["job_id"],
+        user_id="account-a",
+        threads_imported=63,
+        messages_imported=784,
+        phase_key="anthropic_conversations",
+    )
+
+    assert credited["imported_thread_count"] == 63
+    assert credited["imported_message_count"] == 784
+    assert credited["source_system"] == "anthropic"
+
+    # Durable readback through a separate serialization confirms persistence,
+    # including the durable accounting checkpoint entry.
+    reread = service.get_worker_job(job_id=job["job_id"], user_id="account-a")
+    assert reread["imported_thread_count"] == 63
+    assert reread["imported_message_count"] == 784
+    assert reread["checkpoint"]["committed_conversation_totals"] == [
+        {
+            "key": "anthropic_conversations",
+            "threads_imported": 63,
+            "messages_imported": 784,
+        }
+    ]
+
+
+def test_committed_conversation_totals_exact_replay_is_idempotent(
+    account_import_service,
+):
+    service, _sessions, _trace, _staging, _media = account_import_service
+    job = service.create_job(
+        user_id="account-a", total_file_count=1, total_byte_count=2
+    )
+    service.record_committed_conversation_totals(
+        job_id=job["job_id"],
+        user_id="account-a",
+        threads_imported=63,
+        messages_imported=784,
+        phase_key="anthropic_conversations",
+    )
+
+    replay = service.record_committed_conversation_totals(
+        job_id=job["job_id"],
+        user_id="account-a",
+        threads_imported=63,
+        messages_imported=784,
+        phase_key="anthropic_conversations",
+    )
+
+    assert replay["imported_thread_count"] == 63
+    assert replay["imported_message_count"] == 784
+    internal = service.get_worker_job(job_id=job["job_id"], user_id="account-a")
+    assert len(
+        internal["checkpoint"]["committed_conversation_totals"]
+    ) == 1
+
+
+def test_committed_conversation_totals_conflicting_replay_fails_closed(
+    account_import_service,
+):
+    service, _sessions, _trace, _staging, _media = account_import_service
+    job = service.create_job(
+        user_id="account-a", total_file_count=1, total_byte_count=2
+    )
+    service.record_committed_conversation_totals(
+        job_id=job["job_id"],
+        user_id="account-a",
+        threads_imported=63,
+        messages_imported=784,
+        phase_key="anthropic_conversations",
+    )
+
+    with pytest.raises(AccountImportError) as conflict:
+        service.record_committed_conversation_totals(
+            job_id=job["job_id"],
+            user_id="account-a",
+            threads_imported=63,
+            messages_imported=785,
+            phase_key="anthropic_conversations",
+        )
+    assert conflict.value.code == "committed_totals_conflict"
+    assert conflict.value.status_code == 409
+
+    unchanged = service.get_worker_job(job_id=job["job_id"], user_id="account-a")
+    assert unchanged["imported_thread_count"] == 63
+    assert unchanged["imported_message_count"] == 784
+
+
+def test_committed_conversation_totals_positive_counts_satisfy_complete_job(
+    account_import_service,
+):
+    service, _sessions, _trace, _staging, _media = account_import_service
+    job = service.create_job(
+        user_id="account-a", total_file_count=1, total_byte_count=2
+    )
+    service.stage_files(
+        job_id=job["job_id"],
+        user_id="account-a",
+        files=[StagedImportFile("conversations.json", b"[]")],
+    )
+    service.finalize_job(job_id=job["job_id"], user_id="account-a")
+    service.mark_running(job_id=job["job_id"], user_id="account-a")
+    service.record_source_summary(
+        job_id=job["job_id"],
+        user_id="account-a",
+        summary={
+            "conversations_discovered": 65,
+            "conversations_accepted": 65,
+            "conversations_skipped": 0,
+            "conversations_failed": 0,
+            "conversation_transactions_committed": True,
+        },
+    )
+    service.record_committed_conversation_totals(
+        job_id=job["job_id"],
+        user_id="account-a",
+        threads_imported=63,
+        messages_imported=784,
+        phase_key="anthropic_conversations",
+    )
+
+    completed = service.complete_job(job_id=job["job_id"], user_id="account-a")
+
+    assert completed["status"] == "completed"
+    assert completed["imported_thread_count"] == 63
+    assert completed["imported_message_count"] == 784
+    assert completed["source_summary"]["conversation_transactions_committed"] is True
+
+
+def test_committed_conversation_totals_zero_counts_do_not_bypass_guard(
+    account_import_service,
+):
+    service, _sessions, _trace, _staging, _media = account_import_service
+    job = service.create_job(
+        user_id="account-a", total_file_count=1, total_byte_count=2
+    )
+    service.stage_files(
+        job_id=job["job_id"],
+        user_id="account-a",
+        files=[StagedImportFile("conversations.json", b"[]")],
+    )
+    service.finalize_job(job_id=job["job_id"], user_id="account-a")
+    service.mark_running(job_id=job["job_id"], user_id="account-a")
+    zero = service.record_committed_conversation_totals(
+        job_id=job["job_id"],
+        user_id="account-a",
+        threads_imported=0,
+        messages_imported=0,
+        phase_key="anthropic_conversations",
+    )
+    assert zero["imported_thread_count"] == 0
+    assert zero["imported_message_count"] == 0
+    internal = service.get_worker_job(job_id=job["job_id"], user_id="account-a")
+    assert internal["checkpoint"].get("committed_conversation_totals") in (
+        None,
+        [],
+    )
+
+    with pytest.raises(AccountImportError) as exc_info:
+        service.complete_job(job_id=job["job_id"], user_id="account-a")
+    assert exc_info.value.code == AccountImportErrorCode.NO_COMMITTED_ENTITIES.value
+
+
+def test_committed_conversation_totals_phase_keys_accumulate_independently(
+    account_import_service,
+):
+    service, _sessions, _trace, _staging, _media = account_import_service
+    job = service.create_job(
+        user_id="account-a", total_file_count=1, total_byte_count=2
+    )
+    service.record_committed_conversation_totals(
+        job_id=job["job_id"],
+        user_id="account-a",
+        threads_imported=63,
+        messages_imported=784,
+        phase_key="anthropic_conversations",
+    )
+    second = service.record_committed_conversation_totals(
+        job_id=job["job_id"],
+        user_id="account-a",
+        threads_imported=1,
+        messages_imported=1,
+        phase_key="another_source_conversations",
+    )
+    assert second["imported_thread_count"] == 64
+    assert second["imported_message_count"] == 785
+    internal = service.get_worker_job(job_id=job["job_id"], user_id="account-a")
+    assert len(internal["checkpoint"]["committed_conversation_totals"]) == 2
+
+    replay = service.record_committed_conversation_totals(
+        job_id=job["job_id"],
+        user_id="account-a",
+        threads_imported=63,
+        messages_imported=784,
+        phase_key="anthropic_conversations",
+    )
+    assert replay["imported_thread_count"] == 64
+    assert replay["imported_message_count"] == 785
+
+
+# ---------------------------------------------------------------------------
 # Retry seam service tests
 # ---------------------------------------------------------------------------
 

--- a/tests/workers/test_account_import_worker.py
+++ b/tests/workers/test_account_import_worker.py
@@ -67,6 +67,10 @@ class FakeWorkerService:
         self.calls.append(("source-summary", kwargs["summary"]))
         return {}
 
+    def record_committed_conversation_totals(self, **kwargs):
+        self.calls.append(("committed-totals", kwargs))
+        return {}
+
     def import_image_record(self, **kwargs):
         path = kwargs["record"].path
         self.calls.append(("image", path))
@@ -355,6 +359,7 @@ def test_worker_dispatches_anthropic_source_to_anthropic_adapter(
             errors=[],
             conversations_discovered=2,
             conversations_imported=2,
+            messages_imported=2,
             conversations_failed=0,
         )
 
@@ -409,10 +414,73 @@ def test_worker_dispatches_anthropic_source_to_anthropic_adapter(
         for name, payload in service.calls
     )
     assert any(name == "complete" for name, _ in service.calls)
+    # The Anthropic branch credits durable committed totals before completion.
+    assert any(name == "committed-totals" for name, _ in service.calls)
     # Crucially: the OpenAI-only helpers were never called.
     assert not any(
         name in {"conversation-batch", "media-batch"} for name, _ in service.calls
     )
+
+
+def test_worker_anthropic_credits_writer_committed_totals_before_completion(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The Anthropic branch must credit the canonical writer's committed
+    thread/message totals onto the durable job BEFORE terminal classification,
+    in the order: adapter → source summary → committed-total accounting →
+    complete_job. Discovered totals must never be substituted for committed
+    totals (synthetic mismatch: 4 discovered, 3 threads, 12 messages)."""
+
+    service = FakeAnthropicService(source_system="anthropic")
+
+    def _import_anthropic(_root, **kwargs):
+        return SimpleNamespace(
+            errors=[],
+            conversations_discovered=4,
+            conversations_imported=3,
+            messages_imported=12,
+            conversations_failed=0,
+        )
+
+    monkeypatch.setattr(
+        account_import_worker,
+        "import_anthropic_export_conversations",
+        _import_anthropic,
+    )
+
+    result = account_import_worker.process_account_import_task(
+        {
+            "type": TASK_TYPE,
+            "job_id": "job-anthropic-totals",
+            "user_id": "account-a",
+        },
+        service=service,
+    )
+
+    assert result is True
+    names = [name for name, _ in service.calls]
+    assert (
+        names.index("source-summary")
+        < names.index("committed-totals")
+        < names.index("complete")
+    )
+    totals = [
+        payload
+        for name, payload in service.calls
+        if name == "committed-totals"
+    ]
+    assert totals == [
+        {
+            "job_id": "job-anthropic-totals",
+            "user_id": "account-a",
+            "threads_imported": 3,
+            "messages_imported": 12,
+            "phase_key": "anthropic_conversations",
+        }
+    ]
+    # Discovery (4) must never be credited as committed threads (3).
+    assert totals[0]["threads_imported"] == 3
+    assert totals[0]["threads_imported"] != 4
 
 
 def test_worker_keeps_openai_dispatch_unchanged(
@@ -510,6 +578,7 @@ def test_worker_anthropic_dispatch_fails_closed_on_adapter_error(
             errors=["chat_messages payload was missing"],
             conversations_discovered=0,
             conversations_imported=0,
+            messages_imported=0,
             conversations_failed=0,
         )
 


### PR DESCRIPTION
## Summary

- Add Anthropic export adaptation for account imports.
- Wire account-import handling through Guardian services and workers.
- Add frontend import-modal coverage and runtime proof documentation.
- Expand adapter, account-import, and worker tests.

## Testing

- Added and updated focused tests for Anthropic export adaptation, account importing, worker behavior, and the ChatGPT import modal.