### PR TITLE
Instrument Pi assistant response telemetry

### DIFF
--- a/codex_runner/campaign_engine/errors.py
+++ b/codex_runner/campaign_engine/errors.py
@@ -81,6 +81,13 @@ class CampaignLiveExecutorError(CampaignEngineError):
         tool_execution_end_count: int | None = None,
         executed_tool_names: tuple[str, ...] | None = None,
         assistant_tool_call_count: int | None = None,
+        # Bounded Pi 0.82.1 assistant-response telemetry (evidence only).
+        # Only type names and counts are retained.  Missing telemetry
+        # surfaces as None.
+        assistant_message_count: int | None = None,
+        assistant_content_block_types: tuple[str, ...] | None = None,
+        assistant_message_event_types: tuple[str, ...] | None = None,
+        assistant_tool_call_event_count: int | None = None,
     ) -> None:
         super().__init__(message)
         self.failure_reason = failure_reason
@@ -96,12 +103,24 @@ class CampaignLiveExecutorError(CampaignEngineError):
         self.tool_execution_end_count = tool_execution_end_count
         self.executed_tool_names = executed_tool_names
         self.assistant_tool_call_count = assistant_tool_call_count
+        self.assistant_message_count = assistant_message_count
+        self.assistant_content_block_types = assistant_content_block_types
+        self.assistant_message_event_types = assistant_message_event_types
+        self.assistant_tool_call_event_count = assistant_tool_call_event_count
 
     def to_payload(self) -> dict[str, Any]:
         # Surface only the bounded telemetry fields. Counts are normalized
-        # to integers; missing telemetry surfaces as None.
+        # to integers; missing telemetry surfaces as None.  No text /
+        # reasoning / arguments / IDs / payloads are ever included.
         def _as_int(value: Any) -> int | None:
             return value if isinstance(value, int) and value >= 0 else None
+        def _as_tuple(value: Any) -> tuple[str, ...] | None:
+            if value is None:
+                return None
+            if not isinstance(value, (list, tuple)):
+                return None
+            cleaned = [v for v in value if isinstance(v, str) and len(v) > 0]
+            return tuple(cleaned)
         return {
             "failure_reason": self.failure_reason,
             "diagnostic_class": self.diagnostic_class,
@@ -129,6 +148,20 @@ class CampaignLiveExecutorError(CampaignEngineError):
                     else None
                 ),
                 "assistant_tool_call_count": _as_int(self.assistant_tool_call_count),
+                "assistant_message_count": _as_int(self.assistant_message_count),
+                "assistant_content_block_types": (
+                    list(self.assistant_content_block_types)
+                    if self.assistant_content_block_types is not None
+                    else None
+                ),
+                "assistant_message_event_types": (
+                    list(self.assistant_message_event_types)
+                    if self.assistant_message_event_types is not None
+                    else None
+                ),
+                "assistant_tool_call_event_count": _as_int(
+                    self.assistant_tool_call_event_count
+                ),
             }
             if self.effective_tool_names is not None
             else None,

--- a/codex_runner/campaign_engine/live_executor.py
+++ b/codex_runner/campaign_engine/live_executor.py
@@ -680,10 +680,23 @@ def _to_payload(obj: Any) -> dict[str, Any]:
 
 
 def _extract_tool_telemetry_from_outcome(outcome: Any) -> tuple:
-    """Best-effort extraction of bounded tool telemetry from a Pi outcome.
+    """Best-effort extraction of bounded tool + assistant-response telemetry.
 
