### PR TITLE
Unify Guardian approval prompts across chat surfaces

### DIFF
--- a/docs/architecture/chrome-side-panel-client.md
+++ b/docs/architecture/chrome-side-panel-client.md
@@ -8,7 +8,7 @@ The smallest viable network is one operator-controlled Chrome profile, one confi
 
 ## Implementation status
 
-The implementation lives in `frontend/chrome-extension` and builds independently to `frontend/dist/chrome-extension`. It includes the dual-mode connection form, one extension-local profile, local API-key and remote session/JWT transports, thread/message/completion adapters, correlation-bound per-task event observation, explicit task cancellation, a side-panel chat shell, unit tests, and an installation runbook.
+The implementation lives in `frontend/chrome-extension` and builds independently to `frontend/dist/chrome-extension`. It includes the dual-mode connection form, one extension-local profile, local API-key and remote session/JWT transports, thread/message/completion adapters, correlation-bound per-task event observation, explicit task cancellation, a bounded Guardian thread-intervention projection, a side-panel chat shell, unit tests, and an installation runbook.
 
 The original API-key-only build was accepted by Chrome through **Load unpacked**, and its toolbar action opened the native side panel in a live operator screenshot. That proof does not cover the new dual-auth build, remote login, account-scoped chat, completion, session restore, or logout. Those remain code-path and automated-build evidence until the live proof below is completed. None of this is evidence that the extension is a supported Codexify client.
 
@@ -52,6 +52,7 @@ The extension page owns active React state, HTTP requests, and the task-event su
 | State | Source of truth | Consistency / conflict policy |
 |---|---|---|
 | Threads and messages | Existing Codexify backend | Backend-authoritative; the client refreshes derived views. Persisted assistant output is final truth. |
+| Thread intervention and approval decision | Existing Guardian agent-run and browser-approval records | Guardian-authoritative and thread-scoped. The client derives a transient presentation, submits only the exact displayed approval ID, and refreshes; it stores no approval truth and invents no continuation. |
 | Completion attempt | Existing backend task/queue state | Acceptance is non-terminal. Per-task SSE is an observation plane; missing events do not rewrite task truth. |
 | `taskId`, `requestId`, `turnId`, discovery URLs | Completion acceptance receipt | Preserved for the attempt; never silently replaced by a replay. |
 | Backend URL, auth mode, selected thread, verification timestamps | One extension-local record in `chrome.storage.local` | Local to the installed extension. Explicit Save, thread selection, or Disconnect wins. No cross-device merge or Sync. |
@@ -123,6 +124,10 @@ The observable sequence is:
 5. `completed`, `failed_retryable`, or `cancelled`: terminal task evidence.
 6. On completion only, refresh persisted messages and render the stored assistant reply.
 
