### PR TITLE
Document Docker archive retention qualification blocker

### DIFF
--- a/docs/architecture/00-current-state.md
+++ b/docs/architecture/00-current-state.md
@@ -26,6 +26,7 @@ This file is authoritative for:
 - Classified a fresh Chroma startup failure after guarded recovery; Postgres remains canonical and Chroma remains derived, with no retry, restore, or repair authorized.
 - Merged Guardian-owned GitHub Watchdog control-plane preparation and canonical worker settings; qualification stopped before review receipt creation or model invocation because the required policy/model was unavailable.
 - Recorded loss of the previously qualified immutable backend image and replacement of the mutable `latest` tag; deletion mechanism and actor remain unproven.
+- [Attempted the disposable Docker archive-retention qualification](proofs/2026-08-25-disposable-docker-image-archive-retention-qualification-proof.md), but the selected `desktop-linux` authority was unavailable; the run stopped at preflight without producing a retention result or mutating Docker state.
 - Repaired the Pi diagnostic test seam and refreshed DLG metadata hashes; neither change established provider, OAuth, or runtime support.
 
 ## Current supported reality
@@ -49,7 +50,7 @@ This file is authoritative for:
 - Current-tip proof is still missing for health, chat, durable assistant readback, retrieval, queue/worker execution, turn locks, terminal events, and recovery behavior on one supported profile.
 - Fresh-state Chroma startup / retrieval qualification remains blocked after the classified compatibility failure; no historical restore or implementation repair is proven.
 - Watchdog qualification lacks an explicit available provider/model policy and therefore stops before review receipt and model execution.
-- The qualified immutable replay image is unavailable, so retention qualification cannot proceed; canonical-versus-legacy configuration paths also leave startup and operator-state drift risk.
+- Disposable archive-retention qualification is blocked on restoring the intended `desktop-linux` Docker authority and rerunning from a fresh observed `origin/main`; the failed preflight produced no retention result. Canonical-versus-legacy configuration paths also leave startup and operator-state drift risk.
 
 ## This week’s priorities
 
@@ -57,7 +58,7 @@ This file is authoritative for:
 2. Prove health, model inventory, terminal chat, persistence/readback, retrieval, queue/worker, locks, and terminal events on that profile.
 3. Requalify Chroma only under an explicitly authorized, newly classified proof path; keep derived state non-canonical.
 4. Bind one explicit Watchdog provider/model policy and requalify without ambient-model substitution.
-5. Run the disposable image-retention reproduction and reconcile canonical-versus-legacy configuration drift.
+5. Restore the intended `desktop-linux` Docker authority, rerun the disposable image-retention reproduction from a fresh observed `origin/main`, and reconcile canonical-versus-legacy configuration drift.
 
 ## Release definition right now
 

