### PR TITLE
Reverify canonical architecture DLG metadata

### DIFF
--- a/docs/knowledge-graph/nodes/codexify:doc:architecture:adr-index.json
+++ b/docs/knowledge-graph/nodes/codexify:doc:architecture:adr-index.json
@@ -8,20 +8,20 @@
     "ADR reading order",
     "ADR graph navigation"
   ],
-  "content_hash": "71d7c52dde6c2c63080cd3e17d5701a1a647513acd794eec20efab31ee04a4d7",
+  "content_hash": "d3a153bc0ea324dfad997b7682cd31ffb8cfa3e9a777bb0b693601d1a24bfeb7",
   "disposition": "accepted",
   "document_id": "codexify:doc:architecture:adr-index",
   "evidence_class": "documented-contract",
   "freshness": {
-    "reason": "Re-verified ADR-index metadata against committed source revision 5a18dfdd9b4f0957ccc63db325f117a83c66ab0b. The ADR index and declared ADR anchors were reverified against reachable canonical history; the obsolete unreachable [OBSOLETE-SHA-REDACTED] freshness reference was replaced. No ADR identity, numbering, or release semantics changed. ADR-number collisions (053, 076) remain reported separately and are not addressed by this task.",
+    "reason": "Re-reverified ADR-index metadata against committed source revision 55e5475a4e53ecdb92a3be15e284a370a55ed05f. The ADR index and declared ADR anchor set were re-reviewed; ADR-082 (Persona Profile Manifest and Binding Authority) and the intervening Persona Studio / ADR-082 cross-references are included. No ADR identity, numbering, acceptance, or release semantics were changed by this metadata task. ADR-053 and ADR-076 numeric collisions remain reported separately and are not gating.",
     "state": "current",
     "triggers": [
       "an ADR is added, removed, renumbered, or retitled",
       "an indexed ADR review posture changes",
       "the documented ADR graph or reading order changes"
     ],
-    "verified_at": "2026-09-04T18:22:01-04:00",
-    "verified_commit": "5a18dfdd9b4f0957ccc63db325f117a83c66ab0b"
+    "verified_at": "2026-09-05T12:32:56Z",
+    "verified_commit": "55e5475a4e53ecdb92a3be15e284a370a55ed05f"
   },
   "governing_adr_posture": "not_applicable",
   "kind": "runtime_map",

--- a/docs/knowledge-graph/nodes/codexify:doc:architecture:current-state.json
+++ b/docs/knowledge-graph/nodes/codexify:doc:architecture:current-state.json
@@ -8,20 +8,20 @@
     "current priorities",
     "present release promise"
   ],
-  "content_hash": "43a2318038425645671bd7f23d85c8873807776ec2d9554c17c038b50170cdc4",
+  "content_hash": "aad77aa3208bc7d329ffae8a9c0624caf79137622a786a79f58690dca627eda4",
   "disposition": "accepted",
   "document_id": "codexify:doc:architecture:current-state",
   "evidence_class": "documented-contract",
   "freshness": {
-    "reason": "Re-verified current-state against committed source revision 5a18dfdd9b4f0957ccc63db325f117a83c66ab0b after restoring the accepted ADR-069 release-class structure. Source bytes synchronized. No live-runtime proof or release-support boundary widened; TTS/voice and federation remain Out of Beta; CE-L1 still lacks live provider/model execution, terminal durable result, and source-thread readback.",
+    "reason": "Re-reverified current-state metadata against committed source revision 55e5475a4e53ecdb92a3be15e284a370a55ed05f after the canonical weekly current-state override and intervening canonical maintenance. Source bytes are synchronized to the post-override current-state.md. No new live-runtime proof or release support boundary is inferred; CE-L1 still lacks live provider/model execution, terminal durable result, and source-thread readback. Persona Studio and ADR-082 routing remain separate.",
     "state": "current",
     "triggers": [
       "the weekly freshness window expires",
       "the supported profile or release interpretation changes",
       "active blockers, priorities, or the audited implementation tip change"
     ],
-    "verified_at": "2026-09-04T18:22:01-04:00",
-    "verified_commit": "5a18dfdd9b4f0957ccc63db325f117a83c66ab0b",
+    "verified_at": "2026-09-05T12:32:56Z",
+    "verified_commit": "55e5475a4e53ecdb92a3be15e284a370a55ed05f",
     "window_days": 7
   },
   "governing_adr_posture": "not_applicable",

--- a/docs/knowledge-graph/nodes/codexify:doc:architecture:kb-entrypoint.json
+++ b/docs/knowledge-graph/nodes/codexify:doc:architecture:kb-entrypoint.json
@@ -6,20 +6,20 @@
     "Codexify subsystem orientation",
     "architecture change-location guidance"
   ],
-  "content_hash": "6fda41d8a7996efe17e0424791dfc8333a1872e5c68073442759c7932a54f1d5",
+  "content_hash": "fba6eb3e49da5b32780bbb50cd05cd46beb65b36d136093a7edb076f37fe9d01",
   "disposition": "accepted",
   "document_id": "codexify:doc:architecture:kb-entrypoint",
   "evidence_class": "documented-contract",
   "freshness": {
-    "reason": "Re-verified KB entrypoint metadata against committed source revision 5a18dfdd9b4f0957ccc63db325f117a83c66ab0b. The KB entrypoint and all declared freshness-invalidating anchors (including docs/architecture/00-current-state.md) were re-reviewed against the committed source revision; the unreachable [OBSOLETE-SHA-REDACTED] reference is removed. Broken-link warnings in docs/architecture/README.md are not claimed repaired by this task.",
+    "reason": "Re-reverified Architecture KB entrypoint metadata against committed source revision 55e5475a4e53ecdb92a3be15e284a370a55ed05f. The KB entrypoint and all declared freshness-invalidating anchors were re-reviewed: Persona Studio / ADR-082 routing, weekly current-state override, and Guardian route/worker changes. No runtime, release, provider, or authority claim was widened. Unrelated broken-link warnings are not claimed repaired.",
     "state": "current",
     "triggers": [
       "architecture entrypoints or validity guidance change",
       "listed subsystem ownership or change-location paths change",
       "the current-state routing boundary changes"
     ],
-    "verified_at": "2026-09-04T18:22:01-04:00",
-    "verified_commit": "5a18dfdd9b4f0957ccc63db325f117a83c66ab0b"
+    "verified_at": "2026-09-05T12:32:56Z",
+    "verified_commit": "55e5475a4e53ecdb92a3be15e284a370a55ed05f"
   },
   "governing_adr_posture": "not_applicable",
   "kind": "runtime_map",


### PR DESCRIPTION
Re-verifies the current-state, ADR-index, and Architecture KB DLG nodes after canonical source-anchor changes. Metadata-only: exact source hashes plus freshness evidence; no architecture source, release doctrine, runtime behavior, or authority semantics change. Local Architecture Contracts and direct DLG validation are green.