### PR TITLE
Restore current-state release contract

### DIFF
--- a/docs/architecture/00-current-state.md
+++ b/docs/architecture/00-current-state.md
@@ -63,11 +63,150 @@ This file is authoritative for:
 3. Requalify private-preview provider/persistence/canary and CE-L1 live execution/readback with current credentials and source-thread evidence.
 4. Close Project ownership, Safari upload, authenticated browser, Watchdog, retention, and hosted-sandbox gates.
 
+## Release classes
+
+The five release classes below are accepted architecture per ADR-069. They are
+human-facing release interpretations over the existing Product Architecture
+Assertion dimensions and the `00-current-state.md` short-form authority, not
+new schema enums. Evidence maturity and support posture remain orthogonal
+under ADR-069. Support doctrine does not prove every current-tip gate is
+green; the "Not yet true / do not assume" and "Active blockers" sections above
+remain authoritative for the present live-state truth.
+
+### Beta Supported
+
+The current Beta Supported envelope is the local-first supported install
+path and its core surfaces, already enumerated in the "Current supported
+reality" section above and accepted by ADR-069:
+
+- Local Docker Compose runtime with the local-only default provider posture
+  (`CODEXIFY_LOCAL_ONLY_MODE=true`, `ALLOW_CLOUD_PROVIDERS=false`,
+  `LLM_PROVIDER=local`).
+- Local inference and the supported local profile.
+- Ordinary chat, durable threads / messages / tasks, and project / thread /
+  workspace navigation.
+- Documents and media ingestion on currently implemented supported formats.
+- Embedding and workspace-scoped retrieval.
+- Codexify-native identity / authentication boundaries and account-scoped
+  ownership behavior.
+- Operator-visible health and configuration truth required to run the
+  self-hosted node.
+
+This is support doctrine, not current-tip qualification. The "Not yet true
+/ do not assume" and "Active blockers" sections above continue to bound what
+is provably green on the current `main` tip. Implementation presence in a
+code path does not promote a capability to Beta Supported; only the
+architecture-accepted support envelope under ADR-069 does.
+
+### Beta Bounded / Conditional
+
+Surfaces intentionally inside the Beta envelope but only under an explicit
+authority, topology, provider, mode, or capability boundary. The
+classification below is the current accepted one; no new bounded surface
+is added by this section.
+
+- Persona Studio: account-scoped profile creation / editing, persistence,
+  selection, and application of the currently implemented five-field
+  runtime projection to ordinary chat. TTS / voice execution, unsupported
+  permission authoring, unsupported retrieval-policy execution, and
+  "preview UI equals enforcement" claims are excluded from this
+  promotion.
+- Import / continuity entry surfaces: OpenAI / ChatGPT export import,
+  Task Prompt Archive, owner-scoped retry / recovery behavior already
+  implemented, and account export / restore to the exact extent supported
+  by the existing contract and implementation. Not every historical
+  corpus, provider export format, or migration shape is claimed.
+- Repository intelligence on the supported local single-user path:
+  repository candidate discovery, explicit repository import,
+  account / Project `RepositoryBinding`, direct Project-bound repository
+  search, and ordinary-chat repository search exposure only when
+  Guardian resolves exactly one valid active binding and existing
+  authority checks pass. Remote / multi-user / Hosted-Room repository
+  authority remains outside this bounded Beta claim.
+- Bounded Guardian tool execution: read-only health capability, and
+  bounded Project repository search where current eligibility /
+  authority checks pass. Advertised-subset authority, Guardian-owned
+  execution authority, exact capability eligibility, bounded command
+  count, and provider capability checks are preserved. Arbitrary tools,
+  arbitrary write operations, and generic shell / filesystem execution
+  are not promoted.
+- MCP / extensibility: the public MCP extension posture may be described as
+  part of Beta only as a bounded extension interface. A general plugin
+  marketplace, plugin SDK internals as public Beta API, and arbitrary
+  plugin execution bypassing Guardian policy are not claimed.
+- Desktop / Tauri client (if current `main` still contains the functioning
+  local desktop / Tauri presentation layer): Beta Bounded / Conditional
+  when used as a client of the same supported local Guardian node. Not a
+  packaged production desktop distribution, not auto-update support, not
+  an independent desktop persistence / runtime authority, not a separate
+  release topology not currently proven.
+
+### Internal
+
+The following remain explicitly internal, not user-facing release promises:
+
+- direct Command Bus HTTP / control-plane API
+- plugin SDK internals
+- generic tools / API tools surfaces currently marked internal or
+  quarantined
+- developer-only diagnostics
+- unsafe operator mutation surfaces
+- implementation / control-plane mechanisms that support Beta behavior
+  without being user-facing promises
+- Pi 0.82.1 wrapper/API, source-vendor, identity, framing, and telemetry
+  surfaces (per the "Current supported reality" / "Not yet true" sections
+  above; non-inference / OAuth-readiness qualification; not a
+  user-facing release promise at the current `main` tip).
+- CE-L1 wiring (lives in code paths and is required to close active
+  blockers, but remains internal / qualification pending — see below).
+- Campaign / coding-worker substrate (operational substrate that supports
+  Beta behavior; not a user-facing release promise).
+
+Implementation presence of Pi, CE-L1, or coding-worker wiring does not
+promote those surfaces to Beta Supported merely because their code paths
+exist.
+
+### Qualification Pending
+
+Intended or plausible Beta surface with implementation present, but a
+specifically named proof / authority / operational gate remains open.
+Each entry below names its explicit `remaining gate` rather than only
+saying "not supported," per the ADR-069 Qualification-Pending Doctrine.
+
+- **Coding Loop** — `remaining gate` requires: live provider/model
+  execution, terminal durable result, and source-thread readback on the
+  claimed supported profile. CE-L1 wiring remains internal / qualification
+  pending; no `LIVE_EXECUTOR_PROVEN_CANONICAL` is emitted.
+- **Hosted Rooms** — `remaining gate` requires: clean supported / tester
+  startup and owner / guest live semantic proof after migration repair.
+- **DeepSeek / private-preview provider lane** — `remaining gate` requires:
+  required credentials, authenticated provider-specific persisted runtime
+  proof, and explicit supported-profile promotion.
+
+### Out of Beta
+
+Explicitly excluded from the present Beta promise under ADR-069 and not
+classified as Qualification Pending:
+
+- TTS / voice — Out of Beta
+- federation — Out of Beta
+- unrestricted autonomous / recursive agent execution
+- arbitrary write-capability tool use
+- generic shell / filesystem execution through ordinary Beta chat
+- public Command Bus exposure
+- generic cron / unattended automation
+- generic connectors without separate qualification
+- graph-write / Neo4j-derived-write behavior where the supported path remains
+  flagged off or quarantined
+- remote / multi-user repository execution not covered by a separately
+  accepted authority contract and live proof
+
 ## Release definition right now
 
 - [x] Supported local Compose path and Beta boundary are defined on `main`.
 - [x] Support doctrine, bounded/internal surfaces, qualification-pending work, and unproven evidence remain distinct.
