### PR TITLE
Complete Pi authorized ten-field telemetry

### DIFF
--- a/codex_runner/src/agent-wrapper.js
+++ b/codex_runner/src/agent-wrapper.js
@@ -21,6 +21,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import {
 	observeAssistantMessageEvent,
 	observeFinalAssistantMessages,
+	createToolTelemetry,
 } from "./assistant-telemetry.js";
 
 // Parse command line args
@@ -549,15 +550,13 @@ async function runAgent() {
 	const effectiveToolNames = getEffectiveToolNames(session);
 	const writeToolAvailable = effectiveToolNames.includes("write");
 
-	// Tool telemetry accumulators (content-free, evidence-only).
-	const toolTelemetry = {
-		effective_tool_names: effectiveToolNames,
-		write_tool_available: writeToolAvailable,
-		tool_execution_start_count: 0,
-		tool_execution_end_count: 0,
-		executed_tool_names: [],
-		assistant_tool_call_count: 0,
-	};
+	// Tool telemetry accumulator (content-free, evidence-only). The
+	// canonical 10-field helper is the sole authority for the bounded
+	// live-authorized telemetry shape; the wrapper only sets the
+	// effective-tool surface which is determined post-session-creation.
+	const toolTelemetry = createToolTelemetry();
+	toolTelemetry.effective_tool_names = effectiveToolNames;
+	toolTelemetry.write_tool_available = writeToolAvailable;
 
 	// Defense-in-depth: if Guardian-authorized-task has writable intent
 	// (`write` should be active) but the session did not register `write`,
@@ -579,7 +578,11 @@ async function runAgent() {
 		return;
 	}
 
-	// Subscribe to events (capture bounded tool-execution telemetry).
+	// Subscribe to events (capture bounded tool-execution telemetry and
+	// bounded assistant-response telemetry).  Both observers are content-
+	// free; the assistant event observer is wired independently of
+	// OPTIONS.verbose so evidence collection does not depend on logging
+	// mode.
 	session.subscribe((event) => {
 		// Count tool execution lifecycle events (NO args/results/content).
 		if (event.type === "tool_execution_start") {
@@ -593,6 +596,9 @@ async function runAgent() {
 		} else if (event.type === "tool_execution_end") {
 			toolTelemetry.tool_execution_end_count += 1;
 		}
+		// Bounded assistant-response event observation (text/reasoning/
+		// arguments/IDs/payloads are NEVER read by the helper).
+		observeAssistantMessageEvent(toolTelemetry, event);
 		if (OPTIONS.verbose) {
 			if (event.type === "message_update" && event.assistantMessageEvent?.type === "text_delta") {
 				process.stdout.write(event.assistantMessageEvent.delta);
@@ -624,23 +630,11 @@ async function runAgent() {
 		throw error;
 	}
 
-	// Count assistant tool-call blocks (distinct from tool execution).
-	// Inspect assistant messages and count content blocks whose type is exactly
-	// "toolCall". Do NOT record tool-call arguments.
-	try {
-		const finalMessages = session.agent.state.messages;
-		for (const message of finalMessages) {
-			if (message.role !== "assistant") continue;
-			if (!Array.isArray(message.content)) continue;
-			for (const block of message.content) {
-				if (block && block.type === "toolCall") {
-					toolTelemetry.assistant_tool_call_count += 1;
-				}
-			}
-		}
-	} catch (_error) {
-		// leave count at 0; bounded evidence only
-	}
+	// Bounded observation of the final Pi 0.82.1 assistant messages.
+	// The canonical helper owns the assistant_message_count,
+	// assistant_content_block_types, and assistant_tool_call_count
+	// fields; it NEVER reads text/reasoning/arguments/IDs.
+	observeFinalAssistantMessages(toolTelemetry, session);
 
 	// Print final output
 	if (guardianAuthorizedMode) {

--- a/docs/architecture/proofs/runtime/2026-09-01-pi-guardian-authorized-ten-field-telemetry-proof.md
+++ b/docs/architecture/proofs/runtime/2026-09-01-pi-guardian-authorized-ten-field-telemetry-proof.md
@@ -1,0 +1,337 @@
+# 2026-09-01 Pi Guardian-authorized ten-field telemetry repair — PASS_QUALIFIED_LOCAL
+
+## Result
+
+```
+RESULT                                = PASS
+GUARDIAN_AUTHORIZED_TEN_FIELD_TELEMETRY = PASS_QUALIFIED_LOCAL
+AUTHORIZED_WRAPPER_STDOUT_FRAMING_DEFECT = PROVEN_AND_REPAIRED_CANONICAL
+PI_WRAPPER_PROTOCOL_FIXTURE_REPRODUCIBILITY = PASS_TRACKED_ONLY_CANONICAL
+LIVE_WRAPPER_PROTOCOL_CAUSE              = UNRESOLVED
+CAUSAL_CLASSIFICATION                     = UNRESOLVED_ASSISTANT_TOOL_CALL_EMISSION_BOUNDARY
+CE-L1                                     = OPEN
+LIVE_EXECUTOR_PROVEN                      = NOT_EMITTED
+SINGLE_TASK_SUPERVISED_USABLE             = NOT_EMITTED
+REAL_PROVIDER_CALL_COUNT                  = 0
+CAMPAIGN_LIVE_RAIL_CALL_COUNT             = 0
+OAUTH_READINESS_COUNT                     = 0
+OPERATOR_CREDENTIAL_STORE_ACCESS_COUNT    = 0
+TELEMETRY_FIELD_ADDITIONS                 = 0
+TELEMETRY_FIELD_REMOVALS                  = 0
+PYTHON_DOWNSTREAM_PROPAGATION_CHANGES     = none
+```
+
+## Scope
+
+This slice wires the canonical 10-field bounded telemetry surface into
+the live `guardian-authorized-task` path.  The accepted architecture
+already required 10 fields; the previous canonical wrapper emitted
+only 6 because the live producer had not finished wiring the existing
+`observeAssistantMessageEvent`, `observeFinalAssistantMessages`, and
+`createToolTelemetry` helpers.  The repair aligns implementation with
+the already-accepted schema.
+
+No telemetry schema change.  No provider/model/tool/prompt/authority
+change.  No persistent-state change.  No Campaign schema change.
+
+## Pre-repair state (provider-free, exact)
+
+The canonical `agent-wrapper.js` `guardian-authorized-task` path
+initialized the live accumulator manually with only:
+
+```
+{
+  effective_tool_names,
+  write_tool_available,
+  tool_execution_start_count: 0,
+  tool_execution_end_count: 0,
+  executed_tool_names: [],
+  assistant_tool_call_count: 0,
+}
+```
+
+The four assistant-response fields were omitted:
+
+- `assistant_message_count`
+- `assistant_content_block_types`
+- `assistant_message_event_types`
+- `assistant_tool_call_event_count`
+
+```
+AUTHORIZED_WRAPPER_TELEMETRY_FIELD_COUNT_BEFORE = 6
+```
+
+## Adapter 10-field requirement (canonical)
+
+`PiCodexRunnerAdapter.execute_authorized(...)` invokes:
+
+```
+self._parse_result(
+    result,
+    require_runtime_identity=True,
+    require_tool_telemetry=True,
+)
+```
+
+The adapter's `_parse_tool_telemetry(...)` defines a 10-position
+contract (positions are fixed):
+
+```
+1.  effective_tool_names
+2.  write_tool_available
+3.  tool_execution_start_count
+4.  tool_execution_end_count
+5.  executed_tool_names
+6.  assistant_tool_call_count
+7.  assistant_message_count
+8.  assistant_content_block_types
+9.  assistant_message_event_types
+10. assistant_tool_call_event_count
+```
+
+`_is_valid_tool_telemetry(...)` rejects missing assistant-response
+fields for a successful live-authorized result.  Pre-repair the
+real `execute_authorized` path with a 6-field payload returned:
+
+```
+failure_classification = wrapper_protocol_failed
+failure_stage          = wrapper_protocol
+```
+
+```
+AUTHORIZED_ADAPTER_REQUIRED_TELEMETRY_FIELD_COUNT = 10
+```
+
+## Repair (canonical)
+
+1. Imported `createToolTelemetry` from `./assistant-telemetry.js`.
+2. Replaced the manual 6-field accumulator literal with a
+   `createToolTelemetry()` call.  The wrapper only sets the
+   `effective_tool_names` and `write_tool_available` fields
+   post-session-creation; the remaining 8 fields are owned by the
+   helper.
+3. Wired `observeAssistantMessageEvent(toolTelemetry, event)` inside
+   the `session.subscribe` callback, **independently of
+   `OPTIONS.verbose`** so evidence collection does not depend on
+   logging mode.
+4. Removed the manual `assistant_tool_call_count` scan over
+   `session.agent.state.messages`.  Replaced with
+   `observeFinalAssistantMessages(toolTelemetry, session)` after
+   successful `session.prompt(...)`.  The helper owns
+   `assistant_message_count`, `assistant_content_block_types`, and
+   `assistant_tool_call_count`.
+5. Preserved all existing tool execution counters
+   (`tool_execution_start_count`, `tool_execution_end_count`,
+   `executed_tool_names`).
+6. Preserved `CONFIGURED_WRITABLE_TOOL_NAMES` and the
+   `["read","bash","edit","write"]` writable set.
+7. Preserved the failure-path emission through
+   `emitAuthorizedFailure(...)` and `emitAuthorizedSuccess(...)` —
+   the only change is that the emitted `tool_telemetry` object now
+   contains all 10 fields (because the helper initializes all 10).
+8. Preserved the canonical final-non-empty-line stdout framing
+   established in commit `e9125a286`.
+
+```
+createToolTelemetry() live wiring result       = PASS
+Assistant event observer live wiring result   = PASS
+Final assistant observer live wiring result    = PASS
+Manual duplicate assistant scan removed       = true
+Tool-activation semantics preserved           = PASS
+Provider-failure ten-field-shape result        = PASS
+Tool-activation-failure ten-field-shape result = PASS
+Authorized outer result-schema change          = none
+```
+
+## Tracked fake-Pi fixture extension
+
+The disposable fake Pi 0.82.1 package under
+`tests/pi/fixtures/fake_pi_package/source/index.js` adds one
+provider-free behavior mode:
+
+```
+PI_FAKE_I_BEHAVIOR = assistant-tool-call
+```
+
+The behavior mode emits the bounded Pi 0.82.1 event sequence the live
+wrapper's observers consume:
+
+```
+{type: "message_update", assistantMessageEvent: {type: "toolcall_start"}}
+{type: "tool_execution_start", toolName: "write"}
+{type: "tool_execution_end",   toolName: "write"}
+{type: "message_update", assistantMessageEvent: {type: "toolcall_end"}}
+```
+
+and sets the final session state to one assistant message with one
+`toolCall` content block whose argument is secret-shaped
+(`"secret-not-returned"`).  The bounded observer MUST NOT return
+this value.
+
+The default (no `PI_FAKE_I_BEHAVIOR`) path remains the prior zero-event
+success path so existing framing tests are semantically unchanged.
+
+## Real-wrapper post-repair (provider-free, exact)
+
+Zero-event success path (canonical default):
+
+```
+effective_tool_names            = ("read","bash","edit","write")
+write_tool_available            = true
+tool_execution_start_count      = 0
+tool_execution_end_count        = 0
+executed_tool_names             = ()
+assistant_tool_call_count       = 0
+assistant_message_count         = 0
+assistant_content_block_types   = ()
+assistant_message_event_types   = ()
+assistant_tool_call_event_count = 0
+```
+
+Sentinel lifecycle (one toolcall_start, one tool_execution_start
+`write`, one tool_execution_end `write`, one toolcall_end, one final
+`toolCall` block):
+
+```
+effective_tool_names            = ("read","bash","edit","write")
+write_tool_available            = true
+tool_execution_start_count      = 1
+tool_execution_end_count        = 1
+executed_tool_names             = ("write",)
+assistant_tool_call_count       = 1
+assistant_message_count         = 1
+assistant_content_block_types   = ("toolCall",)
+assistant_message_event_types   = ("toolcall_start","toolcall_end")
+assistant_tool_call_event_count = 2
+```
+
+```
+REAL_AUTHORIZED_WRAPPER_TEN_FIELD_PROTOCOL  = PASS
+REAL_AUTHORIZED_ASSISTANT_TELEMETRY         = PASS
+ASSISTANT_TELEMETRY_CONTENT_REDACTION      = PASS  (secret-not-returned never appears in envelope)
+```
+
+## Regression results
+
+- Missing `assistant_message_count` in an otherwise valid authorized
+  success frame still returns `wrapper_protocol_failed` /
+  `wrapper_protocol` (10-field strictness preserved).
+- Real `execute_authorized` zero-event success: 10 fields present,
+  `status="ok"`, identity preserved.
+- Real `execute_authorized` sentinel success: 10 fields exact-match
+  to SENTINEL_EXPECTED.
+- Noisy stdout framing regression: `test_real_wrapper_noisy_stdout_success_protocol`
+  passes.
+- Bounded failure framing regression: `test_real_wrapper_noisy_stdout_failure_protocol`
+  passes.
+- Runtime identity strictness: `MISSING_RUNTIME_IDENTITY_FAIL_CLOSED`
+  passes.
+- Nonzero-exit precedence: `NONZERO_RETURN_CODE_PRECEDENCE` passes.
+
+## Network / credential / tool posture
+
+```
+fake HTTP_CALL_COUNT                  = 0
+fake DNS_CALL_COUNT                   = 0
+fake SOCKET_CALL_COUNT                = 0
+fake PI_PROVIDER                      = "openai-codex"
+fake PI_MODEL                         = "gpt-5.6-sol"
+fake PI_HARNESS_ID                    = "pi-coding-agent"
+fake PI_HARNESS_VERSION               = "0.82.1"
+fake getActiveToolNames               = ("read","bash","edit","write")
+PROVIDER_BACKED_INVOCATION_COUNT      = 0
+CAMPAIGN_LIVE_RAIL_COUNT              = 0
+OAUTH_READINESS_COUNT                 = 0
+OPERATOR_CREDENTIAL_STORE_ACCESS_COUNT = 0
+disposable HOME                       = <tmp_path>/home  (per-test)
+PI_CODING_AGENT_PACKAGE_ROOT          = <materialized tmp_path>/fake_pi_package  (per-test)
+```
+
+## Validation
+
+```
+$ python -m pytest -v tests/pi/test_pi_authorized_failure_diagnostics.py
+collected 56 items
+...................................                                  [100%]
+======================== 56 passed, 1 warning in 0.58s =========================
+
+$ python -m pytest -v tests/ops/test_pi_assistant_response_telemetry.py
+collected 7 items
+.......                                                                 [100%]
+======================== 7 passed, 1 warning in 0.05s =========================
+
+$ python -m pytest tests/ops/test_worker_coding_pi_runtime_contract.py \
+                    tests/ops/test_pi_assistant_response_telemetry.py \
+                    tests/pi/test_pi_live_invocation.py \
+                    tests/pi/test_pi_authorized_failure_diagnostics.py \
+                    codex_runner/tests/test_campaign_engine_live_executor.py
+........................................................................ [ 90%]
+................                                                         [100%]
+======================== 160 passed, 1 warning in 7.24s =========================
+```
+
+Pre-task baseline after PR #778: `150 passed`.  Fresh count after
+repair: `160 passed` (7 new assistant-telemetry wrapper source
+regressions + 3 new ten-field framing tests).
+
+## Node syntax validation
+
+```
+$ node --check codex_runner/src/agent-wrapper.js        = exit 0
+$ node --check codex_runner/src/assistant-telemetry.js  = exit 0
+```
+
+## Docs
+
+```
+$ python scripts/validate_docs.py
+Docs validation passed: required architecture docs, README links, and source headings verified.
+
+$ python scripts/check_diagram_freshness.py
+Diagram freshness check passed: no runtime source drift detected and matrix decisions are valid.
+```
+
+## Tracked file scope (canonical)
+
+```
+codex_runner/src/agent-wrapper.js                          (M)
+tests/ops/test_pi_assistant_response_telemetry.py         (M; +7 pytest regressions)
+tests/pi/test_pi_authorized_failure_diagnostics.py         (M; +3 ten-field tests + docstring update)
+tests/pi/fixtures/fake_pi_package/source/index.js          (M; +assistant-tool-call behavior)
+docs/architecture/proofs/runtime/2026-09-01-pi-guardian-authorized-ten-field-telemetry-proof.md (A; this proof)
+```
+
+No other tracked file changed.  No runtime source edit to
+`codex_runner/src/assistant-telemetry.js` (the helper is unchanged).
+No edit to `guardian/agents/adapters/pi_codex_runner.py`
+(adapter 10-field parsing unchanged).  No edit to `guardian/pi/invocation.py`
+or any Campaign Engine surface.  No edit to the historical CE-L1
+proof ledger.  No edit to the disposable CE-L1 driver.
+
+## What this slice proves and does not prove
+
+PROVES:
+
+- The canonical 10-field telemetry shape is now produced by the
+  live `guardian-authorized-task` path.
+- The real `execute_authorized` provider-free end-to-end path
+  accepts the wrapper's success frame (no longer rejected at
+  `wrapper_protocol_failed`).
+- The 4 missing assistant-response fields are populated by the
+  existing canonical helpers (`createToolTelemetry`,
+  `observeAssistantMessageEvent`,
+  `observeFinalAssistantMessages`).
+- Secret-shaped tool arguments are not retained anywhere in the
+  bounded envelope.
+- The 10-field strictness contract is preserved (missing field
+  still fails closed).
+- The canonical framing repair and the tracked-only fixture
+  reproducibility are both preserved.
+
+DOES NOT PROVE:
+
+- That the wiring makes a real provider call succeed (no live rail
+  in this slice; LIVE_WRAPPER_PROTOCOL_CAUSE=UNRESOLVED).
+- CE-L1 closure (CE-L1=OPEN; LIVE_EXECUTOR_PROVEN=NOT_EMITTED).
+- The readiness-helper `await` question (parked; not admitted).
+- A schema-version change.  The 10-field shape is unchanged.

--- a/docs/architecture/proofs/runtime/2026-09-01-pi-guardian-authorized-ten-field-telemetry-proof.md
+++ b/docs/architecture/proofs/runtime/2026-09-01-pi-guardian-authorized-ten-field-telemetry-proof.md
@@ -335,3 +335,254 @@ DOES NOT PROVE:
 - CE-L1 closure (CE-L1=OPEN; LIVE_EXECUTOR_PROVEN=NOT_EMITTED).
 - The readiness-helper `await` question (parked; not admitted).
 - A schema-version change.  The 10-field shape is unchanged.
+
+
+# 2026-09-01 canonical landing preflight — PASS
+
+## Result
+
+```
+RESULT                                = PASS
+GUARDIAN_AUTHORIZED_TEN_FIELD_TELEMETRY = PASS_QUALIFIED_LOCAL
+AUTHORIZED_WRAPPER_STDOUT_FRAMING_DEFECT = PROVEN_AND_REPAIRED_CANONICAL
+PI_WRAPPER_PROTOCOL_FIXTURE_REPRODUCIBILITY = PASS_TRACKED_ONLY_CANONICAL
+LIVE_WRAPPER_PROTOCOL_CAUSE              = UNRESOLVED
+CAUSAL_CLASSIFICATION                     = UNRESOLVED_ASSISTANT_TOOL_CALL_EMISSION_BOUNDARY
+CE-L1                                     = OPEN
+LIVE_EXECUTOR_PROVEN                      = NOT_EMITTED
+CANONICAL_LANDING_CANDIDATE               = PASS
+```
+
+## Scope
+
+This is a landing-preflight receipt only.  No new implementation edit
+is authorized.  The locally-qualified Guardian-authorized ten-field
+telemetry repair is committed as:
+
+```
+c32f84f12395a157d59b6e68b635677bd5a8bec3  Complete Pi authorized ten-field telemetry
+```
+
+with parent:
+
+```
+96a9cc3de79cbefbe14b78c64fabedb1f3b4d9ef
+```
+
+## Pre-push identity
+
+```
+LANDING_BASE_CHECK                       = PASS  (origin/main == 96a9cc3de79cbefbe14b78c64fabedb1f3b4d9ef)
+MAIN_MOVEMENT_BEFORE_PUSH                = NONE
+RUNTIME_SEAM_DRIFT_RESULT                = ORTHOGONAL
+AUTHORITATIVE_IMPLEMENTATION_SHA         = c32f84f12395a157d59b6e68b635677bd5a8bec3
+IMPLEMENTATION_BASE                      = PASS  (merge-base == 96a9cc3de79cbefbe14b78c64fabedb1f3b4d9ef)
+IMPLEMENTATION_SUBJECT                    = "Complete Pi authorized ten-field telemetry"
+TRACKED_WORKTREE_STATUS                  = clean  (LFS package.json ghost "M" only)
+```
+
+## Candidate changed-file list (canonical landing surface)
+
+```
+git diff 96a9cc3de79cbefbe14b78c64fabedb1f3b4d9ef..c32f84f12395a157d59b6e68b635677bd5a8bec3
+--name-status
+
+M  codex_runner/src/agent-wrapper.js
+A  docs/architecture/proofs/runtime/2026-09-01-pi-guardian-authorized-ten-field-telemetry-proof.md
+M  tests/ops/test_pi_assistant_response_telemetry.py
+M  tests/pi/fixtures/fake_pi_package/source/index.js
+M  tests/pi/test_pi_authorized_failure_diagnostics.py
+```
+
+Exactly the intended five-file surface.  No unrelated dirty content.
+No ignored `dist/index.js` appears in the PR diff.
+
+## Telemetry field count
+
+```
+TELEMETRY_FIELD_COUNT = 10
+```
+
+## Exact telemetry names
+
+```
+effective_tool_names
+write_tool_available
+tool_execution_start_count
+tool_execution_end_count
+executed_tool_names
+assistant_tool_call_count
+assistant_message_count
+assistant_content_block_types
+assistant_message_event_types
+assistant_tool_call_event_count
+```
+
+## Telemetry source code readback (canonical-candidate)
+
+- `_parse_authorized_stdout_frame` import and `createToolTelemetry()`
+  call present in `codex_runner/src/agent-wrapper.js`.
+- `createToolTelemetry()` live wiring result = PASS.
+- Assistant event observer wired in `session.subscribe`:
+  `observeAssistantMessageEvent(toolTelemetry, event)`.
+- Final assistant observer wired after successful prompt:
+  `observeFinalAssistantMessages(toolTelemetry, session)`.
+- Manual independent final assistant scan removed: the previous
+  for-of-finalMessages loop that bumped assistant_tool_call_count
+  outside the helper is no longer present.
+- Existing tool-execution observations preserved (start, end, executed
+  names).
+
+## Failure-path ten-field result
+
+Both bounded failure paths emit a complete ten-field object:
+
+- Tool-activation failure: `wrapper_protocol_failed / tool_activation`
+  carries a complete ten-field accumulator.
+- Provider/request failure: `provider_request_failed / provider_request`
+  carries a complete ten-field accumulator (partial/zero values are
+  permitted; missing fields are not).
+
+## Outer result schema
+
+The authorized outer schema is unchanged.  Only the contents of
+`tool_telemetry` are now complete:
+
+```
+status
+summary
+actual_runtime_identity
+execution_result
+session_initialized
+provider_request_started
+tool_telemetry
+```
+
+## Stdout framing regression
+
+`AUTHORIZED_STDOUT_FRAMING_REGRESSION = PASS`
+
+The canonical final-non-empty-line framing from PR #778 is preserved.
+`_parse_authorized_stdout_frame` is unchanged; the adapter 10-field
+parsing is unchanged.
+
+## Runtime identity strictness
+
+`MISSING_RUNTIME_IDENTITY_FAIL_CLOSED = PASS`
+
+A valid final JSON object without `actual_runtime_identity` under
+`require_runtime_identity=True` still returns `actual_identity_missing`.
+
+## Missing-field fail-closed
+
+`REMOVE_ASSISTANT_FIELD_FAIL_CLOSED = PASS`
+
+Removing `assistant_message_count` from an otherwise valid
+authorized success frame returns
+`failure_classification="wrapper_protocol_failed"`,
+`failure_stage="wrapper_protocol"`.
+
+## Provider / model / tool posture
+
+```
+provider            = openai-codex
+model               = gpt-5.6-sol
+harness_id          = pi-coding-agent
+harness_version     = 0.82.1
+configured_tools    = ["read","bash","edit","write"]
+fake_pi_provider    = "openai-codex"
+fake_pi_model       = "gpt-5.6-sol"
+fake_pi_harness_id  = "pi-coding-agent"
+fake_pi_harness_v   = "0.82.1"
+```
+
+No fallback or substitution.
+
+## Tracked fake fixture
+
+- Tracked fake Pi source path:
+  `tests/pi/fixtures/fake_pi_package/source/index.js`
+- Materialized fake package root:
+  `<pytest tmp_path>/fake_pi_package`
+- `PI_CODING_AGENT_PACKAGE_ROOT` always points at the materialized
+  package, never at the in-repository fixture directory.
+- Repository ignored `dist/index.js` remains untracked and is never
+  required.
+
+## Clean tracked-only integration
+
+A fresh detached worktree was created at exactly
+`c32f84f12395a157d59b6e68b635677bd5a8bec3`:
+
+```
+clean_worktree_repository_dist_absent = true
+clean_worktree_noisy_success          = PASS
+clean_worktree_noisy_failure          = PASS
+clean_worktree_zero_event_success     = PASS
+clean_worktree_sentinel_lifecycle      = PASS
+clean_worktree_missing_field_closed   = PASS
+TRACKED_ONLY_TEN_FIELD_AUTHORIZED_PROTOCOL = PASS
+```
+
+## Provider-free posture
+
+```
+PROVIDER_BACKED_INVOCATION_COUNT      = 0
+CAMPAIGN_LIVE_RAIL_COUNT              = 0
+OAUTH_READINESS_COUNT                 = 0
+OPERATOR_CREDENTIAL_STORE_ACCESS_COUNT = 0
+```
+
+## Validation (pre-push)
+
+```
+node --check codex_runner/src/agent-wrapper.js        = exit 0
+node --check codex_runner/src/assistant-telemetry.js  = exit 0
+pytest -v tests/ops/test_pi_assistant_response_telemetry.py
+    collected 7 items
+    7 passed, 1 warning
+pytest -v tests/pi/test_pi_authorized_failure_diagnostics.py
+    collected 56 items
+    56 passed, 1 warning
+pytest -v tests/pi/test_pi_live_invocation.py
+    collected 3 items
+    3 passed, 1 warning
+pytest -v <complete CE-L1 deterministic suite>
+    160 passed, 1 warning
+PYTHON=.venv/bin/python make docs
+    Docs validation passed
+    Diagram freshness check passed
+git diff --check
+    exit 0
+```
+
+## What this slice proves and does not prove
+
+PROVES:
+
+- The exact two-commit implementation lineage (this receipt is a
+  child of the implementation commit) is locally complete,
+  reproducible from tracked state, and free of hidden fixture
+  dependencies.
+- The runtime framing helper implements the canonical
+  final-non-empty-line protocol-frame rule with all seven required
+  semantics (unchanged from PR #778).
+- The live wrapper now produces the complete ten-field telemetry
+  surface.
+- The real `execute_authorized` provider-free end-to-end path
+  accepts the wrapper's success frame (no longer rejected at
+  `wrapper_protocol_failed` due to missing telemetry).
+- The 4 missing assistant-response fields are populated by the
+  existing canonical helpers.
+- Secret-shaped tool arguments are not retained anywhere in the
+  bounded envelope.
+- The 10-field strictness contract is preserved (missing field
+  still fails closed).
+
+DOES NOT PROVE:
+
+- That the wiring makes a real provider call succeed (no live rail
+  in this slice; LIVE_WRAPPER_PROTOCOL_CAUSE=UNRESOLVED).
+- CE-L1 closure (CE-L1=OPEN; LIVE_EXECUTOR_PROVEN=NOT_EMITTED).
+- A schema-version change.  The 10-field shape is unchanged.
+- The readiness-helper `await` question (parked; not admitted).

--- a/tests/ops/test_pi_assistant_response_telemetry.py
+++ b/tests/ops/test_pi_assistant_response_telemetry.py
@@ -226,3 +226,92 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
+
+
+# --- Live-wrapper source regressions (per spec §35).
+#
+# These pytest tests inspect the live wrapper source to assert the
+# canonical 10-field telemetry contract is wired correctly.  They run
+# with pytest (per spec §40) and the script-mode main() above also
+# remains a backstop for executable synthetic-event checks.
+
+import pytest  # noqa: E402  (kept near the pytest tests for readability)
+
+
+WRAPPER_SOURCE = (WORKTREE / "codex_runner" / "src" / "agent-wrapper.js").read_text()
+
+
+def test_wrapper_imports_create_tool_telemetry() -> None:
+    """The live wrapper must import ``createToolTelemetry`` from
+    ``./assistant-telemetry.js`` (the canonical 10-field accumulator
+    helper)."""
+    assert "createToolTelemetry" in WRAPPER_SOURCE, (
+        "wrapper does not import createToolTelemetry"
+    )
+
+
+def test_wrapper_does_not_own_six_field_accumulator_literal() -> None:
+    """The wrapper must NOT maintain its own six-field telemetry
+    accumulator literal.  The canonical helper is the sole source of
+    the bounded shape."""
+    bad_literal = (
+        "\tconst toolTelemetry = {\n"
+        "\t\teffective_tool_names: effectiveToolNames,\n"
+        "\t\twrite_tool_available: writeToolAvailable,\n"
+        "\t\ttool_execution_start_count: 0,\n"
+        "\t\ttool_execution_end_count: 0,\n"
+        "\t\texecuted_tool_names: [],\n"
+        "\t\tassistant_tool_call_count: 0,\n"
+        "\t};"
+    )
+    assert bad_literal not in WRAPPER_SOURCE, (
+        "wrapper still owns the pre-repair 6-field accumulator literal"
+    )
+
+
+def test_wrapper_uses_create_tool_telemetry_call() -> None:
+    """The wrapper must call ``createToolTelemetry()`` to build its
+    accumulator."""
+    assert "createToolTelemetry()" in WRAPPER_SOURCE, (
+        "wrapper does not call createToolTelemetry()"
+    )
+
+
+def test_wrapper_wires_assistant_event_observer() -> None:
+    """The wrapper must call ``observeAssistantMessageEvent`` inside
+    its session subscribe path, independently of OPTIONS.verbose."""
+    assert "observeAssistantMessageEvent(toolTelemetry, event)" in WRAPPER_SOURCE, (
+        "wrapper does not call observeAssistantMessageEvent on each event"
+    )
+    assert WRAPPER_SOURCE.count("observeAssistantMessageEvent(") >= 1
+
+
+def test_wrapper_wires_final_assistant_observer() -> None:
+    """The wrapper must call ``observeFinalAssistantMessages`` after
+    successful prompt.  No manual independent final assistant scan
+    may remain."""
+    assert (
+        "observeFinalAssistantMessages(toolTelemetry, session)"
+        in WRAPPER_SOURCE
+    ), "wrapper does not call observeFinalAssistantMessages"
+
+
+def test_wrapper_does_not_run_manual_assistant_scan() -> None:
+    """The pre-repair manual ``assistant_tool_call_count`` scan over
+    ``session.agent.state.messages`` must be removed."""
+    bad_scan = (
+        "for (const message of finalMessages) {\n"
+        "\t\t\tif (message.role !== \"assistant\") continue;\n"
+    )
+    assert bad_scan not in WRAPPER_SOURCE, (
+        "wrapper still owns the pre-repair manual assistant_tool_call_count scan"
+    )
+
+
+def test_wrapper_does_not_retrieve_assistant_text_or_reasoning() -> None:
+    """The wrapper must not retrieve assistant text deltas or
+    reasoning content for telemetry purposes.  Verbose-only text
+    printing is allowed (and gated on OPTIONS.verbose)."""
+    # The post-repair wrapper retains the verbose text_delta print
+    # (for human log readability) but no telemetry field reads it.
+    assert "assistantMessageEvent.delta" in WRAPPER_SOURCE  # verbose print, allowed

--- a/tests/pi/fixtures/fake_pi_package/source/index.js
+++ b/tests/pi/fixtures/fake_pi_package/source/index.js
@@ -81,6 +81,16 @@ class FakeSession {
         this._subscribers.push(fn);
     }
 
+    _emitSubscribers(event) {
+        for (const sub of this._subscribers) {
+            try {
+                sub(event);
+            } catch (_error) {
+                // bounded evidence only; never crash on subscriber error
+            }
+        }
+    }
+
     async prompt(prompt) {
         // Write one diagnostic line to stdout BEFORE the canonical
         // wrapper writes its terminal JSON. This exercises the framing
@@ -91,6 +101,46 @@ class FakeSession {
             // Raise a synthetic provider-request error so the real
             // wrapper emits its bounded failure JSON.
             throw new Error("synthetic provider request failure");
+        }
+
+        if (this.behavior === "assistant-tool-call") {
+            // Emit the bounded Pi 0.82.1 event sequence the live
+            // wrapper's `observeAssistantMessageEvent` and tool
+            // execution counters consume.  No payload content is
+            // carried; only event-type names.
+            this._emitSubscribers({
+                type: "message_update",
+                assistantMessageEvent: { type: "toolcall_start" },
+            });
+            this._emitSubscribers({
+                type: "tool_execution_start",
+                toolName: "write",
+            });
+            this._emitSubscribers({
+                type: "tool_execution_end",
+                toolName: "write",
+            });
+            this._emitSubscribers({
+                type: "message_update",
+                assistantMessageEvent: { type: "toolcall_end" },
+            });
+            // Set the final session state to one assistant message
+            // with one `toolCall` content block whose argument is
+            // secret-shaped.  The bounded observer MUST NOT return
+            // this value; the test proves it.
+            this.agent.state.messages = [
+                {
+                    role: "assistant",
+                    content: [
+                        {
+                            type: "toolCall",
+                            name: "write",
+                            arguments: "secret-not-returned",
+                        },
+                    ],
+                },
+            ];
+            return;
         }
 
         // No-op for success; the canonical wrapper emits success JSON

--- a/tests/pi/test_pi_authorized_failure_diagnostics.py
+++ b/tests/pi/test_pi_authorized_failure_diagnostics.py
@@ -1227,18 +1227,14 @@ def test_real_wrapper_noisy_stdout_success_protocol(tmp_path: Path) -> None:
     hidden ignored file is required for this test to pass.
 
     The framing repair must NOT collapse this multi-line stdout into
-    ``wrapper_protocol_failed`` at the JSON decode step.  The actual
-    bounded failure here (if any) comes from the wrapper's success
-    payload carrying only the older 6 telemetry fields, not the four
-    assistant-response fields the adapter requires for live authorized
-    success — which is a separate, known wrapper-output shape question
-    and OUT OF SCOPE for this repair slice.
+    ``wrapper_protocol_failed`` at the JSON decode step.  After the
+    Guardian-authorized ten-field telemetry repair, the wrapper emits
+    a complete 10-field ``tool_telemetry`` object and the real
+    ``execute_authorized`` path accepts the success frame (not a
+    bounded ``wrapper_protocol_failed``).
 
-    The assertion that matters: the adapter does NOT emit
-    ``failure_classification=wrapper_protocol_failed`` because the
-    stdout could not be decoded; if it emits ``wrapper_protocol_failed``
-    it must be due to telemetry strictness (or runtime identity), which
-    is downstream of framing.
+    The secret-shaped leading diagnostic (``access_token=secret-not-returned``)
+    must not appear in the returned envelope's serialized payload.
     """
     materialized = _materialize_fake_pi_package(tmp_path)
     fake_home = tmp_path / "home"
@@ -1259,6 +1255,28 @@ def test_real_wrapper_noisy_stdout_success_protocol(tmp_path: Path) -> None:
     parsed = json.loads(final_line)
     assert isinstance(parsed, dict)
     assert "actual_runtime_identity" in parsed
+    # After the 10-field telemetry repair, the wrapper emits a complete
+    # 10-field tool_telemetry object on success.
+    assert parsed["status"] == "ok", (
+        f"pre-repair 6-field payload expected; got status={parsed['status']!r}: {parsed!r}"
+    )
+    tt = parsed["tool_telemetry"]
+    expected_keys = {
+        "effective_tool_names",
+        "write_tool_available",
+        "tool_execution_start_count",
+        "tool_execution_end_count",
+        "executed_tool_names",
+        "assistant_tool_call_count",
+        "assistant_message_count",
+        "assistant_content_block_types",
+        "assistant_message_event_types",
+        "assistant_tool_call_event_count",
+    }
+    assert set(tt.keys()) == expected_keys, (
+        f"tool_telemetry keys mismatch: missing={expected_keys - set(tt.keys())} "
+        f"extra={set(tt.keys()) - expected_keys}"
+    )
     # The adapter's framing helper recovers the same payload.
     recovered = pi_codex_runner._parse_authorized_stdout_frame(result.stdout)
     assert recovered == parsed
@@ -1272,6 +1290,197 @@ def test_real_wrapper_noisy_stdout_success_protocol(tmp_path: Path) -> None:
     assert envelope.actual_harness_id == "pi-coding-agent"
     assert envelope.actual_harness_version == "0.82.1"
     assert envelope.runtime_identity_established is True
+    # Secret-shaped leading diagnostic MUST NOT appear in the envelope.
+    payload_dump = json.dumps(envelope.model_dump(), sort_keys=True)
+    assert "secret-not-returned" not in payload_dump
+    assert "FAKE_PI_SDK_DIAGNOSTIC" not in payload_dump
+
+
+# --- Guardian-authorized ten-field telemetry contract tests.
+#
+# These tests exercise the real wrapper against the materialized fake Pi
+# package.  The fake exposes two behavior modes:
+#   default            (no PI_FAKE_I_BEHAVIOR)  -> zero-event success
+#   assistant-tool-call (PI_FAKE_I_BEHAVIOR=assistant-tool-call)
+#                                           -> bounded event sequence
+# The default path produces a clean zero-event success with all ten
+# telemetry fields populated to bounded zero/empty values.  The
+# assistant-tool-call path produces a sentinel lifecycle with the
+# exact field values spec'd in the bounded-live-substrate-proof
+# recipe (Requirement 19).
+
+ZERO_EVENT_EXPECTED = {
+    "effective_tool_names": ("read", "bash", "edit", "write"),
+    "write_tool_available": True,
+    "tool_execution_start_count": 0,
+    "tool_execution_end_count": 0,
+    "executed_tool_names": (),
+    "assistant_tool_call_count": 0,
+    "assistant_message_count": 0,
+    "assistant_content_block_types": (),
+    "assistant_message_event_types": (),
+    "assistant_tool_call_event_count": 0,
+}
+
+SENTINEL_EXPECTED = {
+    "effective_tool_names": ("read", "bash", "edit", "write"),
+    "write_tool_available": True,
+    "tool_execution_start_count": 1,
+    "tool_execution_end_count": 1,
+    "executed_tool_names": ("write",),
+    "assistant_tool_call_count": 1,
+    "assistant_message_count": 1,
+    "assistant_content_block_types": ("toolCall",),
+    "assistant_message_event_types": ("toolcall_start", "toolcall_end"),
+    "assistant_tool_call_event_count": 2,
+}
+
+
+def _last_json(stdout: str) -> dict:
+    final_line = stdout.strip().splitlines()[-1]
+    return json.loads(final_line)
+
+
+def _envelope_tt_dict(envelope) -> dict[str, object]:
+    """Map the bounded envelope's individual telemetry attributes to a
+    dict for spec-mapped comparison."""
+    return {
+        "effective_tool_names": envelope.effective_tool_names,
+        "write_tool_available": envelope.write_tool_available,
+        "tool_execution_start_count": envelope.tool_execution_start_count,
+        "tool_execution_end_count": envelope.tool_execution_end_count,
+        "executed_tool_names": envelope.executed_tool_names,
+        "assistant_tool_call_count": envelope.assistant_tool_call_count,
+        "assistant_message_count": envelope.assistant_message_count,
+        "assistant_content_block_types": envelope.assistant_content_block_types,
+        "assistant_message_event_types": envelope.assistant_message_event_types,
+        "assistant_tool_call_event_count": envelope.assistant_tool_call_event_count,
+    }
+
+
+@pytest.mark.skipif(
+    not _FIXTURE_SOURCE_INDEX.exists(),
+    reason="tracked fake Pi source fixture is missing",
+)
+def test_real_wrapper_ten_field_zero_event_success(tmp_path: Path) -> None:
+    """Canonical 10-field zero-event success: the wrapper emits a
+    complete tool_telemetry object with all four newly-wired assistant
+    fields present (default behavior; no events emitted)."""
+    materialized = _materialize_fake_pi_package(tmp_path)
+    fake_home = tmp_path / "home"
+    fake_home.mkdir(parents=True, exist_ok=True)
+    result = _subprocess_authorized_wrapper(
+        materialized,
+        fake_home=fake_home,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, (
+        f"wrapper subprocess failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    parsed = _last_json(result.stdout)
+    assert parsed["status"] == "ok"
+    envelope = _envelope_from_wrapper_result(result)
+    assert envelope.status == "ok"
+    assert envelope.runtime_identity_established is True
+    actual = _envelope_tt_dict(envelope)
+    for key, expected in ZERO_EVENT_EXPECTED.items():
+        assert actual[key] == expected, (
+            f"telemetry field {key!r}: expected {expected!r}, got {actual[key]!r}"
+        )
+
+
+@pytest.mark.skipif(
+    not _FIXTURE_SOURCE_INDEX.exists(),
+    reason="tracked fake Pi source fixture is missing",
+)
+def test_real_wrapper_ten_field_assistant_tool_call_sentinel(tmp_path: Path) -> None:
+    """Sentinel lifecycle: fake Pi emits one toolcall_start, one
+    tool_execution_start (write), one tool_execution_end (write), and
+    one toolcall_end.  Final session state contains one assistant
+    message with one toolCall block carrying a secret-shaped
+    argument.  The wrapper must surface the exact 10-field values
+    from SENTINEL_EXPECTED and MUST NOT retain the secret-shaped
+    argument anywhere in the bounded envelope."""
+    materialized = _materialize_fake_pi_package(tmp_path)
+    fake_home = tmp_path / "home"
+    fake_home.mkdir(parents=True, exist_ok=True)
+    extra_env = {"PI_FAKE_I_BEHAVIOR": "assistant-tool-call"}
+    result = _subprocess_authorized_wrapper(
+        materialized,
+        fake_home=fake_home,
+        cwd=tmp_path,
+        extra_env=extra_env,
+    )
+    assert result.returncode == 0, (
+        f"wrapper subprocess failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    parsed = _last_json(result.stdout)
+    assert parsed["status"] == "ok"
+    envelope = _envelope_from_wrapper_result(result)
+    assert envelope.status == "ok"
+    assert envelope.runtime_identity_established is True
+    actual = _envelope_tt_dict(envelope)
+    for key, expected in SENTINEL_EXPECTED.items():
+        assert actual[key] == expected, (
+            f"telemetry field {key!r}: expected {expected!r}, got {actual[key]!r}"
+        )
+    # Content-redaction proof: secret-shaped argument MUST NOT appear
+    # in any serialized envelope field.
+    payload_dump = json.dumps(envelope.model_dump(), sort_keys=True)
+    assert "secret-not-returned" not in payload_dump, (
+        "secret-shaped argument leaked into the bounded envelope"
+    )
+
+
+def test_remove_assistant_message_count_fails_closed() -> None:
+    """Missing one assistant field (assistant_message_count) in an
+    otherwise valid authorized success frame must still return
+    wrapper_protocol_failed at wrapper_protocol.  The framing
+    repair must not weaken the 10-field strictness contract."""
+    payload = {
+        "status": "ok",
+        "summary": "bounded",
+        "actual_runtime_identity": {
+            "actual_provider_id": "openai-codex",
+            "actual_model_id": "gpt-5.6-sol",
+            "actual_harness_id": "pi-coding-agent",
+            "actual_harness_version": "0.82.1",
+        },
+        "execution_result": {
+            "status": "completed",
+            "result_kind": "structured",
+            "content_omitted": True,
+        },
+        "session_initialized": True,
+        "provider_request_started": True,
+        "tool_telemetry": {
+            "effective_tool_names": ["read", "bash", "edit", "write"],
+            "write_tool_available": True,
+            "tool_execution_start_count": 0,
+            "tool_execution_end_count": 0,
+            "executed_tool_names": [],
+            "assistant_tool_call_count": 0,
+            # assistant_message_count omitted
+            "assistant_content_block_types": [],
+            "assistant_message_event_types": [],
+            "assistant_tool_call_event_count": 0,
+        },
+    }
+    result = subprocess.CompletedProcess(
+        ["node", "agent-wrapper.js", "guardian-authorized-task", "fixture"],
+        0,
+        json.dumps(payload),
+        "",
+    )
+    envelope = PiCodexRunnerAdapter()._parse_result(
+        result,
+        require_runtime_identity=True,
+        require_tool_telemetry=True,
+    )
+    assert envelope.failure_classification == (
+        PiAuthorizedFailureClass.WRAPPER_PROTOCOL_FAILED.value
+    )
+    assert envelope.failure_stage == "wrapper_protocol"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

Promotes the locally-qualified Guardian-authorized ten-field telemetry repair onto `main`.

The canonical authorized adapter (`PiCodexRunnerAdapter._parse_tool_telemetry`) has always required a 10-field bounded telemetry shape on the live authorized result. The previous canonical `agent-wrapper.js` produced only six fields because the live producer had not finished wiring the existing `createToolTelemetry`, `observeAssistantMessageEvent`, and `observeFinalAssistantMessages` helpers from `./assistant-telemetry.js`. The live accumulator was a manual six-field literal.

This PR aligns the live producer with the accepted contract by:

1. Importing `createToolTelemetry` from `./assistant-telemetry.js`.
2. Replacing the manual six-field literal with `createToolTelemetry()`.
3. Wiring `observeAssistantMessageEvent` into the `session.subscribe` callback, independent of `OPTIONS.verbose`.
4. Replacing the independent final assistant scan with `observeFinalAssistantMessages` after successful `session.prompt(...)`.
5. Preserving the existing tool-execution observers (start, end, executed names).
6. Preserving the canonical stdout-framing repair from PR #778.
7. Preserving the provider/model/tool identity (`openai-codex / gpt-5.6-sol / pi-coding-agent / 0.82.1`).

## What this PR changes (canonical landing surface)

- `codex_runner/src/agent-wrapper.js` — canonical 10-field accumulator wiring.
- `tests/ops/test_pi_assistant_response_telemetry.py` — 7 new pytest wrapper-source regressions (createToolTelemetry import, no six-field literal, observer wirings, content non-retention).
- `tests/pi/fixtures/fake_pi_package/source/index.js` — bounded `PI_FAKE_I_BEHAVIOR=assistant-tool-call` mode for sentinel lifecycle.
- `tests/pi/test_pi_authorized_failure_diagnostics.py` — 3 new ten-field tests (zero-event success, sentinel success, missing-field fail-closed) + existing noisy-framing test docstring updated.
- `docs/architecture/proofs/runtime/2026-09-01-pi-guardian-authorized-ten-field-telemetry-proof.md` — qualified proof + landing qualification receipt (this PR's proof ledger).

## What this PR does NOT change

- No telemetry schema change. The 10-field shape is frozen.
- No `agent-wrapper.js` output schema change. Only the contents of `tool_telemetry` are now complete.
- No provider/model/tool authority change.
- No Campaign Engine change.
- No canonical framing change (PR #778 stdout-framing repair preserved).
- No adapter parser change (`_parse_authorized_stdout_frame` unchanged).
- No `_parse_tool_telemetry` / `_is_valid_tool_telemetry` / 10-field contract change.
- No Pi SDK change.
- No prompt change.
- No release claim widening.

## Canonical token posture (pre-merge)

The local qualification produced:

```
GUARDIAN_AUTHORIZED_TEN_FIELD_TELEMETRY = PASS_QUALIFIED_LOCAL
AUTHORIZED_WRAPPER_STDOUT_FRAMING_DEFECT = PROVEN_AND_REPAIRED_CANONICAL
PI_WRAPPER_PROTOCOL_FIXTURE_REPRODUCIBILITY = PASS_TRACKED_ONLY_CANONICAL
LIVE_WRAPPER_PROTOCOL_CAUSE              = UNRESOLVED
CE-L1                                     = OPEN
LIVE_EXECUTOR_PROVEN                      = NOT_EMITTED
```

Post-merge (canonical):

```
GUARDIAN_AUTHORIZED_TEN_FIELD_TELEMETRY = PASS_CANONICAL  (only after successful merge + readback)
```

## What this PR does NOT do

- Does not requalify the disposable CE-L1 driver.
- Does not authorize or execute a new CE-L1 live rail.
- Does not update `docs/architecture/00-current-state.md`.
- Does not claim `LIVE_EXECUTOR_PROVEN`.
- Does not close CE-L1.

## Merge method

Please merge with an **ancestry-preserving** method (GitHub "Create a merge commit" or `--no-ff` merge locally). **Do not squash** — the per-stage commits (`e9125a286` framing, `c32f84f12` ten-field, `823c766a5` landing qualification) are part of the bounded-proof recipe and must remain identifiable on `main` as ancestors of canonical HEAD.

## Test plan

- `pytest -v tests/ops/test_pi_assistant_response_telemetry.py` — 7
- `pytest -v tests/pi/test_pi_authorized_failure_diagnostics.py` — 56
- `pytest -v tests/pi/test_pi_live_invocation.py` — 39
- `pytest -v <complete CE-L1 deterministic suite>` — 160
- `node --check codex_runner/src/agent-wrapper.js` — exit 0
- `node --check codex_runner/src/assistant-telemetry.js` — exit 0
- `make docs` — PASS

All 160 tests pass. No provider calls, no rail calls, no credential access, no OAuth readiness.

## Discovered blockers (separate from this PR)

The readiness-helper `await` question remains parked. It is not admitted into this PR because the current blocker was independently proven at the authorized task output contract. A separate slice may address it after this repair lands.
