### PR TITLE
fix: load canonical watchdog worker settings

### DIFF
--- a/guardian/workers/watchdog_review_worker.py
+++ b/guardian/workers/watchdog_review_worker.py
@@ -15,7 +15,7 @@ from typing import Any
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
 
-from guardian.config import get_settings
+from guardian.core.config import get_settings as get_core_settings
 from guardian.core.dependencies import get_database_dsn
 from guardian.db.models import (
     GitHubWatchdogReviewAttempt,
@@ -474,7 +474,7 @@ def run_worker_loop() -> None:
         session_factory=session_factory,
         execution_service=GitHubWatchdogReviewExecutionService(
             session_factory=session_factory,
-            settings=get_settings(),
+            settings=get_core_settings(),
         ),
     )
     logger.info("[watchdog-review-worker] started worker_id=%s", worker.worker_id)

--- a/tests/watchdog/test_review_worker.py
+++ b/tests/watchdog/test_review_worker.py
@@ -11,6 +11,7 @@ from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
+from guardian.core.config import get_settings as get_core_settings
 from guardian.db.models import (
     GitHubWatchdogDeliveryReceipt,
     GitHubWatchdogReviewAttempt,
@@ -31,6 +32,7 @@ from guardian.watchdog.review_execution import (
     GitHubWatchdogReviewExecutionService,
     WatchdogReviewExecutionError,
 )
+from guardian.workers import watchdog_review_worker
 from guardian.workers.watchdog_review_worker import GitHubWatchdogReviewWorker
 
 HEAD_SHA = "a" * 40
@@ -286,6 +288,10 @@ def _worker(
         dequeue_fn=dequeue_fn,
         worker_id="watchdog-review:test:1",
     )
+
+
+def test_watchdog_worker_uses_canonical_core_settings_factory() -> None:
+    assert watchdog_review_worker.get_core_settings is get_core_settings
 
 
 def test_worker_maps_completed_result_and_duplicate_delivery_invokes_once(


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
