### PR TITLE
Repair Pi 0.82.1 tool activation telemetry

### DIFF
--- a/codex_runner/campaign_engine/errors.py
+++ b/codex_runner/campaign_engine/errors.py
@@ -71,6 +71,16 @@ class CampaignLiveExecutorError(CampaignEngineError):
         retry_count: int = 0,
         fallback_count: int = 0,
         issues: list[str] | None = None,
+        # Bounded Pi 0.82.1 tool telemetry (evidence only). Populated
+        # when the underlying Guardian outcome retained these fields so
+        # the operator can distinguish absence-of-write from absence-of-
+        # tool-execution or absence-of-assistant-tool-call.
+        effective_tool_names: tuple[str, ...] | None = None,
+        write_tool_available: bool | None = None,
+        tool_execution_start_count: int | None = None,
+        tool_execution_end_count: int | None = None,
+        executed_tool_names: tuple[str, ...] | None = None,
+        assistant_tool_call_count: int | None = None,
     ) -> None:
         super().__init__(message)
         self.failure_reason = failure_reason
@@ -80,8 +90,18 @@ class CampaignLiveExecutorError(CampaignEngineError):
         self.retry_count = retry_count
         self.fallback_count = fallback_count
         self.issues: list[str] = list(issues or [])
+        self.effective_tool_names = effective_tool_names
+        self.write_tool_available = write_tool_available
+        self.tool_execution_start_count = tool_execution_start_count
+        self.tool_execution_end_count = tool_execution_end_count
+        self.executed_tool_names = executed_tool_names
+        self.assistant_tool_call_count = assistant_tool_call_count
 
     def to_payload(self) -> dict[str, Any]:
+        # Surface only the bounded telemetry fields. Counts are normalized
+        # to integers; missing telemetry surfaces as None.
+        def _as_int(value: Any) -> int | None:
+            return value if isinstance(value, int) and value >= 0 else None
         return {
             "failure_reason": self.failure_reason,
             "diagnostic_class": self.diagnostic_class,
@@ -90,6 +110,28 @@ class CampaignLiveExecutorError(CampaignEngineError):
             "retry_count": self.retry_count,
             "fallback_count": self.fallback_count,
             "issues": list(self.issues),
+            "tool_telemetry": {
+                "effective_tool_names": (
+                    list(self.effective_tool_names)
+                    if self.effective_tool_names is not None
+                    else None
+                ),
+                "write_tool_available": (
+                    self.write_tool_available
+                    if isinstance(self.write_tool_available, bool)
+                    else None
+                ),
+                "tool_execution_start_count": _as_int(self.tool_execution_start_count),
+                "tool_execution_end_count": _as_int(self.tool_execution_end_count),
+                "executed_tool_names": (
+                    list(self.executed_tool_names)
+                    if self.executed_tool_names is not None
+                    else None
+                ),
+                "assistant_tool_call_count": _as_int(self.assistant_tool_call_count),
+            }
+            if self.effective_tool_names is not None
+            else None,
         }
 
 

--- a/codex_runner/campaign_engine/live_executor.py
+++ b/codex_runner/campaign_engine/live_executor.py
@@ -679,6 +679,44 @@ def _to_payload(obj: Any) -> dict[str, Any]:
         return out
 
 
+def _extract_tool_telemetry_from_outcome(outcome: Any) -> tuple:
+    """Best-effort extraction of bounded tool telemetry from a Pi outcome.
+
+    Returns a 6-tuple matching the bounded fields. Missing fields yield None.
+    Malformed fields yield None.
+    """
+    def _read(obj: Any, name: str) -> Any:
+        if obj is None:
+            return None
+        if isinstance(obj, dict):
+            return obj.get(name)
+        return getattr(obj, name, None)
+
+    def _as_int(value: Any) -> int | None:
+        return value if isinstance(value, int) and value >= 0 else None
+
+    names_raw = _read(outcome, "effective_tool_names")
+    names_out: tuple[str, ...] | None = None
+    if isinstance(names_raw, (list, tuple)):
+        cleaned = [n for n in names_raw if isinstance(n, str) and len(n) > 0]
+        names_out = tuple(cleaned)  # always tuple; empty tuple when none present
+    executed_raw = _read(outcome, "executed_tool_names")
+    executed_out: tuple[str, ...] | None = None
+    if isinstance(executed_raw, (list, tuple)):
+        cleaned = [n for n in executed_raw if isinstance(n, str) and len(n) > 0]
+        executed_out = tuple(cleaned)  # always tuple; empty tuple when none present
+    write_avail = _read(outcome, "write_tool_available")
+    write_avail_out = write_avail if isinstance(write_avail, bool) else None
+    return (
+        names_out,
+        write_avail_out,
+        _as_int(_read(outcome, "tool_execution_start_count")),
+        _as_int(_read(outcome, "tool_execution_end_count")),
+        executed_out,
+        _as_int(_read(outcome, "assistant_tool_call_count")),
+    )
+
+
 def _read_identity(identity_obj: Any) -> dict[str, Any]:
     if identity_obj is None:
         return {"provider_id": None, "model_id": None, "harness_id": None, "harness_version": None}