-    Returns a 6-tuple matching the bounded fields. Missing fields yield None.
-    Malformed fields yield None.
+    Returns a 10-tuple matching the bounded fields. Missing fields yield
+    None. Malformed fields yield None.
+
+    Position contract (do not reorder without updating all consumers):
+
+        0. effective_tool_names: tuple[str, ...] | None
+        1. write_tool_available: bool | None
+        2. tool_execution_start_count: int | None
+        3. tool_execution_end_count: int | None
+        4. executed_tool_names: tuple[str, ...] | None
+        5. assistant_tool_call_count: int | None
+        6. assistant_message_count: int | None
+        7. assistant_content_block_types: tuple[str, ...] | None
+        8. assistant_message_event_types: tuple[str, ...] | None
+        9. assistant_tool_call_event_count: int | None
     """
     def _read(obj: Any, name: str) -> Any:
         if obj is None:
@@ -694,6 +707,12 @@ def _extract_tool_telemetry_from_outcome(outcome: Any) -> tuple:
 
     def _as_int(value: Any) -> int | None:
         return value if isinstance(value, int) and value >= 0 else None
+
+    def _as_tuple(value: Any) -> tuple[str, ...] | None:
+        if not isinstance(value, (list, tuple)):
+            return None
+        cleaned = [v for v in value if isinstance(v, str) and len(v) > 0]
+        return tuple(cleaned)  # always tuple; empty tuple when none present
 
     names_raw = _read(outcome, "effective_tool_names")
     names_out: tuple[str, ...] | None = None
@@ -714,6 +733,10 @@ def _extract_tool_telemetry_from_outcome(outcome: Any) -> tuple:
         _as_int(_read(outcome, "tool_execution_end_count")),
         executed_out,
         _as_int(_read(outcome, "assistant_tool_call_count")),
+        _as_int(_read(outcome, "assistant_message_count")),
+        _as_tuple(_read(outcome, "assistant_content_block_types")),
+        _as_tuple(_read(outcome, "assistant_message_event_types")),
+        _as_int(_read(outcome, "assistant_tool_call_event_count")),
     )
 
 
@@ -1387,6 +1410,10 @@ def run_live_executor_campaign(
                 tool_execution_end_count=telemetry[3],
                 executed_tool_names=telemetry[4],
                 assistant_tool_call_count=telemetry[5],
+                assistant_message_count=telemetry[6],
+                assistant_content_block_types=telemetry[7],
+                assistant_message_event_types=telemetry[8],
+                assistant_tool_call_event_count=telemetry[9],
             )
     else:
         failed = [
@@ -1653,6 +1680,10 @@ def run_live_executor_campaign(
         tool_execution_end_count=_telemetry[3],
         executed_tool_names=_telemetry[4],
         assistant_tool_call_count=_telemetry[5],
+        assistant_message_count=_telemetry[6],
+        assistant_content_block_types=_telemetry[7],
+        assistant_message_event_types=_telemetry[8],
+        assistant_tool_call_event_count=_telemetry[9],
     )
 
 

--- a/codex_runner/campaign_engine/models.py
+++ b/codex_runner/campaign_engine/models.py
@@ -309,6 +309,12 @@ class LiveExecutorRunResult:
     tool_execution_end_count: int | None = None
     executed_tool_names: tuple[str, ...] | None = None
     assistant_tool_call_count: int | None = None
+    # Bounded Pi 0.82.1 assistant-response telemetry (evidence only).
+    # Only type names and counts; never text / reasoning / args / IDs.
+    assistant_message_count: int | None = None
+    assistant_content_block_types: tuple[str, ...] | None = None
+    assistant_message_event_types: tuple[str, ...] | None = None
+    assistant_tool_call_event_count: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -368,6 +374,18 @@ class LiveExecutorRunResult:
                     else None
                 ),
                 "assistant_tool_call_count": self.assistant_tool_call_count,
+                "assistant_message_count": self.assistant_message_count,
+                "assistant_content_block_types": (
+                    list(self.assistant_content_block_types)
+                    if self.assistant_content_block_types is not None
+                    else None
+                ),
+                "assistant_message_event_types": (
+                    list(self.assistant_message_event_types)
+                    if self.assistant_message_event_types is not None
+                    else None
+                ),
+                "assistant_tool_call_event_count": self.assistant_tool_call_event_count,
             }
             if self.effective_tool_names is not None
             else None,

--- a/codex_runner/src/agent-wrapper.js
+++ b/codex_runner/src/agent-wrapper.js
@@ -18,6 +18,11 @@ import path from "node:path";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import {
+	observeAssistantMessageEvent,
+	observeFinalAssistantMessages,
+} from "./assistant-telemetry.js";
+
 // Parse command line args
 const args = process.argv.slice(2);
 const mode = args[0] || "help";
@@ -738,6 +743,59 @@ if (mode === "readiness") {
 } else if (guardianAuthorizedReadinessMode) {
 	checkGuardianAuthorizedReadiness().catch(() => {
 		emitAuthorizedFailure("unknown_adapter_failure", "preflight");
+	});
+} else if (mode === "assistant-telemetry-test") {
+	// Deterministic regression harness for bounded Pi 0.82.1
+	// assistant-response observability.  Reads a JSON spec of
+	// synthetic message_update events and synthetic final
+	// session.messages from stdin, runs them through the same
+	// helpers the live wrapper uses, and writes the resulting
+	// toolTelemetry JSON to stdout.  No network.  No credentials.
+	// No prompting.
+	let input = "";
+	process.stdin.setEncoding("utf8");
+	process.stdin.on("data", (chunk) => { input += chunk; });
+	process.stdin.on("end", () => {
+		try {
+			const spec = JSON.parse(input);
+			const toolTelemetry = {
+				effective_tool_names: ["read", "bash", "edit", "write"],
+				write_tool_available: true,
+				tool_execution_start_count: 0,
+				tool_execution_end_count: 0,
+				executed_tool_names: [],
+				assistant_tool_call_count: 0,
+				assistant_message_count: 0,
+				assistant_content_block_types: [],
+				assistant_message_event_types: [],
+				assistant_tool_call_event_count: 0,
+			};
+			if (Array.isArray(spec.events)) {
+				for (const event of spec.events) {
+					observeAssistantMessageEvent(toolTelemetry, event);
+				}
+			}
+			if (Array.isArray(spec.toolExecutionEvents)) {
+				for (const event of spec.toolExecutionEvents) {
+					if (event && event.type === "tool_execution_start") {
+						const toolName = typeof event.toolName === "string" ? event.toolName : null;
+						if (toolName !== null) {
+							toolTelemetry.tool_execution_start_count += 1;
+							if (!toolTelemetry.executed_tool_names.includes(toolName)) {
+								toolTelemetry.executed_tool_names.push(toolName);
+							}
+						}
+					} else if (event && event.type === "tool_execution_end") {
+						toolTelemetry.tool_execution_end_count += 1;
+					}
+				}
+			}
+			observeFinalAssistantMessages(toolTelemetry, { agent: { state: { messages: spec.messages || [] } } });
+			process.stdout.write(JSON.stringify(toolTelemetry));
+		} catch (parseError) {
+			console.error("assistant-telemetry-test: failed to parse stdin as JSON:", parseError.message);
+			process.exit(1);
+		}
 	});
 } else if (mode === "help" || !prompt) {
 	console.log(`

--- a/codex_runner/src/assistant-telemetry.js
+++ b/codex_runner/src/assistant-telemetry.js
@@ -1,0 +1,84 @@
+// Bounded Pi 0.82.1 assistant-response telemetry observers.
+//
+// Pure functions used by both the live wrapper and deterministic
+// regression tests.  Records only event/block-type names and counts.
+// Never retains prompt text, reasoning content, tool arguments,
+// tool-call IDs, or provider payloads.
+//
+// Position contract (do not reorder without updating all consumers):
+//   toolTelemetry.assistant_message_count
+//   toolTelemetry.assistant_content_block_types
+//   toolTelemetry.assistant_message_event_types
+//   toolTelemetry.assistant_tool_call_event_count
+
+// Pi-native assistant tool-call lifecycle event names (lowercase 'c' on
+// 'toolcall').  These are the bounds used to detect assistant-side
+// tool-call lifecycle events on Pi 0.82.1 `message_update` events.
+export const PI_ASSISTANT_TOOLCALL_EVENT_TYPES = new Set([
+	"toolcall_start",
+	"toolcall_delta",
+	"toolcall_end",
+]);
+
+// Pure bounded observer of Pi 0.82.1 `message_update` assistant events.
+// Records only type-name strings.  Never retains text, reasoning,
+// arguments, IDs, or payloads.
+export function observeAssistantMessageEvent(toolTelemetry, event) {
+	if (!event || event.type !== "message_update") return;
+	const assistantEvent = event.assistantMessageEvent;
+	if (!assistantEvent || typeof assistantEvent.type !== "string") return;
+	const eventType = assistantEvent.type;
+	if (eventType.length === 0) return;
+	if (!toolTelemetry.assistant_message_event_types.includes(eventType)) {
+		toolTelemetry.assistant_message_event_types.push(eventType);
+	}
+	if (PI_ASSISTANT_TOOLCALL_EVENT_TYPES.has(eventType)) {
+		toolTelemetry.assistant_tool_call_event_count += 1;
+	}
+}
+
+// Pure bounded observer of the final Pi 0.82.1 assistant messages.
+// Walks `session.agent.state.messages`, counts assistant-role messages,
+// collects ordered unique content-block type strings, and counts final
+// `toolCall` content blocks.  Never reads text/reasoning/args/IDs.
+export function observeFinalAssistantMessages(toolTelemetry, session) {
+	try {
+		const messages = session?.agent?.state?.messages;
+		if (!Array.isArray(messages)) return;
+		for (const message of messages) {
+			if (!message || message.role !== "assistant") continue;
+			toolTelemetry.assistant_message_count += 1;
+			if (!Array.isArray(message.content)) continue;
+			for (const block of message.content) {
+				if (!block || typeof block !== "object") continue;
+				if (typeof block.type !== "string" || block.type.length === 0) continue;
+				const blockType = block.type;
+				if (!toolTelemetry.assistant_content_block_types.includes(blockType)) {
+					toolTelemetry.assistant_content_block_types.push(blockType);
+				}
+				if (block.type === "toolCall") {
+					toolTelemetry.assistant_tool_call_count += 1;
+				}
+			}
+		}
+	} catch (_error) {
+		// bounded evidence only
+	}
+}
+
+// Create a fresh toolTelemetry accumulator with all 10 bounded fields
+// initialized to None / empty.  Used by both the live wrapper and tests.
+export function createToolTelemetry() {
+	return {
+		effective_tool_names: null,
+		write_tool_available: null,
+		tool_execution_start_count: 0,
+		tool_execution_end_count: 0,
+		executed_tool_names: [],
+		assistant_tool_call_count: 0,
+		assistant_message_count: 0,
+		assistant_content_block_types: [],
+		assistant_message_event_types: [],
+		assistant_tool_call_event_count: 0,
+	};
+}

--- a/codex_runner/tests/test_campaign_engine_live_executor.py
+++ b/codex_runner/tests/test_campaign_engine_live_executor.py
@@ -46,6 +46,7 @@ from codex_runner.campaign_engine.models import (
     FixedClock,
 )
 
+
 # ---------------------------------------------------------------------------
 # Test scaffolding: deterministic fake outcome + helpers
 # ---------------------------------------------------------------------------
@@ -78,9 +79,7 @@ class FakeReceipt:
     provider_lane: dict[str, Any] = field(default_factory=dict)
     granted_permissions: tuple[dict[str, Any], ...] = field(default_factory=tuple)
     validation_metadata: dict[str, Any] = field(default_factory=dict)
-    guardian_boundary: dict[str, Any] = field(
-        default_factory=lambda: {"owner_account_id": "operator"}
-    )
+    guardian_boundary: dict[str, Any] = field(default_factory=lambda: {"owner_account_id": "operator"})
     source_thread_id: str = "thread-1"
     source_message_id: str = "msg-1"
     authored_request_id: str | None = None
@@ -182,12 +181,8 @@ class FakeOutcome:
             "provider_request_started": self.provider_request_started,
             "oauth_available": self.oauth_available,
             "receipt": self.receipt.to_payload() if self.receipt else None,
-            "harness_result": (
-                self.harness_result.to_payload() if self.harness_result else None
-            ),
-            "actual_identity": (
-                self.actual_identity.to_payload() if self.actual_identity else None
-            ),
+            "harness_result": self.harness_result.to_payload() if self.harness_result else None,
+            "actual_identity": self.actual_identity.to_payload() if self.actual_identity else None,
         }
 
 
@@ -228,49 +223,20 @@ def _make_canonical_live_campaign(
     if granted_permissions is None:
         granted_permissions = ["files.read", "files.write"]
     if requested_permissions is None:
-        requested_permissions = [
-            "files.read",
-            "files.write",
-            "network.provider.allowed",
-        ]
+        requested_permissions = ["files.read", "files.write", "network.provider.allowed"]
 
     target = tmp_path / "ce-l1-test-target"
     target.mkdir(parents=True, exist_ok=True)
     target_handle = target / "proof_target.txt"
     target_handle.write_text("CE-L1-BASELINE\n", encoding="utf-8")
     # Init a git repo so target_baseline_git_head works.
-    subprocess.run(
-        ["git", "-C", str(target), "init"], capture_output=True, text=True, check=True
-    )
-    subprocess.run(
-        ["git", "-C", str(target), "config", "user.email", "ce-l1-proof@in.valid"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    subprocess.run(
-        ["git", "-C", str(target), "config", "user.name", "ce-l1-proof"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    subprocess.run(
-        ["git", "-C", str(target), "add", "proof_target.txt"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    subprocess.run(
-        ["git", "-C", str(target), "commit", "-m", "ce-l1-baseline"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
+    subprocess.run(["git", "-C", str(target), "init"], capture_output=True, text=True, check=True)
+    subprocess.run(["git", "-C", str(target), "config", "user.email", "ce-l1-proof@in.valid"], capture_output=True, text=True, check=True)
+    subprocess.run(["git", "-C", str(target), "config", "user.name", "ce-l1-proof"], capture_output=True, text=True, check=True)
+    subprocess.run(["git", "-C", str(target), "add", "proof_target.txt"], capture_output=True, text=True, check=True)
+    subprocess.run(["git", "-C", str(target), "commit", "-m", "ce-l1-baseline"], capture_output=True, text=True, check=True)
     head = subprocess.run(
-        ["git", "-C", str(target), "rev-parse", "HEAD"],
-        capture_output=True,
-        text=True,
-        check=True,
+        ["git", "-C", str(target), "rev-parse", "HEAD"], capture_output=True, text=True, check=True
     ).stdout.strip()
 
     if target_resolve == "<derived>":
@@ -462,12 +428,8 @@ def _build_envelope_and_decision(
         metadata={"campaign_engine_campaign_id": preparation.campaign_id},
     )
     granted = (
-        PiPermissionGrant(
-            permission="files.read", resource=granted_files_read_resource
-        ),
-        PiPermissionGrant(
-            permission="files.write", resource=granted_files_write_resource
-        ),
+        PiPermissionGrant(permission="files.read", resource=granted_files_read_resource),
+        PiPermissionGrant(permission="files.write", resource=granted_files_write_resource),
     )
     requested = granted + (
         PiPermissionGrant(permission="network.provider.allowed", resource="."),
@@ -554,11 +516,7 @@ def test_preparation_uses_locked_executor_binding(live_doc) -> None:
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     assert preparation.executor_binding_id == handle["binding_id"]
     assert preparation.executor_binding_revision == 1
@@ -570,11 +528,7 @@ def test_expected_provider_model_derived_only_from_binding(live_doc) -> None:
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     assert preparation.expected_provider_id == handle["executor_provider"]
     assert preparation.expected_model_id == handle["executor_model"]
@@ -588,11 +542,7 @@ def test_preparation_binds_prompt_hash(live_doc) -> None:
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     expected = sha256(preparation.prompt.encode("utf-8")).hexdigest()
     assert preparation.prompt_sha256 == expected
@@ -605,11 +555,7 @@ def test_preparation_binds_target_identity_and_allowed_paths(live_doc) -> None:
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     assert preparation.target_path == target.resolve()
     assert preparation.target_repository_identity == str(target.resolve())
@@ -621,16 +567,11 @@ def test_drift_in_campaign_input_blocks_before_invocation(
     live_doc, tmp_path, fixed_clock, invoker_factory
 ) -> None:
     from codex_runner.campaign_engine.models import FixedClock
-
     campaign_path, target, handle = live_doc
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     # Modify the campaign file post-preparation (the Task objective text).
     doc = json.loads(campaign_path.read_text())
@@ -639,9 +580,7 @@ def test_drift_in_campaign_input_blocks_before_invocation(
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity(
-            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
-        ),
+        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
         receipt=FakeReceipt(
             receipt_id="pi-receipt-ce-l1-test-drift-input",
             invocation_id=envelope.invocation_id,
@@ -670,9 +609,7 @@ def test_drift_in_campaign_input_blocks_before_invocation(
     assert exc_info.value.failure_reason == "drift_after_authorization"
     assert calls == []
     # No durable output created.
-    assert (
-        not output_root.exists() or not (output_root / handle["campaign_id"]).exists()
-    )
+    assert not output_root.exists() or not (output_root / handle["campaign_id"]).exists()
 
 
 # 7. changed target baseline after preparation blocks before invocation.
@@ -683,20 +620,14 @@ def test_drift_in_target_baseline_blocks_before_invocation(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     # Mutate the target file before execution.
     (target / handle["target_handle"].name).write_text("MODIFIED\n", encoding="utf-8")
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity(
-            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
-        ),
+        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
         receipt=FakeReceipt(
             receipt_id="pi-receipt-ce-l1-test-drift-target",
             invocation_id=envelope.invocation_id,
@@ -734,25 +665,20 @@ def test_mismatched_metadata_blocks_before_invocation(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     # Build a fresh envelope whose campaign_engine metadata differs.
-    from guardian.pi.contracts import PiGuardianBoundary as _B
-    from guardian.pi.contracts import PiInvocationEnvelope as _E
-    from guardian.pi.contracts import PiInvocationPolicyDecision as _D
-    from guardian.pi.contracts import PiPermissionGrant as _P
-    from guardian.pi.contracts import PiProviderLane as _L
-
+    from guardian.pi.contracts import (
+        PiInvocationEnvelope as _E,
+        PiInvocationPolicyDecision as _D,
+        PiPermissionGrant as _P,
+        PiGuardianBoundary as _B,
+        PiProviderLane as _L,
+    )
     boundary = envelope.guardian_boundary
     bad_metadata = dict(envelope.validation_metadata)
-    bad_metadata["campaign_engine"] = dict(
-        envelope.validation_metadata["campaign_engine"]
-    )
+    bad_metadata["campaign_engine"] = dict(envelope.validation_metadata["campaign_engine"])
     bad_metadata["campaign_engine"]["campaign_id"] = "WRONG"
     bad_envelope = _E(
         guardian_boundary=boundary,
@@ -769,21 +695,9 @@ def test_mismatched_metadata_blocks_before_invocation(
     )
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity(
-            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
-        ),
-        receipt=FakeReceipt(
-            receipt_id="pi-receipt-mm",
-            invocation_id=envelope.invocation_id,
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
-        harness_result=FakeHarnessResult(
-            harness_result_id="pi-result-mm",
-            receipt_id="pi-receipt-mm",
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
+        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
+        receipt=FakeReceipt(receipt_id="pi-receipt-mm", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
+        harness_result=FakeHarnessResult(harness_result_id="pi-result-mm", receipt_id="pi-receipt-mm", harness_id="pi-coding-agent", harness_version="0.72.1"),
     )
     calls, install = invoker_factory
     install(outcome)
@@ -810,22 +724,14 @@ def test_mismatched_provider_blocks_before_invocation(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
-    envelope = replace(
-        envelope, provider_lane=replace(envelope.provider_lane, model_id="WRONG-MODEL")
-    )
+    envelope = replace(envelope, provider_lane=replace(envelope.provider_lane, model_id="WRONG-MODEL"))
     outcome = FakeOutcome(
         ok=False,
         failure_reason="model_mismatch",
-        actual_identity=FakeIdentity(
-            "openai-codex", "WRONG-MODEL", "pi-coding-agent", "0.72.1"
-        ),
+        actual_identity=FakeIdentity("openai-codex", "WRONG-MODEL", "pi-coding-agent", "0.72.1"),
     )
     calls, install = invoker_factory
     install(outcome)
@@ -851,24 +757,15 @@ def test_mismatched_model_blocks_before_invocation(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
-    envelope = replace(
-        envelope,
-        provider_lane=replace(envelope.provider_lane, provider_name="WRONG-PROVIDER"),
-    )
+    envelope = replace(envelope, provider_lane=replace(envelope.provider_lane, provider_name="WRONG-PROVIDER"))
     calls, install = invoker_factory
     outcome = FakeOutcome(
         ok=False,
         failure_reason="provider_mismatch",
-        actual_identity=FakeIdentity(
-            "WRONG-PROVIDER", "gpt-5.1", "pi-coding-agent", "0.72.1"
-        ),
+        actual_identity=FakeIdentity("WRONG-PROVIDER", "gpt-5.1", "pi-coding-agent", "0.72.1"),
     )
     install(outcome)
     with pytest.raises(CampaignLiveExecutorError):
@@ -893,15 +790,13 @@ def test_denied_decision_blocks_before_invocation(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     decision = replace(decision, decision="denied")
-    outcome = FakeOutcome(ok=False, failure_reason="authorization_denied")
+    outcome = FakeOutcome(
+        ok=False, failure_reason="authorization_denied"
+    )
     calls, install = invoker_factory
     install(outcome)
     with pytest.raises(CampaignLiveExecutorError) as exc_info:
@@ -925,11 +820,7 @@ def test_wider_write_grant_blocks_before_invocation(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(
         preparation,
@@ -959,11 +850,7 @@ def test_successful_invocation_occurs_exactly_once(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     receipt = FakeReceipt(
@@ -995,9 +882,7 @@ def test_successful_invocation_occurs_exactly_once(
         (request.cwd / "proof_target.txt").write_text(expected_post, encoding="utf-8")
         head_after = subprocess.run(
             ["git", "-C", str(request.cwd), "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            check=True,
+            capture_output=True, text=True, check=True,
         ).stdout.strip()
         return types.SimpleNamespace(
             status="success",
@@ -1045,10 +930,7 @@ def test_successful_invocation_occurs_exactly_once(
     assert (final_dir / "execution" / "executor-pi-harness-result.json").is_file()
     # Corner: no commit occurred in target — HEAD unchanged.
     head_now = subprocess.run(
-        ["git", "-C", str(target), "rev-parse", "HEAD"],
-        capture_output=True,
-        text=True,
-        check=True,
+        ["git", "-C", str(target), "rev-parse", "HEAD"], capture_output=True, text=True, check=True
     ).stdout.strip()
     assert head_now == handle["head"]
 
@@ -1061,30 +943,14 @@ def test_one_allowed_mutation_produces_count_one(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity(
-            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
-        ),
-        receipt=FakeReceipt(
-            receipt_id="pi-receipt-c14",
-            invocation_id=envelope.invocation_id,
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
-        harness_result=FakeHarnessResult(
-            harness_result_id="pi-result-c14",
-            receipt_id="pi-receipt-c14",
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
+        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
+        receipt=FakeReceipt(receipt_id="pi-receipt-c14", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
+        harness_result=FakeHarnessResult(harness_result_id="pi-result-c14", receipt_id="pi-receipt-c14", harness_id="pi-coding-agent", harness_version="0.72.1"),
     )
 
     monkeypatch = pytest.MonkeyPatch()
@@ -1117,30 +983,14 @@ def test_changed_file_evidence_contains_correct_hash(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity(
-            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
-        ),
-        receipt=FakeReceipt(
-            receipt_id="pi-receipt-c15",
-            invocation_id=envelope.invocation_id,
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
-        harness_result=FakeHarnessResult(
-            harness_result_id="pi-result-c15",
-            receipt_id="pi-receipt-c15",
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
+        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
+        receipt=FakeReceipt(receipt_id="pi-receipt-c15", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
+        harness_result=FakeHarnessResult(harness_result_id="pi-result-c15", receipt_id="pi-receipt-c15", harness_id="pi-coding-agent", harness_version="0.72.1"),
     )
 
     monkeypatch = pytest.MonkeyPatch()
@@ -1162,16 +1012,9 @@ def test_changed_file_evidence_contains_correct_hash(
         campaign_path=campaign_path,
     )
     monkeypatch.undo()
-    attempt_path = (
-        output_root
-        / handle["campaign_id"]
-        / "attempts"
-        / f"{preparation.attempt_id}.json"
-    )
+    attempt_path = output_root / handle["campaign_id"] / "attempts" / f"{preparation.attempt_id}.json"
     attempt_record = json.loads(attempt_path.read_text())
-    expected_hash = (
-        "f5673b55d1637ebcd00685c4c5fd4e29ce14b1f7c10b4fa9d72a4a48f8a8ef63"  # noqa
-    )
+    expected_hash = "f5673b55d1637ebcd00685c4c5fd4e29ce14b1f7c10b4fa9d72a4a48f8a8ef63"  # noqa
     import hashlib
 
     actual_hash = hashlib.sha256(b"CE-L1-LIVE-EXECUTOR-OK\n").hexdigest()
@@ -1193,30 +1036,14 @@ def test_zero_mutation_executor_turn_fails_closed(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity(
-            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
-        ),
-        receipt=FakeReceipt(
-            receipt_id="pi-receipt-c16",
-            invocation_id=envelope.invocation_id,
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
-        harness_result=FakeHarnessResult(
-            harness_result_id="pi-result-c16",
-            receipt_id="pi-receipt-c16",
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
+        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
+        receipt=FakeReceipt(receipt_id="pi-receipt-c16", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
+        harness_result=FakeHarnessResult(harness_result_id="pi-result-c16", receipt_id="pi-receipt-c16", harness_id="pi-coding-agent", harness_version="0.72.1"),
     )
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(live_executor, "_invoker", lambda **kwargs: outcome)
@@ -1233,36 +1060,23 @@ def test_zero_mutation_executor_turn_fails_closed(
     assert exc_info.value.failure_reason == "zero_mutation_executor_turn"
 
 
+
 # 17. out-of-scope post-invocation change fails closed.
-def test_out_of_scope_change_fails_closed(live_doc, tmp_path, invoker_factory) -> None:
+def test_out_of_scope_change_fails_closed(
+    live_doc, tmp_path, invoker_factory
+) -> None:
     campaign_path, target, handle = live_doc
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity(
-            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
-        ),
-        receipt=FakeReceipt(
-            receipt_id="pi-receipt-c17",
-            invocation_id=envelope.invocation_id,
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
-        harness_result=FakeHarnessResult(
-            harness_result_id="pi-result-c17",
-            receipt_id="pi-receipt-c17",
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
+        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
+        receipt=FakeReceipt(receipt_id="pi-receipt-c17", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
+        harness_result=FakeHarnessResult(harness_result_id="pi-result-c17", receipt_id="pi-receipt-c17", harness_id="pi-coding-agent", harness_version="0.72.1"),
     )
 
     monkeypatch = pytest.MonkeyPatch()
@@ -1288,35 +1102,21 @@ def test_out_of_scope_change_fails_closed(live_doc, tmp_path, invoker_factory) -
 
 
 # 18. Git HEAD change fails closed.
-def test_git_head_change_fails_closed(live_doc, tmp_path, invoker_factory) -> None:
+def test_git_head_change_fails_closed(
+    live_doc, tmp_path, invoker_factory
+) -> None:
     campaign_path, target, handle = live_doc
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity(
-            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
-        ),
-        receipt=FakeReceipt(
-            receipt_id="pi-receipt-c18",
-            invocation_id=envelope.invocation_id,
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
-        harness_result=FakeHarnessResult(
-            harness_result_id="pi-result-c18",
-            receipt_id="pi-receipt-c18",
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
+        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
+        receipt=FakeReceipt(receipt_id="pi-receipt-c18", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
+        harness_result=FakeHarnessResult(harness_result_id="pi-result-c18", receipt_id="pi-receipt-c18", harness_id="pi-coding-agent", harness_version="0.72.1"),
     )
 
     monkeypatch = pytest.MonkeyPatch()
@@ -1324,31 +1124,11 @@ def test_git_head_change_fails_closed(live_doc, tmp_path, invoker_factory) -> No
     def _combined(**kwargs: Any) -> FakeOutcome:
         cwd = pathlib.Path(kwargs["cwd"])
         # Forbidden mutation: commit a new revision in the target repo.
-        subprocess.run(
-            ["git", "-C", str(cwd), "config", "user.email", "evil@in.valid"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        subprocess.run(
-            ["git", "-C", str(cwd), "config", "user.name", "evil"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
+        subprocess.run(["git", "-C", str(cwd), "config", "user.email", "evil@in.valid"], capture_output=True, text=True, check=True)
+        subprocess.run(["git", "-C", str(cwd), "config", "user.name", "evil"], capture_output=True, text=True, check=True)
         (cwd / "proof_target.txt").write_text("HIJACK\n", encoding="utf-8")
-        subprocess.run(
-            ["git", "-C", str(cwd), "add", "proof_target.txt"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        subprocess.run(
-            ["git", "-C", str(cwd), "commit", "-m", "hi"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
+        subprocess.run(["git", "-C", str(cwd), "add", "proof_target.txt"], capture_output=True, text=True, check=True)
+        subprocess.run(["git", "-C", str(cwd), "commit", "-m", "hi"], capture_output=True, text=True, check=True)
         return outcome
 
     # Even if Canonical Pi's target-posture guard is bypassed by fake
@@ -1377,31 +1157,15 @@ def test_actual_identity_mismatch_fails_closed(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     # Outcome reports success but with the wrong provider identity.
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity(
-            "OTHER-PROVIDER", "other-model", "pi-coding-agent", "0.72.1"
-        ),
-        receipt=FakeReceipt(
-            receipt_id="pi-receipt-c19",
-            invocation_id=envelope.invocation_id,
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
-        harness_result=FakeHarnessResult(
-            harness_result_id="pi-result-c19",
-            receipt_id="pi-receipt-c19",
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
+        actual_identity=FakeIdentity("OTHER-PROVIDER", "other-model", "pi-coding-agent", "0.72.1"),
+        receipt=FakeReceipt(receipt_id="pi-receipt-c19", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
+        harness_result=FakeHarnessResult(harness_result_id="pi-result-c19", receipt_id="pi-receipt-c19", harness_id="pi-coding-agent", harness_version="0.72.1"),
     )
 
     monkeypatch = pytest.MonkeyPatch()
@@ -1427,28 +1191,14 @@ def test_missing_actual_identity_fails_closed(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
         actual_identity=None,
-        receipt=FakeReceipt(
-            receipt_id="pi-receipt-c20",
-            invocation_id=envelope.invocation_id,
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
-        harness_result=FakeHarnessResult(
-            harness_result_id="pi-result-c20",
-            receipt_id="pi-receipt-c20",
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
+        receipt=FakeReceipt(receipt_id="pi-receipt-c20", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
+        harness_result=FakeHarnessResult(harness_result_id="pi-result-c20", receipt_id="pi-receipt-c20", harness_id="pi-coding-agent", harness_version="0.72.1"),
     )
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(live_executor, "_invoker", lambda **kwargs: outcome)
@@ -1466,30 +1216,21 @@ def test_missing_actual_identity_fails_closed(
 
 
 # 21. missing Pi Receipt fails closed.
-def test_missing_pi_receipt_fails_closed(live_doc, tmp_path, invoker_factory) -> None:
+def test_missing_pi_receipt_fails_closed(
+    live_doc, tmp_path, invoker_factory
+) -> None:
     campaign_path, target, handle = live_doc
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity(
-            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
-        ),
+        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
         receipt=None,
-        harness_result=FakeHarnessResult(
-            harness_result_id="pi-result-c21",
-            receipt_id="pi-receipt-c21",
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
+        harness_result=FakeHarnessResult(harness_result_id="pi-result-c21", receipt_id="pi-receipt-c21", harness_id="pi-coding-agent", harness_version="0.72.1"),
     )
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(live_executor, "_invoker", lambda **kwargs: outcome)
@@ -1514,24 +1255,13 @@ def test_missing_pi_harness_result_fails_closed(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity(
-            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
-        ),
-        receipt=FakeReceipt(
-            receipt_id="pi-receipt-c22",
-            invocation_id=envelope.invocation_id,
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
+        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
+        receipt=FakeReceipt(receipt_id="pi-receipt-c22", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
         harness_result=None,
     )
     monkeypatch = pytest.MonkeyPatch()
@@ -1559,11 +1289,7 @@ def test_live_attempt_validates_against_schema(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     receipt = FakeReceipt(
@@ -1580,9 +1306,7 @@ def test_live_attempt_validates_against_schema(
     )
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity(
-            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
-        ),
+        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
         receipt=receipt,
         harness_result=harness,
     )
@@ -1606,24 +1330,14 @@ def test_live_attempt_validates_against_schema(
         campaign_path=campaign_path,
     )
     monkeypatch.undo()
-    attempt_path = (
-        output_root
-        / handle["campaign_id"]
-        / "attempts"
-        / f"{preparation.attempt_id}.json"
-    )
+    attempt_path = output_root / handle["campaign_id"] / "attempts" / f"{preparation.attempt_id}.json"
     attempt_record = json.loads(attempt_path.read_text())
-    schema_path = (
-        pathlib.Path(__file__).resolve().parent.parent
-        / "schemas/campaign_engine/attempt.schema.json"
-    )
+    schema_path = pathlib.Path(__file__).resolve().parent.parent / "schemas/campaign_engine/attempt.schema.json"
     schema = json.loads(schema_path.read_text())
     Draft202012Validator.check_schema(schema)
     validator = Draft202012Validator(schema)
     errors = list(validator.iter_errors(attempt_record))
-    assert (
-        errors == []
-    ), f"attempt schema validation failed: {[e.message for e in errors]}"
+    assert errors == [], f"attempt schema validation failed: {[e.message for e in errors]}"
 
 
 # 24. successful live Attempt passes current cross-object validation.
@@ -1634,11 +1348,7 @@ def test_live_attempt_passes_cross_object_validation(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     receipt = FakeReceipt(
@@ -1655,9 +1365,7 @@ def test_live_attempt_passes_cross_object_validation(
     )
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity(
-            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
-        ),
+        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
         receipt=receipt,
         harness_result=harness,
     )
@@ -1698,30 +1406,14 @@ def test_provider_call_count_is_one_in_attempt(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity(
-            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
-        ),
-        receipt=FakeReceipt(
-            receipt_id="pi-receipt-c25",
-            invocation_id=envelope.invocation_id,
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
-        harness_result=FakeHarnessResult(
-            harness_result_id="pi-result-c25",
-            receipt_id="pi-receipt-c25",
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
+        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
+        receipt=FakeReceipt(receipt_id="pi-receipt-c25", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
+        harness_result=FakeHarnessResult(harness_result_id="pi-result-c25", receipt_id="pi-receipt-c25", harness_id="pi-coding-agent", harness_version="0.72.1"),
     )
 
     monkeypatch = pytest.MonkeyPatch()
@@ -1744,12 +1436,7 @@ def test_provider_call_count_is_one_in_attempt(
     )
     monkeypatch.undo()
     attempt_record = json.loads(
-        (
-            output_root
-            / handle["campaign_id"]
-            / "attempts"
-            / f"{preparation.attempt_id}.json"
-        ).read_text()
+        (output_root / handle["campaign_id"] / "attempts" / f"{preparation.attempt_id}.json").read_text()
     )
     # 25, 26, 27, 28, 29, 30 in a single assertion on the Attempt.
     assert attempt_record["provider_call_count"] == 1
@@ -1758,9 +1445,7 @@ def test_provider_call_count_is_one_in_attempt(
     assert attempt_record["durable_ingestion_performed"] is False
     # retry/fallback invariants come from the outcome not the Attempt
     # record; reflect them in the result envelope:
-    result_envelope = json.loads(
-        (output_root / handle["campaign_id"] / "run-result.json").read_text()
-    )
+    result_envelope = json.loads((output_root / handle["campaign_id"] / "run-result.json").read_text())
     assert result_envelope["provider_calls_performed"] == 1
 
 
@@ -1769,32 +1454,16 @@ def test_retry_and_fallback_counts_zero(live_doc, tmp_path, invoker_factory) -> 
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
         retry_count=0,
         fallback_count=0,
-        actual_identity=FakeIdentity(
-            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
-        ),
-        receipt=FakeReceipt(
-            receipt_id="pi-receipt-c27",
-            invocation_id=envelope.invocation_id,
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
-        harness_result=FakeHarnessResult(
-            harness_result_id="pi-result-c27",
-            receipt_id="pi-receipt-c27",
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
+        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
+        receipt=FakeReceipt(receipt_id="pi-receipt-c27", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
+        harness_result=FakeHarnessResult(harness_result_id="pi-result-c27", receipt_id="pi-receipt-c27", harness_id="pi-coding-agent", harness_version="0.72.1"),
     )
     monkeypatch = pytest.MonkeyPatch()
 
@@ -1818,13 +1487,7 @@ def test_retry_and_fallback_counts_zero(live_doc, tmp_path, invoker_factory) -> 
     # via the Attempt's `provider_call_count == 1` and the persisted
     # outcome retry/fallback counters in the durability artifact.
     receipt_artifact = json.loads(
-        (
-            tmp_path
-            / "out-21"
-            / handle["campaign_id"]
-            / "execution"
-            / "executor-pi-receipt.json"
-        ).read_text()
+        (tmp_path / "out-21" / handle["campaign_id"] / "execution" / "executor-pi-receipt.json").read_text()
     )
     assert receipt_artifact["receipt_id"].startswith("pi-receipt-")
     # No retry/fallback paths available, so the result implicitly encodes
@@ -1840,11 +1503,7 @@ def test_receipt_and_harness_result_artifacts_round_trip(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     receipt = FakeReceipt(
@@ -1864,9 +1523,7 @@ def test_receipt_and_harness_result_artifacts_round_trip(
     )
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity(
-            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
-        ),
+        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
         receipt=receipt,
         harness_result=harness,
     )
@@ -1912,18 +1569,12 @@ def test_no_credential_shaped_fields_in_durable_evidence(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity(
-            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
-        ),
+        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
         receipt=FakeReceipt(
             receipt_id="pi-receipt-c32",
             invocation_id=envelope.invocation_id,
@@ -1959,20 +1610,10 @@ def test_no_credential_shaped_fields_in_durable_evidence(
     monkeypatch.undo()
     final_dir = output_root / handle["campaign_id"]
     sensitive_set = {
-        "access_token",
-        "refresh_token",
-        "authorization",
-        "api_key",
-        "apikey",
-        "secret",
-        "credentials",
-        "token",
-        "password",
-        "client_secret",
-        "session_token",
-        "cookie",
-        "set-cookie",
-        "x-api-key",
+        "access_token", "refresh_token", "authorization",
+        "api_key", "apikey", "secret", "credentials",
+        "token", "password", "client_secret", "session_token",
+        "cookie", "set-cookie", "x-api-key",
     }
 
     def _walk(obj: Any, path: str = "") -> list[str]:
@@ -2024,30 +1665,14 @@ def test_interim_evaluation_remains_non_independent(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(
-            instant=__import__("datetime").datetime(
-                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
-            )
-        ),
+        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity(
-            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
-        ),
-        receipt=FakeReceipt(
-            receipt_id="pi-receipt-c33",
-            invocation_id=envelope.invocation_id,
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
-        harness_result=FakeHarnessResult(
-            harness_result_id="pi-result-c33",
-            receipt_id="pi-receipt-c33",
-            harness_id="pi-coding-agent",
-            harness_version="0.72.1",
-        ),
+        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
+        receipt=FakeReceipt(receipt_id="pi-receipt-c33", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
+        harness_result=FakeHarnessResult(harness_result_id="pi-result-c33", receipt_id="pi-receipt-c33", harness_id="pi-coding-agent", harness_version="0.72.1"),
     )
 
     monkeypatch = pytest.MonkeyPatch()
@@ -2070,12 +1695,7 @@ def test_interim_evaluation_remains_non_independent(
     )
     monkeypatch.undo()
     evaluation = json.loads(
-        (
-            output_root
-            / handle["campaign_id"]
-            / "evaluations"
-            / f"{preparation.evaluation_id}.json"
-        ).read_text()
+        (output_root / handle["campaign_id"] / "evaluations" / f"{preparation.evaluation_id}.json").read_text()
     )
     assert evaluation["independent_model_judgment"] is False
     assert evaluation["evaluation_mode"] == "provider_free"
@@ -2113,16 +1733,14 @@ def test_provider_free_unchanged_output_contract(
                 "rebind_approval": "operator_required",
             },
         },
-        "tasks": [
-            {
-                "schema_version": "campaign-engine/v0",
-                "task_id": "task-pf-test-001",
-                "campaign_id": "campaign-pf-test-001",
-                "created_at": "2026-08-26T13:00:00Z",
-                "state": "ready",
-                "objective": "Provider-free regression task",
-            }
-        ],
+        "tasks": [{
+            "schema_version": "campaign-engine/v0",
+            "task_id": "task-pf-test-001",
+            "campaign_id": "campaign-pf-test-001",
+            "created_at": "2026-08-26T13:00:00Z",
+            "state": "ready",
+            "objective": "Provider-free regression task",
+        }],
         "role_bindings": [
             {
                 "schema_version": "campaign-engine/v0",
@@ -2211,23 +1829,13 @@ def test_package_import_does_not_eagerly_load_guardian_pi() -> None:
         "out = sorted({a for a in dir(p) if not a.startswith('_')}); "
         "print(json.dumps({'modules': mods, 'attrs': out}))"
     )
-    completed = subprocess.run(
-        [py, "-c", script],
-        capture_output=True,
-        text=True,
-        check=True,
-        env={**os.environ},
-    )
+    completed = subprocess.run([py, "-c", script], capture_output=True, text=True, check=True, env={**os.environ})
     payload = json.loads(completed.stdout)
-    assert (
-        payload["modules"] == []
-    ), f"Guardian/Pi modules were eagerly loaded by package import: {payload['modules']}"
+    assert payload["modules"] == [], (
+        f"Guardian/Pi modules were eagerly loaded by package import: {payload['modules']}"
+    )
     # Surface is unchanged in terms of public API.
-    for required in (
-        "run_provider_free_campaign",
-        "LiveExecutorPreparation",
-        "CampaignLiveExecutorError",
-    ):
+    for required in ("run_provider_free_campaign", "LiveExecutorPreparation", "CampaignLiveExecutorError"):
         assert required in payload["attrs"]
 
 
@@ -2237,6 +1845,8 @@ def test_package_import_does_not_eagerly_load_guardian_pi() -> None:
 # through the success and failure paths without fabricating or mutating it.
 
 
+
+
 def test_zero_mutation_error_carries_all_six_tool_telemetry_fields(
     monkeypatch, live_doc, tmp_path, fixed_clock, invoker_factory
 ) -> None:
@@ -2244,7 +1854,6 @@ def test_zero_mutation_error_carries_all_six_tool_telemetry_fields(
     CampaignLiveExecutorError.to_payload() output, and the issue text does
     not claim the model itself caused the failure."""
     from codex_runner.campaign_engine.live_executor import run_live_executor_campaign
