### PR TITLE
Align Settings dock active selector with Theme selector

### DIFF
--- a/frontend/src/features/settings/components/SettingsPanelDock.tsx
+++ b/frontend/src/features/settings/components/SettingsPanelDock.tsx
@@ -25,13 +25,19 @@ export default function SettingsPanelDock({
       )}
       style={
         {
-          "--settings-nav-surface":
-            "color-mix(in srgb, var(--panel-bg) 86%, var(--text) 14%)",
-          "--pill-active-bg": "transparent",
+          // Active selector uses the canonical accent-backed translucent fill
+          // (matches SegmentedThemeControl). The color follows the resolved
+          // --accent / --accent-strong tokens — no hardcoded brand color.
+          "--pill-active-bg":
+            "color-mix(in oklab, var(--accent-strong) 86%, transparent)",
           "--pill-active-text": "var(--text)",
-          "--pill-active-border": "var(--accent)",
+          "--pill-active-border":
+            "color-mix(in oklab, var(--accent-strong) 40%, transparent)",
+          // Restrained layered accent glow — luminous but subordinate to
+          // the tab label. All values are derived from --accent-strong /
+          // --accent-weak; no raw color literals.
           "--pill-active-shadow":
-            "0 0 calc(var(--radius-micro) * 0.75) color-mix(in srgb, var(--accent-weak) 72%, transparent)",
+            "0 0 0 1px color-mix(in oklab, var(--accent-strong) 38%, transparent), 0 8px 22px color-mix(in oklab, var(--accent-strong) 28%, transparent), 0 0 calc(var(--radius-micro) * 1.25) color-mix(in oklab, var(--accent-weak) 60%, transparent)",
           position: "sticky",
           top: SETTINGS_DENSITY.edgeChrome,
           paddingInline: SETTINGS_DENSITY.edgeChrome,
@@ -44,10 +50,9 @@ export default function SettingsPanelDock({
       }}
     >
       <div
-        className="glass-pill isolate relative flex w-full min-w-0 items-stretch overflow-x-auto p-[var(--settings-dock-padding)]"
+        className="settings-panel-dock__glass glass-pill isolate relative flex w-full min-w-0 items-stretch overflow-x-auto p-[var(--settings-dock-padding)]"
         style={
           {
-            background: "var(--settings-nav-surface)",
             "--pill-gap": SETTINGS_DENSITY.dockGap,
             "--pill-font": SETTINGS_DENSITY.dockFontSize,
             "--settings-dock-gap": SETTINGS_DENSITY.dockGap,

--- a/frontend/src/features/settings/components/SettingsPanelDock.tsx
+++ b/frontend/src/features/settings/components/SettingsPanelDock.tsx
@@ -13,6 +13,13 @@ export default function SettingsPanelDock({
   className,
   "data-testid": dataTestId = "settings-panel-dock",
 }: SettingsPanelDockProps) {
+  // The active tab inherits the canonical .pill-tab[data-state="active"]
+  // styling through the shared pill primitives — same as the Theme selector.
+  // No dock-local --pill-active-* overrides are set here, so the selected
+  // tab reads as the same filled glowing accent pill family as the rest of
+  // Codexify. The bounded Settings material hook (settings-panel-dock__glass)
+  // lives in index.css and handles the dark/light glass shell + perimeter
+  // fringe without redefining the active selector.
   return (
     <nav
       data-testid={dataTestId}
@@ -25,19 +32,6 @@ export default function SettingsPanelDock({
       )}
       style={
         {
-          // Active selector uses the canonical accent-backed translucent fill
-          // (matches SegmentedThemeControl). The color follows the resolved
-          // --accent / --accent-strong tokens — no hardcoded brand color.
-          "--pill-active-bg":
-            "color-mix(in oklab, var(--accent-strong) 86%, transparent)",
-          "--pill-active-text": "var(--text)",
-          "--pill-active-border":
-            "color-mix(in oklab, var(--accent-strong) 40%, transparent)",
-          // Restrained layered accent glow — luminous but subordinate to
-          // the tab label. All values are derived from --accent-strong /
-          // --accent-weak; no raw color literals.
-          "--pill-active-shadow":
-            "0 0 0 1px color-mix(in oklab, var(--accent-strong) 38%, transparent), 0 8px 22px color-mix(in oklab, var(--accent-strong) 28%, transparent), 0 0 calc(var(--radius-micro) * 1.25) color-mix(in oklab, var(--accent-weak) 60%, transparent)",
           position: "sticky",
           top: SETTINGS_DENSITY.edgeChrome,
           paddingInline: SETTINGS_DENSITY.edgeChrome,

--- a/frontend/src/features/settings/components/__tests__/SettingsPanelDock.test.tsx
+++ b/frontend/src/features/settings/components/__tests__/SettingsPanelDock.test.tsx
@@ -83,11 +83,11 @@ describe("SettingsPanelDock", () => {
     expect(rail).not.toHaveClass("flex-wrap", "whitespace-normal");
   });
 
-  test("drives the active selector from the system-accent tokens", () => {
-    // The selected tab must read as a luminous accent-backed pill, not a
-    // transparent placeholder. The color must follow the resolved
-    // --accent-strong token so it changes automatically when the system
-    // accent changes.
+  test("does not override the canonical active-selector tokens", () => {
+    // The active tab inherits the canonical .pill-tab[data-state="active"]
+    // styling through the shared pill primitives — same as the Theme
+    // selector. The dock does not set --pill-active-* on the <nav>, so the
+    // selected tab falls back to the canonical defaults.
     render(
       <SettingsPanelDock>
         <button type="button" role="tab" aria-selected="true">
@@ -99,23 +99,13 @@ describe("SettingsPanelDock", () => {
     const dock = screen.getByRole("tablist", { name: "Settings tabs" });
     const navStyle = dock.getAttribute("style") ?? "";
 
-    // The active fill is token-driven and non-transparent.
-    const activeBg = dock.style.getPropertyValue("--pill-active-bg");
-    expect(activeBg).not.toBe("");
-    expect(activeBg.trim().toLowerCase()).not.toBe("transparent");
-    expect(activeBg).toContain("var(--accent-strong)");
+    // The dock must not pin dock-specific --pill-active-* values.
+    expect(navStyle).not.toContain("--pill-active-bg");
+    expect(navStyle).not.toContain("--pill-active-border");
+    expect(navStyle).not.toContain("--pill-active-shadow");
+    expect(navStyle).not.toContain("--pill-active-text");
 
-    // The active border / shadow must derive from accent tokens.
-    const activeBorder = dock.style.getPropertyValue("--pill-active-border");
-    expect(activeBorder).toContain("var(--accent-strong)");
-
-    const activeShadow = dock.style.getPropertyValue("--pill-active-shadow");
-    expect(activeShadow).not.toBe("");
-    expect(activeShadow).toContain("var(--accent-strong)");
-    expect(activeShadow).toContain("var(--accent-weak)");
-
-    // No hardcoded hex/rgb brand color should be embedded in the active
-    // selector overrides — the accent must follow the token system.
+    // And it must not hardcode a brand color for the active selector.
     expect(navStyle.toLowerCase()).not.toMatch(/#[0-9a-f]{3,6}\b/);
   });
 

--- a/frontend/src/features/settings/components/__tests__/SettingsPanelDock.test.tsx
+++ b/frontend/src/features/settings/components/__tests__/SettingsPanelDock.test.tsx
@@ -21,31 +21,128 @@ describe("SettingsPanelDock", () => {
     );
 
     const dock = screen.getByRole("tablist", { name: "Settings tabs" });
-    const navigationSurface =
-      "color-mix(in srgb, var(--panel-bg) 86%, var(--text) 14%)";
     expect(dock).toHaveClass("sticky", "flex", "w-full", "justify-center");
+    expect(dock).toHaveAttribute("aria-orientation", "horizontal");
     expect(dock).toHaveStyle({
-      "--settings-nav-surface": navigationSurface,
-      "--pill-active-bg": "transparent",
-      "--pill-active-text": "var(--text)",
-      "--pill-active-border": "var(--accent)",
-      "--pill-active-shadow":
-        "0 0 calc(var(--radius-micro) * 0.75) color-mix(in srgb, var(--accent-weak) 72%, transparent)",
       position: "sticky",
       top: SETTINGS_DENSITY.edgeChrome,
       paddingInline: SETTINGS_DENSITY.edgeChrome,
     });
-    expect(navigationSurface).toContain("var(--panel-bg)");
-    expect(navigationSurface).toContain("var(--text)");
-    expect(navigationSurface).toContain("86%");
-    expect(navigationSurface).toContain("14%");
-    expect(navigationSurface).not.toContain("var(--accent)");
-    expect(dock).toHaveAttribute("aria-orientation", "horizontal");
-    const rail = screen.getByTestId("settings-panel-dock").querySelector(".glass-pill");
-    expect(rail).toHaveClass("glass-pill", "w-full", "overflow-x-auto");
-    expect(rail).toHaveStyle({ background: "var(--settings-nav-surface)" });
-    expect(rail?.getAttribute("style")).not.toContain("var(--accent)");
+  });
+
+  test("does not paint an opaque panel-bg surface as the rail background", () => {
+    // The legacy dock forced a panel-bg-heavy inline background on the
+    // glass-pill rail. The refractive-glass build must let the canonical
+    // .glass-pill material show through, so no opaque surface override
+    // should be applied here.
+    render(
+      <SettingsPanelDock>
+        <button type="button" role="tab" aria-selected="true">
+          Appearance
+        </button>
+      </SettingsPanelDock>
+    );
+
+    const dock = screen.getByRole("tablist", { name: "Settings tabs" });
+    const navStyle = (dock.getAttribute("style") ?? "").toLowerCase();
+    expect(navStyle).not.toContain("--settings-nav-surface");
+    expect(navStyle).not.toContain("var(--panel-bg) 86%");
+    expect(navStyle).not.toContain("var(--panel-bg) 92%");
+
+    const rail = screen
+      .getByTestId("settings-panel-dock")
+      .querySelector(".glass-pill");
+    expect(rail).toBeTruthy();
+    const railStyle = (rail?.getAttribute("style") ?? "").toLowerCase();
+    expect(railStyle).not.toContain("--settings-nav-surface");
+    // The rail must not redeclare `background:` inline — the canonical
+    // .glass-pill material is the only surface.
+    expect(railStyle).not.toMatch(/(^|;|\s)background\s*:/);
+  });
+
+  test("gives the dock a bounded Settings-specific material class hook", () => {
+    render(
+      <SettingsPanelDock>
+        <button type="button" role="tab" aria-selected="true">
+          Appearance
+        </button>
+      </SettingsPanelDock>
+    );
+
+    const rail = screen
+      .getByTestId("settings-panel-dock")
+      .querySelector(".glass-pill");
+    expect(rail).toHaveClass(
+      "settings-panel-dock__glass",
+      "glass-pill",
+      "w-full",
+      "overflow-x-auto"
+    );
+    // The bounded material hook must not be inherited from .glass-pill —
+    // it is a Settings-specific identifier.
     expect(rail).not.toHaveClass("flex-wrap", "whitespace-normal");
+  });
+
+  test("drives the active selector from the system-accent tokens", () => {
+    // The selected tab must read as a luminous accent-backed pill, not a
+    // transparent placeholder. The color must follow the resolved
+    // --accent-strong token so it changes automatically when the system
+    // accent changes.
+    render(
+      <SettingsPanelDock>
+        <button type="button" role="tab" aria-selected="true">
+          Appearance
+        </button>
+      </SettingsPanelDock>
+    );
+
+    const dock = screen.getByRole("tablist", { name: "Settings tabs" });
+    const navStyle = dock.getAttribute("style") ?? "";
+
+    // The active fill is token-driven and non-transparent.
+    const activeBg = dock.style.getPropertyValue("--pill-active-bg");
+    expect(activeBg).not.toBe("");
+    expect(activeBg.trim().toLowerCase()).not.toBe("transparent");
+    expect(activeBg).toContain("var(--accent-strong)");
+
+    // The active border / shadow must derive from accent tokens.
+    const activeBorder = dock.style.getPropertyValue("--pill-active-border");
+    expect(activeBorder).toContain("var(--accent-strong)");
+
+    const activeShadow = dock.style.getPropertyValue("--pill-active-shadow");
+    expect(activeShadow).not.toBe("");
+    expect(activeShadow).toContain("var(--accent-strong)");
+    expect(activeShadow).toContain("var(--accent-weak)");
+
+    // No hardcoded hex/rgb brand color should be embedded in the active
+    // selector overrides — the accent must follow the token system.
+    expect(navStyle.toLowerCase()).not.toMatch(/#[0-9a-f]{3,6}\b/);
+  });
+
+  test("preserves dock geometry, tab layout, and ARIA semantics", () => {
+    render(
+      <SettingsPanelDock>
+        <button type="button" role="tab" aria-selected="true">
+          Appearance
+        </button>
+        <button type="button" role="tab" aria-selected="false">
+          Imprint
+        </button>
+        <button type="button" role="tab" aria-selected="false">
+          Personal Facts
+        </button>
+      </SettingsPanelDock>
+    );
+
+    const dock = screen.getByRole("tablist", { name: "Settings tabs" });
+    expect(dock).toHaveClass("sticky", "flex", "w-full", "justify-center");
+
+    const rail = screen
+      .getByTestId("settings-panel-dock")
+      .querySelector(".glass-pill");
+    expect(rail).toHaveClass("glass-pill", "w-full", "overflow-x-auto");
+    expect(rail).not.toHaveClass("flex-wrap", "whitespace-normal");
+
     const tabGroup = rail?.firstElementChild;
     expect(tabGroup).toHaveClass(
       "flex",
@@ -55,8 +152,11 @@ describe("SettingsPanelDock", () => {
       "whitespace-nowrap"
     );
     expect(tabGroup).not.toHaveClass("flex-wrap");
+
     expect(screen.getByRole("tab", { name: "Appearance" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Imprint" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Personal Facts" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: "Personal Facts" })
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -305,6 +305,61 @@ button.brand-tab,
     inset 0 1px 0 rgba(255,255,255,0.22);
 }
 
+/* ─────────────────────────────────────────
+   Settings dock — bounded material specialization.
+   Scoped to the Settings nav rail only; does not affect other .glass-pill
+   consumers. Builds on the canonical glass-pill material rather than
+   replacing it.
+   • Light mode: clear glass body (canonical .glass-pill background is
+     preserved) + a subtle accent-tinted spectral fringe around the
+     perimeter (chromatic dispersion). Body stays transparent.
+   • Dark mode: the canonical .dark .glass-pill already provides the
+     smoked transparent shell; this hook only adds a cooler perimeter
+     fringe so the accent glow doesn't over-saturate the smoked pane.
+   • Active selector color follows the resolved --accent tokens via the
+     --pill-active-* overrides set on the <nav> wrapper.
+   ───────────────────────────────────────── */
+.settings-panel-dock__glass {
+  position: relative;
+  isolation: isolate;
+}
+
+/* Perimeter-only chromatic fringe. A pseudo-element layers the spectral
+   edge on top of the canonical glass-pill material without disturbing
+   the canonical .glass-pill box-shadow stack. The pseudo-element is
+   pointer-events: none so it never intercepts clicks on the tabs. All
+   accent-derived values use --accent / --accent-strong / --accent-weak;
+   no raw component-level color literals are introduced. */
+.settings-panel-dock__glass::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow:
+    0 0 0 1px color-mix(in oklab, var(--accent-weak) 35%, transparent),
+    0 0 18px -2px color-mix(in oklab, var(--accent) 22%, transparent),
+    0 0 28px -4px color-mix(in oklab, var(--accent-strong) 18%, transparent);
+}
+
+/* Dark mode: cool the perimeter fringe toward --accent-weak so the
+   accent glow doesn't over-saturate the smoked pane. */
+.dark .settings-panel-dock__glass::before {
+  box-shadow:
+    0 0 0 1px color-mix(in oklab, var(--accent-weak) 28%, transparent),
+    0 0 20px -2px color-mix(in oklab, var(--accent) 18%, transparent),
+    0 0 32px -6px color-mix(in oklab, var(--accent-strong) 14%, transparent);
+}
+
+/* Bring the active tab above the chromatic fringe so the selected tab
+   reads as a luminous pill, not a glowing rail. */
+.settings-panel-dock__glass .pill-tab {
+  position: relative;
+}
+.settings-panel-dock__glass .pill-tab[data-state="active"] {
+  z-index: 1;
+}
+
 /* Session rail hierarchy: one layout rail, split visible islands */
 .session-rail {
   border-color: transparent;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -673,3 +673,54 @@ button.brand-tab,
   --pill-gap: 10px;      /* gap between segments */
   --pill-font: 15px;     /* font size for tabs + brand */
 }
+
+/* ─────────────────────────────────────────
+   Settings dock — active-tab specificity bump.
+   The Settings tab button is rendered through the shared
+   <Button variant="ghost"> wrapper, which adds Tailwind utility classes
+   (including .bg-transparent) to the button. The canonical
+   .pill-tab[data-state="active"] rule lives in @layer components and
+   therefore loses cascade priority to top-level Tailwind utilities.
+
+   This rule is placed at the top level (outside @layer components) and
+   uses a Settings-scoped selector with three classes so its specificity
+   beats Tailwind's single-class utilities. The rule mirrors the canonical
+   .pill-tab[data-state="active"] language exactly — same var names, same
+   fallbacks — so the Settings dock active tab reads as the same filled
+   glowing accent pill as the Theme selector and any other .pill-tab
+   consumer. It does not introduce a second selector system; it only
+   restores the canonical active state for the dock.
+   ───────────────────────────────────────── */
+.settings-panel-dock__glass .pill-tab[data-state="active"] {
+  background: var(
+    --pill-active-bg,
+    color-mix(in oklab, var(--accent-strong) 86%, transparent)
+  );
+  border-color: var(
+    --pill-active-border,
+    color-mix(in oklab, var(--accent-strong) 40%, transparent)
+  );
+  box-shadow: var(
+    --pill-active-shadow,
+    0 12px 24px color-mix(in oklab, var(--accent-strong) 32%, transparent),
+    inset 0 1px 0 rgba(255, 255, 255, 0.38)
+  );
+  color: var(--pill-active-text, var(--text));
+}
+
+/* Dark-mode mirror of the rule above. The canonical .dark .pill-tab
+   rule lives in @layer components and therefore loses cascade priority
+   to top-level Tailwind utilities; this .dark-specific scoped rule
+   restores the same dark-mode active treatment for the Settings dock.
+   Values mirror the canonical dark-mode defaults exactly. */
+.dark .settings-panel-dock__glass .pill-tab[data-state="active"] {
+  background: var(
+    --pill-active-bg,
+    color-mix(in oklab, var(--accent-strong) 70%, rgba(15, 23, 42, 0.4))
+  );
+  box-shadow: var(
+    --pill-active-shadow,
+    0 12px 24px color-mix(in oklab, var(--accent-strong) 28%, transparent),
+    inset 0 1px 0 rgba(255, 255, 255, 0.22)
+  );
+}


### PR DESCRIPTION
## Summary

Restores the Settings navigation dock to the canonical refractive-glass material, then aligns the active-tab treatment with the Theme selector so the dock and the Theme selector read as the same selector family.

Two sequential slices — both touching only the three authorized files in this repo:

| Commit | Slice |
| --- | --- |
| `eb48f06fa` | Restore Settings dock glass material |
| `8927ded97` | Align Settings dock active selector with Theme selector |

### What the Settings dock looked like before

- An opaque `panel-bg`-heavy fill covered the rail (legacy `--settings-nav-surface` inline background).
- The active tab was forced to `background: transparent` with a single low-opacity accent outline — reading as a thin outlined selector that did not match the Theme selector.
- Inconsistent with the rest of the Codexify glass / pill system.

### What it looks like now

**Light mode**
- Clear glass body (the canonical `.glass-pill` `rgba(255,255,255,0.22→0.08)` linear gradient is preserved).
- A perimeter-only accent-tinted spectral fringe via a `::before` pseudo-element (low-opacity `--accent-weak`/`--accent`/`--accent-strong` layered `box-shadow`, `pointer-events: none`).
- Selected tab = the same filled glowing accent pill the Theme selector uses.

**Dark mode**
- The canonical `.dark .glass-pill` smoked-transparent gradient (`rgba(15,23,42,0.72→0.48)`) is the surface — no opaque fill.
- Cooler perimeter fringe so the accent doesn't over-saturate the smoked pane.
- Selected tab = filled glowing accent pill (canonical dark-mode treatment).

**Active selector**
- Filled `color-mix(in oklab, var(--accent-strong) 86%, transparent)` background (light) / 70% accent + dark-navy mix (dark).
- 40% accent rim border.
- 32% accent `0 12px 24px` glow + white inset highlight.
- Token-driven from `--accent` / `--accent-strong` / `--accent-weak`. No hardcoded brand color. Changing `cfy.baseColor` flips the selector automatically.

### Why the active-tab fix needed a Settings-scoped CSS rule

The Settings tab is rendered through the shared `<Button variant="ghost">` wrapper, which adds Tailwind utilities including `.bg-transparent` to the button. The canonical `.pill-tab[data-state="active"]` rule lives in `@layer components`; Tailwind utilities live at the top CSS layer, which wins regardless of specificity — so the canonical rule could not override `.bg-transparent` for any `<Button variant="ghost" class="pill-tab">` consumer.

Fix:
- Removed all dock-local `--pill-active-*` inline overrides from `SettingsPanelDock.tsx` so the dock uses the canonical defaults (same as the Theme selector) — no separate selector system.
- Added two top-level, Settings-scoped rules in `index.css` that mirror the canonical light- and dark-mode defaults exactly (same variable names, same fallbacks). Specificity `(0,3,0)` beats Tailwind's single-class utilities so the canonical treatment wins inside the dock only. No global change to other `.glass-pill` consumers.

## Visual proof (Playwright)

`/Volumes/Dev_SSD/Codexify-main/.playwright-tmp/` (untracked) contains the audit scripts and screenshots. The settings dock active tab's computed `background`, `border`, `box-shadow`, and `color` are now identical to the Theme selector's active tab in both `cfy.themeMode=light` and `cfy.themeMode=dark`, with both the default `cfy.baseColor` and a custom `#0ea5e9` (sky-500).

Inactive dock tabs remain `rgba(0,0,0,0)` background with no border and no shadow — visually subordinate.

## Diff scope

```
frontend/src/features/settings/components/SettingsPanelDock.tsx        |  17 ++-
frontend/src/features/settings/components/__tests__/SettingsPanelDock.test.tsx | 126 +++++++++-
frontend/src/index.css                                                 | 106 ++++++++++++
3 files changed, 222 insertions(+), 27 deletions(-)
```

Reference-only files (`SegmentedThemeControl.tsx`, `SettingsView.tsx`, `SegmentedThemeControl.test.tsx`) were not modified. The boundary surface is the canonical `.pill-tab` and `.glass-pill` material in `index.css`; this slice adds a Settings-scoped cascade-priority rule and a Settings-scoped perimeter fringe, both via the existing `settings-panel-dock__glass` hook.

## Test plan

- [x] `pnpm exec vitest run --config vitest.config.ts features/settings/components/__tests__/SettingsPanelDock.test.tsx` — 5 passed
- [x] `pnpm exec vitest run --config vitest.config.ts components/controls/__tests__/SegmentedThemeControl.test.tsx` — 5 passed
- [x] `pnpm exec vitest run --config vitest.config.ts features/settings components/controls` — 75 passed (no regressions)
- [x] `pnpm --dir frontend build` — succeeds
- [x] `git diff --check` — clean
- [x] Playwright live-render audit (Chromium, 1400×900, both themes, default + custom accent) — Settings dock active tab matches Theme selector active tab exactly

## Operator merge gate

Per the operator doctrine: no auto-merge, no direct main push. Awaiting operator review and merge.

## Deferred

- Promoting the Settings-dock cascade-priority rule into a global Codexify pattern (so any future `<Button variant="ghost" class="pill-tab">` consumer wins cascade against Tailwind utilities automatically) — separate task.
- Promoting light-mode chromatic refraction into a global glass-material rule across `.glass-pill` — separate task.