--- a/docs/architecture/proofs/2026-08-25-disposable-docker-image-archive-retention-qualification-proof.md
+++ b/docs/architecture/proofs/2026-08-25-disposable-docker-image-archive-retention-qualification-proof.md
@@ -1,0 +1,147 @@
+# Disposable Docker image archive retention qualification proof
+
+Date: 2026-08-26
+Execution lane: Architecture-Impact
+Task kind: proof
+Evidence posture: live-runtime preflight attempted; blocked before execution
+Result: `DOCKER_ARCHIVE_QUALIFICATION_DOCKER_UNAVAILABLE`
+Confidence: HIGH for the Docker-authority preflight failure; no retention result
+
+## Decision
+
+The archive-retention qualification stopped at the Docker authority preflight.
+The selected context was `desktop-linux`, but the Docker client could not reach
+a running Docker Desktop server:
+
+```text
+Error response from daemon: Docker Desktop is unable to start
+```
+
+No disposable image, rootfs archive, Docker image archive, verification
+container, or host scratch state was created. No archive save, local image
+removal, archive load, container export, or retention observation occurred.
+
+This is a harness/authority failure, not a retention result.
+
+## Lineage and authority boundary
+
+| Field | Result |
+| --- | --- |
+| Branch | `proof/disposable-docker-image-archive-retention-qualification` |
+| Task base HEAD | `6b383badb1eb5c5301df0c92c88215e605bf9fff` |
+| Observed `origin/main` | `6b383badb1eb5c5301df0c92c88215e605bf9fff` |
+| `git fetch origin main` | PASS; attempted exactly once |
+| Commits above observed main at branch creation | none |
+| R2 retention predecessor | `4efef4c4d2f17831a0087d204503779825b8756e`; evidence only |
+| Retention-classification predecessor | `bc88a3a863ab38f9f95359eab94ed72c42af2fd4`; evidence only |
+| R4 predecessor | `61fbb2805bafa8060e99a5fe390fd3f81f2de1bb`; evidence only |
+| ADR impact | No ADR impact |
+| Governing contracts | ADR-020, ADR-066, ADR-068, Config and Ops, Agent Protocol Operations, and Pi Invocation Boundary Contract |
+
+This proof changes no runtime semantics, Guardian/Pi/provider/credential
+authority, Docker topology, canonical image ownership, persistence, or release
+posture.
+
+## Docker authority preflight
+
+| Field | Result |
+| --- | --- |
+| Docker context | `desktop-linux` |
+| Docker endpoint | NOT OBSERVED; server unavailable before endpoint/runtime qualification |
+| Docker client version | `29.7.2`, `darwin/arm64` |
+| Docker server version | NOT OBSERVED |
+| Docker server OS / architecture | NOT OBSERVED |
+| Docker authority result | FAIL; `Docker Desktop is unable to start` |
+| Probe namespace | NOT EVALUATED; daemon unavailable |
+| Probe namespace preflight | BLOCKED before occupancy could be proven |
+
+The namespace command returned no usable image inventory because the daemon
+returned the same startup error. The empty result is not treated as proof that
+`codexify-retention-archive-probe:*` was unused.
+
+The packet required stopping at this boundary. Docker Desktop was not
+restarted, the Docker context was not changed, and no fallback Docker authority
+was selected.
+
+## Stop point and task invariants
+
+```text
+FIRST_FAILED_BOUNDARY: docker_authority_preflight
+TASK_SCRATCH_ROOT: NOT_CREATED
+TASK_OWNED_IMAGE_IMPORTS: 0
+TASK_OWNED_IMAGE_ARCHIVE_SAVES: 0
+TASK_OWNED_PRE_RESTORE_IMAGE_REMOVALS: 0
+TASK_OWNED_IMAGE_ARCHIVE_LOADS: 0
+TASK_OWNED_VERIFICATION_CONTAINER_CREATIONS: 0
+TASK_OWNED_VERIFICATION_CONTAINER_STARTS: 0
+TASK_OWNED_VERIFICATION_CONTAINER_EXPORTS: 0
+TASK_OWNED_VERIFICATION_CONTAINER_REMOVALS: 0
+TASK_OWNED_FINAL_IMAGE_REMOVALS: 0
+TASK_OWNED_ARCHIVE_STATE_REMAINING: 0
+TASK_OWNED_SCRATCH_STATE_REMAINING: 0
+```
+
+No task-owned Docker mutation occurred. No prune, build, pull, tag, untag,
+image removal, container creation/start/stop/removal, network mutation, volume
+mutation, context change, configuration change, Desktop restart, or daemon
+restart occurred.
+
+```text
+NON_TASK_DOCKER_BUILDS: 0
+NON_TASK_DOCKER_PULLS: 0
+NON_TASK_DOCKER_TAG_CHANGES: 0
+NON_TASK_DOCKER_IMAGE_REMOVALS: 0
+DOCKER_PRUNE_OPERATIONS: 0
+DOCKER_CONTEXT_CHANGES: 0
+DOCKER_CONFIGURATION_CHANGES: 0
+DOCKER_DESKTOP_STARTS: 0
+DOCKER_DESKTOP_RESTARTS: 0
+DOCKER_DAEMON_RESTARTS: 0
+CANONICAL_NETWORK_MUTATIONS: 0
+CANONICAL_VOLUME_MUTATIONS: 0
+```
+
+No OpenSSL, Node, Pi, OAuth, OpenAI, provider, model, or credential activity
+occurred:
+
+```text
+OPENSSL_ACTIVITY: 0
+NODE_ACTIVITY: 0
+PI_EXECUTION_ATTEMPTS: 0
+OAUTH_LOGIN_ATTEMPTS: 0
+OPENAI_HTTP_REQUESTS: 0
+PROVIDER_INFERENCE_REQUESTS: 0
+CREDENTIAL_ACCESS_COUNT: 0
+CREDENTIAL_EXPOSURE: NONE
+```
+
+## Classification and causal posture
+
+```text
+PRIMARY_CLASSIFICATION: DOCKER_ARCHIVE_QUALIFICATION_DOCKER_UNAVAILABLE
+CONFIDENCE: HIGH
+RETENTION_RESULT: NOT_OBSERVED
+ARCHIVE_CHECKSUM_RESULT: NOT_APPLICABLE
+IMMUTABLE_IMAGE_RESTORE_RESULT: NOT_APPLICABLE
+ROOTFS_READBACK_RESULT: NOT_APPLICABLE
+```
+
+Exact causal statement: The selected `desktop-linux` Docker authority was
+unavailable because Docker Desktop could not start. The qualification stopped
+before probe-namespace occupancy, image import, archive creation, intentional
+local deletion, archive restoration, immutable-ID comparison, and rootfs
+readback. No conclusion about Docker archive retention follows.
+
+## Exact next prerequisite
+
+Restore the intended local `desktop-linux` Docker authority so that
+`docker version` returns a server, then repeat this bounded disposable archive
+qualification from a fresh observed `origin/main` task branch. Do not substitute
+a mutable Codexify runtime image, another Docker authority, or any fallback
+retention mechanism in that follow-up.
+
+## Validation and documentation follow-through
+
+Only this focused proof artifact is tracked. No application source changed, so
+no automated application runtime test applies. The archive sequence was not
+executed because Docker authority was unavailable.


### PR DESCRIPTION
## Summary

- Add an architecture proof documenting the disposable Docker image archive-retention qualification.
- Record that the run stopped at the Docker authority preflight because Docker Desktop could not start.
- Explicitly distinguish the infrastructure blocker from a retention result and document that no task-owned Docker mutations or credential/provider activity occurred.
- Capture lineage, governing contracts, stop-point invariants, classification, and the exact prerequisite for a future rerun.

## Testing

- Not run (documentation-only proof artifact; Docker qualification was blocked before execution).