### PR TITLE
Add typed participant hooks to chat completion acceptance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,17 +77,17 @@ repos:
             )
 
 -   repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 26.5.1
     hooks:
     -   id: black
         language_version: python3
-        args: [--line-length=80]
+        args: [--line-length=88]
 
 -   repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
     -   id: isort
-        args: [--profile=black, --line-length=80]
+        args: [--profile=black, --line-length=88]
 
 -   repo: https://github.com/pycqa/flake8
     rev: 6.0.0

--- a/docs/architecture/chat-runtime-contract.md
+++ b/docs/architecture/chat-runtime-contract.md
@@ -29,6 +29,48 @@ The ordinary HTTP completion route and the shared completion acceptance operatio
 
 Request identity, task identity, authored message identity, and turn-lock identity remain distinct. A new completion caller must reuse the shared acceptance operation and must not implement a parallel queue, lock, or task-event sequence. Hosted Room owner and guest invocation routes construct the bounded `ChatCompletionTask.hosted_room_invocation` context only after route-specific authority checks, then use the same shared acceptance operation. Ordinary tasks bypass Hosted Room validation and persistence provenance.
 
+### Optional acceptance participant
+
+`enqueue_chat_completion` may coordinate one optional typed acceptance
+participant without transferring ownership of the acceptance transaction. No
+current route opts into this participant, and the participant object is never
+serialized into `ChatCompletionTask` or sent to a worker.
+
+The canonical order is:
+
+```text
+turn lock acquired
+-> optional participant prepare
+-> queue enqueue
+-> optional participant commit
+-> best-effort task.created
+```
+
+Preparation runs only after the service owns the turn lock and before task
+serialization or enqueue. If preparation fails, the task is not enqueued, the
+service releases the lock, and the failure remains pre-acceptance. If enqueue
+fails after successful preparation, the participant receives one best-effort
+rollback before the service performs its existing lock reconciliation. A
+rollback failure is recorded separately and cannot replace the authoritative
+enqueue failure.
+
+Successful enqueue is irreversible acceptance from this service's perspective.
+The participant commit attempt therefore runs after enqueue and before
+`task.created`. Commit failure never rolls the participant back, releases the
+accepted task's turn lock, retries enqueue, or masquerades as queue
+non-acceptance. It reuses the existing `accepted_degraded` result and
+content-free acceptance-warning mechanism while `task.created` is still
+attempted independently. The warning is
+`acceptance_participant_commit_failed`; participant-commit and task-event
+visibility failures remain separately observable when both occur.
+
+The participant may validate bounded feature-specific ephemeral state and may
+mutate only the already-constructed in-memory task during preparation. It must
+not enqueue, publish events, manipulate locks, execute providers, bypass route
+authorization, or persist messages. This seam is orchestration capability only;
+it does not implement a Browser Context reference, store, or Chrome-sidebar
+binding.
+
 ### Completion task identity context
 
 The optional bounded task context keeps these identities distinct for future

--- a/docs/architecture/completion_pipeline.md
+++ b/docs/architecture/completion_pipeline.md
@@ -15,6 +15,7 @@
 - Shared completion acceptance operation: `guardian/core/chat_completion_service.py::enqueue_chat_completion`
   - construct and normalize the canonical task acceptance identity
   - acquire and reconcile the per-thread turn lock, including evidence-based stale-lock recovery
+  - coordinate an optional typed participant after lock acquisition and around queue acceptance
   - enqueue onto the canonical chat queue
   - emit the best-effort `task.created` breadcrumb
   - calculate `accepted` versus `accepted_degraded` and reconcile queue failures
@@ -58,7 +59,9 @@ UI
      -> route authorization and task preparation
      -> enqueue_chat_completion
         -> Redis turn lock / stale-lock recovery
+        -> optional participant prepare
         -> Redis chat queue
+        -> optional participant commit
         -> best-effort task.created breadcrumb
         -> accepted or accepted_degraded result
      -> worker dequeues
@@ -95,7 +98,11 @@ UI
 
 4. Shared acceptance is queue acceptance, not completion success.
    - `enqueue_chat_completion` enqueues a `ChatCompletionTask` onto `codexify:queue:chat` after the lock is held.
+   - When a typed participant is supplied, its preparation runs after lock acquisition and before task serialization/enqueue. No current route supplies a participant.
+   - Preparation failure prevents enqueue and causes the service to release the lock through a bounded pre-acceptance failure.
+   - Enqueue or synchronous serialization failure after successful preparation invokes one best-effort participant rollback before the existing lock reconciliation. Rollback failure is recorded separately and never replaces the authoritative enqueue failure.
    - If enqueue fails, the operation reconciles the lock and returns a safe typed failure; the route maps it to the existing `503 queue_unavailable` response.
+   - After enqueue succeeds, the participant commit attempt runs before `task.created`. Commit failure cannot undo queue acceptance, release the accepted task's turn lock, or trigger automatic re-enqueue.
    - If enqueue succeeds, the route returns success with `task_id`, `turn_id`, and discovery URLs.
    - What this proves:
      - the task was accepted into the Redis-backed execution lane
@@ -106,9 +113,10 @@ UI
      - the task will complete successfully
 
 5. `task.created` is an important breadcrumb, but best-effort.
-   - The shared acceptance operation attempts to publish `task.created` after enqueue.
+   - The shared acceptance operation attempts to publish `task.created` after enqueue and after any participant commit attempt.
    - This breadcrumb is useful because it gives operators and clients evidence that lifecycle publication started.
    - It is not authoritative acceptance proof by itself because enqueue success is the stronger signal; the `task.created` publish can fail without causing the route to fail.
+   - Participant-commit failure and `task.created` failure are independent degradations and remain separately represented when both occur.
 
 6. Worker execution starts with explicit running state.
    - The chat worker dequeues from `codexify:queue:chat`.
@@ -170,10 +178,10 @@ UI
 ## Acceptance Semantics
 
 - `accepted`
