### PR TITLE
Use Pi 0.82 ModelRuntime for model/auth resolution in agent-wrapper

### DIFF
--- a/codex_runner/src/agent-wrapper.js
+++ b/codex_runner/src/agent-wrapper.js
@@ -142,73 +142,21 @@ async function loadPiSdk() {
 	const packageRoot = process.env.PI_CODING_AGENT_PACKAGE_ROOT
 		? path.resolve(process.env.PI_CODING_AGENT_PACKAGE_ROOT)
 		: path.resolve(wrapperDirectory, "../vendor/pi-coding-agent");
-	const nodeModulesRoot = process.env.PI_CODING_AGENT_NODE_MODULES
-		? path.resolve(process.env.PI_CODING_AGENT_NODE_MODULES)
-		: path.join(packageRoot, "node_modules");
 	const codingAgent = await import(pathToFileURL(path.join(packageRoot, "dist/index.js")).href);
-	const piAi = await import(
-		pathToFileURL(path.join(nodeModulesRoot, "@earendil-works/pi-ai/dist/index.js")).href
-	);
-	const openaiCodexModels = await import(
-		pathToFileURL(
-			path.join(nodeModulesRoot, "@earendil-works/pi-ai/dist/providers/openai-codex.models.js")
-		).href
-	).catch(() => null);
-	const openaiCodexCatalog = (openaiCodexModels && openaiCodexModels.OPENAI_CODEX_MODELS) || {};
 	const packageMetadata = JSON.parse(
 		await readFile(path.join(packageRoot, "package.json"), "utf8")
 	);
-	const KNOWN_PROVIDERS = [
-		"anthropic",
-		"openai",
-		"azure-openai-responses",
-		"openai-codex",
-		"openrouter",
-		"google",
-		"google-vertex",
-		"github-copilot",
-		"vercel-ai-gateway",
-		"xai",
-		"groq",
-		"deepseek",
-		"mistral",
-		"minimax",
-		"cerebras",
-		"zai",
-		"minimax-cn",
-		"moonshotai",
-		"opencode",
-		"kimi-coding",
-		"xiaomi",
-	];
-	const getProviders = () => {
-		const known = new Set(KNOWN_PROVIDERS);
-		for (const id of Object.keys(openaiCodexCatalog)) {
-			const m = openaiCodexCatalog[id];
-			if (m && m.provider) known.add(m.provider);
-		}
-		return [...known];
-	};
-	const getModel = (providerId, modelId) => {
-		if (providerId === "openai-codex" && openaiCodexCatalog[modelId]) {
-			return openaiCodexCatalog[modelId];
-		}
-		for (const m of Object.values(openaiCodexCatalog)) {
-			if (m && m.id === modelId && (!providerId || m.provider === providerId)) {
-				return m;
-			}
-		}
-		return undefined;
-	};
-	const AuthStorage = piAi.AuthStorage;
+	if (packageMetadata.name !== "@earendil-works/pi-coding-agent") {
+		throw new Error(`Unexpected Pi coding-agent package: ${packageMetadata.name || "unknown"}`);
+	}
+	const modelRuntime = await codingAgent.ModelRuntime.create();
 	return {
 		createAgentSession: codingAgent.createAgentSession,
 		SessionManager: codingAgent.SessionManager,
-		AuthStorage,
-		ModelRegistry: codingAgent.ModelRegistry,
+		modelRuntime,
 		createCodingTools: codingAgent.createCodingTools,
-		getModel,
-		getProviders,
+		getModel: modelRuntime.getModel.bind(modelRuntime),
+		getProviders: modelRuntime.getProviders.bind(modelRuntime),
 		harnessId: ACTUAL_HARNESS_ID,
 		harnessVersion: String(packageMetadata.version || ""),
 	};
@@ -234,7 +182,7 @@ async function checkGuardianAuthorizedReadiness() {
 		return;
 	}
 
-	const { AuthStorage, ModelRegistry, getModel, getProviders, harnessId, harnessVersion } = runtime;
+	const { modelRuntime, getModel, getProviders, harnessId, harnessVersion } = runtime;
 	const providerIds = getProviders().map((provider) =>
 		typeof provider === "string" ? provider : provider?.id,
 	);
@@ -267,16 +215,7 @@ async function checkGuardianAuthorizedReadiness() {
 	}
 
 	try {
-		const authStorage = AuthStorage.create();
-		const modelRegistry = ModelRegistry.create(authStorage);
-		if (!authStorage.hasAuth(model.provider)) {
-			emitAuthorizedFailure("oauth_auth_unavailable", "oauth_readiness", {
-				actual_runtime_identity: actualRuntimeIdentity,
-				runtime_identity_established: true,
-			});
-			return;
-		}
-		const available = await modelRegistry.getAvailable();
+		const available = await modelRuntime.getAvailable();
 		if (!available.some((candidate) => candidate.provider === model.provider && candidate.id === model.id)) {
 			emitAuthorizedFailure("model_unresolved", "model_availability", {
 				actual_runtime_identity: actualRuntimeIdentity,
@@ -326,7 +265,7 @@ async function checkReadiness() {
 	};
 
 	try {
-		const { AuthStorage, ModelRegistry, getModel } = await loadPiSdk();
+		const { modelRuntime, getModel } = await loadPiSdk();
 		const resolvedModelId = resolveModel(OPTIONS.model, getModel);
 		payload.effective_model = resolvedModelId;
 		const model = getModel(OPTIONS.provider, resolvedModelId);
@@ -341,11 +280,12 @@ async function checkReadiness() {
 		payload.effective_provider = model.provider;
 		payload.effective_model = model.id;
 
-		const authStorage = AuthStorage.create();
-		ModelRegistry.create(authStorage);
-		// hasAuth checks stored/env/fallback presence without refreshing OAuth or
-		// contacting the provider. Readiness is not credential-validity proof.
-		payload.provider_credential_available = authStorage.hasAuth(model.provider);
+		// getAvailable resolves stored and environment credentials without starting
+		// an agent session or provider request. Readiness is not credential-validity proof.
+		const available = await modelRuntime.getAvailable();
+		payload.provider_credential_available = available.some(
+			(candidate) => candidate.provider === model.provider && candidate.id === model.id,
+		);
 		payload.reason = payload.provider_credential_available
 			? null
 			: "provider_credential_missing";
@@ -358,8 +298,7 @@ async function checkReadiness() {
 async function runAgent() {
 	let createAgentSession;
 	let SessionManager;
-	let AuthStorage;
-	let ModelRegistry;
+	let modelRuntime;
 	let createCodingTools;
 	let getModel;
 	let getProviders;
@@ -374,8 +313,7 @@ async function runAgent() {
 		({
 			createAgentSession,
 			SessionManager,
-			AuthStorage,
-			ModelRegistry,
+			modelRuntime,
 			createCodingTools,
 			getModel,
 			getProviders,
@@ -406,20 +344,6 @@ async function runAgent() {
 	const resolvedProviderId = guardianAuthorizedMode
 		? authorizedIdentity.providerId
 		: OPTIONS.provider;
-
-	// Set up auth and model registry
-	let authStorage;
-	let modelRegistry;
-	try {
-		authStorage = AuthStorage.create();
-		modelRegistry = ModelRegistry.create(authStorage);
-	} catch (error) {
-		if (guardianAuthorizedMode) {
-			emitAuthorizedFailure("oauth_auth_unavailable", "oauth_readiness");
-			return;
-		}
-		throw error;
-	}
 
 	const tools = OPTIONS.disableTools ? [] : createCodingTools(OPTIONS.cwd);
 
@@ -467,7 +391,7 @@ async function runAgent() {
 
 	// Check API key availability
 	try {
-		const available = await modelRegistry.getAvailable();
+		const available = await modelRuntime.getAvailable();
 		const hasModel = available.some(
 			m => m.provider === model.provider && m.id === model.id,
 		);
@@ -525,8 +449,7 @@ async function runAgent() {
 			cwd: OPTIONS.cwd,
 			model,
 			thinkingLevel: OPTIONS.thinking,
-			authStorage,
-			modelRegistry,
+			modelRuntime,
 			tools,
 			sessionManager: SessionManager.inMemory(),
 		});

--- a/tests/ops/test_worker_coding_pi_runtime_contract.py
+++ b/tests/ops/test_worker_coding_pi_runtime_contract.py
@@ -61,11 +61,9 @@ def test_worker_image_installs_exact_declared_pi_runtime_without_credentials() -
 
 
 def test_active_runtime_loader_targets_maintained_pi_ai() -> None:
-    """The wrapper loader must import the maintained Pi AI package, not the
-    deprecated upstream namespace."""
+    """The wrapper loader must not import the deprecated Pi AI namespace."""
     loader = (ROOT / "codex_runner/src/agent-wrapper.js").read_text(encoding="utf-8")
 
-    assert "@earendil-works/pi-ai" in loader
     assert "@mariozechner/pi-ai" not in loader
 
 
@@ -75,8 +73,21 @@ def test_active_runtime_loader_imports_maintained_coding_agent() -> None:
     loader paths."""
     loader = (ROOT / "codex_runner/src/agent-wrapper.js").read_text(encoding="utf-8")
 
-    assert "@earendil-works" in loader
+    assert "@earendil-works/pi-coding-agent" in loader
     assert "@mariozechner" not in loader
+
+
+def test_active_runtime_loader_uses_canonical_model_runtime() -> None:
+    """The 0.82.1 wrapper must use the unified async model/auth facade."""
+    loader = (ROOT / "codex_runner/src/agent-wrapper.js").read_text(encoding="utf-8")
+
+    assert "await codingAgent.ModelRuntime.create()" in loader
+    assert "modelRuntime.getModel.bind(modelRuntime)" in loader
+    assert "modelRuntime.getProviders.bind(modelRuntime)" in loader
+    assert "modelRuntime," in loader
+    assert "AuthStorage" not in loader
+    assert "ModelRegistry" not in loader
+    assert "OPENAI_CODEX_MODELS" not in loader
 
 
 def test_runbook_uses_compose_owned_environment_and_canonical_readiness() -> None:

--- a/tests/pi/test_pi_authorized_failure_diagnostics.py
+++ b/tests/pi/test_pi_authorized_failure_diagnostics.py
@@ -396,53 +396,25 @@ def test_authorized_timeout_and_missing_wrapper_are_classified_without_raw_error
     assert "/secret/path" not in missing_result.model_dump_json()
 
 
-# Regression guard: the readiness rail must use the backend-supplying
-# AuthStorage public construction path (AuthStorage.create() or equivalent)
-# and must never construct a bare `new AuthStorage()` with no backend. The
-# latter was the historical TypeError discriminant isolated in the
-# reconciliation proof commit 4acb7c5c7c23dc4913a90bba9b86b46bec0bc241.
-_READINESS_AUTHSTORAGE_FORBIDDEN_PATTERN = re.compile(
-    r"new\s+AuthStorage\s*\(\s*\)"
-)
-_READINESS_AUTHSTORAGE_REQUIRED_PATTERN = re.compile(
-    r"AuthStorage\.create\s*\("
-)
-
-
-def test_readiness_wrapper_never_constructs_bare_auth_storage() -> None:
-    """Static regression: readiness path must not call `new AuthStorage()`.
-
-    A bare `new AuthStorage()` (no backend) deterministically raises a
-    `TypeError` from `auth-storage.js:203` because `this.storage` is
-    `undefined`. The reconciliation proof isolated that discriminant;
-    canonicalizing this rail must not re-introduce the misuse.
-    """
+def test_readiness_wrapper_does_not_use_removed_auth_registry_facades() -> None:
+    """Static regression: 0.82.1 readiness must use ModelRuntime only."""
 
     wrapper_path = Path(__file__).resolve().parent.parent.parent / "codex_runner" / "src" / "agent-wrapper.js"
     source = wrapper_path.read_text(encoding="utf-8")
 
     readiness_block = _readiness_block(source)
-    forbidden = _READINESS_AUTHSTORAGE_FORBIDDEN_PATTERN.search(readiness_block)
-    assert forbidden is None, (
-        "agent-wrapper.js readiness path must not construct bare `new AuthStorage()`."
-    )
+    assert "AuthStorage" not in readiness_block
+    assert "ModelRegistry" not in readiness_block
 
 
-def test_readiness_wrapper_uses_backend_supplying_auth_storage() -> None:
-    """Static regression: readiness path must use `AuthStorage.create()`.
-
-    Pi's normal public construction path supplies its own backend, which
-    is the only known-good pattern. The reconciliation proof showed that
-    `AuthStorage.create()` succeeds against the current operator auth.json.
-    """
+def test_readiness_wrapper_uses_model_runtime_availability() -> None:
+    """Static regression: readiness uses ModelRuntime's auth-aware catalog."""
 
     wrapper_path = Path(__file__).resolve().parent.parent.parent / "codex_runner" / "src" / "agent-wrapper.js"
     source = wrapper_path.read_text(encoding="utf-8")
 
     readiness_block = _readiness_block(source)
-    assert _READINESS_AUTHSTORAGE_REQUIRED_PATTERN.search(readiness_block) is not None, (
-        "agent-wrapper.js readiness path must call `AuthStorage.create()`."
-    )
+    assert "await modelRuntime.getAvailable()" in readiness_block
 
 
 def test_readiness_wrapper_emits_session_initialized_false_and_no_provider_request() -> None:


### PR DESCRIPTION
### Motivation

- The vendored 0.82.1 Pi SDK replaced legacy `AuthStorage`/`ModelRegistry` and single-provider catalogs with an async `ModelRuntime`, and the wrapper needed to follow that contract to avoid readiness and model-resolution errors. 
- The old compatibility path caused misleading `oauth_auth_unavailable` / `model_unresolved` failures and prevented non-OpenAI providers from resolving.

### Description

- Replaced legacy AuthStorage/ModelRegistry and single-provider catalog logic with the canonical async `ModelRuntime`: call `await codingAgent.ModelRuntime.create()` and expose `modelRuntime` from `loadPiSdk()`.
- Bound `getModel`/`getProviders` to the `modelRuntime` instance and switched readiness/availability checks to `await modelRuntime.getAvailable()` rather than constructing `AuthStorage` or `ModelRegistry`.
- Pass `modelRuntime` into `createAgentSession()` (instead of `authStorage`/`modelRegistry`) so `runAgent()` uses the new runtime for request assembly, auth resolution, and model lookup.
- Added a sanity check to ensure the loaded coding-agent package is the maintained `@earendil-works/pi-coding-agent` and removed the old OpenAI-only catalog and deprecated imports.
- Updated static/regression tests to assert the `ModelRuntime`-based integration and to remove expectations that the wrapper constructs the removed legacy facades.

### Testing

- Ran `git diff --check` and `node --check /tmp/agent-wrapper.mjs` after edits to validate module syntax, both succeeded. 
- Ran targeted pytest selection `pytest -q tests/ops/test_worker_coding_pi_runtime_contract.py -k 'not worker_image_installs_exact_declared_pi_runtime_without_credentials' tests/pi/test_pi_authorized_failure_diagnostics.py` and the modified/related tests passed (regressions for the readiness and runtime loader assertions were fixed). 
- A full test selection initially failed due to repository Git LFS placeholders for vendored runtime JSON files (the checkout has no configured remote), so those LFS-backed runtime files could not be hydrated; this prevented a complete end-to-end run in this environment. 
- Commands executed during validation included `node --check`, `pytest` invocations above, and `git diff --check`, and the code changes pass the static and targeted test guards in this checkout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a90e9116a288321a40c1aeedd96a538)