### PR TITLE
Codex/diagnose tester fresh chroma failure

### DIFF
--- a/docs/architecture/proofs/runtime/2026-08-26-guardian-qwen-health-catalog-qualification-proof.md
+++ b/docs/architecture/proofs/runtime/2026-08-26-guardian-qwen-health-catalog-qualification-proof.md
@@ -1,0 +1,183 @@
+# Guardian Qwen non-inference health/catalog qualification proof
+
+**Result:** `BLOCKED: GUARDIAN_CHAT_INFRA_UNHEALTHY`
+**ADR impact:** Aligned with ADR-074 and existing operator-truth doctrine; no ADR change.
+
+## Scope and proof window
+
+This is a bounded, non-inference qualification attempt. The proof window was
+`2026-08-26T14:26:37Z` through `2026-08-26T14:27:55Z`.
+
+No Guardian, Whoosh'd, launchd, backend, worker, Redis, Postgres, Chroma,
+model-artifact, DeepSeek, or Watchdog configuration was changed. No service
+restart was attempted. The task worktree had no unstaged
+`guardian/workers/watchdog_review_worker.py` modification at entry; this task
+did not edit, stage, restore, or reformat that file.
+
+## Prerequisite and current source identities
+
+- Required prerequisite:
+  `6d3cd915eadbb17df8402d43b0cdfbc6174bbd89`
+  (`Prove Whooshd bootstrap after teardown`).
+- `git cat-file -e` and `git merge-base --is-ancestor` passed before probes.
+- Task worktree branch/HEAD:
+  `codex/diagnose-tester-fresh-chroma-failure` at
+  `c6f2b95dc5cdee090ce581f91b3a8446ef8aaa12`.
+- The active Tester project is `codexify_tester`, not this task worktree.
+- The active backend is bind-mounted from
+  `/Volumes/Dev_SSD/Codexify-main`, at `main`
+  `6b383badb1eb5c5301df0c92c88215e605bf9fff`.
+- Active backend container/image: `codexify_tester-backend-1`,
+  `475bb0079346`, `codexify-backend-runtime:latest`
+  (`sha256:2d02eaf6cfca4b50a8abbde718a8bab847a146b86069b9b5d0bac1b8651980b8`).
+- Active source mounts include `/Volumes/Dev_SSD/Codexify-main/backend` to
+  `/app/backend` and `/Volumes/Dev_SSD/Codexify-main/guardian` to both
+  `/app/guardian` and `/app/codexify`.
+
+The active source identity is therefore sufficiently resolved. The block is
+runtime availability, not uncertain source/image provenance.
+
+## Fresh Whoosh'd baseline
+
+The prerequisite runtime remained unchanged during this proof:
+
+- `system/com.resonant.whooshd` was `running`, with one active instance and
+  PID `50696`.
+- PID `50696` was the listener on `127.0.0.1:8000`.
+- Whoosh'd `HEAD` remained
+  `09e83a8359e3673e7c18a2e0b4733afd334b3bac`.
+- Canonical registry blob remained
+  `dc70602d29c174560e012943f32b67b14b69d12a`.
+- `GET /v1/models` returned exactly `qwen3.8-27b-4bit`, with `mlx_vlm` /
+  `mlx` metadata; no raw filesystem-path Qwen identity was returned.
+- The unchanged registry maps that ID to
+  `/Volumes/Dev_SSD/whooshd/model-weights/Qwen3.8-27B-4bit`.
+- Current startup evidence still records `adapter=stub`.
+
+```text
+WHOOSHD_EXECUTION_ADAPTER=stub
+QWEN_REAL_INFERENCE_STATUS=UNPROVEN
+```
+
+The identity/inventory facts above do not establish executable Qwen inference.
+
+## Active Tester provider posture
+
+The non-secret backend-container environment resolved:
+
+| Setting | Active value |
+| --- | --- |
+| `LLM_PROVIDER` | `local` |
+| `LOCAL_CHAT_MODEL` | `qwen3.8-27b-4bit` |
+| `ALLOW_CLOUD_PROVIDERS` | `true` |
+| `CODEXIFY_LOCAL_ONLY_MODE` | `false` |
+| `CODEXIFY_EGRESS_ALLOWLIST` | `deepseek` |
+
+Thus the active Tester configuration preserves the expected local/Qwen
+authority and bounded DeepSeek lane. These configuration values were read
+from the actual container identity and were not changed.
+
+## Canonical route and semantics inspection
+
+The active mounted `guardian/routes/health.py` defines canonical routes:
+
+- `GET /health`;
+- `GET /health/llm` and `GET /api/health/llm`;
+- `GET /api/llm/catalog` (with optional `include=all`); and
+- `GET /health/chat` and `GET /api/health/chat`.
+
+The active source also contains the strict local failure reason
+`configured_model_not_advertised_by_whooshd`. This shows that the intended
+healthy local posture depends on exact inventory agreement; it does not make
+catalog presence a completion receipt. No running Guardian response was
+available to assess any stronger `online`, `available`, `ready`, or `healthy`
+semantics, so no capability-overclaim conclusion is made.
+
+## First causal blocker
+
+At proof-window start, the actual backend container was already stopped:
+
+```text
+backend_state=exited
+exit_code=255
+finished_at=2026-08-26T10:02:41.971699042Z
+restart_count=0
+```
+
+The published backend port had no listener. The single canonical direct
+Guardian probe was read-only and failed before HTTP transport:
+
+```text
+GET http://127.0.0.1:8889/health
+curl: (7) Couldn't connect to server
+HTTP_STATUS=000
+```
+
+Redis was separately still `running` and `healthy`; `worker-chat` was still
+`running` with restart count `0`. They cannot make the absent backend health,
+LLM-health, catalog, or chat-health routes available.
+
+This is the first causal blocker:
+
+`BLOCKED: GUARDIAN_CHAT_INFRA_UNHEALTHY`
+
+The task permits a backend-only restart only when a healthy, reachable backend
+has source-proven stale provider inventory. Here the backend is unavailable
+before any inventory observation, so that conditional authority does not
+apply. No restart was attempted.
+
+## Deliberately unproven surfaces
+
+Because the canonical Guardian health endpoint was unreachable, the task did
+not probe `/api/health/llm`, `/api/llm/catalog`,
+`/api/llm/catalog?include=all`, or `/health/chat`. Consequently, the
+following remain unproven in this task:
+
+- Guardian's dynamic recognition of exact Qwen inventory;
+- local provider authorization/enabled runtime readback;
+- absence of `configured_model_not_advertised_by_whooshd`;
+- current Guardian health-status semantics;
+- worker heartbeat and chat-queue depth readback; and
+- any Guardian capability-overclaim question.
+
+## Execution and persistence boundaries
+
+```text
+WHOOSHD_RESTARTS_DURING_QUALIFICATION=0
+GUARDIAN_BACKEND_RESTARTS_DURING_QUALIFICATION=0
+WORKER_CHAT_RESTARTS_DURING_QUALIFICATION=0
+MODEL_INVOCATIONS_DURING_GUARDIAN_QUALIFICATION=0
+DEEPSEEK_REQUESTS_DURING_GUARDIAN_QUALIFICATION=0
+WATCHDOG_ACTIVITY_DURING_GUARDIAN_QUALIFICATION=0
+```
+
+The only Whoosh'd request made during the proof was `GET /v1/models`; bounded
+access-log inspection showed inventory/health request classes only and no
+model-generation route. No chat task, provider warmup, completion, DeepSeek
+request, Watchdog work, GitHub I/O, Command Bus action, Build Loop action, or
+manual storage mutation occurred.
+
+`docs/architecture/00-current-state.md` and all prior proof receipts remained
+unchanged.
+
+## Validation record
+
+```text
+git cat-file -e 6d3cd915eadbb17df8402d43b0cdfbc6174bbd89^{commit}
+git merge-base --is-ancestor 6d3cd915eadbb17df8402d43b0cdfbc6174bbd89 HEAD
+git -C /Volumes/Dev_SSD/Codexify-main rev-parse HEAD
+docker compose -p codexify_tester ps --all backend worker-chat redis
+docker inspect 475bb0079346
+launchctl print system/com.resonant.whooshd
+lsof -nP -iTCP:8000 -sTCP:LISTEN
+curl --fail http://127.0.0.1:8000/v1/models
+curl http://127.0.0.1:8889/health
+```
+
+## Deferred next slice
+
+Diagnose and restore the active `/Volumes/Dev_SSD/Codexify-main` Tester backend
+startup under its actual mounted source/image configuration. That separate
+task must not restart Whoosh'd, invoke Qwen, or use a backend restart merely
+as an inventory-refresh experiment. Reattempt Guardian health/catalog
+qualification only after direct backend `/health` is reachable.