-  - The shared acceptance operation acquired the turn lock, enqueued the task successfully, and observed the normal task-created visibility result.
+  - The shared acceptance operation acquired the turn lock, enqueued the task successfully, completed any supplied participant commit, and observed the normal task-created visibility result.
   - This is the normal acceptance case.
 - `accepted_degraded`
-  - Use this term for the current degraded acceptance class where execution was accepted but lifecycle visibility is weaker than normal, for example when the shared operation cannot publish `task.created` or receives no event ID after a successful enqueue.
+  - Use this term for the current degraded acceptance class where execution was accepted but post-acceptance coordination or lifecycle visibility is weaker than normal, for example when an optional participant cannot commit, the shared operation cannot publish `task.created`, or publication returns no event ID after a successful enqueue.
   - Queue publication must still succeed; queue failure is never degraded acceptance.
   - In other words: acceptance can be real while observability is degraded.
 
@@ -181,9 +189,15 @@ UI
 
 - `guardian/routes/chat.py` owns HTTP authentication, request parsing and validation, thread/account/project authorization, retrieval/context preparation, task-input preparation, response serialization, and HTTP error mapping.
 - `guardian/core/chat_completion_service.py::enqueue_chat_completion` owns the reusable acceptance transaction: canonical task identity, thread-scoped lock acquisition, stale-lock recovery, canonical queue publication, task-created publication, acceptance-status calculation, and queue-failure lock reconciliation.
+- The same operation may coordinate one optional typed participant. Preparation occurs after lock acquisition and before enqueue; rollback is pre-acceptance cleanup only; commit occurs after enqueue and before `task.created`. The participant never owns the lock, queue, event stream, worker, or persistence path and is never serialized into the task.
 - `guardian/workers/chat_worker.py` owns dequeue, provider execution, assistant-message persistence, terminal events, and successful-turn lock release.
 - The existing task type and fields, queue name, lock key/TTL, and acceptance event sequence are unchanged. The worker has a bounded metadata-bearing branch, while ordinary worker behavior remains unchanged.
 - Hosted Room invocation routes reuse `enqueue_chat_completion`; they do not implement a parallel lock, queue, or task-event sequence. The worker receives validated provenance through the canonical persistence seam and does not insert a message and apply provenance through a later update.
+
+No current caller opts into the participant. This prerequisite exposes bounded
+orchestration capability only; it does not implement a Browser Context
+reference, attachment store, subject/thread binding, receipt field, or Chrome
+sidebar behavior.
 
 ## Bounded Hosted Room Invocation Context
 

--- a/docs/architecture/flows.md
+++ b/docs/architecture/flows.md
@@ -26,18 +26,20 @@ Trigger:
 
 Sequence:
 1. `guardian/routes/chat.py` validates the thread, turn state, and effective identity depth.
-2. The route acquires a Redis turn lock whose owner is the new `task_id`.
+2. `guardian/core/chat_completion_service.py::enqueue_chat_completion` acquires a Redis turn lock whose owner is the new `task_id`.
 3. If the thread already has a stale lock, recovery only occurs when real evidence says it is safe:
    - terminal task-stream evidence is enough to clear the old lock
    - or the old task is still nonterminal and the worker heartbeat is `stale`, `dead`, or `missing`
    - if task-stream or heartbeat evidence is `unknown`, recovery fails closed and the route returns `429 turn_in_flight`
-4. The route enqueues a `ChatCompletionTask` on `codexify:queue:chat`.
-5. The route attempts to publish `task.created` as a lifecycle breadcrumb.
-6. `guardian/workers/chat_worker.py` dequeues the task and publishes `task.running`.
-7. `guardian/core/chat_completion_service.py` loads recent messages, assembles context, resolves provider/model/profile settings, and carries the live retrieval posture for the turn.
+4. When supplied, one typed acceptance participant prepares bounded ephemeral state after lock acquisition and before task serialization/enqueue. No current route supplies one.
+5. The shared acceptance service enqueues a `ChatCompletionTask` on `codexify:queue:chat`. Enqueue or synchronous serialization failure invokes participant rollback when preparation succeeded, then follows the existing lock-release and bounded failure path.
+6. After successful enqueue, the optional participant commits before lifecycle-start publication. Commit failure cannot undo queue acceptance, release the accepted task's lock, or trigger automatic re-enqueue; it degrades the existing acceptance result.
+7. The shared acceptance service attempts to publish `task.created` as an independent best-effort lifecycle breadcrumb.
+8. `guardian/workers/chat_worker.py` dequeues the task and publishes `task.running`.
+9. `guardian/core/chat_completion_service.py` loads recent messages, assembles context, resolves provider/model/profile settings, and carries the live retrieval posture for the turn.
    - For `retrievalSource="workspace"`, the intended contract is that Obsidian-backed evidence can be selected and injected in executed completion context.
    - Current live behavior for that workspace-local Obsidian selection/injection path remains under active validation and is not currently treated as settled release evidence.
-8. The provider call executes through `guardian/core/ai_router.py`.
+10. The provider call executes through `guardian/core/ai_router.py`.
    - If the provider returns plain assistant text, the existing completion path continues.
    - If the provider returns a structured tool decision, the completion service executes exactly one command through `guardian/command_bus/`, reinjects the result, and requests one final assistant answer.
    - No second tool turn is permitted in this slice.
@@ -49,14 +51,14 @@ Sequence:
    - Remote Recall evidence enters synthesis only as lower-authority bounded retrieval/context data. It is injected as a `user`-role message that is explicitly delimited and labeled as untrusted retrieved data; it MUST NOT be injected as `system` or `developer` authority, and must never be treated as executable instruction. Only Web Evidence Intake Gate-eligible envelopes are injected; blocked evidence remains trace/diagnostic-only.
    - Remote Recall proof depends on terminal task evidence, a persisted assistant message, and `trace["remote_recall"]` metadata (provider, source kinds, candidate/eligible/blocked counts, gate decisions). Route acceptance, a green health endpoint, and unit-test passes are not live proof. One live supported-path proof (PASS) exists on `feature/remote-retrieval` only, under intentionally enabled Groq/egress/posture overrides; it is **not proven on `main`** until the seam is merged and rerun there. See `remote-recall-live-proof.md`.
    - For the workspace proof harness, executed-path worker-visible completion payload evidence is the canonical proof surface; debug trace remains diagnostic-only and cannot replace the executed completion record.
