### PR TITLE
Repair Pi diagnostic monkeypatching and refresh knowledge graph metadata

### DIFF
--- a/docs/knowledge-graph/nodes/codexify:doc:architecture:adr-index.json
+++ b/docs/knowledge-graph/nodes/codexify:doc:architecture:adr-index.json
@@ -18,14 +18,14 @@
   "lifecycle_state": "active",
   "freshness": {
     "state": "current",
-    "verified_at": "2026-08-23T00:00:00Z",
-    "verified_commit": "3b13351ac27933eefa3a172abd1b6fb2adc92751",
+    "verified_at": "2026-08-25T15:42:32Z",
+    "verified_commit": "a3d7882b8dfe826bc2f7ce3407e0677e827fcc17",
     "triggers": [
       "an ADR is added, removed, renumbered, or retitled",
       "an indexed ADR review posture changes",
       "the documented ADR graph or reading order changes"
     ],
-    "reason": "Re-verified the ADR Index metadata against current main at the audited pre-change HEAD 3b13351ac; ADR discovery scope remains a structural routing authority and source hash synchronized."
+    "reason": "Re-verified the ADR Index after current-main ADR additions; ADR discovery/routing remains structural authority, the DLG governance links remain valid, and the source hash is synchronized to a3d7882."
   },
   "disposition": "accepted",
   "evidence_class": "documented-contract",
@@ -77,7 +77,7 @@
     "created_at": "2026-04-14T20:56:05Z",
     "effective_from": "2026-04-14T20:56:05Z"
   },
-  "content_hash": "796f0fe8d104669e4239d70581290619bcb0a043cefd035d2cf76dfd8999aa3e",
+  "content_hash": "82472842e334038d2adc5f21111fdee44e78324bc2d378aad420f927d26af141",
   "relations": [
     {
       "relation_type": "depends_on",

--- a/docs/knowledge-graph/nodes/codexify:doc:architecture:kb-entrypoint.json
+++ b/docs/knowledge-graph/nodes/codexify:doc:architecture:kb-entrypoint.json
@@ -16,14 +16,14 @@
   "lifecycle_state": "active",
   "freshness": {
     "state": "current",
-    "verified_at": "2026-08-24T13:06:45Z",
-    "verified_commit": "ce389e6bc31ba4e7ceb1cd6207328e85fe06e939",
+    "verified_at": "2026-08-25T15:42:32Z",
+    "verified_commit": "a3d7882b8dfe826bc2f7ce3407e0677e827fcc17",
     "triggers": [
       "architecture entrypoints or validity guidance change",
       "listed subsystem ownership or change-location paths change",
       "the current-state routing boundary changes"
     ],
-    "reason": "KB routing was reverified after current-state static input-bundle authoring-aid linkage; README bytes did not change; no release routing changed."
+    "reason": "Re-verified the Architecture KB entrypoint after current-main routing additions; its structural source-routing role, current-state authority boundary, and existing DLG classification remain unchanged, and the source hash is synchronized to a3d7882."
   },
   "disposition": "accepted",
   "evidence_class": "documented-contract",
@@ -95,7 +95,7 @@
     "created_at": "2026-02-17T16:32:37Z",
     "effective_from": "2026-02-17T16:32:37Z"
   },
-  "content_hash": "5613024e025bf999e96bfec5468b39d5b257339bae4b6992d6d2049731e084e4",
+  "content_hash": "252ff0efec55f14cb7d9f42429d393813e0ce4bb564d4ad5941b7b44481ae1f2",
   "relations": [
     {
       "relation_type": "depends_on",

--- a/tests/pi/test_pi_authorized_failure_diagnostics.py
+++ b/tests/pi/test_pi_authorized_failure_diagnostics.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+import guardian.agents.adapters.pi_codex_runner as pi_codex_runner
 from guardian.agents.adapters.base import (
     AgentExecutionIdentity,
     AgentExecutionRequest,
@@ -381,7 +382,7 @@ def test_authorized_timeout_and_missing_wrapper_are_classified_without_raw_error
     def timeout(*_args: object, **_kwargs: object) -> None:
         raise subprocess.TimeoutExpired("node", 1)
 
-    monkeypatch.setattr("guardian.agents.adapters.pi_codex_runner.subprocess.run", timeout)
+    monkeypatch.setattr(pi_codex_runner.subprocess, "run", timeout)
     timeout_result = adapter.execute_authorized(request, identity, read_only=True)
     assert timeout_result.failure_classification == PiAuthorizedFailureClass.ADAPTER_TIMEOUT.value
     assert "timed out after" not in timeout_result.summary
@@ -389,7 +390,7 @@ def test_authorized_timeout_and_missing_wrapper_are_classified_without_raw_error
     def missing(*_args: object, **_kwargs: object) -> None:
         raise FileNotFoundError("/secret/path")
 
-    monkeypatch.setattr("guardian.agents.adapters.pi_codex_runner.subprocess.run", missing)
+    monkeypatch.setattr(pi_codex_runner.subprocess, "run", missing)
     missing_result = adapter.execute_authorized(request, identity, read_only=True)
     assert missing_result.failure_classification == PiAuthorizedFailureClass.WRAPPER_UNAVAILABLE.value
     assert "/secret/path" not in missing_result.model_dump_json()


### PR DESCRIPTION
## Summary

- Use module-based monkeypatching for Pi subprocess diagnostics.
- Refresh ADR index and architecture KB freshness metadata and content hashes.
- Preserve sanitized timeout and wrapper-unavailable failure classifications.

## Testing

Not run (not requested).