--- a/docs/architecture/proofs/runtime/2026-08-26-tester-backend-exit-255-diagnosis-proof.md
+++ b/docs/architecture/proofs/runtime/2026-08-26-tester-backend-exit-255-diagnosis-proof.md
@@ -1,0 +1,214 @@
+# Tester backend exit-255 diagnosis proof
+
+**Result:** `TESTER_BACKEND_EXIT_255_CAUSE_IDENTIFIED`
+
+**First causal classification:** `TESTER_BACKEND_EXTERNAL_TERMINATION`
+
+**ADR impact:** Aligned with ADR-074 and existing operator-truth doctrine; no ADR change.
+
+## Scope and execution boundary
+
+This proof diagnoses the already-stopped Tester backend. It does not start,
+restart, recreate, rebuild, or otherwise modify the backend, image, active
+Tester source, `.env.tester`, Postgres, Redis, Chroma, Whoosh'd, launchd,
+DeepSeek, or Watchdog. The diagnostic window ended at `2026-08-26T15:03:10Z`.
+
+```text
+TESTER_BACKEND_DIAGNOSTIC_RESTARTS=0
+WORKER_CHAT_RESTARTS_DURING_BACKEND_DIAGNOSIS=0
+WHOOSHD_RESTARTS_DURING_BACKEND_DIAGNOSIS=0
+MODEL_INVOCATIONS_DURING_BACKEND_DIAGNOSIS=0
+DEEPSEEK_REQUESTS_DURING_BACKEND_DIAGNOSIS=0
+WATCHDOG_ACTIVITY_DURING_BACKEND_DIAGNOSIS=0
+MANUAL_POSTGRES_REDIS_CHROMA_MODEL_MUTATIONS=0
+```
+
+No Guardian health/catalog qualification, completion, chat task, provider request,
+DeepSeek request, Watchdog operation, GitHub I/O, Command Bus action, or Build Loop
+action was issued.
+
+## Prerequisite and active identities
+
+- Required predecessor: `747ad54462b92240ba88bd869bc72d2c14f6704e`
+  (`Qualify Guardian Qwen health`); `git cat-file -e` and
+  `git merge-base --is-ancestor` passed.
+- Task checkout: `codex/diagnose-tester-fresh-chroma-failure` at
+  `747ad54462b92240ba88bd869bc72d2c14f6704e`, `ahead 1, behind 12`.
+- Actual active source: `/Volumes/Dev_SSD/Codexify-main`, `main`,
+  `6b383badb1eb5c5301df0c92c88215e605bf9fff`,
+  `main...origin/main [behind 17]`, clean, remote
+  `https://github.com/Resonant-Jones/Codexify.git`.
+
+The active Compose project is `codexify_tester`, using `docker-compose.yml`,
+`docker-compose.tester.yml`, `docker-compose.whooshd-deepseek.yml`, and
+`.env.tester`. Relevant containers are `codexify_tester-backend-1`,
+`codexify_tester-db-1`, `codexify_tester-redis-1`, and
+`codexify_tester-worker-chat-1`.
+
+## Backend identity and stopped lifecycle
+
+```text
+container ID: 475bb0079346fe3e7454f2056fa1d451b73fb742472a5bbf4bdc1b91acffa8e5
+configured image: codexify-backend-runtime:latest
+actual image ID: sha256:2508fe43e87e883caea01fe36b5ab5eff3a1d9616d395d7e7903b03204a584cf
+image created: 2026-08-25T14:05:41.611173001Z
+working directory: /app
+state: exited; exit code: 255
+started: 2026-08-25T14:22:20.523380588Z
+finished: 2026-08-26T10:02:41.971699042Z
+restart count: 0; restart policy: no
+OOM killed: false; container error: empty
+health state: starting; retained health-log entries: 0
+```
+
+The container has no PID and no listener remains on `127.0.0.1:8889`.
+The actual image remains the current `codexify-backend-runtime:latest` image
+(`sha256:2508...`). Its historical `com.docker.compose.image` label names
+`sha256:2d02...`, now absent from Docker. That is stale image-tag lineage only:
+the container was pinned to `sha256:2508...`, with no evidence that the label
+caused exit 255.
+
+## Startup code, source coherence, and logs
+
+The immutable `python -c` entrypoint only fails early when a required embeddings
+directory is missing; that path emits an error and exits `1`. Its effective
+`LOCAL_EMBEDDINGS_REQUIRED=0` value rules it out. It then executes the
+bind-mounted script `/app/backend/scripts/docker/run_backend.py` from:
+
+```text
+/Volumes/Dev_SSD/Codexify-main/backend  -> /app/backend
+/Volumes/Dev_SSD/Codexify-main/guardian -> /app/guardian and /app/codexify
+/Volumes/Dev_SSD/Codexify-main/config   -> /app/config (read-only)
+```
+
+The script orders Postgres wait, required-table/Alembic schema probe, default
+seed, then `execve` of Uvicorn for `guardian.guardian_api:app`. The independent
+migrator completed successfully (`exit=0`,
+`2026-08-25T14:22:18.880132379Z` to `14:22:20.205513921Z`).
+
+The backend remained started for about 19 hours 40 minutes. That rules out
+container-creation failure and the immediate embedding precheck. The timestamped
+backend Docker logs from `2026-08-26T09:55:00Z` onward contained no retained
+records; a bounded final-tail search found no error, traceback, shutdown line,
+or `CODEXIFY_STARTUP_FAILURE_RECEIPT`.
+
+`guardian.guardian_api` wraps only unhandled application-lifespan startup
+exceptions in that receipt boundary. Its absence does not prove every inner
+phase succeeded, but it excludes a recorded unhandled lifespan-startup error as
+the available first-cause evidence. The last evidence-backed successful phase is
+**container process launch/long-running lifecycle after the entrypoint**; the
+first failed phase is **external lifecycle termination**, not application startup.
+
+## First causal evidence
+
+The backend did not stop in isolation. Four unrelated long-lived services exited
+`255` in the same approximately 38 ms interval, all with empty Docker error
+fields and `OOMKilled=false`:
+
+| Service | Finished at (UTC) | Exit | Restart policy |
+| --- | --- | --- | --- |
+| backend | `10:02:41.971699042` | `255` | `no` |
+| db (Postgres) | `10:02:41.970122000` | `255` | `no` |
+| frontend | `10:02:42.008126209` | `255` | `no` |
+| neo4j | `10:02:42.007834709` | `255` | `no` |
+
+Services with `unless-stopped` began new lifecycles about three seconds later:
+
+| Service | Prior finished at (UTC) | Current started at (UTC) | State |
+| --- | --- | --- | --- |
+| redis | `10:02:41.991051667` | `10:02:45.053482419` | running, healthy |
+| tailscale-codexify-test | `10:02:41.986467750` | `10:02:45.079078002` | running |
+| worker-chat | `10:02:42.007793542` | `10:02:45.078666210` | running |
+
+Redis logs record a fresh server start at `10:02:45.412Z`; `worker-chat` records
+a new startup at `10:03:18Z`. These are consequences of the project-level
+lifecycle event, not backend startup evidence.
+
+An import, profile validation, migration/schema check, Chroma startup, provider
+validation, database reachability, HTTP bind conflict, or entrypoint return cannot
+independently produce this synchronized multi-image transition. The narrow
+classification is `TESTER_BACKEND_EXTERNAL_TERMINATION`. Docker retained no event
+that identifies the initiating operator, Docker-engine, or host event, so none is
+claimed.
+
+## Effective configuration and dependency boundary
+
+The failed backend's non-secret effective configuration was:
+
+| Setting | Value |
+| --- | --- |
+| `CODEXIFY_SUPPORTED_PROFILE` | `v1-whooshd-deepseek-web` |
+| `CODEXIFY_CONFIG_SOURCE` / `LLM_PROVIDER` | `core` / `local` |
+| local model | `qwen3.8-27b-4bit` |
+| local vendor/base URL | `whooshd` / `http://host.docker.internal:8000/v1` |
+| cloud/local-only/egress | `true` / `false` / `deepseek` |
+| database | `postgresql://<redacted>@db:5432/Codexify` |
+| Redis | `redis://redis:6379/0` |
+| vector store | `chroma`, `./.chroma`, `codexify_vault_supported` |
+
+The active profile contract and local-provider validation require this local
+Whoosh'd posture and `LOCAL_BASE_URL`; the observed values meet those static
+requirements. `VectorStore` is constructed only after configuration and database
+initialization. No Chroma/vector failure appears in the failed-lifecycle evidence,
+so no Chroma investigation or mutation was opened.
+
+Postgres is stopped as part of the simultaneous lifecycle; no database query,
+migration, seed, stamp, or repair was run. Redis is now running and healthy; no
+Redis mutation was run. Migrator and graph-init remain exit `0` from the original
+lifecycle.
+
+Whoosh'd remains launchd `running`, active count `1`, runs `1`, PID `50696`. One
+non-inference inventory GET returned exact `qwen3.8-27b-4bit` with `mlx_vlm` /
+`mlx` metadata. A later three-second inventory GET timed out with the PID unchanged;
+no restart, follow-up repair, model request, or inference was attempted because it
+is not causal to the already-recorded backend stop.
+
+```text
+WHOOSHD_EXECUTION_ADAPTER=stub
+QWEN_REAL_INFERENCE_STATUS=UNPROVEN
+```
+
+## Deferred repair seam
+
+The owning surface is the active `codexify_tester` **Compose/Docker lifecycle**,
+not Guardian source, Tester configuration, the backend image, Chroma, provider
+routing, or model authority.
+
+A separate operator-authorized repair task must first establish the cause and
+intent of the external Docker/Compose interruption, then restore only stopped
+long-lived prerequisites (at minimum Postgres and backend) from their existing
+configuration and image. It may authorize at most one bounded backend
+startup/recreate attempt and must stop after proving direct backend HTTP
+availability and startup health. It must not fold Guardian health/catalog
+qualification, Qwen inference, DeepSeek, Watchdog, or source repair into that
+lifecycle task.
+
+## Worktree, release truth, and validation
+
+At preflight and before this proof was written, the task checkout had no changed
+or staged files. `guardian/workers/watchdog_review_worker.py` was absent from the
+diff and staging area; this diagnosis did not edit, stage, restore, or reformat it.
+`docs/architecture/00-current-state.md` remains unchanged. This is branch/runtime
+diagnostic evidence only and does not claim current-main supported-Compose closure.
+
+```text
+git cat-file -e 747ad54462b92240ba88bd869bc72d2c14f6704e^{commit}
+git merge-base --is-ancestor 747ad54462b92240ba88bd869bc72d2c14f6704e HEAD
+git status --short --branch; git rev-parse HEAD; git branch --show-current
+git -C /Volumes/Dev_SSD/Codexify-main status --short --branch
+git -C /Volumes/Dev_SSD/Codexify-main rev-parse HEAD
+git -C /Volumes/Dev_SSD/Codexify-main branch --show-current
+git -C /Volumes/Dev_SSD/Codexify-main remote -v
+docker compose --project-name codexify_tester ... ps -a
+docker inspect [Tester backend and dependency containers]
+docker logs --timestamps --since 2026-08-26T09:55:00Z codexify_tester-backend-1
+docker logs --timestamps --tail 160 codexify_tester-worker-chat-1
+docker logs --timestamps --tail 120 codexify_tester-redis-1
+docker events --since 2026-08-26T09:55:00Z --until 2026-08-26T10:10:00Z
+docker image inspect codexify-backend-runtime:latest sha256:2508...
+curl --max-time 3 http://127.0.0.1:8000/v1/models
+launchctl print system/com.resonant.whooshd
+```
+
+`python3 scripts/validate_docs.py` passed. `git diff --check` passed before
+staging. The narrow proof commit is recorded in the task closeout.

