### PR TITLE
Reconcile Anthropic Pi default model identity

### DIFF
--- a/codex_runner/src/agent-wrapper.js
+++ b/codex_runner/src/agent-wrapper.js
@@ -31,6 +31,7 @@ const prompt = args.slice(1).join(" ");
 const guardianAuthorizedMode = mode === "guardian-authorized-task";
 const guardianAuthorizedReadinessMode = mode === "guardian-authorized-readiness";
 const ACTUAL_HARNESS_ID = "pi-coding-agent";
+const DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6";
 
 const AUTHORIZED_FAILURE_CLASSES = new Set([
 	"adapter_timeout",
@@ -51,7 +52,7 @@ const AUTHORIZED_FAILURE_CLASSES = new Set([
 
 const OPTIONS = {
 	cwd: process.cwd(),
-	model: process.env.PI_MODEL || "claude-sonnet-4-20250514",
+	model: process.env.PI_MODEL || DEFAULT_ANTHROPIC_MODEL,
 	provider: process.env.PI_PROVIDER || "anthropic",
 	thinking: process.env.PI_THINKING || "medium",
 	verbose: process.env.PI_VERBOSE === "1",
@@ -62,13 +63,13 @@ const OPTIONS = {
 
 // Known model mappings
 const MODEL_ALIASES = {
-	"sonnet": "claude-sonnet-4-20250514",
-	"sonnet4": "claude-sonnet-4-20250514",
+	"sonnet": DEFAULT_ANTHROPIC_MODEL,
+	"sonnet4": DEFAULT_ANTHROPIC_MODEL,
 	"opus": "claude-opus-4-5",
 	"opus4": "claude-opus-4-5",
 	"haiku": "claude-haiku-4",
 	"haiku4": "claude-haiku-4",
-	"sonnet-4": "claude-sonnet-4-20250514",
+	"sonnet-4": DEFAULT_ANTHROPIC_MODEL,
 	"opus-4": "claude-opus-4-5",
 	"haiku-4": "claude-haiku-4",
 };
@@ -83,7 +84,7 @@ function resolveModel(modelId, getModel) {
 	if (model) return modelId;
 	// Try partial match
 	const normalized = modelId.toLowerCase().replace(/[^a-z0-9]/g, "");
-	const models = ["claude-sonnet-4-20250514", "claude-opus-4-5", "claude-haiku-4"];
+	const models = [DEFAULT_ANTHROPIC_MODEL, "claude-opus-4-5", "claude-haiku-4"];
 	for (const m of models) {
 		if (m.toLowerCase().replace(/[^a-z0-9]/g, "").includes(normalized)) {
 			return m;
@@ -440,7 +441,7 @@ async function runAgent() {
 		}
 		console.error(`Model not found: ${resolvedModelId}`);
 		console.error("Available models:");
-		console.error("  - claude-sonnet-4-20250514 (Claude Sonnet 4)");
+		console.error(`  - ${DEFAULT_ANTHROPIC_MODEL} (Claude Sonnet 4.6)`);
 		console.error("  - claude-opus-4-5 (Claude Opus 4)");
 		console.error("  - claude-haiku-4 (Claude Haiku 4)");
 		console.error("Aliases: sonnet, opus, haiku (or with -4 suffix)");
@@ -809,14 +810,14 @@ Modes:
   help     - Show this help
 
 Environment Variables:
-  PI_MODEL      - Model to use (default: claude-sonnet-4-20250514)
+  PI_MODEL      - Model to use (default: ${DEFAULT_ANTHROPIC_MODEL})
   PI_PROVIDER   - Provider to use (default: anthropic)
   PI_THINKING   - Thinking level: off, minimal, low, medium, high, xhigh
   PI_VERBOSE    - Set to 1 for verbose output
   PI_DISABLE_TOOLS - Set to 1 to run without coding tools
 
 Model Aliases:
-  sonnet, sonnet4, sonnet-4  → claude-sonnet-4-20250514
+  sonnet, sonnet4, sonnet-4  → ${DEFAULT_ANTHROPIC_MODEL}
   opus, opus4, opus-4         → claude-opus-4-5
   haiku, haiku4, haiku-4      → claude-haiku-4
 

--- a/codex_runner/src/profile.py
+++ b/codex_runner/src/profile.py
@@ -28,18 +28,19 @@ except ImportError:
 
 PROFILE_DIR = Path.home() / ".config" / "campaign_runner"
 PROFILES_PATH = PROFILE_DIR / "profiles.toml"
+DEFAULT_MODEL = "claude-sonnet-4-6"
 
 # Default profiles
 DEFAULT_PROFILES = {
     "default": {
-        "model": "claude-sonnet-4-20250514",
+        "model": DEFAULT_MODEL,
         "thinking": "medium",
         "passes": 1,
         "verify": False,
         "execute": False,
     },
     "fast": {
-        "model": "claude-sonnet-4-20250514",
+        "model": DEFAULT_MODEL,
         "thinking": "low",
         "passes": 2,
         "verify": False,
@@ -53,7 +54,7 @@ DEFAULT_PROFILES = {
         "execute": True,
     },
     "review": {
-        "model": "claude-sonnet-4-20250514",
+        "model": DEFAULT_MODEL,
         "thinking": "medium",
         "passes": 1,
         "verify": False,
@@ -65,7 +66,7 @@ DEFAULT_PROFILES = {
 @dataclass
 class Profile:
     name: str
-    model: str = "claude-sonnet-4-20250514"
+    model: str = DEFAULT_MODEL
     thinking: str = "medium"
     passes: int = 1
     verify: bool = False
@@ -87,7 +88,7 @@ class Profile:
     def from_dict(cls, name: str, data: dict[str, Any]) -> Profile:
         return cls(
             name=name,
-            model=data.get("model", "claude-sonnet-4-20250514"),
+            model=data.get("model", DEFAULT_MODEL),
             thinking=data.get("thinking", "medium"),
             passes=int(data.get("passes", 1)),
             verify=bool(data.get("verify", False)),

--- a/codex_runner/src/runner_cli.py
+++ b/codex_runner/src/runner_cli.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 # Import profile management
-from profile import Profile, ProfileManager
+from profile import DEFAULT_MODEL, Profile, ProfileManager
 from typing import Any
 
 # Configuration
@@ -85,7 +85,7 @@ def run_pi_agent(
 
     # Build environment
     env = os.environ.copy()
-    env["PI_MODEL"] = options.get("model", "claude-sonnet-4-20250514")
+    env["PI_MODEL"] = options.get("model", DEFAULT_MODEL)
     env["PI_THINKING"] = options.get("thinking", "medium")
     if options.get("verbose"):
         env["PI_VERBOSE"] = "1"
@@ -251,7 +251,7 @@ Respond with JSON only. Format:
 """
 
     agent_options = {
-        "model": profile.model if profile else "claude-sonnet-4-20250514",
+        "model": profile.model if profile else DEFAULT_MODEL,
         "thinking": profile.thinking if profile else "medium",
         "verbose": options.get("verbose", False),
         "cwd": str(repo_root),
@@ -326,7 +326,7 @@ Report your findings and actions as JSON.
 """
 
     agent_options = {
-        "model": profile.model if profile else "claude-sonnet-4-20250514",
+        "model": profile.model if profile else DEFAULT_MODEL,
         "thinking": profile.thinking if profile else "medium",
         "verbose": options.get("verbose", False),
         "cwd": str(repo_root),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -593,7 +593,7 @@ services:
       CAMPAIGN_RUNNER_PI_ROUTE: "${CAMPAIGN_RUNNER_PI_ROUTE:-default}"
       CAMPAIGN_RUNNER_REQUIRE_BACKEND_RECEIPT: "${CAMPAIGN_RUNNER_REQUIRE_BACKEND_RECEIPT:-true}"
       PI_PROVIDER: "${PI_PROVIDER:-anthropic}"
-      PI_MODEL: "${PI_MODEL:-claude-sonnet-4-20250514}"
+      PI_MODEL: "${PI_MODEL:-claude-sonnet-4-6}"
       PI_CODING_AGENT_PACKAGE_ROOT: /opt/codexify/pi-sdk/node_modules/@earendil-works/pi-coding-agent
       PI_CODING_AGENT_NODE_MODULES: /opt/codexify/pi-sdk/node_modules
       # Current default-provider credential; alternate providers use the Pi auth store.

--- a/docs/Ops/SOLO_OPERATOR_CODING_WORKER_RUNBOOK.md
+++ b/docs/Ops/SOLO_OPERATOR_CODING_WORKER_RUNBOOK.md
@@ -75,7 +75,8 @@ unrelated host user and do not loosen auth-file permissions to compensate.
 
 The effective provider and model are selected with `PI_PROVIDER` and
 `PI_MODEL`. Their source-Compose defaults are `anthropic` and
-`claude-sonnet-4-20250514`. For the default provider, Pi may resolve a
+`claude-sonnet-4-6`. The exact model identifier must resolve from the pinned
+Pi runtime registry. For the default provider, Pi may resolve a
 credential from the mounted auth file or from `ANTHROPIC_API_KEY` in the
 worker's Compose environment. Other Pi-supported providers should be selected
 explicitly and authenticated through the same mounted Pi auth store. General
@@ -700,7 +701,7 @@ and is not made Pi-ready by this source-Compose change.
 | `CAMPAIGN_RUNNER_PI_ROUTE` | No | `default` | Declares the requested Pi route label |
 | `CAMPAIGN_RUNNER_REQUIRE_BACKEND_RECEIPT` | No | `true` | Documents that brokered execution should preserve backend receipts |
 | `PI_PROVIDER` | No | `anthropic` | Effective provider resolved by the Pi wrapper |
-| `PI_MODEL` | No | `claude-sonnet-4-20250514` | Effective model resolved for the selected provider |
+| `PI_MODEL` | No | `claude-sonnet-4-6` | Effective model resolved for the selected provider; must resolve from the pinned Pi runtime registry |
 | `ANTHROPIC_API_KEY` | Required only for env-based default-provider auth | None | Worker-only Compose credential alternative; never print or commit it |
 
 ## Pi Broker Operational Note

--- a/docs/architecture/config-and-ops.md
+++ b/docs/architecture/config-and-ops.md
@@ -143,7 +143,8 @@ auth file at `/home/codexify/.pi/agent/auth.json`.
 
 `PI_PROVIDER` and `PI_MODEL` select the coding adapter's effective provider and
 model; their source-Compose defaults are `anthropic` and
-`claude-sonnet-4-20250514`. `ANTHROPIC_API_KEY` is an allowed worker input for
+`claude-sonnet-4-6`. The exact model identifier must resolve from the pinned
+Pi runtime registry. `ANTHROPIC_API_KEY` is an allowed worker input for
 the current default provider, while Pi's mounted auth store remains the
 persistent authentication boundary. These variables do not change general
 chat routing, provider authorization, supported-profile approval, or the

--- a/docs/architecture/proofs/runtime/2026-09-04-pi-anthropic-default-model-reconciliation-proof.md
+++ b/docs/architecture/proofs/runtime/2026-09-04-pi-anthropic-default-model-reconciliation-proof.md
@@ -1,0 +1,440 @@
+# 2026-09-04 — Pi Anthropic Default Model Reconciliation Proof
+
+## 1. Result
+
+~~~text
+RESULT=PASS
+ANTHROPIC_DEFAULT_MODEL_DRIFT=REPAIRED_LOCAL
+CANONICAL_ANTHROPIC_CODING_DEFAULT=claude-sonnet-4-6
+ANTHROPIC_REPLACEMENT_MODEL_RESOLUTION=PASS_EXACT
+ANTHROPIC_REPLACEMENT_SESSION_COMPATIBILITY=PASS_PROVIDER_FREE
+GUARDIAN_AUTHORIZED_MODEL_IDENTITY_EXACT=PASS
+ANTHROPIC_DEFAULT_COHERENCE=PASS
+ANTHROPIC_AUTHORIZED_MODEL_RESOLUTION=PASS_PROVIDER_FREE
+OBSOLETE_ANTHROPIC_ID_SILENT_REMAP=false
+ACTIVE_CODING_RUNTIME_STALE_ID_COUNT=0
+VENDORED_PI_MODEL_REGISTRY_MUTATION_COUNT=0
+~~~
+
+This is a local configuration and runtime-boundary repair. It does not close
+CE-L1, authorize a new provider-backed control, or widen the Codexify Beta
+support claim.
+
+## 2. Scope
+
+This task reconciles the active Codexify coding-worker Anthropic default with
+the exact model identifier supplied by the pinned Pi 0.82.1 registry. It
+preserves Guardian authorization ownership, exact provider/model identity,
+single-attempt behavior, the existing Pi invocation boundary, and the
+provider-free evidence posture.
+
+The task authorized zero provider-backed invocations, zero live Executor
+invocations, zero OAuth actions, and zero operator credential-store access.
+The Pi vendor tree was an authority consumed by the repair, not an edit
+surface.
+
+## 3. Captured canonical-main identity
+
+Task-start capture was performed with git fetch origin, followed by
+git rev-parse origin/main and git show -s --format='%H %s':
+
+~~~text
+AXIS_OBSERVED_AUTHORING_MAIN=a6b2e6cb13f5ac6f2c201d835f99f065871fdea8
+CAPTURED_MAIN=a6b2e6cb13f5ac6f2c201d835f99f065871fdea8
+CAPTURED_MAIN_SUBJECT=Remove September 4 development log
+~~~
+
+The authoring anchor was verified as an ancestor of captured origin/main with
+git merge-base --is-ancestor; the command exited successfully.
+
+The source checkout could not create the requested branch because its Git
+metadata rejected the ref-lock write with Operation not permitted. A fresh
+local clone under the writable Keep root was therefore created from the
+captured SHA, and the implementation branch was created there while clean:
+
+~~~text
+IMPLEMENTATION_ROOT=/Users/resonant_jones/Keep/Resonant_Constructs/projectCodexify/Codexify-pi-anthropic-default-reconciliation
+BRANCH=fix/pi-anthropic-default-model-registry-drift
+PRE_TASK_HEAD=a6b2e6cb13f5ac6f2c201d835f99f065871fdea8
+~~~
+
+The original source checkout's pre-existing modification to
+tests/pi/fixtures/fake_pi_package/package.json was not changed, staged, or
+copied into the implementation branch.
+
+## 4. Main drift classification
+
+The bounded diff from the Axis authoring anchor to captured origin/main over
+the CE-L1/provider/model surfaces was empty:
+
+~~~text
+DRIFT_CLASS=NO_DRIFT
+MATERIAL_CE_L1_FILES_CHANGED_BEFORE_TASK=none
+~~~
+
+The task therefore proceeded from the exact captured main tip. No unrelated
+frontend, migration, operator-log, or private-preview movement was treated as
+provider/runtime drift.
+
+## 5. Governing ADR impact
+
+~~~text
+ADR_IMPACT=ALIGNED_WITH_ADR-020_ADR-066_ADR-068
+NEW_ADR_REQUIRED=false
+~~~
+
+The repair is aligned with:
+
+- ADR-020: Guardian remains the owner of authorization, request identity,
+  lineage, and bounded result return; Pi remains the invocation substrate.
+- ADR-066: the Campaign Engine does not gain provider fallback, retry,
+  rebinding, or provider-selection authority from this configuration repair.
+- ADR-068: exact provider/model identity remains the expected RoleBinding
+  identity for any future live Executor work; this task performs no such live
+  work.
+
+docs/architecture/00-current-state.md was read and intentionally not updated.
+Pi 0.82.1 coding-worker changes remain qualification evidence, not live
+provider support.
+
+## 6. Prior Anthropic failure evidence
+
+The local prior proof commit
+e840868a3fa95dfc8aa2a976ee8631d335362998 records the one already-spent
+Anthropic CE-L1 control. Its exact identity was:
+
+~~~text
+anthropic / claude-sonnet-4-20250514 / pi-coding-agent@0.82.1
+~~~
+
+The bounded failure was:
+
+~~~text
+failure_reason=adapter_execution_failure
+diagnostic_class=model_unresolved
+diagnostic_stage=model_resolution
+provider_transport_reached=false
+~~~
+
+The failure occurred before a provider request, so this task does not rerun or
+reinterpret that rail.
+
+## 7. Old coding default
+
+Before the repair, the obsolete exact ID appeared in the active coding-worker
+default seams:
+
+| Surface | Pre-repair state |
+| --- | --- |
+| codex_runner/src/agent-wrapper.js | wrapper default, generic Sonnet aliases, partial-match list, help text |
+| codex_runner/src/profile.py | default, fast, review, dataclass, and deserialization fallbacks |
+| codex_runner/src/runner_cli.py | direct agent, audit, and run fallbacks |
+| guardian/agents/pi_readiness.py | readiness default |
+| guardian/agents/adapters/pi_codex_runner.py | legacy adapter fallback |
+| docker-compose.yml | worker-coding PI_MODEL default |
+| operator docs | source-Compose default descriptions |
+
+The active startup-gate test also constructed a blocked readiness report with
+the old example value. It was identified before editing and updated under the
+task's explicit discovery allowance because it is directly tied to the active
+coding-worker readiness surface.
+
+## 8. Replacement-model selection
+
+The task specified claude-sonnet-4-6 as the only permitted replacement. No
+alternative model was selected, and no provider policy or fallback behavior
+was changed.
+
+## 9. Exact Pi registry resolution
+
+Using the source-vendored Pi 0.82.1 runtime, with
+ModelRuntime.create({ allowModelNetwork: false }), the exact lookup returned:
+
+~~~json
+{
+  "provider": "anthropic",
+  "id": "claude-sonnet-4-6",
+  "api": "anthropic-messages",
+  "reasoning": true,
+  "input": ["text", "image"],
+  "compat": {
+    "forceAdaptiveThinking": true,
+    "supportsStrictTools": true
+  },
+  "thinkingLevelMap": {
+    "max": "max"
+  }
+}
+~~~
+
+The lookup used an isolated PI_CODING_AGENT_DIR, PI_OFFLINE=1, and
+allowModelNetwork: false. It did not read operator credentials or contact a
+provider. The exact registry resolution passed before implementation edits and
+was repeated by the focused post-edit regression suite.
+
+## 10. Provider-free session compatibility
+
+The same canonical Pi runtime created a session for the replacement model with
+the wrapper's configured posture:
+
+~~~text
+tools=["read","bash","edit","write"]
+requested_thinking=medium
+effective_thinking=medium
+api=anthropic-messages
+provider_transport_started=false
+~~~
+
+The actual session reported the exact four active tool names and included
+medium in its available thinking levels. No prompt was issued. The durable
+regression is
+test_reconciled_anthropic_model_supports_canonical_session_provider_free.
+
+## 11. Active coding-default inventory
+
+The repaired active inventory is:
+
+| Surface | Canonical source of truth | Repaired value |
+| --- | --- | --- |
+| wrapper | DEFAULT_ANTHROPIC_MODEL | claude-sonnet-4-6 |
+| Campaign Runner profiles | DEFAULT_MODEL | claude-sonnet-4-6 |
+| Runner CLI | imported DEFAULT_MODEL | claude-sonnet-4-6 |
+| Guardian readiness | DEFAULT_PI_PROVIDER / DEFAULT_PI_MODEL | anthropic / claude-sonnet-4-6 |
+| legacy adapter | imported DEFAULT_PI_MODEL | claude-sonnet-4-6 |
+| worker Compose service | PI_PROVIDER / PI_MODEL | anthropic / claude-sonnet-4-6 |
+
+The active-surface stale-ID command returned no matches. Therefore:
+
+~~~text
+ACTIVE_CODING_RUNTIME_STALE_ID_COUNT=0
+~~~
+
+## 12. Implementation changes
+
+Changed in the implementation branch:
+
+- codex_runner/src/agent-wrapper.js: introduced one local Anthropic default,
+  routed generic Sonnet aliases and non-authorized Sonnet matching through it,
+  and updated user-facing model text.
+- codex_runner/src/profile.py: introduced DEFAULT_MODEL and applied it to
+  active Sonnet/default profiles and dataclass/deserialization fallbacks.
+- codex_runner/src/runner_cli.py: imported and reused DEFAULT_MODEL for the
+  direct agent, audit, and run fallbacks; the explicit Opus compile fallback is
+  unchanged.
+- guardian/agents/pi_readiness.py: changed only the default model value.
+- guardian/agents/adapters/pi_codex_runner.py: imported the readiness default;
+  authorized identity injection is unchanged.
+- docker-compose.yml: changed only the coding-worker PI_MODEL default.
+- docs/architecture/config-and-ops.md and
+  docs/Ops/SOLO_OPERATOR_CODING_WORKER_RUNBOOK.md: aligned source-Compose
+  default documentation and stated the pinned-registry resolution boundary.
+
+No file beneath codex_runner/vendor/pi-coding-agent/ changed:
+
+~~~text
+VENDORED_PI_MODEL_REGISTRY_MUTATION_COUNT=0
+~~~
+
+## 13. Guardian-authorized exact-identity invariant
+
+requireGuardianAuthorizedIdentity() remains the required source of the
+authorized provider, model, harness, and harness version. The authorized path
+continues to call getModel(identity.providerId, identity.modelId) with the
+exact supplied values. It does not pass authorized model IDs through generic
+aliases or the non-authorized partial-match list.
+
+The replacement authorized-readiness regression established:
+
+~~~text
+actual_provider_id=anthropic
+actual_model_id=claude-sonnet-4-6
+actual_harness_id=pi-coding-agent
+actual_harness_version=0.82.1
+runtime_identity_established=true
+session_initialized=false
+provider_request_started=false
+~~~
+
+~~~text
+GUARDIAN_AUTHORIZED_MODEL_IDENTITY_EXACT=PASS
+~~~
+
+## 14. Default-coherence regression
+
+tests/ops/test_worker_coding_pi_runtime_contract.py now imports the Python
+readiness and adapter defaults, loads the source Campaign Runner profile and
+CLI modules, checks default/fast/review/profile fallbacks, verifies the
+wrapper's local constant and aliases, and checks the Compose provider/model
+pair. It also behaviorally covers the run_pi_agent, cmd_audit, and cmd_run
+fallback paths.
+
+~~~text
+ANTHROPIC_DEFAULT_COHERENCE=PASS
+~~~
+
+## 15. Authorized replacement-resolution regression
+
+The exact authorized-readiness regression invokes the real source-relative
+wrapper with a disposable empty HOME, isolated PI_CODING_AGENT_DIR, PI_OFFLINE=1,
+and no inherited environment or credentials. With
+anthropic / claude-sonnet-4-6 / pi-coding-agent@0.82.1, it established exact
+runtime identity before terminating at the expected no-credential boundary:
+
+~~~text
+failure_class=oauth_auth_unavailable
+failure_stage=oauth_readiness
+session_initialized=false
+provider_request_started=false
+~~~
+
+~~~text
+ANTHROPIC_AUTHORIZED_MODEL_RESOLUTION=PASS_PROVIDER_FREE
+~~~
+
+## 16. Obsolete-ID fail-closed regression
+
+The same isolated authorized-readiness path was run with the exact obsolete
+model ID as input. Pi did not expose that ID in the current Anthropic catalog,
+and the wrapper returned before auth/session/provider activity:
+
+~~~text
+failure_class=model_unresolved
+failure_stage=model_resolution
+runtime_identity_established=false
+actual_runtime_identity=null
+session_initialized=false
+provider_request_started=false
+~~~
+
+The obsolete ID is intentionally retained as a test input so a future registry
+change cannot silently turn exact identity into a replacement alias. Its one
+working-tree occurrence is a fixture_or_example for this fail-closed
+regression, not an active coding default.
+
+~~~text
+OBSOLETE_ANTHROPIC_ID_SILENT_REMAP=false
+~~~
+
+## 17. Remaining stale-ID occurrence classification
+
+The old string was not mass-replaced. Remaining repository occurrences are
+classified as follows:
+
+| Classification | Remaining surfaces |
+| --- | --- |
+| fixture_or_example | intentional obsolete-ID input in tests/ops/test_worker_coding_pi_runtime_contract.py |
+| historical | docs/tasks/TASK-2026-05-01-001_pi_adapter.md, docs/tasks/TASK-2026-05-01-002_pi_tool_wrapper.md, and prior proof/examples outside the active default surface |
+| unrelated_product_surface | Persona Studio store/tests and persona-profile runtime tests |
+| migration | the persona-profile database migration default |
+| vendored_reference | Pi vendor documentation, changelog, SDK examples, and provider SDK type/reference material |
+
+None of these occurrences is an active coding-worker/config/operator default.
+
+## 18. Provider/network/credential isolation
+
+~~~text
+PROVIDER_BACKED_INVOCATION_COUNT=0
+LIVE_EXECUTOR_CALL_COUNT=0
+OAUTH_LOGIN_LOGOUT_COUNT=0
+OPERATOR_CREDENTIAL_STORE_ACCESS_COUNT=0
+~~~
+
+The provider-free probes used empty disposable homes, a disposable Pi agent
+directory, PI_OFFLINE=1, and allowModelNetwork: false. They did not inspect the
+operator auth store, use an API key, run /login, prompt a model, perform
+DNS/socket/HTTP model transport, or invoke the Campaign Engine live Executor.
+
+## 19. Validation
+
+Node syntax:
+
+~~~text
+node --check codex_runner/src/agent-wrapper.js                         PASS
+node --check codex_runner/src/assistant-telemetry.js                    PASS
+~~~
+
+Focused readiness/default suite:
+
+~~~text
+pytest -v guardian/tests/agents/test_pi_readiness.py tests/ops/test_worker_coding_pi_runtime_contract.py
+37 passed, 8 warnings
+~~~
+
+Authorized Pi / CE-L1 regression suite:
+
+~~~text
+pytest -v tests/ops/test_pi_assistant_response_telemetry.py tests/pi/test_pi_live_invocation.py tests/pi/test_pi_authorized_failure_diagnostics.py codex_runner/tests/test_campaign_engine_live_executor.py
+140 passed
+~~~
+
+Combined deterministic seam:
+
+~~~text
+pytest -v guardian/tests/agents/test_pi_readiness.py tests/ops/test_worker_coding_pi_runtime_contract.py tests/ops/test_pi_assistant_response_telemetry.py tests/pi/test_pi_live_invocation.py tests/pi/test_pi_authorized_failure_diagnostics.py codex_runner/tests/test_campaign_engine_live_executor.py
+177 passed, 8 warnings
+~~~
+
+Additional repository checks:
+
+~~~text
+active stale-ID grep                                             PASS (no matches)
+replacement-ID inventory                                         PASS
+git diff --check                                                  PASS
+vendor diff from captured main                                   PASS (empty)
+~~~
+
+The focused and combined pytest commands used the qualified local Python
+runtime /opt/homebrew/Caskroom/miniconda/base/bin/python. The default system
+Python could not collect Guardian tests because bcrypt was not installed; no
+repository or environment mutation was used to bypass that condition.
+
+## 20. What is proven
+
+- Captured origin/main is the task base and the authoring anchor is an
+  ancestor.
+- The bounded CE-L1 seam had no material pre-task drift.
+- claude-sonnet-4-6 resolves exactly from the pinned Pi 0.82.1 catalog as
+  anthropic-messages.
+- The replacement supports the canonical coding tool names and medium thinking
+  without provider transport.
+- Wrapper, profiles, CLI fallback, readiness, legacy fallback, Compose, and
+  operator/config documentation agree on the active default.
+- Guardian-authorized exact identity remains exact, and the obsolete exact ID
+  fails closed instead of remapping.
+- Focused and combined deterministic tests pass, with no vendor mutation and
+  no provider/credential activity.
+
+## 21. What remains unresolved
+
+- No Anthropic inference, tool request, provider response, or live Executor
+  result was observed in this task.
+- Credential presence/validity and provider reachability remain unproven.
+- CE-L1 still lacks the canonical live Executor result, durable terminal
+  result, and source-thread readback required for closure.
+- No canonical landing, push, merge, release, or Beta-support claim was made.
+
+## 22. CE-L1 decision
+
+~~~text
+CE-L1=OPEN
+LIVE_EXECUTOR_PROVEN_CANONICAL=NOT_EMITTED
+SINGLE_TASK_SUPERVISED_USABLE=NOT_EMITTED
+ANTHROPIC_PI_TOOLCALL_REQUEST_OBSERVED=NOT_RETAINED
+~~~
+
+This task repairs the prerequisite identity seam only. It does not authorize
+or perform the next live control.
+
+## 23. Next dependency
+
+~~~text
+SOL_ATTEMPT_BUDGET=SPENT
+LUNA_COMPARISON_BUDGET=SPENT
+SPARK_COMPARISON_BUDGET=SPENT
+ANTHROPIC_CONTROL_BUDGET=SPENT
+NEXT_TASK_REQUIRED=land this Anthropic default-model reconciliation onto then-current canonical main with a bounded CE-L1 drift check; do not authorize a live control yet
+~~~
+
+The local implementation commit, exact changed-file list, and post-capture
+remote movement are reported in the task closeout. Canonical landing remains a
+separate follow-up.

--- a/guardian/agents/adapters/pi_codex_runner.py
+++ b/guardian/agents/adapters/pi_codex_runner.py
@@ -14,6 +14,7 @@ from guardian.agents.adapters.base import (
     AgentExecutionRequest,
     AgentRunEnvelope,
 )
+from guardian.agents.pi_readiness import DEFAULT_PI_MODEL
 from guardian.pi.tokens import (
     PI_AUTHORIZED_FAILURE_CLASSES,
     PiAuthorizedFailureClass,
@@ -53,7 +54,7 @@ class PiCodexRunnerAdapter:
         env = os.environ.copy()
 
         # Set model and thinking from environment or defaults
-        env["PI_MODEL"] = env.get("PI_MODEL", "claude-sonnet-4-20250514")
+        env["PI_MODEL"] = env.get("PI_MODEL", DEFAULT_PI_MODEL)
         env["PI_THINKING"] = env.get("PI_THINKING", "medium")
 
         # Build the command

--- a/guardian/agents/pi_readiness.py
+++ b/guardian/agents/pi_readiness.py
@@ -39,7 +39,7 @@ DEFAULT_PI_PACKAGE_ROOT = (
 )
 DEFAULT_PI_NODE_MODULES = "/opt/codexify/pi-sdk/node_modules"
 DEFAULT_PI_PROVIDER = "anthropic"
-DEFAULT_PI_MODEL = "claude-sonnet-4-20250514"
+DEFAULT_PI_MODEL = "claude-sonnet-4-6"
 
 
 @dataclass(frozen=True)

--- a/guardian/tests/agents/test_pi_readiness.py
+++ b/guardian/tests/agents/test_pi_readiness.py
@@ -8,6 +8,8 @@ import pytest
 
 from guardian.agents import pi_readiness
 from guardian.agents.pi_readiness import (
+    DEFAULT_PI_MODEL,
+    DEFAULT_PI_PROVIDER,
     PI_READINESS_REASONS,
     PI_READINESS_STATES,
     evaluate_pi_readiness,
@@ -50,8 +52,8 @@ def _fixture_environment(
         "PI_WRAPPER_PATH": str(wrapper_path),
         "PI_CODING_AGENT_PACKAGE_ROOT": str(package_root),
         "PI_CODING_AGENT_NODE_MODULES": str(node_modules),
-        "PI_PROVIDER": "anthropic",
-        "PI_MODEL": "claude-sonnet-4-20250514",
+        "PI_PROVIDER": DEFAULT_PI_PROVIDER,
+        "PI_MODEL": DEFAULT_PI_MODEL,
     }
 
 
@@ -70,11 +72,16 @@ def _probe(
             "adapter_initialized": initialized,
             "provider_resolved": resolved,
             "provider_credential_available": credential,
-            "effective_provider": "anthropic",
-            "effective_model": "claude-sonnet-4-20250514",
+            "effective_provider": DEFAULT_PI_PROVIDER,
+            "effective_model": DEFAULT_PI_MODEL,
         }
 
     return probe
+
+
+def test_active_anthropic_default_is_explicitly_reconciled() -> None:
+    assert DEFAULT_PI_PROVIDER == "anthropic"
+    assert DEFAULT_PI_MODEL == "claude-sonnet-4-6"
 
 
 def test_readiness_tokens_are_bounded() -> None:

--- a/tests/ops/test_worker_coding_pi_runtime_contract.py
+++ b/tests/ops/test_worker_coding_pi_runtime_contract.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -14,9 +16,78 @@ ROOT = Path(__file__).resolve().parents[2]
 COMPOSE = ROOT / "docker-compose.yml"
 DOCKERFILE = ROOT / "backend/Dockerfile"
 RUNBOOK = ROOT / "docs/Ops/SOLO_OPERATOR_CODING_WORKER_RUNBOOK.md"
+PROFILE = ROOT / "codex_runner/src/profile.py"
+RUNNER_CLI = ROOT / "codex_runner/src/runner_cli.py"
 RUNTIME_PACKAGE = ROOT / "codex_runner/pi-runtime/package.json"
 RUNTIME_LOCK = ROOT / "codex_runner/pi-runtime/package-lock.json"
 VENDORED_PACKAGE = ROOT / "codex_runner/vendor/pi-coding-agent/package.json"
+CANONICAL_ANTHROPIC_MODEL = "claude-sonnet-4-6"
+OBSOLETE_ANTHROPIC_MODEL = "claude-sonnet-4-20250514"
+
+
+def _load_runner_cli_for_test():
+    """Load the source-only Campaign Runner modules without importing stdlib ``profile``."""
+    profile_spec = importlib.util.spec_from_file_location(
+        "codexify_campaign_profile_under_test", PROFILE
+    )
+    assert profile_spec and profile_spec.loader
+    profile_module = importlib.util.module_from_spec(profile_spec)
+    sys.modules[profile_spec.name] = profile_module
+
+    previous_profile = sys.modules.get("profile")
+    runner_name = "codexify_runner_cli_under_test"
+    try:
+        profile_spec.loader.exec_module(profile_module)
+        runner_spec = importlib.util.spec_from_file_location(runner_name, RUNNER_CLI)
+        assert runner_spec and runner_spec.loader
+        runner_module = importlib.util.module_from_spec(runner_spec)
+        sys.modules["profile"] = profile_module
+        sys.modules[runner_name] = runner_module
+        runner_spec.loader.exec_module(runner_module)
+        return profile_module, runner_module
+    finally:
+        sys.modules.pop(profile_spec.name, None)
+        sys.modules.pop(runner_name, None)
+        if previous_profile is None:
+            sys.modules.pop("profile", None)
+        else:
+            sys.modules["profile"] = previous_profile
+
+
+def _run_guardian_authorized_readiness(
+    model_id: str,
+) -> subprocess.CompletedProcess[str]:
+    """Run the real source-vendored wrapper with an isolated, empty Pi home."""
+    home = Path(tempfile.mkdtemp(prefix="codexify-pi-anthropic-readiness-"))
+    pi_agent_dir = home / "pi-agent"
+    pi_agent_dir.mkdir()
+    try:
+        result = subprocess.run(
+            [
+                "node",
+                str(ROOT / "codex_runner/src/agent-wrapper.js"),
+                "guardian-authorized-readiness",
+            ],
+            cwd=str(home),
+            env={
+                "HOME": str(home),
+                "PATH": "/usr/bin:/bin:/usr/local/bin",
+                "PI_CODING_AGENT_DIR": str(pi_agent_dir),
+                "PI_OFFLINE": "1",
+                "PI_PROVIDER": "anthropic",
+                "PI_MODEL": model_id,
+                "PI_GUARDIAN_AUTHORIZED": "1",
+                "PI_GUARDIAN_HARNESS_ID": "pi-coding-agent",
+                "PI_GUARDIAN_HARNESS_VERSION": "0.82.1",
+                "PI_DISABLE_TOOLS": "1",
+            },
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+    return result
 
 
 def _service_block(text: str, service: str) -> str:
@@ -110,6 +181,93 @@ def test_active_runtime_loader_uses_canonical_model_runtime() -> None:
     assert "authStorage.hasAuth(" not in loader
     assert "ModelRegistry.create(" not in loader
     assert "OPENAI_CODEX_MODELS" not in loader
+
+
+def test_active_coding_worker_defaults_are_coherent() -> None:
+    """The six active default surfaces must share the reconciled model."""
+    from guardian.agents.adapters.pi_codex_runner import (
+        DEFAULT_PI_MODEL as ADAPTER_DEFAULT_PI_MODEL,
+    )
+    from guardian.agents.pi_readiness import (
+        DEFAULT_PI_MODEL,
+        DEFAULT_PI_PROVIDER,
+    )
+
+    profile_module, runner_module = _load_runner_cli_for_test()
+    assert profile_module.DEFAULT_MODEL == CANONICAL_ANTHROPIC_MODEL
+    assert runner_module.DEFAULT_MODEL == profile_module.DEFAULT_MODEL
+    assert profile_module.Profile(name="default").model == CANONICAL_ANTHROPIC_MODEL
+    assert (
+        profile_module.Profile.from_dict("default", {}).model
+        == CANONICAL_ANTHROPIC_MODEL
+    )
+    for name in ("default", "fast", "review"):
+        assert (
+            profile_module.DEFAULT_PROFILES[name]["model"]
+            == CANONICAL_ANTHROPIC_MODEL
+        )
+    assert profile_module.DEFAULT_PROFILES["thorough"]["model"] == "claude-opus-4-5"
+
+    assert DEFAULT_PI_PROVIDER == "anthropic"
+    assert DEFAULT_PI_MODEL == CANONICAL_ANTHROPIC_MODEL
+    assert ADAPTER_DEFAULT_PI_MODEL == DEFAULT_PI_MODEL
+
+    loader = (ROOT / "codex_runner/src/agent-wrapper.js").read_text(encoding="utf-8")
+    assert 'const DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6";' in loader
+    assert "model: process.env.PI_MODEL || DEFAULT_ANTHROPIC_MODEL" in loader
+    for alias in ('"sonnet":', '"sonnet4":', '"sonnet-4":'):
+        assert f"{alias} DEFAULT_ANTHROPIC_MODEL" in loader
+    assert OBSOLETE_ANTHROPIC_MODEL not in loader
+
+    compose = COMPOSE.read_text(encoding="utf-8")
+    assert 'PI_PROVIDER: "${PI_PROVIDER:-anthropic}"' in compose
+    assert f'PI_MODEL: "${{PI_MODEL:-{CANONICAL_ANTHROPIC_MODEL}}}"' in compose
+
+
+def test_runner_cli_uses_canonical_default_for_agent_and_command_fallbacks(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Behaviorally cover run_pi_agent, audit, and run default fallbacks."""
+    _profile_module, runner_module = _load_runner_cli_for_test()
+
+    subprocess_calls: list[dict[str, object]] = []
+
+    def fake_subprocess_run(*args, **kwargs):
+        subprocess_calls.append(kwargs)
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(runner_module.subprocess, "run", fake_subprocess_run)
+    direct_result = runner_module.run_pi_agent(
+        "readiness", "probe", {"cwd": str(tmp_path)}
+    )
+    assert direct_result.success is True
+    assert subprocess_calls[-1]["env"]["PI_MODEL"] == CANONICAL_ANTHROPIC_MODEL
+
+    class EmptyProfileManager:
+        active_profile = "default"
+
+        def load(self):
+            return self
+
+        def get(self, _name):
+            return None
+
+    command_options: list[dict[str, object]] = []
+
+    def fake_agent(_mode: str, _prompt: str, options: dict[str, object]):
+        command_options.append(options)
+        return runner_module.CommandResult(success=True)
+
+    monkeypatch.setattr(runner_module, "ProfileManager", EmptyProfileManager)
+    monkeypatch.setattr(runner_module, "run_pi_agent", fake_agent)
+
+    assert runner_module.cmd_audit(["default probe"], {"cwd": str(ROOT)}).success
+    assert runner_module.cmd_run(["default probe"], {"cwd": str(ROOT)}).success
+    assert [options["model"] for options in command_options] == [
+        CANONICAL_ANTHROPIC_MODEL,
+        CANONICAL_ANTHROPIC_MODEL,
+    ]
 
 
 def test_runbook_uses_compose_owned_environment_and_canonical_readiness() -> None:
@@ -244,6 +402,114 @@ def test_source_relative_wrapper_loads_pi_runtime_with_full_locked_closure() -> 
     assert identity["actual_harness_id"] == "pi-coding-agent"
     assert identity["actual_harness_version"] == "0.82.1"
 
+    assert payload["session_initialized"] is False
+    assert payload["provider_request_started"] is False
+
+
+def test_reconciled_anthropic_model_supports_canonical_session_provider_free() -> None:
+    """Prove the replacement model accepts the wrapper's session posture."""
+    home = Path(tempfile.mkdtemp(prefix="codexify-pi-anthropic-session-"))
+    pi_agent_dir = home / "pi-agent"
+    pi_agent_dir.mkdir()
+    script = r'''
+import { ModelRuntime } from "./codex_runner/vendor/pi-coding-agent/dist/core/model-runtime.js";
+import { createAgentSession } from "./codex_runner/vendor/pi-coding-agent/dist/core/sdk.js";
+import { SessionManager } from "./codex_runner/vendor/pi-coding-agent/dist/core/session-manager.js";
+
+const runtime = await ModelRuntime.create({ allowModelNetwork: false });
+const model = runtime.getModel("anthropic", "claude-sonnet-4-6");
+if (!model) throw new Error("model_unresolved");
+const { session } = await createAgentSession({
+    cwd: process.cwd(),
+    model,
+    modelRuntime: runtime,
+    tools: ["read", "bash", "edit", "write"],
+    thinkingLevel: "medium",
+    sessionManager: SessionManager.inMemory(),
+});
+const activeToolNames = session.getActiveToolNames();
+const thinkingLevels = session.getAvailableThinkingLevels();
+if (JSON.stringify(activeToolNames) !== JSON.stringify(["read", "bash", "edit", "write"])) {
+    throw new Error(`unexpected_tools:${JSON.stringify(activeToolNames)}`);
+}
+if (!thinkingLevels.includes("medium") || session.thinkingLevel !== "medium") {
+    throw new Error(`unexpected_thinking:${JSON.stringify({ thinkingLevels, effective: session.thinkingLevel })}`);
+}
+console.log(JSON.stringify({
+    provider: model.provider,
+    id: model.id,
+    api: model.api,
+    activeToolNames,
+    effectiveThinkingLevel: session.thinkingLevel,
+}));
+'''
+    try:
+        result = subprocess.run(
+            ["node", "--input-type=module", "-e", script],
+            cwd=str(ROOT),
+            env={
+                "HOME": str(home),
+                "PATH": "/usr/bin:/bin:/usr/local/bin",
+                "PI_CODING_AGENT_DIR": str(pi_agent_dir),
+                "PI_OFFLINE": "1",
+            },
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+
+    assert result.returncode == 0, (
+        f"provider-free Anthropic session probe failed: exit {result.returncode}; "
+        f"stderr={result.stderr[:500]!r}"
+    )
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload == {
+        "provider": "anthropic",
+        "id": CANONICAL_ANTHROPIC_MODEL,
+        "api": "anthropic-messages",
+        "activeToolNames": ["read", "bash", "edit", "write"],
+        "effectiveThinkingLevel": "medium",
+    }
+
+
+def test_anthropic_replacement_resolves_through_authorized_readiness_provider_free(
+) -> None:
+    """Exact Guardian-authorized replacement resolution must precede auth use."""
+    result = _run_guardian_authorized_readiness(CANONICAL_ANTHROPIC_MODEL)
+
+    assert result.returncode == 0, (
+        f"authorized replacement readiness failed: exit {result.returncode}; "
+        f"stderr={result.stderr[:500]!r}"
+    )
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload["failure_class"] == "oauth_auth_unavailable"
+    assert payload["failure_stage"] == "oauth_readiness"
+    assert payload["runtime_identity_established"] is True
+    assert payload["actual_runtime_identity"] == {
+        "actual_provider_id": "anthropic",
+        "actual_model_id": CANONICAL_ANTHROPIC_MODEL,
+        "actual_harness_id": "pi-coding-agent",
+        "actual_harness_version": "0.82.1",
+    }
+    assert payload["session_initialized"] is False
+    assert payload["provider_request_started"] is False
+
+
+def test_obsolete_anthropic_identity_fails_closed_without_silent_remap() -> None:
+    """The obsolete exact ID must remain an unresolved identity, not an alias."""
+    result = _run_guardian_authorized_readiness(OBSOLETE_ANTHROPIC_MODEL)
+
+    assert result.returncode == 0, (
+        f"obsolete identity readiness probe failed: exit {result.returncode}; "
+        f"stderr={result.stderr[:500]!r}"
+    )
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload["failure_class"] == "model_unresolved"
+    assert payload["failure_stage"] == "model_resolution"
+    assert payload["runtime_identity_established"] is False
+    assert payload["actual_runtime_identity"] is None
     assert payload["session_initialized"] is False
     assert payload["provider_request_started"] is False
 

--- a/tests/ops/test_worker_coding_startup_gate.py
+++ b/tests/ops/test_worker_coding_startup_gate.py
@@ -29,7 +29,7 @@ def test_blocked_worker_exits_before_proxy_or_queue_consumer(
     report = PiReadinessReport(
         status="blocked",
         effective_provider="anthropic",
-        effective_model="claude-sonnet-4-20250514",
+        effective_model="claude-sonnet-4-6",
         checks=(
             PiReadinessCheck(
                 name="pi_sdk_runtime",


### PR DESCRIPTION
Lands the provider-free proven Anthropic Pi coding-default reconciliation. CE-L1 remains open. No provider-backed invocation or live Executor attempt is part of this change.