@@ -1329,17 +1367,26 @@ def run_live_executor_campaign(
         # CE-L1 Executor turn without an actual file write is not a
         # completed Executor turn.
         if source_mutation_count == 0:
+            # Capture any telemetry retained from the underlying Pi outcome
+            # so the operator can distinguish absence-of-write-tool from
+            # absence-of-tool-execution from absence-of-assistant-tool-call.
+            telemetry = _extract_tool_telemetry_from_outcome(outcome)
             raise CampaignLiveExecutorError(
-                "live Executor turn completed without producing an allowed-path "
-                "mutation; per CE-L1 policy an Executor turn must produce "
-                "source_mutation_count >= 1 within the declared allowed_file_paths",
+                "Harness success produced zero allowed-path mutation; "
+                "inspect bounded tool availability and execution telemetry "
+                "to classify the tool-execution boundary",
                 failure_reason="zero_mutation_executor_turn",
                 diagnostic_stage="post_invocation",
                 issues=[
                     "harness reported result_class=success but emitted no "
-                    "allowed-path mutation; the model did not invoke the "
-                    "declared file_write tool"
+                    "allowed-path mutation; telemetry retained for diagnosis"
                 ],
+                effective_tool_names=telemetry[0],
+                write_tool_available=telemetry[1],
+                tool_execution_start_count=telemetry[2],
+                tool_execution_end_count=telemetry[3],
+                executed_tool_names=telemetry[4],
+                assistant_tool_call_count=telemetry[5],
             )
     else:
         failed = [
@@ -1553,6 +1600,9 @@ def run_live_executor_campaign(
         attempt_state="succeeded",
         evaluation_verdict="passed",
     )
+    # Pull bounded tool telemetry directly from the Pi LiveInvocationOutcome
+    # so the durable run result preserves what Pi actually executed.
+    _telemetry = _extract_tool_telemetry_from_outcome(outcome)
     return LiveExecutorRunResult(
         campaign_id=preparation.campaign_id,
         run_id=preparation.run_id,
@@ -1596,6 +1646,13 @@ def run_live_executor_campaign(
         pi_receipt_id=receipt_id,
         pi_harness_result_id=harness_result_id,
         boundary_validation_hash=boundary_validation_hash,
+        # Bounded Pi 0.82.1 tool telemetry (evidence only).
+        effective_tool_names=_telemetry[0],
+        write_tool_available=_telemetry[1],
+        tool_execution_start_count=_telemetry[2],
+        tool_execution_end_count=_telemetry[3],
+        executed_tool_names=_telemetry[4],
+        assistant_tool_call_count=_telemetry[5],
     )
 
 

--- a/codex_runner/campaign_engine/models.py
+++ b/codex_runner/campaign_engine/models.py
@@ -302,6 +302,13 @@ class LiveExecutorRunResult:
     pi_receipt_id: str
     pi_harness_result_id: str
     boundary_validation_hash: str
+    # Bounded Pi 0.82.1 tool telemetry (evidence only).
+    effective_tool_names: tuple[str, ...] | None = None
+    write_tool_available: bool | None = None
+    tool_execution_start_count: int | None = None
+    tool_execution_end_count: int | None = None
+    executed_tool_names: tuple[str, ...] | None = None
+    assistant_tool_call_count: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -345,4 +352,23 @@ class LiveExecutorRunResult:
             "pi_harness_result_id": self.pi_harness_result_id,
             "boundary_validation_hash": self.boundary_validation_hash,
             "created_at": self.created_at,
+            # Bounded Pi 0.82.1 tool telemetry (evidence only).
+            "tool_telemetry": {
+                "effective_tool_names": (
+                    list(self.effective_tool_names)
+                    if self.effective_tool_names is not None
+                    else None
+                ),
+                "write_tool_available": self.write_tool_available,
+                "tool_execution_start_count": self.tool_execution_start_count,
+                "tool_execution_end_count": self.tool_execution_end_count,
+                "executed_tool_names": (
+                    list(self.executed_tool_names)
+                    if self.executed_tool_names is not None
+                    else None
+                ),
+                "assistant_tool_call_count": self.assistant_tool_call_count,
+            }
+            if self.effective_tool_names is not None
+            else None,
         }

--- a/codex_runner/src/agent-wrapper.js
+++ b/codex_runner/src/agent-wrapper.js
@@ -133,8 +133,50 @@ function emitAuthorizedFailure(failureClass, failureStage, details = {}) {
 		runtime_identity_established: details.runtime_identity_established === true,
 		session_initialized: details.session_initialized === true,
 		provider_request_started: details.provider_request_started === true,
+		tool_telemetry: details.tool_telemetry || null,
 	};
 	console.log(JSON.stringify(payload));
+}
+
+// The maintained Pi 0.82.1 SDK treats `createAgentSession({ tools })` as a
+// collection of tool-NAME strings (not AgentTool objects). The previous
+// `createCodingTools(OPTIONS.cwd)` call returned AgentTool objects, which
+// produced an empty effective tool set. We now pass the exact intended
+// canonical coding tool-NAME set and rely on the maintained `ModelRuntime`
+// for tool definitions.
+const CONFIGURED_WRITABLE_TOOL_NAMES = ["read", "bash", "edit", "write"];
+
+function getEffectiveToolNames(session) {
+	// Preferred source: maintained API method.
+	let names = null;
+	try {
+		if (typeof session?.getActiveToolNames === "function") {
+			names = session.getActiveToolNames();
+		}
+	} catch (_error) {
+		names = null;
+	}
+	// Fallback: read from session.agent.state.tools when API method is missing.
+	if (!Array.isArray(names)) {
+		try {
+			const tools = session?.agent?.state?.tools;
+			if (Array.isArray(tools)) {
+				names = tools.map((t) => t?.name).filter((n) => typeof n === "string");
+			}
+		} catch (_error) {
+			names = [];
+		}
+	}
+	// Normalize: strings only, first-occurrence order, unique, no empty.
+	const seen = new Set();
+	const out = [];
+	for (const name of names || []) {
+		if (typeof name !== "string" || name.length === 0) continue;
+		if (seen.has(name)) continue;
+		seen.add(name);
+		out.push(name);
+	}
+	return out;
 }
 
 async function loadPiSdk() {
@@ -178,7 +220,6 @@ async function loadPiSdk() {
 		createAgentSession: codingAgent.createAgentSession,
 		SessionManager: codingAgent.SessionManager,
 		modelRuntime,
-		createCodingTools: codingAgent.createCodingTools,
 		getModel: modelRuntime.getModel.bind(modelRuntime),
 		getProviders: modelRuntime.getProviders.bind(modelRuntime),
 		harnessId: ACTUAL_HARNESS_ID,
@@ -330,7 +371,6 @@ async function runAgent() {
 	let createAgentSession;
 	let SessionManager;
 	let modelRuntime;
-	let createCodingTools;
 	let getModel;
 	let getProviders;
 	let harnessId;
@@ -345,7 +385,6 @@ async function runAgent() {
 			createAgentSession,
 			SessionManager,
 			modelRuntime,
-			createCodingTools,
 			getModel,
 			getProviders,
 			harnessId,
@@ -376,7 +415,9 @@ async function runAgent() {
 		? authorizedIdentity.providerId
 		: OPTIONS.provider;
 
-	const tools = OPTIONS.disableTools ? [] : createCodingTools(OPTIONS.cwd);
+	// Maintained Pi 0.82.1 contract: `tools` is a string[] of tool NAMES,
+	// not AgentTool objects. Disabled/read-only sessions get `[]`.
+	const configuredToolNames = OPTIONS.disableTools ? [] : [...CONFIGURED_WRITABLE_TOOL_NAMES];
 
 	// Get model
 	const model = getModel(resolvedProviderId, resolvedModelId);
@@ -481,7 +522,7 @@ async function runAgent() {
 			model,
 			thinkingLevel: OPTIONS.thinking,
 			modelRuntime,
-			tools,
+			tools: configuredToolNames,
 			sessionManager: SessionManager.inMemory(),
 		});
 	} catch (error) {
@@ -497,10 +538,58 @@ async function runAgent() {
 
 	session = result.session;
 
-	// Subscribe to events
+	// Capture the effective tool surface from the actual session, NOT from the
+	// configured/intended value. This is the single source of truth for
+	// whether `write` is actually active in the live session.
+	const effectiveToolNames = getEffectiveToolNames(session);
+	const writeToolAvailable = effectiveToolNames.includes("write");
+
+	// Tool telemetry accumulators (content-free, evidence-only).
+	const toolTelemetry = {
+		effective_tool_names: effectiveToolNames,
+		write_tool_available: writeToolAvailable,
+		tool_execution_start_count: 0,
+		tool_execution_end_count: 0,
+		executed_tool_names: [],
+		assistant_tool_call_count: 0,
+	};
+
+	// Defense-in-depth: if Guardian-authorized-task has writable intent
+	// (`write` should be active) but the session did not register `write`,
+	// fail closed BEFORE prompting. This protects against any future SDK
+	// compatibility regression that would silently produce an empty
+	// effective tool set.
+	if (
+		guardianAuthorizedMode
+		&& OPTIONS.disableTools === false
+		&& writeToolAvailable !== true
+	) {
+		emitAuthorizedFailure("wrapper_protocol_failed", "tool_activation", {
+			actual_runtime_identity: actualRuntimeIdentity,
+			runtime_identity_established: true,
+			session_initialized: true,
+			provider_request_started: false,
+			tool_telemetry: toolTelemetry,
+		});
+		return;
+	}
+
+	// Subscribe to events (capture bounded tool-execution telemetry).
 	session.subscribe((event) => {
+		// Count tool execution lifecycle events (NO args/results/content).
+		if (event.type === "tool_execution_start") {
+			const toolName = typeof event.toolName === "string" ? event.toolName : null;
+			if (toolName !== null) {
+				toolTelemetry.tool_execution_start_count += 1;
+				if (!toolTelemetry.executed_tool_names.includes(toolName)) {
+					toolTelemetry.executed_tool_names.push(toolName);
+				}
+			}
+		} else if (event.type === "tool_execution_end") {
+			toolTelemetry.tool_execution_end_count += 1;
+		}
 		if (OPTIONS.verbose) {
-			if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
+			if (event.type === "message_update" && event.assistantMessageEvent?.type === "text_delta") {
 				process.stdout.write(event.assistantMessageEvent.delta);
 			}
 			if (event.type === "tool_execution_start") {
@@ -523,18 +612,34 @@ async function runAgent() {
 				runtime_identity_established: true,
 				session_initialized: true,
 				provider_request_started: true,
+				tool_telemetry: toolTelemetry,
 			});
 			return;
 		}
 		throw error;
 	}
 
-	// Get messages and extract JSON
-	const messages = session.agent.state.messages;
+	// Count assistant tool-call blocks (distinct from tool execution).
+	// Inspect assistant messages and count content blocks whose type is exactly
+	// "toolCall". Do NOT record tool-call arguments.
+	try {
+		const finalMessages = session.agent.state.messages;
+		for (const message of finalMessages) {
+			if (message.role !== "assistant") continue;
+			if (!Array.isArray(message.content)) continue;
+			for (const block of message.content) {
+				if (block && block.type === "toolCall") {
+					toolTelemetry.assistant_tool_call_count += 1;
+				}
+			}
+		}
+	} catch (_error) {
+		// leave count at 0; bounded evidence only
+	}
 
 	// Print final output
 	if (guardianAuthorizedMode) {
-		const response = extractJsonResponse(messages);
+		const response = extractJsonResponse(session.agent.state.messages);
 		console.log(JSON.stringify({
 			status: "ok",
 			summary: "Guardian-authorized Pi task completed",
@@ -546,11 +651,14 @@ async function runAgent() {
 					: "structured",
 				content_omitted: true,
 			},
+			session_initialized: true,
+			provider_request_started: true,
+			tool_telemetry: toolTelemetry,
 		}));
 		return;
 	}
 	if (mode === "audit" || mode === "compile" || mode === "task") {
-		const response = extractJsonResponse(messages);
+		const response = extractJsonResponse(session.agent.state.messages);
 		if (response) {
 			console.log(JSON.stringify(response, null, 2));
 		}

--- a/codex_runner/tests/test_campaign_engine_live_executor.py
+++ b/codex_runner/tests/test_campaign_engine_live_executor.py
@@ -151,6 +151,13 @@ class FakeOutcome:
     receipt: FakeReceipt | None = None
     harness_result: FakeHarnessResult | None = None
     actual_identity: FakeIdentity | None = None
+    # Bounded Pi 0.82.1 tool telemetry (evidence only).
+    effective_tool_names: tuple[str, ...] | None = None
+    write_tool_available: bool | None = None
+    tool_execution_start_count: int | None = None
+    tool_execution_end_count: int | None = None
+    executed_tool_names: tuple[str, ...] | None = None
+    assistant_tool_call_count: int | None = None
 
     def to_payload(self) -> dict[str, Any]:
         return {
@@ -1823,3 +1830,108 @@ def test_package_import_does_not_eagerly_load_guardian_pi() -> None:
     # Surface is unchanged in terms of public API.
     for required in ("run_provider_free_campaign", "LiveExecutorPreparation", "CampaignLiveExecutorError"):
         assert required in payload["attrs"]
+
+
+# --- Pi 0.82.1 tool telemetry propagation regressions ---
+#
+# These tests verify the Campaign Engine propagates bounded tool telemetry
+# through the success and failure paths without fabricating or mutating it.
+
+
+
+
+def test_zero_mutation_error_carries_all_six_tool_telemetry_fields(
+    monkeypatch, live_doc, tmp_path, fixed_clock, invoker_factory
+) -> None:
+    """zero_mutation_executor_turn exposes all six telemetry fields in the
+    CampaignLiveExecutorError.to_payload() output, and the issue text does
+    not claim the model itself caused the failure."""
+    from codex_runner.campaign_engine.live_executor import run_live_executor_campaign
+    campaign_path, target_path, _ = live_doc
+    fake_identity = FakeIdentity(
+        provider_id="openai-codex",
+        model_id="gpt-5.1",
+        harness_id="pi-coding-agent",
+        harness_version="0.82.1",
+    )
+    fake_receipt = FakeReceipt(
+        receipt_id="pi-receipt-tool-telemetry-zero",
+        invocation_id="inv-tool-telemetry-zero",
+        harness_id="pi-coding-agent",
+        harness_version="0.82.1",
+    )
+    fake_harness_result = FakeHarnessResult(
+        harness_result_id="pi-result-tool-telemetry-zero",
+        receipt_id="pi-receipt-tool-telemetry-zero",
+        harness_id="pi-coding-agent",
+        harness_version="0.82.1",
+    )
+    outcome = FakeOutcome(
+        ok=True,
+        receipt=fake_receipt,
+        harness_result=fake_harness_result,
+        actual_identity=fake_identity,
+        # Telemetry shows write WAS active but no tool call / execution occurred.
+        effective_tool_names=("read", "bash", "edit", "write"),
+        write_tool_available=True,
+        tool_execution_start_count=0,
+        tool_execution_end_count=0,
+        executed_tool_names=(),
+        assistant_tool_call_count=0,
+    )
+    _, install = invoker_factory
+    install(outcome)
+    output_root = tmp_path / "ce-l1-zero-mut-telemetry-output"
+    output_root.mkdir(parents=True, exist_ok=True)
+    preparation = prepare_live_executor_campaign(
+        campaign_path,
+        target_path,
+        clock=fixed_clock,
+    )
+    envelope, decision = _build_envelope_and_decision(preparation)
+    try:
+        run_live_executor_campaign(
+            preparation,
+            output_root,
+            envelope=envelope,
+            decision=decision,
+            timeout_seconds=15,
+            campaign_path=campaign_path,
+        )
+    except CampaignLiveExecutorError as exc:
+        payload = exc.to_payload()
+        assert payload["failure_reason"] == "zero_mutation_executor_turn"
+        # All six telemetry fields are present.
+        telemetry = payload["tool_telemetry"]
+        assert telemetry is not None
+        assert telemetry["effective_tool_names"] == [
+            "read", "bash", "edit", "write",
+        ]
+        assert telemetry["write_tool_available"] is True
+        assert telemetry["tool_execution_start_count"] == 0
+        assert telemetry["tool_execution_end_count"] == 0
+        assert telemetry["executed_tool_names"] == []
+        assert telemetry["assistant_tool_call_count"] == 0
+        # Issue text does NOT blame the model.
+        assert "the model did not invoke" not in str(exc)
+        # Issue text is evidence-bounded.
+        assert "tool availability and execution telemetry" in str(exc)
+    else:
+        raise AssertionError(
+            "expected CampaignLiveExecutorError for zero-mutation outcome"
+        )
+
+
+def test_zero_mutation_issue_text_does_not_blame_model() -> None:
+    """The zero_mutation_executor_turn issue text must be evidence-bounded."""
+    err = CampaignLiveExecutorError(
+        "Harness success produced zero allowed-path mutation; "
+        "inspect bounded tool availability and execution telemetry "
+        "to classify the tool-execution boundary",
+        failure_reason="zero_mutation_executor_turn",
+        diagnostic_stage="post_invocation",
+        issues=["allowed-path mutation; telemetry retained for diagnosis"],
+    )
+    msg = str(err)
+    assert "the model did not invoke" not in msg
+    assert "tool availability and execution telemetry" in msg

--- a/docs/architecture/pi-invocation-boundary-contract.md
+++ b/docs/architecture/pi-invocation-boundary-contract.md
@@ -205,6 +205,36 @@ Future proof expectations include:
 
 Diagnostics must align with Codexify's existing observability posture. Noisy harness internals do not belong in the primary chat lane.
 
+### Bounded Pi 0.82.1 tool observability (added 2026-08-29)
+
+Guardian-authorized live Pi execution may retain a bounded `tool_telemetry`
+field.  This telemetry is **evidence only** — it confers no execution
+authority.  The retained fields are:
+
+- `effective_tool_names`: actual active tool names reported by the
+  created session before prompting.  No configured/intended value may
+  substitute.
+- `write_tool_available`: true only if `"write"` is in
+  `effective_tool_names`.
+- `tool_execution_start_count`: count of observed
+  `tool_execution_start` events.
+- `tool_execution_end_count`: count of observed `tool_execution_end`
+  events.
+- `executed_tool_names`: unique tool names observed from
+  `tool_execution_start` in first-observed order.  No args, tool-call
+  IDs, results, or partial results are retained.
+- `assistant_tool_call_count`: post-completion count of assistant
+  content blocks whose type is exactly `toolCall`.  Distinct from
+  execution-start count.
+
+The telemetry contains **only** `string[]` tool names, booleans, and
+integer counts.  It does NOT contain prompt text, assistant text,
+thinking content, tool arguments, tool-call IDs, tool results, file
+contents, provider payloads, headers, tokens, account IDs, credential
+metadata, or environment dumps.  Target readback remains the
+authoritative source for actual mutation.  Telemetry does not broaden
+tool permissions.
+
 ## Explicit Non-Goals
 
 This contract does not:

--- a/docs/architecture/proofs/runtime/2026-08-26-campaign-engine-ce-l1-live-executor-proof.md
+++ b/docs/architecture/proofs/runtime/2026-08-26-campaign-engine-ce-l1-live-executor-proof.md
@@ -616,3 +616,57 @@ This is the only tracked file changed by this requalification.  No runtime
 source file.  No test file.  No Guardian file.  No Campaign Engine schema.
 No credential file.  Disposable driver, target, campaign JSON, and output
 root remain outside the repository (under `/var/folders/kj/.../T/`).
+
+## 2026-08-29 Pi 0.82.1 tool-activation diagnosis
+
+### DIAGNOSIS_RESULT
+
+```text
+DIAGNOSIS_RESULT=PASS
+```
+
+### PRE_REPAIR_CAUSE_CLASSIFICATION
+
+```text
+PRE_REPAIR_CAUSE_CLASSIFICATION=
+UNRESOLVED_TOOL_EXECUTION_BOUNDARY
+```
+
+### ROOT_CAUSE
+
+```text
+ROOT_CAUSE=
+PI_0821_TOOL_OPTIONS_TYPE_MISMATCH_PROVEN
+```
+
+### Pre-edit deterministic probe
+
+```text
+object-tool effective_tool_names=[]
+name-tool effective_tool_names=["read","bash","edit","write"]
+provider_request_count=0
+prompt_count=0
+operator_credential_access_count=0
+```
+
+### Statement
+
+The diagnosis resolves the previously unresolved tool-activation
+sub-boundary.  It does not retroactively convert either BLOCKED CE-L1
+attempt into a PASS.
+
+### Canonical gate truth
+
+```text
+CE-L1_OAUTH_PREREQUISITE=PASS
+CE-L1=OPEN
+LIVE_EXECUTOR_PROVEN=NOT_EMITTED
+SINGLE_TASK_SUPERVISED_USABLE=NOT_EMITTED
+```
+
+### NEXT_TASK_REQUIRED
+
+```text
+land the Pi 0.82.1 tool-activation and bounded telemetry repair on remote
+main
+```

--- a/docs/architecture/proofs/runtime/2026-08-29-pi-0821-tool-activation-telemetry-repair-proof.md
+++ b/docs/architecture/proofs/runtime/2026-08-29-pi-0821-tool-activation-telemetry-repair-proof.md
@@ -1,0 +1,532 @@
+# Pi 0.82.1 Tool Activation and Bounded Telemetry Repair Proof — 2026-08-29
+
+## Result
+
+```text
+TOOL_ACTIVATION_REPAIR=PASS_LOCAL
+```
+
+Canonical local PASS for this bounded repair slice.  The wrapper no
+longer passes AgentTool objects into Pi 0.82.1's
+`createAgentSession({ tools })`.  The maintained session now reports
+`["read", "bash", "edit", "write"]` as the active tool set for writable
+configurations, and `[]` for disabled configurations.  Bounded tool
+telemetry flows from the wrapper through `PiHarnessRuntimeEvidence`,
+`PiLiveInvocationOutcome`, `PiInvocationReceipt`,
+`PiHarnessResult`, `LiveExecutorRunResult`, and `CampaignLiveExecutorError`
+without args/results/content/credentials.  No new Pi failure token was
+created; existing `wrapper_protocol_failed` is reused.
+
+This repair does not yet re-run a live CE-L1 attempt and does not emit
+`LIVE_EXECUTOR_PROVEN`.  CE-L1 remains OPEN.
+
+## Summary
+
+| Field | Value |
+| --- | --- |
+| Campaign | `CAMPAIGN-2026-08-26_001_CAMPAIGN_ENGINE_SUPERVISED_USABILITY_CLOSURE` |
+| Gate | `CE-L1` |
+| Base SHA | `e9ae721cef5112d6e644a1c50657152301aa1666` ("Record CE-L1 gpt-5.6-sol zero-mutation blocker (#775)") |
+| Branch | `fix/pi-0821-tool-activation-telemetry` |
+| Worktree | `/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify-pi-0821-tool-activation-telemetry` |
+| Canonical Pi coding-agent package/version | `@earendil-works/pi-coding-agent@0.82.1` |
+| Canonical Pi AI package/version | `@earendil-works/pi-ai@0.82.1` |
+| Selected provider | `openai-codex` |
+| Selected model | `gpt-5.6-sol` (resolved locally, `allowModelNetwork: false`) |
+| Selected harness | `pi-coding-agent@0.82.1` |
+| Operator HOME preserved | true |
+| `PI_CODING_AGENT_PACKAGE_ROOT` | NOT SET |
+| `PI_CODING_AGENT_NODE_MODULES` | NOT SET |
+
+## Pre-edit wrapper behavior (observed)
+
+`codex_runner/src/agent-wrapper.js` previously computed:
+
+```js
+const tools = OPTIONS.disableTools
+    ? []
+    : createCodingTools(OPTIONS.cwd);
+```
+
+then passed `tools` (an array of `AgentTool` objects) into
+`createAgentSession({ tools })`.  The vendored Pi 0.82.1 SDK treats the
+`tools` option as a collection of tool-NAME strings.  Passing objects
+produced an empty effective tool set even though the wrapper believed
+coding tools were supplied.
+
+## Pi 0.82.1 expected tool argument shape (observed)
+
+`codex_runner/vendor/pi-coding-agent/dist/core/sdk.js`:
+
+```js
+const allowedToolNames = options.tools ?? (options.noTools === "all" ? [] : undefined);
+const initialActiveToolNames = (options.tools ? [...options.tools] : options.noTools ? [] : defaultActiveToolNames)
+    .filter((name) => !excludedToolNameSet?.has(name));
+```
+
+`options.tools` is iterated/spread directly; `setActiveToolsByName` then
+keys a `Map<string, tool>` registry by string tool name.  Objects fail
+`has(...)` and `registry.get(...)`, producing an empty effective tool
+registry.
+
+## `createCodingTools()` return posture
+
+`codex_runner/vendor/pi-coding-agent/dist/core/tools/index.js` returns
+4 `AgentTool` objects corresponding to `read`, `bash`, `edit`, `write`.
+Each object has keys: `name`, `label`, `description`, `parameters`,
+`constrainedSampling`, `prepareArguments`, `executionMode`, `execute`.
+
+## Pre-edit object-tool probe result (non-inference)
+
+```text
+{
+  "object_tool_effective_names": [],
+  "name_tool_effective_names": ["read", "bash", "edit", "write"],
+  "disabled_tool_effective_names": [],
+  "provider_request_count": 0,
+  "prompt_count": 0,
+  "operator_credential_access_count": 0
+}
+```
+
+Probe used a disposable HOME, a disposable auth JSON, the canonical
+source-vendored Pi 0.82.1 runtime with `allowModelNetwork: false`, and
+two consecutive `createAgentSession` calls — one passing
+`createCodingTools(cwd)` and one passing `toolNames.map(t => t.name)`.
+**No provider request was issued.** **No operator credential was
+accessed.**
+
+## Pre-edit name-tool probe result (non-inference)
+
+```text
+{
+  "object_tool_effective_names": [],
+  "name_tool_effective_names": ["read", "bash", "edit", "write"],
+  "disabled_tool_effective_names": [],
+  "provider_request_count": 0,
+  "prompt_count": 0,
+  "operator_credential_access_count": 0
+}
+```
+
+The name-tool path produced exactly the intended four tools.
+
+## Root-cause classification
+
+```text
+ROOT_CAUSE=
+PI_0821_TOOL_OPTIONS_TYPE_MISMATCH_PROVEN
+```
+
+Meaning:
+
+> Codexify supplied AgentTool objects to a Pi 0.82.1 API that interprets
+> the `tools` option as tool-name strings, causing the effective built-in
+> tool registry to reject the intended names.
+
+## Exact wrapper repair
+
+`codex_runner/src/agent-wrapper.js`:
+
+- Removed the active dependency on `createCodingTools(OPTIONS.cwd)`.
+- Added `const CONFIGURED_WRITABLE_TOOL_NAMES = ["read", "bash", "edit", "write"]`.
+- Replaced `const tools = OPTIONS.disableTools ? [] : createCodingTools(OPTIONS.cwd);`
+  with `const configuredToolNames = OPTIONS.disableTools ? [] : [...CONFIGURED_WRITABLE_TOOL_NAMES];`.
+- `createAgentSession({ ... })` now passes `tools: configuredToolNames` (a `string[]`).
+- Added `getEffectiveToolNames(session)` helper that prefers
+  `session.getActiveToolNames()` and falls back to
+  `session.agent.state.tools.map(t => t.name).filter(...)`.
+- After session creation, reads `effectiveToolNames` from the session
+  itself (NOT from the configured value) and computes
+  `writeToolAvailable = effectiveToolNames.includes("write")`.
+- For `guardianAuthorizedMode && OPTIONS.disableTools === false`
+  where `writeToolAvailable !== true`, emits the existing bounded
+  failure `wrapper_protocol_failed` at stage `tool_activation`
+  BEFORE calling `session.prompt(...)`, with `session_initialized=true`
+  and `provider_request_started=false`.  This is defense-in-depth
+  against any future SDK compatibility regression.
+- Subscribes to `session.subscribe((event) => ...)` and counts
+  `tool_execution_start` (with tool name into `executed_tool_names`)
+  and `tool_execution_end` events.
+- After completion, walks `session.agent.state.messages` to count
+  assistant content blocks whose `type` is exactly `"toolCall"`.
+- Emits a bounded `tool_telemetry` field on the Guardian-authorized
+  success payload (`status: "ok"`).
+- Also includes `tool_telemetry` in `emitAuthorizedFailure` failure
+  payloads (defense-in-depth visibility).
+
+`loadPiSdk()` no longer returns `createCodingTools`.  `runAgent` no
+longer destructures `createCodingTools`.
+
+## Configured writable tool names
+
+```text
+["read", "bash", "edit", "write"]
+```
+
+## Post-repair effective tool names
+
+```text
+["read", "bash", "edit", "write"]
+```
+
+Verified by re-running the post-repair non-inference SDK probe:
+
+```text
+{
+  "writable_tool_effective_names": ["read", "bash", "edit", "write"],
+  "disabled_tool_effective_names": [],
+  "provider_request_count": 0,
+  "prompt_count": 0,
+  "operator_credential_access_count": 0
+}
+```
+
+## Disabled/read-only effective tool names
+
+```text
+[]
+```
+
+Verified by the same probe.
+
+## `write_tool_available` result
+
+```text
+true
+```
+
+For writable configuration: `["read","bash","edit","write"]`
+includes `"write"`.  For disabled configuration: `[]` excludes
+`"write"` — the wrapper still sets `configuredToolNames = []` and never
+calls `session.prompt(...)` (the live authorized-task path skips the
+session entirely when `disableTools=true` would have set
+`configuredToolNames=[]`; however the live authorized-task path
+currently does not pass `PI_DISABLE_TOOLS=1` from Campaign Engine
+side — the existing `PI_DISABLE_TOOLS` env-var contract is preserved
+as-is).
+
+## Writable missing-write fail-closed result
+
+```text
+failure_class=wrapper_protocol_failed
+failure_stage=tool_activation
+session_initialized=true
+provider_request_started=false
+tool_telemetry={
+  effective_tool_names=[...],
+  write_tool_available=false,
+  ...
+}
+```
+
+No new Pi failure token was created.
+
+## Telemetry fields implemented
+
+Six bounded fields flow through every layer:
+
+- `effective_tool_names`: `string[]`
+- `write_tool_available`: `bool`
+- `tool_execution_start_count`: `int >= 0`
+- `tool_execution_end_count`: `int >= 0`
+- `executed_tool_names`: `string[]`
+- `assistant_tool_call_count`: `int >= 0`
+
+Propagation path:
+
+```text
+wrapper emitAuthorizedFailure / success payload
+  -> PiCodexRunnerAdapter._parse_result  (require_tool_telemetry=True for live)
+  -> PiHarnessRuntimeEvidence (added 6 fields)
+  -> _run_with_pi_adapter (copies directly)
+  -> invoke_guardian_authorized_pi success branch:
+       PiLiveInvocationOutcome  (added 6 fields)
+       PiInvocationReceipt.validation_metadata.tool_telemetry
+       PiHarnessResult.validation_metadata.tool_telemetry
+  -> run_live_executor_campaign success branch:
+       LiveExecutorRunResult (added 6 fields)
+       LiveExecutorRunResult.to_dict() exposes tool_telemetry
+  -> run_live_executor_campaign failure branch (zero_mutation_executor_turn):
+       CampaignLiveExecutorError (added 6 fields)
+       CampaignLiveExecutorError.to_payload() exposes tool_telemetry
+```
+
+## Telemetry redaction result
+
+The telemetry payload contains **only**:
+
+- `string[]` tool names
+- `bool`
+- `int >= 0` counts
+
+It does NOT contain:
+
+- prompt text
+- assistant text
+- thinking content
+- tool arguments
+- tool-call IDs
+- tool results
+- partial results
+- file contents
+- provider payloads
+- headers
+- tokens
+- account IDs
+- credential metadata
+- environment dumps
+
+## Adapter telemetry parse result
+
+`PiCodexRunnerAdapter._parse_result` accepts a new
+`require_tool_telemetry: bool` parameter (default `False`).
+`execute_authorized` calls it with `True`; `preflight_authorized`
+keeps `False`.  `_parse_tool_telemetry` extracts and normalizes all
+six fields.  `_is_valid_tool_telemetry` requires live-authorized-task
+payloads to carry a complete, well-formed telemetry set; missing or
+malformed fields cause `wrapper_protocol_failed` at stage
+`wrapper_protocol`.
+
+## Readiness-without-live-telemetry regression result
+
+Existing readiness regressions in
+`tests/pi/test_pi_authorized_failure_diagnostics.py` and `tests/pi/test_pi_live_invocation.py`
+continue to pass without requiring tool telemetry.
+
+## Guardian telemetry propagation result
+
+`PiHarnessRuntimeEvidence` and `PiLiveInvocationOutcome` carry the six
+fields directly via `_run_with_pi_adapter` (evidence source =
+AgentRunEnvelope; Guardian does not recompute).  New regression
+`test_tool_telemetry_propagates_into_pi_live_invocation_outcome` and
+`test_tool_telemetry_into_receipt_validation_metadata` pass.
+
+## Receipt telemetry result
+
+`PiInvocationReceipt.validation_metadata["tool_telemetry"]` carries the
+six fields on the successful Guardian-authorized live execution path.
+
+## Harness Result telemetry result
+
+`PiHarnessResult.validation_metadata["tool_telemetry"]` carries the
+six fields on the successful Guardian-authorized live execution path.
+
+## Campaign error telemetry result
+
+`CampaignLiveExecutorError` constructor accepts the six fields and
+`to_payload()` exposes them under `tool_telemetry`.  In particular,
+`zero_mutation_executor_turn` carries all six fields so the operator
+can distinguish absence-of-write-tool from
+absence-of-tool-execution from absence-of-assistant-tool-call.
+
+## Successful Campaign result telemetry result
+
+`LiveExecutorRunResult` carries all six fields populated directly from
+`PiLiveInvocationOutcome`.  `to_dict()` retains them.
+
+## Zero-mutation causal-text correction result
+
+The runtime error message for `zero_mutation_executor_turn` no longer
+contains the inference `the model did not invoke the declared
+file_write tool`.  The new message is:
+
+> Harness success produced zero allowed-path mutation; inspect bounded
+> tool availability and execution telemetry to classify the
+> tool-execution boundary.
+
+The associated issue text also no longer blames the model.
+
+## Confirmation no new failure token
+
+- No new canonical Pi failure class was introduced.
+- Existing `wrapper_protocol_failed`, `tool_activation` stage (already
+  defined in `_failure_stage_for_class`), and the existing
+  `CampaignLiveExecutorError.failure_reason = "zero_mutation_executor_turn"`
+  were reused.
+
+## Confirmation no Campaign schema change
+
+`codex_runner/schemas/campaign_engine/*.json` are unchanged.  The
+runtime result carries telemetry via the `tool_telemetry` nested key
+in `LiveExecutorRunResult.to_dict()` and `CampaignLiveExecutorError.to_payload()`.
+
+## Confirmation no Pi vendor change
+
+`codex_runner/vendor/pi-coding-agent/**` is unchanged.  No vendor
+regeneration.
+
+## Confirmation no provider/model routing change
+
+Provider/model/routing logic is unchanged.
+
+## Confirmation no live provider call
+
+This task issued no live provider-backed prompt.  All probes are
+non-inference; SDK probes use `allowModelNetwork: false`.
+
+## Confirmation no credential readiness call
+
+This task did not re-run `preflight_guardian_authorized_pi` against
+operator credentials.  Canonical `CE-L1_OAUTH_PREREQUISITE=PASS`
+remains the unchanged canonical prerequisite.
+
+## Confirmation no operator credential access
+
+This task never opened, listed, stat-ed, hashed, or inspected the
+operator's credential file or path.
+
+## Permanent source-vendor regression result
+
+`tests/ops/test_worker_coding_pi_runtime_contract.py` adds:
+
+- `test_maintained_pi_0821_treats_tools_as_name_strings`: probes the
+  vendored 0.82.1 SDK with disposable HOME and synthetic OAuth
+  fixture, asserts that writable sessions report `["read", "bash",
+  "edit", "write"]` and disabled sessions report `[]`. **No prompt,
+  no network, no operator credentials.**
+- `test_active_runtime_passes_tool_name_strings_not_agenttool_objects`:
+  source-grep ensures the wrapper no longer calls
+  `createCodingTools(OPTIONS.cwd)` outside a comment, requires the
+  exact writable tool-name string set in the source, and requires
+  `getActiveToolNames` to be used for effective tool readback.
+
+## Full deterministic test results
+
+```text
+tests/ops/test_worker_coding_pi_runtime_contract.py    15 passed
+tests/pi/test_pi_live_invocation.py                    32 passed (includes 3 new telemetry regressions)
+codex_runner/tests/test_campaign_engine_live_executor.py    33 passed (includes 2 new telemetry regressions)
+```
+
+## Post-repair no-inference SDK probe result
+
+```text
+writable_tool_effective_names=["read","bash","edit","write"]
+disabled_tool_effective_names=[]
+provider_request_count=0
+prompt_count=0
+operator_credential_access_count=0
+```
+
+## CE-L1 proof-ledger append-only result
+
+The 2026-08-26 CE-L1 live Executor proof ledger
+(`docs/architecture/proofs/runtime/2026-08-26-campaign-engine-ce-l1-live-executor-proof.md`)
+received an append-only `## 2026-08-29 Pi 0.82.1 tool-activation diagnosis`
+section.  The pre-edit SHA-256 (`1d7567ed82995dcc77cb86bdefb7cef1e6313718308378927233467886a8d389`)
+matched the first 29541 bytes of the new proof after appending.
+The historical 2026-08-26 BLOCKED sections were not modified.
+
+## Detailed proof path
+
+This file:
+`docs/architecture/proofs/runtime/2026-08-29-pi-0821-tool-activation-telemetry-repair-proof.md`
+
+## Docs result
+
+```text
+make docs → PASS
+```
+
+## `git diff --check` result
+
+```text
+clean
+```
+
+## Files changed
+
+```text
+M codex_runner/src/agent-wrapper.js
+M guardian/agents/adapters/base.py
+M guardian/agents/adapters/pi_codex_runner.py
+M guardian/pi/invocation.py
+M codex_runner/campaign_engine/errors.py
+M codex_runner/campaign_engine/models.py
+M codex_runner/campaign_engine/live_executor.py
+M tests/ops/test_worker_coding_pi_runtime_contract.py
+M tests/pi/test_pi_live_invocation.py
+M codex_runner/tests/test_campaign_engine_live_executor.py
+M docs/architecture/pi-invocation-boundary-contract.md
+M docs/architecture/proofs/runtime/2026-08-26-campaign-engine-ce-l1-live-executor-proof.md
+A docs/architecture/proofs/runtime/2026-08-29-pi-0821-tool-activation-telemetry-repair-proof.md
+```
+
+## ADR impact
+
+```text
+Aligned with existing ADR(s); no new ADR required
+```
+
+Governing contracts preserved: ADR-020, ADR-066, ADR-068, Pi Invocation
+Boundary Contract, Agent Tool Loop Contract, Runtime Protocol Token
+Contract.
+
+## Invariants check
+
+- Evidence did not outrun observation: the wrapper reads effective
+  tool names from the actual session, not from the configured value.
+- Historical proof truth remains immutable: 29541 bytes preserved
+  byte-identically.
+- Guardian remains execution authority.
+- Pi remains execution substrate.
+- Campaign Engine never self-authorizes.
+- Tool exposure did not exceed the pre-existing intended coding set
+  (`read`, `bash`, `edit`, `write` — not `grep`/`find`/`ls`).
+- Read-only execution remains tool-disabled under the existing
+  `PI_DISABLE_TOOLS` env-var contract.
+- Tool telemetry grants no authority.
+- Tool telemetry contains no prompt/content/arguments/results/secrets.
+- Actual target readback remains authoritative for mutation.
+- Exact runtime identity remains independent of tool telemetry.
+- No provider/model substitution.
+- No retry.
+- No fallback.
+- No rebinding.
+- No live proof was spent before the deterministic repair is
+  canonical.
+- Release claims remain evidence-bounded.
+
+## Proof results
+
+22 of 22 spec §22 proof items satisfied.
+
+## Documentation follow-through
+
+- Updated only `docs/architecture/pi-invocation-boundary-contract.md`
+  (added a single narrowly-bounded "Bounded Pi 0.82.1 tool
+  observability" subsection under "Observability and Proof Surface").
+- Appended only to
+  `docs/architecture/proofs/runtime/2026-08-26-campaign-engine-ce-l1-live-executor-proof.md`
+  (added a `## 2026-08-29 Pi 0.82.1 tool-activation diagnosis` section).
+- Created only this proof:
+  `docs/architecture/proofs/runtime/2026-08-29-pi-0821-tool-activation-telemetry-repair-proof.md`.
+- Did not modify `docs/architecture/00-current-state.md`.
+- Did not modify ADRs.
+- Did not modify release claims.
+
+## Local proof truth
+
+```text
+ROOT_CAUSE=
+PI_0821_TOOL_OPTIONS_TYPE_MISMATCH_PROVEN
+
+CE-L1_OAUTH_PREREQUISITE=PASS
+CE-L1=OPEN
+LIVE_EXECUTOR_PROVEN=NOT_EMITTED
+SINGLE_TASK_SUPERVISED_USABLE=NOT_EMITTED
+TOOL_ACTIVATION_REPAIR=PASS_LOCAL
+```
+
+## Next task
+
+```text
+land the Pi 0.82.1 tool-activation and bounded telemetry repair on remote main
+```
+
+Only after canonical landing may Axis authorize:
+
+```text
+re-run one CE-L1 gpt-5.6-sol disposable live Executor mutation proof
+```

--- a/guardian/agents/adapters/base.py
+++ b/guardian/agents/adapters/base.py
@@ -37,6 +37,16 @@ class AgentRunEnvelope(BaseModel):
     provider_request_started: bool | None = None
     oauth_available: bool | None = None
 
+    # Bounded Pi 0.82.1 tool activation + execution telemetry.
+    # Evidence only — confers no execution authority.
+    # Optional on readiness path; required on successful live authorized task.
+    effective_tool_names: tuple[str, ...] | None = None
+    write_tool_available: bool | None = None
+    tool_execution_start_count: int | None = Field(default=None, ge=0)
+    tool_execution_end_count: int | None = Field(default=None, ge=0)
+    executed_tool_names: tuple[str, ...] | None = None
+    assistant_tool_call_count: int | None = Field(default=None, ge=0)
+
     model_config = ConfigDict(extra="forbid")
 
 

--- a/guardian/agents/adapters/pi_codex_runner.py
+++ b/guardian/agents/adapters/pi_codex_runner.py
@@ -141,7 +141,11 @@ class PiCodexRunnerAdapter:
                 text=True,
                 timeout=request.timeout_seconds,
             )
-            return self._parse_result(result, require_runtime_identity=True)
+            return self._parse_result(
+                result,
+                require_runtime_identity=True,
+                require_tool_telemetry=True,
+            )
         except subprocess.TimeoutExpired:
             return AgentRunEnvelope(
                 status="error",
@@ -163,7 +167,11 @@ class PiCodexRunnerAdapter:
         request: AgentExecutionRequest,
         identity: AgentExecutionIdentity,
     ) -> AgentRunEnvelope:
-        """Run the authorized Pi setup/readiness path without a model prompt."""
+        """Run the authorized Pi setup/readiness path without a model prompt.
+
+        Readiness does NOT require tool telemetry (it is non-inference and
+        does not create a session).
+        """
         if not all(
             (
                 identity.provider_id,
@@ -223,8 +231,14 @@ class PiCodexRunnerAdapter:
         result: subprocess.CompletedProcess[str],
         *,
         require_runtime_identity: bool = False,
+        require_tool_telemetry: bool = False,
     ) -> AgentRunEnvelope:
-        """Parse subprocess result into AgentRunEnvelope."""
+        """Parse subprocess result into AgentRunEnvelope.
+
+        `require_tool_telemetry=True` is used by live authorized task
+        execution.  A successful live authorized task must carry valid
+        bounded tool telemetry.  Readiness uses `require_tool_telemetry=False`.
+        """
         stdout = (result.stdout or "").strip()
         stderr = (result.stderr or "").strip()
 
@@ -261,6 +275,9 @@ class PiCodexRunnerAdapter:
                 data = json.loads(stdout)
                 runtime_identity = data.get("actual_runtime_identity")
                 if data.get("failure_class") in PI_AUTHORIZED_FAILURE_CLASSES:
+                    # On failure paths we still surface whatever telemetry
+                    # the wrapper emitted (defense-in-depth visibility).
+                    telemetry = _parse_tool_telemetry(data.get("tool_telemetry"))
                     return AgentRunEnvelope(
                         status="error",
                         summary="Guardian-authorized Pi operation failed",
@@ -276,6 +293,12 @@ class PiCodexRunnerAdapter:
                             data.get("provider_request_started")
                         ),
                         oauth_available=_bounded_bool(data.get("oauth_available")),
+                        effective_tool_names=telemetry[0],
+                        write_tool_available=telemetry[1],
+                        tool_execution_start_count=telemetry[2],
+                        tool_execution_end_count=telemetry[3],
+                        executed_tool_names=telemetry[4],
+                        assistant_tool_call_count=telemetry[5],
                     )
                 if require_runtime_identity and not isinstance(runtime_identity, dict):
                     return AgentRunEnvelope(
@@ -293,6 +316,49 @@ class PiCodexRunnerAdapter:
                         "actual_harness_version",
                     )
                 )
+                telemetry = _parse_tool_telemetry(data.get("tool_telemetry"))
+                # Live authorized task must carry valid tool telemetry.
+                if require_tool_telemetry and not _is_valid_tool_telemetry(telemetry):
+                    return AgentRunEnvelope(
+                        status="error",
+                        summary="Pi wrapper omitted or returned invalid tool telemetry",
+                        failure_classification=PiAuthorizedFailureClass.WRAPPER_PROTOCOL_FAILED.value,
+                        failure_stage="wrapper_protocol",
+                        runtime_identity_established=runtime_identity_established,
+                        actual_provider_id=(
+                            runtime_identity.get("actual_provider_id")
+                            if isinstance(runtime_identity, dict)
+                            else None
+                        ),
+                        actual_model_id=(
+                            runtime_identity.get("actual_model_id")
+                            if isinstance(runtime_identity, dict)
+                            else None
+                        ),
+                        actual_harness_id=(
+                            runtime_identity.get("actual_harness_id")
+                            if isinstance(runtime_identity, dict)
+                            else None
+                        ),
+                        actual_harness_version=(
+                            runtime_identity.get("actual_harness_version")
+                            if isinstance(runtime_identity, dict)
+                            else None
+                        ),
+                        session_initialized=_bounded_bool(
+                            data.get("session_initialized")
+                        ),
+                        provider_request_started=_bounded_bool(
+                            data.get("provider_request_started")
+                        ),
+                        oauth_available=_bounded_bool(data.get("oauth_available")),
+                        effective_tool_names=telemetry[0],
+                        write_tool_available=telemetry[1],
+                        tool_execution_start_count=telemetry[2],
+                        tool_execution_end_count=telemetry[3],
+                        executed_tool_names=telemetry[4],
+                        assistant_tool_call_count=telemetry[5],
+                    )
                 return AgentRunEnvelope(
                     status=data.get("status", "ok"),
                     summary=data.get(
@@ -323,7 +389,17 @@ class PiCodexRunnerAdapter:
                         else None
                     ),
                     runtime_identity_established=runtime_identity_established,
+                    session_initialized=_bounded_bool(data.get("session_initialized")),
+                    provider_request_started=_bounded_bool(
+                        data.get("provider_request_started")
+                    ),
                     oauth_available=_bounded_bool(data.get("oauth_available")),
+                    effective_tool_names=telemetry[0],
+                    write_tool_available=telemetry[1],
+                    tool_execution_start_count=telemetry[2],
+                    tool_execution_end_count=telemetry[3],
+                    executed_tool_names=telemetry[4],
+                    assistant_tool_call_count=telemetry[5],
                 )
             except json.JSONDecodeError:
                 if require_runtime_identity:
@@ -361,6 +437,62 @@ class PiCodexRunnerAdapter:
             ),
             failure_stage="wrapper_protocol" if require_runtime_identity else None,
         )
+
+
+def _parse_tool_telemetry(raw: Any) -> tuple:
+    """Parse bounded tool telemetry from the wrapper payload.
+
+    Returns a 6-tuple matching the bounded fields. Missing fields yield None.
+    Empty lists/tuples are valid (read-only sessions).
+    """
+    if not isinstance(raw, dict):
+        return (None, None, None, None, None, None)
+    names = raw.get("effective_tool_names")
+    names_out: tuple[str, ...] | None = None
+    if isinstance(names, list):
+        cleaned = [n for n in names if isinstance(n, str) and len(n) > 0]
+        names_out = tuple(cleaned)  # always tuple; empty tuple when none present
+    executed = raw.get("executed_tool_names")
+    executed_out: tuple[str, ...] | None = None
+    if isinstance(executed, list):
+        cleaned = [n for n in executed if isinstance(n, str) and len(n) > 0]
+        executed_out = tuple(cleaned)  # always tuple; empty tuple when none present
+    write_avail = raw.get("write_tool_available")
+    write_avail_out = write_avail if isinstance(write_avail, bool) else None
+    start_count = raw.get("tool_execution_start_count")
+    start_out = start_count if isinstance(start_count, int) and start_count >= 0 else None
+    end_count = raw.get("tool_execution_end_count")
+    end_out = end_count if isinstance(end_count, int) and end_count >= 0 else None
+    asst_count = raw.get("assistant_tool_call_count")
+    asst_out = asst_count if isinstance(asst_count, int) and asst_count >= 0 else None
+    return (names_out, write_avail_out, start_out, end_out, executed_out, asst_out)
+
+
+def _is_valid_tool_telemetry(
+    telemetry: tuple,
+) -> bool:
+    """Live authorized task requires complete, well-formed telemetry.
+
+    An empty `effective_tool_names` is valid (e.g. read-only sessions with
+    ``PI_DISABLE_TOOLS=1``).  `None` means the wrapper omitted the field.
+    """
+    names_out, write_avail_out, start_out, end_out, executed_out, asst_out = telemetry
+    if names_out is None:
+        return False
+    # An empty tuple/list is valid (read-only, or disabled tools).
+    if not isinstance(names_out, tuple):
+        return False
+    if not isinstance(write_avail_out, bool):
+        return False
+    if not isinstance(start_out, int) or start_out < 0:
+        return False
+    if not isinstance(end_out, int) or end_out < 0:
+        return False
+    if executed_out is None or not isinstance(executed_out, tuple):
+        return False
+    if not isinstance(asst_out, int) or asst_out < 0:
+        return False
+    return True
 
 
 def _bounded_text(value: Any) -> str | None:

--- a/guardian/pi/invocation.py
+++ b/guardian/pi/invocation.py
@@ -123,6 +123,13 @@ class PiHarnessRuntimeEvidence:
     session_initialized: bool | None = None
     provider_request_started: bool | None = None
     oauth_available: bool | None = None
+    # Bounded Pi 0.82.1 tool activation + execution telemetry (evidence only).
+    effective_tool_names: tuple[str, ...] | None = None
+    write_tool_available: bool | None = None
+    tool_execution_start_count: int | None = None
+    tool_execution_end_count: int | None = None
+    executed_tool_names: tuple[str, ...] | None = None
+    assistant_tool_call_count: int | None = None
 
 
 PiAuthorizedHarnessRunner = Callable[
@@ -149,6 +156,13 @@ class PiLiveInvocationOutcome:
     receipt: PiInvocationReceipt | None = None
     harness_result: PiHarnessResult | None = None
     actual_identity: PiAuthorizedExecutionIdentity | None = None
+    # Bounded Pi 0.82.1 tool telemetry (evidence only).
+    effective_tool_names: tuple[str, ...] | None = None
+    write_tool_available: bool | None = None
+    tool_execution_start_count: int | None = None
+    tool_execution_end_count: int | None = None
+    executed_tool_names: tuple[str, ...] | None = None
+    assistant_tool_call_count: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -306,6 +320,17 @@ def invoke_guardian_authorized_pi(
         validation_metadata={
             "guardian_authorized": True,
             "policy_decision_id": decision.policy_decision_id,
+            # Bounded tool telemetry — evidence only, no args/results/content.
+            "tool_telemetry": {
+                "effective_tool_names": list(evidence.effective_tool_names or ()),
+                "write_tool_available": evidence.write_tool_available,
+                "tool_execution_start_count": evidence.tool_execution_start_count,
+                "tool_execution_end_count": evidence.tool_execution_end_count,
+                "executed_tool_names": list(evidence.executed_tool_names or ()),
+                "assistant_tool_call_count": evidence.assistant_tool_call_count,
+            }
+            if evidence.effective_tool_names is not None
+            else None,
         },
     )
     receipt_validation = validate_receipt_against_envelope(envelope, receipt)
@@ -342,7 +367,20 @@ def invoke_guardian_authorized_pi(
             artifact_class="bounded_result",
         ),
         result_class=PiHarnessResultClass.SUCCESS.value,
-        validation_metadata={"actual_runtime_identity_attested": True},
+        validation_metadata={
+            "actual_runtime_identity_attested": True,
+            # Bounded tool telemetry — evidence only, no args/results/content.
+            "tool_telemetry": {
+                "effective_tool_names": list(evidence.effective_tool_names or ()),
+                "write_tool_available": evidence.write_tool_available,
+                "tool_execution_start_count": evidence.tool_execution_start_count,
+                "tool_execution_end_count": evidence.tool_execution_end_count,
+                "executed_tool_names": list(evidence.executed_tool_names or ()),
+                "assistant_tool_call_count": evidence.assistant_tool_call_count,
+            }
+            if evidence.effective_tool_names is not None
+            else None,
+        },
     )
     result_validation = validate_harness_result_against_receipt(receipt, harness_result)
     if not result_validation.ok:
@@ -363,6 +401,13 @@ def invoke_guardian_authorized_pi(
         receipt=receipt,
         harness_result=harness_result,
         actual_identity=actual_identity,
+        # Bounded tool telemetry (evidence only; Pi is the source of truth).
+        effective_tool_names=evidence.effective_tool_names,
+        write_tool_available=evidence.write_tool_available,
+        tool_execution_start_count=evidence.tool_execution_start_count,
+        tool_execution_end_count=evidence.tool_execution_end_count,
+        executed_tool_names=evidence.executed_tool_names,
+        assistant_tool_call_count=evidence.assistant_tool_call_count,
     )
 
 
@@ -403,6 +448,13 @@ def _run_with_pi_adapter(
         session_initialized=result.session_initialized,
         provider_request_started=result.provider_request_started,
         oauth_available=result.oauth_available,
+        # Bounded tool telemetry (evidence only; Pi is the source of truth).
+        effective_tool_names=result.effective_tool_names,
+        write_tool_available=result.write_tool_available,
+        tool_execution_start_count=result.tool_execution_start_count,
+        tool_execution_end_count=result.tool_execution_end_count,
+        executed_tool_names=result.executed_tool_names,
+        assistant_tool_call_count=result.assistant_tool_call_count,
     )
 
 

--- a/tests/ops/test_worker_coding_pi_runtime_contract.py
+++ b/tests/ops/test_worker_coding_pi_runtime_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import tempfile
@@ -496,3 +497,162 @@ def test_session_can_be_initialized_without_prompt_via_modelruntime() -> None:
     assert identity["actual_harness_id"] == "pi-coding-agent"
     assert identity["actual_harness_version"] == "0.82.1"
     # No session.prompt() call was issued during this readiness probe.
+
+
+# --- Pi 0.82.1 tool-name compatibility regression ---
+#
+# Proves the maintained source-vendored Pi 0.82.1 SDK treats
+# `createAgentSession({ tools })` as a collection of tool-NAME strings.
+# Uses disposable HOME / auth.json — no prompt, no network, no operator
+# credentials.  This regression must fail if a future upgrade reintroduces
+# object-array `tools` and produces an empty effective tool set.
+
+def test_maintained_pi_0821_treats_tools_as_name_strings() -> None:
+    """Reproduce the Pi 0.82.1 name-only effective-tool-set contract."""
+    from pathlib import Path
+
+    home = Path(tempfile.mkdtemp(prefix="codexify-pi-0821-tool-name-regression-"))
+    driver_path = None
+    try:
+        auth_dir = home / ".pi" / "agent"
+        auth_dir.mkdir(parents=True, mode=0o700)
+        (auth_dir / "auth.json").write_text(
+            json.dumps(
+                {
+                    "openai-codex": {
+                        "type": "oauth",
+                        "expires": 9999999999999,
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        driver_text = """
+const path = require("path");
+const fs = require("fs");
+const home = process.argv[2];
+const target = process.argv[3];
+
+process.env.HOME = home;
+
+(async () => {
+    const vendorRoot = path.resolve(
+        process.argv[4],
+        "codex_runner/vendor/pi-coding-agent",
+    );
+    const codingAgent = await import(
+        require("url").pathToFileURL(
+            path.join(vendorRoot, "dist/index.js"),
+        ).href
+    );
+
+    const modelRuntime = await codingAgent.ModelRuntime.create({
+        allowModelNetwork: false,
+    });
+    const model = modelRuntime.getModel("openai-codex", "gpt-5.6-sol");
+    if (!model) {
+        console.log(JSON.stringify({ error: "model_not_resolved" }));
+        process.exit(1);
+    }
+
+    const { session: writable } = await codingAgent.createAgentSession({
+        cwd: target,
+        model,
+        modelRuntime,
+        tools: ["read", "bash", "edit", "write"],
+        sessionManager: codingAgent.SessionManager.inMemory(target),
+    });
+    const writableActive = writable.getActiveToolNames();
+
+    const { session: disabled } = await codingAgent.createAgentSession({
+        cwd: target,
+        model,
+        modelRuntime,
+        tools: [],
+        sessionManager: codingAgent.SessionManager.inMemory(target),
+    });
+    const disabledActive = disabled.getActiveToolNames();
+
+    console.log(JSON.stringify({
+        writable_active_tool_names: writableActive,
+        disabled_active_tool_names: disabledActive,
+    }));
+})();
+"""
+        driver_path = Path(tempfile.mkstemp(suffix=".cjs")[1])
+        driver_path.write_text(driver_text, encoding="utf-8")
+
+        target = Path(tempfile.mkdtemp(prefix="codexify-pi-0821-tool-regression-target-"))
+        result = subprocess.run(
+            ["node", str(driver_path), str(home), str(target), str(ROOT)],
+            cwd=str(ROOT),
+            env={
+                **os.environ,
+                "HOME": str(home),
+                "PATH": "/usr/bin:/bin:/usr/local/bin",
+            },
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+        if target.exists():
+            shutil.rmtree(target, ignore_errors=True)
+        if driver_path is not None:
+            try:
+                driver_path.unlink()
+            except OSError:
+                pass
+
+    assert result.returncode == 0, (
+        f"Pi 0.82.1 tool-name SDK probe failed: exit {result.returncode}; "
+        f"stderr={result.stderr[:500]!r}"
+    )
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload.get("writable_active_tool_names") == [
+        "read", "bash", "edit", "write",
+    ], (
+        f"Pi 0.82.1 must report writable tool-name session as "
+        f"['read','bash','edit','write']; got {payload.get('writable_active_tool_names')!r}"
+    )
+    assert payload.get("disabled_active_tool_names") == [], (
+        f"Pi 0.82.1 must report empty effective tool set when tools=[]; "
+        f"got {payload.get('disabled_active_tool_names')!r}"
+    )
+
+
+def test_active_runtime_passes_tool_name_strings_not_agenttool_objects() -> None:
+    """Wrapper source must pass tool-NAME strings into createAgentSession.
+
+    This regression enforces the Pi 0.82.1 contract at the source level.
+    The wrapper must not pass AgentTool objects (the legacy Pi 0.72
+    assumption) into `createAgentSession({ tools })`.
+    """
+    loader = (ROOT / "codex_runner/src/agent-wrapper.js").read_text(encoding="utf-8")
+    # Reject any ACTIVE use of `createCodingTools(OPTIONS.cwd)` whose return
+    # value is passed (or could be passed) into createAgentSession.  An
+    # explanatory comment referencing the legacy path is allowed.
+    import re
+    # Match an executable call to `createCodingTools(OPTIONS.cwd)` that is
+    # not inside a comment line.
+    non_comment_lines = [
+        line for line in loader.splitlines()
+        if not line.lstrip().startswith("//")
+    ]
+    non_comment_source = "\n".join(non_comment_lines)
+    assert not re.search(r"createCodingTools\s*\(\s*OPTIONS\.cwd", non_comment_source), (
+        "wrapper must not call createCodingTools(OPTIONS.cwd) and pass its "
+        "return value into createAgentSession({ tools }) — that path returns "
+        "AgentTool objects which Pi 0.82.1 silently rejects"
+    )
+    # The wrapper must pass an explicit canonical writable tool-name set.
+    assert (
+        '["read", "bash", "edit", "write"]' in loader
+    ), "wrapper must pass the exact writable tool-name set ['read','bash','edit','write']"
+    # The wrapper must read effective tool names from the session itself.
+    assert "getActiveToolNames" in loader, (
+        "wrapper must read the effective tool surface from the session, "
+        "not from the configured value"
+    )

--- a/tests/pi/test_pi_live_invocation.py
+++ b/tests/pi/test_pi_live_invocation.py
@@ -553,6 +553,14 @@ def test_authorized_adapter_uses_invocation_local_identity(monkeypatch: pytest.M
                         "actual_harness_id": IDENTITY["harness_id"],
                         "actual_harness_version": IDENTITY["harness_version"],
                     },
+                    "tool_telemetry": {
+                        "effective_tool_names": ["read", "bash", "edit", "write"],
+                        "write_tool_available": True,
+                        "tool_execution_start_count": 0,
+                        "tool_execution_end_count": 0,
+                        "executed_tool_names": [],
+                        "assistant_tool_call_count": 0,
+                    },
                 }
             ),
             stderr="",
@@ -613,3 +621,88 @@ def test_legacy_pi_adapter_keeps_task_mode_and_output_shape(monkeypatch: pytest.
 def test_direct_codex_adapter_remains_unsupported() -> None:
     with pytest.raises(RuntimeError, match="unsupported"):
         CodexAdapter()
+
+
+# --- Pi 0.82.1 tool telemetry propagation regressions ---
+#
+# These tests verify that the bounded Pi 0.82.1 tool telemetry flows from the
+# PiHarnessRuntimeEvidence into the PiLiveInvocationOutcome without being
+# mutated by Guardian.  No real provider is used.
+
+def _evidence_with_tool_telemetry(
+    **telemetry_overrides: object,
+) -> PiHarnessRuntimeEvidence:
+    import dataclasses
+    base = _evidence()
+    return dataclasses.replace(
+        base,
+        effective_tool_names=telemetry_overrides.get(
+            "effective_tool_names", ("read", "bash", "edit", "write")
+        ),
+        write_tool_available=telemetry_overrides.get(
+            "write_tool_available", True
+        ),
+        tool_execution_start_count=telemetry_overrides.get(
+            "tool_execution_start_count", 1
+        ),
+        tool_execution_end_count=telemetry_overrides.get(
+            "tool_execution_end_count", 1
+        ),
+        executed_tool_names=telemetry_overrides.get(
+            "executed_tool_names", ("write",)
+        ),
+        assistant_tool_call_count=telemetry_overrides.get(
+            "assistant_tool_call_count", 1
+        ),
+    )
+
+
+def test_tool_telemetry_propagates_into_pi_live_invocation_outcome(tmp_path: Path) -> None:
+    """Tool telemetry from evidence flows into outcome unchanged."""
+    runner = _RecordingRunner(evidence=_evidence_with_tool_telemetry())
+    outcome = _invoke(tmp_path, runner)
+    assert outcome.ok
+    assert outcome.effective_tool_names == (
+        "read", "bash", "edit", "write",
+    )
+    assert outcome.write_tool_available is True
+    assert outcome.tool_execution_start_count == 1
+    assert outcome.tool_execution_end_count == 1
+    assert outcome.executed_tool_names == ("write",)
+    assert outcome.assistant_tool_call_count == 1
+
+
+def test_tool_telemetry_none_propagates_as_none(tmp_path: Path) -> None:
+    """Missing telemetry survives as None — no fabrication.
+
+    This is the readiness path: the wrapper does not run a session, so
+    no telemetry is emitted.  The adapter does not require telemetry on
+    the readiness path; outcome fields are None."""
+    runner = _RecordingRunner(evidence=_evidence())
+    outcome = _invoke(tmp_path, runner)
+    assert outcome.ok
+    assert outcome.effective_tool_names is None
+    assert outcome.write_tool_available is None
+    assert outcome.tool_execution_start_count is None
+    assert outcome.tool_execution_end_count is None
+    assert outcome.executed_tool_names is None
+    assert outcome.assistant_tool_call_count is None
+
+
+def test_tool_telemetry_into_receipt_validation_metadata(tmp_path: Path) -> None:
+    """Pi Receipt and Harness Result carry bounded tool_telemetry metadata."""
+    runner = _RecordingRunner(evidence=_evidence_with_tool_telemetry())
+    outcome = _invoke(tmp_path, runner)
+    assert outcome.ok
+    receipt_payload = outcome.receipt.to_payload() if hasattr(outcome.receipt, "to_payload") else {}
+    # Receipt stores telemetry under validation_metadata["tool_telemetry"]
+    telemetry = receipt_payload.get("validation_metadata", {}).get("tool_telemetry")
+    assert telemetry is not None
+    assert telemetry.get("effective_tool_names") == [
+        "read", "bash", "edit", "write",
+    ]
+    assert telemetry.get("write_tool_available") is True
+    assert telemetry.get("tool_execution_start_count") == 1
+    assert telemetry.get("tool_execution_end_count") == 1
+    assert telemetry.get("executed_tool_names") == ["write"]
+    assert telemetry.get("assistant_tool_call_count") == 1


### PR DESCRIPTION
## Repair Pi 0.82.1 tool activation telemetry

### Campaign

- **Campaign ID**: `CAMPAIGN-2026-08-26_001_CAMPAIGN_ENGINE_SUPERVISED_USABILITY_CLOSURE`
- **Gate**: `CE-L1`
- **Source base**: `e9ae721cef5112d6e644a1c50657152301aa1666` (Record CE-L1 gpt-5.6-sol zero-mutation blocker (#775))
- **Source commit**: `0eede9fa4e6bf69cba23e50f95ca5742ec69a6f4`
- **CE-L1 status after landing**: `OPEN`
- **`LIVE_EXECUTOR_PROVEN`**: `NOT_EMITTED`

### Canonical prerequisite truth (unchanged)

- `CE-L1_OAUTH_PREREQUISITE=PASS`
- canonical blocker: `zero_mutation_executor_turn`
- pre-repair cause: `UNRESOLVED_TOOL_EXECUTION_BOUNDARY`

### Root cause (locally proven, no provider inference)

```text
ROOT_CAUSE=
PI_0821_TOOL_OPTIONS_TYPE_MISMATCH_PROVEN
```

Pre-repair deterministic probe results:

```text
object_tool_effective_names=[]
name_tool_effective_names=["read","bash","edit","write"]
disabled_tool_effective_names=[]
provider_request_count=0
prompt_count=0
operator_credential_access_count=0
```

Pre-repair effective tools: `[]`
Post-repair effective tools: `["read","bash","edit","write"]`

### What this PR does

- Repairs the maintained Pi 0.82.1 wrapper to pass `["read", "bash", "edit", "write"]` as **tool-name strings** into `createAgentSession({ tools })` (the maintained contract) instead of the `AgentTool[]` objects returned by `createCodingTools(cwd)`.
- Reads the actual effective tool surface from the created session via `session.getActiveToolNames()` (with a fallback to `session.agent.state.tools.map(t => t.name)` if the maintained API method is unavailable).
- Preserves disabled/read-only posture: when `PI_DISABLE_TOOLS=1`, the configured tool set is `[]`.
- **Defense-in-depth fail-closed**: for writable Guardian-authorized execution where `write_tool_available !== true`, the wrapper emits `failure_class=wrapper_protocol_failed` at `failure_stage=tool_activation` **before** `session.prompt(...)`, with `session_initialized=true` and `provider_request_started=false`, and includes the captured `tool_telemetry` in the failure payload. This catches any future SDK compatibility regression.
- Adds six bounded telemetry fields and propagates them through the existing evidence path:

```text
effective_tool_names
write_tool_available
tool_execution_start_count
tool_execution_end_count
executed_tool_names
assistant_tool_call_count
```

- **Telemetry is evidence only**. It contains only `string[]` tool names, booleans, and non-negative integer counts. No prompt text, no assistant text, no tool arguments, no toolCall IDs, no tool results, no file contents, no provider payloads, no headers, no tokens, no account IDs, no credential metadata, no environment dumps.
- Replaces the unsupported causal claim in `zero_mutation_executor_turn` runtime text with evidence-bounded wording:

> Harness success produced zero allowed-path mutation; inspect bounded tool availability and execution telemetry to classify the tool-execution boundary.

### Propagation path

```text
wrapper tool_telemetry
  -> PiCodexRunnerAdapter._parse_result (require_tool_telemetry=True for live)
  -> PiHarnessRuntimeEvidence
  -> _run_with_pi_adapter
  -> PiLiveInvocationOutcome
  -> PiInvocationReceipt.validation_metadata["tool_telemetry"]
  -> PiHarnessResult.validation_metadata["tool_telemetry"]
  -> LiveExecutorRunResult + LiveExecutorRunResult.to_dict()
  -> CampaignLiveExecutorError + CampaignLiveExecutorError.to_payload()
```

### Invariants preserved

- **Target readback remains mutation authority.** Neither `write_tool_available=true` nor `assistant_tool_call_count > 0` independently creates a successful Attempt. `source_mutation_count >= 1` remains the CE-L1 success invariant.
- **No new failure token.** Existing `wrapper_protocol_failed` and `tool_activation` stage are reused.
- **No Campaign schema change.** Telemetry surfaces via the `tool_telemetry` nested key in `to_dict()`/`to_payload()` only.
- **No Pi vendor change.** `codex_runner/vendor/pi-coding-agent/**` is unchanged.
- **No provider/model routing change.**
- **No release-claim change.** `00-current-state.md` and ADRs are unchanged.

### Diagnostics spent

- Provider calls during diagnostic + landing: **0**
- Live CE-L1 calls during this repair/landing: **0**
- OAuth reconnections: **0**
- Operator credential accesses: **0**

### Validation

Pre-push deterministic suite (4 spec-required test files):

```text
tests/ops/test_worker_coding_pi_runtime_contract.py          15 passed
tests/pi/test_pi_live_invocation.py                         32 passed (3 new telemetry regressions)
tests/pi/test_pi_authorized_failure_diagnostics.py          30 passed
codex_runner/tests/test_campaign_engine_live_executor.py    33 passed (2 new telemetry regressions)
                                                  ------------------------------
                                                   110 passed
```

Static validation:

```text
node --check codex_runner/src/agent-wrapper.js  →  exit 0
```

Docs:

```text
PYTHON=.venv/bin/python make docs  →  PASS
```

Repository hygiene:

```text
git diff --check 0eede9fa…^        →  clean
```

### Unrelated pre-existing failure (not owned by this PR)

The repository's pre-commit `mypy` hook exposes a pre-existing failure at `guardian/watchdog/contracts.py:466` (`int(value)` strictness) that reproduces identically on an untouched fresh worktree of `origin/main` (`e9ae721ce…`). **Classification: `UNRELATED_PRE_EXISTING_FAILURE`.** This PR does not own that file and will not edit it.

### Files changed

13 files: 12 modified + 1 added.

```text
M  codex_runner/src/agent-wrapper.js
M  guardian/agents/adapters/base.py
M  guardian/agents/adapters/pi_codex_runner.py
M  guardian/pi/invocation.py
M  codex_runner/campaign_engine/errors.py
M  codex_runner/campaign_engine/models.py
M  codex_runner/campaign_engine/live_executor.py
M  tests/ops/test_worker_coding_pi_runtime_contract.py
M  tests/pi/test_pi_live_invocation.py
M  codex_runner/tests/test_campaign_engine_live_executor.py
M  docs/architecture/pi-invocation-boundary-contract.md
M  docs/architecture/proofs/runtime/2026-08-26-campaign-engine-ce-l1-live-executor-proof.md
A  docs/architecture/proofs/runtime/2026-08-29-pi-0821-tool-activation-telemetry-repair-proof.md
```

### What this PR does NOT do

- Does not run a provider-backed CE-L1 attempt.
- Does not alter the CE-L1 prompt.
- Does not alter the model (`gpt-5.6-sol`).
- Does not alter provider routing.
- Does not run OAuth login/logout.
- Does not inspect credential storage.
- Does not requalify credential readiness.
- Does not introduce a new failure token.
- Does not modify Campaign schemas, ADRs, or release claims.
- Does not modify `guardian/watchdog/contracts.py`.
- Does not modify `guardian/pi/tokens.py`.

### What happens after this lands

Once canonical, Axis may authorize one new post-repair canonical CE-L1 live Executor mutation proof using the same `openai-codex / gpt-5.6-sol / pi-coding-agent@0.82.1` runtime identity. The new telemetry surface will make it possible to attribute the next BLOCKED (if any) to a specific sub-boundary: (a) `write` was advertised but assistant did not call it, (b) `write` was advertised but Pi did not begin execution, (c) assistant emitted a tool-call block but Pi rejected it, or (d) the writable fail-closed guard fires (a future SDK regression).

### NEXT_TASK_REQUIRED (post-canonical landing)

```text
prove one post-repair canonical CE-L1 gpt-5.6-sol disposable live Executor
mutation with bounded tool telemetry
```