+Relevant active-task lifecycle evidence also refreshes the selected thread's
+derived intervention projection. The refresh does not create another completion,
+replay work, or infer approval from elapsed time or model text.
+
 The client imports canonical `CHAT_REQUEST_STATES` instead of inventing parallel runtime tokens. `connection_lost` is an extension transport-view state, deliberately not the server-side `orphaned` request state.
 
 The MV3 service worker uses `chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true })`. Chrome's [side-panel contract](https://developer.chrome.com/docs/extensions/reference/api/sidePanel) defines that action behavior, while Chrome's [service-worker lifecycle](https://developer.chrome.com/docs/extensions/develop/concepts/service-workers/lifecycle) requires the worker to tolerate termination rather than own long-running chat state.
@@ -137,6 +142,8 @@ The extension changes no routes and uses these current contracts directly:
 - `GET /api/user/profile` and `PATCH /api/user/profile` for the account-scoped accent colour preference.
 - `GET /api/chat/threads` and `POST /api/chat/threads` for persisted thread listing/creation.
 - `GET /api/chat/{threadId}/messages` and `POST /api/chat/{threadId}/messages` for authoritative transcript reads and user-message persistence.
+- `GET /api/chat/{threadId}/agent-runs` plus `GET /api/browser/approvals?status_value=PENDING` for the selected thread's derived intervention presentation.
+- `POST /api/browser/approvals/{approvalId}/approve` and `POST /api/browser/approvals/{approvalId}/deny` for one explicit decision bound to the exact displayed pending approval.
 - `POST /api/chat/{threadId}/complete` with a generated `turn_id`, `X-Request-ID`, and an optional `browser_context` payload carrying explicitly captured selection evidence for exactly that one completion attempt. The backend treats `browser_context` as untrusted, turn-scoped context that is never persisted, embedded, or written into message metadata, memory, retrieval, or identity stores; it is absent for normal web clients.
 - `GET /api/tasks/{taskId}/events` with the selected local API-key or remote Bearer credential for attempt lifecycle observation.
 - Completion receipt fields `task_id`, `thread_id`, `turn_id`, `acceptance_status`, `acceptance_warnings`, `messages_url`, and `trace_url`.
@@ -147,7 +154,15 @@ Shared reuse is deliberately bounded:
 - `frontend/src/contracts/runtimeTokens.ts` supplies canonical chat-request tokens.
 - `frontend/src/lib/guardianEventSource.ts` supplies authenticated SSE parsing and reconnect behavior.
 
-`runtimeConfig.ts`, `api.ts`, and `useLiveEvents.ts` are not imported because their current interfaces own normal-web/Tauri environment resolution, Axios/auth-shell behavior, browser `sessionStorage`, session-spine state, or application-global event coordination. `codexifyExtensionApi.ts` is therefore a contract-equivalent fetch adapter that preserves the same local-versus-remote header rule without importing application navigation or provider state. No existing frontend source file was changed to create this seam.
+`runtimeConfig.ts`, `api.ts`, and `useLiveEvents.ts` are not imported because their current interfaces own normal-web/Tauri environment resolution, Axios/auth-shell behavior, browser `sessionStorage`, session-spine state, or application-global event coordination. `codexifyExtensionApi.ts` is therefore a contract-equivalent fetch adapter that preserves the same local-versus-remote header rule without importing application navigation or provider state. The shared intervention interpreter contains no application-shell or authentication behavior.
+
+The transport-neutral interpretation module at
+`frontend/src/features/chat/approvals/threadIntervention.ts` is shared with
+normal Guardian Chat. It classifies actionable run states, correlates only
+pending Guardian approvals, and derives the presentation and redirection prompt.
+It owns no transport, authentication, React state, browser storage, or approval
+authority. Each client keeps surface-specific rendering while consuming this one
+semantic seam.
 
 ## Release-truth boundary
 
@@ -164,6 +179,9 @@ An installable build proves only that the extension artifacts exist. Unit tests 
 - Persisted assistant messages, not event payloads, are the final transcript.
 - The local API key, remote username/password, session token, and backend origin are runtime input, never build input.
 - Local and remote credentials are mutually exclusive on every protected request.
+- Guardian remains the only approval authority; the extension stores no authoritative approval state and cannot manufacture an approval ID.
+- Hiding, navigating, reconnecting, rerendering, or submitting the composer never approves an action.
+- Approval acceptance is not evidence that execution resumed; the client does not add replay, retry, or continuation semantics.
 - Remote passwords are never stored; remote session tokens are never written to `chrome.storage.local` or Sync.
 - The full `AppShell` and normal web navigation are absent.
 - No active-page or browser-control authority exists.
@@ -175,6 +193,8 @@ Automated proof:
 
 - URL/profile/storage/permission unit tests.
 - Side-panel first-run, connected-shell, empty-submit, acceptance/terminal, transcript-refresh, and disconnect tests.
+- Shared intervention classification/correlation tests plus side-panel thread hydration, thread switching, exact approve/deny, busy-state, redirection, and lifecycle-refresh tests.
+- Local approval reads/decisions send only `X-API-Key`; remote approval reads/decisions send only Bearer auth.
 - Independent Vite production build.
 - Generated-manifest and artifact inspection.
 - Existing frontend tests and diff hygiene.
@@ -191,7 +211,7 @@ Manual live proof still required for a specific environment:
 
 ## Non-goals and deferred features
 
-Not implemented: page awareness, selection capture, content scripts, page summarization, screenshots, tabs, form filling, browser automation, context menus, document upload, Workspace/Shelf/Scratchpad/Inspector, voice, provider/model/profile selectors, persona editing, tools/command-bus UI, Web Store packaging, automatic updates, hosted-auth redesign, backend changes, or release-support expansion.
+Not implemented: a generic approvals inbox, command-bus or arbitrary tool UI, page awareness, selection capture, content scripts, page summarization, screenshots, tabs, form filling, browser automation, context menus, document upload, Workspace/Shelf/Scratchpad/Inspector, voice, provider/model/profile selectors, persona editing, Web Store packaging, automatic updates, hosted-auth redesign, backend changes, or release-support expansion.
 
 Deferred deliberately:
 

--- a/frontend/chrome-extension/README.md
+++ b/frontend/chrome-extension/README.md
@@ -79,6 +79,30 @@ The side panel includes a compact accent-colour selector next to the connection 
 - If the backend cannot be reached, the accent falls back to the neutral default and chat continues normally.
 - The accent is a presentation-preference token, not a CSS literal or raw colour value. No accent value is written to Chrome local or sync storage.
 
+## Guardian intervention prompts
+
+For the selected thread, the side panel projects the same bounded Guardian
+approval, clarification, and blocked-intervention interpretation used by normal
+Guardian Chat. A supported pending approval appears immediately above the
+composer with explicit **Approve**, **Deny**, **Inspect context**, and **Tell
+Guardian what to do instead** controls. Clarification or blocked states without
+an actual pending approval ID offer redirection instead of presenting fake
+approval actions.
+
+Guardian remains the only approval authority. The extension reads existing
+thread-run and pending-approval state, submits a decision for the exact displayed
+approval ID, and then refreshes Guardian truth. It stores no authoritative
+approval state and does not replay, retry, or claim that work continued after a
+decision. Closing the card, changing threads, reconnecting, or pressing Enter in
+the composer never approves an action.
+
+Approval reads and decisions use the same authenticated request adapter as chat:
+local mode sends only `X-API-Key`, and remote mode sends only `Authorization:
+Bearer`. No Chrome permission, content script, tab/page access, browser
+automation authority, or service-worker responsibility is added. Generic
+command-bus and tool UI remain out of scope, and this bounded projection does not
+promote the private side panel into Codexify's supported Beta surface.
+
 ## Markdown rendering
 
 Assistant messages are rendered as safe Markdown using the same `react-markdown` + `remark-gfm` stack as the main Codexify frontend.
@@ -95,6 +119,7 @@ User-authored messages remain literal and are not reinterpreted as Markdown.
 - Remote sessions require a new login after Chrome restart or extension disable/reload/update; there is no refresh-token or silent-renewal flow.
 - Manual unpacked installation and manual rebuild/reload only.
 - The side panel observes task lifecycle events but renders only persisted assistant messages as final output; it does not fabricate token streaming.
+- Guardian intervention state is refreshed from backend truth; the extension does not retain an approval inbox or authoritative browser-local approval record.
 - Closing or reloading the side panel preserves the configured connection and selected thread, but does not persist an active task-event subscription. Reopen the selected thread to read any reply that completed while the panel was closed.
 - No page awareness, selected-text capture, content scripts, screenshots, tab control, browser automation, context menus, uploads, voice, provider/model selection, persona editing, or command-bus UI.
 - No full Codexify `AppShell`, workspace navigation, documents, gallery, settings application, or secondary inspector panels.
@@ -114,8 +139,10 @@ For a live proof, use an already-healthy backend and verify in order:
 7. **Completion accepted** remains pending until task-terminal evidence arrives.
 8. The completed assistant reply is re-read from the backend transcript.
 9. During a pending completion, **Cancel** requests cancellation and the panel remains pending until correlated `task.cancelled` evidence arrives.
-10. Closing and reopening the side panel restores the connection and selected thread within the same Chrome session.
-11. Disconnect returns to the connection form and clears the credential.
+10. A thread with a correlated pending Guardian approval shows the decision card; **Approve** or **Deny** submits exactly that displayed approval ID and refreshes the card.
+11. Switching to a thread without an intervention removes the prior thread's card, while **Tell Guardian what to do instead** prefills the ordinary composer without submitting.
+12. Closing and reopening the side panel restores the connection and selected thread within the same Chrome session.
+13. Disconnect returns to the connection form and clears the credential.
 
 When a completion is pending, **Cancel** calls the existing task-cancellation
 route for that accepted task. The panel remains observation-bound until a

--- a/frontend/chrome-extension/src/SidePanelApp.tsx
+++ b/frontend/chrome-extension/src/SidePanelApp.tsx
@@ -11,6 +11,10 @@ import {
   type ChatRequestState,
 } from "../../src/contracts/runtimeTokens"
 import {
+  interpretGuardianThreadIntervention,
+  type GuardianThreadIntervention,
+} from "../../src/features/chat/approvals/threadIntervention"
+import {
   buildOriginPermissionPattern,
   chromeOriginPermissionClient,
   createConnectionProfile,
@@ -31,6 +35,7 @@ import {
   createCodexifyExtensionApi,
   loginRemoteSession,
   type CodexifyExtensionApi,
+  type CodexifyBrowserApproval,
   type CodexifyMessage,
   type CodexifyThread,
   type CompletionReceipt,
@@ -59,6 +64,7 @@ type CompletionViewState =
   | "cancellation_requested"
 type MessageLoadState = "idle" | "loading" | "ready" | "failed"
 type ProfileSyncState = "idle" | "loading" | "ready" | "failed"
+type InterventionDecisionAction = "approve" | "deny"
 
 export interface SidePanelAppProps {
   storage?: ConnectionStorage
@@ -192,6 +198,120 @@ function isWorkerProgressEvent(event: TaskLifecycleEvent): boolean {
 
 const currentIsoTimestamp = (): string => new Date().toISOString()
 
+interface SidePanelInterventionCardProps {
+  busyAction: InterventionDecisionAction | null
+  error: string | null
+  intervention: GuardianThreadIntervention
+  notice: string | null
+  onApprove(): void
+  onDeny(): void
+  onTellGuardian(): void
+}
+
+function SidePanelInterventionCard({
+  busyAction,
+  error,
+  intervention,
+  notice,
+  onApprove,
+  onDeny,
+  onTellGuardian,
+}: SidePanelInterventionCardProps): React.JSX.Element {
+  const [showContext, setShowContext] = useState(false)
+  const decisionBusy = busyAction !== null
+  const canDecide = intervention.decision.supported &&
+    typeof intervention.decision.approvalId === "number"
+  const contextId = `side-panel-intervention-${intervention.id.replace(
+    /[^a-zA-Z0-9_-]/gu,
+    "-",
+  )}`
+
+  useEffect(() => {
+    setShowContext(false)
+  }, [intervention.id])
+
+  return (
+    <section
+      className="intervention-card"
+      aria-busy={decisionBusy}
+      aria-labelledby={`${contextId}-title`}
+      data-testid="side-panel-intervention"
+    >
+      <p className="intervention-eyebrow">{intervention.statusLabel}</p>
+      <h2 id={`${contextId}-title`}>{intervention.title}</h2>
+      <p className="intervention-summary">{intervention.summary}</p>
+
+      <div className="intervention-actions">
+        {canDecide ? (
+          <>
+            <button
+              className="intervention-button intervention-button--approve"
+              type="button"
+              aria-label="Approve Guardian request"
+              disabled={decisionBusy}
+              onClick={onApprove}
+            >
+              {busyAction === "approve" ? "Approving…" : "Approve"}
+            </button>
+            <button
+              className="intervention-button intervention-button--deny"
+              type="button"
+              aria-label="Deny Guardian request"
+              disabled={decisionBusy}
+              onClick={onDeny}
+            >
+              {busyAction === "deny" ? "Denying…" : "Deny"}
+            </button>
+          </>
+        ) : null}
+        {intervention.details.length > 0 ? (
+          <button
+            className="intervention-button intervention-button--quiet"
+            type="button"
+            aria-controls={contextId}
+            aria-expanded={showContext}
+            onClick={() => setShowContext((current) => !current)}
+          >
+            {showContext ? "Hide context" : "Inspect context"}
+          </button>
+        ) : null}
+        {intervention.canRedirect ? (
+          <button
+            className={`intervention-button ${
+              canDecide
+                ? "intervention-button--quiet"
+                : "intervention-button--approve"
+            }`}
+            type="button"
+            onClick={onTellGuardian}
+          >
+            Tell Guardian what to do instead
+          </button>
+        ) : null}
+      </div>
+
+      {showContext && intervention.details.length > 0 ? (
+        <ul id={contextId} className="intervention-context">
+          {intervention.details.map((detail) => (
+            <li key={detail}>{detail}</li>
+          ))}
+        </ul>
+      ) : null}
+
+      {notice ? (
+        <p className="intervention-feedback intervention-feedback--notice" role="status">
+          {notice}
+        </p>
+      ) : null}
+      {error ? (
+        <p className="intervention-feedback intervention-feedback--error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </section>
+  )
+}
+
 export function SidePanelApp({
   storage = chromeConnectionStorage,
   permissionClient = chromeOriginPermissionClient,
@@ -223,12 +343,26 @@ export function SidePanelApp({
   const [accentPickerOpen, setAccentPickerOpen] = useState(false)
   const [accentSaveError, setAccentSaveError] = useState<string | null>(null)
   const [profileSyncState, setProfileSyncState] = useState<ProfileSyncState>("idle")
+  const [intervention, setIntervention] = useState<GuardianThreadIntervention | null>(null)
+  const [interventionLoading, setInterventionLoading] = useState(false)
+  const [interventionError, setInterventionError] = useState<string | null>(null)
+  const [interventionNotice, setInterventionNotice] = useState<string | null>(null)
+  const [interventionBusyAction, setInterventionBusyAction] =
+    useState<InterventionDecisionAction | null>(null)
 
   const apiRef = useRef<CodexifyExtensionApi | null>(null)
   const activeTaskStopRef = useRef<(() => void) | null>(null)
   const messageEndRef = useRef<HTMLDivElement | null>(null)
   const accentPickerRef = useRef<HTMLDivElement | null>(null)
   const lastConfirmedAccentRef = useRef<UserAccentToken>(DEFAULT_USER_ACCENT_TOKEN)
+  const composerRef = useRef<HTMLTextAreaElement | null>(null)
+  const interventionLoadVersionRef = useRef(0)
+  const interventionDecisionInFlightRef = useRef(false)
+  const selectedThreadIdRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    selectedThreadIdRef.current = selectedThreadId
+  }, [selectedThreadId])
 
   const selectedThread = useMemo(
     () => threads.find((thread) => thread.id === selectedThreadId) ?? null,
@@ -273,6 +407,62 @@ export function SidePanelApp({
     }
   }, [recordConnectionFailure])
 
+  const loadIntervention = useCallback(async (
+    api: CodexifyExtensionApi,
+    threadId: number | null,
+    acknowledgement: string | null = null,
+  ): Promise<void> => {
+    const loadVersion = ++interventionLoadVersionRef.current
+    if (threadId === null) {
+      setIntervention(null)
+      setInterventionLoading(false)
+      setInterventionError(null)
+      setInterventionNotice(null)
+      return
+    }
+
+    setInterventionLoading(true)
+    setInterventionError(null)
+    if (!acknowledgement) setInterventionNotice(null)
+
+    try {
+      const agentRuns = await api.listAgentRuns(threadId)
+      const initialIntervention = interpretGuardianThreadIntervention({
+        agentRuns,
+        pendingApprovals: [],
+        threadId,
+      })
+      let pendingApprovals: CodexifyBrowserApproval[] = []
+      let warning: string | null = null
+
+      if (initialIntervention?.kind === "approval_required") {
+        try {
+          pendingApprovals = await api.listPendingApprovals()
+        } catch {
+          warning = "Approval decisions are temporarily unavailable."
+        }
+      }
+
+      if (interventionLoadVersionRef.current !== loadVersion) return
+      setIntervention(
+        interpretGuardianThreadIntervention({
+          agentRuns,
+          pendingApprovals,
+          threadId,
+        }),
+      )
+      setInterventionNotice(warning ?? acknowledgement)
+    } catch (error) {
+      if (interventionLoadVersionRef.current !== loadVersion) return
+      setIntervention(null)
+      setInterventionError(displayError(error))
+    } finally {
+      if (interventionLoadVersionRef.current === loadVersion) {
+        setInterventionLoading(false)
+      }
+    }
+  }, [])
+
   const rememberSelectedThread = useCallback(async (threadId: number | null): Promise<void> => {
     setProfile((current) => current ? { ...current, selectedThreadId: threadId } : current)
     await storage.updateSelectedThreadId(threadId)
@@ -295,15 +485,19 @@ export function SidePanelApp({
       if (nextSelectedThreadId === null) {
         setMessages([])
         setMessageLoadState("ready")
+        await loadIntervention(api, null)
       } else {
-        await loadMessages(api, nextSelectedThreadId)
+        await Promise.all([
+          loadMessages(api, nextSelectedThreadId),
+          loadIntervention(api, nextSelectedThreadId),
+        ])
       }
     } catch (error) {
       recordConnectionFailure(error)
     } finally {
       setThreadsLoading(false)
     }
-  }, [loadMessages, recordConnectionFailure, rememberSelectedThread])
+  }, [loadIntervention, loadMessages, recordConnectionFailure, rememberSelectedThread])
 
   useEffect(() => {
     let cancelled = false
@@ -624,6 +818,10 @@ export function SidePanelApp({
       setPasswordInput("")
       setCompletionState("idle")
       setCompletionReceipt(null)
+      setIntervention(null)
+      setInterventionError(null)
+      setInterventionNotice(null)
+      setInterventionBusyAction(null)
       setThreadDrawerOpen(false)
       setSurfaceError(null)
       setConnectionAttempt(null)
@@ -645,12 +843,19 @@ export function SidePanelApp({
     activeTaskStopRef.current = null
     setCompletionState("idle")
     setCompletionReceipt(null)
+    selectedThreadIdRef.current = threadId
     setSelectedThreadId(threadId)
     setMessages([])
+    setIntervention(null)
+    setInterventionError(null)
+    setInterventionNotice(null)
     setSurfaceError(null)
     setThreadDrawerOpen(false)
     await rememberSelectedThread(threadId)
-    await loadMessages(api, threadId)
+    await Promise.all([
+      loadMessages(api, threadId),
+      loadIntervention(api, threadId),
+    ])
   }
 
   const createNewThread = async (title = "New Chat"): Promise<CodexifyThread | null> => {
@@ -662,7 +867,11 @@ export function SidePanelApp({
       const thread = await api.createThread(title)
       setThreads((current) => [thread, ...current.filter((item) => item.id !== thread.id)])
       setSelectedThreadId(thread.id)
+      selectedThreadIdRef.current = thread.id
       setMessages([])
+      setIntervention(null)
+      setInterventionError(null)
+      setInterventionNotice(null)
       setMessageLoadState("ready")
       setCompletionState("idle")
       setCompletionReceipt(null)
@@ -684,12 +893,18 @@ export function SidePanelApp({
   ): Promise<void> => {
     activeTaskStopRef.current = null
     if (outcome === "completed") {
-      const refreshed = await loadMessages(api, receipt.threadId, receipt.messagesUrl)
+      const [refreshed] = await Promise.all([
+        loadMessages(api, receipt.threadId, receipt.messagesUrl),
+        loadIntervention(api, receipt.threadId),
+      ])
       setCompletionState(refreshed ? CHAT_REQUEST_STATES.COMPLETED : "connection_lost")
       return
     }
 
-    await loadMessages(api, receipt.threadId)
+    await Promise.all([
+      loadMessages(api, receipt.threadId),
+      loadIntervention(api, receipt.threadId),
+    ])
     setCompletionState(
       outcome === "cancelled"
         ? CHAT_REQUEST_STATES.CANCELLED
@@ -751,6 +966,63 @@ export function SidePanelApp({
     }
   }, [accentToken])
 
+  const handleInterventionDecision = async (
+    action: InterventionDecisionAction,
+  ): Promise<void> => {
+    const api = apiRef.current
+    const currentIntervention = intervention
+    const approvalId = currentIntervention?.decision.approvalId
+    if (
+      !api ||
+      !currentIntervention ||
+      typeof approvalId !== "number" ||
+      interventionDecisionInFlightRef.current
+    ) {
+      return
+    }
+
+    interventionDecisionInFlightRef.current = true
+    setInterventionBusyAction(action)
+    setInterventionError(null)
+    setInterventionNotice(null)
+    const acknowledgement = action === "approve" ? "Approved." : "Denied."
+
+    try {
+      if (action === "approve") {
+        await api.approveBrowserApproval(
+          approvalId,
+          `Approved from thread ${currentIntervention.threadId} side panel.`,
+        )
+      } else {
+        await api.denyBrowserApproval(
+          approvalId,
+          `Denied from thread ${currentIntervention.threadId} side panel.`,
+        )
+      }
+      if (selectedThreadIdRef.current === currentIntervention.threadId) {
+        setInterventionNotice(acknowledgement)
+        await loadIntervention(
+          api,
+          currentIntervention.threadId,
+          acknowledgement,
+        )
+      }
+    } catch (error) {
+      if (selectedThreadIdRef.current === currentIntervention.threadId) {
+        setInterventionError(displayError(error))
+      }
+    } finally {
+      interventionDecisionInFlightRef.current = false
+      setInterventionBusyAction(null)
+    }
+  }
+
+  const handleTellGuardianWhatToDoInstead = (): void => {
+    if (!intervention) return
+    setComposerValue(intervention.redirectPrompt)
+    composerRef.current?.focus()
+  }
+
   const handleSend = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
     event.preventDefault()
     const content = composerValue.trim()
@@ -780,6 +1052,7 @@ export function SidePanelApp({
       receipt = await api.requestCompletion(threadId)
       setCompletionReceipt(receipt)
       setCompletionState(CHAT_REQUEST_STATES.AWAITING_ACK)
+      void loadIntervention(api, threadId)
     } catch (error) {
       recordConnectionFailure(error)
       setCompletionState(CHAT_REQUEST_STATES.FAILED_RETRYABLE)
@@ -798,6 +1071,7 @@ export function SidePanelApp({
           if (isWorkerProgressEvent(taskEvent)) {
             setCompletionState(CHAT_REQUEST_STATES.AWAITING_MODEL)
           }
+          void loadIntervention(api, receipt.threadId)
         },
         onConnectionLost: () => setCompletionState("connection_lost"),
         onUnauthorized: () => {
@@ -1164,7 +1438,7 @@ export function SidePanelApp({
         </section>
       </main>
 
-      <footer className="composer-dock">
+      <footer className="composer-dock" aria-busy={interventionLoading}>
         {completionState !== "idle" ? (
           <div
             className={`task-indicator task-indicator--${completionPresentation.tone}`}
@@ -1196,9 +1470,22 @@ export function SidePanelApp({
           </div>
         ) : null}
 
+        {intervention ? (
+          <SidePanelInterventionCard
+            busyAction={interventionBusyAction}
+            error={interventionError}
+            intervention={intervention}
+            notice={interventionNotice}
+            onApprove={() => void handleInterventionDecision("approve")}
+            onDeny={() => void handleInterventionDecision("deny")}
+            onTellGuardian={handleTellGuardianWhatToDoInstead}
+          />
+        ) : null}
+
         <form className="composer" onSubmit={handleSend}>
           <label className="sr-only" htmlFor="composer-input">Message Codexify</label>
           <textarea
+            ref={composerRef}
             id="composer-input"
             value={composerValue}
             onChange={(event) => setComposerValue(event.target.value)}

--- a/frontend/chrome-extension/src/__tests__/SidePanelApp.test.tsx
+++ b/frontend/chrome-extension/src/__tests__/SidePanelApp.test.tsx
@@ -149,6 +149,20 @@ function apiMock(overrides: Partial<CodexifyExtensionApi> = {}): CodexifyExtensi
     listThreads: vi.fn(async () => [thread]),
     createThread: vi.fn(async () => thread),
     listMessages: vi.fn(async () => [userMessage, assistantMessage]),
+    listAgentRuns: vi.fn(async () => []),
+    listPendingApprovals: vi.fn(async () => []),
+    approveBrowserApproval: vi.fn(async (approvalId) => ({
+      approvalId,
+      operation: "evaluate",
+      status: "APPROVED",
+      target: null,
+    })),
+    denyBrowserApproval: vi.fn(async (approvalId) => ({
+      approvalId,
+      operation: "evaluate",
+      status: "DENIED",
+      target: null,
+    })),
     persistUserMessage: vi.fn(async () => undefined),
     requestCompletion: vi.fn(async () => receipt),
     cancelTask: vi.fn(async () => undefined),
@@ -343,6 +357,189 @@ describe("Codexify Chrome side panel", () => {
     expect(userArticle!.textContent).toContain("Persisted user message")
   })
 
+  it("projects the selected thread's Guardian approval above the composer", async () => {
+    const { storage } = memoryStorage(savedProfile())
+    const api = apiMock({
+      listAgentRuns: vi.fn(async () => [{
+        run_id: "run_7",
+        runtime_target: "guardian",
+        status: "awaiting_approval",
+        thread_id: 7,
+        worktree_id: "worktree_7",
+        worktree_path: "/private/worktree-7",
+      }]),
+      listPendingApprovals: vi.fn(async () => [{
+        id: 17,
+        operation: "evaluate",
+        request_reason: "Guarded action for thread_id:7 run_7",
+        status: "PENDING",
+        target: "browser action",
+      }]),
+    })
+
+    render(
+      <SidePanelApp
+        storage={storage}
+        permissionClient={permissionMock()}
+        apiFactory={() => api}
+        now={fixedNow}
+      />,
+    )
+
+    const card = await screen.findByTestId("side-panel-intervention")
+    const composer = screen.getByLabelText("Message Codexify")
+    expect(screen.getByText("Guardian needs your approval")).toBeVisible()
+    expect(screen.queryByText("Run: run_7")).not.toBeInTheDocument()
+    expect(
+      card.compareDocumentPosition(composer) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+
+    fireEvent.click(screen.getByRole("button", { name: "Inspect context" }))
+    expect(screen.getByText("Run: run_7")).toBeVisible()
+  })
+
+  it("submits one exact approval decision and refreshes Guardian truth", async () => {
+    const { storage } = memoryStorage(savedProfile())
+    const listPendingApprovals = vi
+      .fn<CodexifyExtensionApi["listPendingApprovals"]>()
+      .mockResolvedValueOnce([{
+        id: 17,
+        operation: "evaluate",
+        request_reason: "thread_id:7 run_7",
+        status: "PENDING",
+        target: "browser action",
+      }])
+      .mockResolvedValue([])
+    const api = apiMock({
+      listAgentRuns: vi.fn(async () => [{
+        run_id: "run_7",
+        runtime_target: null,
+        status: "awaiting_approval",
+        thread_id: 7,
+        worktree_id: null,
+        worktree_path: null,
+      }]),
+      listPendingApprovals,
+    })
+
+    render(
+      <SidePanelApp
+        storage={storage}
+        permissionClient={permissionMock()}
+        apiFactory={() => api}
+        now={fixedNow}
+      />,
+    )
+
+    const approve = await screen.findByRole("button", {
+      name: "Approve Guardian request",
+    })
+    fireEvent.click(approve)
+    fireEvent.click(approve)
+
+    expect(await screen.findByText("Approved.")).toBeVisible()
+    expect(api.approveBrowserApproval).toHaveBeenCalledTimes(1)
+    expect(api.approveBrowserApproval).toHaveBeenCalledWith(
+      17,
+      "Approved from thread 7 side panel.",
+    )
+    expect(listPendingApprovals).toHaveBeenCalledTimes(2)
+    expect(
+      screen.queryByRole("button", { name: "Approve Guardian request" }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("submits one exact denial and never treats composer Enter as approval", async () => {
+    const { storage } = memoryStorage(savedProfile())
+    const api = apiMock({
+      listAgentRuns: vi.fn(async () => [{
+        run_id: "run_7",
+        runtime_target: null,
+        status: "awaiting_approval",
+        thread_id: 7,
+        worktree_id: null,
+        worktree_path: null,
+      }]),
+      listPendingApprovals: vi.fn(async () => [{
+        id: 23,
+        operation: "evaluate",
+        request_reason: "thread_id:7 run_7",
+        status: "PENDING",
+        target: null,
+      }]),
+    })
+
+    render(
+      <SidePanelApp
+        storage={storage}
+        permissionClient={permissionMock()}
+        apiFactory={() => api}
+        now={fixedNow}
+      />,
+    )
+
+    const composer = await screen.findByLabelText("Message Codexify")
+    fireEvent.change(composer, { target: { value: "Do something else" } })
+    fireEvent.keyDown(composer, { key: "Enter" })
+    expect(api.approveBrowserApproval).not.toHaveBeenCalled()
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Deny Guardian request" }),
+    )
+    await waitFor(() => {
+      expect(api.denyBrowserApproval).toHaveBeenCalledTimes(1)
+    })
+    expect(api.denyBrowserApproval).toHaveBeenCalledWith(
+      23,
+      "Denied from thread 7 side panel.",
+    )
+  })
+
+  it("removes stale intervention state when the selected thread changes", async () => {
+    const { storage } = memoryStorage(savedProfile())
+    const secondThread: CodexifyThread = {
+      ...thread,
+      id: 8,
+      title: "Second thread",
+    }
+    const api = apiMock({
+      listThreads: vi.fn(async () => [thread, secondThread]),
+      listAgentRuns: vi.fn(async (threadId) => threadId === 7 ? [{
+        run_id: "run_7",
+        runtime_target: null,
+        status: "awaiting_approval",
+        thread_id: 7,
+        worktree_id: null,
+        worktree_path: null,
+      }] : []),
+      listPendingApprovals: vi.fn(async () => [{
+        id: 17,
+        operation: "evaluate",
+        request_reason: "thread_id:7 run_7",
+        status: "PENDING",
+        target: null,
+      }]),
+    })
+
+    render(
+      <SidePanelApp
+        storage={storage}
+        permissionClient={permissionMock()}
+        apiFactory={() => api}
+        now={fixedNow}
+      />,
+    )
+
+    expect(await screen.findByTestId("side-panel-intervention")).toBeVisible()
+    fireEvent.click(screen.getByRole("button", { name: /Existing thread/ }))
+    fireEvent.click(screen.getByRole("button", { name: "Second thread" }))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("side-panel-intervention")).not.toBeInTheDocument()
+    })
+    expect(api.listAgentRuns).toHaveBeenCalledWith(8)
+  })
+
   it("renders assistant messages as Markdown and keeps user messages literal", async () => {
     const { storage } = memoryStorage(savedProfile())
     const mdAssistant: CodexifyMessage = {
@@ -444,6 +641,64 @@ describe("Codexify Chrome side panel", () => {
 
     // After terminal completion, the assistant message still uses the Markdown renderer.
     expect(document.querySelector(".codexify-markdown")).toBeTruthy()
+  })
+
+  it("refreshes intervention visibility from active task lifecycle evidence", async () => {
+    const { storage } = memoryStorage(savedProfile())
+    let callbacks: TaskLifecycleCallbacks | null = null
+    const listAgentRuns = vi
+      .fn<CodexifyExtensionApi["listAgentRuns"]>()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([{
+        run_id: "run_lifecycle",
+        runtime_target: null,
+        status: "awaiting_approval",
+        thread_id: 7,
+        worktree_id: null,
+        worktree_path: null,
+      }])
+    const api = apiMock({
+      listAgentRuns,
+      listPendingApprovals: vi.fn(async () => [{
+        id: 41,
+        operation: "evaluate",
+        request_reason: "thread_id:7 run_lifecycle",
+        status: "PENDING",
+        target: null,
+      }]),
+      subscribeToTask: vi.fn((_receipt, nextCallbacks) => {
+        callbacks = nextCallbacks
+        return () => undefined
+      }),
+    })
+
+    render(
+      <SidePanelApp
+        storage={storage}
+        permissionClient={permissionMock()}
+        apiFactory={() => api}
+        now={fixedNow}
+      />,
+    )
+
+    const composer = await screen.findByLabelText("Message Codexify")
+    fireEvent.change(composer, { target: { value: "Run guarded work" } })
+    fireEvent.submit(composer.closest("form") as HTMLFormElement)
+    expect(await screen.findByText("Completion accepted")).toBeVisible()
+    expect(screen.queryByTestId("side-panel-intervention")).not.toBeInTheDocument()
+
+    await act(async () => {
+      callbacks?.onEvent?.({
+        type: "task.running",
+        state: "running",
+        data: { task_id: receipt.taskId },
+      })
+    })
+
+    expect(await screen.findByTestId("side-panel-intervention")).toBeVisible()
+    expect(listAgentRuns).toHaveBeenCalledTimes(3)
+    expect(api.requestCompletion).toHaveBeenCalledTimes(1)
   })
 
   it("requests cancellation and waits for terminal cancelled evidence", async () => {

--- a/frontend/chrome-extension/src/__tests__/codexifyExtensionApi.test.ts
+++ b/frontend/chrome-extension/src/__tests__/codexifyExtensionApi.test.ts
@@ -111,6 +111,75 @@ describe("Codexify extension auth transport", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
+  it("uses only X-API-Key for local approval reads and an exact approval decision", async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const headers = new Headers(init?.headers)
+      expect(headers.get("X-API-Key")).toBe(localCredential())
+      expect(headers.get("Authorization")).toBeNull()
+      if (url.endsWith("/api/chat/7/agent-runs")) {
+        return new Response(JSON.stringify({
+          runs: [{ run_id: "run_7", status: "awaiting_approval", thread_id: 7 }],
+        }), { status: 200 })
+      }
+      if (url.endsWith("/api/browser/approvals?status_value=PENDING")) {
+        return new Response(JSON.stringify({
+          items: [{ id: 17, status: "PENDING", request_reason: "thread_id:7" }],
+        }), { status: 200 })
+      }
+      expect(url).toBe("http://127.0.0.1:8888/api/browser/approvals/17/approve")
+      expect(init?.method).toBe("POST")
+      expect(JSON.parse(String(init?.body))).toEqual({ reason: "Approved in test." })
+      return new Response(JSON.stringify({ id: 17, status: "APPROVED" }), { status: 200 })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    const profile = createConnectionProfile({
+      backendBaseUrl: "http://127.0.0.1:8888",
+      apiKey: localCredential(),
+      connectedAt: fixedTimestamp,
+      lastVerifiedAt: fixedTimestamp,
+    })
+    const api = createCodexifyExtensionApi(profile)
+
+    await expect(api.listAgentRuns(7)).resolves.toHaveLength(1)
+    await expect(api.listPendingApprovals()).resolves.toHaveLength(1)
+    await expect(
+      api.approveBrowserApproval(17, "Approved in test."),
+    ).resolves.toMatchObject({ approvalId: 17, status: "APPROVED" })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it("uses only Bearer auth for remote approval reads and an exact denial", async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const headers = new Headers(init?.headers)
+      expect(headers.get("Authorization")).toBe(`Bearer ${remoteSession.token}`)
+      expect(headers.get("X-API-Key")).toBeNull()
+      if (url.endsWith("/api/browser/approvals?status_value=PENDING")) {
+        return new Response(JSON.stringify({
+          items: [{ id: 23, status: "PENDING", request_reason: "thread_id:7" }],
+        }), { status: 200 })
+      }
+      expect(url).toBe("https://codexify.test/api/browser/approvals/23/deny")
+      expect(init?.method).toBe("POST")
+      expect(JSON.parse(String(init?.body))).toEqual({ reason: "Denied in test." })
+      return new Response(JSON.stringify({ id: 23, status: "DENIED" }), { status: 200 })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    const profile = createRemoteConnectionProfile({
+      backendBaseUrl: "https://codexify.test",
+      sessionUserId: remoteSession.userId,
+      sessionExpiresAt: remoteSession.expiresAt,
+      connectedAt: fixedTimestamp,
+      lastVerifiedAt: fixedTimestamp,
+    })
+    const api = createCodexifyExtensionApi(profile, remoteSession)
+
+    await expect(api.listPendingApprovals()).resolves.toHaveLength(1)
+    await expect(
+      api.denyBrowserApproval(23, "Denied in test."),
+    ).resolves.toMatchObject({ approvalId: 23, status: "DENIED" })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
   it("sends the accepted completion's root request and turn correlation", async () => {
     const requestId = "req-extension-test"
     const turnId = "turn-extension-test"

--- a/frontend/chrome-extension/src/codexifyExtensionApi.ts
+++ b/frontend/chrome-extension/src/codexifyExtensionApi.ts
@@ -40,6 +40,30 @@ export interface CodexifyMessage {
   turnId: string | null
 }
 
+export interface CodexifyAgentRun {
+  run_id: string | null
+  runtime_target: string | null
+  status: string | null
+  thread_id: number | null
+  worktree_id: string | null
+  worktree_path: string | null
+}
+
+export interface CodexifyBrowserApproval {
+  id: number | null
+  operation: string | null
+  request_reason: string | null
+  status: string | null
+  target: string | null
+}
+
+export interface CodexifyApprovalDecision {
+  approvalId: number
+  operation: string | null
+  status: string
+  target: string | null
+}
+
 export interface CompletionReceipt {
   taskId: string
   requestId: string
@@ -88,6 +112,10 @@ export interface CodexifyExtensionApi {
   listThreads(): Promise<CodexifyThread[]>
   createThread(title?: string): Promise<CodexifyThread>
   listMessages(threadId: number, discoveryUrl?: string | null): Promise<CodexifyMessage[]>
+  listAgentRuns(threadId: number): Promise<CodexifyAgentRun[]>
+  listPendingApprovals(): Promise<CodexifyBrowserApproval[]>
+  approveBrowserApproval(approvalId: number, reason: string): Promise<CodexifyApprovalDecision>
+  denyBrowserApproval(approvalId: number, reason: string): Promise<CodexifyApprovalDecision>
   persistUserMessage(threadId: number, content: string): Promise<void>
   requestCompletion(
     threadId: number,
@@ -166,6 +194,34 @@ function normalizeMessage(value: unknown, fallbackThreadId: number): CodexifyMes
     content,
     createdAt: firstString(record, "created_at", "createdAt"),
     turnId: firstString(record, "turn_id", "turnId"),
+  }
+}
+
+function normalizeAgentRun(value: unknown): CodexifyAgentRun | null {
+  const record = asRecord(value)
+  const status = firstString(record, "status")
+  if (!status) return null
+  return {
+    run_id: firstString(record, "run_id", "runId"),
+    runtime_target: firstString(record, "runtime_target", "runtimeTarget"),
+    status,
+    thread_id: parseThreadId(record.thread_id ?? record.threadId),
+    worktree_id: firstString(record, "worktree_id", "worktreeId"),
+    worktree_path: firstString(record, "worktree_path", "worktreePath"),
+  }
+}
+
+function normalizeBrowserApproval(value: unknown): CodexifyBrowserApproval | null {
+  const record = asRecord(value)
+  const idValue = typeof record.id === "number" ? record.id : Number(record.id)
+  const id = Number.isInteger(idValue) && idValue > 0 ? idValue : null
+  if (id === null) return null
+  return {
+    id,
+    operation: firstString(record, "operation"),
+    request_reason: firstString(record, "request_reason", "requestReason"),
+    status: firstString(record, "status"),
+    target: firstString(record, "target"),
   }
 }
 
@@ -381,6 +437,40 @@ export class FetchCodexifyExtensionApi implements CodexifyExtensionApi {
     )
   }
 
+  async listAgentRuns(threadId: number): Promise<CodexifyAgentRun[]> {
+    const body = asRecord(
+      await this.requestJson(`/api/chat/${threadId}/agent-runs`),
+    )
+    const rawRuns = Array.isArray(body.runs) ? body.runs : []
+    return rawRuns
+      .map(normalizeAgentRun)
+      .filter((run): run is CodexifyAgentRun => run !== null)
+  }
+
+  async listPendingApprovals(): Promise<CodexifyBrowserApproval[]> {
+    const body = asRecord(
+      await this.requestJson("/api/browser/approvals?status_value=PENDING"),
+    )
+    const rawApprovals = Array.isArray(body.items) ? body.items : []
+    return rawApprovals
+      .map(normalizeBrowserApproval)
+      .filter((approval): approval is CodexifyBrowserApproval => approval !== null)
+  }
+
+  async approveBrowserApproval(
+    approvalId: number,
+    reason: string,
+  ): Promise<CodexifyApprovalDecision> {
+    return this.decideBrowserApproval(approvalId, "approve", reason)
+  }
+
+  async denyBrowserApproval(
+    approvalId: number,
+    reason: string,
+  ): Promise<CodexifyApprovalDecision> {
+    return this.decideBrowserApproval(approvalId, "deny", reason)
+  }
+
   async persistUserMessage(threadId: number, content: string): Promise<void> {
     await this.requestJson(`/api/chat/${threadId}/messages`, {
       method: "POST",
@@ -502,6 +592,29 @@ export class FetchCodexifyExtensionApi implements CodexifyExtensionApi {
     return rawThreads
       .map(normalizeThread)
       .filter((thread): thread is CodexifyThread => thread !== null)
+  }
+
+  private async decideBrowserApproval(
+    approvalId: number,
+    decision: "approve" | "deny",
+    reason: string,
+  ): Promise<CodexifyApprovalDecision> {
+    const body = asRecord(
+      await this.requestJson(
+        `/api/browser/approvals/${approvalId}/${decision}`,
+        {
+          method: "POST",
+          body: JSON.stringify({ reason }),
+        },
+      ),
+    )
+    return {
+      approvalId:
+        typeof body.id === "number" ? body.id : approvalId,
+      operation: firstString(body, "operation"),
+      status: firstString(body, "status") ?? "UNKNOWN",
+      target: firstString(body, "target"),
+    }
   }
 
   private async fetchReachabilityProbe(): Promise<void> {

--- a/frontend/chrome-extension/src/sidepanel.css
+++ b/frontend/chrome-extension/src/sidepanel.css
@@ -818,6 +818,113 @@ textarea:focus-visible {
   opacity: 0.6;
 }
 
+.intervention-card {
+  display: grid;
+  gap: calc(var(--card-pad) / 2);
+  margin-bottom: calc(var(--card-pad) / 2);
+  padding: var(--card-pad);
+  border: 1px solid color-mix(in oklab, var(--panel-border) 66%, var(--accent) 34%);
+  border-radius: var(--card-radius);
+  background: color-mix(in oklab, var(--panel-sheet) 90%, var(--accent-weak) 10%);
+}
+
+.intervention-eyebrow,
+.intervention-summary,
+.intervention-feedback {
+  margin: 0;
+}
+
+.intervention-eyebrow {
+  color: var(--accent);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.intervention-card h2 {
+  margin: 0;
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.25;
+}
+
+.intervention-summary {
+  color: var(--text-subtle);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.intervention-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: calc(var(--card-pad) / 2);
+}
+
+.intervention-button {
+  min-height: calc(var(--card-pad) * 2.5);
+  padding: calc(var(--card-pad) / 2) var(--card-pad);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-micro);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.intervention-button--approve {
+  border-color: color-mix(in oklab, var(--accent) 48%, var(--panel-border));
+  background: color-mix(in oklab, var(--accent-strong) 24%, var(--panel-sheet));
+  color: var(--text-on-accent);
+}
+
+.intervention-button--deny {
+  border-color: var(--danger-border);
+  background: var(--danger-surface);
+  color: var(--danger-text);
+}
+
+.intervention-button--quiet {
+  background: var(--surface-soft);
+  color: var(--muted);
+}
+
+.intervention-button--quiet:hover {
+  background: var(--surface-hover);
+}
+
+.intervention-context {
+  display: grid;
+  gap: calc(var(--card-pad) / 3);
+  margin: 0;
+  padding: calc(var(--card-pad) / 2) calc(var(--card-pad) * 1.75);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-micro);
+  background: var(--surface-soft);
+  color: var(--text-subtle);
+  font-size: 10px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.intervention-feedback {
+  padding: calc(var(--card-pad) / 2);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-micro);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.intervention-feedback--notice {
+  border-color: color-mix(in oklab, var(--accent) 34%, var(--panel-border));
+  background: color-mix(in oklab, var(--accent-weak) 18%, var(--panel-sheet));
+  color: var(--text);
+}
+
+.intervention-feedback--error {
+  border-color: var(--danger-border);
+  background: var(--danger-surface);
+  color: var(--danger-text);
+}
+
 .composer {
   min-height: 48px;
   gap: 8px;
@@ -1029,6 +1136,10 @@ textarea:focus-visible {
   .task-indicator--danger .task-dot {
     animation: none;
   }
+
+  .intervention-card {
+    animation: intervention-enter 150ms ease-out;
+  }
 }
 
 @keyframes drawer-enter {
@@ -1039,6 +1150,17 @@ textarea:focus-visible {
 @keyframes task-pulse {
   0%, 100% { opacity: 0.55; }
   50% { opacity: 1; }
+}
+
+@keyframes intervention-enter {
+  from {
+    opacity: 0;
+    transform: translateY(calc(var(--card-pad) / 2));
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* ── Accent colour picker ─────────────────────────────────────────── */

--- a/frontend/src/features/chat/GuardianChat.tsx
+++ b/frontend/src/features/chat/GuardianChat.tsx
@@ -4451,7 +4451,6 @@ export function GuardianChat({
               }}
             >
               <GuardianThreadApprovalRail
-                className="mb-3"
                 onTellGuardianWhatToDoInstead={handleTellGuardianWhatToDoInstead}
                 reloadSignal={chatReloadVersion}
                 threadId={effectiveThreadId ?? undefined}

--- a/frontend/src/features/chat/__tests__/GuardianThreadApprovalRail.test.tsx
+++ b/frontend/src/features/chat/__tests__/GuardianThreadApprovalRail.test.tsx
@@ -75,7 +75,10 @@ describe("GuardianThreadApprovalRail", () => {
   test("shows a compact rail when active thread has pending intervention", () => {
     useGuardianThreadApprovalRailMock.mockReturnValue(
       buildHookState({
-        intervention: buildIntervention(),
+        canSubmitDecision: true,
+        intervention: buildIntervention({
+          decision: { approvalId: 17, supported: true },
+        }),
         visible: true,
       })
     );
@@ -91,8 +94,12 @@ describe("GuardianThreadApprovalRail", () => {
         "A guarded action for this thread is waiting for explicit user approval."
       )
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Approve" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Deny" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Approve Guardian request" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Deny Guardian request" })
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Tell Guardian what to do instead" })
     ).toBeInTheDocument();
@@ -174,7 +181,7 @@ describe("GuardianThreadApprovalRail", () => {
     });
   });
 
-  test("keeps approve and deny disabled when mutation is unsupported", () => {
+  test("does not present fake approval actions when mutation is unsupported", () => {
     useGuardianThreadApprovalRailMock.mockReturnValue(
       buildHookState({
         canSubmitDecision: false,
@@ -187,12 +194,88 @@ describe("GuardianThreadApprovalRail", () => {
 
     render(<GuardianThreadApprovalRail threadId={42} />);
 
-    expect(screen.getByRole("button", { name: "Approve" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Deny" })).toBeDisabled();
     expect(
-      screen.getByText(
-        "Direct approve/deny is unavailable for this thread intervention."
-      )
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: /Approve Guardian request/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Deny Guardian request/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Tell Guardian what to do instead" })
+    ).toBeEnabled();
+  });
+
+  test("keeps diagnostic context collapsed until explicitly inspected", async () => {
+    const user = userEvent.setup();
+    useGuardianThreadApprovalRailMock.mockReturnValue(
+      buildHookState({
+        intervention: buildIntervention(),
+        visible: true,
+      })
+    );
+
+    render(<GuardianThreadApprovalRail threadId={42} />);
+
+    expect(screen.queryByText("Run: run_123")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Inspect context" }));
+    expect(screen.getByText("Run: run_123")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Hide context" })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+  });
+
+  test("submits each explicit decision through the rail hook", async () => {
+    const user = userEvent.setup();
+    const approve = vi.fn().mockResolvedValue(true);
+    const deny = vi.fn().mockResolvedValue(true);
+    useGuardianThreadApprovalRailMock.mockReturnValue(
+      buildHookState({
+        approve,
+        canSubmitDecision: true,
+        deny,
+        intervention: buildIntervention({
+          decision: { approvalId: 17, supported: true },
+        }),
+        visible: true,
+      })
+    );
+
+    render(<GuardianThreadApprovalRail threadId={42} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Approve Guardian request" })
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Deny Guardian request" })
+    );
+    expect(approve).toHaveBeenCalledTimes(1);
+    expect(deny).toHaveBeenCalledTimes(1);
+  });
+
+  test("conveys the decision-busy state and prevents another choice", () => {
+    useGuardianThreadApprovalRailMock.mockReturnValue(
+      buildHookState({
+        canSubmitDecision: true,
+        intervention: buildIntervention({
+          decision: { approvalId: 17, supported: true },
+        }),
+        submittingAction: "approve",
+        visible: true,
+      })
+    );
+
+    render(<GuardianThreadApprovalRail threadId={42} />);
+
+    expect(screen.getByTestId("guardian-thread-approval-rail")).toHaveAttribute(
+      "aria-busy",
+      "true"
+    );
+    expect(
+      screen.getByRole("button", { name: "Approve Guardian request" })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Deny Guardian request" })
+    ).toBeDisabled();
   });
 });

--- a/frontend/src/features/chat/__tests__/threadIntervention.test.ts
+++ b/frontend/src/features/chat/__tests__/threadIntervention.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  interpretGuardianThreadIntervention,
+  type GuardianPendingApprovalInput,
+  type GuardianThreadRunInput,
+} from "@/features/chat/approvals/threadIntervention";
+
+const threadId = 42;
+
+function run(
+  status: string,
+  overrides: Partial<GuardianThreadRunInput> = {}
+): GuardianThreadRunInput {
+  return {
+    run_id: "run_123",
+    runtime_target: "guardian",
+    status,
+    thread_id: threadId,
+    worktree_id: "worktree_123",
+    worktree_path: "/private/worktree",
+    ...overrides,
+  };
+}
+
+function approval(
+  overrides: Partial<GuardianPendingApprovalInput> = {}
+): GuardianPendingApprovalInput {
+  return {
+    id: 17,
+    operation: "evaluate",
+    request_reason: "Approval required for thread_id:42 run_123",
+    status: "PENDING",
+    target: "browser action",
+    ...overrides,
+  };
+}
+
+describe("interpretGuardianThreadIntervention", () => {
+  test.each(["awaiting_approval", "approval_required", "pending"])(
+    "maps %s to an approval-required presentation",
+    (status) => {
+      const result = interpretGuardianThreadIntervention({
+        agentRuns: [run(status)],
+        pendingApprovals: [approval()],
+        threadId,
+      });
+
+      expect(result).toMatchObject({
+        kind: "approval_required",
+        statusLabel: "Approval required",
+        decision: { approvalId: 17, supported: true },
+      });
+    }
+  );
+
+  test("maps clarification without manufacturing an approval decision", () => {
+    const result = interpretGuardianThreadIntervention({
+      agentRuns: [run("clarification_required")],
+      pendingApprovals: [approval()],
+      threadId,
+    });
+
+    expect(result).toMatchObject({
+      kind: "clarification_required",
+      decision: { approvalId: null, supported: false },
+      title: "Guardian needs clarification",
+    });
+  });
+
+  test("maps blocked state to user redirection without approval controls", () => {
+    const result = interpretGuardianThreadIntervention({
+      agentRuns: [run("blocked")],
+      pendingApprovals: [],
+      threadId,
+    });
+
+    expect(result).toMatchObject({
+      kind: "blocked_waiting_for_user",
+      decision: { approvalId: null, supported: false },
+      canRedirect: true,
+    });
+  });
+
+  test("ignores unrelated runs", () => {
+    expect(
+      interpretGuardianThreadIntervention({
+        agentRuns: [run("running")],
+        pendingApprovals: [approval()],
+        threadId,
+      })
+    ).toBeNull();
+  });
+
+  test("correlates a pending approval by the exact thread context", () => {
+    const result = interpretGuardianThreadIntervention({
+      agentRuns: [run("awaiting_approval")],
+      pendingApprovals: [
+        approval({
+          id: 31,
+          request_reason: "Guardian paused /api/chat/42 before evaluate",
+        }),
+      ],
+      threadId,
+    });
+
+    expect(result?.decision).toEqual({ approvalId: 31, supported: true });
+  });
+
+  test("correlates a pending approval by run ID", () => {
+    const result = interpretGuardianThreadIntervention({
+      agentRuns: [run("awaiting_approval")],
+      pendingApprovals: [
+        approval({
+          id: 32,
+          request_reason: "Guarded action for RUN_123",
+        }),
+      ],
+      threadId,
+    });
+
+    expect(result?.decision).toEqual({ approvalId: 32, supported: true });
+  });
+
+  test("does not correlate unrelated or already-resolved approvals", () => {
+    const result = interpretGuardianThreadIntervention({
+      agentRuns: [run("awaiting_approval")],
+      pendingApprovals: [
+        approval({ id: 91, request_reason: "thread_id:99" }),
+        approval({ id: 92, status: "APPROVED" }),
+      ],
+      threadId,
+    });
+
+    expect(result?.decision).toEqual({ approvalId: null, supported: false });
+  });
+
+  test("keeps diagnostic details secondary in the presentation model", () => {
+    const result = interpretGuardianThreadIntervention({
+      agentRuns: [run("awaiting_approval")],
+      pendingApprovals: [],
+      threadId,
+    });
+
+    expect(result?.title).toBe("Guardian needs your approval");
+    expect(result?.details).toEqual([
+      "Run: run_123",
+      "Runtime: guardian",
+      "Worktree: worktree_123",
+      "Path: /private/worktree",
+      "Raw status: awaiting_approval",
+    ]);
+  });
+});

--- a/frontend/src/features/chat/api/threadApprovals.ts
+++ b/frontend/src/features/chat/api/threadApprovals.ts
@@ -1,30 +1,15 @@
 import api from "@/lib/api";
-import { type AgentRunResponse } from "@/features/chat/api/actionCenter";
+import {
+  interpretGuardianThreadIntervention,
+  type GuardianPendingApprovalInput,
+  type GuardianThreadRunInput,
+} from "@/features/chat/approvals/threadIntervention";
 
-export type GuardianThreadInterventionKind =
-  | "approval_required"
-  | "clarification_required"
-  | "blocked_waiting_for_user";
-
-export type GuardianThreadApprovalDecision = {
-  approvalId: number | null;
-  supported: boolean;
-};
-
-export type GuardianThreadIntervention = {
-  canRedirect: boolean;
-  decision: GuardianThreadApprovalDecision;
-  details: string[];
-  id: string;
-  kind: GuardianThreadInterventionKind;
-  rawStatus: string;
-  redirectPrompt: string;
-  runId: string | null;
-  statusLabel: string;
-  summary: string;
-  threadId: number;
-  title: string;
-};
+export type {
+  GuardianThreadApprovalDecision,
+  GuardianThreadIntervention,
+  GuardianThreadInterventionKind,
+} from "@/features/chat/approvals/threadIntervention";
 
 export type GuardianThreadApprovalSnapshot = {
   intervention: GuardianThreadIntervention | null;
@@ -32,7 +17,7 @@ export type GuardianThreadApprovalSnapshot = {
 };
 
 export type GuardianThreadApprovalContext = {
-  agentRuns?: AgentRunResponse[] | null;
+  agentRuns?: GuardianThreadRunInput[] | null;
   threadId?: number | null;
 };
 
@@ -47,13 +32,7 @@ type BrowserApprovalsResponse = {
   items?: BrowserApprovalResponse[] | null;
 };
 
-type BrowserApprovalResponse = {
-  id?: number | null;
-  operation?: string | null;
-  request_reason?: string | null;
-  status?: string | null;
-  target?: string | null;
-};
+type BrowserApprovalResponse = GuardianPendingApprovalInput;
 
 type ApprovalDecisionResponse = {
   id?: number | null;
@@ -61,172 +40,6 @@ type ApprovalDecisionResponse = {
   status?: string | null;
   target?: string | null;
 };
-
-type ActionableRun = {
-  kind: GuardianThreadInterventionKind;
-  rawStatus: string;
-  runId: string | null;
-  runtimeTarget: string | null;
-  worktreeId: string | null;
-  worktreePath: string | null;
-};
-
-function normalizeStatus(status: unknown): string {
-  return String(status ?? "")
-    .trim()
-    .toLowerCase();
-}
-
-function classifyRunKind(rawStatus: string): GuardianThreadInterventionKind | null {
-  if (
-    rawStatus === "awaiting_approval" ||
-    rawStatus === "approval_required" ||
-    rawStatus === "pending"
-  ) {
-    return "approval_required";
-  }
-
-  if (
-    rawStatus === "clarification_required" ||
-    rawStatus === "requires_clarification" ||
-    rawStatus === "clarification_needed" ||
-    rawStatus === "needs_clarification"
-  ) {
-    return "clarification_required";
-  }
-
-  if (rawStatus === "blocked" || rawStatus === "escalated") {
-    return "blocked_waiting_for_user";
-  }
-
-  return null;
-}
-
-function findActionableRun(runs: AgentRunResponse[]): ActionableRun | null {
-  for (const run of runs) {
-    const rawStatus = normalizeStatus(run.status);
-    const kind = classifyRunKind(rawStatus);
-    if (!kind) continue;
-
-    return {
-      kind,
-      rawStatus,
-      runId:
-        typeof run.run_id === "string" && run.run_id.trim()
-          ? run.run_id
-          : null,
-      runtimeTarget:
-        typeof run.runtime_target === "string" && run.runtime_target.trim()
-          ? run.runtime_target
-          : null,
-      worktreeId:
-        typeof run.worktree_id === "string" && run.worktree_id.trim()
-          ? run.worktree_id
-          : null,
-      worktreePath:
-        typeof run.worktree_path === "string" && run.worktree_path.trim()
-          ? run.worktree_path
-          : null,
-    };
-  }
-
-  return null;
-}
-
-function kindStatusLabel(kind: GuardianThreadInterventionKind): string {
-  if (kind === "approval_required") return "Approval required";
-  if (kind === "clarification_required") return "Clarification required";
-  return "Blocked waiting for user";
-}
-
-function kindTitle(kind: GuardianThreadInterventionKind): string {
-  if (kind === "approval_required") return "Guardian needs your approval";
-  if (kind === "clarification_required") return "Guardian needs clarification";
-  return "Guardian is blocked in this thread";
-}
-
-function interventionSummary(run: ActionableRun): string {
-  if (run.kind === "approval_required") {
-    return "A guarded action for this thread is waiting for explicit user approval.";
-  }
-  if (run.kind === "clarification_required") {
-    return "Guardian paused this run and needs direction before it can continue.";
-  }
-  return "This thread run is blocked and waiting for user intervention.";
-}
-
-function buildRedirectPrompt(run: ActionableRun): string {
-  const runFragment = run.runId ? ` for run ${run.runId}` : "";
-  return `Guardian, do this instead${runFragment}: `;
-}
-
-function maybeMatchesThreadContext(
-  approval: BrowserApprovalResponse,
-  threadId: number,
-  runId: string | null
-): boolean {
-  const haystack = [
-    approval.operation,
-    approval.target,
-    approval.request_reason,
-  ]
-    .filter((value): value is string => typeof value === "string")
-    .join(" ")
-    .toLowerCase();
-
-  if (!haystack.trim()) return false;
-
-  const threadTokens = [
-    `thread ${threadId}`,
-    `thread:${threadId}`,
-    `thread_id:${threadId}`,
-    `thread_id=${threadId}`,
-    `"thread_id":${threadId}`,
-    `/chat/${threadId}`,
-  ];
-
-  if (threadTokens.some((token) => haystack.includes(token))) {
-    return true;
-  }
-
-  if (runId && haystack.includes(runId.toLowerCase())) {
-    return true;
-  }
-
-  return false;
-}
-
-function buildIntervention(
-  run: ActionableRun,
-  threadId: number,
-  linkedApprovalId: number | null
-): GuardianThreadIntervention {
-  const details = [
-    run.runId ? `Run: ${run.runId}` : null,
-    run.runtimeTarget ? `Runtime: ${run.runtimeTarget}` : null,
-    run.worktreeId ? `Worktree: ${run.worktreeId}` : null,
-    run.worktreePath ? `Path: ${run.worktreePath}` : null,
-    run.rawStatus ? `Raw status: ${run.rawStatus}` : null,
-  ].filter((value): value is string => Boolean(value));
-
-  return {
-    canRedirect: true,
-    decision: {
-      approvalId: linkedApprovalId,
-      supported: linkedApprovalId != null,
-    },
-    details,
-    id: `${threadId}:${run.runId ?? run.kind}`,
-    kind: run.kind,
-    rawStatus: run.rawStatus,
-    redirectPrompt: buildRedirectPrompt(run),
-    runId: run.runId,
-    statusLabel: kindStatusLabel(run.kind),
-    summary: interventionSummary(run),
-    threadId,
-    title: kindTitle(run.kind),
-  };
-}
 
 function parseDecisionResult(
   data: ApprovalDecisionResponse,
@@ -265,39 +78,36 @@ export async function fetchGuardianThreadApprovalSnapshot(
     return { intervention: null, warnings };
   }
 
-  const actionableRun = findActionableRun(runs);
-  if (!actionableRun) {
+  const initialIntervention = interpretGuardianThreadIntervention({
+    agentRuns: runs,
+    pendingApprovals: [],
+    threadId,
+  });
+  if (!initialIntervention) {
     return { intervention: null, warnings };
   }
 
-  let linkedApprovalId: number | null = null;
-  if (actionableRun.kind === "approval_required") {
+  let pendingApprovals: BrowserApprovalResponse[] = [];
+  if (initialIntervention.kind === "approval_required") {
     try {
       const approvalsResponse = await api.get<BrowserApprovalsResponse>(
         "/api/browser/approvals",
         { params: { status_value: "PENDING" } }
       );
-      const matchingApproval = Array.isArray(approvalsResponse.data?.items)
-        ? approvalsResponse.data.items.find((approval) =>
-            maybeMatchesThreadContext(
-              approval,
-              threadId,
-              actionableRun.runId
-            )
-          ) ?? null
-        : null;
-
-      linkedApprovalId =
-        matchingApproval && typeof matchingApproval.id === "number"
-          ? matchingApproval.id
-          : null;
+      pendingApprovals = Array.isArray(approvalsResponse.data?.items)
+        ? approvalsResponse.data.items
+        : [];
     } catch {
       warnings.push("Approval decision route is currently unavailable.");
     }
   }
 
   return {
-    intervention: buildIntervention(actionableRun, threadId, linkedApprovalId),
+    intervention: interpretGuardianThreadIntervention({
+      agentRuns: runs,
+      pendingApprovals,
+      threadId,
+    }),
     warnings,
   };
 }

--- a/frontend/src/features/chat/approvals/threadIntervention.ts
+++ b/frontend/src/features/chat/approvals/threadIntervention.ts
@@ -1,0 +1,238 @@
+export type GuardianThreadInterventionKind =
+  | "approval_required"
+  | "clarification_required"
+  | "blocked_waiting_for_user";
+
+export type GuardianThreadApprovalDecision = {
+  approvalId: number | null;
+  supported: boolean;
+};
+
+export type GuardianThreadIntervention = {
+  canRedirect: boolean;
+  decision: GuardianThreadApprovalDecision;
+  details: string[];
+  id: string;
+  kind: GuardianThreadInterventionKind;
+  rawStatus: string;
+  redirectPrompt: string;
+  runId: string | null;
+  statusLabel: string;
+  summary: string;
+  threadId: number;
+  title: string;
+};
+
+export type GuardianThreadRunInput = {
+  run_id?: string | null;
+  runtime_target?: string | null;
+  status?: string | null;
+  thread_id?: number | null;
+  worktree_id?: string | null;
+  worktree_path?: string | null;
+};
+
+export type GuardianPendingApprovalInput = {
+  id?: number | null;
+  operation?: string | null;
+  request_reason?: string | null;
+  status?: string | null;
+  target?: string | null;
+};
+
+export type GuardianThreadInterventionInput = {
+  agentRuns?: readonly GuardianThreadRunInput[] | null;
+  pendingApprovals?: readonly GuardianPendingApprovalInput[] | null;
+  threadId?: number | null;
+};
+
+type ActionableRun = {
+  kind: GuardianThreadInterventionKind;
+  rawStatus: string;
+  runId: string | null;
+  runtimeTarget: string | null;
+  worktreeId: string | null;
+  worktreePath: string | null;
+};
+
+function normalizeStatus(status: unknown): string {
+  return String(status ?? "")
+    .trim()
+    .toLowerCase();
+}
+
+export function classifyGuardianThreadRunKind(
+  status: unknown
+): GuardianThreadInterventionKind | null {
+  const rawStatus = normalizeStatus(status);
+  if (
+    rawStatus === "awaiting_approval" ||
+    rawStatus === "approval_required" ||
+    rawStatus === "pending"
+  ) {
+    return "approval_required";
+  }
+
+  if (
+    rawStatus === "clarification_required" ||
+    rawStatus === "requires_clarification" ||
+    rawStatus === "clarification_needed" ||
+    rawStatus === "needs_clarification"
+  ) {
+    return "clarification_required";
+  }
+
+  if (rawStatus === "blocked" || rawStatus === "escalated") {
+    return "blocked_waiting_for_user";
+  }
+
+  return null;
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function findActionableRun(
+  runs: readonly GuardianThreadRunInput[]
+): ActionableRun | null {
+  for (const run of runs) {
+    const rawStatus = normalizeStatus(run.status);
+    const kind = classifyGuardianThreadRunKind(rawStatus);
+    if (!kind) continue;
+
+    return {
+      kind,
+      rawStatus,
+      runId: optionalString(run.run_id),
+      runtimeTarget: optionalString(run.runtime_target),
+      worktreeId: optionalString(run.worktree_id),
+      worktreePath: optionalString(run.worktree_path),
+    };
+  }
+
+  return null;
+}
+
+function kindStatusLabel(kind: GuardianThreadInterventionKind): string {
+  if (kind === "approval_required") return "Approval required";
+  if (kind === "clarification_required") return "Clarification required";
+  return "Blocked waiting for user";
+}
+
+function kindTitle(kind: GuardianThreadInterventionKind): string {
+  if (kind === "approval_required") return "Guardian needs your approval";
+  if (kind === "clarification_required") return "Guardian needs clarification";
+  return "Guardian is blocked in this thread";
+}
+
+function interventionSummary(run: ActionableRun): string {
+  if (run.kind === "approval_required") {
+    return "A guarded action for this thread is waiting for explicit user approval.";
+  }
+  if (run.kind === "clarification_required") {
+    return "Guardian paused this run and needs direction before it can continue.";
+  }
+  return "This thread run is blocked and waiting for user intervention.";
+}
+
+function buildRedirectPrompt(run: ActionableRun): string {
+  const runFragment = run.runId ? ` for run ${run.runId}` : "";
+  return `Guardian, do this instead${runFragment}: `;
+}
+
+export function guardianApprovalMatchesThread(
+  approval: GuardianPendingApprovalInput,
+  threadId: number,
+  runId: string | null
+): boolean {
+  if (normalizeStatus(approval.status) !== "pending") return false;
+
+  const haystack = [
+    approval.operation,
+    approval.target,
+    approval.request_reason,
+  ]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ")
+    .toLowerCase();
+
+  if (!haystack.trim()) return false;
+
+  const threadTokens = [
+    `thread ${threadId}`,
+    `thread:${threadId}`,
+    `thread_id:${threadId}`,
+    `thread_id=${threadId}`,
+    `"thread_id":${threadId}`,
+    `/chat/${threadId}`,
+  ];
+
+  if (threadTokens.some((token) => haystack.includes(token))) {
+    return true;
+  }
+
+  return Boolean(runId && haystack.includes(runId.toLowerCase()));
+}
+
+export function interpretGuardianThreadIntervention({
+  agentRuns,
+  pendingApprovals,
+  threadId,
+}: GuardianThreadInterventionInput): GuardianThreadIntervention | null {
+  if (typeof threadId !== "number") return null;
+
+  const actionableRun = findActionableRun(
+    Array.isArray(agentRuns) ? agentRuns : []
+  );
+  if (!actionableRun) return null;
+
+  const matchingApproval =
+    actionableRun.kind === "approval_required" &&
+    Array.isArray(pendingApprovals)
+      ? pendingApprovals.find((approval) =>
+          guardianApprovalMatchesThread(
+            approval,
+            threadId,
+            actionableRun.runId
+          )
+        ) ?? null
+      : null;
+  const linkedApprovalId =
+    matchingApproval && typeof matchingApproval.id === "number"
+      ? matchingApproval.id
+      : null;
+  const details = [
+    actionableRun.runId ? `Run: ${actionableRun.runId}` : null,
+    actionableRun.runtimeTarget
+      ? `Runtime: ${actionableRun.runtimeTarget}`
+      : null,
+    actionableRun.worktreeId
+      ? `Worktree: ${actionableRun.worktreeId}`
+      : null,
+    actionableRun.worktreePath
+      ? `Path: ${actionableRun.worktreePath}`
+      : null,
+    actionableRun.rawStatus
+      ? `Raw status: ${actionableRun.rawStatus}`
+      : null,
+  ].filter((value): value is string => Boolean(value));
+
+  return {
+    canRedirect: true,
+    decision: {
+      approvalId: linkedApprovalId,
+      supported: linkedApprovalId != null,
+    },
+    details,
+    id: `${threadId}:${actionableRun.runId ?? actionableRun.kind}`,
+    kind: actionableRun.kind,
+    rawStatus: actionableRun.rawStatus,
+    redirectPrompt: buildRedirectPrompt(actionableRun),
+    runId: actionableRun.runId,
+    statusLabel: kindStatusLabel(actionableRun.kind),
+    summary: interventionSummary(actionableRun),
+    threadId,
+    title: kindTitle(actionableRun.kind),
+  };
+}

--- a/frontend/src/features/chat/components/GuardianThreadApprovalRail.tsx
+++ b/frontend/src/features/chat/components/GuardianThreadApprovalRail.tsx
@@ -29,7 +29,6 @@ export default function GuardianThreadApprovalRail({
     intervention,
     loading,
     notice,
-    reload,
     submittingAction,
     visible,
   } = useGuardianThreadApprovalRail({ threadId, reloadSignal });
@@ -48,14 +47,17 @@ export default function GuardianThreadApprovalRail({
   }
 
   const railClassName = [
-    "rounded-xl border px-3 py-3",
+    "rounded-[var(--card-radius)] border p-[var(--card-pad)]",
     className ?? "",
   ]
     .filter(Boolean)
     .join(" ");
   const decisionBusy = submittingAction != null;
-  const decisionDisabled = decisionBusy || !canSubmitDecision;
   const hasContext = intervention.details.length > 0;
+  const contextId = `guardian-intervention-context-${intervention.id.replace(
+    /[^a-zA-Z0-9_-]/g,
+    "-"
+  )}`;
 
   const handleTellGuardian = () => {
     if (onTellGuardianWhatToDoInstead) {
@@ -78,56 +80,65 @@ export default function GuardianThreadApprovalRail({
     <section
       className={railClassName}
       style={{
-        background: "color-mix(in srgb, var(--panel-bg) 92%, transparent)",
-        borderColor: "var(--panel-border)",
+        background:
+          "color-mix(in oklab, var(--panel-bg) 90%, var(--accent-weak) 10%)",
+        borderColor:
+          "color-mix(in oklab, var(--panel-border) 66%, var(--accent) 34%)",
+        marginBottom: "var(--card-pad)",
       }}
+      aria-busy={decisionBusy}
+      aria-labelledby={`${contextId}-title`}
       data-testid="guardian-thread-approval-rail"
     >
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
-          <div
-            className="text-[11px] font-semibold uppercase tracking-[0.08em]"
-            style={{ color: "var(--muted)" }}
-          >
-            {intervention.statusLabel}
-          </div>
-          <h3 className="mt-1 text-sm font-semibold" style={{ color: "var(--text)" }}>
-            {intervention.title}
-          </h3>
-          <p className="mt-1 text-xs leading-5" style={{ color: "var(--muted)" }}>
-            {intervention.summary}
-          </p>
-        </div>
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          className="border border-[var(--panel-border)]"
-          onClick={() => void reload()}
-          disabled={loading || decisionBusy}
+      <div className="min-w-0">
+        <div
+          className="text-[11px] font-semibold uppercase tracking-[0.08em]"
+          style={{ color: "var(--accent)" }}
         >
-          {loading ? "Checking…" : "Reload"}
-        </Button>
+          {intervention.statusLabel}
+        </div>
+        <h3
+          id={`${contextId}-title`}
+          className="text-sm font-semibold"
+          style={{ color: "var(--text)", marginTop: "calc(var(--card-pad) / 3)" }}
+        >
+          {intervention.title}
+        </h3>
+        <p
+          className="text-xs leading-5"
+          style={{ color: "var(--muted)", marginTop: "calc(var(--card-pad) / 3)" }}
+        >
+          {intervention.summary}
+        </p>
       </div>
 
-      <div className="mt-3 flex flex-wrap gap-2">
-        <Button
-          type="button"
-          size="sm"
-          onClick={() => void approve()}
-          disabled={decisionDisabled}
-        >
-          {submittingAction === "approve" ? "Approving…" : "Approve"}
-        </Button>
-        <Button
-          type="button"
-          size="sm"
-          variant="destructive"
-          onClick={() => void deny()}
-          disabled={decisionDisabled}
-        >
-          {submittingAction === "deny" ? "Denying…" : "Deny"}
-        </Button>
+      <div
+        className="flex flex-wrap"
+        style={{ gap: "calc(var(--card-pad) / 2)", marginTop: "var(--card-pad)" }}
+      >
+        {canSubmitDecision ? (
+          <>
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => void approve()}
+              disabled={decisionBusy}
+              aria-label="Approve Guardian request"
+            >
+              {submittingAction === "approve" ? "Approving…" : "Approve"}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="destructive"
+              onClick={() => void deny()}
+              disabled={decisionBusy}
+              aria-label="Deny Guardian request"
+            >
+              {submittingAction === "deny" ? "Denying…" : "Deny"}
+            </Button>
+          </>
+        ) : null}
         {hasContext ? (
           <Button
             type="button"
@@ -135,6 +146,8 @@ export default function GuardianThreadApprovalRail({
             variant="ghost"
             className="border border-[var(--panel-border)]"
             onClick={() => setShowContext((current) => !current)}
+            aria-controls={contextId}
+            aria-expanded={showContext}
           >
             {showContext ? "Hide context" : "Inspect context"}
           </Button>
@@ -143,7 +156,7 @@ export default function GuardianThreadApprovalRail({
           <Button
             type="button"
             size="sm"
-            variant="ghost"
+            variant={canSubmitDecision ? "ghost" : "default"}
             className="border border-[var(--panel-border)]"
             onClick={handleTellGuardian}
           >
@@ -152,16 +165,16 @@ export default function GuardianThreadApprovalRail({
         ) : null}
       </div>
 
-      {!canSubmitDecision ? (
-        <p className="mt-2 text-xs" style={{ color: "var(--muted)" }}>
-          Direct approve/deny is unavailable for this thread intervention.
-        </p>
-      ) : null}
-
       {showContext && hasContext ? (
         <ul
-          className="mt-2 space-y-1 rounded-lg border px-2 py-2 text-xs"
-          style={{ borderColor: "var(--panel-border)", color: "var(--muted)" }}
+          id={contextId}
+          className="grid rounded-[var(--radius-micro)] border p-[var(--card-pad)] text-xs"
+          style={{
+            borderColor: "var(--panel-border)",
+            color: "var(--muted)",
+            gap: "calc(var(--card-pad) / 3)",
+            marginTop: "calc(var(--card-pad) / 2)",
+          }}
         >
           {intervention.details.map((item) => (
             <li key={item}>{item}</li>
@@ -171,11 +184,15 @@ export default function GuardianThreadApprovalRail({
 
       {notice ? (
         <div
-          className="mt-2 rounded-lg border px-2 py-1 text-xs"
+          className="rounded-[var(--radius-micro)] border text-xs"
           style={{
-            borderColor: "rgba(34, 197, 94, 0.35)",
-            background: "rgba(34, 197, 94, 0.12)",
+            borderColor:
+              "color-mix(in oklab, var(--accent) 34%, var(--panel-border))",
+            background:
+              "color-mix(in oklab, var(--accent-weak) 18%, var(--panel-bg))",
             color: "var(--text)",
+            marginTop: "calc(var(--card-pad) / 2)",
+            padding: "calc(var(--card-pad) / 2)",
           }}
           role="status"
         >
@@ -185,11 +202,13 @@ export default function GuardianThreadApprovalRail({
 
       {error ? (
         <div
-          className="mt-2 rounded-lg border px-2 py-1 text-xs"
+          className="rounded-[var(--radius-micro)] border text-xs"
           style={{
-            borderColor: "rgba(239, 68, 68, 0.35)",
-            background: "rgba(239, 68, 68, 0.12)",
-            color: "var(--text)",
+            borderColor: "var(--danger-border)",
+            background: "var(--danger-surface)",
+            color: "var(--danger-text)",
+            marginTop: "calc(var(--card-pad) / 2)",
+            padding: "calc(var(--card-pad) / 2)",
           }}
           role="alert"
         >


### PR DESCRIPTION
## Summary

- introduces one shared thread-intervention interpretation contract (`frontend/src/features/chat/approvals/threadIntervention.ts`);
- converts Guardian Chat approval handling into a focused decision card;
- projects the same Guardian-owned approval state into the Chrome side panel;
- preserves exact-ID Approve/Deny behavior;
- keeps Guardian as sole approval authority.

## Architecture

- aligned with existing ADR-051 and approval contracts;
- no new ADR;
- no backend/schema changes;
- no Chrome permission changes;
- no authentication-mode changes;
- no Beta/release expansion.

## Validation

- shared/main approval suites: `20/20 passed`;
- Chrome extension regression suite: `77/77 passed`;
- Chrome production build: passed, 292 modules transformed;
- `git diff --check`: passed;
- manifest permission regression: no diff.

## Known unrelated issue

The broad frontend test script is not claimed green. Existing `GuardianChat.test.tsx` behavior independently reproduced a Node/V8 approximately 4 GB heap OOM. The focused task-owned suites pass, and no heap/Docker/test-infrastructure workaround is part of this PR.

## Evidence posture

- code-path/test/build evidence;
- no live unpacked-Chrome/browser proof claimed.

## Deferred

- Guardian/model-thinking animated visual treatment;
- separate GuardianChat/Vitest heap diagnostic.