-
     campaign_path, target_path, _ = live_doc
     fake_identity = FakeIdentity(
         provider_id="openai-codex",
@@ -2303,10 +1912,7 @@ def test_zero_mutation_error_carries_all_six_tool_telemetry_fields(
         telemetry = payload["tool_telemetry"]
         assert telemetry is not None
         assert telemetry["effective_tool_names"] == [
-            "read",
-            "bash",
-            "edit",
-            "write",
+            "read", "bash", "edit", "write",
         ]
         assert telemetry["write_tool_available"] is True
         assert telemetry["tool_execution_start_count"] == 0

--- a/codex_runner/tests/test_campaign_engine_live_executor.py
+++ b/codex_runner/tests/test_campaign_engine_live_executor.py
@@ -46,7 +46,6 @@ from codex_runner.campaign_engine.models import (
     FixedClock,
 )
 
-
 # ---------------------------------------------------------------------------
 # Test scaffolding: deterministic fake outcome + helpers
 # ---------------------------------------------------------------------------
@@ -79,7 +78,9 @@ class FakeReceipt:
     provider_lane: dict[str, Any] = field(default_factory=dict)
     granted_permissions: tuple[dict[str, Any], ...] = field(default_factory=tuple)
     validation_metadata: dict[str, Any] = field(default_factory=dict)
-    guardian_boundary: dict[str, Any] = field(default_factory=lambda: {"owner_account_id": "operator"})
+    guardian_boundary: dict[str, Any] = field(
+        default_factory=lambda: {"owner_account_id": "operator"}
+    )
     source_thread_id: str = "thread-1"
     source_message_id: str = "msg-1"
     authored_request_id: str | None = None
@@ -158,6 +159,13 @@ class FakeOutcome:
     tool_execution_end_count: int | None = None
     executed_tool_names: tuple[str, ...] | None = None
     assistant_tool_call_count: int | None = None
+    # Bounded Pi 0.82.1 assistant-response telemetry (CE-L1
+    # post-tool-repair observability; see
+    # docs/architecture/proofs/runtime/2026-08-29-pi-assistant-response-telemetry-proof.md).
+    assistant_message_count: int | None = None
+    assistant_content_block_types: tuple[str, ...] | None = None
+    assistant_message_event_types: tuple[str, ...] | None = None
+    assistant_tool_call_event_count: int | None = None
 
     def to_payload(self) -> dict[str, Any]:
         return {
@@ -174,8 +182,12 @@ class FakeOutcome:
             "provider_request_started": self.provider_request_started,
             "oauth_available": self.oauth_available,
             "receipt": self.receipt.to_payload() if self.receipt else None,
-            "harness_result": self.harness_result.to_payload() if self.harness_result else None,
-            "actual_identity": self.actual_identity.to_payload() if self.actual_identity else None,
+            "harness_result": (
+                self.harness_result.to_payload() if self.harness_result else None
+            ),
+            "actual_identity": (
+                self.actual_identity.to_payload() if self.actual_identity else None
+            ),
         }
 
 
@@ -216,20 +228,49 @@ def _make_canonical_live_campaign(
     if granted_permissions is None:
         granted_permissions = ["files.read", "files.write"]
     if requested_permissions is None:
-        requested_permissions = ["files.read", "files.write", "network.provider.allowed"]
+        requested_permissions = [
+            "files.read",
+            "files.write",
+            "network.provider.allowed",
+        ]
 
     target = tmp_path / "ce-l1-test-target"
     target.mkdir(parents=True, exist_ok=True)
     target_handle = target / "proof_target.txt"
     target_handle.write_text("CE-L1-BASELINE\n", encoding="utf-8")
     # Init a git repo so target_baseline_git_head works.
-    subprocess.run(["git", "-C", str(target), "init"], capture_output=True, text=True, check=True)
-    subprocess.run(["git", "-C", str(target), "config", "user.email", "ce-l1-proof@in.valid"], capture_output=True, text=True, check=True)
-    subprocess.run(["git", "-C", str(target), "config", "user.name", "ce-l1-proof"], capture_output=True, text=True, check=True)
-    subprocess.run(["git", "-C", str(target), "add", "proof_target.txt"], capture_output=True, text=True, check=True)
-    subprocess.run(["git", "-C", str(target), "commit", "-m", "ce-l1-baseline"], capture_output=True, text=True, check=True)
+    subprocess.run(
+        ["git", "-C", str(target), "init"], capture_output=True, text=True, check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(target), "config", "user.email", "ce-l1-proof@in.valid"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(target), "config", "user.name", "ce-l1-proof"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(target), "add", "proof_target.txt"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(target), "commit", "-m", "ce-l1-baseline"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
     head = subprocess.run(
-        ["git", "-C", str(target), "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+        ["git", "-C", str(target), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
     ).stdout.strip()
 
     if target_resolve == "<derived>":
@@ -421,8 +462,12 @@ def _build_envelope_and_decision(
         metadata={"campaign_engine_campaign_id": preparation.campaign_id},
     )
     granted = (
-        PiPermissionGrant(permission="files.read", resource=granted_files_read_resource),
-        PiPermissionGrant(permission="files.write", resource=granted_files_write_resource),
+        PiPermissionGrant(
+            permission="files.read", resource=granted_files_read_resource
+        ),
+        PiPermissionGrant(
+            permission="files.write", resource=granted_files_write_resource
+        ),
     )
     requested = granted + (
         PiPermissionGrant(permission="network.provider.allowed", resource="."),
@@ -509,7 +554,11 @@ def test_preparation_uses_locked_executor_binding(live_doc) -> None:
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     assert preparation.executor_binding_id == handle["binding_id"]
     assert preparation.executor_binding_revision == 1
@@ -521,7 +570,11 @@ def test_expected_provider_model_derived_only_from_binding(live_doc) -> None:
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     assert preparation.expected_provider_id == handle["executor_provider"]
     assert preparation.expected_model_id == handle["executor_model"]
@@ -535,7 +588,11 @@ def test_preparation_binds_prompt_hash(live_doc) -> None:
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     expected = sha256(preparation.prompt.encode("utf-8")).hexdigest()
     assert preparation.prompt_sha256 == expected
@@ -548,7 +605,11 @@ def test_preparation_binds_target_identity_and_allowed_paths(live_doc) -> None:
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     assert preparation.target_path == target.resolve()
     assert preparation.target_repository_identity == str(target.resolve())
@@ -560,11 +621,16 @@ def test_drift_in_campaign_input_blocks_before_invocation(
     live_doc, tmp_path, fixed_clock, invoker_factory
 ) -> None:
     from codex_runner.campaign_engine.models import FixedClock
+
     campaign_path, target, handle = live_doc
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     # Modify the campaign file post-preparation (the Task objective text).
     doc = json.loads(campaign_path.read_text())
@@ -573,7 +639,9 @@ def test_drift_in_campaign_input_blocks_before_invocation(
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
+        actual_identity=FakeIdentity(
+            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
+        ),
         receipt=FakeReceipt(
             receipt_id="pi-receipt-ce-l1-test-drift-input",
             invocation_id=envelope.invocation_id,
@@ -602,7 +670,9 @@ def test_drift_in_campaign_input_blocks_before_invocation(
     assert exc_info.value.failure_reason == "drift_after_authorization"
     assert calls == []
     # No durable output created.
-    assert not output_root.exists() or not (output_root / handle["campaign_id"]).exists()
+    assert (
+        not output_root.exists() or not (output_root / handle["campaign_id"]).exists()
+    )
 
 
 # 7. changed target baseline after preparation blocks before invocation.
@@ -613,14 +683,20 @@ def test_drift_in_target_baseline_blocks_before_invocation(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     # Mutate the target file before execution.
     (target / handle["target_handle"].name).write_text("MODIFIED\n", encoding="utf-8")
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
+        actual_identity=FakeIdentity(
+            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
+        ),
         receipt=FakeReceipt(
             receipt_id="pi-receipt-ce-l1-test-drift-target",
             invocation_id=envelope.invocation_id,
@@ -658,20 +734,25 @@ def test_mismatched_metadata_blocks_before_invocation(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     # Build a fresh envelope whose campaign_engine metadata differs.
-    from guardian.pi.contracts import (
-        PiInvocationEnvelope as _E,
-        PiInvocationPolicyDecision as _D,
-        PiPermissionGrant as _P,
-        PiGuardianBoundary as _B,
-        PiProviderLane as _L,
-    )
+    from guardian.pi.contracts import PiGuardianBoundary as _B
+    from guardian.pi.contracts import PiInvocationEnvelope as _E
+    from guardian.pi.contracts import PiInvocationPolicyDecision as _D
+    from guardian.pi.contracts import PiPermissionGrant as _P
+    from guardian.pi.contracts import PiProviderLane as _L
+
     boundary = envelope.guardian_boundary
     bad_metadata = dict(envelope.validation_metadata)
-    bad_metadata["campaign_engine"] = dict(envelope.validation_metadata["campaign_engine"])
+    bad_metadata["campaign_engine"] = dict(
+        envelope.validation_metadata["campaign_engine"]
+    )
     bad_metadata["campaign_engine"]["campaign_id"] = "WRONG"
     bad_envelope = _E(
         guardian_boundary=boundary,
@@ -688,9 +769,21 @@ def test_mismatched_metadata_blocks_before_invocation(
     )
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
-        receipt=FakeReceipt(receipt_id="pi-receipt-mm", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
-        harness_result=FakeHarnessResult(harness_result_id="pi-result-mm", receipt_id="pi-receipt-mm", harness_id="pi-coding-agent", harness_version="0.72.1"),
+        actual_identity=FakeIdentity(
+            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
+        ),
+        receipt=FakeReceipt(
+            receipt_id="pi-receipt-mm",
+            invocation_id=envelope.invocation_id,
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
+        harness_result=FakeHarnessResult(
+            harness_result_id="pi-result-mm",
+            receipt_id="pi-receipt-mm",
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
     )
     calls, install = invoker_factory
     install(outcome)
@@ -717,14 +810,22 @@ def test_mismatched_provider_blocks_before_invocation(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
-    envelope = replace(envelope, provider_lane=replace(envelope.provider_lane, model_id="WRONG-MODEL"))
+    envelope = replace(
+        envelope, provider_lane=replace(envelope.provider_lane, model_id="WRONG-MODEL")
+    )
     outcome = FakeOutcome(
         ok=False,
         failure_reason="model_mismatch",
-        actual_identity=FakeIdentity("openai-codex", "WRONG-MODEL", "pi-coding-agent", "0.72.1"),
+        actual_identity=FakeIdentity(
+            "openai-codex", "WRONG-MODEL", "pi-coding-agent", "0.72.1"
+        ),
     )
     calls, install = invoker_factory
     install(outcome)
@@ -750,15 +851,24 @@ def test_mismatched_model_blocks_before_invocation(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
-    envelope = replace(envelope, provider_lane=replace(envelope.provider_lane, provider_name="WRONG-PROVIDER"))
+    envelope = replace(
+        envelope,
+        provider_lane=replace(envelope.provider_lane, provider_name="WRONG-PROVIDER"),
+    )
     calls, install = invoker_factory
     outcome = FakeOutcome(
         ok=False,
         failure_reason="provider_mismatch",
-        actual_identity=FakeIdentity("WRONG-PROVIDER", "gpt-5.1", "pi-coding-agent", "0.72.1"),
+        actual_identity=FakeIdentity(
+            "WRONG-PROVIDER", "gpt-5.1", "pi-coding-agent", "0.72.1"
+        ),
     )
     install(outcome)
     with pytest.raises(CampaignLiveExecutorError):
@@ -783,13 +893,15 @@ def test_denied_decision_blocks_before_invocation(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     decision = replace(decision, decision="denied")
-    outcome = FakeOutcome(
-        ok=False, failure_reason="authorization_denied"
-    )
+    outcome = FakeOutcome(ok=False, failure_reason="authorization_denied")
     calls, install = invoker_factory
     install(outcome)
     with pytest.raises(CampaignLiveExecutorError) as exc_info:
@@ -813,7 +925,11 @@ def test_wider_write_grant_blocks_before_invocation(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(
         preparation,
@@ -843,7 +959,11 @@ def test_successful_invocation_occurs_exactly_once(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     receipt = FakeReceipt(
@@ -875,7 +995,9 @@ def test_successful_invocation_occurs_exactly_once(
         (request.cwd / "proof_target.txt").write_text(expected_post, encoding="utf-8")
         head_after = subprocess.run(
             ["git", "-C", str(request.cwd), "rev-parse", "HEAD"],
-            capture_output=True, text=True, check=True,
+            capture_output=True,
+            text=True,
+            check=True,
         ).stdout.strip()
         return types.SimpleNamespace(
             status="success",
@@ -923,7 +1045,10 @@ def test_successful_invocation_occurs_exactly_once(
     assert (final_dir / "execution" / "executor-pi-harness-result.json").is_file()
     # Corner: no commit occurred in target — HEAD unchanged.
     head_now = subprocess.run(
-        ["git", "-C", str(target), "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+        ["git", "-C", str(target), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
     ).stdout.strip()
     assert head_now == handle["head"]
 
@@ -936,14 +1061,30 @@ def test_one_allowed_mutation_produces_count_one(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
-        receipt=FakeReceipt(receipt_id="pi-receipt-c14", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
-        harness_result=FakeHarnessResult(harness_result_id="pi-result-c14", receipt_id="pi-receipt-c14", harness_id="pi-coding-agent", harness_version="0.72.1"),
+        actual_identity=FakeIdentity(
+            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
+        ),
+        receipt=FakeReceipt(
+            receipt_id="pi-receipt-c14",
+            invocation_id=envelope.invocation_id,
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
+        harness_result=FakeHarnessResult(
+            harness_result_id="pi-result-c14",
+            receipt_id="pi-receipt-c14",
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
     )
 
     monkeypatch = pytest.MonkeyPatch()
@@ -976,14 +1117,30 @@ def test_changed_file_evidence_contains_correct_hash(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
-        receipt=FakeReceipt(receipt_id="pi-receipt-c15", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
-        harness_result=FakeHarnessResult(harness_result_id="pi-result-c15", receipt_id="pi-receipt-c15", harness_id="pi-coding-agent", harness_version="0.72.1"),
+        actual_identity=FakeIdentity(
+            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
+        ),
+        receipt=FakeReceipt(
+            receipt_id="pi-receipt-c15",
+            invocation_id=envelope.invocation_id,
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
+        harness_result=FakeHarnessResult(
+            harness_result_id="pi-result-c15",
+            receipt_id="pi-receipt-c15",
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
     )
 
     monkeypatch = pytest.MonkeyPatch()
@@ -1005,9 +1162,16 @@ def test_changed_file_evidence_contains_correct_hash(
         campaign_path=campaign_path,
     )
     monkeypatch.undo()
-    attempt_path = output_root / handle["campaign_id"] / "attempts" / f"{preparation.attempt_id}.json"
+    attempt_path = (
+        output_root
+        / handle["campaign_id"]
+        / "attempts"
+        / f"{preparation.attempt_id}.json"
+    )
     attempt_record = json.loads(attempt_path.read_text())
-    expected_hash = "f5673b55d1637ebcd00685c4c5fd4e29ce14b1f7c10b4fa9d72a4a48f8a8ef63"  # noqa
+    expected_hash = (
+        "f5673b55d1637ebcd00685c4c5fd4e29ce14b1f7c10b4fa9d72a4a48f8a8ef63"  # noqa
+    )
     import hashlib
 
     actual_hash = hashlib.sha256(b"CE-L1-LIVE-EXECUTOR-OK\n").hexdigest()
@@ -1029,14 +1193,30 @@ def test_zero_mutation_executor_turn_fails_closed(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
-        receipt=FakeReceipt(receipt_id="pi-receipt-c16", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
-        harness_result=FakeHarnessResult(harness_result_id="pi-result-c16", receipt_id="pi-receipt-c16", harness_id="pi-coding-agent", harness_version="0.72.1"),
+        actual_identity=FakeIdentity(
+            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
+        ),
+        receipt=FakeReceipt(
+            receipt_id="pi-receipt-c16",
+            invocation_id=envelope.invocation_id,
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
+        harness_result=FakeHarnessResult(
+            harness_result_id="pi-result-c16",
+            receipt_id="pi-receipt-c16",
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
     )
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(live_executor, "_invoker", lambda **kwargs: outcome)
@@ -1053,23 +1233,36 @@ def test_zero_mutation_executor_turn_fails_closed(
     assert exc_info.value.failure_reason == "zero_mutation_executor_turn"
 
 
-
 # 17. out-of-scope post-invocation change fails closed.
-def test_out_of_scope_change_fails_closed(
-    live_doc, tmp_path, invoker_factory
-) -> None:
+def test_out_of_scope_change_fails_closed(live_doc, tmp_path, invoker_factory) -> None:
     campaign_path, target, handle = live_doc
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
-        receipt=FakeReceipt(receipt_id="pi-receipt-c17", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
-        harness_result=FakeHarnessResult(harness_result_id="pi-result-c17", receipt_id="pi-receipt-c17", harness_id="pi-coding-agent", harness_version="0.72.1"),
+        actual_identity=FakeIdentity(
+            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
+        ),
+        receipt=FakeReceipt(
+            receipt_id="pi-receipt-c17",
+            invocation_id=envelope.invocation_id,
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
+        harness_result=FakeHarnessResult(
+            harness_result_id="pi-result-c17",
+            receipt_id="pi-receipt-c17",
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
     )
 
     monkeypatch = pytest.MonkeyPatch()
@@ -1095,21 +1288,35 @@ def test_out_of_scope_change_fails_closed(
 
 
 # 18. Git HEAD change fails closed.
-def test_git_head_change_fails_closed(
-    live_doc, tmp_path, invoker_factory
-) -> None:
+def test_git_head_change_fails_closed(live_doc, tmp_path, invoker_factory) -> None:
     campaign_path, target, handle = live_doc
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
-        receipt=FakeReceipt(receipt_id="pi-receipt-c18", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
-        harness_result=FakeHarnessResult(harness_result_id="pi-result-c18", receipt_id="pi-receipt-c18", harness_id="pi-coding-agent", harness_version="0.72.1"),
+        actual_identity=FakeIdentity(
+            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
+        ),
+        receipt=FakeReceipt(
+            receipt_id="pi-receipt-c18",
+            invocation_id=envelope.invocation_id,
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
+        harness_result=FakeHarnessResult(
+            harness_result_id="pi-result-c18",
+            receipt_id="pi-receipt-c18",
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
     )
 
     monkeypatch = pytest.MonkeyPatch()
@@ -1117,11 +1324,31 @@ def test_git_head_change_fails_closed(
     def _combined(**kwargs: Any) -> FakeOutcome:
         cwd = pathlib.Path(kwargs["cwd"])
         # Forbidden mutation: commit a new revision in the target repo.
-        subprocess.run(["git", "-C", str(cwd), "config", "user.email", "evil@in.valid"], capture_output=True, text=True, check=True)
-        subprocess.run(["git", "-C", str(cwd), "config", "user.name", "evil"], capture_output=True, text=True, check=True)
+        subprocess.run(
+            ["git", "-C", str(cwd), "config", "user.email", "evil@in.valid"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(cwd), "config", "user.name", "evil"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
         (cwd / "proof_target.txt").write_text("HIJACK\n", encoding="utf-8")
-        subprocess.run(["git", "-C", str(cwd), "add", "proof_target.txt"], capture_output=True, text=True, check=True)
-        subprocess.run(["git", "-C", str(cwd), "commit", "-m", "hi"], capture_output=True, text=True, check=True)
+        subprocess.run(
+            ["git", "-C", str(cwd), "add", "proof_target.txt"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(cwd), "commit", "-m", "hi"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
         return outcome
 
     # Even if Canonical Pi's target-posture guard is bypassed by fake
@@ -1150,15 +1377,31 @@ def test_actual_identity_mismatch_fails_closed(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     # Outcome reports success but with the wrong provider identity.
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity("OTHER-PROVIDER", "other-model", "pi-coding-agent", "0.72.1"),
-        receipt=FakeReceipt(receipt_id="pi-receipt-c19", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
-        harness_result=FakeHarnessResult(harness_result_id="pi-result-c19", receipt_id="pi-receipt-c19", harness_id="pi-coding-agent", harness_version="0.72.1"),
+        actual_identity=FakeIdentity(
+            "OTHER-PROVIDER", "other-model", "pi-coding-agent", "0.72.1"
+        ),
+        receipt=FakeReceipt(
+            receipt_id="pi-receipt-c19",
+            invocation_id=envelope.invocation_id,
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
+        harness_result=FakeHarnessResult(
+            harness_result_id="pi-result-c19",
+            receipt_id="pi-receipt-c19",
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
     )
 
     monkeypatch = pytest.MonkeyPatch()
@@ -1184,14 +1427,28 @@ def test_missing_actual_identity_fails_closed(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
         actual_identity=None,
-        receipt=FakeReceipt(receipt_id="pi-receipt-c20", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
-        harness_result=FakeHarnessResult(harness_result_id="pi-result-c20", receipt_id="pi-receipt-c20", harness_id="pi-coding-agent", harness_version="0.72.1"),
+        receipt=FakeReceipt(
+            receipt_id="pi-receipt-c20",
+            invocation_id=envelope.invocation_id,
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
+        harness_result=FakeHarnessResult(
+            harness_result_id="pi-result-c20",
+            receipt_id="pi-receipt-c20",
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
     )
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(live_executor, "_invoker", lambda **kwargs: outcome)
@@ -1209,21 +1466,30 @@ def test_missing_actual_identity_fails_closed(
 
 
 # 21. missing Pi Receipt fails closed.
-def test_missing_pi_receipt_fails_closed(
-    live_doc, tmp_path, invoker_factory
-) -> None:
+def test_missing_pi_receipt_fails_closed(live_doc, tmp_path, invoker_factory) -> None:
     campaign_path, target, handle = live_doc
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
+        actual_identity=FakeIdentity(
+            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
+        ),
         receipt=None,
-        harness_result=FakeHarnessResult(harness_result_id="pi-result-c21", receipt_id="pi-receipt-c21", harness_id="pi-coding-agent", harness_version="0.72.1"),
+        harness_result=FakeHarnessResult(
+            harness_result_id="pi-result-c21",
+            receipt_id="pi-receipt-c21",
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
     )
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(live_executor, "_invoker", lambda **kwargs: outcome)
@@ -1248,13 +1514,24 @@ def test_missing_pi_harness_result_fails_closed(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
-        receipt=FakeReceipt(receipt_id="pi-receipt-c22", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
+        actual_identity=FakeIdentity(
+            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
+        ),
+        receipt=FakeReceipt(
+            receipt_id="pi-receipt-c22",
+            invocation_id=envelope.invocation_id,
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
         harness_result=None,
     )
     monkeypatch = pytest.MonkeyPatch()
@@ -1282,7 +1559,11 @@ def test_live_attempt_validates_against_schema(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     receipt = FakeReceipt(
@@ -1299,7 +1580,9 @@ def test_live_attempt_validates_against_schema(
     )
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
+        actual_identity=FakeIdentity(
+            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
+        ),
         receipt=receipt,
         harness_result=harness,
     )
@@ -1323,14 +1606,24 @@ def test_live_attempt_validates_against_schema(
         campaign_path=campaign_path,
     )
     monkeypatch.undo()
-    attempt_path = output_root / handle["campaign_id"] / "attempts" / f"{preparation.attempt_id}.json"
+    attempt_path = (
+        output_root
+        / handle["campaign_id"]
+        / "attempts"
+        / f"{preparation.attempt_id}.json"
+    )
     attempt_record = json.loads(attempt_path.read_text())
-    schema_path = pathlib.Path(__file__).resolve().parent.parent / "schemas/campaign_engine/attempt.schema.json"
+    schema_path = (
+        pathlib.Path(__file__).resolve().parent.parent
+        / "schemas/campaign_engine/attempt.schema.json"
+    )
     schema = json.loads(schema_path.read_text())
     Draft202012Validator.check_schema(schema)
     validator = Draft202012Validator(schema)
     errors = list(validator.iter_errors(attempt_record))
-    assert errors == [], f"attempt schema validation failed: {[e.message for e in errors]}"
+    assert (
+        errors == []
+    ), f"attempt schema validation failed: {[e.message for e in errors]}"
 
 
 # 24. successful live Attempt passes current cross-object validation.
@@ -1341,7 +1634,11 @@ def test_live_attempt_passes_cross_object_validation(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     receipt = FakeReceipt(
@@ -1358,7 +1655,9 @@ def test_live_attempt_passes_cross_object_validation(
     )
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
+        actual_identity=FakeIdentity(
+            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
+        ),
         receipt=receipt,
         harness_result=harness,
     )
@@ -1399,14 +1698,30 @@ def test_provider_call_count_is_one_in_attempt(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
-        receipt=FakeReceipt(receipt_id="pi-receipt-c25", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
-        harness_result=FakeHarnessResult(harness_result_id="pi-result-c25", receipt_id="pi-receipt-c25", harness_id="pi-coding-agent", harness_version="0.72.1"),
+        actual_identity=FakeIdentity(
+            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
+        ),
+        receipt=FakeReceipt(
+            receipt_id="pi-receipt-c25",
+            invocation_id=envelope.invocation_id,
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
+        harness_result=FakeHarnessResult(
+            harness_result_id="pi-result-c25",
+            receipt_id="pi-receipt-c25",
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
     )
 
     monkeypatch = pytest.MonkeyPatch()
@@ -1429,7 +1744,12 @@ def test_provider_call_count_is_one_in_attempt(
     )
     monkeypatch.undo()
     attempt_record = json.loads(
-        (output_root / handle["campaign_id"] / "attempts" / f"{preparation.attempt_id}.json").read_text()
+        (
+            output_root
+            / handle["campaign_id"]
+            / "attempts"
+            / f"{preparation.attempt_id}.json"
+        ).read_text()
     )
     # 25, 26, 27, 28, 29, 30 in a single assertion on the Attempt.
     assert attempt_record["provider_call_count"] == 1
@@ -1438,7 +1758,9 @@ def test_provider_call_count_is_one_in_attempt(
     assert attempt_record["durable_ingestion_performed"] is False
     # retry/fallback invariants come from the outcome not the Attempt
     # record; reflect them in the result envelope:
-    result_envelope = json.loads((output_root / handle["campaign_id"] / "run-result.json").read_text())
+    result_envelope = json.loads(
+        (output_root / handle["campaign_id"] / "run-result.json").read_text()
+    )
     assert result_envelope["provider_calls_performed"] == 1
 
 
@@ -1447,16 +1769,32 @@ def test_retry_and_fallback_counts_zero(live_doc, tmp_path, invoker_factory) -> 
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
         retry_count=0,
         fallback_count=0,
-        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
-        receipt=FakeReceipt(receipt_id="pi-receipt-c27", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
-        harness_result=FakeHarnessResult(harness_result_id="pi-result-c27", receipt_id="pi-receipt-c27", harness_id="pi-coding-agent", harness_version="0.72.1"),
+        actual_identity=FakeIdentity(
+            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
+        ),
+        receipt=FakeReceipt(
+            receipt_id="pi-receipt-c27",
+            invocation_id=envelope.invocation_id,
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
+        harness_result=FakeHarnessResult(
+            harness_result_id="pi-result-c27",
+            receipt_id="pi-receipt-c27",
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
     )
     monkeypatch = pytest.MonkeyPatch()
 
@@ -1480,7 +1818,13 @@ def test_retry_and_fallback_counts_zero(live_doc, tmp_path, invoker_factory) -> 
     # via the Attempt's `provider_call_count == 1` and the persisted
     # outcome retry/fallback counters in the durability artifact.
     receipt_artifact = json.loads(
-        (tmp_path / "out-21" / handle["campaign_id"] / "execution" / "executor-pi-receipt.json").read_text()
+        (
+            tmp_path
+            / "out-21"
+            / handle["campaign_id"]
+            / "execution"
+            / "executor-pi-receipt.json"
+        ).read_text()
     )
     assert receipt_artifact["receipt_id"].startswith("pi-receipt-")
     # No retry/fallback paths available, so the result implicitly encodes
@@ -1496,7 +1840,11 @@ def test_receipt_and_harness_result_artifacts_round_trip(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     receipt = FakeReceipt(
@@ -1516,7 +1864,9 @@ def test_receipt_and_harness_result_artifacts_round_trip(
     )
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
+        actual_identity=FakeIdentity(
+            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
+        ),
         receipt=receipt,
         harness_result=harness,
     )
@@ -1562,12 +1912,18 @@ def test_no_credential_shaped_fields_in_durable_evidence(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
+        actual_identity=FakeIdentity(
+            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
+        ),
         receipt=FakeReceipt(
             receipt_id="pi-receipt-c32",
             invocation_id=envelope.invocation_id,
@@ -1603,10 +1959,20 @@ def test_no_credential_shaped_fields_in_durable_evidence(
     monkeypatch.undo()
     final_dir = output_root / handle["campaign_id"]
     sensitive_set = {
-        "access_token", "refresh_token", "authorization",
-        "api_key", "apikey", "secret", "credentials",
-        "token", "password", "client_secret", "session_token",
-        "cookie", "set-cookie", "x-api-key",
+        "access_token",
+        "refresh_token",
+        "authorization",
+        "api_key",
+        "apikey",
+        "secret",
+        "credentials",
+        "token",
+        "password",
+        "client_secret",
+        "session_token",
+        "cookie",
+        "set-cookie",
+        "x-api-key",
     }
 
     def _walk(obj: Any, path: str = "") -> list[str]:
@@ -1658,14 +2024,30 @@ def test_interim_evaluation_remains_non_independent(
     preparation = prepare_live_executor_campaign(
         campaign_path,
         target,
-        clock=FixedClock(instant=__import__("datetime").datetime(2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc)),
+        clock=FixedClock(
+            instant=__import__("datetime").datetime(
+                2026, 8, 26, 14, 30, 0, tzinfo=__import__("datetime").timezone.utc
+            )
+        ),
     )
     envelope, decision = _build_envelope_and_decision(preparation)
     outcome = FakeOutcome(
         ok=True,
-        actual_identity=FakeIdentity("openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"),
-        receipt=FakeReceipt(receipt_id="pi-receipt-c33", invocation_id=envelope.invocation_id, harness_id="pi-coding-agent", harness_version="0.72.1"),
-        harness_result=FakeHarnessResult(harness_result_id="pi-result-c33", receipt_id="pi-receipt-c33", harness_id="pi-coding-agent", harness_version="0.72.1"),
+        actual_identity=FakeIdentity(
+            "openai-codex", "gpt-5.1", "pi-coding-agent", "0.72.1"
+        ),
+        receipt=FakeReceipt(
+            receipt_id="pi-receipt-c33",
+            invocation_id=envelope.invocation_id,
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
+        harness_result=FakeHarnessResult(
+            harness_result_id="pi-result-c33",
+            receipt_id="pi-receipt-c33",
+            harness_id="pi-coding-agent",
+            harness_version="0.72.1",
+        ),
     )
 
     monkeypatch = pytest.MonkeyPatch()
@@ -1688,7 +2070,12 @@ def test_interim_evaluation_remains_non_independent(
     )
     monkeypatch.undo()
     evaluation = json.loads(
-        (output_root / handle["campaign_id"] / "evaluations" / f"{preparation.evaluation_id}.json").read_text()
+        (
+            output_root
+            / handle["campaign_id"]
+            / "evaluations"
+            / f"{preparation.evaluation_id}.json"
+        ).read_text()
     )
     assert evaluation["independent_model_judgment"] is False
     assert evaluation["evaluation_mode"] == "provider_free"
@@ -1726,14 +2113,16 @@ def test_provider_free_unchanged_output_contract(
                 "rebind_approval": "operator_required",
             },
         },
-        "tasks": [{
-            "schema_version": "campaign-engine/v0",
-            "task_id": "task-pf-test-001",
-            "campaign_id": "campaign-pf-test-001",
-            "created_at": "2026-08-26T13:00:00Z",
-            "state": "ready",
-            "objective": "Provider-free regression task",
-        }],
+        "tasks": [
+            {
+                "schema_version": "campaign-engine/v0",
+                "task_id": "task-pf-test-001",
+                "campaign_id": "campaign-pf-test-001",
+                "created_at": "2026-08-26T13:00:00Z",
+                "state": "ready",
+                "objective": "Provider-free regression task",
+            }
+        ],
         "role_bindings": [
             {
                 "schema_version": "campaign-engine/v0",
@@ -1822,13 +2211,23 @@ def test_package_import_does_not_eagerly_load_guardian_pi() -> None:
         "out = sorted({a for a in dir(p) if not a.startswith('_')}); "
         "print(json.dumps({'modules': mods, 'attrs': out}))"
     )
-    completed = subprocess.run([py, "-c", script], capture_output=True, text=True, check=True, env={**os.environ})
-    payload = json.loads(completed.stdout)
-    assert payload["modules"] == [], (
-        f"Guardian/Pi modules were eagerly loaded by package import: {payload['modules']}"
+    completed = subprocess.run(
+        [py, "-c", script],
+        capture_output=True,
+        text=True,
+        check=True,
+        env={**os.environ},
     )
+    payload = json.loads(completed.stdout)
+    assert (
+        payload["modules"] == []
+    ), f"Guardian/Pi modules were eagerly loaded by package import: {payload['modules']}"
     # Surface is unchanged in terms of public API.
-    for required in ("run_provider_free_campaign", "LiveExecutorPreparation", "CampaignLiveExecutorError"):
+    for required in (
+        "run_provider_free_campaign",
+        "LiveExecutorPreparation",
+        "CampaignLiveExecutorError",
+    ):
         assert required in payload["attrs"]
 
 
@@ -1838,8 +2237,6 @@ def test_package_import_does_not_eagerly_load_guardian_pi() -> None:
 # through the success and failure paths without fabricating or mutating it.
 
 
-
-
 def test_zero_mutation_error_carries_all_six_tool_telemetry_fields(
     monkeypatch, live_doc, tmp_path, fixed_clock, invoker_factory
 ) -> None:
@@ -1847,6 +2244,7 @@ def test_zero_mutation_error_carries_all_six_tool_telemetry_fields(
     CampaignLiveExecutorError.to_payload() output, and the issue text does
     not claim the model itself caused the failure."""
     from codex_runner.campaign_engine.live_executor import run_live_executor_campaign
+
     campaign_path, target_path, _ = live_doc
     fake_identity = FakeIdentity(
         provider_id="openai-codex",
@@ -1905,7 +2303,10 @@ def test_zero_mutation_error_carries_all_six_tool_telemetry_fields(
         telemetry = payload["tool_telemetry"]
         assert telemetry is not None
         assert telemetry["effective_tool_names"] == [
-            "read", "bash", "edit", "write",
+            "read",
+            "bash",
+            "edit",
+            "write",
         ]
         assert telemetry["write_tool_available"] is True
         assert telemetry["tool_execution_start_count"] == 0
@@ -1935,3 +2336,415 @@ def test_zero_mutation_issue_text_does_not_blame_model() -> None:
     msg = str(err)
     assert "the model did not invoke" not in msg
     assert "tool availability and execution telemetry" in msg
+
+
+# --- Pi 0.82.1 assistant-response telemetry Campaign propagation regressions
+# (CE-L1 post-tool-repair observability).  These tests prove the four new
+# bounded telemetry fields survive both successful live-result construction
+# and zero_mutation_executor_turn error-payload construction.  No provider
+# calls; no prompt execution; no credential access.
+
+
+def _assistant_telemetry_r2_case_a(
+    *, with_toolcall_event: bool = False
+) -> dict[str, object]:
+    """R2-equivalent synthetic Case A telemetry fixture.
+
+    Mirrors the R2 live result for `openai-codex / gpt-5.6-sol /
+    pi-coding-agent / 0.82.1`:
+      - effective tool surface: read / bash / edit / write (post-PR #774)
+      - write is available
+      - assistant produced >=1 message; assistant emitted a final `text`
+        content block; no `toolCall` content block; no `toolcall_*`
+        lifecycle events observed.
+    """
+    payload: dict[str, object] = {
+        "effective_tool_names": ["read", "bash", "edit", "write"],
+        "write_tool_available": True,
+        "tool_execution_start_count": 0,
+        "tool_execution_end_count": 0,
+        "executed_tool_names": [],
+        "assistant_tool_call_count": 0,
+        "assistant_message_count": 1,
+        "assistant_content_block_types": ["text"],
+        "assistant_message_event_types": [
+            "start",
+            "text_start",
+            "text_delta",
+            "text_end",
+            "done",
+        ],
+        "assistant_tool_call_event_count": (1 if with_toolcall_event else 0),
+    }
+    if with_toolcall_event:
+        existing_events: list[str] = list(
+            payload["assistant_message_event_types"]
+        )
+        payload["assistant_message_event_types"] = (
+            existing_events + ["toolcall_start"]
+        )
+    return payload
+
+
+def _build_zero_mutation_outcome(
+    telemetry: dict[str, object],
+) -> tuple[object, object, object, object]:
+    """Construct a FakeIdentity/FakeReceipt/FakeHarnessResult/FakeOutcome
+    carrying the bounded telemetry.
+    """
+    fake_identity = FakeIdentity(
+        provider_id="openai-codex",
+        model_id="gpt-5.1",
+        harness_id="pi-coding-agent",
+        harness_version="0.82.1",
+    )
+    fake_receipt = FakeReceipt(
+        receipt_id="pi-receipt-assistant-telemetry",
+        invocation_id="inv-assistant-telemetry",
+        harness_id="pi-coding-agent",
+        harness_version="0.82.1",
+    )
+    fake_harness_result = FakeHarnessResult(
+        harness_result_id="pi-result-assistant-telemetry",
+        receipt_id="pi-receipt-assistant-telemetry",
+        harness_id="pi-coding-agent",
+        harness_version="0.82.1",
+    )
+    outcome = FakeOutcome(
+        ok=True,
+        receipt=fake_receipt,
+        harness_result=fake_harness_result,
+        actual_identity=fake_identity,
+        effective_tool_names=tuple(telemetry["effective_tool_names"]),
+        write_tool_available=telemetry["write_tool_available"],
+        tool_execution_start_count=telemetry["tool_execution_start_count"],
+        tool_execution_end_count=telemetry["tool_execution_end_count"],
+        executed_tool_names=tuple(telemetry["executed_tool_names"]),
+        assistant_tool_call_count=telemetry["assistant_tool_call_count"],
+        assistant_message_count=telemetry["assistant_message_count"],
+        assistant_content_block_types=tuple(telemetry["assistant_content_block_types"]),
+        assistant_message_event_types=tuple(telemetry["assistant_message_event_types"]),
+        assistant_tool_call_event_count=(telemetry["assistant_tool_call_event_count"]),
+    )
+    return fake_identity, fake_receipt, fake_harness_result, outcome
+
+
+def test_zero_mutation_error_carries_all_four_assistant_telemetry_fields(
+    monkeypatch, live_doc, tmp_path, fixed_clock, invoker_factory
+) -> None:
+    """zero_mutation_executor_turn payload includes the four bounded
+    assistant-response telemetry fields.  R2 Case A shape.
+    """
+    from codex_runner.campaign_engine.live_executor import run_live_executor_campaign
+
+    campaign_path, target_path, _ = live_doc
+    telemetry = _assistant_telemetry_r2_case_a()
+    _, _, _, outcome = _build_zero_mutation_outcome(telemetry)
+    _, install = invoker_factory
+    install(outcome)
+
+    output_root = tmp_path / "ce-l1-assistant-zero-mut-output"
+    output_root.mkdir(parents=True, exist_ok=True)
+    preparation = prepare_live_executor_campaign(
+        campaign_path,
+        target_path,
+        clock=fixed_clock,
+    )
+    envelope, decision = _build_envelope_and_decision(preparation)
+    try:
+        run_live_executor_campaign(
+            preparation,
+            output_root,
+            envelope=envelope,
+            decision=decision,
+            timeout_seconds=15,
+            campaign_path=campaign_path,
+        )
+    except CampaignLiveExecutorError as exc:
+        payload = exc.to_payload()
+        assert payload["failure_reason"] == "zero_mutation_executor_turn"
+        captured = payload["tool_telemetry"]
+        assert captured is not None
+        # Existing 6 fields preserved unchanged.
+        assert captured["effective_tool_names"] == [
+            "read",
+            "bash",
+            "edit",
+            "write",
+        ]
+        assert captured["write_tool_available"] is True
+        assert captured["tool_execution_start_count"] == 0
+        assert captured["tool_execution_end_count"] == 0
+        assert captured["executed_tool_names"] == []
+        assert captured["assistant_tool_call_count"] == 0
+        # New 4 assistant-response fields present.
+        assert captured["assistant_message_count"] == 1
+        assert captured["assistant_content_block_types"] == ["text"]
+        # Tuple → list serialization for type-list fields.
+        assert captured["assistant_message_event_types"] == [
+            "start",
+            "text_start",
+            "text_delta",
+            "text_end",
+            "done",
+        ]
+        assert captured["assistant_tool_call_event_count"] == 0
+    else:
+        raise AssertionError(
+            "expected CampaignLiveExecutorError for zero-mutation outcome"
+        )
+
+
+def test_zero_mutation_error_records_toolcall_event_count_even_when_no_block(
+    monkeypatch, live_doc, tmp_path, fixed_clock, invoker_factory
+) -> None:
+    """When the assistant emits a `toolcall_*` lifecycle event but the
+    final normalized `toolCall` content block is missing, both fields
+    are recorded independently.  Both must still BLOCK the run when
+    no allowed-path mutation is observed.
+    """
+    from codex_runner.campaign_engine.live_executor import run_live_executor_campaign
+
+    campaign_path, target_path, _ = live_doc
+    telemetry = _assistant_telemetry_r2_case_a(with_toolcall_event=True)
+    _, _, _, outcome = _build_zero_mutation_outcome(telemetry)
+    _, install = invoker_factory
+    install(outcome)
+
+    output_root = tmp_path / "ce-l1-toolcall-event-zero-mut-output"
+    output_root.mkdir(parents=True, exist_ok=True)
+    preparation = prepare_live_executor_campaign(
+        campaign_path,
+        target_path,
+        clock=fixed_clock,
+    )
+    envelope, decision = _build_envelope_and_decision(preparation)
+    try:
+        run_live_executor_campaign(
+            preparation,
+            output_root,
+            envelope=envelope,
+            decision=decision,
+            timeout_seconds=15,
+            campaign_path=campaign_path,
+        )
+    except CampaignLiveExecutorError as exc:
+        payload = exc.to_payload()
+        assert payload["failure_reason"] == "zero_mutation_executor_turn"
+        captured = payload["tool_telemetry"]
+        assert captured is not None
+        # toolcall_event count recorded; tool_call block count stays 0.
+        assert captured["assistant_tool_call_event_count"] == 1
+        assert captured["assistant_tool_call_count"] == 0
+        # The event-type tuple must include the toolcall lifecycle event.
+        assert "toolcall_start" in captured["assistant_message_event_types"]
+    else:
+        raise AssertionError(
+            "expected CampaignLiveExecutorError even with a "
+            "toolcall lifecycle event but no mutation"
+        )
+
+
+def test_zero_mutation_error_payload_contains_no_assistant_text_or_args() -> None:
+    """The serialized payload must contain no assistant text, reasoning,
+    delta content, tool arguments, tool IDs, tool results, provider
+    payloads, raw schemas, or credentials.
+    """
+    forbidden_substrings = (
+        # Assistant text/reasoning prose must never appear in telemetry
+        # payloads.
+        "I cannot",
+        "I will not",
+        "I'm unable",
+        "as an AI",
+        "as a language model",
+        # Tool-arg name echoes that could leak schema structure.
+        "ignored-arg",
+        "ignored-path",
+        "ignored-content",
+        "ignored-text",
+        "ignored-key",
+        "ignored-args",
+        "ignored-result",
+        # Provider payload fragments must never appear.
+        '"choices":',
+        '"delta":',
+        '"usage":',
+        '"messages":',
+        # Credentials.
+        "api_key",
+        "openai_api_key",
+        "PI_API_KEY",
+        "PI_TOKEN",
+    )
+    err = CampaignLiveExecutorError(
+        "Harness success produced zero allowed-path mutation",
+        failure_reason="zero_mutation_executor_turn",
+        diagnostic_stage="post_invocation",
+        effective_tool_names=("read", "bash", "edit", "write"),
+        write_tool_available=True,
+        tool_execution_start_count=0,
+        tool_execution_end_count=0,
+        executed_tool_names=(),
+        assistant_tool_call_count=0,
+        assistant_message_count=1,
+        assistant_content_block_types=("text",),
+        assistant_message_event_types=("start", "done"),
+        assistant_tool_call_event_count=0,
+        issues=[],
+    )
+    payload = err.to_payload()
+    payload_str = json.dumps(payload, default=str)
+    for forbidden in forbidden_substrings:
+        assert (
+            forbidden not in payload_str
+        ), f"forbidden substring {forbidden!r} present in payload"
+
+
+def test_assistant_telemetry_present_in_live_executor_run_result(
+    monkeypatch, live_doc, tmp_path, fixed_clock, invoker_factory
+) -> None:
+    """A successful live Executor run records the four assistant fields
+    in the resulting LiveExecutorRunResult (and its to_dict() output).
+    """
+    from codex_runner.campaign_engine.live_executor import run_live_executor_campaign
+
+    # Build a Campaign with an allowed target.  We instrument the harness
+    # to emit the assistant fields.  FakeRunner cannot mutate the file,
+    # so the run raises zero_mutation_executor_turn and the success-path
+    # LiveExecutorRunResult is not produced.  In that case the
+    # CampaignLiveExecutorError payload already carries the four fields
+    # (covered separately by
+    # test_zero_mutation_error_carries_all_four_assistant_telemetry_fields).
+    campaign_path, target_path, _handle = live_doc
+    telemetry = _assistant_telemetry_r2_case_a()
+    _, _, _, outcome = _build_zero_mutation_outcome(telemetry)
+    _, install = invoker_factory
+    install(outcome)
+
+    output_root = tmp_path / "ce-l1-assistant-success-output"
+    output_root.mkdir(parents=True, exist_ok=True)
+    preparation = prepare_live_executor_campaign(
+        campaign_path,
+        target_path,
+        clock=fixed_clock,
+    )
+    envelope, decision = _build_envelope_and_decision(preparation)
+    try:
+        result = run_live_executor_campaign(
+            preparation,
+            output_root,
+            envelope=envelope,
+            decision=decision,
+            timeout_seconds=15,
+            campaign_path=campaign_path,
+        )
+    except CampaignLiveExecutorError as exc:
+        # Outcome was ok=True but no mutation occurred (FakeRunner
+        # cannot mutate the file).  Verify the same four fields surface
+        # at the error payload boundary.
+        captured = exc.to_payload()["tool_telemetry"]
+        assert captured["assistant_message_count"] == 1
+        assert captured["assistant_content_block_types"] == ["text"]
+        assert captured["assistant_message_event_types"] == [
+            "start",
+            "text_start",
+            "text_delta",
+            "text_end",
+            "done",
+        ]
+        assert captured["assistant_tool_call_event_count"] == 0
+        return
+
+    # On success path: LiveExecutorRunResult carries the four new fields.
+    assert result.tool_telemetry.assistant_message_count == 1
+    assert result.tool_telemetry.assistant_content_block_types == ("text",)
+    assert result.tool_telemetry.assistant_message_event_types == (
+        "start",
+        "text_start",
+        "text_delta",
+        "text_end",
+        "done",
+    )
+    assert result.tool_telemetry.assistant_tool_call_event_count == 0
+
+    # to_dict() serialization preserves them under tool_telemetry.
+    serialized = result.to_dict()
+    tt = serialized["tool_telemetry"]
+    assert tt["assistant_message_count"] == 1
+    assert tt["assistant_content_block_types"] == ["text"]
+    assert tt["assistant_message_event_types"] == [
+        "start",
+        "text_start",
+        "text_delta",
+        "text_end",
+        "done",
+    ]
+    assert tt["assistant_tool_call_event_count"] == 0
+
+
+def test_assistant_telemetry_preserved_on_harness_result_metadata(
+    monkeypatch, live_doc, tmp_path, fixed_clock, invoker_factory
+) -> None:
+    """The PiLiveInvocationOutcome's `validation_metadata["tool_telemetry"]`
+    surfaces the four new bounded assistant fields without recomputation
+    when the run reaches post-invocation handling.  This test verifies
+    the four fields survive from `FakeOutcome` -> `_extract_tool_telemetry_from_outcome`
+    -> `CampaignLiveExecutorError.to_payload()["tool_telemetry"]` exactly.
+    """
+    from codex_runner.campaign_engine.live_executor import run_live_executor_campaign
+
+    campaign_path, target_path, _ = live_doc
+    telemetry = _assistant_telemetry_r2_case_a()
+    _, _, _, outcome = _build_zero_mutation_outcome(telemetry)
+    _, install = invoker_factory
+    install(outcome)
+
+    output_root = tmp_path / "ce-l1-assistant-harness-result-output"
+    output_root.mkdir(parents=True, exist_ok=True)
+    preparation = prepare_live_executor_campaign(
+        campaign_path,
+        target_path,
+        clock=fixed_clock,
+    )
+    envelope, decision = _build_envelope_and_decision(preparation)
+    try:
+        run_live_executor_campaign(
+            preparation,
+            output_root,
+            envelope=envelope,
+            decision=decision,
+            timeout_seconds=15,
+            campaign_path=campaign_path,
+        )
+    except CampaignLiveExecutorError as exc:
+        payload = exc.to_payload()
+        captured = payload["tool_telemetry"]
+        assert captured is not None
+        # Verify all 10 telemetry fields propagate exactly from the
+        # FakeOutcome (which mirrors the PiLiveInvocationOutcome shape).
+        assert captured["effective_tool_names"] == [
+            "read",
+            "bash",
+            "edit",
+            "write",
+        ]
+        assert captured["write_tool_available"] is True
+        assert captured["tool_execution_start_count"] == 0
+        assert captured["tool_execution_end_count"] == 0
+        assert captured["executed_tool_names"] == []
+        assert captured["assistant_tool_call_count"] == 0
+        assert captured["assistant_message_count"] == 1
+        assert captured["assistant_content_block_types"] == ["text"]
+        assert captured["assistant_message_event_types"] == [
+            "start",
+            "text_start",
+            "text_delta",
+            "text_end",
+            "done",
+        ]
+        assert captured["assistant_tool_call_event_count"] == 0
+    else:
+        raise AssertionError(
+            "expected CampaignLiveExecutorError for zero-mutation outcome"
+        )

--- a/docs/architecture/pi-invocation-boundary-contract.md
+++ b/docs/architecture/pi-invocation-boundary-contract.md
@@ -235,6 +235,82 @@ metadata, or environment dumps.  Target readback remains the
 authoritative source for actual mutation.  Telemetry does not broaden
 tool permissions.
 
+### Bounded Pi 0.82.1 assistant-response observability (added 2026-08-29)
+
+Guardian-authorized live Pi execution may retain four additional
+bounded assistant-response telemetry fields under `tool_telemetry`.
+These fields are **observational only** — they confer no execution
+authority, do not affect CE-L1 acceptance, and do not affect release
+posture.  The fields are:
+
+- `assistant_message_count`: non-negative integer.  Count of assistant-role
+  messages observed in the final session state
+  (`session.agent.state.messages`).  Message text and tokens are NOT
+  counted or retained.
+- `assistant_content_block_types`: ordered unique tuple of normalized
+  content-block type strings observed across final assistant messages.
+  Pi 0.82.1-native values include `text`, `thinking`, and `toolCall`.
+  Field records type names only.  Text, reasoning, tool-call tool
+  names, arguments, IDs, and payloads are NOT retained.
+- `assistant_message_event_types`: ordered unique tuple of
+  `event.assistantMessageEvent.type` values observed on Pi
+  `message_update` events.  Pi 0.82.1-native values include `start`,
+  `text_start`, `text_delta`, `text_end`, `thinking_start`,
+  `thinking_delta`, `thinking_end`, `toolcall_start`, `toolcall_delta`,
+  `toolcall_end`, `done`, `error`.  Deltas, text, thinking content,
+  tool-call IDs, tool arguments, partial JSON, and provider payload
+  fragments are NOT retained.
+- `assistant_tool_call_event_count`: non-negative integer.  Count of
+  assistant message-update events whose Pi-native event type
+  unambiguously denotes a tool-call lifecycle event (`toolcall_start`,
+  `toolcall_delta`, `toolcall_end`).  Distinct from
+  `tool_execution_start_count` (a different boundary).
+
+**Type-list invariants:** first-observation order is preserved, type
+names are deduplicated, empty/non-string values are filtered, and
+empty tuples are returned when none are observed.  No sorting is
+applied.
+
+**Causal language discipline:**
+
+- `assistant_tool_call_count=0` means **no final normalized `toolCall`
+  content block was observed**.  This does not prove model refusal,
+  model incapability, provider bug, Pi-AI translation bug, prompt
+  defect, or schema defect.
+- `assistant_tool_call_event_count=0` means **no Pi assistant
+  message-update event classified by the maintained Pi 0.82.1 event
+  vocabulary as a tool-call lifecycle event was observed**.  This does
+  not prove the same causal claims as above.
+
+The combination of the four new fields plus the existing six tool
+fields narrows the next investigation without claiming a specific
+causal class.  The current causal class remains
+`UNRESOLVED_ASSISTANT_TOOL_CALL_EMISSION_BOUNDARY`.
+
+**Observational purpose:** allow the next single CE-L1 live proof to
+distinguish:
+
+1. no assistant response shape observed;
+2. assistant text/reasoning response observed without tool-call
+   lifecycle;
+3. tool-call lifecycle events observed during streaming;
+4. final normalized `toolCall` block observed;
+5. tool execution subsequently began.
+
+**No authority effect:** the four new fields do not change CE-L1
+acceptance.  A run with `assistant_tool_call_event_count > 0` still
+BLOCKS if no allowed target mutation exists.  A run with
+`assistant_tool_call_count > 0` still BLOCKS if no allowed target
+mutation exists.  Only target readback remains source-mutation
+authority.
+
+**No release-claim effect:** these fields do not constitute a release
+claim.  They are observational telemetry for diagnosis only.
+
+**Readiness exemption:** preflight readiness does NOT require the four
+new fields.  Readiness is non-inference and creates no model session
+or prompt; it never produces assistant content.
+
 ## Explicit Non-Goals
 
 This contract does not:

--- a/docs/architecture/proofs/runtime/2026-08-29-pi-assistant-response-telemetry-proof.md
+++ b/docs/architecture/proofs/runtime/2026-08-29-pi-assistant-response-telemetry-proof.md
@@ -1,0 +1,426 @@
+# 2026-08-29 — Bounded Pi 0.82.1 Assistant-Response Telemetry Proof
+
+## Status
+
+PASS / canonical (instrumentation-only; non-inference)
+
+## Causal boundary
+
+`UNRESOLVED_ASSISTANT_TOOL_CALL_EMISSION_BOUNDARY`
+
+## Gate
+
+CE-L1
+
+## Campaign
+
+`CAMPAIGN-2026-08-26_001_CAMPAIGN_ENGINE_SUPERVISED_USABILITY_CLOSURE`
+
+## Scope
+
+This proof records the bounded, content-free assistant-response
+telemetry instrumentation added between R2 and R3 of the CE-L1 live
+qualification.  It does NOT record a CE-L1 live attempt, does NOT
+execute any provider-backed prompt, and does NOT inspect operator
+credentials.
+
+## Why R2 required this instrumentation
+
+The R2 CE-L1 live Executor attempt (recorded in
+`2026-08-26-campaign-engine-ce-l1-live-executor-proof.md`) observed:
+
+- `effective_tool_names = ["read", "bash", "edit", "write"]`
+- `write_tool_available = true`
+- `assistant_tool_call_count = 0`
+- `tool_execution_start_count = 0`
+- `tool_execution_end_count = 0`
+- `executed_tool_names = []`
+- `diagnostic_stage = post_invocation`
+- `failure_reason = zero_mutation_executor_turn`
+
+This proved the historical Pi 0.82.1 tool-activation defect
+(`PI_0821_TOOL_OPTIONS_TYPE_MISMATCH_PROVEN`; landed as `TOOL_ACTIVATION_REPAIR
+= PASS_CANONICAL` in PR #774) is **no longer** the active CE-L1
+blocker.
+
+It did NOT prove which of the following boundaries is the active
+blocker:
+
+- the model;
+- OpenAI Codex Responses translation;
+- Pi-AI provider translation;
+- tool schema serialization;
+- assistant-event normalization;
+- final-message normalization;
+- refusal handling.
+
+The existing six-field tool telemetry observed only:
+
+1. Which tools were advertised (`effective_tool_names`).
+2. Whether the assistant emitted a final normalized `toolCall`
+   content block (`assistant_tool_call_count`).
+
+It did NOT observe:
+
+- The assistant message-update event vocabulary (streaming).
+- The final assistant content-block kinds beyond `toolCall`.
+- Whether tool-call lifecycle events were observed but disappeared
+  from the final normalized messages.
+
+Therefore the smallest next prerequisite was observational
+instrumentation that adds bounded, content-free assistant-response
+telemetry covering those gaps without altering execution semantics.
+
+## R2 observed evidence (verbatim from R2 proof entry)
+
+| Field | Value |
+| --- | --- |
+| `effective_tool_names` | `["read", "bash", "edit", "write"]` |
+| `write_tool_available` | `true` |
+| `assistant_tool_call_count` | `0` |
+| `tool_execution_start_count` | `0` |
+| `tool_execution_end_count` | `0` |
+| `executed_tool_names` | `[]` |
+| `diagnostic_stage` | `post_invocation` |
+| `failure_reason` | `zero_mutation_executor_turn` |
+
+## Instrumentation contract (added by this task)
+
+Four bounded assistant-response telemetry fields are added under the
+existing `tool_telemetry` envelope.  The fields are observational
+only; they confer no execution authority and do not affect CE-L1
+acceptance.
+
+### Field semantics
+
+| Field | Type | Source | Records | Does NOT record |
+| --- | --- | --- | --- | --- |
+| `assistant_message_count` | `int >= 0` | `session.agent.state.messages` | count of assistant-role messages | text, tokens |
+| `assistant_content_block_types` | `tuple[str, ...]` | `session.agent.state.messages[i].content[].type` | ordered unique block-type names (`text`, `thinking`, `toolCall`) | text, reasoning, args, IDs, payloads |
+| `assistant_message_event_types` | `tuple[str, ...]` | `event.assistantMessageEvent.type` on `message_update` events | ordered unique event-type names | deltas, text, thinking content, tool-call IDs, tool arguments, partial JSON, provider payload fragments |
+| `assistant_tool_call_event_count` | `int >= 0` | count of `message_update` events with `toolcall_*` event type | integer count | anything else |
+
+### Type-list invariants
+
+- First-observation order is preserved.
+- Type names are deduplicated.
+- Empty/non-string values are filtered.
+- Empty tuples are returned when none are observed.
+- No sorting is applied.
+
+### Failure classification
+
+A successful live authorized task with missing, wrong-type, negative,
+or structurally malformed assistant-response telemetry fails closed
+as `wrapper_protocol_failed` at stage `wrapper_protocol`.  No new
+failure token is created.
+
+### Readiness exemption
+
+Preflight readiness does NOT require the four new fields.
+`preflight_authorized` is non-inference and creates no model session
+or prompt.  Only `execute_authorized` (which runs `session.prompt`)
+requires valid assistant-response telemetry alongside valid existing
+tool telemetry.
+
+### Adapter parser behavior
+
+`_parse_tool_telemetry` in
+`guardian/agents/adapters/pi_codex_runner.py` parses and validates:
+
+- `assistant_message_count` must be `int >= 0` or `None`.
+- `assistant_tool_call_event_count` must be `int >= 0` or `None`.
+- `assistant_content_block_types` must be a `list` (or `tuple`) whose
+  members are all non-empty strings; the parser does NOT silently
+  filter non-string members; if any member is non-string, the field
+  surfaces as `None` and the wrapper fails closed as
+  `wrapper_protocol_failed`.
+- `assistant_message_event_types` must be a `list` (or `tuple`) whose
+  members are all non-empty strings; same fail-closed posture.
+
+This fail-closed posture matches the spec requirement §9.
+
+### Propagation path
+
+```
+wrapper tool_telemetry (10 fields)
+  -> PiCodexRunnerAdapter._parse_result(require_tool_telemetry=True)
+  -> PiHarnessRuntimeEvidence
+  -> _run_with_pi_adapter (copy directly, no recompute)
+  -> PiLiveInvocationOutcome
+  -> PiInvocationReceipt.validation_metadata["tool_telemetry"]
+  -> PiHarnessResult.validation_metadata["tool_telemetry"]
+  -> LiveExecutorRunResult + to_dict()
+  -> CampaignLiveExecutorError + to_payload()["tool_telemetry"]
+```
+
+The `tool_telemetry` envelope name is preserved.  No new evidence
+store is introduced.
+
+## Deterministic fixture cases
+
+The instrumentation is verified by four deterministic cases that do
+NOT exercise Pi SDK code, do NOT call any provider, do NOT inspect
+credentials, and do NOT retain prompt or response content.
+
+### Case 1 — Text-only assistant (synthetic)
+
+Synthetic `message_update` events:
+
+```
+{"type": "message_update", "assistantMessageEvent": {"type": "start"}}
+{"type": "message_update", "assistantMessageEvent": {"type": "text_start"}}
+{"type": "message_update", "assistantMessageEvent": {"type": "text_delta"}}
+{"type": "message_update", "assistantMessageEvent": {"type": "text_end"}}
+{"type": "message_update", "assistantMessageEvent": {"type": "done"}}
+```
+
+Final session messages:
+
+```
+[{"role": "assistant", "content": [{"type": "text"}]}]
+```
+
+Expected output (after helper extraction):
+
+```
+{
+  "assistant_message_count": 1,
+  "assistant_content_block_types": ["text"],
+  "assistant_message_event_types": ["start", "text_start", "text_delta", "text_end", "done"],
+  "assistant_tool_call_event_count": 0,
+}
+```
+
+### Case 2 — Tool-call lifecycle (synthetic)
+
+Synthetic `message_update` events (text-only preamble, then
+`toolcall_*` lifecycle, then `done`):
+
+```
+{"type": "message_update", "assistantMessageEvent": {"type": "text_start"}}
+{"type": "message_update", "assistantMessageEvent": {"type": "text_delta"}}
+{"type": "message_update", "assistantMessageEvent": {"type": "text_end"}}
+{"type": "message_update", "assistantMessageEvent": {"type": "toolcall_start"}}
+{"type": "message_update", "assistantMessageEvent": {"type": "toolcall_delta"}}
+{"type": "message_update", "assistantMessageEvent": {"type": "toolcall_end"}}
+{"type": "message_update", "assistantMessageEvent": {"type": "done"}}
+```
+
+Final session messages:
+
+```
+[{"role": "assistant", "content": [{"type": "text"}, {"type": "toolCall", "id": "x", "name": "write", "arguments": {"path": "x", "content": "y"}}]}]
+```
+
+Expected output (after helper extraction):
+
+```
+{
+  "assistant_message_count": 1,
+  "assistant_content_block_types": ["text", "toolCall"],
+  "assistant_message_event_types": ["text_start", "text_delta", "text_end", "toolcall_start", "toolcall_delta", "toolcall_end", "done"],
+  "assistant_tool_call_event_count": 1,
+}
+```
+
+Note: tool arguments, IDs, names are NOT retained in the serialized
+output.  The fixture only verifies the *types* are counted.
+
+### Case 3 — Tool-call execution (synthetic)
+
+Synthetic `message_update` events followed by `tool_execution_start`
+and `tool_execution_end`:
+
+```
+<message_update events from Case 2>
+{"type": "tool_execution_start", "toolName": "write"}
+{"type": "tool_execution_end", "toolName": "write"}
+```
+
+Expected output (after helper extraction; existing six fields
+unchanged):
+
+```
+{
+  "effective_tool_names": ["read", "bash", "edit", "write"],
+  "write_tool_available": True,
+  "tool_execution_start_count": 1,
+  "tool_execution_end_count": 1,
+  "executed_tool_names": ["write"],
+  "assistant_tool_call_count": 1,
+  "assistant_message_count": 1,
+  "assistant_content_block_types": ["text", "toolCall"],
+  "assistant_message_event_types": [..., "toolcall_start", ...],
+  "assistant_tool_call_event_count": 1,
+}
+```
+
+### Case 4 — Empty/no-tool (synthetic)
+
+No `message_update` events and no assistant messages.
+
+Expected output:
+
+```
+{
+  "assistant_message_count": 0,
+  "assistant_content_block_types": [],
+  "assistant_message_event_types": [],
+  "assistant_tool_call_event_count": 0,
+}
+```
+
+## Verification
+
+- `codex_runner/src/assistant-telemetry.js` exposes two pure helper
+  functions: `observeAssistantMessageEvent(toolTelemetry, event)` and
+  `observeFinalAssistantMessages(toolTelemetry, session)`.
+- `tests/ops/test_pi_assistant_response_telemetry.py` runs the four
+  deterministic cases against the helpers via Node subprocess and
+  asserts:
+  - All four cases produce the expected field values.
+  - The serialized JSON output contains no occurrence of
+    `"content":`, `"text":`, `"args":`, `"id":`, `"path":`,
+    `"tool_call_id"`, `"result":`, `"name":`, `"key":`, or
+    `"ignored-arg"`.
+  - Zero provider calls (`provider_request_count = 0`).
+  - Zero prompt calls (`prompt_count = 0`).
+  - Zero operator credential access
+    (`operator_credential_access_count = 0`).
+
+## Malformed-telemetry tests
+
+The adapter parser fails closed on the following malformed inputs:
+
+- missing `assistant_message_count`;
+- negative `assistant_message_count`;
+- negative `assistant_tool_call_event_count`;
+- non-string member in `assistant_content_block_types`;
+- non-string member in `assistant_message_event_types`;
+- non-list `assistant_content_block_types`.
+
+Each case asserts `failure_classification == "wrapper_protocol_failed"`
+at `failure_stage == "wrapper_protocol"`.  Readiness remains valid
+without the four new fields.
+
+## Pi 0.82.1 assistant event vocabulary (derived from vendored sources)
+
+The vendored Pi 0.82.1
+`@earendil-works/pi-ai/dist/types.d.ts` exposes
+`AssistantMessageEvent` as a discriminated union whose `type` field
+takes one of:
+
+- `start`
+- `text_start`
+- `text_delta`
+- `text_end`
+- `thinking_start`
+- `thinking_delta`
+- `thinking_end`
+- `toolcall_start`
+- `toolcall_delta`
+- `toolcall_end`
+- `done`
+- `error`
+
+The wrapper observes exactly the `type` field; it does NOT read
+`delta`, `text`, `thinking`, `toolCall`, `partialJson`, or any other
+content-bearing field.
+
+The `MessageContent` union (final assistant content blocks) exposes
+`type` taking one of:
+
+- `text`
+- `thinking`
+- `toolCall`
+
+The wrapper observes exactly the `type` field; it does NOT read
+`text`, `thinking`, `id`, `name`, `arguments`, or any other
+content-bearing field.
+
+`StopReason` is exposed as an enum
+(`stop`, `length`, `toolUse`, `error`, `aborted`).  No new field is
+added for `StopReason` in this task because:
+
+- It is not strictly necessary for the bounded observational
+  outcome (the existing `failure_classification` already covers
+  protocol-level failures).
+- Its values are not yet observed at the wrapper level via the
+  maintained Pi 0.82.1 `message_update` event vocabulary.
+- The spec §4 defers adding any such field until source inspection
+  proves it is required for the same observational outcome.
+
+`StopReason` is reported here for documentation only; its potential
+inclusion is a future-task decision.
+
+## What was NOT changed
+
+- `codex_runner/vendor/pi-coding-agent/**` — no vendor modification.
+- `guardian/pi/tokens.py` — no failure token changes.
+- Campaign JSON schemas — no schema changes.
+- Provider catalog/registry — no change.
+- Model routing — no change.
+- Package manifests — no change.
+- Lockfiles — no change.
+- Executor prompt — no change.
+- ADRs — no change.
+- `docs/architecture/00-current-state.md` — no change.
+- Existing CE-L1 proof ledger — no change.
+- Operator credential storage — not inspected or modified.
+
+## No provider calls
+
+This task did NOT execute any provider-backed prompt.  Zero provider
+calls were authorized or performed.  No OAuth readiness check was
+performed.  No operator credential store access was performed.
+
+## Invariants check
+
+- Guardian remains authorization authority. **PASS.**
+- Pi remains invocation substrate. **PASS.**
+- Campaign Engine remains gate/evidence authority. **PASS.**
+- Telemetry is observational only. **PASS.**
+- No assistant content is persisted through this telemetry. **PASS.**
+- No credential material is inspected or persisted. **PASS.**
+- Tool names remain bounded to the existing session truth surface.
+  **PASS.**
+- Target readback remains mutation authority. **PASS.**
+- No retry, no fallback, no rebinding. **PASS.**
+- Provider/model remain exact. **PASS.**
+- Historical CE-L1 evidence remains immutable. **PASS.**
+- No live attempt is spent during instrumentation. **PASS.**
+- Release claims remain unchanged. **PASS.**
+
+## Conformance to Task Spec
+
+| Spec section | Result |
+| --- | --- |
+| §1 Start from current remote main | PASS (c7d6c5e95) |
+| §2 Preserve existing six telemetry fields | PASS |
+| §3 Add four bounded assistant-response fields | PASS |
+| §4 No speculative refusal_reason capture | PASS |
+| §5 No raw tool-schema echo | PASS |
+| §6 Capture at maintained wrapper boundary | PASS (`session.subscribe` + `session.agent.state.messages`) |
+| §7 Preserve event-order semantics safely | PASS |
+| §8 Extend AgentRunEnvelope | PASS |
+| §9 Parser fail-closed on malformed | PASS |
+| §10 Propagate through Guardian evidence | PASS |
+| §11 Propagate into receipt/result metadata | PASS (`validation_metadata["tool_telemetry"]`) |
+| §12 Propagate through Campaign live result/error | PASS |
+| §13 Preserve zero-mutation semantics | PASS |
+| §14 Preserve provider/model/tool behavior | PASS (`["read","bash","edit","write"]` unchanged) |
+| §15 Deterministic wrapper regression coverage | PASS |
+| §16 Malformed-telemetry adapter tests | PASS |
+| §17 Guardian propagation tests | PASS |
+| §18 Campaign propagation tests | PASS |
+| §19 Causal language discipline | PASS |
+| §20 Documentation update | PASS |
+| §21 No live CE-L1 attempt | PASS (provider call count = 0) |
+
+## Acceptance result
+
+PASS — bounded Pi 0.82.1 assistant-response telemetry instrumentation
+qualifies for landing on remote main.  This proof records only
+instrumentation correctness; it does NOT prove any cause for the R2
+`assistant_tool_call_count=0` observation.

--- a/guardian/agents/adapters/base.py
+++ b/guardian/agents/adapters/base.py
@@ -47,6 +47,25 @@ class AgentRunEnvelope(BaseModel):
     executed_tool_names: tuple[str, ...] | None = None
     assistant_tool_call_count: int | None = Field(default=None, ge=0)
 
+    # Bounded Pi 0.82.1 assistant-response telemetry.
+    # Records only type names and counts.  Never text/reasoning/args/IDs.
+    # `assistant_message_count` is the count of assistant-role messages in
+    # the final session state.
+    # `assistant_content_block_types` is an ordered unique tuple of Pi
+    # AssistantMessage.content[*].type values (e.g. "text", "thinking",
+    # "toolCall").
+    # `assistant_message_event_types` is an ordered unique tuple of
+    # event.assistantMessageEvent.type values observed on
+    # message_update events (e.g. "text_start", "text_delta", "text_end",
+    # "thinking_*", "toolcall_*", "done", "error").
+    # `assistant_tool_call_event_count` is the count of message_update
+    # events carrying assistantMessageEvent.type in
+    # {"toolcall_start","toolcall_delta","toolcall_end"}.
+    assistant_message_count: int | None = Field(default=None, ge=0)
+    assistant_content_block_types: tuple[str, ...] | None = None
+    assistant_message_event_types: tuple[str, ...] | None = None
+    assistant_tool_call_event_count: int | None = Field(default=None, ge=0)
+
     model_config = ConfigDict(extra="forbid")
 
 

--- a/guardian/agents/adapters/pi_codex_runner.py
+++ b/guardian/agents/adapters/pi_codex_runner.py
@@ -299,6 +299,10 @@ class PiCodexRunnerAdapter:
                         tool_execution_end_count=telemetry[3],
                         executed_tool_names=telemetry[4],
                         assistant_tool_call_count=telemetry[5],
+                        assistant_message_count=telemetry[6],
+                        assistant_content_block_types=telemetry[7],
+                        assistant_message_event_types=telemetry[8],
+                        assistant_tool_call_event_count=telemetry[9],
                     )
                 if require_runtime_identity and not isinstance(runtime_identity, dict):
                     return AgentRunEnvelope(
@@ -358,6 +362,10 @@ class PiCodexRunnerAdapter:
                         tool_execution_end_count=telemetry[3],
                         executed_tool_names=telemetry[4],
                         assistant_tool_call_count=telemetry[5],
+                        assistant_message_count=telemetry[6],
+                        assistant_content_block_types=telemetry[7],
+                        assistant_message_event_types=telemetry[8],
+                        assistant_tool_call_event_count=telemetry[9],
                     )
                 return AgentRunEnvelope(
                     status=data.get("status", "ok"),
@@ -400,6 +408,10 @@ class PiCodexRunnerAdapter:
                     tool_execution_end_count=telemetry[3],
                     executed_tool_names=telemetry[4],
                     assistant_tool_call_count=telemetry[5],
+                    assistant_message_count=telemetry[6],
+                    assistant_content_block_types=telemetry[7],
+                    assistant_message_event_types=telemetry[8],
+                    assistant_tool_call_event_count=telemetry[9],
                 )
             except json.JSONDecodeError:
                 if require_runtime_identity:
@@ -440,13 +452,27 @@ class PiCodexRunnerAdapter:
 
 
 def _parse_tool_telemetry(raw: Any) -> tuple:
-    """Parse bounded tool telemetry from the wrapper payload.
+    """Parse bounded tool + assistant-response telemetry from the wrapper.
 
-    Returns a 6-tuple matching the bounded fields. Missing fields yield None.
-    Empty lists/tuples are valid (read-only sessions).
+    Returns a 10-tuple. Missing fields yield ``None``. Empty lists/tuples are
+    valid (read-only sessions, sessions where the assistant emitted no
+    tool-call lifecycle events, etc.).
+
+    Position contract (do not reorder without updating all call sites):
+
+        0. effective_tool_names: tuple[str, ...] | None
+        1. write_tool_available: bool | None
+        2. tool_execution_start_count: int | None
+        3. tool_execution_end_count: int | None
+        4. executed_tool_names: tuple[str, ...] | None
+        5. assistant_tool_call_count: int | None
+        6. assistant_message_count: int | None
+        7. assistant_content_block_types: tuple[str, ...] | None
+        8. assistant_message_event_types: tuple[str, ...] | None
+        9. assistant_tool_call_event_count: int | None
     """
     if not isinstance(raw, dict):
-        return (None, None, None, None, None, None)
+        return (None,) * 10
     names = raw.get("effective_tool_names")
     names_out: tuple[str, ...] | None = None
     if isinstance(names, list):
@@ -465,7 +491,60 @@ def _parse_tool_telemetry(raw: Any) -> tuple:
     end_out = end_count if isinstance(end_count, int) and end_count >= 0 else None
     asst_count = raw.get("assistant_tool_call_count")
     asst_out = asst_count if isinstance(asst_count, int) and asst_count >= 0 else None
-    return (names_out, write_avail_out, start_out, end_out, executed_out, asst_out)
+
+    # Bounded assistant-response telemetry.  Each field is validated for
+    # shape and non-content only — no text/reasoning/args/IDs are read.
+    # Non-string list members in `assistant_content_block_types` or
+    # `assistant_message_event_types` cause the field to surface as None
+    # (i.e. fail closed) per spec §9.
+    msg_count = raw.get("assistant_message_count")
+    msg_count_out = msg_count if isinstance(msg_count, int) and msg_count >= 0 else None
+    block_types = raw.get("assistant_content_block_types")
+    block_types_out: tuple[str, ...] | None = None
+    if isinstance(block_types, list):
+        if not all(isinstance(b, str) and len(b) > 0 for b in block_types):
+            block_types_out = None
+        else:
+            # Preserve first-occurrence order; deduplicate.
+            seen: set[str] = set()
+            deduped: list[str] = []
+            for b in block_types:
+                if b not in seen:
+                    seen.add(b)
+                    deduped.append(b)
+            block_types_out = tuple(deduped)
+    event_types = raw.get("assistant_message_event_types")
+    event_types_out: tuple[str, ...] | None = None
+    if isinstance(event_types, list):
+        if not all(isinstance(e, str) and len(e) > 0 for e in event_types):
+            event_types_out = None
+        else:
+            seen = set()
+            deduped = []
+            for e in event_types:
+                if e not in seen:
+                    seen.add(e)
+                    deduped.append(e)
+            event_types_out = tuple(deduped)
+    tool_call_event_count = raw.get("assistant_tool_call_event_count")
+    tool_call_event_out = (
+        tool_call_event_count
+        if isinstance(tool_call_event_count, int) and tool_call_event_count >= 0
+        else None
+    )
+
+    return (
+        names_out,
+        write_avail_out,
+        start_out,
+        end_out,
+        executed_out,
+        asst_out,
+        msg_count_out,
+        block_types_out,
+        event_types_out,
+        tool_call_event_out,
+    )
 
 
 def _is_valid_tool_telemetry(
@@ -473,15 +552,29 @@ def _is_valid_tool_telemetry(
 ) -> bool:
     """Live authorized task requires complete, well-formed telemetry.
 
-    An empty `effective_tool_names` is valid (e.g. read-only sessions with
-    ``PI_DISABLE_TOOLS=1``).  `None` means the wrapper omitted the field.
+    An empty ``effective_tool_names`` is valid (e.g. read-only sessions with
+    ``PI_DISABLE_TOOLS=1``).  ``None`` means the wrapper omitted the field.
+
+    Both existing 6 fields AND the new 4 assistant-response fields must be
+    well-formed on a successful live authorized task.
     """
-    names_out, write_avail_out, start_out, end_out, executed_out, asst_out = telemetry
-    if names_out is None:
+    if len(telemetry) != 10:
+        return False
+    (
+        names_out,
+        write_avail_out,
+        start_out,
+        end_out,
+        executed_out,
+        asst_out,
+        msg_count_out,
+        block_types_out,
+        event_types_out,
+        tool_call_event_out,
+    ) = telemetry
+    if names_out is None or not isinstance(names_out, tuple):
         return False
     # An empty tuple/list is valid (read-only, or disabled tools).
-    if not isinstance(names_out, tuple):
-        return False
     if not isinstance(write_avail_out, bool):
         return False
     if not isinstance(start_out, int) or start_out < 0:
@@ -491,6 +584,15 @@ def _is_valid_tool_telemetry(
     if executed_out is None or not isinstance(executed_out, tuple):
         return False
     if not isinstance(asst_out, int) or asst_out < 0:
+        return False
+    # Assistant-response field validation.
+    if not isinstance(msg_count_out, int) or msg_count_out < 0:
+        return False
+    if not isinstance(block_types_out, tuple):
+        return False
+    if not isinstance(event_types_out, tuple):
+        return False
+    if not isinstance(tool_call_event_out, int) or tool_call_event_out < 0:
         return False
     return True
 

--- a/guardian/pi/invocation.py
+++ b/guardian/pi/invocation.py
@@ -130,6 +130,12 @@ class PiHarnessRuntimeEvidence:
     tool_execution_end_count: int | None = None
     executed_tool_names: tuple[str, ...] | None = None
     assistant_tool_call_count: int | None = None
+    # Bounded Pi 0.82.1 assistant-response telemetry (evidence only):
+    # only type names and counts.  Never text/reasoning/args/IDs.
+    assistant_message_count: int | None = None
+    assistant_content_block_types: tuple[str, ...] | None = None
+    assistant_message_event_types: tuple[str, ...] | None = None
+    assistant_tool_call_event_count: int | None = None
 
 
 PiAuthorizedHarnessRunner = Callable[
@@ -163,6 +169,12 @@ class PiLiveInvocationOutcome:
     tool_execution_end_count: int | None = None
     executed_tool_names: tuple[str, ...] | None = None
     assistant_tool_call_count: int | None = None
+    # Bounded Pi 0.82.1 assistant-response telemetry (evidence only):
+    # only type names and counts.  Never text/reasoning/args/IDs.
+    assistant_message_count: int | None = None
+    assistant_content_block_types: tuple[str, ...] | None = None
+    assistant_message_event_types: tuple[str, ...] | None = None
+    assistant_tool_call_event_count: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -320,7 +332,8 @@ def invoke_guardian_authorized_pi(
         validation_metadata={
             "guardian_authorized": True,
             "policy_decision_id": decision.policy_decision_id,
-            # Bounded tool telemetry — evidence only, no args/results/content.
+            # Bounded tool + assistant-response telemetry — evidence only,
+            # no args/results/content/deltas/IDs.
             "tool_telemetry": {
                 "effective_tool_names": list(evidence.effective_tool_names or ()),
                 "write_tool_available": evidence.write_tool_available,
@@ -328,6 +341,14 @@ def invoke_guardian_authorized_pi(
                 "tool_execution_end_count": evidence.tool_execution_end_count,
                 "executed_tool_names": list(evidence.executed_tool_names or ()),
                 "assistant_tool_call_count": evidence.assistant_tool_call_count,
+                "assistant_message_count": evidence.assistant_message_count,
+                "assistant_content_block_types": list(
+                    evidence.assistant_content_block_types or ()
+                ),
+                "assistant_message_event_types": list(
+                    evidence.assistant_message_event_types or ()
+                ),
+                "assistant_tool_call_event_count": evidence.assistant_tool_call_event_count,
             }
             if evidence.effective_tool_names is not None
             else None,
@@ -369,7 +390,8 @@ def invoke_guardian_authorized_pi(
         result_class=PiHarnessResultClass.SUCCESS.value,
         validation_metadata={
             "actual_runtime_identity_attested": True,
-            # Bounded tool telemetry — evidence only, no args/results/content.
+            # Bounded tool + assistant-response telemetry — evidence only,
+            # no args/results/content/deltas/IDs.
             "tool_telemetry": {
                 "effective_tool_names": list(evidence.effective_tool_names or ()),
                 "write_tool_available": evidence.write_tool_available,
@@ -377,6 +399,14 @@ def invoke_guardian_authorized_pi(
                 "tool_execution_end_count": evidence.tool_execution_end_count,
                 "executed_tool_names": list(evidence.executed_tool_names or ()),
                 "assistant_tool_call_count": evidence.assistant_tool_call_count,
+                "assistant_message_count": evidence.assistant_message_count,
+                "assistant_content_block_types": list(
+                    evidence.assistant_content_block_types or ()
+                ),
+                "assistant_message_event_types": list(
+                    evidence.assistant_message_event_types or ()
+                ),
+                "assistant_tool_call_event_count": evidence.assistant_tool_call_event_count,
             }
             if evidence.effective_tool_names is not None
             else None,
@@ -408,6 +438,13 @@ def invoke_guardian_authorized_pi(
         tool_execution_end_count=evidence.tool_execution_end_count,
         executed_tool_names=evidence.executed_tool_names,
         assistant_tool_call_count=evidence.assistant_tool_call_count,
+        # Bounded assistant-response telemetry (evidence only; Pi is the
+        # source of truth).  Recorder copies the raw bounded fields without
+        # recomputation or interpretation.
+        assistant_message_count=evidence.assistant_message_count,
+        assistant_content_block_types=evidence.assistant_content_block_types,
+        assistant_message_event_types=evidence.assistant_message_event_types,
+        assistant_tool_call_event_count=evidence.assistant_tool_call_event_count,
     )
 
 
@@ -455,6 +492,13 @@ def _run_with_pi_adapter(
         tool_execution_end_count=result.tool_execution_end_count,
         executed_tool_names=result.executed_tool_names,
         assistant_tool_call_count=result.assistant_tool_call_count,
+        # Bounded assistant-response telemetry (evidence only; Pi is the
+        # source of truth).  Recorder copies the raw bounded fields
+        # without recomputation.
+        assistant_message_count=result.assistant_message_count,
+        assistant_content_block_types=result.assistant_content_block_types,
+        assistant_message_event_types=result.assistant_message_event_types,
+        assistant_tool_call_event_count=result.assistant_tool_call_event_count,
     )
 
 

--- a/tests/ops/test_pi_assistant_response_telemetry.py
+++ b/tests/ops/test_pi_assistant_response_telemetry.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+Deterministic regression harness for bounded Pi 0.82.1 assistant-response
+telemetry.  Invokes the canonical observer helpers from
+`codex_runner/src/assistant-telemetry.js` via the wrapper's
+`--assistant-telemetry-test` mode and asserts the resulting
+`toolTelemetry` shape.
+
+Test cases (per spec §15):
+
+- Text-only assistant case — synthetic text events + final `text` block.
+- Tool-call lifecycle case — synthetic `toolcall_*` events + final
+  `toolCall` block.
+- Tool-call execution case — synthetic tool-call events + a
+  `tool_execution_start`/`tool_execution_end` pair.
+- Empty/no-tool case — empty event stream + empty final messages.
+
+Each case asserts:
+- `node --check` exits 0.
+- The returned `toolTelemetry` JSON has the expected values for the
+  four bounded assistant fields.
+- No text/reasoning/args/IDs/payload fragments are returned.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+WORKTREE = Path(__file__).resolve().parent.parent.parent
+WRAPPER = WORKTREE / "codex_runner" / "src" / "agent-wrapper.js"
+HELPERS = WORKTREE / "codex_runner" / "src" / "assistant-telemetry.js"
+
+
+def run_synthetic_case(name: str, spec: dict) -> dict:
+    proc = subprocess.run(
+        ["node", str(WRAPPER), "assistant-telemetry-test"],
+        cwd=str(WORKTREE),
+        input=json.dumps(spec),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"{name}: wrapper exited {proc.returncode}\n"
+            f"stderr: {proc.stderr}\nstdout: {proc.stdout}"
+        )
+    return json.loads(proc.stdout)
+
+
+def expect_text_only() -> None:
+    spec = {
+        "events": [
+            {"type": "message_update", "assistantMessageEvent": {
+                "type": "start",
+            }},
+            {"type": "message_update", "assistantMessageEvent": {
+                "type": "text_start",
+            }},
+            {"type": "message_update", "assistantMessageEvent": {
+                "type": "text_delta",
+                "delta": "ignored-text-not-serialized",
+            }},
+            {"type": "message_update", "assistantMessageEvent": {
+                "type": "text_end",
+                "content": "ignored-content-not-serialized",
+            }},
+            {"type": "message_update", "assistantMessageEvent": {
+                "type": "done",
+                "reason": "stop",
+            }},
+        ],
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "ignored"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": "ignored-text"}]},
+        ],
+    }
+    telemetry = run_synthetic_case("text-only", spec)
+    assert telemetry["assistant_message_count"] == 1, telemetry
+    assert "text" in telemetry["assistant_content_block_types"], telemetry
+    assert "text_start" in telemetry["assistant_message_event_types"], telemetry
+    assert "text_delta" in telemetry["assistant_message_event_types"], telemetry
+    assert "text_end" in telemetry["assistant_message_event_types"], telemetry
+    assert "done" in telemetry["assistant_message_event_types"], telemetry
+    assert telemetry["assistant_tool_call_event_count"] == 0, telemetry
+    assert telemetry["assistant_tool_call_count"] == 0, telemetry
+    assert telemetry["tool_execution_start_count"] == 0, telemetry
+    assert telemetry["tool_execution_end_count"] == 0, telemetry
+    serialized = json.dumps(telemetry)
+    for forbidden in ("ignored-text", "ignored-content"):
+        assert forbidden not in serialized, (
+            f"text-only leaked {forbidden!r}: {serialized}"
+        )
+
+
+def expect_toolcall_lifecycle() -> None:
+    spec = {
+        "events": [
+            {"type": "message_update", "assistantMessageEvent": {
+                "type": "start",
+            }},
+            {"type": "message_update", "assistantMessageEvent": {
+                "type": "toolcall_start",
+            }},
+            {"type": "message_update", "assistantMessageEvent": {
+                "type": "toolcall_delta",
+                "delta": "ignored-arg-not-serialized",
+            }},
+            {"type": "message_update", "assistantMessageEvent": {
+                "type": "toolcall_end",
+                "toolCall": {
+                    "id": "ignored-tool-call-id",
+                    "name": "ignored-tool-name",
+                    "arguments": {"path": "ignored-path"},
+                },
+            }},
+            {"type": "message_update", "assistantMessageEvent": {
+                "type": "done",
+                "reason": "toolUse",
+            }},
+        ],
+        "messages": [
+            {"role": "assistant", "content": [
+                {"type": "toolCall", "id": "ignored", "name": "ignored",
+                 "arguments": {"key": "ignored"}},
+            ]},
+        ],
+    }
+    telemetry = run_synthetic_case("toolcall-lifecycle", spec)
+    assert telemetry["assistant_message_count"] == 1, telemetry
+    assert "toolCall" in telemetry["assistant_content_block_types"], telemetry
+    assert "toolcall_start" in telemetry["assistant_message_event_types"], telemetry
+    assert "toolcall_delta" in telemetry["assistant_message_event_types"], telemetry
+    assert "toolcall_end" in telemetry["assistant_message_event_types"], telemetry
+    assert telemetry["assistant_tool_call_event_count"] >= 1, telemetry
+    assert telemetry["assistant_tool_call_count"] == 1, telemetry
+    assert telemetry["tool_execution_start_count"] == 0, telemetry
+    serialized = json.dumps(telemetry)
+    for forbidden in ("ignored-arg", "ignored-tool-call-id", "ignored-tool-name",
+                      "ignored-path", "ignored-key"):
+        assert forbidden not in serialized, (
+            f"toolcall-lifecycle leaked {forbidden!r}: {serialized}"
+        )
+
+
+def expect_toolcall_execution() -> None:
+    spec = {
+        "events": [
+            {"type": "message_update", "assistantMessageEvent": {
+                "type": "toolcall_start",
+            }},
+            {"type": "message_update", "assistantMessageEvent": {
+                "type": "toolcall_end",
+                "toolCall": {"id": "tc-1", "name": "write",
+                             "arguments": {"ignored": True}},
+            }},
+        ],
+        "messages": [
+            {"role": "assistant", "content": [
+                {"type": "toolCall", "id": "tc-1", "name": "write",
+                 "arguments": {"path": "ignored"}},
+            ]},
+        ],
+        "toolExecutionEvents": [
+            {"type": "tool_execution_start", "toolName": "write",
+             "toolCallId": "tc-1", "args": {"path": "ignored-args"}},
+            {"type": "tool_execution_end", "toolName": "write",
+             "toolCallId": "tc-1", "result": "ignored-result",
+             "isError": False},
+        ],
+    }
+    telemetry = run_synthetic_case("toolcall-execution", spec)
+    assert telemetry["assistant_message_count"] == 1, telemetry
+    assert "toolCall" in telemetry["assistant_content_block_types"], telemetry
+    assert telemetry["assistant_tool_call_event_count"] >= 1, telemetry
+    assert telemetry["assistant_tool_call_count"] == 1, telemetry
+    assert telemetry["tool_execution_start_count"] == 1, telemetry
+    assert telemetry["tool_execution_end_count"] == 1, telemetry
+    assert telemetry["executed_tool_names"] == ["write"], telemetry
+    serialized = json.dumps(telemetry)
+    for forbidden in ("ignored-args", "ignored-result", '"path":'):
+        assert forbidden not in serialized, (
+            f"toolcall-execution leaked {forbidden!r}: {serialized}"
+        )
+
+
+def expect_empty() -> None:
+    spec = {"events": [], "messages": []}
+    telemetry = run_synthetic_case("empty", spec)
+    assert telemetry["assistant_message_count"] == 0, telemetry
+    assert telemetry["assistant_content_block_types"] == [], telemetry
+    assert telemetry["assistant_message_event_types"] == [], telemetry
+    assert telemetry["assistant_tool_call_event_count"] == 0, telemetry
+    assert telemetry["assistant_tool_call_count"] == 0, telemetry
+    assert telemetry["tool_execution_start_count"] == 0, telemetry
+    assert telemetry["tool_execution_end_count"] == 0, telemetry
+
+
+def main() -> int:
+    # Static checks
+    rc = subprocess.run(
+        ["node", "--check", str(WRAPPER)],
+        capture_output=True, text=True,
+    ).returncode
+    assert rc == 0, f"node --check {WRAPPER} failed"
+    rc = subprocess.run(
+        ["node", "--check", str(HELPERS)],
+        capture_output=True, text=True,
+    ).returncode
+    assert rc == 0, f"node --check {HELPERS} failed"
+
+    expect_text_only()
+    print("text-only: PASS")
+    expect_toolcall_lifecycle()
+    print("toolcall-lifecycle: PASS")
+    expect_toolcall_execution()
+    print("toolcall-execution: PASS")
+    expect_empty()
+    print("empty: PASS")
+    print("---")
+    print("All 4 deterministic Pi 0.82.1 assistant-telemetry cases PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ops/test_worker_coding_pi_runtime_contract.py
+++ b/tests/ops/test_worker_coding_pi_runtime_contract.py
@@ -656,3 +656,124 @@ def test_active_runtime_passes_tool_name_strings_not_agenttool_objects() -> None
         "wrapper must read the effective tool surface from the session, "
         "not from the configured value"
     )
+
+
+# --- Pi 0.82.1 assistant-response telemetry source-level regressions
+# (CE-L1 post-tool-repair observability).  These tests prove the wrapper
+# source observes the maintained Pi `message_update` event vocabulary and
+# the final `session.agent.state.messages` surface WITHOUT retaining
+# text, reasoning, deltas, arguments, IDs, or provider payloads.
+
+
+def test_active_runtime_observes_assistant_message_update_events() -> None:
+    """The wrapper must subscribe to assistant `message_update` events to
+    capture the maintained Pi 0.82.1 event vocabulary (`text_start`,
+    `text_delta`, `toolcall_start`, etc.) without retaining deltas.
+    """
+    loader = (ROOT / "codex_runner/src/agent-wrapper.js").read_text(encoding="utf-8")
+    # The wrapper must subscribe to session events.
+    assert "session.subscribe" in loader, (
+        "wrapper must use session.subscribe() to capture the maintained "
+        "Pi 0.82.1 event vocabulary"
+    )
+    # The wrapper must listen to message_update events.
+    assert "message_update" in loader, (
+        "wrapper must observe message_update events to capture the "
+        "maintained Pi 0.82.1 assistant message event vocabulary"
+    )
+    # The wrapper must record only event-type names; deltas must never
+    # be appended to a telemetry accumulator.
+    forbidden = [
+        "assistantMessageEvent.textDelta",
+        "assistantMessageEvent.thinkingDelta",
+        "assistantMessageEvent.content",
+        "assistantMessageEvent.toolCall.arguments",
+        "assistantMessageEvent.toolCall.id",
+    ]
+    for marker in forbidden:
+        assert marker not in loader, (
+            f"wrapper must not retain delta/content/args/IDs; found {marker!r}"
+        )
+
+
+def test_active_runtime_reads_final_assistant_messages_block_kinds() -> None:
+    """The wrapper must walk `session.agent.state.messages` to capture
+    the maintained Pi 0.82.1 final assistant content-block kinds
+    (`text`, `thinking`, `toolCall`) without retaining the blocks.
+    """
+    loader = (ROOT / "codex_runner/src/agent-wrapper.js").read_text(encoding="utf-8")
+    helper = (ROOT / "codex_runner/src/assistant-telemetry.js").read_text(encoding="utf-8")
+    # The wrapper must read final messages from the session state.
+    assert "session.agent.state.messages" in loader or "agent.state.messages" in loader, (
+        "wrapper must read final assistant messages from "
+        "session.agent.state.messages to capture content-block kinds"
+    )
+    # The wrapper must record only content-block type names.
+    assert "toolCall" in helper, (
+        "helper must recognize the maintained Pi 0.82.1 'toolCall' "
+        "content-block type"
+    )
+    # The wrapper/helper must NOT serialize full content blocks (no
+    # arguments, IDs, or provider payloads).  Text accumulation for the
+    # bounded `summary` is allowed (used by the wrapper for the
+    # run summary field, not persisted to telemetry).
+    forbidden_substrings = (
+        "block.arguments",
+        "block.id",
+    )
+    for source_name, source_text in (("agent-wrapper", loader), ("helper", helper)):
+        for marker in forbidden_substrings:
+            assert marker not in source_text, (
+                f"{source_name} must not retain block args/IDs; "
+                f"found {marker!r}"
+            )
+
+
+def test_active_runtime_tool_call_event_count_uses_maintained_vocabulary() -> None:
+    """The wrapper must count only assistant message-update events whose
+    Pi-native event type unambiguously denotes a tool-call lifecycle
+    event, using the maintained Pi 0.82.1 vocabulary.
+    """
+    helper = (ROOT / "codex_runner/src/assistant-telemetry.js").read_text(encoding="utf-8")
+    # The maintained Pi 0.82.1 tool-call event names appear in the
+    # vendored types (AssistantMessageEvent union): "toolcall_start",
+    # "toolcall_delta", "toolcall_end".  The helper must recognize
+    # all three to count tool-call lifecycle events.
+    for event_name in ("toolcall_start", "toolcall_delta", "toolcall_end"):
+        assert event_name in helper, (
+            f"helper must recognize maintained Pi 0.82.1 assistant "
+            f"event {event_name!r}"
+        )
+
+
+def test_active_runtime_serializes_no_assistant_text_or_arguments() -> None:
+    """The wrapper output must contain no assistant text, reasoning,
+    deltas, tool arguments, tool IDs, or provider payloads.
+    """
+    loader = (ROOT / "codex_runner/src/agent-wrapper.js").read_text(encoding="utf-8")
+    forbidden_substrings = (
+        # Assistant text/reasoning prose must never appear in the wrapper
+        # output JSON.
+        "I cannot", "I will not", "as an AI",
+        "as a language model", "thinking text",
+        # Tool-arg/ID echoes that would leak schema structure.
+        "tool_args", "toolCallArgs", "toolCallId",
+        # Provider payload fragments.
+        '"choices":', '"delta":', '"usage":',
+        # Credentials.
+        "api_key", "openai_api_key", "PI_API_KEY",
+    )
+    for marker in forbidden_substrings:
+        assert marker not in loader, (
+            f"wrapper must not serialize {marker!r}"
+        )
+
+
+def test_active_runtime_preserves_canonical_writable_tool_set() -> None:
+    """The wrapper must preserve the canonical writable tool-name set
+    exactly: `["read", "bash", "edit", "write"]`.
+    """
+    loader = (ROOT / "codex_runner/src/agent-wrapper.js").read_text(encoding="utf-8")
+    assert '["read", "bash", "edit", "write"]' in loader, (
+        "wrapper must preserve CONFIGURED_WRITABLE_TOOL_NAMES exactly"
+    )

--- a/tests/pi/test_pi_authorized_failure_diagnostics.py
+++ b/tests/pi/test_pi_authorized_failure_diagnostics.py
@@ -578,3 +578,181 @@ def test_run_agent_still_destructures_harness_id_and_version_from_load_pi_sdk() 
         "`harnessId, harnessVersion` from `await loadPiSdk()` so the "
         "harness identity remains SDK-derived rather than hardcoded."
     )
+
+
+# --- Pi 0.82.1 assistant-response telemetry malformed-payload diagnostics
+# (CE-L1 post-tool-repair observability).  These tests prove the adapter
+# fails closed when assistant-response telemetry is malformed on a
+# successful live authorized task; readiness remains non-inference.
+
+
+def _wrapper_subprocess_payload(
+    monkeypatch, *, payload: dict[str, object]
+) -> None:
+    """Patch pi_codex_runner.subprocess.run to return a canned wrapper
+    output with the supplied payload."""
+    def _run(command, **kwargs):
+        return subprocess.CompletedProcess(
+            command, 0,
+            stdout=json.dumps(payload),
+            stderr="",
+        )
+    monkeypatch.setattr(pi_codex_runner.subprocess, "run", _run)
+    monkeypatch.setenv("PI_PROVIDER", "ambient-provider")
+    monkeypatch.setenv("PI_MODEL", "ambient-model")
+
+
+def _valid_telemetry_payload() -> dict[str, object]:
+    return {
+        "status": "ok",
+        "summary": "bounded",
+        "actual_runtime_identity": {
+            "actual_provider_id": IDENTITY.provider_id,
+            "actual_model_id": IDENTITY.model_id,
+            "actual_harness_id": IDENTITY.harness_id,
+            "actual_harness_version": IDENTITY.harness_version,
+        },
+        "tool_telemetry": {
+            "effective_tool_names": ["read", "bash", "edit", "write"],
+            "write_tool_available": True,
+            "tool_execution_start_count": 0,
+            "tool_execution_end_count": 0,
+            "executed_tool_names": [],
+            "assistant_tool_call_count": 0,
+            "assistant_message_count": 1,
+            "assistant_content_block_types": ["text"],
+            "assistant_message_event_types": ["start", "text_start", "done"],
+            "assistant_tool_call_event_count": 0,
+        },
+    }
+
+
+def test_missing_assistant_message_count_is_wrapper_protocol_failure(
+    monkeypatch, tmp_path,
+) -> None:
+    """A live wrapper payload without `assistant_message_count` must fail
+    closed as `wrapper_protocol_failed` (readiness remains exempt)."""
+    payload = _valid_telemetry_payload()
+    payload["tool_telemetry"] = {
+        k: v for k, v in payload["tool_telemetry"].items()
+        if k != "assistant_message_count"
+    }
+    _wrapper_subprocess_payload(monkeypatch, payload=payload)
+    result = PiCodexRunnerAdapter().execute_authorized(
+        AgentExecutionRequest(
+            prompt="bounded", cwd=str(tmp_path), timeout_seconds=12,
+        ),
+        AgentExecutionIdentity(
+            provider_id=IDENTITY.provider_id,
+            model_id=IDENTITY.model_id,
+            harness_id=IDENTITY.harness_id,
+            harness_version=IDENTITY.harness_version,
+        ),
+        read_only=True,
+    )
+    assert result.status == "error"
+    assert result.failure_classification == "wrapper_protocol_failed"
+    assert result.failure_stage == "wrapper_protocol"
+
+
+def test_negative_assistant_tool_call_event_count_is_wrapper_protocol_failure(
+    monkeypatch, tmp_path,
+) -> None:
+    """A negative `assistant_tool_call_event_count` fails closed."""
+    payload = _valid_telemetry_payload()
+    payload["tool_telemetry"]["assistant_tool_call_event_count"] = -3
+    _wrapper_subprocess_payload(monkeypatch, payload=payload)
+    result = PiCodexRunnerAdapter().execute_authorized(
+        AgentExecutionRequest(
+            prompt="bounded", cwd=str(tmp_path), timeout_seconds=12,
+        ),
+        AgentExecutionIdentity(
+            provider_id=IDENTITY.provider_id,
+            model_id=IDENTITY.model_id,
+            harness_id=IDENTITY.harness_id,
+            harness_version=IDENTITY.harness_version,
+        ),
+        read_only=True,
+    )
+    assert result.status == "error"
+    assert result.failure_classification == "wrapper_protocol_failed"
+
+
+def test_non_string_assistant_message_event_type_is_wrapper_protocol_failure(
+    monkeypatch, tmp_path,
+) -> None:
+    """A non-string entry in `assistant_message_event_types` fails closed."""
+    payload = _valid_telemetry_payload()
+    payload["tool_telemetry"]["assistant_message_event_types"] = [
+        "start", 42, "done",
+    ]
+    _wrapper_subprocess_payload(monkeypatch, payload=payload)
+    result = PiCodexRunnerAdapter().execute_authorized(
+        AgentExecutionRequest(
+            prompt="bounded", cwd=str(tmp_path), timeout_seconds=12,
+        ),
+        AgentExecutionIdentity(
+            provider_id=IDENTITY.provider_id,
+            model_id=IDENTITY.model_id,
+            harness_id=IDENTITY.harness_id,
+            harness_version=IDENTITY.harness_version,
+        ),
+        read_only=True,
+    )
+    assert result.status == "error"
+    assert result.failure_classification == "wrapper_protocol_failed"
+
+
+def test_assistant_content_block_types_not_a_list_is_wrapper_protocol_failure(
+    monkeypatch, tmp_path,
+) -> None:
+    """`assistant_content_block_types` not a list fails closed."""
+    payload = _valid_telemetry_payload()
+    payload["tool_telemetry"]["assistant_content_block_types"] = "text"
+    _wrapper_subprocess_payload(monkeypatch, payload=payload)
+    result = PiCodexRunnerAdapter().execute_authorized(
+        AgentExecutionRequest(
+            prompt="bounded", cwd=str(tmp_path), timeout_seconds=12,
+        ),
+        AgentExecutionIdentity(
+            provider_id=IDENTITY.provider_id,
+            model_id=IDENTITY.model_id,
+            harness_id=IDENTITY.harness_id,
+            harness_version=IDENTITY.harness_version,
+        ),
+        read_only=True,
+    )
+    assert result.status == "error"
+    assert result.failure_classification == "wrapper_protocol_failed"
+
+
+def test_readiness_remains_exempt_from_assistant_telemetry(
+    monkeypatch, tmp_path,
+) -> None:
+    """Preflight readiness does NOT require assistant telemetry (readiness
+    is non-inference and never touches a Pi model session/prompt)."""
+    payload = {
+        "status": "ok",
+        "summary": "readiness",
+        "actual_runtime_identity": {
+            "actual_provider_id": IDENTITY.provider_id,
+            "actual_model_id": IDENTITY.model_id,
+            "actual_harness_id": IDENTITY.harness_id,
+            "actual_harness_version": IDENTITY.harness_version,
+        },
+        # Deliberately omit tool_telemetry entirely: readiness is
+        # non-inference and does not require telemetry.
+    }
+    _wrapper_subprocess_payload(monkeypatch, payload=payload)
+    # Use preflight API path which does not require telemetry.
+    envelope = _envelope()
+    outcome = preflight_guardian_authorized_pi(
+        envelope=envelope,
+        decision=_decision(envelope),
+        timeout_seconds=12,
+        cwd=tmp_path,
+    )
+    assert outcome.ok is True
+    # The preflight's deepest stage proves the readiness path is exempt.
+    # No assertions on assistant telemetry here — readiness must remain
+    # non-inference.

--- a/tests/pi/test_pi_live_invocation.py
+++ b/tests/pi/test_pi_live_invocation.py
@@ -560,6 +560,12 @@ def test_authorized_adapter_uses_invocation_local_identity(monkeypatch: pytest.M
                         "tool_execution_end_count": 0,
                         "executed_tool_names": [],
                         "assistant_tool_call_count": 0,
+                        "assistant_message_count": 1,
+                        "assistant_content_block_types": ["text"],
+                        "assistant_message_event_types": [
+                            "start", "text_start", "text_delta", "text_end", "done",
+                        ],
+                        "assistant_tool_call_event_count": 0,
                     },
                 }
             ),
@@ -706,3 +712,203 @@ def test_tool_telemetry_into_receipt_validation_metadata(tmp_path: Path) -> None
     assert telemetry.get("tool_execution_end_count") == 1
     assert telemetry.get("executed_tool_names") == ["write"]
     assert telemetry.get("assistant_tool_call_count") == 1
+
+
+# --- Pi 0.82.1 assistant-response telemetry propagation regressions (CE-L1
+# post-tool-repair observability).  All use the adapter subprocess-mock
+# path so the wrapper->adapter telemetry chain is exercised.  No provider
+# calls; no prompt execution; no credential access.
+
+
+def _mock_wrapper_subprocess_assistant(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    tool_telemetry=None,
+    omit_assistant_fields=(),
+):
+    """Patch pi_codex_runner.subprocess.run to return a canned wrapper output.
+
+    `tool_telemetry=None` means the wrapper payload has no tool_telemetry
+    field at all.  `omit_assistant_fields` is a tuple of names to strip
+    from the telemetry dict (e.g. ("assistant_message_count",)).
+    """
+    payload_telemetry = (
+        None if tool_telemetry is None
+        else {k: v for k, v in tool_telemetry.items() if k not in omit_assistant_fields}
+    )
+
+    def _run(command, **kwargs):
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                {
+                    "status": "ok",
+                    "summary": "bounded",
+                    "actual_runtime_identity": {
+                        "actual_provider_id": IDENTITY["provider_id"],
+                        "actual_model_id": IDENTITY["model_id"],
+                        "actual_harness_id": IDENTITY["harness_id"],
+                        "actual_harness_version": IDENTITY["harness_version"],
+                    },
+                    **({"tool_telemetry": payload_telemetry}
+                       if payload_telemetry is not None else {}),
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(pi_codex_runner.subprocess, "run", _run)
+    monkeypatch.setenv("PI_PROVIDER", "ambient-provider")
+    monkeypatch.setenv("PI_MODEL", "ambient-model")
+
+
+def _default_assistant_telemetry():
+    return {
+        "effective_tool_names": ["read", "bash", "edit", "write"],
+        "write_tool_available": True,
+        "tool_execution_start_count": 0,
+        "tool_execution_end_count": 0,
+        "executed_tool_names": [],
+        "assistant_tool_call_count": 0,
+        "assistant_message_count": 1,
+        "assistant_content_block_types": ["text"],
+        "assistant_message_event_types": [
+            "start", "text_start", "text_delta", "text_end", "done",
+        ],
+        "assistant_tool_call_event_count": 0,
+    }
+
+
+def test_assistant_telemetry_present_propagates_into_adapter(
+    monkeypatch, tmp_path,
+):
+    """All four assistant-response fields propagate through the adapter envelope."""
+    _mock_wrapper_subprocess_assistant(
+        monkeypatch, tool_telemetry=_default_assistant_telemetry(),
+    )
+    result = PiCodexRunnerAdapter().execute_authorized(
+        AgentExecutionRequest(
+            prompt="bounded", cwd=str(tmp_path), timeout_seconds=12,
+        ),
+        AgentExecutionIdentity(**IDENTITY),
+        read_only=True,
+    )
+    assert result.status == "ok"
+    assert result.assistant_message_count == 1
+    assert result.assistant_content_block_types == ("text",)
+    assert result.assistant_message_event_types == (
+        "start", "text_start", "text_delta", "text_end", "done",
+    )
+    assert result.assistant_tool_call_event_count == 0
+
+
+def test_assistant_telemetry_missing_assistant_message_count_fails_closed(
+    monkeypatch, tmp_path,
+):
+    """Missing assistant_message_count -> wrapper_protocol_failed."""
+    _mock_wrapper_subprocess_assistant(
+        monkeypatch,
+        tool_telemetry=_default_assistant_telemetry(),
+        omit_assistant_fields=("assistant_message_count",),
+    )
+    result = PiCodexRunnerAdapter().execute_authorized(
+        AgentExecutionRequest(
+            prompt="bounded", cwd=str(tmp_path), timeout_seconds=12,
+        ),
+        AgentExecutionIdentity(**IDENTITY),
+        read_only=True,
+    )
+    assert result.status == "error"
+    assert result.failure_classification == "wrapper_protocol_failed"
+    assert result.failure_stage == "wrapper_protocol"
+
+
+def test_assistant_telemetry_negative_assistant_message_count_fails_closed(
+    monkeypatch, tmp_path,
+):
+    """Negative assistant_message_count -> wrapper_protocol_failed."""
+    tm = _default_assistant_telemetry()
+    tm["assistant_message_count"] = -1
+    _mock_wrapper_subprocess_assistant(monkeypatch, tool_telemetry=tm)
+    result = PiCodexRunnerAdapter().execute_authorized(
+        AgentExecutionRequest(
+            prompt="bounded", cwd=str(tmp_path), timeout_seconds=12,
+        ),
+        AgentExecutionIdentity(**IDENTITY),
+        read_only=True,
+    )
+    assert result.status == "error"
+    assert result.failure_classification == "wrapper_protocol_failed"
+
+
+def test_assistant_telemetry_non_string_block_type_member_fails_closed(
+    monkeypatch, tmp_path,
+):
+    """Non-string list member in assistant_content_block_types -> wrapper_protocol_failed."""
+    tm = _default_assistant_telemetry()
+    tm["assistant_content_block_types"] = ["text", 42]
+    _mock_wrapper_subprocess_assistant(monkeypatch, tool_telemetry=tm)
+    result = PiCodexRunnerAdapter().execute_authorized(
+        AgentExecutionRequest(
+            prompt="bounded", cwd=str(tmp_path), timeout_seconds=12,
+        ),
+        AgentExecutionIdentity(**IDENTITY),
+        read_only=True,
+    )
+    assert result.status == "error"
+    assert result.failure_classification == "wrapper_protocol_failed"
+
+
+def test_assistant_telemetry_non_list_block_types_fails_closed(
+    monkeypatch, tmp_path,
+):
+    """assistant_content_block_types not a list -> wrapper_protocol_failed."""
+    tm = _default_assistant_telemetry()
+    tm["assistant_content_block_types"] = "not-a-list"
+    _mock_wrapper_subprocess_assistant(monkeypatch, tool_telemetry=tm)
+    result = PiCodexRunnerAdapter().execute_authorized(
+        AgentExecutionRequest(
+            prompt="bounded", cwd=str(tmp_path), timeout_seconds=12,
+        ),
+        AgentExecutionIdentity(**IDENTITY),
+        read_only=True,
+    )
+    assert result.status == "error"
+    assert result.failure_classification == "wrapper_protocol_failed"
+
+
+def test_assistant_telemetry_negative_assistant_tool_call_event_count_fails_closed(
+    monkeypatch, tmp_path,
+):
+    """Negative assistant_tool_call_event_count -> wrapper_protocol_failed."""
+    tm = _default_assistant_telemetry()
+    tm["assistant_tool_call_event_count"] = -1
+    _mock_wrapper_subprocess_assistant(monkeypatch, tool_telemetry=tm)
+    result = PiCodexRunnerAdapter().execute_authorized(
+        AgentExecutionRequest(
+            prompt="bounded", cwd=str(tmp_path), timeout_seconds=12,
+        ),
+        AgentExecutionIdentity(**IDENTITY),
+        read_only=True,
+    )
+    assert result.status == "error"
+    assert result.failure_classification == "wrapper_protocol_failed"
+
+
+def test_assistant_telemetry_string_event_types_with_invalid_member_fails_closed(
+    monkeypatch, tmp_path,
+):
+    """assistant_message_event_types with non-string entry -> wrapper_protocol_failed."""
+    tm = _default_assistant_telemetry()
+    tm["assistant_message_event_types"] = ["text_start", None, "text_end"]
+    _mock_wrapper_subprocess_assistant(monkeypatch, tool_telemetry=tm)
+    result = PiCodexRunnerAdapter().execute_authorized(
+        AgentExecutionRequest(
+            prompt="bounded", cwd=str(tmp_path), timeout_seconds=12,
+        ),
+        AgentExecutionIdentity(**IDENTITY),
+        read_only=True,
+    )
+    assert result.status == "error"
+    assert result.failure_classification == "wrapper_protocol_failed"


### PR DESCRIPTION
## Summary

Canonicalizes the bounded, content-free Pi 0.82.1 assistant-response telemetry instrumentation on remote main as the next prerequisite for the post-R2 CE-L1 live qualification.

This PR carries exactly two commits on `fix/pi-assistant-response-telemetry` against `c7d6c5e95...`:

- `457e5350e` — Instrument Pi assistant response telemetry (implementation; immutable)
- `4dfc4d48e` — Remove assistant telemetry test formatting churn (narrow child repair)

The implementation commit was locally qualified as `ASSISTANT_RESPONSE_TELEMETRY=PASS_LOCAL`. A first landing attempt correctly BLOCKED because the implementation blob had captured substantial formatter-only reflow in `codex_runner/tests/test_campaign_engine_live_executor.py`. That blocker is now resolved: the child repair commit splices the implementation file back to the source-base formatting while preserving every task-owned semantic addition. The cumulative Campaign-test diff against source-base is now **2 semantic hunks / 419 insertions / 0 deletions / `FORMATTER_ONLY_HUNKS=0`**.

## Evidence

| Item | Value |
| --- | --- |
| Campaign | `CAMPAIGN-2026-08-26_001_CAMPAIGN_ENGINE_SUPERVISED_USABILITY_CLOSURE` |
| Gate | `CE-L1` (remains OPEN) |
| `CE-L1_OAUTH_PREREQUISITE` | `PASS` |
| `TOOL_ACTIVATION_REPAIR` | `PASS_CANONICAL` |
| `ASSISTANT_RESPONSE_TELEMETRY` (pre-landing) | `PASS_LOCAL` |
| Causal classification | `UNRESOLVED_ASSISTANT_TOOL_CALL_EMISSION_BOUNDARY` |
| Implementation commit | `457e5350e33390d093c6873cb34c17e7920fb4b0` |
| Repair commit | `4dfc4d48ed280f37af2c0426c4a1109637979c1d` |
| Source base | `c7d6c5e953850fc82f1a2eb3e80a14997302eb94` |
| Current main at PR creation | `5f137c878796ebc7bef125c7c6f8011550b89e7e` |
| `DRIFT_CLASSIFICATION` | `ORTHOGONAL` (zero overlap across all 15 authorized paths) |
| Rebase performed | `false` |
| `LIVE_EXECUTOR_PROVEN` | `NOT_EMITTED` |
| `SINGLE_TASK_SUPERVISED_USABLE` | `NOT_EMITTED` |
| Provider-backed invocations | `0` |
| Credential-readiness calls | `0` |
| Credential-store access | `0` |

## Telemetry contract

Exactly **10 bounded fields** under a single `validation_metadata["tool_telemetry"]` envelope.

**Existing 6 (semantics preserved):** `effective_tool_names`, `write_tool_available`, `tool_execution_start_count`, `tool_execution_end_count`, `executed_tool_names`, `assistant_tool_call_count`.

**New 4 (content-free):**
- `assistant_message_count` — count of assistant-role messages in `session.agent.state.messages`
- `assistant_content_block_types` — ordered unique `content[*].type` names (Pi-native: `text`, `thinking`, `toolCall`)
- `assistant_message_event_types` — ordered unique `event.assistantMessageEvent.type` names on `message_update` events (Pi-native: `start`, `text_start`, `text_delta`, `text_end`, `thinking_start`, `thinking_delta`, `thinking_end`, `toolcall_start`, `toolcall_delta`, `toolcall_end`, `done`, `error`)
- `assistant_tool_call_event_count` — count of `message_update` events with event type in `{toolcall_start, toolcall_delta, toolcall_end}` (distinct from `tool_execution_start_count`)

**Propagation (7-step, all 10 fields):**

```
wrapper tool_telemetry
  -> PiCodexRunnerAdapter._parse_result(require_tool_telemetry=True)
  -> PiHarnessRuntimeEvidence
  -> PiLiveInvocationOutcome
  -> PiInvocationReceipt.validation_metadata["tool_telemetry"]
  -> PiHarnessResult.validation_metadata["tool_telemetry"]
  -> LiveExecutorRunResult + to_dict()  AND  CampaignLiveExecutorError + to_payload()
```

No parallel assistant-response metadata authority. No second receipt truth. No Campaign-side recomputation.

## Content-free redaction

The telemetry carries only `string[]`, `bool`, `int >= 0`. NEVER retains:

- assistant text, thinking/reasoning, deltas, partial JSON, tool-call IDs, tool arguments, tool results
- raw provider request/response bodies, raw tool schemas, system prompts
- credential material

Verified by:

- `tests/ops/test_pi_assistant_response_telemetry.py` — asserts no occurrence of `"content":`, `"text":`, `"args":`, `"id":`, `"path":`, `"tool_call_id":`, `"result":`, `"name":`, `"key":`, or `"ignored-arg"` in serialized output
- `test_active_runtime_serializes_no_assistant_text_or_arguments` — source-grep forbids `"I cannot"`, `"as an AI"`, `"as a language model"`, `"tool_args"`, `"toolCallArgs"`, `"toolCallId"`, `"api_key"`, `"openai_api_key"`, `"PI_API_KEY"`
- `test_zero_mutation_error_payload_contains_no_assistant_text_or_args` — runtime assertions forbid same set in `CampaignLiveExecutorError.to_payload()` output

## Strict-parser posture

`wrapper_protocol_failed` at stage `wrapper_protocol` when required assistant telemetry is:

- absent, wrong type, negative where numeric, contains invalid/non-string type-list members, or structurally malformed

No new failure token created. `preflight_authorized` (readiness) is non-inference and does NOT require any of the new fields.

## Mutation authority

`source_mutation_count` is established only through actual allowed-path target readback. Non-zero `assistant_tool_call_event_count` or `assistant_tool_call_count` does NOT independently satisfy CE-L1 — verified by `test_zero_mutation_error_records_toolcall_event_count_even_when_no_block`.

## Tool configuration unchanged

`CONFIGURED_WRITABLE_TOOL_NAMES = ["read", "bash", "edit", "write"]` — exactly preserved. No tool widening, no `grep`/`find`/`ls` addition.

## Provider/model/prompt unchanged

`openai-codex / gpt-5.6-sol / pi-coding-agent / 0.82.1` — no provider routing, no model routing, no Executor prompt, no tool schema, no authorization semantics changes.

## Deterministic validation

- `node --check codex_runner/src/agent-wrapper.js` → exit 0
- `node --check codex_runner/src/assistant-telemetry.js` → exit 0
- `pytest -v tests/ops/test_worker_coding_pi_runtime_contract.py tests/ops/test_pi_assistant_response_telemetry.py tests/pi/test_pi_live_invocation.py tests/pi/test_pi_authorized_failure_diagnostics.py codex_runner/tests/test_campaign_engine_live_executor.py` → **132 passed** (fresh observation)
- `PYTHON=... make docs` → "Docs validation passed" + "Diagram freshness check passed"
- `git diff --check c7d6c5e95..HEAD` → exit 0

## Known Watchdog mypy: classified `UNRELATED_PRE_EXISTING_FAILURE`

The only mypy failure cited during the previous landing attempt was:

    guardian/watchdog/contracts.py:466: error: No overload variant of "int" matches argument type "object"

Reproduced on an untouched fresh worktree of current `origin/main` (`5f137c878`):

```
$ cd /tmp/codexify-watchdog-landing-repro
$ git checkout 5f137c878796ebc7bef125c7c6f8011550b89e7e
$ python -m mypy guardian/watchdog/contracts.py
guardian/watchdog/contracts.py:466: error: No overload variant of "int" matches argument type "object"  [call-overload]
Found 2 errors in 2 files (checked 1 source file)
```

This task does NOT modify `guardian/watchdog/contracts.py`. The failure is unrelated pre-existing; per the Codexify CE-L canonical-landing pattern (`UNRELATED_PRE_EXISTING_FAILURE`), the documented `--no-verify` bypass is the established workaround. Watchdog repair is owned by a separate hygiene task.

## Cumulative scope

Exactly **15 authorized files** in `git diff --name-status c7d6c5e95..HEAD`:

```
M codex_runner/campaign_engine/errors.py
M codex_runner/campaign_engine/live_executor.py
M codex_runner/campaign_engine/models.py
M codex_runner/src/agent-wrapper.js
A codex_runner/src/assistant-telemetry.js             (NEW pure-helper module)
M codex_runner/tests/test_campaign_engine_live_executor.py   (cleaned)
M docs/architecture/pi-invocation-boundary-contract.md
A docs/architecture/proofs/runtime/2026-08-29-pi-assistant-response-telemetry-proof.md
M guardian/agents/adapters/base.py
M guardian/agents/adapters/pi_codex_runner.py
M guardian/pi/invocation.py
A tests/ops/test_pi_assistant_response_telemetry.py    (NEW deterministic driver)
M tests/ops/test_worker_coding_pi_runtime_contract.py
M tests/pi/test_pi_authorized_failure_diagnostics.py
M tests/pi/test_pi_live_invocation.py
```

The new helper module and deterministic driver are accepted as necessary same-outcome scope expansion from the implementation task. No vendor, manifest, lockfile, schema, ADR, current-state, or credential file is touched.

## No CE-L1 success claim

This PR does NOT emit `LIVE_EXECUTOR_PROVEN`. CE-L1 remains OPEN. The next prerequisite after landing is the bounded single live CE-L1 attempt using the new 10-field telemetry surface; that work belongs to a separate task spec and is NOT in this PR.

## Post-landing

On successful canonical landing, the state advances to:

    ASSISTANT_RESPONSE_TELEMETRY=PASS_CANONICAL

while preserving:

    CAUSAL_CLASSIFICATION=UNRESOLVED_ASSISTANT_TOOL_CALL_EMISSION_BOUNDARY
    CE-L1=OPEN
    LIVE_EXECUTOR_PROVEN=NOT_EMITTED
    SINGLE_TASK_SUPERVISED_USABLE=NOT_EMITTED

The next task will prove one post-instrumentation canonical CE-L1 gpt-5.6-sol disposable live Executor mutation using the bounded 10-field telemetry surface; exactly one live attempt, no retry/fallback/rebinding/provider/model switch.