--- a/docs/architecture/proofs/runtime/2026-08-26-tester-backend-lifecycle-restoration-proof.md
+++ b/docs/architecture/proofs/runtime/2026-08-26-tester-backend-lifecycle-restoration-proof.md
@@ -1,0 +1,205 @@
+**Result:** `BLOCKED: TESTER_BACKEND_RESTART_OTHER_FAILURE`
+
+**Backend health observation:** successful, but PASS is withheld because the
+single canonical Compose backend start transitively executed the explicitly
+forbidden one-shot migrator/seed path.
+
+**ADR impact:** Aligned with existing Tester runtime doctrine and ADR-074; no
+ADR change.
+
+## Scope and boundary
+
+This task restored the existing Postgres container and attempted one start of
+the existing Tester backend. It did not rebuild, recreate, reconfigure, migrate
+by direct command, qualify Guardian, execute Qwen, invoke DeepSeek, or perform
+Watchdog work. The backend is now healthy, but the task cannot claim its strict
+PASS because `docker compose start backend` automatically started declared
+stopped one-shot dependencies, including `migrator` and `seed_defaults`.
+
+The original diagnosis remains `TESTER_BACKEND_EXTERNAL_TERMINATION`; its
+initiating actor remains unattributed.
+
+```text
+TESTER_POSTGRES_START_ATTEMPTS=1
+TESTER_BACKEND_START_ATTEMPTS=1
+WORKER_CHAT_RESTARTS_DURING_BACKEND_RESTORATION=0
+WHOOSHD_RESTARTS_DURING_BACKEND_RESTORATION=0
+MODEL_INVOCATIONS_DURING_BACKEND_RESTORATION=0
+DEEPSEEK_REQUESTS_DURING_BACKEND_RESTORATION=0
+WATCHDOG_ACTIVITY_DURING_BACKEND_RESTORATION=0
+MANUAL_REDIS_CHROMA_MODEL_MUTATIONS=0
+```
+
+No frontend was started. No Guardian Qwen health/catalog qualification or
+completion endpoint was called; the only backend HTTP probe was `/health`.
+
+## Lineage and active runtime identity
+
+- Required predecessor: `cb9779c629b02eb5d0a5072272d34ec23df54ebe`
+  (`Diagnose tester backend exit 255`); `git cat-file -e` and
+  `git merge-base --is-ancestor` passed.
+- Task checkout: `/Users/chriscastillo/.codex/worktrees/5ab6/Codexify-main`,
+  branch `codex/diagnose-tester-fresh-chroma-failure`, at
+  `cb9779c629b02eb5d0a5072272d34ec23df54ebe` before this proof.
+- Actual active Tester source: `/Volumes/Dev_SSD/Codexify-main`, branch `main`,
+  `6b383badb1eb5c5301df0c92c88215e605bf9fff`, clean, remote
+  `https://github.com/Resonant-Jones/Codexify.git`.
+- Compose project: `codexify_tester` using
+  `docker-compose.yml`, `docker-compose.tester.yml`,
+  `docker-compose.whooshd-deepseek.yml`, and `.env.tester`.
+
+The backend remained the original container
+`codexify_tester-backend-1`, image
+`sha256:2508fe43e87e883caea01fe36b5ab5eff3a1d9616d395d7e7903b03204a584cf`,
+with the active source bind-mounted at `/app/backend`, `/app/guardian`,
+`/app/codexify`, `/app/config`, and the existing data/model paths.
+
+## Pre-restoration state and minimum prerequisites
+
+At task start: backend and Postgres were `exited (255)` with restart count 0;
+Redis was `running (healthy)` with restart count 0; `worker-chat` was running
+with restart count 0; frontend and Neo4j were exited 255. Migrator, model-prep,
+and graph-init were exited 0 from the prior lifecycle.
+
+The active Compose definition declares backend dependencies of `db:
+service_healthy`, `migrator`, `model-prep`, and `graph-init` completed
+successfully. `graph-init` itself depends on healthy Neo4j, making Neo4j a
+transitive startup prerequisite for this existing Compose contract. Redis is
+not in backend `depends_on`, but was verified healthy and reachable from the
+Compose network because it is required by the already-running worker/completion
+topology. Frontend is unrelated to backend HTTP startup.
+
+Redis verification was read-only: health was `healthy`, restart count remained
+0, and a socket probe from `worker-chat` reached `redis:6379`.
+
+## Postgres restoration
+
+The existing `codexify_tester-db-1` container was started exactly once with
+the active Compose project. Its original volume remained attached:
+
+```text
+volume: codexify_tester_pg_data
+target: /var/lib/postgresql/data
+volume mountpoint: /var/lib/docker/volumes/codexify_tester_pg_data/_data
+```
+
+After the start, Postgres was `running`, health `healthy`, restart count 0,
+and `pg_isready -h localhost -U codexify -d Codexify` reported accepting
+connections. Logs show PostgreSQL automatic WAL recovery from the prior
+interruption and then `database system is ready to accept connections`; the
+existing data directory was not initialized or replaced. No volume was
+created/removed, and no direct query, migration, stamp, seed, or repair command
+was run by this task.
+
+## Backend identity and single start
+
+Immediately before the backend start, the source remained at
+`6b383badb1eb5c5301df0c92c88215e605bf9fff` and the existing container still
+referenced image `sha256:2508fe43e87e883caea01fe36b5ab5eff3a1d9616d395d7e7903b03204a584cf`.
+The non-secret posture remained `local / qwen3.8-27b-4bit`, vendor `whooshd`,
+base URL `http://host.docker.internal:8000/v1`, profile
+`v1-whooshd-deepseek-web`, Redis host `redis:6379`, and Postgres host `db`.
+No configuration changed.
+
+One bounded non-inference Whoosh'd GET immediately before the start returned
+the exact single model ID `qwen3.8-27b-4bit`; no restart or registry operation
+was performed. The runtime still advertises `adapter=stub`, so executable
+inference remains unproven.
+
+The one backend lifecycle command was:
+
+```text
+docker compose --project-name codexify_tester --env-file .env.tester \
+  -f docker-compose.yml -f docker-compose.tester.yml \
+  -f docker-compose.whooshd-deepseek.yml start backend
+```
+
+It began the existing backend container at
+`2026-08-26T15:34:56.359647755Z`; no rebuild or recreation occurred. Compose
+also started the stopped declared one-shot dependencies before the backend:
+
+| Container | Start | Finish | Result |
+| --- | --- | --- | --- |
+| model-prep | `15:34:42.102364638Z` | `15:34:42.518987055Z` | exit 0 |
+| migrator | `15:34:42.616520638Z` | `15:34:44.208537014Z` | exit 0 |
+| graph-init | `15:34:54.240333837Z` | `15:34:55.847565672Z` | exit 0 |
+| neo4j | `15:34:42.122809263Z` | running healthy | transitive dependency |
+
+The migrator log explicitly contains `alembic ... upgrade heads` and
+`Running seed defaults`. This was an automatic Compose dependency fan-out,
+not a separately issued command, but it violates this task's explicit
+no-migrator/no-seeding boundary. Therefore the strict lifecycle PASS is
+withheld and the permitted classification is:
+
+```text
+BLOCKED: TESTER_BACKEND_RESTART_OTHER_FAILURE
+```
+
+No second backend start, retry, rollback, or cleanup lifecycle operation was
+performed after this boundary was observed.
+
+## Backend health result
+
+The single backend start itself succeeded:
+
+```text
+state=running
+restart_count=0
+health=healthy
+listener=127.0.0.1:8889 (Docker proxy PID 58541)
+GET http://127.0.0.1:8889/health -> HTTP 200
+```
+
+The response reported `status=ok`, profile
+`v1-whooshd-deepseek-web`, `valid=true`, no profile mismatches, and selected
+provider `local`. This is only the canonical base startup/readiness proof; no
+LLM-health, catalog, chat-health, completion, or inference endpoint was called.
+
+## Boundary accounting and deferred action
+
+The frontend remained stopped. Neo4j was started only because it is a
+transitive prerequisite of the active backend `graph-init` dependency; it was
+not independently restored as a feature. The canonical Whoosh'd registry and
+process were untouched. The only Whoosh'd operation in this task was the
+bounded inventory GET described above.
+
+No model request, warmup, chat message, completion, DeepSeek request, Watchdog
+attempt, GitHub I/O, Command Bus action, Build Loop action, Redis flush, Chroma
+operation, Postgres data operation, or model-artifact operation occurred.
+
+The task checkout's unrelated
+`guardian/workers/watchdog_review_worker.py` remained untouched and unstaged;
+`docs/architecture/00-current-state.md` remained unchanged.
+
+The backend is usable for the next separately authorized qualification, but
+this proof must not be treated as `TESTER_BACKEND_LIFECYCLE_RESTORED` because
+the one start command reran the forbidden migrator/seed path. The next slice
+requires an explicit decision on the Compose dependency fan-out (or a
+canonical no-dependency existing-container start) before another lifecycle
+proof is claimed. No second backend attempt is authorized by this task.
+
+## Validation
+
+```text
+git cat-file -e cb9779c629b02eb5d0a5072272d34ec23df54ebe^{commit}
+git merge-base --is-ancestor cb9779c629b02eb5d0a5072272d34ec23df54ebe HEAD
+git -C /Volumes/Dev_SSD/Codexify-main status --short --branch
+git -C /Volumes/Dev_SSD/Codexify-main rev-parse HEAD
+docker compose --project-name codexify_tester ... config --no-interpolate
+docker compose --project-name codexify_tester ... ps -a
+docker inspect [backend, db, redis, worker-chat, neo4j, frontend]
+docker volume inspect codexify_tester_pg_data
+docker exec codexify_tester-worker-chat-1 python -c 'redis socket probe'
+docker exec codexify_tester-db-1 pg_isready -h localhost -U codexify -d Codexify
+docker compose --project-name codexify_tester ... start db
+docker compose --project-name codexify_tester ... start backend
+docker logs --timestamps --since 2026-08-26T15:34:37Z codexify_tester-backend-1
+docker logs --timestamps --since 2026-08-26T15:34:37Z codexify_tester-migrator-1
+lsof -nP -iTCP:8889 -sTCP:LISTEN
+curl --max-time 5 http://127.0.0.1:8889/health
+python3 scripts/validate_docs.py
+git diff --check
+```
+
+`python3 scripts/validate_docs.py` passed and `git diff --check` passed before
+staging. Only this proof file is task-attributable.


