### PR TITLE
Reconcile Phase 3 DLG node count

### DIFF
--- a/tests/architecture/test_document_lifecycle_graph_phase3.py
+++ b/tests/architecture/test_document_lifecycle_graph_phase3.py
@@ -184,14 +184,14 @@ def contract_and_adr() -> tuple[dict, dict]:
     return adr, contract
 
 
-def test_current_nine_node_corpus_validates() -> None:
+def test_current_canonical_node_corpus_validates() -> None:
     result = dlg.validate_repository(
         REPO_ROOT, current_repository_revision(), BASE_GENERATED_AT
     )
 
     assert not result.has_errors
-    assert result.schema_valid_node_count == 9
-    assert result.source_hash_match_count == 9
+    assert result.schema_valid_node_count == 10
+    assert result.source_hash_match_count == 10
 
 
 def test_current_relationship_baseline_and_target_resolution() -> None:
@@ -639,5 +639,5 @@ def test_validator_cli_runs_without_runtime_services() -> None:
 
     assert completed.returncode == 0, completed.stdout + completed.stderr
     summary = json.loads(completed.stdout)
-    assert summary["corpus"]["node_count"] == 9
+    assert summary["corpus"]["node_count"] == 10
     assert summary["corpus"]["edge_count"] == 8


### PR DESCRIPTION
## Reconcile Phase 3 DLG node count

Follow-up flagged in PR #728's closeout: the packet-required addition of the canonical DLG evidence node `codexify:doc:proof:2026-08-19-anthropic-account-import-supported-runtime-proof-r2` moved the corpus from 9 to 10 nodes, but `tests/architecture/test_document_lifecycle_graph_phase3.py` still hard-pinned the count at 9.

Changes (4 lines):

- `test_current_nine_node_corpus_validates` → renamed `test_current_canonical_node_corpus_validates`; `schema_valid_node_count` 9 → 10, `source_hash_match_count` 9 → 10
- `test_validator_cli_runs_without_runtime_services`: CLI `node_count` 9 → 10

### Honest CI note — pre-existing DLG drift, not introduced here

With the pins corrected, two phase3 tests still fail on this branch — but with an error set **identical to a clean checkout of current `origin/main`** (`a391fd802`), verified by direct validator comparison:

- `content_hash_mismatch` × 3: `codexify:doc:architecture:adr-index`, `codexify:doc:architecture:current-state`, `codexify:doc:architecture:kb-entrypoint`
- `broken_local_markdown_link` warnings × 7 (kb-entrypoint ×6, current-state ×1)

The current-state mismatch predates the Anthropic import work (verified: `15227e6f8` already mismatched). Repairing these three node hashes is the separate DLG freshness-reverification task (`architecture-control-plane-freshness-reverification`), not this pin reconciliation.
