### PR TITLE
Align user profile accent proof route posture

### DIFF
--- a/config/supported_profiles/v1-user-profile-accent-proof.yaml
+++ b/config/supported_profiles/v1-user-profile-accent-proof.yaml
@@ -44,6 +44,7 @@ route_posture:
     - connections
     - notion_knowledge
     - google_drive_knowledge
+    - share
   internal_only:
     - coding_work_orders
     - command_bus
@@ -58,7 +59,6 @@ route_posture:
     - memory
     - agent
     - research
-    - share
     - federation
     - collaboration
     - connectors


### PR DESCRIPTION
Restores the proof-only supported profile's intended parity with the default profile after the share route was promoted to enabled. The only intentional route-posture difference remains user_profile. This is an independent canonical-main regression repair and does not modify Chroma PR #806.