-9. Assistant output is persisted to Postgres, audited, optionally embedded, and emitted as domain events.
-10. After the assistant row is durably stored, the worker captures a trace snapshot, persists it to Postgres, and best-effort enqueues an eval task on the derived inspection lane.
+11. Assistant output is persisted to Postgres, audited, optionally embedded, and emitted as domain events.
+12. After the assistant row is durably stored, the worker captures a trace snapshot, persists it to Postgres, and best-effort enqueues an eval task on the derived inspection lane.
    - The snapshot is expected to carry containment-grade retrieval policy, provenance, suppression, and image-routing truth when available, including explicit absence reasons rather than silent nulls.
    - For workspace-local completions, the terminal task payload and persisted snapshot keep the executed retrieval posture and evidence counts aligned with the worker attempt.
    - For workspace-local proof, the worker-visible task payload is the canonical evidence surface; the debug trace remains diagnostic and must not backfill missing workspace evidence.
-11. The eval worker later reads the snapshot, produces attempt-scoped verdict rows, and stores them in Postgres without affecting chat completion success.
-12. The worker publishes terminal task events and releases the turn lock in `finally`.
-13. The live debug RAG trace endpoint promotes completion metadata from the latest task event payload when available, and can fall back to the latest eval snapshot to expose retrieval policy, provenance, suppression summaries, image-routing decisions, and model-selection truth for operator diagnosis.
+13. The eval worker later reads the snapshot, produces attempt-scoped verdict rows, and stores them in Postgres without affecting chat completion success.
+14. The worker publishes terminal task events and releases the turn lock in `finally`.
+15. The live debug RAG trace endpoint promotes completion metadata from the latest task event payload when available, and can fall back to the latest eval snapshot to expose retrieval policy, provenance, suppression summaries, image-routing decisions, and model-selection truth for operator diagnosis.
 
 Outputs:
 - Immediate HTTP response with `task_id`, `turn_id`, `messages_url`, and `trace_url`
@@ -80,9 +82,10 @@ Failure modes:
 - Task-event publish failures that degrade progress or terminal visibility without necessarily stopping execution
 
 Acceptance semantics:
-- Normal acceptance means the route acquired the turn lock and enqueued the task.
+- Normal acceptance means the shared acceptance service acquired the turn lock, enqueued the task, completed any supplied participant commit, and observed normal lifecycle-start visibility.
 - The route does not prove dequeue, eventual success, or UI receipt.
 - If enqueue succeeds but `task.created` cannot be published, the system is operationally in a degraded-acceptance state even though the current route payload still returns success. The queue acceptance is real; the lifecycle visibility is weaker.
+- If enqueue succeeds but an optional participant cannot commit, queue acceptance remains authoritative and the existing `accepted_degraded` result records a separate participant warning. `task.created` is still attempted, and its failure remains distinguishable from participant degradation.
 - Post-completion eval is derived inspection only. It does not change acceptance, does not gate completion, and does not replace the transcript as the canonical chat output.
 - A canonical live-proof harness is still the intended way to validate the workspace retrieval seam end-to-end: `scripts/proofs/prove_workspace_obsidian_e2e.py`. A prior PASS interpretation was superseded by later testing, so current release interpretation remains in-progress pending renewed live evidence.
 - For the workspace proof harness on the supported local Compose path, acceptance is only the first milestone; the proof must also verify terminal task evidence, persisted assistant text, and workspace-local retrieval posture before it can pass.
@@ -116,6 +119,8 @@ Concrete anchors:
 sequenceDiagram
     participant UI as Frontend
     participant ChatAPI as chat route
+    participant Acceptance as acceptance service
+    participant Participant as optional participant
     participant Redis as Redis
     participant Worker as chat worker
     participant Service as completion service
@@ -123,9 +128,17 @@ sequenceDiagram
     participant PG as Postgres
 
     UI->>ChatAPI: POST /api/chat/{thread_id}/complete
-    ChatAPI->>Redis: acquire turn lock
-    ChatAPI->>Redis: enqueue ChatCompletionTask
-    ChatAPI->>Redis: best-effort task.created
+    ChatAPI->>Acceptance: authorized task input
+    Acceptance->>Redis: acquire turn lock
+    opt participant supplied
+        Acceptance->>Participant: prepare(task)
+    end
+    Acceptance->>Redis: enqueue ChatCompletionTask
+    opt participant supplied
+        Acceptance->>Participant: commit()
+    end
+    Acceptance->>Redis: best-effort task.created
+    Acceptance-->>ChatAPI: accepted or accepted_degraded
     ChatAPI-->>UI: accepted task_id and URLs
     Worker->>Redis: dequeue chat task
     Worker->>Redis: task.running

