### PR TITLE
Land Pi wrapper harness identity repair

### DIFF
--- a/codex_runner/src/agent-wrapper.js
+++ b/codex_runner/src/agent-wrapper.js
@@ -314,6 +314,8 @@ async function runAgent() {
 	let createCodingTools;
 	let getModel;
 	let getProviders;
+	let harnessId;
+	let harnessVersion;
 
 	const authorizedIdentity = guardianAuthorizedMode
 		? requireGuardianAuthorizedIdentity()

--- a/tests/pi/test_pi_authorized_failure_diagnostics.py
+++ b/tests/pi/test_pi_authorized_failure_diagnostics.py
@@ -490,3 +490,119 @@ def _readiness_block(source: str) -> str:
             if depth == 0:
                 return source[body_open : i + 1]
     raise AssertionError("checkGuardianAuthorizedReadiness body close brace not found")
+
+
+# Regression guard for the live `runAgent()` task-mode path.
+#
+# The CE-L0 live qualification proof (2026-08-26) established that
+# `runAgent()` destructures `harnessId` and `harnessVersion` from
+# `await loadPiSdk()` without first declaring those bindings. Because
+# the wrapper runs as an ES module (strict mode), the destructuring
+# assignment raised `ReferenceError: harnessId is not defined` before
+# provider execution. The readiness path (`checkGuardianAuthorizedReadiness`)
+# does not exercise this destructuring, and the Python `test_pi_live_invocation`
+# suite stubs `harness_runner` before the wrapper subprocess reaches this
+# code, so the existing tests cannot catch this regression. These static
+# regressions lock the binding declarations in place.
+_HARNESS_ID_LET_PATTERN = re.compile(r"^\s*let\s+harnessId\s*;\s*$", re.MULTILINE)
+_HARNESS_VERSION_LET_PATTERN = re.compile(r"^\s*let\s+harnessVersion\s*;\s*$", re.MULTILINE)
+_RUN_AGENT_DESTRUCTURES_HARNESS_ID_PATTERN = re.compile(
+    r"\bharnessId\s*,\s*\n\s*harnessVersion\s*,"
+)
+
+
+def _run_agent_block(source: str) -> str:
+    """Locate the bounded `runAgent` body in agent-wrapper.js.
+
+    Returns the function body (between the `async function runAgent() {` opener
+    and the closing brace) so static assertions evaluate only the live task
+    body, not the readiness body or help text.
+    """
+
+    fn_marker = "async function runAgent"
+    fn_start = source.find(fn_marker)
+    assert fn_start != -1, "runAgent not found in agent-wrapper.js"
+    body_open = source.find("{", fn_start)
+    assert body_open != -1, "runAgent body open brace not found"
+    depth = 0
+    for i in range(body_open, len(source)):
+        ch = source[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return source[body_open : i + 1]
+    raise AssertionError("runAgent body close brace not found")
+
+
+def test_run_agent_declares_harness_id_before_load_pi_sdk_destructuring() -> None:
+    """Static regression: `runAgent()` must declare `harnessId` with `let`.
+
+    The destructuring assignment `({ ..., harnessId, harnessVersion } = await
+    loadPiSdk())` requires both names to be declared before assignment; in
+    ES-module strict mode an undeclared binding raises `ReferenceError`,
+    which the rail classifies as `wrapper_unavailable / runtime_load`.
+    """
+
+    wrapper_path = (
+        Path(__file__).resolve().parent.parent.parent
+        / "codex_runner"
+        / "src"
+        / "agent-wrapper.js"
+    )
+    source = wrapper_path.read_text(encoding="utf-8")
+
+    run_agent_body = _run_agent_block(source)
+    assert _HARNESS_ID_LET_PATTERN.search(run_agent_body) is not None, (
+        "agent-wrapper.js runAgent() must declare `let harnessId;` so the "
+        "`await loadPiSdk()` destructuring assignment does not raise "
+        "`ReferenceError: harnessId is not defined` in strict ES-module mode."
+    )
+
+
+def test_run_agent_declares_harness_version_before_load_pi_sdk_destructuring() -> None:
+    """Static regression: `runAgent()` must declare `harnessVersion` with `let`.
+
+    Same rationale as the `harnessId` regression: `harnessVersion` is
+    destructured from `loadPiSdk()` and must be declared first.
+    """
+
+    wrapper_path = (
+        Path(__file__).resolve().parent.parent.parent
+        / "codex_runner"
+        / "src"
+        / "agent-wrapper.js"
+    )
+    source = wrapper_path.read_text(encoding="utf-8")
+
+    run_agent_body = _run_agent_block(source)
+    assert _HARNESS_VERSION_LET_PATTERN.search(run_agent_body) is not None, (
+        "agent-wrapper.js runAgent() must declare `let harnessVersion;` so the "
+        "`await loadPiSdk()` destructuring assignment does not raise "
+        "`ReferenceError: harnessVersion is not defined` in strict ES-module mode."
+    )
+
+
+def test_run_agent_still_destructures_harness_id_and_version_from_load_pi_sdk() -> None:
+    """Static regression: `runAgent()` must keep destructuring both bindings.
+
+    The repair adds the local `let` declarations; the destructuring
+    assignment from `await loadPiSdk()` must remain unchanged so harness
+    identity still flows from the SDK/runtime rather than being hardcoded.
+    """
+
+    wrapper_path = (
+        Path(__file__).resolve().parent.parent.parent
+        / "codex_runner"
+        / "src"
+        / "agent-wrapper.js"
+    )
+    source = wrapper_path.read_text(encoding="utf-8")
+
+    run_agent_body = _run_agent_block(source)
+    assert _RUN_AGENT_DESTRUCTURES_HARNESS_ID_PATTERN.search(run_agent_body) is not None, (
+        "agent-wrapper.js runAgent() must continue destructuring "
+        "`harnessId, harnessVersion` from `await loadPiSdk()` so the "
+        "harness identity remains SDK-derived rather than hardcoded."
+    )


### PR DESCRIPTION
## CE-L0 prerequisite repair

This PR reconciles the already-proven Pi wrapper harness-binding repair onto current `main` (base `af053308e...`).

### Original failure

The first CE-L0 live qualification (commit `cf252a542...`) returned:

```text
wrapper_unavailable / runtime_load
ReferenceError: harnessId is not defined
provider_request_started=false
runner_call_count=1
retry_count=0
fallback_count=0
```

`codex_runner/src/agent-wrapper.js::runAgent()` destructured `harnessId` and `harnessVersion` from `await loadPiSdk()` without first declaring those bindings. Under ES-module strict mode this raised `ReferenceError` before any provider request began. The rail classifies this as `wrapper_unavailable / runtime_load`.

### Repair

Add the missing local declarations inside `runAgent()`, immediately after the existing seven `let` bindings:

```js
let harnessId;
let harnessVersion;
```

No other change to the wrapper. `loadPiSdk()`'s return shape, the destructuring assignment, and every downstream use of `harnessId` / `harnessVersion` are preserved.

### Identity provenance preserved

Harness identity continues to flow from the SDK/runtime via `loadPiSdk()`. No hardcoded `pi-coding-agent`, no hardcoded `0.72.1`, no hardcoded provider or model ID. The regression test `test_run_agent_still_destructures_harness_id_and_version_from_load_pi_sdk` enforces this invariant.

### Files changed

```text
codex_runner/src/agent-wrapper.js                  |   2 +
tests/pi/test_pi_authorized_failure_diagnostics.py | 116 +++++++++++++++++++++
2 files changed, 118 insertions(+)
```

### Regression coverage added

Three new static regression tests in `tests/pi/test_pi_authorized_failure_diagnostics.py`:

1. `test_run_agent_declares_harness_id_before_load_pi_sdk_destructuring`
2. `test_run_agent_declares_harness_version_before_load_pi_sdk_destructuring`
3. `test_run_agent_still_destructures_harness_id_and_version_from_load_pi_sdk`

The two `let` assertions fail on the pre-repair source and pass on the post-repair source.

### Validation

- `pytest -v tests/pi/test_pi_authorized_failure_diagnostics.py` — **30 / 30 PASS**
- `pytest -v tests/pi/test_pi_live_invocation.py` — **29 / 29 PASS**
- `pytest tests/pi/test_pi_authorized_failure_diagnostics.py tests/pi/test_pi_live_invocation.py` — **59 / 59 PASS**
- `node --check codex_runner/src/agent-wrapper.js` — **PASS**
- `git diff --check origin/main...HEAD` — **clean**

### Scope and safety

- No live provider request was made.
- No OAuth operation occurred.
- No credential mutation occurred.
- No Campaign Engine file was changed.
- No ADR was modified.
- No release claim was widened.
- The historical CE-L0 BLOCKED proof (`docs/architecture/proofs/runtime/2026-08-26-campaign-engine-ce-l0-guardian-pi-live-invocation-proof.md`) remains immutable historical evidence of the failed first attempt.

### ADR impact

`No ADR impact`. Aligned with existing ADR-020 (Guardian-Mediated Coding Agent Execution Contract), ADR-066 (Campaign Engine Runtime Recovery Contract), ADR-068 (Campaign Engine Live Role Execution Contract), and the Pi Invocation Boundary Contract.

### CE-L0 status

CE-L0 remains `BLOCKED` pending a fresh live qualification from the now-repaired current-main lineage. This PR only reconciles a substrate defect; it does not retry CE-L0 and does not emit `GUARDIAN_PI_LIVE_READY`.