### PR TITLE
Preserve non-Markdown repository links in the Atlas reader

### DIFF
--- a/projection-ui-map/rc-atlas-prototype.html
+++ b/projection-ui-map/rc-atlas-prototype.html
@@ -691,7 +691,7 @@
       const target = String(value || "").trim();
       return target && !/^(?:javascript|data|vbscript):/i.test(target) ? target : null;
     }
-    function renderMarkdownInline(value) {
+    function renderMarkdownInline(value, baseUrl) {
       const held = [];
       const hold = html => "\u0000" + (held.push(html) - 1) + "\u0000";
       let text = String(value == null ? "" : value);
@@ -708,7 +708,11 @@
       text = text.replace(/\[([^\]]+)\]\(([^)\s]+)(?:\s+["']([^"']+)["'])?\)/g, (_, rawLabel, rawTarget, rawTitle) => {
         const target = safeMarkdownTarget(rawTarget), label = escapeMarkdown(rawLabel);
         const title = rawTitle ? ' title="' + escapeMarkdown(rawTitle) + '"' : "";
-        return target ? hold('<a href="#" data-markdown-href="' + escapeMarkdown(target) + '"' + title + ">" + label + "</a>") : label;
+        if (!target) return label;
+        if (/\.md(?:[#?]|$)/i.test(target)) return hold('<a href="#" data-markdown-href="' + escapeMarkdown(target) + '"' + title + ">" + label + "</a>");
+        let href = target;
+        try { if (baseUrl && !/^[a-z][a-z\d+.-]*:/i.test(target)) href = new URL(target, baseUrl).href; } catch (_) { return label; }
+        return hold('<a href="' + escapeMarkdown(href) + '"' + title + ">" + label + "</a>");
       });
       text = escapeMarkdown(text)
         .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
@@ -718,7 +722,7 @@
         .replace(/(^|[\s(])_([^_\n]+)_(?=$|[\s).,!?:;])/g, "$1<em>$2</em>");
       return text.replace(/\u0000(\d+)\u0000/g, (_, index) => held[+index] || "");
     }
-    function renderFrontmatter(lines) {
+    function renderFrontmatter(lines, baseUrl) {
       const fields = [];
       let current = null;
       lines.forEach(line => {
@@ -729,7 +733,7 @@
         if (item && current) current.values.push(item[1]);
       });
       if (!fields.length) return "";
-      return '<aside class="markdown-frontmatter"><strong>Document metadata</strong><dl>' + fields.map(field => '<dt>' + escapeMarkdown(field.key) + '</dt><dd>' + (field.values.length ? field.values.map(renderMarkdownInline).join('<span aria-hidden="true"> · </span>') : "—") + "</dd>").join("") + "</dl></aside>";
+      return '<aside class="markdown-frontmatter"><strong>Document metadata</strong><dl>' + fields.map(field => '<dt>' + escapeMarkdown(field.key) + '</dt><dd>' + (field.values.length ? field.values.map(value => renderMarkdownInline(value, baseUrl)).join('<span aria-hidden="true"> · </span>') : "—") + "</dd>").join("") + "</dl></aside>";
     }
     function splitMarkdownTableRow(line) {
       const cells = [];
@@ -756,13 +760,14 @@
       const line = lines[index] || "";
       return !line.trim() || /^\s*```/.test(line) || /^#{1,6}\s+/.test(line) || /^\s*>/.test(line) || /^\s*(?:[-+*]|\d+\.)\s+/.test(line) || /^\s*(?:-{3,}|\*{3,}|_{3,})\s*$/.test(line) || (index + 1 < lines.length && line.includes("|") && tableDivider(lines[index + 1]));
     }
-    function renderMarkdown(markdown) {
+    function renderMarkdown(markdown, baseUrl) {
+      const renderInline = value => renderMarkdownInline(value, baseUrl);
       const lines = String(markdown == null ? "" : markdown).replace(/^\uFEFF/, "").replace(/\r\n?/g, "\n").split("\n");
       const output = [];
       let index = 0;
       if (lines[0] && lines[0].trim() === "---") {
         const end = lines.findIndex((line, lineIndex) => lineIndex > 0 && line.trim() === "---");
-        if (end > 0) { output.push(renderFrontmatter(lines.slice(1, end))); index = end + 1; }
+        if (end > 0) { output.push(renderFrontmatter(lines.slice(1, end), baseUrl)); index = end + 1; }
       }
       while (index < lines.length) {
         const line = lines[index];
@@ -780,20 +785,20 @@
         if (heading) {
           const level = heading[1].length;
           const id = heading[2].toLowerCase().replace(/<[^>]*>/g, "").replace(/[^a-z0-9\s-]/g, "").trim().replace(/\s+/g, "-") || "section-" + index;
-          output.push("<h" + level + ' id="' + escapeMarkdown(id) + '">' + renderMarkdownInline(heading[2]) + "</h" + level + ">"); index += 1; continue;
+          output.push("<h" + level + ' id="' + escapeMarkdown(id) + '">' + renderInline(heading[2]) + "</h" + level + ">"); index += 1; continue;
         }
         if (/^\s*(?:-{3,}|\*{3,}|_{3,})\s*$/.test(line)) { output.push("<hr>"); index += 1; continue; }
         if (line.includes("|") && index + 1 < lines.length && tableDivider(lines[index + 1])) {
           const headings = splitMarkdownTableRow(line); index += 2;
           const rows = [];
           while (index < lines.length && lines[index].includes("|") && lines[index].trim()) { rows.push(splitMarkdownTableRow(lines[index])); index += 1; }
-          output.push('<div class="markdown-table-wrap"><table><thead><tr>' + headings.map(cell => "<th>" + renderMarkdownInline(cell) + "</th>").join("") + "</tr></thead><tbody>" + rows.map(row => "<tr>" + headings.map((_, cellIndex) => "<td>" + renderMarkdownInline(row[cellIndex] || "") + "</td>").join("") + "</tr>").join("") + "</tbody></table></div>");
+          output.push('<div class="markdown-table-wrap"><table><thead><tr>' + headings.map(cell => "<th>" + renderInline(cell) + "</th>").join("") + "</tr></thead><tbody>" + rows.map(row => "<tr>" + headings.map((_, cellIndex) => "<td>" + renderInline(row[cellIndex] || "") + "</td>").join("") + "</tr>").join("") + "</tbody></table></div>");
           continue;
         }
         if (/^\s*>/.test(line)) {
           const quote = [];
           while (index < lines.length && /^\s*>/.test(lines[index])) { quote.push(lines[index].replace(/^\s*>\s?/, "")); index += 1; }
-          output.push("<blockquote>" + renderMarkdown(quote.join("\n")) + "</blockquote>"); continue;
+          output.push("<blockquote>" + renderMarkdown(quote.join("\n"), baseUrl) + "</blockquote>"); continue;
         }
         const list = line.match(/^\s*(?:([-+*])|(\d+)\.)\s+(.+)$/);
         if (list) {
@@ -804,14 +809,14 @@
             let content = item[3]; index += 1;
             while (index < lines.length && /^\s{2,}\S/.test(lines[index]) && !/^\s*(?:[-+*]|\d+\.)\s+/.test(lines[index])) { content += " " + lines[index].trim(); index += 1; }
             const task = content.match(/^\[([ xX])\]\s+(.+)$/);
-            items.push({ value: ordered ? Math.max(1, +item[2]) : null, html: task ? '<input type="checkbox" disabled' + (task[1].toLowerCase() === "x" ? " checked" : "") + "> " + renderMarkdownInline(task[2]) : renderMarkdownInline(content) });
+            items.push({ value: ordered ? Math.max(1, +item[2]) : null, html: task ? '<input type="checkbox" disabled' + (task[1].toLowerCase() === "x" ? " checked" : "") + "> " + renderInline(task[2]) : renderInline(content) });
           }
           const tag = ordered ? "ol" : "ul", startAttribute = ordered && start !== 1 ? ' start="' + start + '"' : "";
           output.push("<" + tag + startAttribute + ">" + items.map(item => "<li" + (ordered ? ' value="' + item.value + '"' : "") + ">" + item.html + "</li>").join("") + "</" + tag + ">"); continue;
         }
         const paragraph = [line.trim()]; index += 1;
         while (index < lines.length && !markdownBlockStart(lines, index)) { paragraph.push(lines[index].trim()); index += 1; }
-        output.push("<p>" + renderMarkdownInline(paragraph.join(" ")) + "</p>");
+        output.push("<p>" + renderInline(paragraph.join(" ")) + "</p>");
       }
       return output.filter(Boolean).join("\n");
     }
@@ -1073,7 +1078,7 @@
         const base = baseUrl && !raw.startsWith("/") && !raw.startsWith("docs/") ? new URL(baseUrl) : root;
         const url = new URL(raw, base);
         if (url.origin !== root.origin || !url.pathname.startsWith(root.pathname)) return null;
-        if (!/\.md$/i.test(url.pathname)) url.pathname += ".md";
+        if (!/\.md$/i.test(url.pathname)) return null;
         return url;
       } catch (_) { return null; }
     }
@@ -1108,7 +1113,7 @@
           markdown = await response.text();
         }
         if (loadToken !== state.readerLoadToken || !els.reader.classList.contains("open")) return;
-        els.readerArticle.innerHTML = M.renderMarkdown(markdown);
+        els.readerArticle.innerHTML = M.renderMarkdown(markdown, url.href);
         const heading = els.readerArticle.querySelector("h1"); if (heading) els.readerTitle.textContent = heading.textContent;
         setReaderMode("markdown");
         els.readerArticle.parentElement.scrollTop = restoreScroll;

--- a/projection-ui-map/rc-atlas-prototype.test.cjs
+++ b/projection-ui-map/rc-atlas-prototype.test.cjs
@@ -12,7 +12,7 @@ const scripts = [...html.matchAll(/<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/gi)]
 const modelMatch = html.match(/<script\s+data-atlas-model>([\s\S]*?)<\/script>/i);
 
 assert.ok(modelMatch, "prototype exposes the pure Atlas model script");
-const context = { console };
+const context = { console, URL };
 context.globalThis = context;
 vm.createContext(context);
 vm.runInContext(modelMatch[1], context, { filename: "rc-atlas-model.js" });
@@ -411,6 +411,16 @@ const safe = true;
   assert.doesNotMatch(rendered, /<script>|javascript:/);
 });
 
+test("repository links to non-Markdown files bypass the document reader", () => {
+  const rendered = M.renderMarkdown(
+    "[Protocol tokens](../../guardian/protocol_tokens.py) and [ADR index](adr/adr-index.md)",
+    "file:///repo/docs/architecture/00-current-state.md"
+  );
+  assert.match(rendered, /href="file:\/\/\/repo\/guardian\/protocol_tokens\.py"/);
+  assert.doesNotMatch(rendered, /data-markdown-href="\.\.\/\.\.\/guardian\/protocol_tokens\.py"/);
+  assert.match(rendered, /data-markdown-href="adr\/adr-index\.md"/);
+});
+
 test("full-document loading supports offline sources and preserves original access", () => {
   const loader = html.match(/function repositoryRootUrl\(\)[\s\S]*?function closeReader\(\)/)?.[0] || "";
   assert.match(loader, /https\?\|file/);
@@ -487,6 +497,7 @@ test("inspector document history preserves projection state and restores its pri
       assert.ok(!classes.has('document-mode'));
       assert.equal(env.markdownSourceUrl('https://outside.example/document.md'), null);
       assert.equal(env.markdownSourceUrl('../../outside.md'), null);
+      assert.equal(env.markdownSourceUrl('../../guardian/protocol_tokens.py'), null);
       assert.equal(env.markdownSourceUrl('javascript:alert(1)'), null);
     }
   }


### PR DESCRIPTION
### Motivation

- The Atlas document reader currently forces every repository link through the Markdown reader by appending `.md`, which breaks links to non-Markdown artifacts (e.g., `guardian/protocol_tokens.py`) and causes dead `*.md` requests for safe resources.
- Offline and file-mode readers must preserve safe absolute `http`/`https` anchors and repository artifact links as ordinary anchors while still delegating true Markdown destinations to the in-reader navigation.

### Description

- Changed the inline renderer to accept a `baseUrl` and render non-`.md` repository targets as ordinary anchors resolved relative to the source document, while continuing to use `data-markdown-href` for Markdown destinations only (`renderMarkdownInline(value, baseUrl)`).
- Threaded `baseUrl` through frontmatter, headings, tables, blockquotes, lists, and paragraphs so all inline rendering resolves relative links correctly (`renderFrontmatter(..., baseUrl)` and `renderMarkdown(markdown, baseUrl)`).
- Stopped `markdownSourceUrl` from fabricating a `.md` suffix and instead reject non-Markdown paths so non-Markdown artifacts never enter the Markdown reader.
- Pass the loaded document URL into the Markdown renderer in `openMarkdownReader` so repository-relative artifact links resolve in both served and offline `file:` modes (`M.renderMarkdown(markdown, url.href)`).
- Added a regression test `repository links to non-Markdown files bypass the document reader` and adjusted the test harness context to include `URL` for relative resolution.
- Files changed: `projection-ui-map/rc-atlas-prototype.html`, `projection-ui-map/rc-atlas-prototype.test.cjs`.
- Commit: `6de81e2293d0f895040d0eb60b07ea06497de654`.

### Testing

- Ran the focused test pattern: `node --test --test-name-pattern='all executable inline JavaScript|bounded Markdown rendering|repository links to non-Markdown|inspector document history' projection-ui-map/rc-atlas-prototype.test.cjs`, which passed for the selected tests.
- Ran the full prototype suite: `node projection-ui-map/rc-atlas-prototype.test.cjs`, resulting in 35/36 tests passing; the single failing test is a pre-existing offline embedded ADR snapshot fidelity check caused by a stale embedded ADR index (this matches a separate review finding and is outside the scope of this change).
- Ran repository checks: `git diff --check` and `git diff --cached --check` (both clean) and confirmed working tree state with `git status --short --branch` after commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6aa52fce2c40832da1d3ee6a350741f8)