--- a/guardian/core/chat_acceptance_participant.py
+++ b/guardian/core/chat_acceptance_participant.py
@@ -1,0 +1,38 @@
+"""Typed participant boundary for canonical chat queue acceptance.
+
+Participants coordinate bounded, feature-specific ephemeral state around the
+existing acceptance transaction. They never own the turn lock, queue, task
+events, worker execution, or transcript persistence.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from guardian.tasks.types import ChatCompletionTask
+
+
+class ChatAcceptanceParticipant(Protocol):
+    """Optional lifecycle participant in one chat acceptance attempt.
+
+    ``prepare`` runs after the canonical turn lock is held and before task
+    serialization/enqueue. A successful return means the participant prepared
+    state that must be rolled back if queue acceptance subsequently fails.
+    Implementations must make a failed ``prepare`` atomic or clean up any
+    partial state themselves.
+
+    ``rollback`` is pre-acceptance cleanup only. ``commit`` runs after queue
+    acceptance and must be monotonic/idempotent because accepted work cannot be
+    withdrawn or automatically re-enqueued by this lifecycle. Implementations
+    must not mutate task/request/user/thread identity, provider selection,
+    retrieval policy, or the accepted task after enqueue.
+    """
+
+    def prepare(self, task: ChatCompletionTask, /) -> None:
+        """Prepare bounded state and optionally mutate the in-memory task."""
+
+    def rollback(self, /) -> None:
+        """Idempotently release prepared state after enqueue did not occur."""
+
+    def commit(self, /) -> None:
+        """Commit prepared state after irreversible queue acceptance."""

--- a/guardian/core/chat_completion_service.py
+++ b/guardian/core/chat_completion_service.py
@@ -7,6 +7,7 @@ fork context assembly, prompt construction, provider routing, or persistence.
 from __future__ import annotations
 
 import asyncio
+import copy
 import inspect
 import json
 import logging
@@ -705,6 +706,26 @@ def enqueue_chat_completion(
 
     participant_prepared = False
     if participant is not None:
+        authoritative_fields = (
+            "task_id",
+            "user_id",
+            "thread_id",
+            "turn_id",
+            "turn_lock_owner",
+            "turn_lock",
+            "provider",
+            "model",
+            "requested_provider",
+            "requested_model",
+            "selection_source",
+            "provider_pinned",
+            "requested_source_mode",
+            "retrieval_override",
+        )
+        authoritative_snapshot = {
+            field: copy.deepcopy(getattr(task, field))
+            for field in authoritative_fields
+        }
         try:
             participant.prepare(task)
             participant_prepared = True
@@ -726,6 +747,37 @@ def enqueue_chat_completion(
                 "acceptance_participant_prepare_failed",
                 cause_class=type(exc).__name__,
             ) from None
+
+        mutated_fields = tuple(
+            field
+            for field, original_value in authoritative_snapshot.items()
+            if getattr(task, field) != original_value
+        )
+        if mutated_fields:
+            for field, original_value in authoritative_snapshot.items():
+                setattr(task, field, original_value)
+            logger.warning(
+                (
+                    "[chat.complete] acceptance participant mutated "
+                    "authoritative task fields thread_id=%s task_id=%s "
+                    "turn_id=%s participant_type=%s fields=%s"
+                ),
+                thread_id,
+                task_identity,
+                turn_id,
+                type(participant).__name__,
+                ",".join(mutated_fields),
+            )
+            _rollback_acceptance_participant(
+                participant,
+                thread_id=thread_id,
+                task_id=task_identity,
+                turn_id=turn_id,
+            )
+            _best_effort_release_turn_lock(thread_id, task.turn_lock_owner)
+            raise ChatCompletionEnqueueError(
+                "acceptance_participant_authoritative_fields_mutated"
+            )
 
     try:
         run_with_redis_timeout(

--- a/guardian/core/chat_completion_service.py
+++ b/guardian/core/chat_completion_service.py
@@ -101,6 +101,7 @@ from guardian.core.request_correlation import (
     generate_attempt_id,
     normalize_request_id,
 )
+from guardian.core.chat_acceptance_participant import ChatAcceptanceParticipant
 from guardian.core.chat_attachments import (
     extract_attachments_and_text,
     render_content_for_inference,
@@ -187,6 +188,9 @@ COMPLETION_ACCEPTANCE_WARNING_TASK_CREATED_PUBLISH_FAILED = (
 )
 COMPLETION_ACCEPTANCE_WARNING_TASK_CREATED_MISSING_EVENT_ID = (
     "task_created_event_missing_event_id"
+)
+COMPLETION_ACCEPTANCE_WARNING_PARTICIPANT_COMMIT_FAILED = (
+    "acceptance_participant_commit_failed"
 )
 TASK_EVENT_TYPE_TASK_CREATED = TaskEventType.TASK_CREATED.value
 CHAT_COMPLETION_QUEUE_NAME = "codexify:queue:chat"
@@ -511,6 +515,60 @@ def _completion_acceptance_outcome(
     return AcceptanceStatus.ACCEPTED.value, ()
 
 
+def _rollback_acceptance_participant(
+    participant: ChatAcceptanceParticipant,
+    *,
+    thread_id: int,
+    task_id: str,
+    turn_id: str,
+) -> None:
+    """Best-effort participant cleanup without obscuring enqueue failure."""
+
+    try:
+        participant.rollback()
+    except Exception as exc:
+        logger.error(
+            (
+                "[chat.complete] acceptance participant rollback failed "
+                "thread_id=%s task_id=%s turn_id=%s participant_type=%s "
+                "cause_class=%s"
+            ),
+            thread_id,
+            task_id,
+            turn_id,
+            type(participant).__name__,
+            type(exc).__name__,
+        )
+
+
+def _commit_acceptance_participant(
+    participant: ChatAcceptanceParticipant,
+    *,
+    thread_id: int,
+    task_id: str,
+    turn_id: str,
+) -> bool:
+    """Commit post-enqueue state and report content-free degradation truth."""
+
+    try:
+        participant.commit()
+    except Exception as exc:
+        logger.error(
+            (
+                "[chat.complete] acceptance participant commit failed after "
+                "queue acceptance thread_id=%s task_id=%s turn_id=%s "
+                "participant_type=%s cause_class=%s"
+            ),
+            thread_id,
+            task_id,
+            turn_id,
+            type(participant).__name__,
+            type(exc).__name__,
+        )
+        return False
+    return True
+
+
 def _recover_orphaned_turn_lock(thread_id: int) -> bool:
     stale_lock = _run_completion_redis_op(
         lambda: get_turn_lock(thread_id),
@@ -609,6 +667,7 @@ def enqueue_chat_completion(
     thread_id: int,
     turn_id: str,
     request_id: str | None = None,
+    participant: ChatAcceptanceParticipant | None = None,
 ) -> ChatCompletionEnqueueResult:
     """Accept one canonical chat completion task into the chat execution lane."""
 
@@ -644,11 +703,42 @@ def enqueue_chat_completion(
         turn_id=turn_id,
     )
 
+    participant_prepared = False
+    if participant is not None:
+        try:
+            participant.prepare(task)
+            participant_prepared = True
+        except Exception as exc:
+            logger.warning(
+                (
+                    "[chat.complete] acceptance participant prepare failed "
+                    "thread_id=%s task_id=%s turn_id=%s participant_type=%s "
+                    "cause_class=%s"
+                ),
+                thread_id,
+                task_identity,
+                turn_id,
+                type(participant).__name__,
+                type(exc).__name__,
+            )
+            _best_effort_release_turn_lock(thread_id, task.turn_lock_owner)
+            raise ChatCompletionEnqueueError(
+                "acceptance_participant_prepare_failed",
+                cause_class=type(exc).__name__,
+            ) from None
+
     try:
         run_with_redis_timeout(
             lambda: enqueue(task, CHAT_COMPLETION_QUEUE_NAME)
         )
     except QueueEnqueueError as exc:
+        if participant is not None and participant_prepared:
+            _rollback_acceptance_participant(
+                participant,
+                thread_id=thread_id,
+                task_id=task_identity,
+                turn_id=turn_id,
+            )
         _best_effort_release_turn_lock(thread_id, task.turn_lock_owner)
         raise ChatCompletionEnqueueError(
             "queue_unavailable",
@@ -663,11 +753,27 @@ def enqueue_chat_completion(
             ),
         ) from exc
     except (RedisOperationTimeout, Exception) as exc:
+        if participant is not None and participant_prepared:
+            _rollback_acceptance_participant(
+                participant,
+                thread_id=thread_id,
+                task_id=task_identity,
+                turn_id=turn_id,
+            )
         _best_effort_release_turn_lock(thread_id, task.turn_lock_owner)
         raise ChatCompletionEnqueueError(
             "queue_unavailable",
             cause_class=type(exc).__name__,
         ) from exc
+
+    participant_commit_succeeded = True
+    if participant is not None:
+        participant_commit_succeeded = _commit_acceptance_participant(
+            participant,
+            thread_id=thread_id,
+            task_id=task_identity,
+            turn_id=turn_id,
+        )
 
     try:
         task_created_publish_result = _publish_completion_start_event(
@@ -691,6 +797,12 @@ def enqueue_chat_completion(
             "event_id": task_created_event.event_id,
         }
     )
+    if not participant_commit_succeeded:
+        acceptance_status = AcceptanceStatus.ACCEPTED_DEGRADED.value
+        acceptance_warnings = (
+            COMPLETION_ACCEPTANCE_WARNING_PARTICIPANT_COMMIT_FAILED,
+            *acceptance_warnings,
+        )
     return ChatCompletionEnqueueResult(
         task=task,
         task_id=task_identity,

--- a/tests/core/test_chat_completion_enqueue_service.py
+++ b/tests/core/test_chat_completion_enqueue_service.py
@@ -49,6 +49,54 @@ def _event_result(task: ChatCompletionTask, *, event_id: str | None = "evt-1"):
     }
 
 
+class _FakeParticipant:
+    def __init__(
+        self,
+        events: list[str],
+        *,
+        prepare_error: Exception | None = None,
+        rollback_error: Exception | None = None,
+        commit_error: Exception | None = None,
+    ) -> None:
+        self.events = events
+        self.prepare_error = prepare_error
+        self.rollback_error = rollback_error
+        self.commit_error = commit_error
+        self.prepared_task: ChatCompletionTask | None = None
+        self.prepare_calls = 0
+        self.rollback_calls = 0
+        self.commit_calls = 0
+
+    def prepare(self, task: ChatCompletionTask) -> None:
+        self.events.append("prepare")
+        self.prepare_calls += 1
+        self.prepared_task = task
+        if self.prepare_error is not None:
+            raise self.prepare_error
+
+    def rollback(self) -> None:
+        self.events.append("rollback")
+        self.rollback_calls += 1
+        if self.rollback_error is not None:
+            raise self.rollback_error
+
+    def commit(self) -> None:
+        self.events.append("commit")
+        self.commit_calls += 1
+        if self.commit_error is not None:
+            raise self.commit_error
+
+
+def _failed_event_result(task: ChatCompletionTask) -> dict[str, object]:
+    return {
+        **_event_result(task, event_id=None),
+        "ok": False,
+        "error_code": "TASK_EVENT_PUBLISH_FAILED",
+        "failure_class": "RuntimeError",
+        "exception": RuntimeError("event transport unavailable"),
+    }
+
+
 @pytest.fixture
 def immediate_redis(monkeypatch):
     monkeypatch.setattr(
@@ -105,6 +153,464 @@ def test_success_preserves_queue_event_and_serialization_contract(
             "latest_turn_message_id": 7,
         },
     )
+
+
+def test_no_participant_preserves_exact_acceptance_order(
+    monkeypatch, immediate_redis
+):
+    task = _task()
+    events: list[str] = []
+    lock = _lock(task, turn_id="turn-1")
+
+    def acquire(*_args, **_kwargs):
+        events.append("lock_acquired")
+        return lock
+
+    def enqueue(_task, _queue_name):
+        events.append("enqueue")
+
+    def publish(*_args, **_kwargs):
+        events.append("task_created")
+        return _event_result(task)
+
+    monkeypatch.setattr(service, "acquire_turn_lock", acquire)
+    monkeypatch.setattr(service, "enqueue", enqueue)
+    monkeypatch.setattr(service.task_events, "publish_with_visibility", publish)
+
+    result = service.enqueue_chat_completion(task, thread_id=1, turn_id="turn-1")
+
+    assert events == ["lock_acquired", "enqueue", "task_created"]
+    assert result.acceptance_status == AcceptanceStatus.ACCEPTED.value
+    assert result.acceptance_warnings == ()
+
+
+def test_participant_happy_path_has_exact_order_and_is_not_serialized(
+    monkeypatch, immediate_redis
+):
+    task = _task()
+    events: list[str] = []
+    participant = _FakeParticipant(events)
+    lock = _lock(task, turn_id="turn-1")
+    queued_payloads: list[dict[str, object]] = []
+
+    def acquire(*_args, **_kwargs):
+        events.append("lock_acquired")
+        return lock
+
+    def enqueue(queued_task, _queue_name):
+        events.append("enqueue")
+        queued_payloads.append(queued_task.to_dict())
+
+    def publish(*_args, **_kwargs):
+        events.append("task_created")
+        return _event_result(task)
+
+    monkeypatch.setattr(service, "acquire_turn_lock", acquire)
+    monkeypatch.setattr(service, "enqueue", enqueue)
+    monkeypatch.setattr(service.task_events, "publish_with_visibility", publish)
+
+    result = service.enqueue_chat_completion(
+        task,
+        thread_id=1,
+        turn_id="turn-1",
+        participant=participant,
+    )
+
+    assert events == [
+        "lock_acquired",
+        "prepare",
+        "enqueue",
+        "commit",
+        "task_created",
+    ]
+    assert participant.prepared_task is task
+    assert participant.rollback_calls == 0
+    assert result.acceptance_status == AcceptanceStatus.ACCEPTED.value
+    assert result.acceptance_warnings == ()
+    assert len(queued_payloads) == 1
+    assert not any("participant" in key for key in queued_payloads[0])
+
+
+def test_participant_prepare_failure_releases_lock_without_enqueue(
+    monkeypatch, immediate_redis, caplog
+):
+    task = _task()
+    events: list[str] = []
+    participant = _FakeParticipant(
+        events,
+        prepare_error=RuntimeError("prepare secret must not escape"),
+    )
+    lock = _lock(task, turn_id="turn-1")
+    enqueue = MagicMock()
+    publish = MagicMock()
+
+    def acquire(*_args, **_kwargs):
+        events.append("lock_acquired")
+        return lock
+
+    def release(_thread_id, _owner):
+        events.append("lock_release")
+
+    monkeypatch.setattr(service, "acquire_turn_lock", acquire)
+    monkeypatch.setattr(service, "release_turn_lock", release)
+    monkeypatch.setattr(service, "enqueue", enqueue)
+    monkeypatch.setattr(service.task_events, "publish_with_visibility", publish)
+
+    with pytest.raises(service.ChatCompletionEnqueueError) as exc_info:
+        service.enqueue_chat_completion(
+            task,
+            thread_id=1,
+            turn_id="turn-1",
+            participant=participant,
+        )
+
+    assert events == ["lock_acquired", "prepare", "lock_release"]
+    assert exc_info.value.reason == "acceptance_participant_prepare_failed"
+    assert exc_info.value.cause_class == "RuntimeError"
+    assert exc_info.value.__cause__ is None
+    assert "prepare secret" not in str(exc_info.value)
+    assert "prepare secret" not in caplog.text
+    assert participant.rollback_calls == 0
+    assert participant.commit_calls == 0
+    enqueue.assert_not_called()
+    publish.assert_not_called()
+
+
+def test_participant_is_not_called_when_turn_lock_is_unavailable(
+    monkeypatch, immediate_redis
+):
+    task = _task()
+    events: list[str] = []
+    participant = _FakeParticipant(events)
+    enqueue = MagicMock()
+    monkeypatch.setattr(service, "acquire_turn_lock", lambda *_a, **_k: None)
+    monkeypatch.setattr(service, "_recover_orphaned_turn_lock", lambda *_: False)
+    monkeypatch.setattr(service, "enqueue", enqueue)
+
+    with pytest.raises(service.ChatCompletionEnqueueError) as exc_info:
+        service.enqueue_chat_completion(
+            task,
+            thread_id=1,
+            turn_id="turn-1",
+            participant=participant,
+        )
+
+    assert exc_info.value.reason == "turn_in_flight"
+    assert events == []
+    assert participant.prepare_calls == 0
+    assert participant.rollback_calls == 0
+    assert participant.commit_calls == 0
+    enqueue.assert_not_called()
+
+
+def test_enqueue_failure_rolls_back_before_lock_release(
+    monkeypatch, immediate_redis
+):
+    task = _task()
+    events: list[str] = []
+    participant = _FakeParticipant(events)
+    lock = _lock(task, turn_id="turn-1")
+    publish = MagicMock()
+
+    def acquire(*_args, **_kwargs):
+        events.append("lock_acquired")
+        return lock
+
+    def enqueue(_task, _queue_name):
+        events.append("enqueue_failure")
+        raise QueueEnqueueError(
+            "codexify:queue:chat",
+            cause=RuntimeError("redis down"),
+        )
+
+    def release(_thread_id, _owner):
+        events.append("lock_release")
+
+    monkeypatch.setattr(service, "acquire_turn_lock", acquire)
+    monkeypatch.setattr(service, "enqueue", enqueue)
+    monkeypatch.setattr(service, "release_turn_lock", release)
+    monkeypatch.setattr(service.task_events, "publish_with_visibility", publish)
+
+    with pytest.raises(service.ChatCompletionEnqueueError) as exc_info:
+        service.enqueue_chat_completion(
+            task,
+            thread_id=1,
+            turn_id="turn-1",
+            participant=participant,
+        )
+
+    assert events == [
+        "lock_acquired",
+        "prepare",
+        "enqueue_failure",
+        "rollback",
+        "lock_release",
+    ]
+    assert exc_info.value.reason == "queue_unavailable"
+    assert participant.rollback_calls == 1
+    assert participant.commit_calls == 0
+    publish.assert_not_called()
+
+
+def test_synchronous_serialization_failure_rolls_back_before_lock_release(
+    monkeypatch, immediate_redis
+):
+    task = _task()
+    events: list[str] = []
+    participant = _FakeParticipant(events)
+    lock = _lock(task, turn_id="turn-1")
+    publish = MagicMock()
+
+    def acquire(*_args, **_kwargs):
+        events.append("lock_acquired")
+        return lock
+
+    def enqueue(_task, _queue_name):
+        events.append("serialization_failure")
+        raise TypeError("task serialization failed")
+
+    def release(_thread_id, _owner):
+        events.append("lock_release")
+
+    monkeypatch.setattr(service, "acquire_turn_lock", acquire)
+    monkeypatch.setattr(service, "enqueue", enqueue)
+    monkeypatch.setattr(service, "release_turn_lock", release)
+    monkeypatch.setattr(service.task_events, "publish_with_visibility", publish)
+
+    with pytest.raises(service.ChatCompletionEnqueueError) as exc_info:
+        service.enqueue_chat_completion(
+            task,
+            thread_id=1,
+            turn_id="turn-1",
+            participant=participant,
+        )
+
+    assert events == [
+        "lock_acquired",
+        "prepare",
+        "serialization_failure",
+        "rollback",
+        "lock_release",
+    ]
+    assert exc_info.value.reason == "queue_unavailable"
+    assert exc_info.value.cause_class == "TypeError"
+    assert participant.rollback_calls == 1
+    assert participant.commit_calls == 0
+    publish.assert_not_called()
+
+
+def test_rollback_failure_preserves_enqueue_failure_and_releases_lock(
+    monkeypatch, immediate_redis, caplog
+):
+    task = _task()
+    events: list[str] = []
+    participant = _FakeParticipant(
+        events,
+        rollback_error=RuntimeError("rollback secret must not escape"),
+    )
+    lock = _lock(task, turn_id="turn-1")
+    enqueue_calls = 0
+
+    def acquire(*_args, **_kwargs):
+        events.append("lock_acquired")
+        return lock
+
+    def enqueue(_task, _queue_name):
+        nonlocal enqueue_calls
+        enqueue_calls += 1
+        events.append("enqueue_failure")
+        raise QueueEnqueueError(
+            "codexify:queue:chat",
+            cause=RuntimeError("authoritative enqueue failure"),
+        )
+
+    def release(_thread_id, _owner):
+        events.append("lock_release")
+
+    monkeypatch.setattr(service, "acquire_turn_lock", acquire)
+    monkeypatch.setattr(service, "enqueue", enqueue)
+    monkeypatch.setattr(service, "release_turn_lock", release)
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(service.ChatCompletionEnqueueError) as exc_info:
+            service.enqueue_chat_completion(
+                task,
+                thread_id=1,
+                turn_id="turn-1",
+                participant=participant,
+            )
+
+    assert events == [
+        "lock_acquired",
+        "prepare",
+        "enqueue_failure",
+        "rollback",
+        "lock_release",
+    ]
+    assert exc_info.value.reason == "queue_unavailable"
+    assert enqueue_calls == 1
+    assert participant.commit_calls == 0
+    assert "acceptance participant rollback failed" in caplog.text
+    assert "cause_class=RuntimeError" in caplog.text
+    assert "rollback secret" not in caplog.text
+
+
+def test_commit_failure_is_accepted_degraded_without_rollback_or_reenqueue(
+    monkeypatch, immediate_redis, caplog
+):
+    task = _task()
+    events: list[str] = []
+    participant = _FakeParticipant(
+        events,
+        commit_error=RuntimeError("commit secret must not escape"),
+    )
+    lock = _lock(task, turn_id="turn-1")
+    enqueue_calls = 0
+    release = MagicMock()
+
+    def acquire(*_args, **_kwargs):
+        events.append("lock_acquired")
+        return lock
+
+    def enqueue(_task, _queue_name):
+        nonlocal enqueue_calls
+        enqueue_calls += 1
+        events.append("enqueue")
+
+    def publish(*_args, **_kwargs):
+        events.append("task_created")
+        return _event_result(task)
+
+    monkeypatch.setattr(service, "acquire_turn_lock", acquire)
+    monkeypatch.setattr(service, "enqueue", enqueue)
+    monkeypatch.setattr(service, "release_turn_lock", release)
+    monkeypatch.setattr(service.task_events, "publish_with_visibility", publish)
+
+    with caplog.at_level("ERROR"):
+        result = service.enqueue_chat_completion(
+            task,
+            thread_id=1,
+            turn_id="turn-1",
+            participant=participant,
+        )
+
+    assert events == [
+        "lock_acquired",
+        "prepare",
+        "enqueue",
+        "commit",
+        "task_created",
+    ]
+    assert enqueue_calls == 1
+    assert participant.rollback_calls == 0
+    release.assert_not_called()
+    assert result.queue_accepted is True
+    assert result.acceptance_status == AcceptanceStatus.ACCEPTED_DEGRADED.value
+    assert result.acceptance_warnings == (
+        "acceptance_participant_commit_failed",
+    )
+    assert "acceptance participant commit failed" in caplog.text
+    assert "commit secret" not in caplog.text
+
+
+def test_start_event_failure_after_participant_commit_preserves_semantics(
+    monkeypatch, immediate_redis
+):
+    task = _task()
+    events: list[str] = []
+    participant = _FakeParticipant(events)
+    lock = _lock(task, turn_id="turn-1")
+
+    def acquire(*_args, **_kwargs):
+        events.append("lock_acquired")
+        return lock
+
+    def enqueue(_task, _queue_name):
+        events.append("enqueue")
+
+    def publish(*_args, **_kwargs):
+        events.append("task_created_failure")
+        return _failed_event_result(task)
+
+    monkeypatch.setattr(service, "acquire_turn_lock", acquire)
+    monkeypatch.setattr(service, "enqueue", enqueue)
+    monkeypatch.setattr(service.task_events, "publish_with_visibility", publish)
+
+    result = service.enqueue_chat_completion(
+        task,
+        thread_id=1,
+        turn_id="turn-1",
+        participant=participant,
+    )
+
+    assert events == [
+        "lock_acquired",
+        "prepare",
+        "enqueue",
+        "commit",
+        "task_created_failure",
+    ]
+    assert result.queue_accepted is True
+    assert result.acceptance_status == AcceptanceStatus.ACCEPTED_DEGRADED.value
+    assert result.acceptance_warnings == ("task_created_event_publish_failed",)
+    assert result.task_created_event.raised_publish_error is True
+
+
+def test_commit_and_start_event_failures_remain_distinguishable(
+    monkeypatch, immediate_redis
+):
+    task = _task()
+    events: list[str] = []
+    participant = _FakeParticipant(
+        events,
+        commit_error=RuntimeError("commit unavailable"),
+    )
+    lock = _lock(task, turn_id="turn-1")
+    enqueue_calls = 0
+    release = MagicMock()
+
+    def acquire(*_args, **_kwargs):
+        events.append("lock_acquired")
+        return lock
+
+    def enqueue(_task, _queue_name):
+        nonlocal enqueue_calls
+        enqueue_calls += 1
+        events.append("enqueue")
+
+    def publish(*_args, **_kwargs):
+        events.append("task_created_failure")
+        return _failed_event_result(task)
+
+    monkeypatch.setattr(service, "acquire_turn_lock", acquire)
+    monkeypatch.setattr(service, "enqueue", enqueue)
+    monkeypatch.setattr(service, "release_turn_lock", release)
+    monkeypatch.setattr(service.task_events, "publish_with_visibility", publish)
+
+    result = service.enqueue_chat_completion(
+        task,
+        thread_id=1,
+        turn_id="turn-1",
+        participant=participant,
+    )
+
+    assert events == [
+        "lock_acquired",
+        "prepare",
+        "enqueue",
+        "commit",
+        "task_created_failure",
+    ]
+    assert enqueue_calls == 1
+    assert participant.rollback_calls == 0
+    release.assert_not_called()
+    assert result.queue_accepted is True
+    assert result.acceptance_status == AcceptanceStatus.ACCEPTED_DEGRADED.value
+    assert result.acceptance_warnings == (
+        "acceptance_participant_commit_failed",
+        "task_created_event_publish_failed",
+    )
+    assert result.task_created_event.raised_publish_error is True
 
 
 def test_missing_event_id_is_accepted_degraded(monkeypatch, immediate_redis):

--- a/tests/core/test_chat_completion_enqueue_service.py
+++ b/tests/core/test_chat_completion_enqueue_service.py
@@ -276,6 +276,100 @@ def test_participant_prepare_failure_releases_lock_without_enqueue(
     publish.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    ("field", "mutated_value"),
+    (
+        ("thread_id", 2),
+        ("user_id", "other-user"),
+        ("task_id", "other-task"),
+        ("provider", "ollama"),
+        ("requested_source_mode", "workspace"),
+        ("retrieval_override", {"mode": "personal_knowledge"}),
+    ),
+)
+def test_participant_cannot_mutate_authoritative_task_fields(
+    monkeypatch, immediate_redis, field, mutated_value
+):
+    task = _task()
+    task.requested_source_mode = "project"
+    task.retrieval_override = {"mode": "project"}
+    original_value = getattr(task, field)
+    events: list[str] = []
+    participant = _FakeParticipant(events)
+    lock = _lock(task, turn_id="turn-1")
+    enqueue = MagicMock()
+    publish = MagicMock()
+
+    def prepare(prepared_task):
+        events.append("prepare")
+        participant.prepare_calls += 1
+        participant.prepared_task = prepared_task
+        setattr(prepared_task, field, mutated_value)
+
+    def release(_thread_id, _owner):
+        events.append("lock_release")
+
+    participant.prepare = prepare
+    monkeypatch.setattr(service, "acquire_turn_lock", lambda *_a, **_k: lock)
+    monkeypatch.setattr(service, "release_turn_lock", release)
+    monkeypatch.setattr(service, "enqueue", enqueue)
+    monkeypatch.setattr(service.task_events, "publish_with_visibility", publish)
+
+    with pytest.raises(service.ChatCompletionEnqueueError) as exc_info:
+        service.enqueue_chat_completion(
+            task,
+            thread_id=1,
+            turn_id="turn-1",
+            participant=participant,
+        )
+
+    assert exc_info.value.reason == (
+        "acceptance_participant_authoritative_fields_mutated"
+    )
+    assert events == ["prepare", "rollback", "lock_release"]
+    assert getattr(task, field) == original_value
+    assert participant.rollback_calls == 1
+    assert participant.commit_calls == 0
+    enqueue.assert_not_called()
+    publish.assert_not_called()
+
+
+def test_participant_cannot_mutate_retrieval_override_in_place(
+    monkeypatch, immediate_redis
+):
+    task = _task()
+    task.retrieval_override = {"mode": "project"}
+    events: list[str] = []
+    participant = _FakeParticipant(events)
+    lock = _lock(task, turn_id="turn-1")
+    enqueue = MagicMock()
+
+    def prepare(prepared_task):
+        events.append("prepare")
+        participant.prepare_calls += 1
+        prepared_task.retrieval_override["mode"] = "personal_knowledge"
+
+    participant.prepare = prepare
+    monkeypatch.setattr(service, "acquire_turn_lock", lambda *_a, **_k: lock)
+    monkeypatch.setattr(service, "enqueue", enqueue)
+    monkeypatch.setattr(service, "release_turn_lock", lambda *_a: None)
+
+    with pytest.raises(service.ChatCompletionEnqueueError) as exc_info:
+        service.enqueue_chat_completion(
+            task,
+            thread_id=1,
+            turn_id="turn-1",
+            participant=participant,
+        )
+
+    assert exc_info.value.reason == (
+        "acceptance_participant_authoritative_fields_mutated"
+    )
+    assert task.retrieval_override == {"mode": "project"}
+    assert participant.rollback_calls == 1
+    enqueue.assert_not_called()
+
+
 def test_participant_is_not_called_when_turn_lock_is_unavailable(
     monkeypatch, immediate_redis
 ):


### PR DESCRIPTION
## Summary

- Add an optional typed participant boundary around canonical chat queue acceptance.
- Define the prepare, rollback, and post-enqueue commit lifecycle without transferring ownership of locks, queues, events, workers, or persistence.
- Preserve authoritative queue acceptance semantics and report participant commit failures through `accepted_degraded` with a content-free warning.
- Roll back prepared participant state on pre-acceptance enqueue failures while preserving the original queue error and lock reconciliation behavior.
- Document the acceptance ordering, failure modes, and updated completion flow.
- Add focused service coverage for participant lifecycle behavior and degradation handling.

## Testing

- Added unit coverage for participant preparation, rollback, commit ordering, enqueue failure handling, and post-acceptance commit degradation.
- Existing test execution status is not included in the supplied context.