### PR TITLE
Use Pi AI 0.82.1 compat catalog for full model/provider resolution

### DIFF
--- a/codex_runner/src/agent-wrapper.js
+++ b/codex_runner/src/agent-wrapper.js
@@ -149,57 +149,14 @@ async function loadPiSdk() {
 	const piAi = await import(
 		pathToFileURL(path.join(nodeModulesRoot, "@earendil-works/pi-ai/dist/index.js")).href
 	);
-	const openaiCodexModels = await import(
+	const piAiCompat = await import(
 		pathToFileURL(
-			path.join(nodeModulesRoot, "@earendil-works/pi-ai/dist/providers/openai-codex.models.js")
+			path.join(nodeModulesRoot, "@earendil-works/pi-ai/dist/compat.js")
 		).href
-	).catch(() => null);
-	const openaiCodexCatalog = (openaiCodexModels && openaiCodexModels.OPENAI_CODEX_MODELS) || {};
+	);
 	const packageMetadata = JSON.parse(
 		await readFile(path.join(packageRoot, "package.json"), "utf8")
 	);
-	const KNOWN_PROVIDERS = [
-		"anthropic",
-		"openai",
-		"azure-openai-responses",
-		"openai-codex",
-		"openrouter",
-		"google",
-		"google-vertex",
-		"github-copilot",
-		"vercel-ai-gateway",
-		"xai",
-		"groq",
-		"deepseek",
-		"mistral",
-		"minimax",
-		"cerebras",
-		"zai",
-		"minimax-cn",
-		"moonshotai",
-		"opencode",
-		"kimi-coding",
-		"xiaomi",
-	];
-	const getProviders = () => {
-		const known = new Set(KNOWN_PROVIDERS);
-		for (const id of Object.keys(openaiCodexCatalog)) {
-			const m = openaiCodexCatalog[id];
-			if (m && m.provider) known.add(m.provider);
-		}
-		return [...known];
-	};
-	const getModel = (providerId, modelId) => {
-		if (providerId === "openai-codex" && openaiCodexCatalog[modelId]) {
-			return openaiCodexCatalog[modelId];
-		}
-		for (const m of Object.values(openaiCodexCatalog)) {
-			if (m && m.id === modelId && (!providerId || m.provider === providerId)) {
-				return m;
-			}
-		}
-		return undefined;
-	};
 	const AuthStorage = piAi.AuthStorage;
 	return {
 		createAgentSession: codingAgent.createAgentSession,
@@ -207,8 +164,8 @@ async function loadPiSdk() {
 		AuthStorage,
 		ModelRegistry: codingAgent.ModelRegistry,
 		createCodingTools: codingAgent.createCodingTools,
-		getModel,
-		getProviders,
+		getModel: piAiCompat.getModel,
+		getProviders: piAiCompat.getProviders,
 		harnessId: ACTUAL_HARNESS_ID,
 		harnessVersion: String(packageMetadata.version || ""),
 	};

--- a/tests/ops/test_worker_coding_pi_runtime_contract.py
+++ b/tests/ops/test_worker_coding_pi_runtime_contract.py
@@ -69,6 +69,16 @@ def test_active_runtime_loader_targets_maintained_pi_ai() -> None:
     assert "@mariozechner/pi-ai" not in loader
 
 
+def test_active_runtime_loader_uses_full_builtin_model_catalog() -> None:
+    """Model resolution must cover every provider exposed by the Pi SDK."""
+    loader = (ROOT / "codex_runner/src/agent-wrapper.js").read_text(encoding="utf-8")
+
+    assert "@earendil-works/pi-ai/dist/compat.js" in loader
+    assert "getModel: piAiCompat.getModel" in loader
+    assert "getProviders: piAiCompat.getProviders" in loader
+    assert "OPENAI_CODEX_MODELS" not in loader
+
+
 def test_active_runtime_loader_imports_maintained_coding_agent() -> None:
     """The wrapper loader must read coding-agent from the maintained package
     metadata; the deprecated upstream namespace must not appear in active


### PR DESCRIPTION
### Motivation

- The wrapper previously used a single-provider/static OpenAI-Codex catalog which caused `getProviders()` to advertise providers while `getModel()` returned `undefined` for non-OpenAI-Codex entries, producing `model_unresolved` errors at runtime.
- The updated Pi SDK (0.82.1) exposes a canonical async model/auth facade via a compatibility entrypoint; the wrapper should delegate to that to resolve the full built-in provider and model catalog.

### Description

- Replaced the custom OpenAI-Codex-only model/catalog lookup with the maintained Pi AI compatibility entrypoint and delegated `getModel`/`getProviders` to `@earendil-works/pi-ai` compat exports by importing `dist/compat.js` and returning `getModel: piAiCompat.getModel` and `getProviders: piAiCompat.getProviders` from `loadPiSdk()` in `codex_runner/src/agent-wrapper.js`.
- Removed the brittle `OPENAI_CODEX_MODELS` ad-hoc catalog and the static provider list used to synthesize `getProviders`/`getModel`.
- Added a regression test `test_active_runtime_loader_uses_full_builtin_model_catalog` to `tests/ops/test_worker_coding_pi_runtime_contract.py` to ensure the loader imports the compat entrypoint and exposes `piAiCompat.getModel`/`getProviders` instead of the old single-provider lookup.
- Kept the change scoped to model/catalog resolution; the separate migration to `ModelRuntime` remains out of scope for this patch.

### Testing

- Ran targeted pytest checks: `python -m pytest tests/ops/test_worker_coding_pi_runtime_contract.py::test_active_runtime_loader_uses_full_builtin_model_catalog tests/ops/test_worker_coding_pi_runtime_contract.py::test_active_runtime_loader_targets_maintained_pi_ai tests/ops/test_worker_coding_pi_runtime_contract.py::test_active_runtime_loader_imports_maintained_coding_agent tests/pi/test_pi_authorized_failure_diagnostics.py -q`, and the focused loader/diagnostic assertions passed.
- Performed `git diff --check` and committed the change as `761312db4ccf6dde6f230fdba59a92787d75ab03` (`Fix Pi model catalog resolution`).
- Environment-limited notes: running the full test collection (`tests/ops/...` + `tests/pi/...`) and Node ESM checks encountered repository-environment issues because several vendored/package JSON files are Git LFS pointers (not hydrated JSON) which causes Node package parsing to fail; this is an external limitation and not a regression introduced by this change.
- Manual runtime validation: installed `@earendil-works/pi-ai@0.82.1` in a temporary project and confirmed `compat.getModel()` resolves representative Anthropic, OpenAI, Google, and OpenAI-Codex fixtures, demonstrating that delegating to the SDK compat entrypoint yields the full built-in catalog resolution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a90e91c0e5c8321b8aa1cee8da0d0de)