### PR DESCRIPTION
## Summary

- Title: <!-- short, imperative -->
- Context: <!-- why this change is needed -->

## Changes

- Files touched (high-level):
- Key diffs: <!-- link code sections or summarize -->

## Artifacts

- Preflight summary: `artifacts/preflight/<timestamp>/summary.md`
- Run manifest: `docs/prompts/run-manifest.yml`
- Infra prompt pack: `docs/prompts/infra-codex-pack.md`
- Batch run summary (if executed): `artifacts/runs/<timestamp>/summary.md`

## Validation

- [ ] Preflight ACCEPT (clean tree, tag, branch, env, ports, prompts)
- [ ] Lint/typecheck pass
- [ ] Tests pass (unit/integration as applicable)
- [ ] Security/Privacy Check: no secrets committed; local-first defaults
- [ ] Mobile limits respected (embedders ≤ 3 GB; LLM ≤ 3 GB)
- [ ] Preserved files intact: `src/TagSelector.tsx`, `src/ThreadPromptBox.tsx`, `src/PersonaEngine.ts`

## Screenshots / Logs

<!-- drop relevant images or log excerpts -->

## Risks & Rollback

- Risk level: low/medium/high
- Rollback plan: revert to tag `vX.Y.Z` and stash failures in `artifacts/failures/<timestamp>`

## Next Steps

- Follow-ups / dependent tasks:
- Link to run-manifest stages affected:
