### PR TITLE
Keep Resonant Constructs Atlas relationship arrows visible

### DIFF
--- a/projection-ui-map/rc-atlas-prototype.html
+++ b/projection-ui-map/rc-atlas-prototype.html
@@ -666,6 +666,17 @@
       const history = (state && state.history ? state.history : []).slice();
       return { selectedId: history.pop() || "completion-assembly-execution", history };
     }
+    function routeEndpoint(from, to, halfWidth = 103, halfHeight = 62, markerLength = 10) {
+      const dx = to.x - from.x, dy = to.y - from.y;
+      const distance = Math.hypot(dx, dy);
+      if (!distance) return { x: to.x, y: to.y };
+      const boundaryDistance = Math.min(
+        dx ? halfWidth * distance / Math.abs(dx) : Infinity,
+        dy ? halfHeight * distance / Math.abs(dy) : Infinity
+      );
+      const visibleDistance = boundaryDistance + markerLength;
+      return { x: to.x - dx * visibleDistance / distance, y: to.y - dy * visibleDistance / distance };
+    }
     const PRIMARY_VIEWS = Object.freeze(["atlas", "directory", "sources"]);
     function createReaderReturn(state, scrollTop, pageScrollTop) {
       const input = state && typeof state === "object" ? state : {};
@@ -859,7 +870,7 @@
       if (JSON.stringify(graphIds(model.entities)) !== JSON.stringify(listIds(model.entities))) errors.push("graph-list-parity");
       return errors;
     }
-    root.AtlasModel = Object.freeze({ data, byId, graphIds, listIds, categorySlug, fitViewport, defaultPresentation, inspectorBounds, clampInspectorWidth, loadPresentation, createNavigation, navigate, back, createReaderReturn, mobilePreview, nextMobileSheetState, renderMarkdown, validate });
+    root.AtlasModel = Object.freeze({ data, byId, graphIds, listIds, categorySlug, fitViewport, defaultPresentation, inspectorBounds, clampInspectorWidth, loadPresentation, createNavigation, navigate, back, routeEndpoint, createReaderReturn, mobilePreview, nextMobileSheetState, renderMarkdown, validate });
   })(typeof globalThis !== "undefined" ? globalThis : this);
   </script>
 
@@ -980,7 +991,9 @@
       els.edgeLabels.innerHTML = "";
       D.relationships.forEach(rel => {
         const from = state.positions[rel.from], to = state.positions[rel.to]; if (!from || !to) return;
-        const x1 = from.x + 103, y1 = from.y + 62, x2 = to.x + 103, y2 = to.y + 62;
+        const x1 = from.x + 103, y1 = from.y + 62;
+        const endpoint = M.routeEndpoint({ x: x1, y: y1 }, { x: to.x + 103, y: to.y + 62 });
+        const x2 = endpoint.x, y2 = endpoint.y;
         const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
         path.setAttribute("d", "M " + x1 + " " + y1 + " L " + x2 + " " + y2);
         path.setAttribute("class", rel.kind);

--- a/projection-ui-map/rc-atlas-prototype.test.cjs
+++ b/projection-ui-map/rc-atlas-prototype.test.cjs
@@ -146,6 +146,16 @@ test("node and edge meaning is not encoded by color alone", () => {
   assert.match(html, /<dt>Target module<\/dt>/);
 });
 
+test("relationship arrows stop outside target cards so their markers remain visible", () => {
+  assert.deepEqual(plain(M.routeEndpoint({ x: 0, y: 0 }, { x: 300, y: 0 })), { x: 187, y: 0 });
+  assert.deepEqual(plain(M.routeEndpoint({ x: 300, y: 0 }, { x: 0, y: 0 })), { x: 113, y: 0 });
+  assert.deepEqual(plain(M.routeEndpoint({ x: 0, y: 0 }, { x: 0, y: 300 })), { x: 0, y: 228 });
+
+  const diagonal = M.routeEndpoint({ x: 0, y: 0 }, { x: 300, y: 300 });
+  assert.ok(diagonal.x < 238 && diagonal.y < 238, "marker tip remains beyond the top-left card boundary");
+  assert.match(html, /M\.routeEndpoint\(\{ x: x1, y: y1 \}, \{ x: to\.x \+ 103, y: to\.y \+ 62 \}\)/);
+});
+
 test("external dependencies remain inspector details rather than invented module nodes", () => {
   const names = new Set(M.data.entities.map(item => item.name.toLowerCase()));
   for (const external of ["redis", "postgres", "browser storage", "provider credentials", "external network", "environment configuration"]) {


### PR DESCRIPTION
### Motivation

- Arrowheads were being drawn underneath opaque module cards because routes ended at the card center, making relationship direction visually unavailable.  
- Compute endpoints at the target card boundary and reserve marker-length clearance so the arrow tip remains visible above the card.

### Description

- Added `routeEndpoint(from, to, halfWidth = 103, halfHeight = 62, markerLength = 10)` to compute a visible path endpoint on the target card boundary and exported it on `AtlasModel` as `routeEndpoint`.  
- Updated `renderRoutes()` to call `M.routeEndpoint(...)` and draw relationship `path` to that endpoint instead of the target center.  
- Added a regression test `relationship arrows stop outside target cards so their markers remain visible` in `projection-ui-map/rc-atlas-prototype.test.cjs` to cover horizontal, vertical, reverse, and diagonal geometry and verify renderer integration.  
- No ADR or architecture-contract impact; this is a localized prototype rendering fix.

### Testing

- `node --test --test-name-pattern='relationship arrows stop|node and edge meaning' projection-ui-map/rc-atlas-prototype.test.cjs` — targeted tests passed.  
- `node projection-ui-map/rc-atlas-prototype.test.cjs` — full suite: 35/36 tests passed; one pre-existing unrelated test fails due to an embedded ADR-index snapshot mismatch (matches separate review finding).  
- `git diff --check` and cached diff checks passed.  
- Commit: `0e433802c3d534fd285a90b32b11fecb9c43d5e2`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6aa52f803a64832d927e2ca0ced2b5ad)