### PR TITLE
Restore canonical architecture contract truth

### DIFF
--- a/docs/architecture/00-current-state.md
+++ b/docs/architecture/00-current-state.md
@@ -81,3 +81,150 @@ This file is authoritative for:
 - `config-and-ops.md` explains operator/runtime truth.
 - `roadmap-signals.md` is planning guidance, not live status.
 - `tech-debt-and-risks.md` is a risk register, not the active blocker list unless repeated here.
+
+## Release classes
+
+The five release classes below are accepted architecture per ADR-069. They are
+human-facing release interpretations over the existing Product Architecture
+Assertion dimensions and the `00-current-state.md` short-form authority, not
+new schema enums. Evidence maturity and support posture remain orthogonal
+under ADR-069. Support doctrine does not prove every current-tip gate is
+green; the "Not yet true / do not assume" and "Active blockers" sections above
+remain authoritative for the present live-state truth.
+
+### Beta Supported
+
+The current Beta Supported envelope is the local-first supported install
+path and its core surfaces, already present in this document and accepted
+by ADR-069:
+
+- Local Docker Compose runtime, with the local-only default provider posture
+  (`CODEXIFY_LOCAL_ONLY_MODE=true`, `ALLOW_CLOUD_PROVIDERS=false`,
+  `LLM_PROVIDER=local`).
+- Local inference (Whoosh'd) and the supported local profile.
+- Core startup / migration lifecycle.
+- Queue-backed chat completion lifecycle.
+- Durable thread / message / task persistence.
+- Supported health and runtime diagnostics.
+- Ordinary chat, threads, durable conversation history, projects, and
+  project / thread / workspace navigation.
+- Documents and media ingestion on currently implemented supported formats.
+- Embedding and workspace-scoped retrieval.
+- Codexify-native identity / authentication boundaries and account-scoped
+  ownership behavior.
+- Operator-visible health and configuration truth required to run the
+  self-hosted node.
+
+This is support doctrine, not current-tip qualification. The "Not yet true
+/ do not assume" section above continues to bound what is provably green
+on the current `main` tip. Implementation presence in a code path does not
+promote a capability to Beta Supported; only the architecture-accepted
+support envelope under ADR-069 does.
+
+### Beta Bounded / Conditional
+
+Surfaces intentionally inside the Beta envelope but only under an explicit
+authority, topology, provider, mode, or capability boundary. The
+classification below is the current accepted one; no new bounded surface
+is added by this section.
+
+- Persona Studio: profile creation / editing, persistence, selection, and
+  application of supported persona / profile configuration to ordinary chat.
+  TTS / voice execution, unsupported permission authoring, unsupported
+  retrieval-policy execution, and "preview UI equals enforcement" claims
+  are excluded from this promotion.
+- Import / continuity entry surfaces: OpenAI / ChatGPT export import, Task
+  Prompt Archive, owner-scoped retry / recovery behavior already
+  implemented, and account export / restore to the exact extent supported
+  by the existing contract and implementation. Not every historical
+  corpus, provider export format, or migration shape is claimed.
+- Repository intelligence on the supported local single-user path:
+  repository candidate discovery, explicit repository import,
+  account / Project `RepositoryBinding`, direct Project-bound repository
+  search, and ordinary-chat repository search exposure only when
+  Guardian resolves exactly one valid active binding and existing
+  authority checks pass. Remote / multi-user / Hosted-Room repository
+  authority remains outside this bounded Beta claim.
+- Bounded Guardian tool execution: read-only health capability, and
+  bounded Project repository search where current eligibility /
+  authority checks pass. Advertised-subset authority, Guardian-owned
+  execution authority, exact capability eligibility, bounded command
+  count, and provider capability checks are preserved. Arbitrary tools,
+  arbitrary write operations, and generic shell / filesystem execution
+  are not promoted.
+- MCP / extensibility: the public MCP extension posture may be described as
+  part of Beta only as a bounded extension interface. A general plugin
+  marketplace, plugin SDK internals as public Beta API, and arbitrary
+  plugin execution bypassing Guardian policy are not claimed.
+- Desktop / Tauri client (if current `main` still contains the functioning
+  local desktop / Tauri presentation layer): Beta Bounded / Conditional
+  when used as a client of the same supported local Guardian node. Not a
+  packaged production desktop distribution, not auto-update support, not
+  an independent desktop persistence / runtime authority, not a separate
+  release topology not currently proven.
+
+### Internal
+
+The following remain explicitly internal, not user-facing release promises:
+
+- direct Command Bus HTTP / control-plane API
+- plugin SDK internals
+- generic tools / API tools surfaces currently marked internal or
+  quarantined
+- developer-only diagnostics
+- unsafe operator mutation surfaces
+- implementation / control-plane mechanisms that support Beta behavior
+  without being user-facing promises
+- Pi 0.82.1 wrapper/API, source-vendor, identity, framing, and telemetry
+  surfaces (per the "Current supported reality" / "Not yet true" sections
+  above; non-inference / OAuth-readiness qualification; not a
+  user-facing release promise at the current `main` tip).
+- CE-L1 wiring (lives in code paths and is required to close active
+  blockers, but remains internal / qualification pending — see below).
+- Campaign / coding-worker substrate (operational substrate that supports
+  Beta behavior; not a user-facing release promise).
+
+Implementation presence of Pi, CE-L1, or coding-worker wiring does not
+promote those surfaces to Beta Supported merely because their code paths
+exist.
+
+### Qualification Pending
+
+Intended or plausible Beta surface with implementation present, but a
+specifically named proof / authority / operational gate remains open.
+Each entry below names its explicit `remaining gate` rather than only
+saying "not supported," per the ADR-069 Qualification-Pending Doctrine.
+
+- **Coding Loop** — `remaining gate` requires: live provider/model
+  execution, terminal durable result, and source-thread readback on the
+  claimed supported profile. CE-L1 wiring remains internal / qualification
+  pending; no `LIVE_EXECUTOR_PROVEN_CANONICAL` is emitted by this section.
+- **Hosted Rooms** — `remaining gate` requires: clean supported / tester
+  startup and owner / guest live semantic proof after migration repair.
+- **DeepSeek / private-preview provider lane** — `remaining gate` requires
+  required credentials, authenticated provider-specific persisted runtime
+  proof, and explicit supported-profile promotion.
+- **Browser side-panel / Browser Host release surface** — `remaining gate`
+  follows whichever current host / auth / release proof remains open on the
+  current `main` tip after the present private-preview gates.
+- **Any desktop packaging behavior not covered by the bounded local-client
+  claim** in the Beta Bounded / Conditional section above.
+
+### Out of Beta
+
+The following are explicitly excluded from the present Beta promise under
+ADR-069 and are not classified as qualification-pending; they are
+intentionally out of scope:
+
+- TTS / voice — Out of Beta
+- federation — Out of Beta
+- unrestricted autonomous / recursive agent execution
+- arbitrary write-capability tool use
+- generic shell / filesystem execution through ordinary Beta chat
+- public Command Bus exposure
+- generic cron / unattended automation
+- generic connectors without separate qualification
+- graph-write / Neo4j-derived-write behavior where the supported path
+  remains flagged off or quarantined
+- remote / multi-user repository execution not covered by a separately
+  accepted authority contract and live proof

--- a/docs/knowledge-graph/nodes/codexify:doc:architecture:adr-index.json
+++ b/docs/knowledge-graph/nodes/codexify:doc:architecture:adr-index.json
@@ -1,11 +1,4 @@
 {
-  "schema_version": "1.0.0",
-  "record_type": "document_node",
-  "document_id": "codexify:doc:architecture:adr-index",
-  "path": "docs/architecture/adr/adr-index.md",
-  "title": "ADR Index",
-  "kind": "runtime_map",
-  "summary": "Structural routing index for the Architecture Decision Record set, its reading order, and its recorded ADR graph.",
   "aliases": [
     "Architecture Decision Record Index"
   ],
@@ -15,86 +8,93 @@
     "ADR reading order",
     "ADR graph navigation"
   ],
-  "lifecycle_state": "active",
+  "content_hash": "71d7c52dde6c2c63080cd3e17d5701a1a647513acd794eec20efab31ee04a4d7",
+  "disposition": "accepted",
+  "document_id": "codexify:doc:architecture:adr-index",
+  "evidence_class": "documented-contract",
   "freshness": {
+    "reason": "Re-verified ADR-index metadata against committed source revision 5a18dfdd9b4f0957ccc63db325f117a83c66ab0b. The ADR index and declared ADR anchors were reverified against reachable canonical history; the obsolete unreachable [OBSOLETE-SHA-REDACTED] freshness reference was replaced. No ADR identity, numbering, or release semantics changed. ADR-number collisions (053, 076) remain reported separately and are not addressed by this task.",
     "state": "current",
-    "verified_at": "2026-08-31T13:37:17Z",
-    "verified_commit": "9d5b7a8570ac605e0773892e2b5ba0300a960d80",
     "triggers": [
       "an ADR is added, removed, renumbered, or retitled",
       "an indexed ADR review posture changes",
       "the documented ADR graph or reading order changes"
     ],
-    "reason": "Re-reviewed the ADR index after acceptance and indexing of ADR-077 Sandbox Execution Authority and Provider Boundary; source bytes synchronized during the same focused documentation change; no runtime or release posture changed."
+    "verified_at": "2026-09-04T18:22:01-04:00",
+    "verified_commit": "5a18dfdd9b4f0957ccc63db325f117a83c66ab0b"
   },
-  "disposition": "accepted",
-  "evidence_class": "documented-contract",
-  "owners": [
-    "Codexify architecture maintainers"
-  ],
-  "source_anchors": [
-    {
-      "path": "docs/architecture/adr/adr-index.md",
-      "anchor_type": "document",
-      "invalidates_freshness": true
-    },
-    {
-      "path": "docs/architecture/adr/*.md",
-      "anchor_type": "document",
-      "invalidates_freshness": true
-    }
-  ],
-  "read_when": [
-    "locating an applicable Architecture Decision Record",
-    "reviewing the ADR reading order or documented ADR graph",
-    "checking which decision document should be read directly"
-  ],
+  "governing_adr_posture": "not_applicable",
+  "kind": "runtime_map",
+  "lifecycle_state": "active",
   "must_not_prove": [
     "acceptance or decision authority independently of the indexed ADR",
     "runtime implementation of an indexed decision",
     "release support for capabilities mentioned by indexed ADRs"
   ],
+  "owners": [
+    "Codexify architecture maintainers"
+  ],
+  "path": "docs/architecture/adr/adr-index.md",
+  "read_when": [
+    "locating an applicable Architecture Decision Record",
+    "reviewing the ADR reading order or documented ADR graph",
+    "checking which decision document should be read directly"
+  ],
+  "record_type": "document_node",
+  "relations": [
+    {
+      "authority_scope": "ADR discovery and routing for the indexed Document Lifecycle Graph decision",
+      "canonicality": "canonical",
+      "rationale": "The ADR Index directly indexes ADR-056 as a current architecture decision, and its declared freshness contract requires re-review when indexed ADR identity, numbering, title, or review posture changes.",
+      "relation_type": "depends_on",
+      "review_status": "accepted",
+      "target_document_id": "codexify:doc:adr:056-document-lifecycle-graph-control-plane"
+    },
+    {
+      "authority_scope": "ADR discovery and routing for the indexed Product Architecture Ontology decision",
+      "canonicality": "canonical",
+      "rationale": "The ADR Index directly indexes ADR-057 as a current architecture decision, and its declared freshness contract requires re-review when indexed ADR identity, numbering, title, or review posture changes.",
+      "relation_type": "depends_on",
+      "review_status": "accepted",
+      "target_document_id": "codexify:doc:adr:057-product-architecture-ontology-dlg-integration"
+    }
+  ],
   "retrieval_policy": {
-    "default_policy": "conditional",
     "applicable_intents": [
       "adr_discovery",
       "architecture_decision",
       "historical_provenance"
     ],
+    "default_policy": "conditional",
     "excluded_intents": [
       "live_runtime_proof",
       "release_support"
     ],
+    "maximum_chunk_budget": 5,
     "priority": "supporting",
     "section_hints": [
       "Purpose",
       "Reading Order",
       "ADR Graph"
-    ],
-    "maximum_chunk_budget": 5
+    ]
   },
+  "schema_version": "1.0.0",
+  "source_anchors": [
+    {
+      "anchor_type": "document",
+      "invalidates_freshness": true,
+      "path": "docs/architecture/adr/adr-index.md"
+    },
+    {
+      "anchor_type": "document",
+      "invalidates_freshness": true,
+      "path": "docs/architecture/adr/*.md"
+    }
+  ],
+  "summary": "Structural routing index for the Architecture Decision Record set, its reading order, and its recorded ADR graph.",
   "temporal": {
     "created_at": "2026-04-14T20:56:05Z",
     "effective_from": "2026-04-14T20:56:05Z"
   },
-  "content_hash": "26ca6a555a1bb10187dbd48f07fa7f1c6a6d3a0929ef2ff8eddf61e4289ed258",
-  "relations": [
-    {
-      "relation_type": "depends_on",
-      "target_document_id": "codexify:doc:adr:056-document-lifecycle-graph-control-plane",
-      "authority_scope": "ADR discovery and routing for the indexed Document Lifecycle Graph decision",
-      "canonicality": "canonical",
-      "review_status": "accepted",
-      "rationale": "The ADR Index directly indexes ADR-056 as a current architecture decision, and its declared freshness contract requires re-review when indexed ADR identity, numbering, title, or review posture changes."
-    },
-    {
-      "relation_type": "depends_on",
-      "target_document_id": "codexify:doc:adr:057-product-architecture-ontology-dlg-integration",
-      "authority_scope": "ADR discovery and routing for the indexed Product Architecture Ontology decision",
-      "canonicality": "canonical",
-      "review_status": "accepted",
-      "rationale": "The ADR Index directly indexes ADR-057 as a current architecture decision, and its declared freshness contract requires re-review when indexed ADR identity, numbering, title, or review posture changes."
-    }
-  ],
-  "governing_adr_posture": "not_applicable"
+  "title": "ADR Index"
 }

--- a/docs/knowledge-graph/nodes/codexify:doc:architecture:current-state.json
+++ b/docs/knowledge-graph/nodes/codexify:doc:architecture:current-state.json
@@ -1,79 +1,79 @@
 {
-"schema_version": "1.0.0",
-"record_type": "document_node",
-"document_id": "codexify:doc:architecture:current-state",
-"path": "docs/architecture/00-current-state.md",
-"title": "Codexify Current State",
-"kind": "current_state",
-"summary": "Canonical short-horizon authority for release readiness, supported paths, active blockers, current priorities, and the present release promise.",
-"aliases": [],
-"authority_class": "release_authority",
-"authority_scopes": [
-"release readiness",
-"supported install path",
-"active release blockers",
-"current priorities",
-"present release promise"
-],
-"lifecycle_state": "active",
-"freshness": {
-"state": "current",
-"verified_at": "2026-08-27T17:48:19Z",
-"verified_commit": "3b7264d36310a08e95a220dbfbf71de0893c7759",
-"triggers": [
-"the weekly freshness window expires",
-"the supported profile or release interpretation changes",
-"active blockers, priorities, or the audited implementation tip change"
-],
-"window_days": 7,
-"reason": "Re-verified current-state metadata against committed source revision 3b7264d36310a08e95a220dbfbf71de0893c7759 after restoring local Guardian Evidence bounded-read tooling truth; source hash synchronized, release posture unchanged, and no live-runtime proof or release-support expansion implied."
-},
-"disposition": "accepted",
-"evidence_class": "documented-contract",
-"owners": [
-"Codexify release maintainers"
-],
-"source_anchors": [
-{
-"path": "docs/architecture/00-current-state.md",
-"anchor_type": "document",
-"invalidates_freshness": true
-}
-],
-"read_when": [
-"answering release readiness or support questions",
-"checking the supported install path, active blockers, or current priorities",
-"bounding a product or architecture claim to the present release promise"
-],
-"must_not_prove": [
-"live runtime health at the current head",
-"implementation or support outside its declared release scope",
-"long-term architecture decisions outside current-state scope"
-],
-"retrieval_policy": {
-"default_policy": "include",
-"applicable_intents": [
-"architecture_decision",
-"current_state",
-"release_support"
-],
-"excluded_intents": [
-"live_runtime_proof"
-],
-"priority": "required",
-"section_hints": [
-"Current supported reality",
-"Not yet true / do not assume",
-"Active blockers",
-"Release definition right now"
-],
-"maximum_chunk_budget": 6
-},
-"temporal": {
-"created_at": "2026-03-11T13:30:22Z",
-"effective_from": "2026-08-08T00:00:00Z"
-},
-"content_hash": "eace9dc89bfc28f8f2fa74331602f607309589f348a7acc0818adfa4849bf478",
-"relations": [],
-"governing_adr_posture": "not_applicable"
+  "aliases": [],
+  "authority_class": "release_authority",
+  "authority_scopes": [
+    "release readiness",
+    "supported install path",
+    "active release blockers",
+    "current priorities",
+    "present release promise"
+  ],
+  "content_hash": "43a2318038425645671bd7f23d85c8873807776ec2d9554c17c038b50170cdc4",
+  "disposition": "accepted",
+  "document_id": "codexify:doc:architecture:current-state",
+  "evidence_class": "documented-contract",
+  "freshness": {
+    "reason": "Re-verified current-state against committed source revision 5a18dfdd9b4f0957ccc63db325f117a83c66ab0b after restoring the accepted ADR-069 release-class structure. Source bytes synchronized. No live-runtime proof or release-support boundary widened; TTS/voice and federation remain Out of Beta; CE-L1 still lacks live provider/model execution, terminal durable result, and source-thread readback.",
+    "state": "current",
+    "triggers": [
+      "the weekly freshness window expires",
+      "the supported profile or release interpretation changes",
+      "active blockers, priorities, or the audited implementation tip change"
+    ],
+    "verified_at": "2026-09-04T18:22:01-04:00",
+    "verified_commit": "5a18dfdd9b4f0957ccc63db325f117a83c66ab0b",
+    "window_days": 7
+  },
+  "governing_adr_posture": "not_applicable",
+  "kind": "current_state",
+  "lifecycle_state": "active",
+  "must_not_prove": [
+    "live runtime health at the current head",
+    "implementation or support outside its declared release scope",
+    "long-term architecture decisions outside current-state scope"
+  ],
+  "owners": [
+    "Codexify release maintainers"
+  ],
+  "path": "docs/architecture/00-current-state.md",
+  "read_when": [
+    "answering release readiness or support questions",
+    "checking the supported install path, active blockers, or current priorities",
+    "bounding a product or architecture claim to the present release promise"
+  ],
+  "record_type": "document_node",
+  "relations": [],
+  "retrieval_policy": {
+    "applicable_intents": [
+      "architecture_decision",
+      "current_state",
+      "release_support"
+    ],
+    "default_policy": "include",
+    "excluded_intents": [
+      "live_runtime_proof"
+    ],
+    "maximum_chunk_budget": 6,
+    "priority": "required",
+    "section_hints": [
+      "Current supported reality",
+      "Not yet true / do not assume",
+      "Active blockers",
+      "Release definition right now"
+    ]
+  },
+  "schema_version": "1.0.0",
+  "source_anchors": [
+    {
+      "anchor_type": "document",
+      "invalidates_freshness": true,
+      "path": "docs/architecture/00-current-state.md"
+    }
+  ],
+  "summary": "Canonical short-horizon authority for release readiness, supported paths, active blockers, current priorities, and the present release promise.",
+  "temporal": {
+    "created_at": "2026-03-11T13:30:22Z",
+    "effective_from": "2026-08-08T00:00:00Z"
+  },
+  "title": "Codexify Current State"
 }

--- a/docs/knowledge-graph/nodes/codexify:doc:architecture:kb-entrypoint.json
+++ b/docs/knowledge-graph/nodes/codexify:doc:architecture:kb-entrypoint.json
@@ -1,11 +1,4 @@
 {
-  "schema_version": "1.0.0",
-  "record_type": "document_node",
-  "document_id": "codexify:doc:architecture:kb-entrypoint",
-  "path": "docs/architecture/README.md",
-  "title": "Codexify Architecture KB",
-  "kind": "runtime_map",
-  "summary": "Architecture KB entrypoint that routes readers to current truth, governing documents, subsystem maps, and change locations.",
   "aliases": [],
   "authority_class": "structural_authority",
   "authority_scopes": [
@@ -13,98 +6,105 @@
     "Codexify subsystem orientation",
     "architecture change-location guidance"
   ],
-  "lifecycle_state": "active",
+  "content_hash": "6fda41d8a7996efe17e0424791dfc8333a1872e5c68073442759c7932a54f1d5",
+  "disposition": "accepted",
+  "document_id": "codexify:doc:architecture:kb-entrypoint",
+  "evidence_class": "documented-contract",
   "freshness": {
+    "reason": "Re-verified KB entrypoint metadata against committed source revision 5a18dfdd9b4f0957ccc63db325f117a83c66ab0b. The KB entrypoint and all declared freshness-invalidating anchors (including docs/architecture/00-current-state.md) were re-reviewed against the committed source revision; the unreachable [OBSOLETE-SHA-REDACTED] reference is removed. Broken-link warnings in docs/architecture/README.md are not claimed repaired by this task.",
     "state": "current",
-    "verified_at": "2026-08-31T13:37:17Z",
-    "verified_commit": "9d5b7a8570ac605e0773892e2b5ba0300a960d80",
     "triggers": [
       "architecture entrypoints or validity guidance change",
       "listed subsystem ownership or change-location paths change",
       "the current-state routing boundary changes"
     ],
-    "reason": "Re-reviewed the Architecture KB after adding the ADR-077 routing entry. Source bytes are synchronized during the same focused documentation change; the entry routes sandbox execution work without promoting runtime or release support."
+    "verified_at": "2026-09-04T18:22:01-04:00",
+    "verified_commit": "5a18dfdd9b4f0957ccc63db325f117a83c66ab0b"
   },
-  "disposition": "accepted",
-  "evidence_class": "documented-contract",
-  "owners": [
-    "Codexify architecture maintainers"
-  ],
-  "source_anchors": [
-    {
-      "path": "docs/architecture/README.md",
-      "anchor_type": "document",
-      "invalidates_freshness": true
-    },
-    {
-      "path": "docs/architecture/00-current-state.md",
-      "anchor_type": "document",
-      "invalidates_freshness": true
-    },
-    {
-      "path": "docs/architecture/",
-      "anchor_type": "document",
-      "invalidates_freshness": true
-    },
-    {
-      "path": "guardian/routes/",
-      "anchor_type": "code",
-      "invalidates_freshness": true
-    },
-    {
-      "path": "guardian/workers/",
-      "anchor_type": "code",
-      "invalidates_freshness": true
-    },
-    {
-      "path": "frontend/src/App.tsx",
-      "anchor_type": "code",
-      "invalidates_freshness": true
-    }
-  ],
-  "read_when": [
-    "orienting to the Codexify architecture corpus",
-    "finding the governing source for a subsystem or task",
-    "locating the code and documents affected by a proposed change"
-  ],
+  "governing_adr_posture": "not_applicable",
+  "kind": "runtime_map",
+  "lifecycle_state": "active",
   "must_not_prove": [
     "release readiness or supported-path truth independently of current-state authority",
     "live runtime behavior",
     "normative authority inherited from linked ADRs or contracts"
   ],
+  "owners": [
+    "Codexify architecture maintainers"
+  ],
+  "path": "docs/architecture/README.md",
+  "read_when": [
+    "orienting to the Codexify architecture corpus",
+    "finding the governing source for a subsystem or task",
+    "locating the code and documents affected by a proposed change"
+  ],
+  "record_type": "document_node",
+  "relations": [
+    {
+      "authority_scope": "release-truth routing and short-horizon architecture orientation",
+      "canonicality": "canonical",
+      "rationale": "The Architecture KB explicitly instructs readers to start with 00-current-state.md for release readiness, supported-path interpretation, active blockers, and short-horizon priorities, and the KB node already treats current-state as a freshness-invalidating source anchor.",
+      "relation_type": "depends_on",
+      "review_status": "accepted",
+      "target_document_id": "codexify:doc:architecture:current-state"
+    }
+  ],
   "retrieval_policy": {
-    "default_policy": "conditional",
     "applicable_intents": [
       "architecture_orientation",
       "implementation_planning",
       "source_routing"
     ],
+    "default_policy": "conditional",
     "excluded_intents": [
       "current_head_proof",
       "live_runtime_proof"
     ],
+    "maximum_chunk_budget": 8,
     "priority": "primary",
     "section_hints": [
       "Doc Map",
       "Start Here",
       "Where Do I Change X?"
-    ],
-    "maximum_chunk_budget": 8
+    ]
   },
+  "schema_version": "1.0.0",
+  "source_anchors": [
+    {
+      "anchor_type": "document",
+      "invalidates_freshness": true,
+      "path": "docs/architecture/README.md"
+    },
+    {
+      "anchor_type": "document",
+      "invalidates_freshness": true,
+      "path": "docs/architecture/00-current-state.md"
+    },
+    {
+      "anchor_type": "document",
+      "invalidates_freshness": true,
+      "path": "docs/architecture/"
+    },
+    {
+      "anchor_type": "code",
+      "invalidates_freshness": true,
+      "path": "guardian/routes/"
+    },
+    {
+      "anchor_type": "code",
+      "invalidates_freshness": true,
+      "path": "guardian/workers/"
+    },
+    {
+      "anchor_type": "code",
+      "invalidates_freshness": true,
+      "path": "frontend/src/App.tsx"
+    }
+  ],
+  "summary": "Architecture KB entrypoint that routes readers to current truth, governing documents, subsystem maps, and change locations.",
   "temporal": {
     "created_at": "2026-02-17T16:32:37Z",
     "effective_from": "2026-02-17T16:32:37Z"
   },
-  "content_hash": "9384fcf5d713a5e2653f24cd2b9490d88cc084a71908c8b27e6bd16514e6a79d",
-  "relations": [
-    {
-      "relation_type": "depends_on",
-      "target_document_id": "codexify:doc:architecture:current-state",
-      "authority_scope": "release-truth routing and short-horizon architecture orientation",
-      "canonicality": "canonical",
-      "review_status": "accepted",
-      "rationale": "The Architecture KB explicitly instructs readers to start with 00-current-state.md for release readiness, supported-path interpretation, active blockers, and short-horizon priorities, and the KB node already treats current-state as a freshness-invalidating source anchor."
-    }
-  ],
-  "governing_adr_posture": "not_applicable"
+  "title": "Codexify Architecture KB"
 }


### PR DESCRIPTION
Restores accepted ADR-069 release-class structure and re-verifies the current-state, ADR-index, and KB-entrypoint DLG nodes against reachable canonical history. Local Architecture Contracts pass 217/217 with zero DLG errors. This diff is documentation/DLG-only; Guardian backend CI should take its no-op path. No release boundary, ADR identity, DLG semantics, or runtime authority changes.