### PR TITLE
Hermeticize startup import storage fixture

### DIFF
--- a/tests/core/test_memory_store_startup_boundary.py
+++ b/tests/core/test_memory_store_startup_boundary.py
@@ -115,12 +115,14 @@ def _run_isolated_import_check(
         "sys.stdout.write(f'DB_CREATED={created}\\nDB_SIZE={size}\\n')\n"
         "sys.exit(0)\n"
     )
+    env = _clean_subprocess_env()
+    env["STORAGE_BASE_PATH"] = str(cwd / "data" / "media")
     result = subprocess.run(
         [sys.executable, "-E", "-c", probe],
         capture_output=True,
         text=True,
         cwd=str(cwd),
-        env=_clean_subprocess_env(),
+        env=env,
         timeout=timeout,
     )
     last_lines = (result.stdout or "").strip().splitlines()[-2:]
@@ -195,6 +197,12 @@ def test_import_seam_does_not_create_legacy_sqlite_store_db(
     if stderr:
         sys.stderr.write(
             f"[{target_module}] subprocess stderr: {stderr[:2000]}\n"
+        )
+
+    if target_module == "guardian.guardian_api":
+        assert (subprocess_cwd / "data" / "media").is_dir(), (
+            "Guardian application import must initialize media storage beneath "
+            "the probe-owned temporary path"
         )
 
     assert not store_db_exists, (


### PR DESCRIPTION
## Summary

Repairs the fail-closed MemoryStore startup-boundary regression so its
isolated Guardian application import does not depend on the container-only
/app/data/media path.

The probe now supplies a per-test writable STORAGE_BASE_PATH beneath pytest's
tmp_path and verifies guardian.guardian_api actually reaches media-storage
initialization there.

## Why

The first current-tip NX-1 retry stopped before Docker because the isolated
host subprocess imported guardian.guardian_api without STORAGE_BASE_PATH.

Production storage correctly defaulted to /app/data/media, which is valid in
the supported Compose runtime but not writable from that arbitrary host
subprocess.

That host-path failure was unrelated to the legacy SQLite MemoryStore boundary
the test exists to protect.

## Validation

- tests/core/test_memory_store_startup_boundary.py: 5 passed
- failed-import negative control remains fail-closed
- explicit MemoryStore(temp_path) construction passes
- guardian.guardian_api import initializes probe-owned media storage
- no guardian/memory/store.db is created
- production storage/API/media/Compose/.env template diffs are empty
- git diff --check: PASS

## Scope

This PR changes one test file only.

It does not:

- change runtime storage behavior;
- change /app/data/media;
- change MemoryStore behavior;
- change Docker or supported-profile configuration;
- repair configuration coherence;
- close NX-1;
- widen the Beta release claim.

After merge, NX-1 should be retried from a fresh exact origin/main checkout.