-- [ ] Current-tip Compose proves healthy startup, model inventory, terminal chat, persistence/readback, retrieval, and event delivery.
+- [x] Private-preview migration preservation/readback and ingress proofs are bounded without guest admission or release widening.
+- [ ] Current-tip Compose proves healthy startup, model inventory, terminal chat, persistence/readback, and event delivery.
 - [ ] Queue, worker bind readiness, locks, migrations, configuration, recovery, browser, and account-import claimed-path gates are green.
 - [ ] Every claimed preview/provider lane has current-main proof for execution, durable readback, isolation, and recovery where applicable.
 

--- a/docs/knowledge-graph/nodes/codexify:doc:architecture:current-state.json
+++ b/docs/knowledge-graph/nodes/codexify:doc:architecture:current-state.json
@@ -8,20 +8,20 @@
     "current priorities",
     "present release promise"
   ],
-  "content_hash": "aad77aa3208bc7d329ffae8a9c0624caf79137622a786a79f58690dca627eda4",
+  "content_hash": "e11146094a2ca469fd40153f90f3b8c49911f365ca7a6e90fc2c6e8f1290fc3c",
   "disposition": "accepted",
   "document_id": "codexify:doc:architecture:current-state",
   "evidence_class": "documented-contract",
   "freshness": {
-    "reason": "Re-reverified current-state metadata against committed source revision 55e5475a4e53ecdb92a3be15e284a370a55ed05f after the canonical weekly current-state override and intervening canonical maintenance. Source bytes are synchronized to the post-override current-state.md. No new live-runtime proof or release support boundary is inferred; CE-L1 still lacks live provider/model execution, terminal durable result, and source-thread readback. Persona Studio and ADR-082 routing remain separate.",
+    "reason": "Re-verified current-state metadata against committed source revision 0ef78e03dce504288b008af4f42cea6d486ea99c after restoring ADR-069 release-class structure. Current 2026-09-06 short-horizon blockers and priorities preserved. No capability promoted or demoted; no new runtime proof inferred; CE-L1 still lacks live provider/model execution, terminal durable result, source-thread readback.",
     "state": "current",
     "triggers": [
       "the weekly freshness window expires",
       "the supported profile or release interpretation changes",
       "active blockers, priorities, or the audited implementation tip change"
     ],
-    "verified_at": "2026-09-05T12:32:56Z",
-    "verified_commit": "55e5475a4e53ecdb92a3be15e284a370a55ed05f",
+    "verified_at": "2026-09-06T13:59:09Z",
+    "verified_commit": "0ef78e03dce504288b008af4f42cea6d486ea99c",
     "window_days": 7
   },
   "governing_adr_posture": "not_applicable",

--- a/docs/knowledge-graph/nodes/codexify:doc:architecture:kb-entrypoint.json
+++ b/docs/knowledge-graph/nodes/codexify:doc:architecture:kb-entrypoint.json
@@ -6,20 +6,20 @@
     "Codexify subsystem orientation",
     "architecture change-location guidance"
   ],
-  "content_hash": "fba6eb3e49da5b32780bbb50cd05cd46beb65b36d136093a7edb076f37fe9d01",
+  "content_hash": "cf86c9d9a0b8ce1ce4f0c414559e49bca5caf43abda847397b13c9f29b1550bc",
   "disposition": "accepted",
   "document_id": "codexify:doc:architecture:kb-entrypoint",
   "evidence_class": "documented-contract",
   "freshness": {
-    "reason": "Re-reverified Architecture KB entrypoint metadata against committed source revision 55e5475a4e53ecdb92a3be15e284a370a55ed05f. The KB entrypoint and all declared freshness-invalidating anchors were re-reviewed: Persona Studio / ADR-082 routing, weekly current-state override, and Guardian route/worker changes. No runtime, release, provider, or authority claim was widened. Unrelated broken-link warnings are not claimed repaired.",
+    "reason": "Re-verified Architecture KB entrypoint metadata against committed source revision 0ef78e03dce504288b008af4f42cea6d486ea99c. The KB entrypoint and all declared freshness-invalidating anchors were re-reviewed. The current-state ADR-069 restoration is included. Current Architecture KB routing remains semantically valid; no runtime, release, provider, or authority claim was widened. Unrelated warnings/collisions are not claimed repaired.",
     "state": "current",
     "triggers": [
       "architecture entrypoints or validity guidance change",
       "listed subsystem ownership or change-location paths change",
       "the current-state routing boundary changes"
     ],
-    "verified_at": "2026-09-05T12:32:56Z",
-    "verified_commit": "55e5475a4e53ecdb92a3be15e284a370a55ed05f"
+    "verified_at": "2026-09-06T13:59:09Z",
+    "verified_commit": "0ef78e03dce504288b008af4f42cea6d486ea99c"
   },
   "governing_adr_posture": "not_applicable",
   "kind": "runtime_map",


### PR DESCRIPTION
Restores the five accepted ADR-069 human-facing release classes while preserving current 2026-09-06 operational truth, then re-verifies the two DLG nodes currently failing source-integrity validation: current-state and Architecture KB entrypoint. README source is unchanged. No release promotion, runtime change, provider activity, or CE-L1 execution.